### PR TITLE
Remove link to legacy details page

### DIFF
--- a/src/html/classic/ng/src/web/pages/ovaldefs/row.js
+++ b/src/html/classic/ng/src/web/pages/ovaldefs/row.js
@@ -32,8 +32,6 @@ import {na, render_component} from '../../utils/render.js';
 
 import {withEntityRow, RowDetailsToggle} from '../../entities/row.js';
 
-import InfoLink from '../../components/link/infolink.js';
-
 import SeverityBar from '../../components/bar/severitybar.js';
 
 import Comment from '../../components/comment/comment.js';
@@ -54,13 +52,6 @@ const Row = ({
       <TableRow>
         <TableData
           rowSpan="2">
-          <InfoLink
-            legacy
-            details
-            type="ovaldef"
-            id={entity.id}>
-            {entity.name}
-          </InfoLink>
           <RowDetailsToggle
             name={entity.id}
             onClick={onToggleDetailsClick}>


### PR DESCRIPTION
Remove the link to the old legacy details page from the list of
ovaldefs.