### PR TITLE
Remove refresh_interval in Advanced Task and Modify Task wizards. (GSA 7.0)

### DIFF
--- a/src/html/classic/wizard.xsl
+++ b/src/html/classic/wizard.xsl
@@ -179,7 +179,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <input type="hidden" name="cmd" value="run_wizard"/>
     <input type="hidden" name="caller" value="{/envelope/caller}"/>
     <input type="hidden" name="name" value="quick_task"/>
-    <input type="hidden" name="refresh_interval" value="{30}"/>
     <input type="hidden" name="overrides" value="{/envelope/params/overrides}"/>
     <input type="hidden" name="filter" value="{/envelope/params/filter}"/>
     <input type="hidden" name="filt_id" value="{/envelope/params/filt_id}"/>
@@ -466,7 +465,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <input type="hidden" name="cmd" value="run_wizard"/>
     <input type="hidden" name="caller" value="{/envelope/caller}"/>
     <input type="hidden" name="name" value="modify_task"/>
-    <input type="hidden" name="refresh_interval" value="{30}"/>
     <input type="hidden" name="overrides" value="{/envelope/params/overrides}"/>
     <input type="hidden" name="filter" value="{/envelope/params/filter}"/>
     <input type="hidden" name="filt_id" value="{/envelope/params/filt_id}"/>


### PR DESCRIPTION
The refresh is only supposed to be set by the "Quick First Task" wizard,
 while other wizards should leave the refresh interval as it is.