### PR TITLE
Entity permission loading

### DIFF
--- a/ng/src/web/entity/container.js
+++ b/ng/src/web/entity/container.js
@@ -119,15 +119,9 @@ class EntityContainer extends React.Component {
 
   load(id) {
     const {gmp} = this.context;
-    const {loaders, loadPermissions = true} = this.props;
+    const {loaders} = this.props;
 
     const all_loaders = [this.loadEntity];
-
-    if (loadPermissions) {
-      // TODO remove me
-      // all entitycontainers should set their desired loaders
-      all_loaders.push(permissions_resource_loader);
-    }
 
     if (is_defined(loaders)) {
       all_loaders.push(...this.props.loaders);
@@ -243,7 +237,6 @@ class EntityContainer extends React.Component {
 }
 
 EntityContainer.propTypes = {
-  loadPermissions: PropTypes.bool,
   loaders: PropTypes.array,
   name: PropTypes.string.isRequired,
   params: PropTypes.object.isRequired,

--- a/ng/src/web/pages/certbund/detailspage.js
+++ b/ng/src/web/pages/certbund/detailspage.js
@@ -146,7 +146,6 @@ const CertBundAdvPage = props => (
   <EntityContainer
     {...props}
     name="certbundadv"
-    loadPermissions={false}
   >
     {({
       onChanged,

--- a/ng/src/web/pages/cpes/detailspage.js
+++ b/ng/src/web/pages/cpes/detailspage.js
@@ -174,7 +174,6 @@ const CpePage = props => (
   <EntityContainer
     {...props}
     name="cpe"
-    loadPermissions={false}
   >
     {({
       onChanged,

--- a/ng/src/web/pages/cves/detailspage.js
+++ b/ng/src/web/pages/cves/detailspage.js
@@ -208,7 +208,6 @@ const CvePage = props => (
   <EntityContainer
     {...props}
     name="cve"
-    loadPermissions={false}
   >
     {({
       onChanged,

--- a/ng/src/web/pages/dfncert/detailspage.js
+++ b/ng/src/web/pages/dfncert/detailspage.js
@@ -131,7 +131,6 @@ const DfnCertAdvPage = props => (
   <EntityContainer
     {...props}
     name="dfncertadv"
-    loadPermissions={false}
   >
     {({
       onChanged,

--- a/ng/src/web/pages/groups/detailspage.js
+++ b/ng/src/web/pages/groups/detailspage.js
@@ -27,7 +27,9 @@ import _ from 'gmp/locale.js';
 import PropTypes from '../../utils/proptypes.js';
 
 import EntityPage from '../../entity/page.js';
-import EntityContainer from '../../entity/container.js';
+import EntityContainer, {
+  permissions_subject_loader,
+} from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
 
 import ExportIcon from '../../components/icon/exporticon.js';
@@ -153,6 +155,9 @@ const GroupPage = props => (
   <EntityContainer
     {...props}
     name="group"
+    loaders={[
+      permissions_subject_loader,
+    ]}
   >
     {cprops => <Page {...props} {...cprops} />}
   </EntityContainer>

--- a/ng/src/web/pages/hosts/detailspage.js
+++ b/ng/src/web/pages/hosts/detailspage.js
@@ -52,7 +52,9 @@ import TableData from '../../components/table/data.js';
 import TableRow from '../../components/table/row.js';
 
 import EntityPage from '../../entity/page.js';
-import EntityContainer from '../../entity/container.js';
+import EntityContainer, {
+  permissions_resource_loader,
+} from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
 
 import CloneIcon from '../../entity/icon/cloneicon.js';
@@ -327,6 +329,9 @@ const HostPage = props => (
   <EntityContainer
     {...props}
     name="host"
+    loaders={[
+      permissions_resource_loader,
+    ]}
   >
     {cprops => <Page {...props} {...cprops} />}
   </EntityContainer>

--- a/ng/src/web/pages/notes/detailspage.js
+++ b/ng/src/web/pages/notes/detailspage.js
@@ -45,7 +45,9 @@ import TableData from '../../components/table/data.js';
 import TableRow from '../../components/table/row.js';
 
 import EntityPage from '../../entity/page.js';
-import EntityContainer from '../../entity/container.js';
+import EntityContainer, {
+  permissions_resource_loader,
+} from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
 
 import CloneIcon from '../../entity/icon/cloneicon.js';
@@ -229,6 +231,9 @@ const NotePage = props => (
   <EntityContainer
     {...props}
     name="note"
+    loaders={[
+      permissions_resource_loader,
+    ]}
   >
     {cprops => <Page {...props} {...cprops} />}
   </EntityContainer>

--- a/ng/src/web/pages/nvts/detailspage.js
+++ b/ng/src/web/pages/nvts/detailspage.js
@@ -292,7 +292,6 @@ const NvtPage = props => (
   <EntityContainer
     {...props}
     name="nvt"
-    loadPermissions={false}
     loaders={[
       loader('notes', nvt_id_filter),
       loader('overrides', nvt_id_filter),

--- a/ng/src/web/pages/os/detailspage.js
+++ b/ng/src/web/pages/os/detailspage.js
@@ -28,7 +28,9 @@ import _ from 'gmp/locale.js';
 import PropTypes from '../../utils/proptypes.js';
 
 import EntityPage from '../../entity/page.js';
-import EntityContainer from '../../entity/container.js';
+import EntityContainer, {
+  permissions_resource_loader,
+} from '../../entity/container.js';
 import {goto_list} from '../../entity/component.js';
 
 import Badge from '../../components/badge/badge.js';
@@ -222,6 +224,9 @@ const HostPage = props => (
     {...props}
     name="operatingsystem"
     resourceType="os"
+    loaders={[
+      permissions_resource_loader,
+    ]}
   >
     {cprops => (
       <Page {...props} {...cprops} />

--- a/ng/src/web/pages/ovaldefs/detailspage.js
+++ b/ng/src/web/pages/ovaldefs/detailspage.js
@@ -313,7 +313,6 @@ const CvePage = props => (
   <EntityContainer
     {...props}
     name="ovaldef"
-    loadPermissions={false}
   >
     {({
       onChanged,

--- a/ng/src/web/pages/overrides/detailspage.js
+++ b/ng/src/web/pages/overrides/detailspage.js
@@ -45,7 +45,9 @@ import TableData from '../../components/table/data.js';
 import TableRow from '../../components/table/row.js';
 
 import EntityPage from '../../entity/page.js';
-import EntityContainer from '../../entity/container.js';
+import EntityContainer, {
+  permissions_resource_loader,
+} from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
 
 import CloneIcon from '../../entity/icon/cloneicon.js';
@@ -229,6 +231,9 @@ const OverridePage = props => (
   <EntityContainer
     {...props}
     name="override"
+    loaders={[
+      permissions_resource_loader,
+    ]}
   >
     {cprops => <Page {...props} {...cprops} />}
   </EntityContainer>

--- a/ng/src/web/pages/results/detailspage.js
+++ b/ng/src/web/pages/results/detailspage.js
@@ -361,6 +361,7 @@ class Page extends React.Component {
           title={_('Result')}
           toolBarIcons={ToolBarIcons}
           detailsComponent={Details}
+          permissionsComponent={false}
           onNoteCreateClick={this.openNoteDialog}
           onOverrideCreateClick={this.openOverrideDialog}
         />
@@ -389,7 +390,6 @@ const ResultPage = props => (
   <EntityContainer
     {...props}
     name="result"
-    permissionsComponent={false}
   >
     {cprops => <Page {...cprops} />}
   </EntityContainer>

--- a/ng/src/web/pages/roles/detailspage.js
+++ b/ng/src/web/pages/roles/detailspage.js
@@ -230,7 +230,6 @@ const RolePage = props => (
   <EntityContainer
     {...props}
     name="role"
-    loadPermissions={false}
     loaders={[
       general_permissions_loader,
       permissions_subject_loader,

--- a/ng/src/web/pages/targets/detailspage.js
+++ b/ng/src/web/pages/targets/detailspage.js
@@ -47,7 +47,9 @@ import TableRow from '../../components/table/row.js';
 
 import EntityPage from '../../entity/page.js';
 import EntityPermissions from '../../entity/permissions.js';
-import EntityContainer from '../../entity/container.js';
+import EntityContainer, {
+  permissions_resource_loader,
+} from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
 
 import CloneIcon from '../../entity/icon/cloneicon.js';
@@ -180,6 +182,7 @@ const Page = ({
         <EntityPage
           {...props}
           detailsComponent={Details}
+          permissionsComponent={TargetPermissions}
           sectionIcon="target.svg"
           toolBarIcons={ToolBarIcons}
           title={_('Target')}
@@ -223,7 +226,9 @@ const TargetPage = props => (
   <EntityContainer
     {...props}
     name="target"
-    permissionsComponent={TargetPermissions}
+    loaders={[
+      permissions_resource_loader,
+    ]}
   >
     {cprops => <Page {...props} {...cprops} />}
   </EntityContainer>

--- a/ng/src/web/pages/tasks/detailspage.js
+++ b/ng/src/web/pages/tasks/detailspage.js
@@ -35,7 +35,10 @@ import withComponentDefaults from '../../utils/withComponentDefaults.js';
 
 import EntityPage from '../../entity/page.js';
 import EntityPermissions from '../../entity/permissions.js';
-import EntityContainer, {loader} from '../../entity/container.js';
+import EntityContainer, {
+  loader,
+  permissions_resource_loader,
+} from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
 
 import CloneIcon from '../../entity/icon/cloneicon.js';
@@ -379,6 +382,7 @@ const Page = ({
         title={_('Task')}
         toolBarIcons={ToolBarIcons}
         detailsComponent={Details}
+        permissionsComponent={TaskPermissions}
         onChanged={onChanged}
         onError={onError}
         onContainerTaskCreateClick={createcontainer}
@@ -449,8 +453,8 @@ const TaskPage = props => (
     loaders={[
       loader('notes', task_id_filter),
       loader('overrides', task_id_filter),
+      permissions_resource_loader,
     ]}
-    permissionsComponent={TaskPermissions}
   >
     {cprops => <Page {...props} {...cprops} />}
   </EntityContainer>

--- a/ng/src/web/pages/users/detailspage.js
+++ b/ng/src/web/pages/users/detailspage.js
@@ -27,7 +27,9 @@ import _ from 'gmp/locale.js';
 import PropTypes from '../../utils/proptypes.js';
 
 import EntityPage from '../../entity/page.js';
-import EntityContainer from '../../entity/container.js';
+import EntityContainer, {
+  permissions_subject_loader,
+} from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
 
 import ExportIcon from '../../components/icon/exporticon.js';
@@ -153,6 +155,9 @@ const UserPage = props => (
   <EntityContainer
     {...props}
     name="user"
+    loaders={[
+      permissions_subject_loader,
+    ]}
   >
     {cprops => <Page {...props} {...cprops} />}
   </EntityContainer>


### PR DESCRIPTION
Get rid of the EntityComponent loadPermissions prop and cleanup loading of permissions list at the different details pages.