### PR TITLE
Add a State component

### DIFF
--- a/src/html/classic/ng/CMakeLists.txt
+++ b/src/html/classic/ng/CMakeLists.txt
@@ -568,6 +568,7 @@ set (NG_JS_SRC_FILES
      ${NG_SRC_DIR}/src/web/utils/render.js
      ${NG_SRC_DIR}/src/web/utils/selectiontype.js
      ${NG_SRC_DIR}/src/web/utils/theme.js
+     ${NG_SRC_DIR}/src/web/utils/state.js
      ${NG_SRC_DIR}/src/web/utils/urls.js
      ${NG_SRC_DIR}/src/web/utils/withCache.js
      ${NG_SRC_DIR}/src/web/utils/withCapabilities.js

--- a/src/html/classic/ng/src/web/utils/state.js
+++ b/src/html/classic/ng/src/web/utils/state.js
@@ -1,0 +1,56 @@
+/* Greenbone Security Assistant
+ *
+ * Authors:
+ * Björn Ricks <bjoern.ricks@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2017 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import React from 'react';
+
+import PropTypes from './proptypes.js';
+
+class State extends React.Component {
+
+  constructor(...args) {
+    super(...args);
+
+    this.state = {
+      ...this.props,
+    };
+
+    this.handleValueChange = this.handleValueChange.bind(this);
+  }
+
+  handleValueChange(value, name) {
+    this.setState([name]: value);
+  }
+
+  render() {
+    const {children} = this.props;
+    return children({state: this.state, onValueChange: this.handleValueChange});
+  }
+}
+
+State.propTypes = {
+  children: PropTypes.func.isRequired,
+};
+
+export default State;
+
+// vim: set ts=2 sw=2 tw=80:


### PR DESCRIPTION
The new State component uses the render props pattern to store a state.
The state can be changed by calling onValueChange(value, name).
Afterwards value will be stored in the passed state e.g. state[name] ===
value.

Example for using the State component:
```jsx
<State>
{({
  state,
  onValueChange,
}) => {
  const {myvalue} = state;
  return (
    <TextField
      value={myvalue}
      name="myvalue"
      onChange={onValueChange}
    />
    <button onClick={() => onSave(state)} />
  );
}}
</State>
```
With the state component it will not be necessary to re-implement the
state handling in components using forms.