### PR TITLE
Refactor group list page to use GroupComponent

### DIFF
--- a/src/html/classic/ng/src/web/pages/groups/listpage.js
+++ b/src/html/classic/ng/src/web/pages/groups/listpage.js
@@ -24,7 +24,6 @@
 import React from 'react';
 
 import _ from 'gmp/locale.js';
-import {is_defined} from 'gmp/utils.js';
 
 import PropTypes from '../../utils/proptypes.js';
 
@@ -40,11 +39,11 @@ import {createFilterDialog} from '../../components/powerfilter/dialog.js';
 
 import {GROUPS_FILTER_FILTER} from 'gmp/models/filter.js';
 
-import GroupDialog from './dialog.js';
+import GroupComponent from './component.js';
 import Table, {SORT_FIELDS} from './table.js';
 
 const ToolBarIcons = ({
-  onNewGroupClick,
+  onGroupCreateClick,
 }, {capabilities}) => {
   return (
     <Layout flex box>
@@ -54,85 +53,75 @@ const ToolBarIcons = ({
       {capabilities.mayCreate('group') &&
         <NewIcon
           title={_('New Group')}
-          onClick={onNewGroupClick}/>
+          onClick={onGroupCreateClick}/>
       }
     </Layout>
   );
 };
 
 ToolBarIcons.propTypes = {
-  onNewGroupClick: PropTypes.func.isRequired,
+  onGroupCreateClick: PropTypes.func.isRequired,
 };
 
 ToolBarIcons.contextTypes = {
   capabilities: PropTypes.capabilities.isRequired,
 };
 
-class Page extends React.Component {
+const GroupsFilterDialog = createFilterDialog({sortFields: SORT_FIELDS});
 
-  constructor(...args) {
-    super(...args);
+const GroupsPage = ({
+  onChanged,
+  onDownloaded,
+  onError,
+  ...props
+}) => (
+  <GroupComponent
+    onCreated={onChanged}
+    onSaved={onChanged}
+    onCloned={onChanged}
+    onCloneError={onError}
+    onDeleted={onChanged}
+    onDeleteError={onError}
+    onDownloaded={onDownloaded}
+    onDownloadError={onError}
+  >
+    {({
+      clone,
+      create,
+      delete: delete_func,
+      download,
+      edit,
+      save,
+    }) => (
+      <EntitiesPage
+        {...props}
+        filterEditDialog={GroupsFilterDialog}
+        sectionIcon="group.svg"
+        table={Table}
+        title={_('Groups')}
+        toolBarIcons={ToolBarIcons}
+        onChanged={onChanged}
+        onDownloaded={onDownloaded}
+        onError={onError}
+        onGroupCloneClick={clone}
+        onGroupCreateClick={create}
+        onGroupDeleteClick={delete_func}
+        onGroupDownloadClick={download}
+        onGroupEditClick={edit}
+        onGroupSaveClick={save}
+      />
+    )}
+  </GroupComponent>
+);
 
-    this.openDialog = this.openDialog.bind(this);
-  }
-
-  openDialog(group) {
-    const {gmp} = this.context;
-
-    if (is_defined(group)) {
-      this.dialog.show({
-        id: group.id,
-        name: group.name,
-        comment: group.comment,
-        users: group.users,
-      }, {
-        title: _('Edit Group {{name}}', group),
-      });
-    }
-    else {
-      this.dialog.show({});
-    }
-
-    gmp.users.getAll().then(users => {
-      this.dialog.setValue('all_users', users);
-    });
-  }
-
-  render() {
-    const {onEntitySave} = this.props;
-    return (
-      <Layout>
-        <EntitiesPage
-          {...this.props}
-          onNewGroupClick={this.openDialog}
-          onEditGroup={this.openDialog}
-        />
-        <GroupDialog
-          ref={ref => this.dialog = ref}
-          onSave={onEntitySave}
-        />
-      </Layout>
-    );
-  }
-}
-
-Page.propTypes = {
-  onEntitySave: PropTypes.func.isRequired,
-};
-
-Page.contextTypes = {
-  gmp: PropTypes.gmp.isRequired,
+GroupsPage.propTypes = {
+  onChanged: PropTypes.func.isRequired,
+  onDownloaded: PropTypes.func.isRequired,
+  onError: PropTypes.func.isRequired,
 };
 
 export default withEntitiesContainer('group', {
-  filterEditDialog: createFilterDialog({
-    sortFields: SORT_FIELDS,
-  }),
   filtersFilter: GROUPS_FILTER_FILTER,
-  sectionIcon: 'group.svg',
-  table: Table,
-  title: _('Groups'),
-  toolBarIcons: ToolBarIcons,
-})(Page);
+})(GroupsPage);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/src/html/classic/ng/src/web/pages/groups/row.js
+++ b/src/html/classic/ng/src/web/pages/groups/row.js
@@ -44,10 +44,10 @@ import TableRow from '../../components/table/row.js';
 
 const IconActions = ({
     entity,
-    onEditGroup,
-    onEntityClone,
-    onEntityDelete,
-    onEntityDownload,
+    onGroupEditClick,
+    onGroupCloneClick,
+    onGroupDeleteClick,
+    onGroupDownloadClick,
   }) => {
   return (
     <Layout flex align={['center', 'center']}>
@@ -55,23 +55,23 @@ const IconActions = ({
         displayName={_('Group')}
         name="group"
         entity={entity}
-        onClick={onEntityDelete}/>
+        onClick={onGroupDeleteClick}/>
       <EditIcon
         displayName={_('Group')}
         name="group"
         entity={entity}
-        onClick={onEditGroup}/>
+        onClick={onGroupEditClick}/>
       <CloneIcon
         displayName={_('Group')}
         name="user"
         entity={entity}
         title={_('Clone Group')}
         value={entity}
-        onClick={onEntityClone}/>
+        onClick={onGroupCloneClick}/>
       <ExportIcon
         value={entity}
         title={_('Export Group')}
-        onClick={onEntityDownload}
+        onClick={onGroupDownloadClick}
       />
     </Layout>
   );
@@ -79,10 +79,10 @@ const IconActions = ({
 
 IconActions.propTypes = {
   entity: PropTypes.model.isRequired,
-  onEditGroup: PropTypes.func.isRequired,
-  onEntityClone: PropTypes.func.isRequired,
-  onEntityDelete: PropTypes.func.isRequired,
-  onEntityDownload: PropTypes.func.isRequired,
+  onGroupCloneClick: PropTypes.func.isRequired,
+  onGroupDeleteClick: PropTypes.func.isRequired,
+  onGroupDownloadClick: PropTypes.func.isRequired,
+  onGroupEditClick: PropTypes.func.isRequired,
 };
 
 const Row = ({


### PR DESCRIPTION
Avoid duplicate code (e.g. opening the group edit/create dialog) by
using the GroupComponent also for the group list page.