### PR TITLE
Parse severity of cert models

### DIFF
--- a/src/html/classic/ng/src/gmp/models/certbund.js
+++ b/src/html/classic/ng/src/gmp/models/certbund.js
@@ -23,6 +23,8 @@
 
 import {extend} from '../utils.js';
 
+import {parse_severity} from '../parser.js';
+
 import Info from './info.js';
 
 class CertBundAdv extends Info {
@@ -32,7 +34,7 @@ class CertBundAdv extends Info {
   parseProperties(elem) {
     const ret = super.parseProperties(elem, 'cert_bund_adv');
 
-    ret.severity = ret.max_cvss;
+    ret.severity = parse_severity(ret.max_cvss);
     delete ret.max_cvss;
 
     return ret;

--- a/src/html/classic/ng/src/gmp/models/dfncert.js
+++ b/src/html/classic/ng/src/gmp/models/dfncert.js
@@ -22,6 +22,8 @@
  */
 
 
+import {parse_severity} from '../parser.js';
+
 import Info from './info.js';
 
 class DfnCertAdv extends Info {
@@ -31,7 +33,7 @@ class DfnCertAdv extends Info {
   parseProperties(elem) {
     const ret = super.parseProperties(elem, 'dfn_cert_adv');
 
-    ret.severity = ret.max_cvss;
+    ret.severity = parse_severity(ret.max_cvss);
     delete ret.max_cvss;
 
     return ret;


### PR DESCRIPTION
To be able to compare severities all severities should be parsed as a js
number. Therefore use the parser function parse_severity in cert bund
and dfn cert models.