### PR TITLE
Fix parsing user_tags of info models

### DIFF
--- a/src/html/classic/ng/src/gmp/models/certbund.js
+++ b/src/html/classic/ng/src/gmp/models/certbund.js
@@ -30,12 +30,7 @@ class CertBundAdv extends Info {
   static info_type = 'cert_bund_adv';
 
   parseProperties(elem) {
-    let ret = super.parseProperties(elem);
-
-    if (elem.cert_bund_adv) { // we have an info element
-      extend(ret, elem.cert_bund_adv);
-      delete ret.cert_bund_adv;
-    }
+    const ret = super.parseProperties(elem, 'cert_bund_adv');
 
     ret.severity = ret.max_cvss;
     delete ret.max_cvss;

--- a/src/html/classic/ng/src/gmp/models/cpe.js
+++ b/src/html/classic/ng/src/gmp/models/cpe.js
@@ -21,7 +21,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import {is_defined, is_empty, map, extend} from '../utils.js';
+import {is_defined, is_empty, map} from '../utils.js';
 
 import Info from './info.js';
 
@@ -32,12 +32,7 @@ class Cpe extends Info {
   static info_type = 'cpe';
 
   parseProperties(elem) {
-    const ret = super.parseProperties(elem);
-
-    if (elem.cpe) { // we have an info element
-      extend(ret, elem.cpe);
-      delete ret.cpe;
-    }
+    const ret = super.parseProperties(elem, 'cpe');
 
     ret.severity = parse_severity(ret.max_cvss);
     delete ret.max_cvss;

--- a/src/html/classic/ng/src/gmp/models/cve.js
+++ b/src/html/classic/ng/src/gmp/models/cve.js
@@ -23,7 +23,7 @@
 
 import moment from 'moment';
 
-import {is_empty, is_defined, extend, map} from '../utils.js';
+import {is_empty, is_defined, map} from '../utils.js';
 
 import {
   parse_severity,
@@ -55,12 +55,7 @@ class Cve extends Info {
   static info_type = 'cve';
 
   parseProperties(elem) {
-    const ret = super.parseProperties(elem);
-
-    if (elem.cve) { // we have an info element
-      extend(ret, elem.cve);
-      delete ret.cve;
-    }
+    const ret = super.parseProperties(elem, 'cve');
 
     if (is_defined(ret.update_time)) {
       ret.update_time = moment(ret.update_time);

--- a/src/html/classic/ng/src/gmp/models/dfncert.js
+++ b/src/html/classic/ng/src/gmp/models/dfncert.js
@@ -21,7 +21,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import {extend} from '../utils.js';
 
 import Info from './info.js';
 
@@ -30,12 +29,7 @@ class DfnCertAdv extends Info {
   static info_type = 'dfn_cert_adv';
 
   parseProperties(elem) {
-    let ret = super.parseProperties(elem);
-
-    if (elem.dfn_cert_adv) { // we have an info element
-      extend(ret, elem.dfn_cert_adv);
-      delete ret.dfn_cert_adv;
-    }
+    const ret = super.parseProperties(elem, 'dfn_cert_adv');
 
     ret.severity = ret.max_cvss;
     delete ret.max_cvss;

--- a/src/html/classic/ng/src/gmp/models/info.js
+++ b/src/html/classic/ng/src/gmp/models/info.js
@@ -38,6 +38,21 @@ class Info extends Model {
         this.constructor.info_type;
     }
   }
+
+  parseProperties(elem, info_type) {
+    const info_elem = elem[info_type];
+
+    if (is_defined(info_elem)) { // elem is an info element content is in its child
+      elem = {
+        ...elem,
+        ...info_elem,
+      };
+
+      delete elem[info_type];
+    }
+
+    return super.parseProperties(elem);
+  }
 }
 
 export default Info;

--- a/src/html/classic/ng/src/gmp/models/nvt.js
+++ b/src/html/classic/ng/src/gmp/models/nvt.js
@@ -22,7 +22,6 @@
  */
 
 import {
-  extend,
   is_defined,
   is_empty,
   is_string,
@@ -62,16 +61,9 @@ class Nvt extends Info {
   static info_type = 'nvt';
 
   parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+    const ret = super.parseProperties(elem, 'nvt');
 
-    ret.nvt_type = elem.type;
-
-    if (elem.nvt) { // we have an info element
-      extend(ret, elem.nvt);
-      ret.nvt_type = ret.type;
-      delete ret.type;
-      delete ret.nvt;
-    }
+    ret.nvt_type = elem._type;
 
     ret.oid = ret._oid;
     ret.id = ret.oid;

--- a/src/html/classic/ng/src/gmp/models/ovaldef.js
+++ b/src/html/classic/ng/src/gmp/models/ovaldef.js
@@ -23,7 +23,7 @@
 
 import moment from 'moment';
 
-import {is_defined, is_empty, extend, map} from '../utils.js';
+import {is_defined, is_empty, map} from '../utils.js';
 
 import {parse_severity, parse_yesno, YES_VALUE} from '../parser.js';
 
@@ -76,12 +76,7 @@ class Ovaldef extends Info {
   static info_type = 'ovaldef';
 
   parseProperties(elem) {
-    const ret = super.parseProperties(elem);
-
-    if (elem.ovaldef) { // we have an info element
-      extend(ret, elem.ovaldef);
-      delete ret.ovaldef;
-    }
+    const ret = super.parseProperties(elem, 'ovaldef');
 
     ret.severity = parse_severity(ret.max_cvss);
     delete ret.max_cvss;


### PR DESCRIPTION
The response of a info entity contains a sub element with the actual
data. This includes the user_tags. Therefore to parse the user tags
correctly in the Model base class the actual data must be moved to the
main object BEFORE parsing the properties in the Model calss.

This adds a generic data movement into the Info base class and calls
Model.parseProperties afterwards.