### PR TITLE
Allow to override config locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 tags
 node_modules/
 .env.local
+config.local.js

--- a/src/html/classic/ng/public/index.html
+++ b/src/html/classic/ng/public/index.html
@@ -6,6 +6,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script type="text/javascript" src="%PUBLIC_URL%/config.js"></script>
+    <script type="text/javascript" src="%PUBLIC_URL%/config.local.js"></script>
     <script type="text/javascript" src="%PUBLIC_URL%/js/lib/jquery-2.1.4.js"></script>
     <script type="text/javascript" src="%PUBLIC_URL%/js/lib/jquery-ui.js"></script>
     <script type="text/javascript" src="%PUBLIC_URL%/js/lib/d3.v3.js"></script>


### PR DESCRIPTION
With this change it is possible to add a config.local.js file under
ng/public/config.local.js that may local config settings. the
config.local.js file is ignored for git.