### PR TITLE
Update the German translations for GSA 7.0

### DIFF
--- a/src/html/classic/js/gsa_bubble_chart.js
+++ b/src/html/classic/js/gsa_bubble_chart.js
@@ -99,11 +99,10 @@
         false, this.show_stat_type);
 
     if (!gsa.is_defined(this.empty_text)) {
-      this.empty_text = gsa._('No matching {{resource_type}}',
+      this.empty_text = gsa._('No matching {{- resource_type}}',
           {
             resource_type: gch.resource_type_name(
                                column_info.columns.label_value.type),
-            interpolation: {escape: false},
           });
     }
 

--- a/src/html/classic/js/gsa_chart_helpers.js
+++ b/src/html/classic/js/gsa_chart_helpers.js
@@ -1525,10 +1525,9 @@
   gch.field_name = function(field, type) {
     switch (field.toLowerCase()) {
       case 'c_count':
-        return gsa._('total {{resource_type_plural}}',
+        return gsa._('total {{- resource_type_plural}}',
             {
               resource_type_plural: gch.resource_type_name_plural(type),
-              interpolation: {escape: false},
             });
       case 'count':
         return gch.resource_type_name_plural(type);
@@ -1598,24 +1597,20 @@
     if (include_stat) {
       switch (info.stat) {
         case 'min':
-          label = label + gsa._('min. {{field_name}}',
-                                {field_name: field_name,
-                                 interpolation: {escape: false}});
+          label = label + gsa._('min. {{- field_name}}',
+                                {field_name: field_name});
           break;
         case 'max':
-          label = label + gsa._('max. {{field_name}}',
-                                {field_name: field_name,
-                                 interpolation: {escape: false}});
+          label = label + gsa._('max. {{- field_name}}',
+                                {field_name: field_name});
           break;
         case 'mean':
-          label = label + gsa._('average {{field_name}}',
-                                {field_name: field_name,
-                                 interpolation: {escape: false}});
+          label = label + gsa._('average {{- field_name}}',
+                                {field_name: field_name});
           break;
         case 'sum':
-          label = label + gsa._('summed {{field_name}}',
-                                {field_name: field_name,
-                                 interpolation: {escape: false}});
+          label = label + gsa._('summed {{- field_name}}',
+                                {field_name: field_name});
           break;
       }
     }

--- a/src/html/classic/js/gsa_chart_helpers.js
+++ b/src/html/classic/js/gsa_chart_helpers.js
@@ -1534,6 +1534,8 @@
         return gch.resource_type_name_plural(type);
       case 'created':
         return gsa._('creation time');
+      case 'duration':
+        return gsa._('duration');
       case 'modified':
         return gsa._('modification time');
       case 'qod':
@@ -1544,6 +1546,8 @@
         return gsa._('High');
       case 'high_per_host':
         return gsa._('High / host');
+      case 'duration_per_host':
+        return gsa._('Duration / host')
       default:
         if (gsa.is_string(field)) {
           return field.replace('_', ' ');
@@ -1587,25 +1591,37 @@
   gch.default_column_label = function(info, capitalize_label,
                                   include_type, include_stat) {
     var label = '';
+    var field_name
+          = label + gch.field_name(info.column ? info.column : info.stat,
+                                   info.type);
+
     if (include_stat) {
       switch (info.stat) {
         case 'min':
-          label = label + 'min. ';
+          label = label + gsa._('min. {{field_name}}',
+                                {field_name: field_name,
+                                 interpolation: {escape: false}});
           break;
         case 'max':
-          label = label + 'max. ';
+          label = label + gsa._('max. {{field_name}}',
+                                {field_name: field_name,
+                                 interpolation: {escape: false}});
           break;
         case 'mean':
-          label = label + 'average ';
+          label = label + gsa._('average {{field_name}}',
+                                {field_name: field_name,
+                                 interpolation: {escape: false}});
           break;
         case 'sum':
-          label = label + 'summed ';
+          label = label + gsa._('summed {{field_name}}',
+                                {field_name: field_name,
+                                 interpolation: {escape: false}});
           break;
       }
     }
-
-    label = label + gch.field_name(info.column ? info.column : info.stat,
-                                   info.type);
+    else {
+      label = label + field_name;
+    }
 
     if (include_type && info.stat !== 'count' && info.stat !== 'c_count') {
       label = label + ' (' + gch.resource_type_name(info.type) + ')';

--- a/src/po/gsad_js-de.po
+++ b/src/po/gsad_js-de.po
@@ -3,7 +3,7 @@
 # Description: German user interface translations.
 #
 # Copyright:
-# Copyright (C) 2016 Greenbone Networks GmbH
+# Copyright (C) 2016-2017 Greenbone Networks GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -24,8 +24,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-18 10:12+0200\n"
-"PO-Revision-Date: 2016-10-18 08:33+0200\n"
+"POT-Creation-Date: 2017-11-08 10:13+0100\n"
+"PO-Revision-Date: 2017-11-08 08:46+0200\n"
 "Last-Translator: Timo <timo.pollmeier@greenbone.net>\n"
 "Language-Team: German <openvas-devel@wald.intevation.org>\n"
 "Language: de\n"
@@ -34,49 +34,45 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.5.1.3\n"
-"X-POOTLE-MTIME: 1476776012.656652\n"
+"X-POOTLE-MTIME: 1510127176.742283\n"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:590
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1276
+#: src/html/classic/js/greenbone.js:623 src/html/classic/js/greenbone.js:1345
 msgid "Save"
 msgstr "Speichern"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1157
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1158
+#: src/html/classic/js/greenbone.js:1197 src/html/classic/js/greenbone.js:1198
 msgid "Unfold {{name}}"
 msgstr "{{name}} ausklappen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1163
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1164
+#: src/html/classic/js/greenbone.js:1203 src/html/classic/js/greenbone.js:1204
 msgid "Fold {{name}}"
 msgstr "{{name}} einklappen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1285
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1293
+#: src/html/classic/js/greenbone.js:1354 src/html/classic/js/greenbone.js:1362
 msgid "Create"
 msgstr "Erstellen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1301
+#: src/html/classic/js/greenbone.js:1370
 msgid "Delete"
 msgstr "Löschen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1391
+#: src/html/classic/js/greenbone.js:1461
 msgid "Please wait..."
 msgstr "Bitte warten..."
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1481
+#: src/html/classic/js/greenbone.js:1557
 msgid "Update Filter"
 msgstr "Filter aktualisieren"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1498
+#: src/html/classic/js/greenbone.js:1574
 msgid "Select date"
 msgstr "Datum auswählen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1786
+#: src/html/classic/js/greenbone.js:1892
 msgid "Follow link?"
 msgstr "Link folgen?"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1789
+#: src/html/classic/js/greenbone.js:1895
 msgid ""
 "This dialog will open a new window for <a>{{url}}</a> if you click on follow "
 "link. Following this link is on your own responsibility. Greenbone doesn't "
@@ -86,375 +82,402 @@ msgstr ""
 "den Folgen-Link klicken. Diesem Link zu folgen geschieht auf Ihre eigene "
 "Verantwortung. Greenbone befürwortet nicht die Inhalte, die Sie dort sehen."
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1794
+#: src/html/classic/js/greenbone.js:1900
 msgid "Abort"
 msgstr "Abbrechen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1795
+#: src/html/classic/js/greenbone.js:1901
 msgid "Follow link"
 msgstr "Link folgen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1868
+#: src/html/classic/js/greenbone.js:1974
 msgid "{{subject}} {{subject_id}} {{description}} to {{resource}} {{id}}"
-msgstr ""
+msgstr "{{subject}} {{subject_id}} {{description}} nach {{resource}} {{id}}"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1876
+#: src/html/classic/js/greenbone.js:1982
 msgid "{{subject}} {{subject_id}} {{description}}  {{id}}"
-msgstr ""
+msgstr "{{subject}} {{subject_id}} {{description}}  {{resource}} {{id}}"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/greenbone.js:1881
+#: src/html/classic/js/greenbone.js:1987
 msgid "{{subject}} {{subject_id}} {{description}}"
-msgstr ""
+msgstr "{{subject}} {{subject_id}} {{description}}"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_bar_chart.js:68
+#: src/html/classic/js/gsa_bar_chart.js:68
 msgid "Loading bar chart ..."
 msgstr "Lade Balkendiagramm ..."
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_bar_chart.js:68
+#: src/html/classic/js/gsa_bar_chart.js:68
 msgid "Bar Chart"
 msgstr "Balkendiagramm"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_bubble_chart.js:57
+#: src/html/classic/js/gsa_bubble_chart.js:57
 msgid "Loading bubble chart ..."
 msgstr "Lade Blasendiagramm ..."
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_bubble_chart.js:57
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_line_chart.js:79
+#: src/html/classic/js/gsa_bubble_chart.js:57
+#: src/html/classic/js/gsa_line_chart.js:79
 msgid "Bubble Chart"
 msgstr "Blasendiagramm"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_bubble_chart.js:102
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_gantt_chart.js:123
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_h_bar_chart.js:152
+#: src/html/classic/js/gsa_bubble_chart.js:102
+#: src/html/classic/js/gsa_gantt_chart.js:125
+#: src/html/classic/js/gsa_h_bar_chart.js:152
 msgid "No matching {{resource_type}}"
 msgstr "Kein(e) passende(r/s) {{resource_type}}"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1424
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1545
+#: src/html/classic/js/gsa_chart_helpers.js:1423
+#: src/html/classic/js/gsa_chart_helpers.js:1546
 msgid "High"
 msgstr "Hoch"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1427
+#: src/html/classic/js/gsa_chart_helpers.js:1426
 msgid "Medium"
 msgstr "Mittel"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1430
+#: src/html/classic/js/gsa_chart_helpers.js:1429
 msgid "Low"
 msgstr "Niedrig"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1433
+#: src/html/classic/js/gsa_chart_helpers.js:1432
 msgid "Log"
 msgstr "Log"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1436
+#: src/html/classic/js/gsa_chart_helpers.js:1435
 msgid "False Positive"
 msgstr "Falsch-Positiv"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1439
+#: src/html/classic/js/gsa_chart_helpers.js:1438
 msgid "Debug"
 msgstr "Debug"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1442
+#: src/html/classic/js/gsa_chart_helpers.js:1441
 msgid "Error"
 msgstr "Fehler"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1445
+#: src/html/classic/js/gsa_chart_helpers.js:1444
 msgid "N/A"
 msgstr "N/A"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1459
+#: src/html/classic/js/gsa_chart_helpers.js:1458
 msgid "Operating System"
 msgstr "Betriebssystem"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1461
+#: src/html/classic/js/gsa_chart_helpers.js:1460
 msgid "OVAL definition"
 msgstr "OVAL-Definition"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1463
+#: src/html/classic/js/gsa_chart_helpers.js:1462
 msgid "CERT-Bund Advisory"
 msgstr "CERT-Bund-Meldung"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1465
+#: src/html/classic/js/gsa_chart_helpers.js:1464
 msgid "DFN-CERT Advisory"
 msgstr "DFN-CERT-Meldung"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1467
+#: src/html/classic/js/gsa_chart_helpers.js:1466
 msgid "SecInfo Item"
 msgstr "SecInfo-Eintrag"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1483
+#: src/html/classic/js/gsa_chart_helpers.js:1482
 msgid "DFN-CERT Advisories"
 msgstr "DFN-CERT-Meldungen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1485
+#: src/html/classic/js/gsa_chart_helpers.js:1484
 msgid "CERT-Bund Advisories"
 msgstr "CERT-Bund-Meldungen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1529
+#: src/html/classic/js/gsa_chart_helpers.js:1528
 msgid "total {{resource_type_plural}}"
 msgstr "{{resource_type_plural}} gesamt"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1537
+#: src/html/classic/js/gsa_chart_helpers.js:1536
 msgid "creation time"
 msgstr "Erstellungszeit"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1539
+#: src/html/classic/js/gsa_chart_helpers.js:1538
+msgid "duration"
+msgstr "Laufzeit"
+
+#: src/html/classic/js/gsa_chart_helpers.js:1540
 msgid "modification time"
 msgstr "Änderungszeit"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1541
+#: src/html/classic/js/gsa_chart_helpers.js:1542
 msgid "QoD"
 msgstr "QoD"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1543
+#: src/html/classic/js/gsa_chart_helpers.js:1544
 msgid "QoD type"
 msgstr "QoD-Typ"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:1547
+#: src/html/classic/js/gsa_chart_helpers.js:1548
 msgid "High / host"
 msgstr "Hoch / Host"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:2017
+#: src/html/classic/js/gsa_chart_helpers.js:1550
+msgid "Duration / host"
+msgstr "Laufzeit / Host"
+
+#: src/html/classic/js/gsa_chart_helpers.js:1601
+msgid "min. {{field_name}}"
+msgstr "min. {{field_name}}"
+
+#: src/html/classic/js/gsa_chart_helpers.js:1606
+msgid "max. {{field_name}}"
+msgstr "max. {{field_name}}"
+
+#: src/html/classic/js/gsa_chart_helpers.js:1611
+msgid "average {{field_name}}"
+msgstr "durchschn. {{field_name}}"
+
+#: src/html/classic/js/gsa_chart_helpers.js:1616
+msgid "summed {{field_name}}"
+msgstr "Summe {{field_name}}"
+
+#: src/html/classic/js/gsa_chart_helpers.js:2032
 msgid "None"
 msgstr "Keiner"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:2020
+#: src/html/classic/js/gsa_chart_helpers.js:2035
 msgid "Exploit"
 msgstr "Exploit"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:2023
+#: src/html/classic/js/gsa_chart_helpers.js:2038
 msgid "Remote vulnerability"
 msgstr "Remote-Schwachstelle"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:2026
+#: src/html/classic/js/gsa_chart_helpers.js:2041
 msgid "Package check"
 msgstr "Package-Check"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:2029
+#: src/html/classic/js/gsa_chart_helpers.js:2044
 msgid "Registry check"
 msgstr "Registry-Check"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:2032
-#, fuzzy
+#: src/html/classic/js/gsa_chart_helpers.js:2047
 msgid "Executable version"
 msgstr "Programmdatei-Version"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:2035
+#: src/html/classic/js/gsa_chart_helpers.js:2050
 msgid "Remote analysis"
 msgstr "Remote-Analyse"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:2038
+#: src/html/classic/js/gsa_chart_helpers.js:2053
 msgid "Remote probe"
-msgstr ""
+msgstr "Fern-Test"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:2041
+#: src/html/classic/js/gsa_chart_helpers.js:2056
 msgid "Unreliable rem. banner"
-msgstr ""
+msgstr "Unzuverlässiger Banner"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:2044
-#, fuzzy
+#: src/html/classic/js/gsa_chart_helpers.js:2059
 msgid "Unreliable exec. version"
 msgstr "Unzuverlässige Prog.-Version"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:2521
+#: src/html/classic/js/gsa_chart_helpers.js:2551
 msgid "{{title}} (Loading...)"
 msgstr "{{title}} (Lädt...)"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:2528
+#: src/html/classic/js/gsa_chart_helpers.js:2558
 msgid "{{title}} {{filter_text}} (Total: {{count}})"
 msgstr "{{title}} {{filter_text}} (Gesamt: {{count}})"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:2625
+#: src/html/classic/js/gsa_chart_helpers.js:2655
 msgid "Greenbone Security Assistant - Chart data table"
 msgstr "Greenbone Security Assistant - Datentabelle"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_chart_helpers.js:2677
+#: src/html/classic/js/gsa_chart_helpers.js:2707
 msgid "Applied filter: {{filter}}"
 msgstr "Angewandter Filter: {{filter}}"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_cloud_chart.js:54
+#: src/html/classic/js/gsa_cloud_chart.js:54
 msgid "Loading word cloud ..."
 msgstr "Lade Wortwolke ..."
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_cloud_chart.js:55
+#: src/html/classic/js/gsa_cloud_chart.js:55
 msgid "Word Cloud"
 msgstr "Wortwolke"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:231
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:232
+#: src/html/classic/js/gsa_dashboard.js:231
+#: src/html/classic/js/gsa_dashboard.js:232
 msgid "Edit Dashboard"
 msgstr "Dashboard bearbeiten"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:245
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:246
+#: src/html/classic/js/gsa_dashboard.js:245
+#: src/html/classic/js/gsa_dashboard.js:246
 msgid "Add new Chart"
 msgstr "Neues Diagramm hinzufügen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:261
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:262
+#: src/html/classic/js/gsa_dashboard.js:261
+#: src/html/classic/js/gsa_dashboard.js:262
 msgid "Reset to defaults"
 msgstr "Auf Voreinstellungen zurücksetzen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:277
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:278
+#: src/html/classic/js/gsa_dashboard.js:277
+#: src/html/classic/js/gsa_dashboard.js:278
 msgid "Cancel Editing"
 msgstr "Bearbeitung abbrechen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:293
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:294
+#: src/html/classic/js/gsa_dashboard.js:293
+#: src/html/classic/js/gsa_dashboard.js:294
 msgid "Save Changes"
 msgstr "Änderungen speichern"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:1584
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:1585
+#: src/html/classic/js/gsa_dashboard.js:1585
+#: src/html/classic/js/gsa_dashboard.js:1586
 msgid "Remove"
 msgstr "Entfernen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:1592
+#: src/html/classic/js/gsa_dashboard.js:1593
 msgid "Initializing display for \"{{display}}\"..."
 msgstr "Initialisiere Anzeige für \"{{display}}\""
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:1611
+#: src/html/classic/js/gsa_dashboard.js:1612
 msgid "Loading data ..."
 msgstr "Daten werden geladen ..."
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2389
+#: src/html/classic/js/gsa_dashboard.js:2388
 msgid "Could not load chart {{chart}}"
 msgstr "Konnte Diagramm \"{{chart}}\" nicht laden"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2861
+#: src/html/classic/js/gsa_dashboard.js:2860
 msgid "Loading aborted"
 msgstr "Laden wurde abgebrochen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2873
+#: src/html/classic/js/gsa_dashboard.js:2872
 msgid "HTTP error {{error}}"
 msgstr "HTTP Fehler {{error}}"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2874
+#: src/html/classic/js/gsa_dashboard.js:2873
 msgid "Error: HTTP request returned status {{status}} for URL: {{url}}"
 msgstr ""
 "Fehler: Die HTTP Anfrage hat den Status {{status}} für die URL {{url}} "
 "zurückgegeben"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2880
+#: src/html/classic/js/gsa_dashboard.js:2879
 msgid "Error reading XML"
 msgstr "Fehler beim Lesen der XML Daten"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2881
+#: src/html/classic/js/gsa_dashboard.js:2880
 msgid "Error reading XML from URL {{url}}: {{error}}"
 msgstr "Fehler beim Lesen der XML Daten von der URL {{url}}: {{error}}"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2889
+#: src/html/classic/js/gsa_dashboard.js:2888
 msgid "Error parsing XML data"
 msgstr "Fehler beim Parsen der XML Daten"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2890
+#: src/html/classic/js/gsa_dashboard.js:2889
 msgid "Error parsing XML data. Details: {{details}}"
 msgstr "Fehler beim Parsen der XML Daten. Details: {{details}}"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2919
+#: src/html/classic/js/gsa_dashboard.js:2918
 msgid "Internal error: Invalid request"
 msgstr "Interner Fehler: Ungültige Anfrage"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2920
+#: src/html/classic/js/gsa_dashboard.js:2919
 msgid "Invalid request command: \"{{command}}"
 msgstr "Ungültiger Befehl für Anfrage: \"{{command}}\""
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2927
+#: src/html/classic/js/gsa_dashboard.js:2926
 msgid "Error {{omp_status}}: {{omp_status_text}}"
 msgstr "Fehler {{omp_status}}: {{omp_status_text}}"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2929
+#: src/html/classic/js/gsa_dashboard.js:2928
 msgid "OMP Error {{omp_status}}: {{omp_status_text}}"
 msgstr "OMP Fehler {{omp_status}}: {{omp_status_text}}"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:3216
+#: src/html/classic/js/gsa_dashboard.js:3217
 msgid "{{title_text}} (Loading...)"
 msgstr "{{title_text}} (Lädt...)"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:3221
+#: src/html/classic/js/gsa_dashboard.js:3222
 msgid "Unknown chart"
 msgstr "Unbekanntes Diagramm"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_donut_chart.js:64
+#: src/html/classic/js/gsa_donut_chart.js:64
 msgid "Loading donut chart ..."
 msgstr "Lade Ringdiagramm ..."
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_donut_chart.js:64
+#: src/html/classic/js/gsa_donut_chart.js:64
 msgid "Donut Chart"
 msgstr "Ringdiagramm"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_donut_chart.js:672
+#: src/html/classic/js/gsa_donut_chart.js:686
 msgid "Inactive"
 msgstr "Inaktiv"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_donut_chart.js:675
+#: src/html/classic/js/gsa_donut_chart.js:689
 msgid "Active (unlimited)"
 msgstr "Aktiv (unbegrenzt)"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_donut_chart.js:678
+#: src/html/classic/js/gsa_donut_chart.js:692
 msgid "Active for next {{days}} days"
 msgstr "Aktiv für die nächsten {{days}} Tage"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_gantt_chart.js:77
+#: src/html/classic/js/gsa_gantt_chart.js:79
 msgid "Loading Gantt chart ..."
 msgstr "Lade Gantt-Diagramm ..."
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_gantt_chart.js:77
+#: src/html/classic/js/gsa_gantt_chart.js:79
 msgid "Gantt Chart"
 msgstr "Gantt-Diagramm"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_graphics_base.js:203
+#: src/html/classic/js/gsa_graphics_base.js:203
 msgid "Show detached chart window"
 msgstr "In neuem Fenster öffnen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_graphics_base.js:220
+#: src/html/classic/js/gsa_graphics_base.js:220
 msgid "Download CSV"
 msgstr "CSV Daten herunterladen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_graphics_base.js:243
+#: src/html/classic/js/gsa_graphics_base.js:244
 msgid "Show HTML table"
 msgstr "HTML Tabelle anzeigen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_graphics_base.js:267
+#: src/html/classic/js/gsa_graphics_base.js:268
 msgid "Show copyable SVG"
 msgstr "Kopierbare SVG Grafik anzeigen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_graphics_base.js:275
+#: src/html/classic/js/gsa_graphics_base.js:276
 msgid "Download SVG"
 msgstr "SVG Grafik herunterladen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_h_bar_chart.js:109
+#: src/html/classic/js/gsa_h_bar_chart.js:109
 msgid "Loading horizontal bar chart ..."
 msgstr "Lade horizontales Balkendiagramm ..."
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_h_bar_chart.js:110
+#: src/html/classic/js/gsa_h_bar_chart.js:110
 msgid "Horizontal Bar Chart"
 msgstr "Horizontales Balkendiagramm"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_h_bar_chart.js:275
+#: src/html/classic/js/gsa_h_bar_chart.js:275
 msgid "<br/>({{assets}} Host(s) with average severity {{severity}})"
 msgstr ""
+"<br/>({{assets}} Host(s) mit durchschnittlichem Schweregrad {{severity}})"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_line_chart.js:79
+#: src/html/classic/js/gsa_line_chart.js:79
 msgid "Loading line chart ..."
-msgstr "Lade Liniediagramm ..."
+msgstr "Lade Liniendiagramm ..."
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_topology_chart.js:47
+#: src/html/classic/js/gsa_topology_chart.js:47
 msgid "Loading topology chart ..."
 msgstr "Lade Topologiediagramm"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_topology_chart.js:47
+#: src/html/classic/js/gsa_topology_chart.js:47
 msgid "Topology Chart"
 msgstr "Topologiediagramm"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_topology_chart.js:90
+#: src/html/classic/js/gsa_topology_chart.js:90
 msgid "Too many nodes to display"
 msgstr "Zu viele Knoten zum Anzeigen"
 
-#: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_topology_chart.js:96
+#: src/html/classic/js/gsa_topology_chart.js:96
 msgid "Please try a filter selecting less hosts"
 msgstr "Bitte versuchen Sie einen Filter, der weniger Hosts auswählt"
+
+#: src/html/classic/js/gsa_topology_chart.js:143
+msgid "No hosts with topology selected"
+msgstr "Keine Hosts mit Topologie ausgewählt"
 
 #~ msgid "Add new Component"
 #~ msgstr "Neue Komponente hinzufügen"

--- a/src/po/gsad_js-de.po
+++ b/src/po/gsad_js-de.po
@@ -24,8 +24,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-11-08 10:13+0100\n"
-"PO-Revision-Date: 2017-11-08 08:46+0200\n"
+"POT-Creation-Date: 2017-11-08 13:41+0100\n"
+"PO-Revision-Date: 2017-11-08 12:30+0200\n"
 "Last-Translator: Timo <timo.pollmeier@greenbone.net>\n"
 "Language-Team: German <openvas-devel@wald.intevation.org>\n"
 "Language: de\n"
@@ -34,7 +34,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.5.1.3\n"
-"X-POOTLE-MTIME: 1510127176.742283\n"
+"X-POOTLE-MTIME: 1510140607.106193\n"
 
 #: src/html/classic/js/greenbone.js:623 src/html/classic/js/greenbone.js:1345
 msgid "Save"
@@ -120,13 +120,11 @@ msgid "Bubble Chart"
 msgstr "Blasendiagramm"
 
 #: src/html/classic/js/gsa_bubble_chart.js:102
-#: src/html/classic/js/gsa_gantt_chart.js:125
-#: src/html/classic/js/gsa_h_bar_chart.js:152
-msgid "No matching {{resource_type}}"
-msgstr "Kein(e) passende(r/s) {{resource_type}}"
+msgid "No matching {{- resource_type}}"
+msgstr "Kein(e) passende(r/s) {{- resource_type}}"
 
 #: src/html/classic/js/gsa_chart_helpers.js:1423
-#: src/html/classic/js/gsa_chart_helpers.js:1546
+#: src/html/classic/js/gsa_chart_helpers.js:1545
 msgid "High"
 msgstr "Hoch"
 
@@ -187,106 +185,106 @@ msgid "CERT-Bund Advisories"
 msgstr "CERT-Bund-Meldungen"
 
 #: src/html/classic/js/gsa_chart_helpers.js:1528
-msgid "total {{resource_type_plural}}"
-msgstr "{{resource_type_plural}} gesamt"
+msgid "total {{- resource_type_plural}}"
+msgstr "{{- resource_type_plural}} gesamt"
 
-#: src/html/classic/js/gsa_chart_helpers.js:1536
+#: src/html/classic/js/gsa_chart_helpers.js:1535
 msgid "creation time"
 msgstr "Erstellungszeit"
 
-#: src/html/classic/js/gsa_chart_helpers.js:1538
+#: src/html/classic/js/gsa_chart_helpers.js:1537
 msgid "duration"
 msgstr "Laufzeit"
 
-#: src/html/classic/js/gsa_chart_helpers.js:1540
+#: src/html/classic/js/gsa_chart_helpers.js:1539
 msgid "modification time"
 msgstr "Änderungszeit"
 
-#: src/html/classic/js/gsa_chart_helpers.js:1542
+#: src/html/classic/js/gsa_chart_helpers.js:1541
 msgid "QoD"
 msgstr "QoD"
 
-#: src/html/classic/js/gsa_chart_helpers.js:1544
+#: src/html/classic/js/gsa_chart_helpers.js:1543
 msgid "QoD type"
 msgstr "QoD-Typ"
 
-#: src/html/classic/js/gsa_chart_helpers.js:1548
+#: src/html/classic/js/gsa_chart_helpers.js:1547
 msgid "High / host"
 msgstr "Hoch / Host"
 
-#: src/html/classic/js/gsa_chart_helpers.js:1550
+#: src/html/classic/js/gsa_chart_helpers.js:1549
 msgid "Duration / host"
 msgstr "Laufzeit / Host"
 
-#: src/html/classic/js/gsa_chart_helpers.js:1601
-msgid "min. {{field_name}}"
-msgstr "min. {{field_name}}"
+#: src/html/classic/js/gsa_chart_helpers.js:1600
+msgid "min. {{- field_name}}"
+msgstr "min. {{- field_name}}"
 
-#: src/html/classic/js/gsa_chart_helpers.js:1606
-msgid "max. {{field_name}}"
-msgstr "max. {{field_name}}"
+#: src/html/classic/js/gsa_chart_helpers.js:1604
+msgid "max. {{- field_name}}"
+msgstr "max. {{- field_name}}"
 
-#: src/html/classic/js/gsa_chart_helpers.js:1611
-msgid "average {{field_name}}"
-msgstr "durchschn. {{field_name}}"
+#: src/html/classic/js/gsa_chart_helpers.js:1608
+msgid "average {{- field_name}}"
+msgstr "durchschn. {{- field_name}}"
 
-#: src/html/classic/js/gsa_chart_helpers.js:1616
-msgid "summed {{field_name}}"
-msgstr "Summe {{field_name}}"
+#: src/html/classic/js/gsa_chart_helpers.js:1612
+msgid "summed {{- field_name}}"
+msgstr "Summe {{- field_name}}"
 
-#: src/html/classic/js/gsa_chart_helpers.js:2032
+#: src/html/classic/js/gsa_chart_helpers.js:2027
 msgid "None"
 msgstr "Keiner"
 
-#: src/html/classic/js/gsa_chart_helpers.js:2035
+#: src/html/classic/js/gsa_chart_helpers.js:2030
 msgid "Exploit"
 msgstr "Exploit"
 
-#: src/html/classic/js/gsa_chart_helpers.js:2038
+#: src/html/classic/js/gsa_chart_helpers.js:2033
 msgid "Remote vulnerability"
 msgstr "Remote-Schwachstelle"
 
-#: src/html/classic/js/gsa_chart_helpers.js:2041
+#: src/html/classic/js/gsa_chart_helpers.js:2036
 msgid "Package check"
 msgstr "Package-Check"
 
-#: src/html/classic/js/gsa_chart_helpers.js:2044
+#: src/html/classic/js/gsa_chart_helpers.js:2039
 msgid "Registry check"
 msgstr "Registry-Check"
 
-#: src/html/classic/js/gsa_chart_helpers.js:2047
+#: src/html/classic/js/gsa_chart_helpers.js:2042
 msgid "Executable version"
 msgstr "Programmdatei-Version"
 
-#: src/html/classic/js/gsa_chart_helpers.js:2050
+#: src/html/classic/js/gsa_chart_helpers.js:2045
 msgid "Remote analysis"
 msgstr "Remote-Analyse"
 
-#: src/html/classic/js/gsa_chart_helpers.js:2053
+#: src/html/classic/js/gsa_chart_helpers.js:2048
 msgid "Remote probe"
 msgstr "Fern-Test"
 
-#: src/html/classic/js/gsa_chart_helpers.js:2056
+#: src/html/classic/js/gsa_chart_helpers.js:2051
 msgid "Unreliable rem. banner"
 msgstr "Unzuverlässiger Banner"
 
-#: src/html/classic/js/gsa_chart_helpers.js:2059
+#: src/html/classic/js/gsa_chart_helpers.js:2054
 msgid "Unreliable exec. version"
 msgstr "Unzuverlässige Prog.-Version"
 
-#: src/html/classic/js/gsa_chart_helpers.js:2551
+#: src/html/classic/js/gsa_chart_helpers.js:2546
 msgid "{{title}} (Loading...)"
 msgstr "{{title}} (Lädt...)"
 
-#: src/html/classic/js/gsa_chart_helpers.js:2558
+#: src/html/classic/js/gsa_chart_helpers.js:2553
 msgid "{{title}} {{filter_text}} (Total: {{count}})"
 msgstr "{{title}} {{filter_text}} (Gesamt: {{count}})"
 
-#: src/html/classic/js/gsa_chart_helpers.js:2655
+#: src/html/classic/js/gsa_chart_helpers.js:2650
 msgid "Greenbone Security Assistant - Chart data table"
 msgstr "Greenbone Security Assistant - Datentabelle"
 
-#: src/html/classic/js/gsa_chart_helpers.js:2707
+#: src/html/classic/js/gsa_chart_helpers.js:2702
 msgid "Applied filter: {{filter}}"
 msgstr "Angewandter Filter: {{filter}}"
 
@@ -422,6 +420,11 @@ msgstr "Lade Gantt-Diagramm ..."
 msgid "Gantt Chart"
 msgstr "Gantt-Diagramm"
 
+#: src/html/classic/js/gsa_gantt_chart.js:125
+#: src/html/classic/js/gsa_h_bar_chart.js:152
+msgid "No matching {{resource_type}}"
+msgstr "Kein(e) passende(r/s) {{resource_type}}"
+
 #: src/html/classic/js/gsa_graphics_base.js:203
 msgid "Show detached chart window"
 msgstr "In neuem Fenster öffnen"
@@ -478,6 +481,21 @@ msgstr "Bitte versuchen Sie einen Filter, der weniger Hosts auswählt"
 #: src/html/classic/js/gsa_topology_chart.js:143
 msgid "No hosts with topology selected"
 msgstr "Keine Hosts mit Topologie ausgewählt"
+
+#~ msgid "total {{resource_type_plural}}"
+#~ msgstr "{{resource_type_plural}} gesamt"
+
+#~ msgid "min. {{field_name}}"
+#~ msgstr "min. {{field_name}}"
+
+#~ msgid "max. {{field_name}}"
+#~ msgstr "max. {{field_name}}"
+
+#~ msgid "average {{field_name}}"
+#~ msgstr "durchschn. {{field_name}}"
+
+#~ msgid "summed {{field_name}}"
+#~ msgstr "Summe {{field_name}}"
 
 #~ msgid "Add new Component"
 #~ msgstr "Neue Komponente hinzufügen"

--- a/src/po/gsad_xsl-de.po
+++ b/src/po/gsad_xsl-de.po
@@ -6,7 +6,7 @@
 # Timo Pollmeier <timo.pollmeier@greenbone.net>
 #
 # Copyright:
-# Copyright (C) 2015 Greenbone Networks GmbH
+# Copyright (C) 2015-2017 Greenbone Networks GmbH
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -27,8 +27,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-18 10:13+0200\n"
-"PO-Revision-Date: 2016-10-18 08:16+0200\n"
+"POT-Creation-Date: 2017-11-08 09:18+0200\n"
+"PO-Revision-Date: 2017-11-08 08:11+0200\n"
 "Last-Translator: Timo <timo.pollmeier@greenbone.net>\n"
 "Language-Team: German <openvas-devel@wald.intevation.org>\n"
 "Language: de\n"
@@ -37,7 +37,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Pootle 2.5.1.3\n"
-"X-POOTLE-MTIME: 1476774990.224178\n"
+"X-POOTLE-MTIME: 1510125108.779037\n"
 
 #: classic/graphics.xsl:87
 msgid "Tasks by CVSS"
@@ -183,8 +183,8 @@ msgstr "SecInfo-Einträge nach Typ"
 msgid "Reports: Duration timeline"
 msgstr "Berichte: Laufzeit-Zeitlinie"
 
-#: classic/graphics.xsl:1132 classic/gsad.xsl:405 classic/gsad.xsl:415
-#: classic/gsad.xsl:463 classic/gsad.xsl:492
+#: classic/graphics.xsl:1132 classic/gsad.xsl:408 classic/gsad.xsl:418
+#: classic/gsad.xsl:467 classic/gsad.xsl:498
 msgid "Dashboard"
 msgstr "Dashboard"
 
@@ -208,8 +208,8 @@ msgstr "Bericht: Vorhersage-Ergebnisse"
 msgid "Report: Delta Results"
 msgstr "Bericht: Delta-Ergebnisse"
 
-#: classic/omp.xsl:699 classic/omp.xsl:32806 classic/omp.xsl:32812
-#: classic/omp.xsl:33377 classic/omp.xsl:33609
+#: classic/omp.xsl:699 classic/omp.xsl:32172 classic/omp.xsl:32178
+#: classic/omp.xsl:32743 classic/omp.xsl:32975
 msgid "Report: Results"
 msgstr "Bericht: Ergebnisse"
 
@@ -233,7 +233,7 @@ msgstr "Bericht: Vorhersage-Hosts"
 msgid "Report: Hosts"
 msgstr "Bericht: Hosts"
 
-#: classic/omp.xsl:705 classic/omp.xsl:32831
+#: classic/omp.xsl:705 classic/omp.xsl:32197
 msgid "Report: Ports"
 msgstr "Bericht: Ports"
 
@@ -301,860 +301,848 @@ msgstr "darf den Mülleimer leeren"
 msgid "may get the dependencies of NVTs"
 msgstr "darf die Abhängigkeiten von NVTs abrufen"
 
-#: classic/omp.xsl:759 classic/dynamic_strings.xsl:747
-msgid "may get NVT feed version information"
-msgstr "darf Versionsinformationen des NVT-Feeds abrufen"
-
-#: classic/omp.xsl:762
+#: classic/omp.xsl:759
 msgid "may get version information"
 msgstr "darf Versionsinformationen abrufen"
 
-#: classic/omp.xsl:765 classic/dynamic_strings.xsl:765
+#: classic/omp.xsl:762 classic/dynamic_strings.xsl:765
 msgid "may get the help text"
 msgstr "darf den Hilfetext abrufen"
 
-#: classic/omp.xsl:768 classic/dynamic_strings.xsl:793
+#: classic/omp.xsl:765 classic/dynamic_strings.xsl:793
 msgid "has write access to the authentication configuration"
 msgstr "hat Schreibzugriff auf die Authentifizierungskonfiguration"
 
-#: classic/omp.xsl:771 classic/dynamic_strings.xsl:816
+#: classic/omp.xsl:768 classic/dynamic_strings.xsl:816
 msgid "may restore items from the trashcan"
 msgstr "darf Objekte aus dem Mülleimer wiederherstellen"
 
-#: classic/omp.xsl:778 classic/dynamic_strings.xsl:742
+#: classic/omp.xsl:775 classic/dynamic_strings.xsl:742
 msgid "has read access to SecInfo"
 msgstr "hat Lesezugriff auf Sicherheitsinfos"
 
-#: classic/omp.xsl:804 classic/dynamic_strings.xsl:706
+#: classic/omp.xsl:801 classic/dynamic_strings.xsl:706
 msgid "may get details about the authentication configuration"
 msgstr "darf Details über die Authentifizierungskonfiguration abrufen"
 
-#: classic/omp.xsl:808
+#: classic/omp.xsl:805
 msgid "may get details about %1"
 msgstr "darf Details über %1 abrufen"
 
-#: classic/omp.xsl:820 classic/dynamic_strings.xsl:831
+#: classic/omp.xsl:817 classic/dynamic_strings.xsl:831
 msgid "may sync the CERT feed"
 msgstr "darf den CERT-Feed synchronisieren"
 
-#: classic/omp.xsl:823 classic/dynamic_strings.xsl:832
+#: classic/omp.xsl:820 classic/dynamic_strings.xsl:832
 msgid "may sync the NVT feed"
 msgstr "darf den NVT-Feed synchronisieren"
 
-#: classic/omp.xsl:826 classic/dynamic_strings.xsl:833
+#: classic/omp.xsl:823 classic/dynamic_strings.xsl:833
 msgid "may sync the SCAP feed"
 msgstr "darf den SCAP-Feed synchronisieren"
 
-#: classic/omp.xsl:830 classic/dynamic_strings.xsl:834
+#: classic/omp.xsl:827 classic/dynamic_strings.xsl:834
 msgid "may sync %1"
 msgstr "darf %1 synchronisieren"
 
-#: classic/omp.xsl:959
+#: classic/omp.xsl:956
 msgid "Send feedback to"
 msgstr "Feedback senden an"
 
-#: classic/omp.xsl:959
+#: classic/omp.xsl:956
 msgid "Feedback"
 msgstr "Feedback"
 
-#: classic/omp.xsl:996 classic/omp.xsl:3219
+#: classic/omp.xsl:993 classic/omp.xsl:3164
 msgctxt "Pagination"
 msgid "First"
 msgstr "Erste"
 
-#: classic/omp.xsl:999 classic/omp.xsl:1014 classic/omp.xsl:3227
-#: classic/omp.xsl:3228
+#: classic/omp.xsl:996 classic/omp.xsl:1011 classic/omp.xsl:3172
+#: classic/omp.xsl:3173
 msgctxt "Pagination"
 msgid "Already on first page"
 msgstr "Bereits auf der ersten Seite"
 
-#: classic/omp.xsl:1006 classic/omp.xsl:1011 classic/omp.xsl:3223
+#: classic/omp.xsl:1003 classic/omp.xsl:1008 classic/omp.xsl:3168
 msgctxt "Pagination"
 msgid "Previous"
 msgstr "Vorherige"
 
-#: classic/omp.xsl:1021 classic/omp.xsl:3231
+#: classic/omp.xsl:1018 classic/omp.xsl:3176
 msgid "%1 - %2 of %3"
 msgstr "%1 - %2 von %3"
 
-#: classic/omp.xsl:1030 classic/omp.xsl:3236
+#: classic/omp.xsl:1027 classic/omp.xsl:3181
 msgctxt "Pagination"
 msgid "Next"
 msgstr "Nächste"
 
-#: classic/omp.xsl:1033 classic/omp.xsl:1043 classic/omp.xsl:3244
-#: classic/omp.xsl:3245
+#: classic/omp.xsl:1030 classic/omp.xsl:1040 classic/omp.xsl:3189
+#: classic/omp.xsl:3190
 msgctxt "Pagination"
 msgid "Already on last page"
 msgstr "Bereits auf der letzten Seite"
 
-#: classic/omp.xsl:1040 classic/omp.xsl:3240
+#: classic/omp.xsl:1037 classic/omp.xsl:3185
 msgctxt "Pagination"
 msgid "Last"
 msgstr "Letzte"
 
-#: classic/omp.xsl:1156 classic/omp.xsl:1294 classic/omp.xsl:10922
-#: classic/omp.xsl:12272 classic/omp.xsl:12888 classic/omp.xsl:13084
-#: classic/omp.xsl:13306 classic/omp.xsl:14096 classic/omp.xsl:35736
+#: classic/omp.xsl:1153 classic/omp.xsl:1291 classic/omp.xsl:10738
+#: classic/omp.xsl:12182 classic/omp.xsl:12798 classic/omp.xsl:12994
+#: classic/omp.xsl:13209 classic/omp.xsl:13999 classic/omp.xsl:35277
 #: classic/dynamic_strings.xsl:85
 msgid "Filter"
 msgstr "Filter"
 
-#: classic/omp.xsl:1166 classic/omp.xsl:3906
+#: classic/omp.xsl:1163 classic/omp.xsl:3851
 msgid "Update Filter"
 msgstr "Filter aktualisieren"
 
-#: classic/omp.xsl:1168 classic/omp.xsl:3092 classic/omp.xsl:3095
-#: classic/omp.xsl:3096 classic/omp.xsl:3909 classic/omp.xsl:29493
-#: classic/omp.xsl:29496 classic/omp.xsl:35608 classic/omp.xsl:35610
+#: classic/omp.xsl:1165 classic/omp.xsl:3037 classic/omp.xsl:3040
+#: classic/omp.xsl:3041 classic/omp.xsl:3854 classic/omp.xsl:28853
+#: classic/omp.xsl:28856 classic/omp.xsl:35151 classic/omp.xsl:35152
 msgctxt "Action Verb"
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: classic/omp.xsl:1171
+#: classic/omp.xsl:1168
 msgid "Reset Filter"
 msgstr "Filter zurücksetzen"
 
-#: classic/omp.xsl:1176 classic/omp.xsl:1792 classic/omp.xsl:2529
-#: classic/omp.xsl:3064 classic/omp.xsl:3252 classic/omp.xsl:3910
-#: classic/omp.xsl:5381 classic/omp.xsl:5388 classic/omp.xsl:5853
-#: classic/omp.xsl:6308 classic/omp.xsl:7890 classic/omp.xsl:9458
-#: classic/omp.xsl:13445 classic/omp.xsl:14236 classic/omp.xsl:14581
-#: classic/omp.xsl:16510 classic/omp.xsl:16662 classic/omp.xsl:17432
-#: classic/omp.xsl:17830 classic/omp.xsl:19589 classic/omp.xsl:20464
-#: classic/omp.xsl:22523 classic/omp.xsl:22815 classic/omp.xsl:22966
-#: classic/omp.xsl:23231 classic/omp.xsl:23420 classic/omp.xsl:23856
-#: classic/omp.xsl:26633 classic/omp.xsl:27966 classic/omp.xsl:28556
-#: classic/omp.xsl:28676 classic/omp.xsl:29445 classic/omp.xsl:30751
-#: classic/omp.xsl:33723 classic/omp.xsl:34875 classic/omp.xsl:35503
-#: classic/omp.xsl:35914 classic/omp.xsl:37206 classic/omp.xsl:37230
-#: classic/omp.xsl:37279 classic/omp.xsl:37564 classic/omp.xsl:38191
-#: classic/omp.xsl:38878 classic/omp.xsl:38932 classic/omp.xsl:39174
-#: classic/omp.xsl:40081 classic/gsad.xsl:705
+#: classic/omp.xsl:1173 classic/omp.xsl:1789 classic/omp.xsl:2474
+#: classic/omp.xsl:3009 classic/omp.xsl:3197 classic/omp.xsl:3855
+#: classic/omp.xsl:5294 classic/omp.xsl:5301 classic/omp.xsl:5766
+#: classic/omp.xsl:9203 classic/omp.xsl:13348 classic/omp.xsl:14132
+#: classic/omp.xsl:14477 classic/omp.xsl:16401 classic/omp.xsl:16553
+#: classic/omp.xsl:17323 classic/omp.xsl:17721 classic/omp.xsl:19484
+#: classic/omp.xsl:21865 classic/omp.xsl:22157 classic/omp.xsl:22308
+#: classic/omp.xsl:22573 classic/omp.xsl:22772 classic/omp.xsl:23212
+#: classic/omp.xsl:25993 classic/omp.xsl:27326 classic/omp.xsl:27916
+#: classic/omp.xsl:28036 classic/omp.xsl:28805 classic/omp.xsl:30113
+#: classic/omp.xsl:33089 classic/omp.xsl:34237 classic/omp.xsl:34891
+#: classic/omp.xsl:35438 classic/omp.xsl:36715 classic/omp.xsl:36739
+#: classic/omp.xsl:36788 classic/omp.xsl:37073 classic/omp.xsl:37691
+#: classic/omp.xsl:38372 classic/omp.xsl:38426 classic/omp.xsl:38675
+#: classic/omp.xsl:39593 classic/gsad.xsl:706
 msgid "Help"
 msgstr "Hilfe"
 
-#: classic/omp.xsl:1176 classic/omp.xsl:3910
+#: classic/omp.xsl:1173 classic/omp.xsl:3855
 msgid "Powerfilter"
 msgstr "Powerfilter"
 
-#: classic/omp.xsl:1236 classic/omp.xsl:13442 classic/omp.xsl:13445
+#: classic/omp.xsl:1233 classic/omp.xsl:13345 classic/omp.xsl:13348
 #: classic/dynamic_strings.xsl:404
 msgid "New Filter"
 msgstr "Neuer Filter"
 
-#: classic/omp.xsl:1308 classic/omp.xsl:4687 classic/omp.xsl:12681
-#: classic/omp.xsl:13196 classic/omp.xsl:14208 classic/omp.xsl:24218
-#: classic/omp.xsl:24589 classic/omp.xsl:24939 classic/omp.xsl:25407
-#: classic/omp.xsl:25841 classic/omp.xsl:26268 classic/omp.xsl:29936
-#: classic/omp.xsl:35871 classic/wizard.xsl:503 classic/dynamic_strings.xsl:64
+#: classic/omp.xsl:1305 classic/omp.xsl:4634 classic/omp.xsl:12591
+#: classic/omp.xsl:13099 classic/omp.xsl:14104 classic/omp.xsl:23574
+#: classic/omp.xsl:23945 classic/omp.xsl:24295 classic/omp.xsl:24765
+#: classic/omp.xsl:25199 classic/omp.xsl:25626 classic/omp.xsl:29298
+#: classic/omp.xsl:35396 classic/wizard.xsl:504 classic/dynamic_strings.xsl:64
 msgid "Task"
 msgstr "Aufgabe"
 
-#: classic/omp.xsl:1325 classic/omp.xsl:3490
+#: classic/omp.xsl:1322 classic/omp.xsl:3435
 msgid "Show delta results"
 msgstr "Delta-Ergebnisse zeigen"
 
-#: classic/omp.xsl:1339 classic/omp.xsl:3502
+#: classic/omp.xsl:1336 classic/omp.xsl:3447
 msgctxt "Delta Result"
 msgid "same"
 msgstr "gleich"
 
-#: classic/omp.xsl:1353 classic/omp.xsl:3516
+#: classic/omp.xsl:1350 classic/omp.xsl:3461
 msgctxt "Delta Result"
 msgid "new"
 msgstr "neu"
 
-#: classic/omp.xsl:1367 classic/omp.xsl:3530
+#: classic/omp.xsl:1364 classic/omp.xsl:3475
 msgctxt "Delta Result"
 msgid "gone"
 msgstr "verschwunden"
 
-#: classic/omp.xsl:1381 classic/omp.xsl:3544
+#: classic/omp.xsl:1378 classic/omp.xsl:3489
 msgctxt "Delta Result"
 msgid "changed"
 msgstr "verändert"
 
-#: classic/omp.xsl:1400 classic/omp.xsl:3083 classic/omp.xsl:3087
-#: classic/omp.xsl:29483 classic/omp.xsl:29487
+#: classic/omp.xsl:1397 classic/omp.xsl:3028 classic/omp.xsl:3032
+#: classic/omp.xsl:28843 classic/omp.xsl:28847
 msgid "Apply overrides"
 msgstr "Übersteuerung anwenden"
 
-#: classic/omp.xsl:1420 classic/omp.xsl:3578
+#: classic/omp.xsl:1417 classic/omp.xsl:3523
 msgid "Auto-FP"
 msgstr "Auto-FP"
 
-#: classic/omp.xsl:1433 classic/omp.xsl:3589
+#: classic/omp.xsl:1430 classic/omp.xsl:3534
 msgid "Trust vendor security updates"
 msgstr "Sicherheitsupdates des Anbieters vertrauen"
 
-#: classic/omp.xsl:1447 classic/omp.xsl:3601
+#: classic/omp.xsl:1444 classic/omp.xsl:3546
 msgid "Full CVE match"
 msgstr "Vollständige CVE-Übereinstimmung"
 
-#: classic/omp.xsl:1460 classic/omp.xsl:3612
+#: classic/omp.xsl:1457 classic/omp.xsl:3557
 msgid "Partial CVE match"
 msgstr "Teilweise CVE-Übereinstimmung"
 
-#: classic/omp.xsl:1469 classic/omp.xsl:3634
+#: classic/omp.xsl:1466 classic/omp.xsl:3579
 msgid "Show Notes"
 msgstr "Notizen zeigen"
 
-#: classic/omp.xsl:1489 classic/omp.xsl:3650
+#: classic/omp.xsl:1486 classic/omp.xsl:3595
 msgid "Show Overrides"
 msgstr "Übersteuerungen zeigen"
 
-#: classic/omp.xsl:1509 classic/omp.xsl:3659 classic/omp.xsl:3665
+#: classic/omp.xsl:1506 classic/omp.xsl:3604 classic/omp.xsl:3610
 msgid "Only show hosts that have results"
 msgstr "Nur Hosts mit Ergebnissen zeigen"
 
-#: classic/omp.xsl:1529 classic/omp.xsl:3942 classic/omp.xsl:22111
-#: classic/omp.xsl:30988 classic/omp.xsl:30992 classic/omp.xsl:32131
+#: classic/omp.xsl:1526 classic/omp.xsl:3887 classic/omp.xsl:21445
+#: classic/omp.xsl:30350 classic/omp.xsl:30354 classic/omp.xsl:31495
 msgid "QoD"
 msgstr "QdE"
 
-#: classic/omp.xsl:1534
+#: classic/omp.xsl:1531
 msgctxt "QoD"
 msgid "must be at least"
 msgstr "muss mindestens ... sein"
 
-#: classic/omp.xsl:1545 classic/omp.xsl:3733 classic/omp.xsl:18676
-#: classic/omp.xsl:18939 classic/omp.xsl:19399 classic/omp.xsl:37593
-#: classic/omp.xsl:38212
+#: classic/omp.xsl:1542 classic/omp.xsl:3678 classic/omp.xsl:18571
+#: classic/omp.xsl:18834 classic/omp.xsl:19294 classic/omp.xsl:37102
+#: classic/omp.xsl:37712
 msgid "Timezone"
 msgstr "Zeitzone"
 
-#: classic/omp.xsl:1569
+#: classic/omp.xsl:1566
 msgid "Severity (Class)"
 msgstr "Schweregrad (Klasse)"
 
-#: classic/omp.xsl:1658
+#: classic/omp.xsl:1655
 msgid "First result"
 msgstr "Erstes Ergebnis"
 
-#: classic/omp.xsl:1680 classic/omp.xsl:3118 classic/omp.xsl:3552
+#: classic/omp.xsl:1677 classic/omp.xsl:3063 classic/omp.xsl:3497
 msgid "Results per page"
 msgstr "Ergebnisse pro Seite"
 
-#: classic/omp.xsl:1695
+#: classic/omp.xsl:1692
 msgid "Sort by"
 msgstr "Sortieren nach"
 
-#: classic/omp.xsl:1755 classic/omp.xsl:15700
+#: classic/omp.xsl:1752 classic/omp.xsl:15591
 msgid "Ascending"
 msgstr "Aufsteigend"
 
-#: classic/omp.xsl:1766 classic/omp.xsl:15704
+#: classic/omp.xsl:1763 classic/omp.xsl:15595
 msgid "Descending"
 msgstr "Absteigend"
 
-#: classic/omp.xsl:1806 classic/omp.xsl:12149 classic/omp.xsl:12261
-#: classic/omp.xsl:12307 classic/omp.xsl:12335 classic/omp.xsl:12898
-#: classic/omp.xsl:12954 classic/omp.xsl:13371 classic/omp.xsl:16351
-#: classic/omp.xsl:18094 classic/omp.xsl:19489 classic/omp.xsl:20233
-#: classic/omp.xsl:20933 classic/omp.xsl:21835 classic/omp.xsl:22722
-#: classic/omp.xsl:22727 classic/omp.xsl:22782 classic/omp.xsl:27299
-#: classic/omp.xsl:27321 classic/omp.xsl:27407 classic/omp.xsl:27435
-#: classic/omp.xsl:27492 classic/omp.xsl:28320 classic/omp.xsl:29311
-#: classic/omp.xsl:29830 classic/omp.xsl:30256 classic/omp.xsl:30530
-#: classic/omp.xsl:31460 classic/omp.xsl:35337 classic/omp.xsl:35351
-#: classic/omp.xsl:35371
+#: classic/omp.xsl:1803 classic/omp.xsl:12059 classic/omp.xsl:12171
+#: classic/omp.xsl:12217 classic/omp.xsl:12245 classic/omp.xsl:12808
+#: classic/omp.xsl:12864 classic/omp.xsl:13274 classic/omp.xsl:16242
+#: classic/omp.xsl:17987 classic/omp.xsl:19384 classic/omp.xsl:20107
+#: classic/omp.xsl:21163 classic/omp.xsl:22064 classic/omp.xsl:22069
+#: classic/omp.xsl:22124 classic/omp.xsl:26656 classic/omp.xsl:26678
+#: classic/omp.xsl:26764 classic/omp.xsl:26792 classic/omp.xsl:26798
+#: classic/omp.xsl:26855 classic/omp.xsl:27680 classic/omp.xsl:28671
+#: classic/omp.xsl:29190 classic/omp.xsl:29618 classic/omp.xsl:29892
+#: classic/omp.xsl:30822 classic/omp.xsl:34699 classic/omp.xsl:34713
+#: classic/omp.xsl:34733
 msgid "Details"
 msgstr "Details"
 
-#: classic/omp.xsl:1836 classic/dynamic_strings.xsl:199
+#: classic/omp.xsl:1833 classic/dynamic_strings.xsl:199
 msgid "Filter Details"
 msgstr "Filter-Details"
 
-#: classic/omp.xsl:1980
+#: classic/omp.xsl:1979
 msgid "Cannot move to trashcan."
 msgstr "Kann nicht in den Mülleimer verschieben."
 
-#: classic/omp.xsl:1985 classic/omp.xsl:2215 classic/omp.xsl:6013
-#: classic/omp.xsl:17894 classic/omp.xsl:35114 classic/omp.xsl:35122
+#: classic/omp.xsl:1984 classic/omp.xsl:2217 classic/omp.xsl:5926
+#: classic/omp.xsl:17785 classic/omp.xsl:34476 classic/omp.xsl:34484
 msgctxt "Action Verb"
 msgid "To Trashcan"
 msgstr "In den Mülleimer"
 
-#: classic/omp.xsl:1999 classic/omp.xsl:2017 classic/omp.xsl:6035
-#: classic/omp.xsl:16645 classic/omp.xsl:16818 classic/omp.xsl:17106
-#: classic/omp.xsl:17582 classic/omp.xsl:17901 classic/omp.xsl:30260
-#: classic/omp.xsl:30265 classic/omp.xsl:30273 classic/omp.xsl:30280
-#: classic/omp.xsl:30287 classic/omp.xsl:30294 classic/omp.xsl:30301
-#: classic/omp.xsl:30308 classic/omp.xsl:30534 classic/omp.xsl:30539
-#: classic/omp.xsl:30547 classic/omp.xsl:30554 classic/omp.xsl:30561
-#: classic/omp.xsl:30568 classic/omp.xsl:30575 classic/omp.xsl:30582
-#: classic/omp.xsl:38191 classic/omp.xsl:39212 classic/omp.xsl:39230
-#: classic/omp.xsl:39702 classic/omp.xsl:39720
+#: classic/omp.xsl:2001 classic/omp.xsl:2019 classic/omp.xsl:5948
+#: classic/omp.xsl:16536 classic/omp.xsl:16709 classic/omp.xsl:16997
+#: classic/omp.xsl:17473 classic/omp.xsl:17792 classic/omp.xsl:29622
+#: classic/omp.xsl:29627 classic/omp.xsl:29635 classic/omp.xsl:29642
+#: classic/omp.xsl:29649 classic/omp.xsl:29656 classic/omp.xsl:29663
+#: classic/omp.xsl:29670 classic/omp.xsl:29896 classic/omp.xsl:29901
+#: classic/omp.xsl:29909 classic/omp.xsl:29916 classic/omp.xsl:29923
+#: classic/omp.xsl:29930 classic/omp.xsl:29937 classic/omp.xsl:29944
+#: classic/omp.xsl:37691 classic/omp.xsl:38713 classic/omp.xsl:38731
+#: classic/omp.xsl:39214 classic/omp.xsl:39232
 msgctxt "Action Verb"
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: classic/omp.xsl:2029 classic/omp.xsl:2044 classic/omp.xsl:2045
-#: classic/omp.xsl:2052 classic/omp.xsl:2058 classic/omp.xsl:5907
-#: classic/omp.xsl:5917 classic/omp.xsl:5925 classic/omp.xsl:5926
-#: classic/omp.xsl:17847 classic/omp.xsl:17848 classic/omp.xsl:17863
-#: classic/omp.xsl:30316 classic/omp.xsl:30385 classic/omp.xsl:30590
-#: classic/omp.xsl:30659
+#: classic/omp.xsl:2031 classic/omp.xsl:2046 classic/omp.xsl:2047
+#: classic/omp.xsl:2054 classic/omp.xsl:2060 classic/omp.xsl:5820
+#: classic/omp.xsl:5830 classic/omp.xsl:5838 classic/omp.xsl:5839
+#: classic/omp.xsl:17738 classic/omp.xsl:17739 classic/omp.xsl:17754
+#: classic/omp.xsl:29678 classic/omp.xsl:29747 classic/omp.xsl:29952
+#: classic/omp.xsl:30021
 msgctxt "Action Verb"
 msgid "Clone"
 msgstr "Klonen"
 
-#: classic/omp.xsl:2060 classic/omp.xsl:17865 classic/omp.xsl:30387
-#: classic/omp.xsl:30661
+#: classic/omp.xsl:2062 classic/omp.xsl:17756 classic/omp.xsl:29749
+#: classic/omp.xsl:30023
 msgid "Permission to clone denied"
 msgstr "Keine Berechtigung zum Klonen"
 
-#: classic/omp.xsl:2071 classic/omp.xsl:30394 classic/omp.xsl:30668
-#: classic/omp.xsl:39740 classic/omp.xsl:39832
+#: classic/omp.xsl:2073 classic/omp.xsl:29756 classic/omp.xsl:30030
+#: classic/omp.xsl:39252 classic/omp.xsl:39344
 msgctxt "Action Verb"
 msgid "Export"
 msgstr "Exportieren"
 
-#: classic/omp.xsl:2089 classic/omp.xsl:2090 classic/omp.xsl:2109
-#: classic/omp.xsl:2111 classic/omp.xsl:2121 classic/omp.xsl:2122
-#: classic/omp.xsl:5951 classic/omp.xsl:5980 classic/omp.xsl:7012
-#: classic/omp.xsl:7018 classic/omp.xsl:9153 classic/omp.xsl:12290
-#: classic/omp.xsl:13282 classic/omp.xsl:14019 classic/omp.xsl:16091
-#: classic/omp.xsl:18522 classic/omp.xsl:19335 classic/omp.xsl:20445
-#: classic/omp.xsl:20829 classic/omp.xsl:26539 classic/omp.xsl:27517
-#: classic/omp.xsl:28192 classic/omp.xsl:28437 classic/omp.xsl:28438
-#: classic/omp.xsl:28444 classic/omp.xsl:29008 classic/omp.xsl:35258
-#: classic/omp.xsl:36557 classic/omp.xsl:36570 classic/omp.xsl:36572
-#: classic/omp.xsl:36577 classic/omp.xsl:38954 classic/omp.xsl:39202
-#: classic/omp.xsl:39691 classic/omp.xsl:39824
+#: classic/omp.xsl:2091 classic/omp.xsl:2092 classic/omp.xsl:2111
+#: classic/omp.xsl:2113 classic/omp.xsl:2123 classic/omp.xsl:2124
+#: classic/omp.xsl:5864 classic/omp.xsl:5893 classic/omp.xsl:6866
+#: classic/omp.xsl:6872 classic/omp.xsl:8948 classic/omp.xsl:12200
+#: classic/omp.xsl:13185 classic/omp.xsl:13922 classic/omp.xsl:15982
+#: classic/omp.xsl:18417 classic/omp.xsl:19230 classic/omp.xsl:20320
+#: classic/omp.xsl:25899 classic/omp.xsl:26880 classic/omp.xsl:27552
+#: classic/omp.xsl:27797 classic/omp.xsl:27798 classic/omp.xsl:27804
+#: classic/omp.xsl:28368 classic/omp.xsl:34620 classic/omp.xsl:36066
+#: classic/omp.xsl:36079 classic/omp.xsl:36081 classic/omp.xsl:36086
+#: classic/omp.xsl:38448 classic/omp.xsl:38703 classic/omp.xsl:39203
+#: classic/omp.xsl:39336
 msgid "Delete"
 msgstr "Löschen"
 
-#: classic/omp.xsl:2141 classic/omp.xsl:2142 classic/omp.xsl:8229
-#: classic/omp.xsl:12271 classic/omp.xsl:16073 classic/omp.xsl:20431
-#: classic/omp.xsl:20815
+#: classic/omp.xsl:2143 classic/omp.xsl:2144 classic/omp.xsl:8022
+#: classic/omp.xsl:12181 classic/omp.xsl:15964 classic/omp.xsl:20306
 msgid "Restore"
 msgstr "Wiederherstellen"
 
-#: classic/omp.xsl:2160 classic/omp.xsl:2161 classic/omp.xsl:4567
-#: classic/omp.xsl:4571 classic/omp.xsl:4577 classic/omp.xsl:4595
+#: classic/omp.xsl:2162 classic/omp.xsl:2163 classic/omp.xsl:4513
+#: classic/omp.xsl:4517 classic/omp.xsl:4523 classic/omp.xsl:4541
 msgid "Resume"
 msgstr "Fortsetzen"
 
-#: classic/omp.xsl:2172 classic/omp.xsl:4462 classic/omp.xsl:4521
-#: classic/omp.xsl:4538
+#: classic/omp.xsl:2174 classic/omp.xsl:4408 classic/omp.xsl:4467
+#: classic/omp.xsl:4484
 msgctxt "Action Verb"
 msgid "Start"
 msgstr "Starten"
 
-#: classic/omp.xsl:2201 classic/omp.xsl:2202
+#: classic/omp.xsl:2203 classic/omp.xsl:2204
 msgctxt "Action Verb"
 msgid "Stop"
 msgstr "Stoppen"
 
-#: classic/omp.xsl:2214
+#: classic/omp.xsl:2216
 msgid "Moving to trashcan..."
 msgstr "In den Mülleimer verschieben .."
 
-#: classic/omp.xsl:2216 classic/omp.xsl:35115
+#: classic/omp.xsl:2218 classic/omp.xsl:34477
 msgctxt "Action Verb"
 msgid "Move To Trashcan"
 msgstr "In den Mülleimer verschieben"
 
-#: classic/omp.xsl:2412 classic/omp.xsl:25384 classic/omp.xsl:25783
+#: classic/omp.xsl:2357 classic/omp.xsl:24742 classic/omp.xsl:25141
 msgctxt "Severity"
 msgid "High"
 msgstr "Hoch"
 
-#: classic/omp.xsl:2415 classic/omp.xsl:25385 classic/omp.xsl:25790
+#: classic/omp.xsl:2360 classic/omp.xsl:24743 classic/omp.xsl:25148
 msgctxt "Severity"
 msgid "Medium"
 msgstr "Mittel"
 
-#: classic/omp.xsl:2418 classic/omp.xsl:25386 classic/omp.xsl:25797
+#: classic/omp.xsl:2363 classic/omp.xsl:24744 classic/omp.xsl:25155
 msgctxt "Severity"
 msgid "Low"
 msgstr "Niedrig"
 
-#: classic/omp.xsl:2421 classic/omp.xsl:24208 classic/omp.xsl:25365
-#: classic/omp.xsl:25387 classic/omp.xsl:25804
+#: classic/omp.xsl:2366 classic/omp.xsl:23564 classic/omp.xsl:24723
+#: classic/omp.xsl:24745 classic/omp.xsl:25162
 msgctxt "Severity"
 msgid "Log"
 msgstr "Log"
 
-#: classic/omp.xsl:2424
+#: classic/omp.xsl:2369
 msgctxt "Severity"
 msgid "False Pos."
 msgstr "Falsch Pos."
 
-#: classic/omp.xsl:2529
+#: classic/omp.xsl:2474
 msgid "User Tags list"
 msgstr "Liste der Benutzer-Tags"
 
-#: classic/omp.xsl:2536
+#: classic/omp.xsl:2481
 msgid "New tag"
 msgstr "Neuer Tag"
 
-#: classic/omp.xsl:2539 classic/omp.xsl:2547 classic/omp.xsl:2555
+#: classic/omp.xsl:2484 classic/omp.xsl:2492 classic/omp.xsl:2500
 msgid "Add tag"
 msgstr "Tag hinzufügen"
 
-#: classic/omp.xsl:2544 classic/omp.xsl:2552 classic/omp.xsl:14233
-#: classic/omp.xsl:14236 classic/dynamic_strings.xsl:405
+#: classic/omp.xsl:2489 classic/omp.xsl:2497 classic/omp.xsl:14129
+#: classic/omp.xsl:14132 classic/dynamic_strings.xsl:405
 msgid "New Tag"
 msgstr "Neuer Tag"
 
-#: classic/omp.xsl:2561 classic/omp.xsl:13880 classic/omp.xsl:14241
-#: classic/omp.xsl:14242 classic/omp.xsl:30399 classic/omp.xsl:30674
-#: classic/omp.xsl:36206 classic/dynamic_strings.xsl:118 classic/gsad.xsl:604
+#: classic/omp.xsl:2506 classic/omp.xsl:13783 classic/omp.xsl:14137
+#: classic/omp.xsl:14138 classic/omp.xsl:29761 classic/omp.xsl:30036
+#: classic/omp.xsl:35715 classic/dynamic_strings.xsl:118 classic/gsad.xsl:605
 msgid "Tags"
 msgstr "Tags"
 
-#: classic/omp.xsl:2564
+#: classic/omp.xsl:2509
 msgid "User Tags"
 msgstr "Benutzer-Tags"
 
-#: classic/omp.xsl:2570
+#: classic/omp.xsl:2515
 msgctxt "Tags"
 msgid "none"
 msgstr "keine"
 
-#: classic/omp.xsl:2582
+#: classic/omp.xsl:2527
 msgid "Adding Tag..."
 msgstr "Tag hinzufügen ..."
 
-#: classic/omp.xsl:2593 classic/omp.xsl:2611 classic/omp.xsl:2612
-#: classic/omp.xsl:6859
+#: classic/omp.xsl:2538 classic/omp.xsl:2556 classic/omp.xsl:2557
+#: classic/omp.xsl:6713
 msgid "Add Tag"
 msgstr "Tag hinzufügen"
 
-#: classic/omp.xsl:2606 classic/omp.xsl:6874
+#: classic/omp.xsl:2551 classic/omp.xsl:6728
 msgctxt "Tag"
 msgid "with Value"
 msgstr "mit Wert"
 
-#: classic/omp.xsl:2661 classic/omp.xsl:2922 classic/omp.xsl:4469
-#: classic/omp.xsl:4696 classic/omp.xsl:4710 classic/omp.xsl:4734
-#: classic/omp.xsl:4766 classic/omp.xsl:4879 classic/omp.xsl:4914
-#: classic/omp.xsl:4940 classic/omp.xsl:6331 classic/omp.xsl:6494
-#: classic/omp.xsl:7727 classic/omp.xsl:8309 classic/omp.xsl:8495
-#: classic/omp.xsl:8685 classic/omp.xsl:8751 classic/omp.xsl:9274
-#: classic/omp.xsl:9324 classic/omp.xsl:9373 classic/omp.xsl:9478
-#: classic/omp.xsl:9537 classic/omp.xsl:9576 classic/omp.xsl:9783
-#: classic/omp.xsl:10284 classic/omp.xsl:10906 classic/omp.xsl:10981
-#: classic/omp.xsl:12944 classic/omp.xsl:13315 classic/omp.xsl:13361
-#: classic/omp.xsl:13399 classic/omp.xsl:13420 classic/omp.xsl:13464
-#: classic/omp.xsl:13536 classic/omp.xsl:13737 classic/omp.xsl:13908
-#: classic/omp.xsl:14285 classic/omp.xsl:14441 classic/omp.xsl:14613
-#: classic/omp.xsl:14914 classic/omp.xsl:15645 classic/omp.xsl:16166
-#: classic/omp.xsl:16206 classic/omp.xsl:16238 classic/omp.xsl:16265
-#: classic/omp.xsl:16292 classic/omp.xsl:16341 classic/omp.xsl:16448
-#: classic/omp.xsl:16582 classic/omp.xsl:16710 classic/omp.xsl:17132
-#: classic/omp.xsl:17152 classic/omp.xsl:17193 classic/omp.xsl:17257
-#: classic/omp.xsl:17273 classic/omp.xsl:17297 classic/omp.xsl:18084
-#: classic/omp.xsl:18148 classic/omp.xsl:18256 classic/omp.xsl:18624
-#: classic/omp.xsl:18752 classic/omp.xsl:18874 classic/omp.xsl:19368
-#: classic/omp.xsl:19479 classic/omp.xsl:19608 classic/omp.xsl:19746
-#: classic/omp.xsl:19879 classic/omp.xsl:20138 classic/omp.xsl:20223
-#: classic/omp.xsl:20483 classic/omp.xsl:20558 classic/omp.xsl:20653
-#: classic/omp.xsl:20922 classic/omp.xsl:21940 classic/omp.xsl:22000
-#: classic/omp.xsl:22075 classic/omp.xsl:22153 classic/omp.xsl:22228
-#: classic/omp.xsl:22290 classic/omp.xsl:22351 classic/omp.xsl:22714
-#: classic/omp.xsl:22752 classic/omp.xsl:22777 classic/omp.xsl:22929
-#: classic/omp.xsl:23080 classic/omp.xsl:26596 classic/omp.xsl:26616
-#: classic/omp.xsl:26654 classic/omp.xsl:26729 classic/omp.xsl:26907
-#: classic/omp.xsl:27380 classic/omp.xsl:27541 classic/omp.xsl:27564
-#: classic/omp.xsl:27628 classic/omp.xsl:27985 classic/omp.xsl:28040
-#: classic/omp.xsl:28310 classic/omp.xsl:28377 classic/omp.xsl:28644
-#: classic/omp.xsl:28772 classic/omp.xsl:29021 classic/omp.xsl:29132
-#: classic/omp.xsl:29301 classic/omp.xsl:34893 classic/omp.xsl:34955
-#: classic/omp.xsl:34998 classic/omp.xsl:35089 classic/omp.xsl:35331
-#: classic/omp.xsl:35365 classic/omp.xsl:35399 classic/omp.xsl:35418
-#: classic/omp.xsl:35699 classic/omp.xsl:35712 classic/omp.xsl:35732
-#: classic/omp.xsl:35748 classic/omp.xsl:35764 classic/omp.xsl:35776
-#: classic/omp.xsl:35792 classic/omp.xsl:35808 classic/omp.xsl:35824
-#: classic/omp.xsl:35840 classic/omp.xsl:35855 classic/omp.xsl:36390
-#: classic/omp.xsl:37589 classic/omp.xsl:38208 classic/omp.xsl:38898
-#: classic/omp.xsl:38983 classic/omp.xsl:39117 classic/omp.xsl:39349
-#: classic/omp.xsl:39507 classic/omp.xsl:39554
+#: classic/omp.xsl:2606 classic/omp.xsl:2867 classic/omp.xsl:4415
+#: classic/omp.xsl:4643 classic/omp.xsl:4657 classic/omp.xsl:4681
+#: classic/omp.xsl:4713 classic/omp.xsl:4826 classic/omp.xsl:4861
+#: classic/omp.xsl:6231 classic/omp.xsl:6348 classic/omp.xsl:7536
+#: classic/omp.xsl:8102 classic/omp.xsl:8290 classic/omp.xsl:8480
+#: classic/omp.xsl:8546 classic/omp.xsl:9069 classic/omp.xsl:9118
+#: classic/omp.xsl:9223 classic/omp.xsl:9282 classic/omp.xsl:9321
+#: classic/omp.xsl:9529 classic/omp.xsl:10030 classic/omp.xsl:10722
+#: classic/omp.xsl:10797 classic/omp.xsl:12854 classic/omp.xsl:13218
+#: classic/omp.xsl:13264 classic/omp.xsl:13302 classic/omp.xsl:13323
+#: classic/omp.xsl:13367 classic/omp.xsl:13439 classic/omp.xsl:13640
+#: classic/omp.xsl:13811 classic/omp.xsl:14181 classic/omp.xsl:14337
+#: classic/omp.xsl:14509 classic/omp.xsl:14807 classic/omp.xsl:15536
+#: classic/omp.xsl:16057 classic/omp.xsl:16097 classic/omp.xsl:16129
+#: classic/omp.xsl:16156 classic/omp.xsl:16183 classic/omp.xsl:16232
+#: classic/omp.xsl:16339 classic/omp.xsl:16473 classic/omp.xsl:16601
+#: classic/omp.xsl:17023 classic/omp.xsl:17043 classic/omp.xsl:17084
+#: classic/omp.xsl:17148 classic/omp.xsl:17164 classic/omp.xsl:17188
+#: classic/omp.xsl:17977 classic/omp.xsl:18041 classic/omp.xsl:18149
+#: classic/omp.xsl:18519 classic/omp.xsl:18647 classic/omp.xsl:18769
+#: classic/omp.xsl:19263 classic/omp.xsl:19374 classic/omp.xsl:19503
+#: classic/omp.xsl:19631 classic/omp.xsl:19764 classic/omp.xsl:20012
+#: classic/omp.xsl:20097 classic/omp.xsl:21270 classic/omp.xsl:21332
+#: classic/omp.xsl:21409 classic/omp.xsl:21489 classic/omp.xsl:21566
+#: classic/omp.xsl:21630 classic/omp.xsl:21693 classic/omp.xsl:22056
+#: classic/omp.xsl:22094 classic/omp.xsl:22119 classic/omp.xsl:22271
+#: classic/omp.xsl:22422 classic/omp.xsl:25956 classic/omp.xsl:25976
+#: classic/omp.xsl:26014 classic/omp.xsl:26089 classic/omp.xsl:26267
+#: classic/omp.xsl:26737 classic/omp.xsl:26904 classic/omp.xsl:26927
+#: classic/omp.xsl:26991 classic/omp.xsl:27345 classic/omp.xsl:27400
+#: classic/omp.xsl:27670 classic/omp.xsl:27737 classic/omp.xsl:28004
+#: classic/omp.xsl:28132 classic/omp.xsl:28381 classic/omp.xsl:28492
+#: classic/omp.xsl:28661 classic/omp.xsl:34255 classic/omp.xsl:34317
+#: classic/omp.xsl:34360 classic/omp.xsl:34451 classic/omp.xsl:34693
+#: classic/omp.xsl:34727 classic/omp.xsl:34761 classic/omp.xsl:34780
+#: classic/omp.xsl:35240 classic/omp.xsl:35253 classic/omp.xsl:35273
+#: classic/omp.xsl:35289 classic/omp.xsl:35305 classic/omp.xsl:35317
+#: classic/omp.xsl:35333 classic/omp.xsl:35349 classic/omp.xsl:35365
+#: classic/omp.xsl:35380 classic/omp.xsl:35899 classic/omp.xsl:37098
+#: classic/omp.xsl:37708 classic/omp.xsl:38392 classic/omp.xsl:38477
+#: classic/omp.xsl:38618 classic/omp.xsl:38850 classic/omp.xsl:39015
+#: classic/omp.xsl:39064
 msgid "Name"
 msgstr "Name"
 
-#: classic/omp.xsl:2662 classic/omp.xsl:13741 classic/omp.xsl:13896
-#: classic/omp.xsl:14300 classic/omp.xsl:14456 classic/omp.xsl:17133
-#: classic/omp.xsl:29022 classic/omp.xsl:29133 classic/omp.xsl:29638
-#: classic/omp.xsl:35841 classic/omp.xsl:37086 classic/omp.xsl:37158
-#: classic/omp.xsl:37590 classic/omp.xsl:38209 classic/omp.xsl:39350
+#: classic/omp.xsl:2607 classic/omp.xsl:13644 classic/omp.xsl:13799
+#: classic/omp.xsl:14196 classic/omp.xsl:14352 classic/omp.xsl:17024
+#: classic/omp.xsl:28382 classic/omp.xsl:28493 classic/omp.xsl:28998
+#: classic/omp.xsl:35366 classic/omp.xsl:36595 classic/omp.xsl:36667
+#: classic/omp.xsl:37099 classic/omp.xsl:37709 classic/omp.xsl:38851
 msgid "Value"
 msgstr "Wert"
 
-#: classic/omp.xsl:2663 classic/omp.xsl:4700 classic/omp.xsl:6338
-#: classic/omp.xsl:6502 classic/omp.xsl:7741 classic/omp.xsl:8503
-#: classic/omp.xsl:8762 classic/omp.xsl:9189 classic/omp.xsl:9485
-#: classic/omp.xsl:9583 classic/omp.xsl:9787 classic/omp.xsl:10291
-#: classic/omp.xsl:10990 classic/omp.xsl:12400 classic/omp.xsl:13319
-#: classic/omp.xsl:13472 classic/omp.xsl:13546 classic/omp.xsl:13892
-#: classic/omp.xsl:14293 classic/omp.xsl:14449 classic/omp.xsl:14621
-#: classic/omp.xsl:14924 classic/omp.xsl:16124 classic/omp.xsl:16456
-#: classic/omp.xsl:17958 classic/omp.xsl:18155 classic/omp.xsl:18632
-#: classic/omp.xsl:18885 classic/omp.xsl:19372 classic/omp.xsl:19615
-#: classic/omp.xsl:19886 classic/omp.xsl:20035 classic/omp.xsl:20491
-#: classic/omp.xsl:20660 classic/omp.xsl:20862 classic/omp.xsl:26572
-#: classic/omp.xsl:26662 classic/omp.xsl:26739 classic/omp.xsl:26973
-#: classic/omp.xsl:27384 classic/omp.xsl:27669 classic/omp.xsl:27993
-#: classic/omp.xsl:28225 classic/omp.xsl:28384 classic/omp.xsl:34901
-#: classic/omp.xsl:34965 classic/omp.xsl:35291 classic/omp.xsl:35752
-#: classic/omp.xsl:38905 classic/omp.xsl:39128 classic/omp.xsl:39259
+#: classic/omp.xsl:2608 classic/omp.xsl:4647 classic/omp.xsl:6240
+#: classic/omp.xsl:6356 classic/omp.xsl:7550 classic/omp.xsl:8298
+#: classic/omp.xsl:8557 classic/omp.xsl:8984 classic/omp.xsl:9230
+#: classic/omp.xsl:9328 classic/omp.xsl:9533 classic/omp.xsl:10037
+#: classic/omp.xsl:10806 classic/omp.xsl:12310 classic/omp.xsl:13222
+#: classic/omp.xsl:13375 classic/omp.xsl:13449 classic/omp.xsl:13795
+#: classic/omp.xsl:14189 classic/omp.xsl:14345 classic/omp.xsl:14517
+#: classic/omp.xsl:14817 classic/omp.xsl:16015 classic/omp.xsl:16347
+#: classic/omp.xsl:17851 classic/omp.xsl:18048 classic/omp.xsl:18527
+#: classic/omp.xsl:18780 classic/omp.xsl:19267 classic/omp.xsl:19510
+#: classic/omp.xsl:19771 classic/omp.xsl:19909 classic/omp.xsl:25932
+#: classic/omp.xsl:26022 classic/omp.xsl:26099 classic/omp.xsl:26333
+#: classic/omp.xsl:26741 classic/omp.xsl:27032 classic/omp.xsl:27353
+#: classic/omp.xsl:27585 classic/omp.xsl:27744 classic/omp.xsl:34263
+#: classic/omp.xsl:34327 classic/omp.xsl:34653 classic/omp.xsl:35293
+#: classic/omp.xsl:38399 classic/omp.xsl:38629 classic/omp.xsl:38760
 msgid "Comment"
 msgstr "Kommentar"
 
-#: classic/omp.xsl:2664 classic/omp.xsl:2928 classic/omp.xsl:5592
-#: classic/omp.xsl:13402 classic/omp.xsl:16588 classic/omp.xsl:17134
-#: classic/omp.xsl:17157 classic/omp.xsl:17196 classic/omp.xsl:17260
-#: classic/omp.xsl:17276 classic/omp.xsl:17767 classic/omp.xsl:25047
-#: classic/omp.xsl:26384 classic/omp.xsl:26597 classic/omp.xsl:27546
-#: classic/omp.xsl:28416 classic/omp.xsl:31023 classic/omp.xsl:32298
-#: classic/omp.xsl:34189 classic/omp.xsl:35091 classic/omp.xsl:35400
-#: classic/omp.xsl:35701 classic/omp.xsl:35715 classic/omp.xsl:35737
-#: classic/omp.xsl:35753 classic/omp.xsl:35765 classic/omp.xsl:35781
-#: classic/omp.xsl:35797 classic/omp.xsl:35813 classic/omp.xsl:35829
-#: classic/omp.xsl:35844 classic/omp.xsl:35860 classic/omp.xsl:35876
-#: classic/omp.xsl:39353
+#: classic/omp.xsl:2609 classic/omp.xsl:2873 classic/omp.xsl:5505
+#: classic/omp.xsl:13305 classic/omp.xsl:16479 classic/omp.xsl:17025
+#: classic/omp.xsl:17048 classic/omp.xsl:17087 classic/omp.xsl:17151
+#: classic/omp.xsl:17167 classic/omp.xsl:17658 classic/omp.xsl:24405
+#: classic/omp.xsl:25744 classic/omp.xsl:25957 classic/omp.xsl:26909
+#: classic/omp.xsl:27776 classic/omp.xsl:30385 classic/omp.xsl:31662
+#: classic/omp.xsl:33562 classic/omp.xsl:34453 classic/omp.xsl:34762
+#: classic/omp.xsl:35242 classic/omp.xsl:35256 classic/omp.xsl:35278
+#: classic/omp.xsl:35294 classic/omp.xsl:35306 classic/omp.xsl:35322
+#: classic/omp.xsl:35338 classic/omp.xsl:35354 classic/omp.xsl:35369
+#: classic/omp.xsl:35385 classic/omp.xsl:35401 classic/omp.xsl:38854
 msgid "Actions"
 msgstr "Aktionen"
 
-#: classic/omp.xsl:2711 classic/dynamic_strings.xsl:200
+#: classic/omp.xsl:2656 classic/dynamic_strings.xsl:200
 msgid "Tag Details"
 msgstr "Tag-Details"
 
-#: classic/omp.xsl:2791 classic/omp.xsl:2798 classic/omp.xsl:2805
-#: classic/omp.xsl:14385 classic/dynamic_strings.xsl:618
+#: classic/omp.xsl:2736 classic/omp.xsl:2743 classic/omp.xsl:2750
+#: classic/omp.xsl:14281 classic/dynamic_strings.xsl:618
 msgid "Edit Tag"
 msgstr "Tag bearbeiten"
 
-#: classic/omp.xsl:2821
+#: classic/omp.xsl:2766
 msgid "Toggling Tag..."
 msgstr "Tag umschalten ..."
 
-#: classic/omp.xsl:2824 classic/omp.xsl:2825
+#: classic/omp.xsl:2769 classic/omp.xsl:2770
 msgid "Enable Tag"
 msgstr "Tag aktivieren"
 
-#: classic/omp.xsl:2828 classic/omp.xsl:2829
+#: classic/omp.xsl:2773 classic/omp.xsl:2774
 msgid "Disable Tag"
 msgstr "Tag deaktivieren"
 
-#: classic/omp.xsl:2896 classic/omp.xsl:27119
+#: classic/omp.xsl:2841 classic/omp.xsl:26476
 msgid "Create Multiple Permissions"
 msgstr "Mehrere Berechtigungen erstellen"
 
-#: classic/omp.xsl:2904 classic/omp.xsl:2907 classic/omp.xsl:27368
-#: classic/omp.xsl:36143 classic/dynamic_strings.xsl:119 classic/gsad.xsl:610
+#: classic/omp.xsl:2849 classic/omp.xsl:2852 classic/omp.xsl:26725
+#: classic/omp.xsl:35661 classic/dynamic_strings.xsl:119 classic/gsad.xsl:611
 msgid "Permissions"
 msgstr "Berechtigungen"
 
-#: classic/omp.xsl:2913
+#: classic/omp.xsl:2858
 msgctxt "Permissions"
 msgid "none"
 msgstr "keine"
 
-#: classic/omp.xsl:2923 classic/omp.xsl:20126 classic/omp.xsl:20139
-#: classic/omp.xsl:22584 classic/omp.xsl:22793 classic/omp.xsl:23062
-#: classic/omp.xsl:23066 classic/omp.xsl:23354 classic/omp.xsl:23360
-#: classic/omp.xsl:27097 classic/omp.xsl:27388 classic/omp.xsl:27568
-#: classic/omp.xsl:27908 classic/omp.xsl:29245 classic/omp.xsl:35090
-#: classic/omp.xsl:35332 classic/omp.xsl:35366
+#: classic/omp.xsl:2868 classic/omp.xsl:20000 classic/omp.xsl:20013
+#: classic/omp.xsl:21926 classic/omp.xsl:22135 classic/omp.xsl:22404
+#: classic/omp.xsl:22408 classic/omp.xsl:22700 classic/omp.xsl:22706
+#: classic/omp.xsl:26454 classic/omp.xsl:26745 classic/omp.xsl:26931
+#: classic/omp.xsl:27268 classic/omp.xsl:28605 classic/omp.xsl:34452
+#: classic/omp.xsl:34694 classic/omp.xsl:34728
 msgid "Description"
 msgstr "Beschreibung"
 
-#: classic/omp.xsl:2924 classic/omp.xsl:13749 classic/omp.xsl:13931
-#: classic/omp.xsl:14307 classic/omp.xsl:14463 classic/omp.xsl:26988
-#: classic/omp.xsl:27542 classic/omp.xsl:27572 classic/omp.xsl:27767
-#: classic/omp.xsl:35842
+#: classic/omp.xsl:2869 classic/omp.xsl:13652 classic/omp.xsl:13834
+#: classic/omp.xsl:14203 classic/omp.xsl:14359 classic/omp.xsl:26348
+#: classic/omp.xsl:26905 classic/omp.xsl:26935 classic/omp.xsl:27130
+#: classic/omp.xsl:35367
 msgid "Resource Type"
 msgstr "Ressourcen-Typ"
 
-#: classic/omp.xsl:2925 classic/omp.xsl:27418 classic/omp.xsl:27543
-#: classic/omp.xsl:27576
+#: classic/omp.xsl:2870 classic/omp.xsl:26775 classic/omp.xsl:26906
+#: classic/omp.xsl:26939
 msgid "Resource"
 msgstr "Ressource"
 
-#: classic/omp.xsl:2926 classic/omp.xsl:27544 classic/omp.xsl:27580
+#: classic/omp.xsl:2871 classic/omp.xsl:26907 classic/omp.xsl:26943
 msgctxt "Permission"
 msgid "Subject Type"
 msgstr "Subjekt-Typ"
 
-#: classic/omp.xsl:2927 classic/omp.xsl:26981 classic/omp.xsl:27545
-#: classic/omp.xsl:27584 classic/omp.xsl:27678
+#: classic/omp.xsl:2872 classic/omp.xsl:26341 classic/omp.xsl:26908
+#: classic/omp.xsl:26947 classic/omp.xsl:27041
 msgctxt "Permission"
 msgid "Subject"
 msgstr "Subjekt"
 
-#: classic/omp.xsl:2954 classic/omp.xsl:4456 classic/omp.xsl:7889
-#: classic/omp.xsl:7890
+#: classic/omp.xsl:2899 classic/omp.xsl:4402
 msgid "Import Report"
 msgstr "Bericht importieren"
 
-#: classic/omp.xsl:2969 classic/omp.xsl:10782 classic/omp.xsl:10855
-#: classic/omp.xsl:11792 classic/omp.xsl:11896 classic/omp.xsl:12663
-#: classic/omp.xsl:12716 classic/omp.xsl:12818 classic/omp.xsl:13126
-#: classic/omp.xsl:14152 classic/omp.xsl:29514 classic/omp.xsl:34461
-#: classic/omp.xsl:34496
+#: classic/omp.xsl:2914 classic/omp.xsl:10531 classic/omp.xsl:10604
+#: classic/omp.xsl:11621 classic/omp.xsl:11725 classic/omp.xsl:12573
+#: classic/omp.xsl:12626 classic/omp.xsl:12728 classic/omp.xsl:13036
+#: classic/omp.xsl:14055 classic/omp.xsl:28874 classic/omp.xsl:33834
+#: classic/omp.xsl:33869
 msgid "Report"
 msgstr "Bericht"
 
-#: classic/omp.xsl:2973
+#: classic/omp.xsl:2918
 msgid "Container Task"
 msgstr "Benutzer-Tags"
 
-#: classic/omp.xsl:2988
+#: classic/omp.xsl:2933
 msgid "Create a new container task"
 msgstr "Neuen Container-Task erstellen"
 
-#: classic/omp.xsl:2996 classic/omp.xsl:4812 classic/omp.xsl:33918
+#: classic/omp.xsl:2941 classic/omp.xsl:4759 classic/omp.xsl:33285
 msgid "Add to Assets"
 msgstr "Zu Assets hinzufügen"
 
-#: classic/omp.xsl:2999 classic/omp.xsl:33900
+#: classic/omp.xsl:2944 classic/omp.xsl:33267
 msgid "Add to Assets with QoD>=%1%% and Overrides enabled"
 msgstr "Zu den Assets mit QoD>=%1%% und aktivierten Übersteuerungen hinzufügen"
 
-#: classic/omp.xsl:3003 classic/omp.xsl:4847 classic/omp.xsl:6624
-#: classic/omp.xsl:6658 classic/omp.xsl:6702 classic/omp.xsl:7432
-#: classic/omp.xsl:7454 classic/omp.xsl:7487 classic/omp.xsl:7507
-#: classic/omp.xsl:7560 classic/omp.xsl:24038 classic/omp.xsl:24046
-#: classic/omp.xsl:24422 classic/omp.xsl:24428 classic/omp.xsl:24435
-#: classic/omp.xsl:24453 classic/omp.xsl:24459 classic/omp.xsl:24477
-#: classic/omp.xsl:24483 classic/omp.xsl:24737 classic/omp.xsl:24884
-#: classic/omp.xsl:24887 classic/omp.xsl:25193 classic/omp.xsl:25200
-#: classic/omp.xsl:25601 classic/omp.xsl:25607 classic/omp.xsl:25613
-#: classic/omp.xsl:25629 classic/omp.xsl:25635 classic/omp.xsl:25651
-#: classic/omp.xsl:25657 classic/omp.xsl:26039 classic/omp.xsl:26186
-#: classic/omp.xsl:26189 classic/omp.xsl:28798 classic/omp.xsl:28812
-#: classic/omp.xsl:28904 classic/omp.xsl:28991 classic/omp.xsl:29055
-#: classic/omp.xsl:29065 classic/omp.xsl:29150 classic/omp.xsl:29234
+#: classic/omp.xsl:2948 classic/omp.xsl:4794 classic/omp.xsl:6478
+#: classic/omp.xsl:6512 classic/omp.xsl:6556 classic/omp.xsl:7239
+#: classic/omp.xsl:7261 classic/omp.xsl:7295 classic/omp.xsl:7315
+#: classic/omp.xsl:7369 classic/omp.xsl:23394 classic/omp.xsl:23402
+#: classic/omp.xsl:23778 classic/omp.xsl:23784 classic/omp.xsl:23791
+#: classic/omp.xsl:23809 classic/omp.xsl:23815 classic/omp.xsl:23833
+#: classic/omp.xsl:23839 classic/omp.xsl:24093 classic/omp.xsl:24240
+#: classic/omp.xsl:24243 classic/omp.xsl:24551 classic/omp.xsl:24558
+#: classic/omp.xsl:24959 classic/omp.xsl:24965 classic/omp.xsl:24971
+#: classic/omp.xsl:24987 classic/omp.xsl:24993 classic/omp.xsl:25009
+#: classic/omp.xsl:25015 classic/omp.xsl:25397 classic/omp.xsl:25544
+#: classic/omp.xsl:25547 classic/omp.xsl:28158 classic/omp.xsl:28172
+#: classic/omp.xsl:28264 classic/omp.xsl:28351 classic/omp.xsl:28415
+#: classic/omp.xsl:28425 classic/omp.xsl:28510 classic/omp.xsl:28594
 msgid "yes"
 msgstr "ja"
 
-#: classic/omp.xsl:3007 classic/omp.xsl:4844 classic/omp.xsl:6643
-#: classic/omp.xsl:6667 classic/omp.xsl:6717 classic/omp.xsl:7442
-#: classic/omp.xsl:7464 classic/omp.xsl:7496 classic/omp.xsl:7516
-#: classic/omp.xsl:7575 classic/omp.xsl:24060 classic/omp.xsl:24445
-#: classic/omp.xsl:24469 classic/omp.xsl:24493 classic/omp.xsl:24734
-#: classic/omp.xsl:24881 classic/omp.xsl:25213 classic/omp.xsl:25621
-#: classic/omp.xsl:25643 classic/omp.xsl:25665 classic/omp.xsl:26036
-#: classic/omp.xsl:26183 classic/omp.xsl:28804 classic/omp.xsl:28818
-#: classic/omp.xsl:28901 classic/omp.xsl:28988 classic/omp.xsl:29059
-#: classic/omp.xsl:29069 classic/omp.xsl:29147 classic/omp.xsl:29231
+#: classic/omp.xsl:2952 classic/omp.xsl:4791 classic/omp.xsl:6497
+#: classic/omp.xsl:6521 classic/omp.xsl:6571 classic/omp.xsl:7249
+#: classic/omp.xsl:7271 classic/omp.xsl:7304 classic/omp.xsl:7324
+#: classic/omp.xsl:7384 classic/omp.xsl:23416 classic/omp.xsl:23801
+#: classic/omp.xsl:23825 classic/omp.xsl:23849 classic/omp.xsl:24090
+#: classic/omp.xsl:24237 classic/omp.xsl:24571 classic/omp.xsl:24979
+#: classic/omp.xsl:25001 classic/omp.xsl:25023 classic/omp.xsl:25394
+#: classic/omp.xsl:25541 classic/omp.xsl:28164 classic/omp.xsl:28178
+#: classic/omp.xsl:28261 classic/omp.xsl:28348 classic/omp.xsl:28419
+#: classic/omp.xsl:28429 classic/omp.xsl:28507 classic/omp.xsl:28591
 msgid "no"
 msgstr "nein"
 
-#: classic/omp.xsl:3063
+#: classic/omp.xsl:3008
 msgid "Host Filtering"
 msgstr "Host-Filterung"
 
-#: classic/omp.xsl:3064 classic/omp.xsl:3252 classic/omp.xsl:14627
-#: classic/omp.xsl:14933 classic/omp.xsl:15256 classic/omp.xsl:15649
-#: classic/omp.xsl:16128 classic/omp.xsl:24067 classic/omp.xsl:24502
-#: classic/omp.xsl:24897 classic/omp.xsl:25220 classic/omp.xsl:25674
-#: classic/omp.xsl:26199 classic/omp.xsl:29445 classic/omp.xsl:29450
-#: classic/omp.xsl:29451 classic/omp.xsl:33248 classic/omp.xsl:33334
-#: classic/omp.xsl:33445 classic/omp.xsl:33588 classic/omp.xsl:33685
-#: classic/omp.xsl:34081 classic/omp.xsl:35856 classic/omp.xsl:38883
-#: classic/omp.xsl:38884 classic/omp.xsl:39029 classic/omp.xsl:39032
-#: classic/omp.xsl:39183 classic/omp.xsl:39184 classic/omp.xsl:39247
-#: classic/omp.xsl:39446 classic/omp.xsl:39461 classic/omp.xsl:39581
-#: classic/omp.xsl:39788 classic/gsad.xsl:468
+#: classic/omp.xsl:3009 classic/omp.xsl:3197 classic/omp.xsl:14523
+#: classic/omp.xsl:14826 classic/omp.xsl:15148 classic/omp.xsl:15540
+#: classic/omp.xsl:16019 classic/omp.xsl:23423 classic/omp.xsl:23858
+#: classic/omp.xsl:24253 classic/omp.xsl:24578 classic/omp.xsl:25032
+#: classic/omp.xsl:25557 classic/omp.xsl:28805 classic/omp.xsl:28810
+#: classic/omp.xsl:28811 classic/omp.xsl:32614 classic/omp.xsl:32700
+#: classic/omp.xsl:32811 classic/omp.xsl:32954 classic/omp.xsl:33051
+#: classic/omp.xsl:33454 classic/omp.xsl:35381 classic/omp.xsl:38377
+#: classic/omp.xsl:38378 classic/omp.xsl:38523 classic/omp.xsl:38526
+#: classic/omp.xsl:38684 classic/omp.xsl:38685 classic/omp.xsl:38748
+#: classic/omp.xsl:38947 classic/omp.xsl:38962 classic/omp.xsl:39091
+#: classic/omp.xsl:39300 classic/gsad.xsl:473
 msgid "Hosts"
 msgstr "Hosts"
 
-#: classic/omp.xsl:3082 classic/omp.xsl:3086 classic/omp.xsl:3399
-#: classic/omp.xsl:3401 classic/omp.xsl:8341 classic/omp.xsl:8342
-#: classic/omp.xsl:8366 classic/omp.xsl:8368 classic/omp.xsl:29482
-#: classic/omp.xsl:29486 classic/omp.xsl:29951 classic/omp.xsl:29952
-#: classic/omp.xsl:29976 classic/omp.xsl:29978 classic/omp.xsl:30964
-#: classic/omp.xsl:30965 classic/omp.xsl:32082 classic/omp.xsl:32083
-#: classic/omp.xsl:32107 classic/omp.xsl:32109
+#: classic/omp.xsl:3027 classic/omp.xsl:3031 classic/omp.xsl:3344
+#: classic/omp.xsl:3346 classic/omp.xsl:8134 classic/omp.xsl:8135
+#: classic/omp.xsl:8159 classic/omp.xsl:8161 classic/omp.xsl:28842
+#: classic/omp.xsl:28846 classic/omp.xsl:29313 classic/omp.xsl:29314
+#: classic/omp.xsl:29338 classic/omp.xsl:29340 classic/omp.xsl:30326
+#: classic/omp.xsl:30327 classic/omp.xsl:31446 classic/omp.xsl:31447
+#: classic/omp.xsl:31471 classic/omp.xsl:31473
 msgid "No Overrides"
 msgstr "Keine Übersteuerung"
 
-#: classic/omp.xsl:3124
+#: classic/omp.xsl:3069
 msgid "Text phrase"
 msgstr "Textphrase"
 
-#: classic/omp.xsl:3130 classic/omp.xsl:3130 classic/omp.xsl:3740
-#: classic/omp.xsl:3740
+#: classic/omp.xsl:3075 classic/omp.xsl:3075 classic/omp.xsl:3685
+#: classic/omp.xsl:3685
 msgid "Apply"
 msgstr "Anwenden"
 
-#: classic/omp.xsl:3133 classic/omp.xsl:3743 classic/omp.xsl:3938
-#: classic/omp.xsl:16584 classic/omp.xsl:16712 classic/omp.xsl:22897
-#: classic/omp.xsl:22930 classic/omp.xsl:23029 classic/omp.xsl:23305
-#: classic/omp.xsl:23475 classic/omp.xsl:24157 classic/omp.xsl:24555
-#: classic/omp.xsl:24923 classic/omp.xsl:25314 classic/omp.xsl:25727
-#: classic/omp.xsl:26225 classic/omp.xsl:29793 classic/omp.xsl:30420
-#: classic/omp.xsl:30842 classic/omp.xsl:30943 classic/omp.xsl:30950
-#: classic/omp.xsl:33180 classic/omp.xsl:33249 classic/omp.xsl:33335
-#: classic/omp.xsl:33446 classic/omp.xsl:33590 classic/omp.xsl:33687
-#: classic/omp.xsl:34083 classic/omp.xsl:35874 classic/omp.xsl:39310
-#: classic/omp.xsl:39523 classic/omp.xsl:39563
+#: classic/omp.xsl:3078 classic/omp.xsl:3688 classic/omp.xsl:3883
+#: classic/omp.xsl:16475 classic/omp.xsl:16603 classic/omp.xsl:22239
+#: classic/omp.xsl:22272 classic/omp.xsl:22371 classic/omp.xsl:22647
+#: classic/omp.xsl:22831 classic/omp.xsl:23513 classic/omp.xsl:23911
+#: classic/omp.xsl:24279 classic/omp.xsl:24672 classic/omp.xsl:25085
+#: classic/omp.xsl:25583 classic/omp.xsl:29153 classic/omp.xsl:29782
+#: classic/omp.xsl:30204 classic/omp.xsl:30305 classic/omp.xsl:30312
+#: classic/omp.xsl:32546 classic/omp.xsl:32615 classic/omp.xsl:32701
+#: classic/omp.xsl:32812 classic/omp.xsl:32956 classic/omp.xsl:33053
+#: classic/omp.xsl:33456 classic/omp.xsl:35399 classic/omp.xsl:38811
+#: classic/omp.xsl:39031 classic/omp.xsl:39073
 msgid "Severity"
 msgstr "Schwereg."
 
-#: classic/omp.xsl:3211
+#: classic/omp.xsl:3156
 msgid "Filtered Hosts"
 msgstr "Gefilterte Hosts"
 
-#: classic/omp.xsl:3259
+#: classic/omp.xsl:3204
 msgid "No hosts available for Prognostic Report"
 msgstr "Keine Hosts für Vorhersage-Bericht verfügbar"
 
-#: classic/omp.xsl:3267
+#: classic/omp.xsl:3212
 msgid "No SCAP data available for Prognostic Report"
 msgstr "Keine SCAP-Daten für Vorhersage-Bericht verfügbar"
 
-#: classic/omp.xsl:3276 classic/omp.xsl:3277 classic/omp.xsl:29455
-#: classic/omp.xsl:29461 classic/omp.xsl:29462 classic/omp.xsl:32417
-#: classic/omp.xsl:32419
+#: classic/omp.xsl:3221 classic/omp.xsl:3222 classic/omp.xsl:28815
+#: classic/omp.xsl:28821 classic/omp.xsl:28822 classic/omp.xsl:31781
+#: classic/omp.xsl:31783
 msgid "Prognostic Report"
 msgstr "Vorhersage-Bericht"
 
-#: classic/omp.xsl:3285
+#: classic/omp.xsl:3230
 msgid "0 hosts"
 msgstr "0 Hosts"
 
-#: classic/omp.xsl:3321 classic/omp.xsl:3322
+#: classic/omp.xsl:3266 classic/omp.xsl:3267
 msgid "Collapse details of all vulnerabilities"
 msgstr "Details aller Schwachstellen einklappen"
 
-#: classic/omp.xsl:3327 classic/omp.xsl:3328
+#: classic/omp.xsl:3272 classic/omp.xsl:3273
 msgid "Expand to full details of all vulnerabilities"
 msgstr "Details aller Schwachstellen ausklappen"
 
-#: classic/omp.xsl:3392 classic/omp.xsl:3394 classic/omp.xsl:8347
-#: classic/omp.xsl:8348 classic/omp.xsl:8376 classic/omp.xsl:8378
-#: classic/omp.xsl:29957 classic/omp.xsl:29958 classic/omp.xsl:29986
-#: classic/omp.xsl:29988 classic/omp.xsl:30973 classic/omp.xsl:30974
-#: classic/omp.xsl:32088 classic/omp.xsl:32089 classic/omp.xsl:32117
-#: classic/omp.xsl:32119
+#: classic/omp.xsl:3337 classic/omp.xsl:3339 classic/omp.xsl:8140
+#: classic/omp.xsl:8141 classic/omp.xsl:8169 classic/omp.xsl:8171
+#: classic/omp.xsl:29319 classic/omp.xsl:29320 classic/omp.xsl:29348
+#: classic/omp.xsl:29350 classic/omp.xsl:30335 classic/omp.xsl:30336
+#: classic/omp.xsl:31452 classic/omp.xsl:31453 classic/omp.xsl:31481
+#: classic/omp.xsl:31483
 msgid "Overrides are Applied"
 msgstr "Übersteuerungen werden angewendet"
 
-#: classic/omp.xsl:3569 classic/omp.xsl:4822 classic/omp.xsl:6651
-#: classic/omp.xsl:7477
+#: classic/omp.xsl:3514 classic/omp.xsl:4769 classic/omp.xsl:6505
+#: classic/omp.xsl:7285
 msgid "Apply Overrides"
 msgstr "Übersteuerungen anwenden"
 
-#: classic/omp.xsl:3868 classic/omp.xsl:3871
+#: classic/omp.xsl:3813 classic/omp.xsl:3816
 msgid "Use filtered results (all pages)"
 msgstr "Gefilterte Ergebnisse nutzen (alle Seiten)"
 
-#: classic/omp.xsl:3876 classic/omp.xsl:3879
+#: classic/omp.xsl:3821 classic/omp.xsl:3824
 msgid "Use all unfiltered results"
 msgstr "Alle ungefilterten Ergebnisse nutzen"
 
-#: classic/omp.xsl:3884 classic/omp.xsl:3887
+#: classic/omp.xsl:3829 classic/omp.xsl:3832
 msgid "Use filtered results (current page)"
 msgstr "Gefilterte Ergebnisse nutzen (aktuelle Seite)"
 
-#: classic/omp.xsl:3930 classic/omp.xsl:30910 classic/omp.xsl:30914
-#: classic/omp.xsl:32063 classic/omp.xsl:33332
+#: classic/omp.xsl:3875 classic/omp.xsl:30272 classic/omp.xsl:30276
+#: classic/omp.xsl:31427 classic/omp.xsl:32698
 msgid "Vulnerability"
 msgstr "Schwachstelle"
 
-#: classic/omp.xsl:3934 classic/omp.xsl:22101 classic/omp.xsl:23735
-#: classic/omp.xsl:30928 classic/omp.xsl:30933 classic/omp.xsl:30933
-#: classic/omp.xsl:31415 classic/omp.xsl:32067
+#: classic/omp.xsl:3879 classic/omp.xsl:21435 classic/omp.xsl:23091
+#: classic/omp.xsl:30290 classic/omp.xsl:30295 classic/omp.xsl:30295
+#: classic/omp.xsl:30777 classic/omp.xsl:31431
 msgid "Solution type"
 msgstr "Art der Lösung"
 
-#: classic/omp.xsl:3946 classic/omp.xsl:10821 classic/omp.xsl:11849
-#: classic/omp.xsl:12702 classic/omp.xsl:12767 classic/omp.xsl:14047
-#: classic/omp.xsl:19621 classic/omp.xsl:19750 classic/omp.xsl:19894
-#: classic/omp.xsl:20040 classic/omp.xsl:20497 classic/omp.xsl:20562
-#: classic/omp.xsl:20667 classic/omp.xsl:20866 classic/omp.xsl:29504
-#: classic/omp.xsl:31001 classic/omp.xsl:31005 classic/omp.xsl:32136
-#: classic/omp.xsl:32912 classic/omp.xsl:33177 classic/omp.xsl:34004
-#: classic/omp.xsl:34187 classic/omp.xsl:34351 classic/omp.xsl:34435
-#: classic/omp.xsl:35793 classic/omp.xsl:35825 classic/omp.xsl:37108
-#: classic/omp.xsl:37178 classic/omp.xsl:39174 classic/omp.xsl:39250
+#: classic/omp.xsl:3891 classic/omp.xsl:10570 classic/omp.xsl:11678
+#: classic/omp.xsl:12612 classic/omp.xsl:12677 classic/omp.xsl:13950
+#: classic/omp.xsl:19516 classic/omp.xsl:19635 classic/omp.xsl:19779
+#: classic/omp.xsl:19914 classic/omp.xsl:28864 classic/omp.xsl:30363
+#: classic/omp.xsl:30367 classic/omp.xsl:31500 classic/omp.xsl:32278
+#: classic/omp.xsl:32543 classic/omp.xsl:33377 classic/omp.xsl:33560
+#: classic/omp.xsl:33724 classic/omp.xsl:33808 classic/omp.xsl:35334
+#: classic/omp.xsl:36617 classic/omp.xsl:36687 classic/omp.xsl:38675
+#: classic/omp.xsl:38751
 msgid "Host"
 msgstr "Host"
 
-#: classic/omp.xsl:3950
+#: classic/omp.xsl:3895
 msgctxt "Host"
 msgid "Location"
 msgstr "Ort"
 
-#: classic/omp.xsl:4139 classic/omp.xsl:4714 classic/omp.xsl:4738
-#: classic/omp.xsl:4770 classic/omp.xsl:4883 classic/omp.xsl:4918
-#: classic/omp.xsl:4944 classic/omp.xsl:5819 classic/omp.xsl:12130
-#: classic/omp.xsl:12688 classic/omp.xsl:13912 classic/omp.xsl:16170
-#: classic/omp.xsl:16210 classic/omp.xsl:16242 classic/omp.xsl:16269
-#: classic/omp.xsl:16296 classic/omp.xsl:17930 classic/omp.xsl:22537
-#: classic/omp.xsl:22830 classic/omp.xsl:22980 classic/omp.xsl:23245
-#: classic/omp.xsl:23434 classic/omp.xsl:23882
+#: classic/omp.xsl:4084 classic/omp.xsl:4661 classic/omp.xsl:4685
+#: classic/omp.xsl:4717 classic/omp.xsl:4830 classic/omp.xsl:4865
+#: classic/omp.xsl:5732 classic/omp.xsl:12040 classic/omp.xsl:12598
+#: classic/omp.xsl:13815 classic/omp.xsl:16061 classic/omp.xsl:16101
+#: classic/omp.xsl:16133 classic/omp.xsl:16160 classic/omp.xsl:16187
+#: classic/omp.xsl:17823 classic/omp.xsl:21879 classic/omp.xsl:22172
+#: classic/omp.xsl:22322 classic/omp.xsl:22587 classic/omp.xsl:22786
+#: classic/omp.xsl:23238
 msgid "ID"
 msgstr "ID"
 
-#: classic/omp.xsl:4145 classic/omp.xsl:5827 classic/omp.xsl:13757
-#: classic/omp.xsl:16683 classic/omp.xsl:17453 classic/omp.xsl:17938
-#: classic/omp.xsl:21948 classic/omp.xsl:22088 classic/omp.xsl:22174
-#: classic/omp.xsl:22364 classic/omp.xsl:22554 classic/omp.xsl:22836
-#: classic/omp.xsl:22990 classic/omp.xsl:23255 classic/omp.xsl:23444
-#: classic/omp.xsl:23889 classic/omp.xsl:30402 classic/omp.xsl:30679
+#: classic/omp.xsl:4090 classic/omp.xsl:5740 classic/omp.xsl:13660
+#: classic/omp.xsl:16574 classic/omp.xsl:17344 classic/omp.xsl:17831
+#: classic/omp.xsl:21278 classic/omp.xsl:21422 classic/omp.xsl:21510
+#: classic/omp.xsl:21706 classic/omp.xsl:21896 classic/omp.xsl:22178
+#: classic/omp.xsl:22332 classic/omp.xsl:22597 classic/omp.xsl:22796
+#: classic/omp.xsl:23245 classic/omp.xsl:29764 classic/omp.xsl:30041
 msgctxt "Date"
 msgid "Modified"
 msgstr "Geändert"
 
-#: classic/omp.xsl:4149 classic/omp.xsl:5823 classic/omp.xsl:16679
-#: classic/omp.xsl:17449 classic/omp.xsl:17934 classic/omp.xsl:22083
-#: classic/omp.xsl:22169 classic/omp.xsl:22236 classic/omp.xsl:22298
-#: classic/omp.xsl:22359 classic/omp.xsl:22842 classic/omp.xsl:22986
-#: classic/omp.xsl:23251 classic/omp.xsl:23440 classic/omp.xsl:23895
-#: classic/omp.xsl:32145 classic/omp.xsl:39351
+#: classic/omp.xsl:4094 classic/omp.xsl:5736 classic/omp.xsl:16570
+#: classic/omp.xsl:17340 classic/omp.xsl:17827 classic/omp.xsl:21417
+#: classic/omp.xsl:21505 classic/omp.xsl:21574 classic/omp.xsl:21638
+#: classic/omp.xsl:21701 classic/omp.xsl:22184 classic/omp.xsl:22328
+#: classic/omp.xsl:22593 classic/omp.xsl:22792 classic/omp.xsl:23251
+#: classic/omp.xsl:31509 classic/omp.xsl:38852
 msgctxt "Date"
 msgid "Created"
 msgstr "Erstellt"
 
-#: classic/omp.xsl:4153 classic/omp.xsl:5831
+#: classic/omp.xsl:4098 classic/omp.xsl:5744
 msgid "Owner"
 msgstr "Besitzer"
 
-#: classic/omp.xsl:4175 classic/omp.xsl:5513
+#: classic/omp.xsl:4120 classic/omp.xsl:5426
 msgid "%1 of %2"
 msgstr "%1 von %2"
 
-#: classic/omp.xsl:4243 classic/omp.xsl:8416 classic/omp.xsl:9871
-#: classic/omp.xsl:39851
+#: classic/omp.xsl:4188 classic/omp.xsl:8211 classic/omp.xsl:9617
+#: classic/omp.xsl:39363
 msgid "Applied filter:"
 msgstr "Angewandter Filter:"
 
-#: classic/omp.xsl:4258
+#: classic/omp.xsl:4203
 msgid "The report is empty. This can happen for the following reasons:"
 msgstr "Der Bericht ist leer. Dies kann aus folgenden Gründen der Fall sein:"
 
-#: classic/omp.xsl:4264
+#: classic/omp.xsl:4209
 msgid "The scan just started and no results have arrived yet."
 msgstr ""
 "Der Scan wurde gerade erst gestartet und es sind noch keine Ergebnisse "
 "eingetroffen."
 
-#: classic/omp.xsl:4270 classic/omp.xsl:4285
+#: classic/omp.xsl:4215 classic/omp.xsl:4230
 msgid "Click here to reload this page and update the status."
 msgstr ""
 "Klicken Sie hier um die Seite neu zu laden und den Status zu aktualisieren."
 
-#: classic/omp.xsl:4279
+#: classic/omp.xsl:4224
 msgid "The scan is still running and no results have arrived yet."
 msgstr ""
 "Der Scan läuft noch und es sind bisher noch keine Ergebnisse eingetroffen."
 
-#: classic/omp.xsl:4294
+#: classic/omp.xsl:4239
 msgid "The target hosts could be regarded dead."
 msgstr "Die Ziel-Hosts können als tot angesehen werden."
 
-#: classic/omp.xsl:4302 classic/omp.xsl:14876 classic/dynamic_strings.xsl:607
+#: classic/omp.xsl:4247 classic/omp.xsl:14769 classic/dynamic_strings.xsl:607
 msgid "Edit Target"
 msgstr "Ziel bearbeiten"
 
-#: classic/omp.xsl:4305 classic/omp.xsl:4315
+#: classic/omp.xsl:4250 classic/omp.xsl:4260
 msgid ""
 "You could change the Alive Test method of the target. However, if the "
 "targets are indeed dead, the scan duration might increase significantly."
@@ -1162,166 +1150,166 @@ msgstr ""
 "Sie können die Alive-Test-Methode des Ziels ändern. Sind die Zielsysteme "
 "allerdings in der Tat tod, so kann sich die Scan-Zeit erheblich erhöhen."
 
-#: classic/omp.xsl:4307
+#: classic/omp.xsl:4252
 msgid "Click here to edit the target"
 msgstr "Klicken Sie hier um das Ziel zu bearbeiten"
 
-#: classic/omp.xsl:4327
+#: classic/omp.xsl:4272
 msgid "The report is empty."
 msgstr "Der Bericht ist leer"
 
-#: classic/omp.xsl:4329
+#: classic/omp.xsl:4274
 msgid "The filter does not match any of %1 results."
 msgstr "Der Filter entspricht keinem von %1 Ergebnissen."
 
-#: classic/omp.xsl:4338
+#: classic/omp.xsl:4283
 msgid "The report only contains log messages, which are currently excluded."
 msgstr ""
 "Der Bericht enthält nur Log-Meldungen die aktuell nicht gefiltert werden. "
 
-#: classic/omp.xsl:4341
+#: classic/omp.xsl:4286
 msgid "Log messages are currently excluded."
 msgstr "Log-Meldungen werden aktuell nicht gefiltert."
 
-#: classic/omp.xsl:4347
+#: classic/omp.xsl:4292
 msgid "Add log messages to the filter"
 msgstr "Füge Log-Meldungen zum Filter hinzu"
 
-#: classic/omp.xsl:4350
+#: classic/omp.xsl:4295
 msgid "Include log messages in your filter setting."
 msgstr "Nimm Log-Meldungen in den Filtereinstellungen auf."
 
-#: classic/omp.xsl:4360
+#: classic/omp.xsl:4305
 msgid "You are using keywords setting a minimum limit on severity."
 msgstr ""
 "Sie verwenden Schlüsselworte die eine Mindestgrenze des Schweregrades setzen."
 
-#: classic/omp.xsl:4364
+#: classic/omp.xsl:4309
 msgid "Remove severity limit"
 msgstr "Schweregrad-Grenze entfernen"
 
-#: classic/omp.xsl:4367
+#: classic/omp.xsl:4312
 msgid "Remove the severity limit from your filter settings."
 msgstr "Schweregrade-Grenze aus den Filtereinstellungen entfernen."
 
-#: classic/omp.xsl:4377
+#: classic/omp.xsl:4322
 msgid ""
 "There may be results below the current minimum Quality of Detection level."
 msgstr ""
 "Es könnten Ergebnisse vorliegen die unterhalb der aktuellen Grenze für die "
 "Quality of Detection liegen."
 
-#: classic/omp.xsl:4381
+#: classic/omp.xsl:4326
 msgid "Descrease minimum QoD"
 msgstr "QoD-Minimum verringern"
 
-#: classic/omp.xsl:4384
+#: classic/omp.xsl:4329
 msgid ""
 "Decrease the minimum QoD in the Filter to 30 percent to see those results."
 msgstr ""
 "Die Minimum-QoD im Filter auf 30 Prozent verringern um diese Ergebnisse zu "
 "sehen."
 
-#: classic/omp.xsl:4394
+#: classic/omp.xsl:4339
 msgid "You are using keywords setting a lower limit on QoD."
 msgstr "Sie benutzen Schlüsselwörter, die eine QoD-Untergrenze setzen."
 
-#: classic/omp.xsl:4398
+#: classic/omp.xsl:4343
 msgid "Remove QoD limit"
 msgstr "QoD-Grenze entfernen"
 
-#: classic/omp.xsl:4401
+#: classic/omp.xsl:4346
 msgid "Remove Quality of Detection limit."
 msgstr "\"Quality of Detection\"-Grenze entfernen."
 
-#: classic/omp.xsl:4409
+#: classic/omp.xsl:4354
 msgid "Your filter settings may be too refined."
 msgstr "Ihr Filter könnte zu fein eingestellt sein."
 
-#: classic/omp.xsl:4413
+#: classic/omp.xsl:4358
 msgid "Edit filter"
 msgstr "Filter bearbeiten"
 
-#: classic/omp.xsl:4416
+#: classic/omp.xsl:4361
 msgid "Adjust and update your filter settings."
 msgstr "Ihre Filtereinstellungen anpassen und aktualisieren."
 
-#: classic/omp.xsl:4423
+#: classic/omp.xsl:4368
 msgid "Your last filter change may be too restrictive."
 msgstr "Ihre letzte Filteränderung könnte zu einschränkend sein."
 
-#: classic/omp.xsl:4427
+#: classic/omp.xsl:4372
 msgid "Reset filter"
 msgstr "Filter zurücksetzen"
 
-#: classic/omp.xsl:4430
+#: classic/omp.xsl:4375
 msgid "Reset the filter settings to the defaults."
 msgstr "Die Filtereinstellungen auf den Standardwert zurücksetzen."
 
-#: classic/omp.xsl:4462
+#: classic/omp.xsl:4408
 msgid "Permission to start task denied"
 msgstr "Keine Berechtigung, Aufgabe zu starten"
 
-#: classic/omp.xsl:4468 classic/omp.xsl:4469
+#: classic/omp.xsl:4414 classic/omp.xsl:4415
 msgid "Schedule Unavailable"
 msgstr "Zeitplan nicht verfügbar"
 
-#: classic/omp.xsl:4477 classic/omp.xsl:4786
+#: classic/omp.xsl:4423 classic/omp.xsl:4733
 msgctxt "Task|Schedule"
 msgid "Next due: over"
 msgstr "Fälligkeit: abgelaufen"
 
-#: classic/omp.xsl:4483 classic/omp.xsl:4790
+#: classic/omp.xsl:4429 classic/omp.xsl:4737
 msgctxt "Task|Schedule"
 msgid "Next due"
 msgstr "Fälligkeit"
 
-#: classic/omp.xsl:4486 classic/omp.xsl:4793 classic/omp.xsl:6590
-#: classic/omp.xsl:6591 classic/omp.xsl:7388 classic/omp.xsl:7389
-#: classic/omp.xsl:7399 classic/omp.xsl:7400 classic/omp.xsl:19207
-#: classic/omp.xsl:19289 classic/omp.xsl:19412
+#: classic/omp.xsl:4432 classic/omp.xsl:4740 classic/omp.xsl:6444
+#: classic/omp.xsl:6445 classic/omp.xsl:7188 classic/omp.xsl:7189
+#: classic/omp.xsl:7199 classic/omp.xsl:7200 classic/omp.xsl:19102
+#: classic/omp.xsl:19184 classic/omp.xsl:19307
 msgid "Once"
 msgstr "Einmalig"
 
-#: classic/omp.xsl:4489 classic/omp.xsl:4796 classic/omp.xsl:7395
+#: classic/omp.xsl:4435 classic/omp.xsl:4743 classic/omp.xsl:7195
 msgid "more times"
 msgstr "mehrmals"
 
-#: classic/omp.xsl:4501 classic/dynamic_strings.xsl:194
+#: classic/omp.xsl:4447 classic/dynamic_strings.xsl:194
 msgid "Schedule Details"
 msgstr "Zeitplan-Details"
 
-#: classic/omp.xsl:4521 classic/omp.xsl:4538
+#: classic/omp.xsl:4467 classic/omp.xsl:4484
 msgid "Task is already active"
 msgstr "Aufgabe ist bereits aktiv"
 
-#: classic/omp.xsl:4567
+#: classic/omp.xsl:4513
 msgid "Task is a container"
 msgstr "Aufgabe ist ein Container"
 
-#: classic/omp.xsl:4571
+#: classic/omp.xsl:4517
 msgid "Task is scheduled"
 msgstr "Aufgabe ist durch Zeitplan gesteuert"
 
-#: classic/omp.xsl:4577
+#: classic/omp.xsl:4523
 msgid "Permission to resume task denied"
 msgstr "Keine Berechtigung, Aufgabe fortzusetzen"
 
-#: classic/omp.xsl:4595
+#: classic/omp.xsl:4541
 msgid "Task is not stopped"
 msgstr "Aufgabe ist nicht gestoppt"
 
-#: classic/omp.xsl:4619
+#: classic/omp.xsl:4565
 msgctxt "Task"
 msgid "Move to Master"
 msgstr "Zum Master verschieben"
 
-#: classic/omp.xsl:4634
+#: classic/omp.xsl:4580
 msgctxt "Task"
 msgid "Move to Slave \"%1\""
 msgstr "Zum Slave \"%1\" verschieben"
 
-#: classic/omp.xsl:4667 classic/omp.xsl:4668
+#: classic/omp.xsl:4613 classic/omp.xsl:4614
 msgid ""
 "This is an Alterable Task. Reports may not relate to current Scan Config or "
 "Target!"
@@ -1329,1725 +1317,1707 @@ msgstr ""
 "Dies ist eine änderbare Aufgabe. Berichte könnten sich nicht auf die "
 "aktuelle Scan-Konfig oder das aktuelle Ziel beziehen."
 
-#: classic/omp.xsl:4684 classic/omp.xsl:6313 classic/omp.xsl:6315
-#: classic/omp.xsl:12925 classic/omp.xsl:16322 classic/omp.xsl:18065
-#: classic/omp.xsl:19460 classic/omp.xsl:20204 classic/omp.xsl:36224
-#: classic/dynamic_strings.xsl:95 classic/gsad.xsl:422
+#: classic/omp.xsl:4631 classic/omp.xsl:12835 classic/omp.xsl:16213
+#: classic/omp.xsl:17958 classic/omp.xsl:19355 classic/omp.xsl:20078
+#: classic/omp.xsl:35733 classic/dynamic_strings.xsl:95 classic/gsad.xsl:425
 msgid "Tasks"
 msgstr "Aufgaben"
 
-#: classic/omp.xsl:4704 classic/omp.xsl:13189 classic/omp.xsl:14201
-#: classic/omp.xsl:16115 classic/dynamic_strings.xsl:73
+#: classic/omp.xsl:4651 classic/omp.xsl:13092 classic/omp.xsl:14097
+#: classic/omp.xsl:16006 classic/dynamic_strings.xsl:73
 msgid "Target"
 msgstr "Ziel"
 
-#: classic/omp.xsl:4708 classic/omp.xsl:4732 classic/omp.xsl:4764
-#: classic/omp.xsl:4877 classic/omp.xsl:4912 classic/omp.xsl:4938
-#: classic/omp.xsl:9280 classic/omp.xsl:9330 classic/omp.xsl:9381
-#: classic/omp.xsl:12128 classic/omp.xsl:12519 classic/omp.xsl:12539
-#: classic/omp.xsl:12688 classic/omp.xsl:12892 classic/omp.xsl:12950
-#: classic/omp.xsl:13367 classic/omp.xsl:13906 classic/omp.xsl:16164
-#: classic/omp.xsl:16204 classic/omp.xsl:16236 classic/omp.xsl:16263
-#: classic/omp.xsl:16290 classic/omp.xsl:16347 classic/omp.xsl:18090
-#: classic/omp.xsl:19485 classic/omp.xsl:20229 classic/omp.xsl:20929
-#: classic/omp.xsl:27403 classic/omp.xsl:27431 classic/omp.xsl:28316
-#: classic/omp.xsl:29307 classic/omp.xsl:36625 classic/omp.xsl:36643
+#: classic/omp.xsl:4655 classic/omp.xsl:4679 classic/omp.xsl:4711
+#: classic/omp.xsl:4824 classic/omp.xsl:4859 classic/omp.xsl:9075
+#: classic/omp.xsl:9126 classic/omp.xsl:12038 classic/omp.xsl:12429
+#: classic/omp.xsl:12449 classic/omp.xsl:12598 classic/omp.xsl:12802
+#: classic/omp.xsl:12860 classic/omp.xsl:13270 classic/omp.xsl:13809
+#: classic/omp.xsl:16055 classic/omp.xsl:16095 classic/omp.xsl:16127
+#: classic/omp.xsl:16154 classic/omp.xsl:16181 classic/omp.xsl:16238
+#: classic/omp.xsl:17983 classic/omp.xsl:19380 classic/omp.xsl:20103
+#: classic/omp.xsl:26760 classic/omp.xsl:26788 classic/omp.xsl:27676
+#: classic/omp.xsl:28667 classic/omp.xsl:36134 classic/omp.xsl:36152
 msgid "Unavailable"
 msgstr "Nicht verfügbar"
 
-#: classic/omp.xsl:4727 classic/omp.xsl:6538 classic/omp.xsl:7226
-#: classic/omp.xsl:12388 classic/omp.xsl:13342 classic/omp.xsl:29282
-#: classic/omp.xsl:36080 classic/dynamic_strings.xsl:111 classic/gsad.xsl:561
+#: classic/omp.xsl:4674 classic/omp.xsl:6392 classic/omp.xsl:7080
+#: classic/omp.xsl:12298 classic/omp.xsl:13245 classic/omp.xsl:28642
+#: classic/omp.xsl:35598 classic/dynamic_strings.xsl:111 classic/gsad.xsl:568
 msgid "Alerts"
 msgstr "Benachrichtigungen"
 
-#: classic/omp.xsl:4757 classic/omp.xsl:6560 classic/omp.xsl:7347
-#: classic/omp.xsl:13154 classic/omp.xsl:14187 classic/omp.xsl:19359
+#: classic/omp.xsl:4704 classic/omp.xsl:6414 classic/omp.xsl:7147
+#: classic/omp.xsl:13064 classic/omp.xsl:14090 classic/omp.xsl:19254
 #: classic/dynamic_strings.xsl:80
 msgid "Schedule"
 msgstr "Zeitplan"
 
-#: classic/omp.xsl:4829 classic/omp.xsl:6674 classic/omp.xsl:7528
+#: classic/omp.xsl:4776 classic/omp.xsl:6528 classic/omp.xsl:7336
 msgid "Min QoD"
 msgstr "Min QoD"
 
-#: classic/omp.xsl:4838 classic/omp.xsl:6688 classic/omp.xsl:7545
+#: classic/omp.xsl:4785 classic/omp.xsl:6542 classic/omp.xsl:7354
 msgid "Alterable Task"
 msgstr "Änderbare Aufgabe"
 
-#: classic/omp.xsl:4856 classic/omp.xsl:6724 classic/omp.xsl:7584
+#: classic/omp.xsl:4803 classic/omp.xsl:6578 classic/omp.xsl:7393
 msgid "Auto Delete Reports"
 msgstr "Berichte automatisch löschen"
 
-#: classic/omp.xsl:4861 classic/omp.xsl:6751 classic/omp.xsl:7630
+#: classic/omp.xsl:4808 classic/omp.xsl:6605 classic/omp.xsl:7439
 msgctxt "Task|Auto Delete Reports"
 msgid "Automatically delete oldest reports but always keep newest "
 msgstr "Älteste Berichte automatisch löschen aber neueste "
 
-#: classic/omp.xsl:4863 classic/omp.xsl:6757 classic/omp.xsl:7643
+#: classic/omp.xsl:4810 classic/omp.xsl:6611 classic/omp.xsl:7452
 msgctxt "Task|Auto Delete Reports"
 msgid " reports"
 msgstr " Berichte behalten."
 
-#: classic/omp.xsl:4866 classic/omp.xsl:6738 classic/omp.xsl:7617
+#: classic/omp.xsl:4813 classic/omp.xsl:6592 classic/omp.xsl:7426
 msgid "Do not automatically delete reports"
 msgstr "Berichte nicht automatisch löschen"
 
-#: classic/omp.xsl:4873 classic/omp.xsl:6765 classic/omp.xsl:7129
-#: classic/omp.xsl:7259 classic/omp.xsl:17962 classic/omp.xsl:18163
-#: classic/omp.xsl:20026 classic/dynamic_strings.xsl:84
+#: classic/omp.xsl:4820 classic/omp.xsl:6619 classic/omp.xsl:6983
+#: classic/omp.xsl:7113 classic/omp.xsl:17855 classic/omp.xsl:18056
+#: classic/omp.xsl:19900 classic/dynamic_strings.xsl:84
 msgid "Scanner"
 msgstr "Scanner"
 
-#: classic/omp.xsl:4892 classic/omp.xsl:8513 classic/omp.xsl:8689
-#: classic/omp.xsl:8769 classic/omp.xsl:9193 classic/omp.xsl:13327
-#: classic/omp.xsl:13401 classic/omp.xsl:13428 classic/omp.xsl:13484
-#: classic/omp.xsl:13562 classic/omp.xsl:19629 classic/omp.xsl:19760
-#: classic/omp.xsl:19926 classic/omp.xsl:20067 classic/omp.xsl:20140
-#: classic/omp.xsl:22355 classic/omp.xsl:23079 classic/omp.xsl:35749
-#: classic/omp.xsl:35795 classic/omp.xsl:35947 classic/omp.xsl:37296
+#: classic/omp.xsl:4839 classic/omp.xsl:8308 classic/omp.xsl:8484
+#: classic/omp.xsl:8564 classic/omp.xsl:8988 classic/omp.xsl:13230
+#: classic/omp.xsl:13304 classic/omp.xsl:13331 classic/omp.xsl:13387
+#: classic/omp.xsl:13465 classic/omp.xsl:19524 classic/omp.xsl:19645
+#: classic/omp.xsl:19811 classic/omp.xsl:19941 classic/omp.xsl:20014
+#: classic/omp.xsl:21697 classic/omp.xsl:22421 classic/omp.xsl:35290
+#: classic/omp.xsl:35336 classic/omp.xsl:35471 classic/omp.xsl:36805
 msgid "Type"
 msgstr "Typ"
 
-#: classic/omp.xsl:4909 classic/omp.xsl:6361 classic/omp.xsl:6814
-#: classic/omp.xsl:7071 classic/omp.xsl:7109 classic/omp.xsl:13168
-#: classic/omp.xsl:14180 classic/omp.xsl:16666 classic/omp.xsl:16668
-#: classic/omp.xsl:17949 classic/wizard.xsl:228 classic/dynamic_strings.xsl:77
+#: classic/omp.xsl:4856 classic/omp.xsl:6259 classic/omp.xsl:6668
+#: classic/omp.xsl:6925 classic/omp.xsl:6963 classic/omp.xsl:13078
+#: classic/omp.xsl:14083 classic/omp.xsl:16557 classic/omp.xsl:16559
+#: classic/omp.xsl:17842 classic/wizard.xsl:228 classic/dynamic_strings.xsl:77
 msgid "Scan Config"
 msgstr "Scan-Konfiguration"
 
-#: classic/omp.xsl:4935 classic/omp.xsl:6383 classic/omp.xsl:7293
-#: classic/omp.xsl:13175 classic/omp.xsl:14194 classic/omp.xsl:20853
-#: classic/omp.xsl:34591 classic/wizard.xsl:421 classic/dynamic_strings.xsl:82
-msgid "Slave"
-msgstr "Slave"
-
-#: classic/omp.xsl:4961 classic/omp.xsl:6435 classic/omp.xsl:7665
+#: classic/omp.xsl:4881 classic/omp.xsl:6292 classic/omp.xsl:7474
 msgid "Order for target hosts"
-msgstr "Reihefolge der Ziel-Hosts"
+msgstr "Reihenfolge der Ziel-Hosts"
 
-#: classic/omp.xsl:4963 classic/omp.xsl:6439 classic/omp.xsl:7672
+#: classic/omp.xsl:4883 classic/omp.xsl:6296 classic/omp.xsl:7481
 msgctxt "Task|Hosts Ordering"
 msgid "Sequential"
 msgstr "Sequentiell"
 
-#: classic/omp.xsl:4964 classic/omp.xsl:6440 classic/omp.xsl:7677
+#: classic/omp.xsl:4884 classic/omp.xsl:6297 classic/omp.xsl:7486
 msgctxt "Task|Hosts Ordering"
 msgid "Random"
 msgstr "Zufällig"
 
-#: classic/omp.xsl:4965 classic/omp.xsl:6441 classic/omp.xsl:7682
+#: classic/omp.xsl:4885 classic/omp.xsl:6298 classic/omp.xsl:7491
 msgctxt "Task|Hosts Ordering"
 msgid "Reverse"
 msgstr "Umgekehrt"
 
-#: classic/omp.xsl:4966 classic/omp.xsl:13813 classic/omp.xsl:13995
-#: classic/omp.xsl:17637 classic/omp.xsl:17666 classic/omp.xsl:17711
-#: classic/omp.xsl:17804 classic/omp.xsl:18361 classic/omp.xsl:18383
-#: classic/omp.xsl:18390 classic/omp.xsl:18412 classic/omp.xsl:18455
-#: classic/omp.xsl:18477 classic/omp.xsl:18484 classic/omp.xsl:18506
-#: classic/omp.xsl:20044 classic/omp.xsl:20057 classic/omp.xsl:21140
-#: classic/omp.xsl:21150 classic/omp.xsl:21167 classic/omp.xsl:21210
-#: classic/omp.xsl:21220 classic/omp.xsl:21230 classic/omp.xsl:21240
-#: classic/omp.xsl:21250 classic/omp.xsl:21260 classic/omp.xsl:21270
-#: classic/omp.xsl:21284 classic/omp.xsl:21389 classic/omp.xsl:21452
-#: classic/omp.xsl:21462 classic/omp.xsl:21472 classic/omp.xsl:21482
-#: classic/omp.xsl:21492 classic/omp.xsl:21509 classic/omp.xsl:21578
-#: classic/omp.xsl:21632 classic/omp.xsl:21676 classic/omp.xsl:21686
-#: classic/omp.xsl:21696 classic/omp.xsl:21709 classic/omp.xsl:22907
-#: classic/omp.xsl:23039 classic/omp.xsl:23315 classic/omp.xsl:23485
+#: classic/omp.xsl:4886 classic/omp.xsl:13716 classic/omp.xsl:13898
+#: classic/omp.xsl:17528 classic/omp.xsl:17557 classic/omp.xsl:17602
+#: classic/omp.xsl:17695 classic/omp.xsl:18254 classic/omp.xsl:18276
+#: classic/omp.xsl:18283 classic/omp.xsl:18305 classic/omp.xsl:18350
+#: classic/omp.xsl:18372 classic/omp.xsl:18379 classic/omp.xsl:18401
+#: classic/omp.xsl:19918 classic/omp.xsl:19931 classic/omp.xsl:20467
+#: classic/omp.xsl:20477 classic/omp.xsl:20494 classic/omp.xsl:20537
+#: classic/omp.xsl:20547 classic/omp.xsl:20557 classic/omp.xsl:20567
+#: classic/omp.xsl:20577 classic/omp.xsl:20587 classic/omp.xsl:20597
+#: classic/omp.xsl:20611 classic/omp.xsl:20716 classic/omp.xsl:20779
+#: classic/omp.xsl:20789 classic/omp.xsl:20799 classic/omp.xsl:20809
+#: classic/omp.xsl:20819 classic/omp.xsl:20836 classic/omp.xsl:20905
+#: classic/omp.xsl:20959 classic/omp.xsl:21003 classic/omp.xsl:21013
+#: classic/omp.xsl:21023 classic/omp.xsl:21036 classic/omp.xsl:22249
+#: classic/omp.xsl:22381 classic/omp.xsl:22657 classic/omp.xsl:22841
 msgid "N/A"
 msgstr "N/A"
 
-#: classic/omp.xsl:4973 classic/omp.xsl:6423 classic/omp.xsl:7653
-#: classic/omp.xsl:34602
+#: classic/omp.xsl:4893 classic/omp.xsl:6280 classic/omp.xsl:7462
+#: classic/omp.xsl:33964
 msgid "Network Source Interface"
 msgstr "Netzwerk-Quell-Interface"
 
-#: classic/omp.xsl:4994 classic/omp.xsl:8313 classic/omp.xsl:22161
-#: classic/omp.xsl:22891 classic/omp.xsl:23153 classic/omp.xsl:23158
-#: classic/omp.xsl:29642 classic/omp.xsl:29932 classic/omp.xsl:35872
-#: classic/omp.xsl:37300
+#: classic/omp.xsl:4914 classic/omp.xsl:8106 classic/omp.xsl:21497
+#: classic/omp.xsl:22233 classic/omp.xsl:22495 classic/omp.xsl:22500
+#: classic/omp.xsl:29002 classic/omp.xsl:29294 classic/omp.xsl:35397
+#: classic/omp.xsl:36809
 msgid "Status"
 msgstr "Status"
 
-#: classic/omp.xsl:5017
+#: classic/omp.xsl:4937
 msgid "Duration of last scan"
 msgstr "Dauer des letzten Scans"
 
-#: classic/omp.xsl:5027
+#: classic/omp.xsl:4947
 msgid "Average scan duration"
 msgstr "Durchschnittliche Scan-Dauer"
 
-#: classic/omp.xsl:5034 classic/omp.xsl:8317 classic/omp.xsl:29542
-#: classic/omp.xsl:32297 classic/omp.xsl:32465 classic/omp.xsl:35873
-#: classic/gsad.xsl:428
+#: classic/omp.xsl:4954 classic/omp.xsl:8110 classic/omp.xsl:28902
+#: classic/omp.xsl:31661 classic/omp.xsl:31831 classic/omp.xsl:35398
+#: classic/gsad.xsl:431
 msgid "Reports"
 msgstr "Berichte"
 
-#: classic/omp.xsl:5038 classic/omp.xsl:5049
+#: classic/omp.xsl:4958 classic/omp.xsl:4969
 msgid "Reports on Task %1"
 msgstr "Berichte für Aufgabe %1"
 
-#: classic/omp.xsl:5042
+#: classic/omp.xsl:4962
 msgctxt "Task|Report"
 msgid "Current"
 msgstr "Aktueller"
 
-#: classic/omp.xsl:5047
+#: classic/omp.xsl:4967
 msgctxt "Task|Reports"
 msgid "Finished"
 msgstr "Abgeschlossene"
 
-#: classic/omp.xsl:5053 classic/omp.xsl:8324 classic/omp.xsl:35881
+#: classic/omp.xsl:4973 classic/omp.xsl:8117 classic/omp.xsl:35406
 msgctxt "Task|Report"
 msgid "Last"
 msgstr "Letzter"
 
-#: classic/omp.xsl:5062 classic/omp.xsl:30806 classic/gsad.xsl:434
+#: classic/omp.xsl:4982 classic/omp.xsl:30168 classic/gsad.xsl:437
 msgid "Results"
 msgstr "Ergebnisse"
 
-#: classic/omp.xsl:5066
+#: classic/omp.xsl:4986
 msgid "Results on Task %1"
 msgstr "Ergebnis für Aufgabe %1"
 
-#: classic/omp.xsl:5073 classic/omp.xsl:17312 classic/omp.xsl:23568
-#: classic/omp.xsl:24822 classic/omp.xsl:31059 classic/omp.xsl:31060
-#: classic/omp.xsl:31064 classic/omp.xsl:31066 classic/omp.xsl:33354
-#: classic/omp.xsl:33356 classic/omp.xsl:36125 classic/dynamic_strings.xsl:96
-#: classic/gsad.xsl:441
+#: classic/omp.xsl:4993 classic/omp.xsl:17203 classic/omp.xsl:22924
+#: classic/omp.xsl:24178 classic/omp.xsl:30421 classic/omp.xsl:30422
+#: classic/omp.xsl:30426 classic/omp.xsl:30428 classic/omp.xsl:32720
+#: classic/omp.xsl:32722 classic/omp.xsl:35643 classic/dynamic_strings.xsl:96
+#: classic/gsad.xsl:444
 msgid "Notes"
 msgstr "Notizen"
 
-#: classic/omp.xsl:5077
+#: classic/omp.xsl:4997
 msgid "Notes on Task %1"
 msgstr "Notizen für Aufgabe %1"
 
-#: classic/omp.xsl:5084 classic/omp.xsl:17318 classic/omp.xsl:23577
-#: classic/omp.xsl:26124 classic/omp.xsl:31076 classic/omp.xsl:31077
-#: classic/omp.xsl:31081 classic/omp.xsl:31083 classic/omp.xsl:33365
-#: classic/omp.xsl:33367 classic/omp.xsl:36134 classic/dynamic_strings.xsl:97
-#: classic/gsad.xsl:448
+#: classic/omp.xsl:5004 classic/omp.xsl:17209 classic/omp.xsl:22933
+#: classic/omp.xsl:25482 classic/omp.xsl:30438 classic/omp.xsl:30439
+#: classic/omp.xsl:30443 classic/omp.xsl:30445 classic/omp.xsl:32731
+#: classic/omp.xsl:32733 classic/omp.xsl:35652 classic/dynamic_strings.xsl:97
+#: classic/gsad.xsl:451
 msgid "Overrides"
 msgstr "Übersteuerungen"
 
-#: classic/omp.xsl:5088
+#: classic/omp.xsl:5008
 msgid "Overrides on Task %1"
 msgstr "Übersteuerungen für Aufgabe %1"
 
-#: classic/omp.xsl:5178 classic/omp.xsl:5180
+#: classic/omp.xsl:5095 classic/omp.xsl:5097
 msgid "Severity increased"
 msgstr "Schweregrad hat zugenommen"
 
-#: classic/omp.xsl:5183 classic/omp.xsl:5185
+#: classic/omp.xsl:5100 classic/omp.xsl:5102
 msgid "Severity decreased"
 msgstr "Schweregrad hat abgenommen"
 
-#: classic/omp.xsl:5188 classic/omp.xsl:5190
+#: classic/omp.xsl:5105 classic/omp.xsl:5107
 msgid "Vulnerability count increased"
 msgstr "Anzahl Schwachstellen hat zugenommen"
 
-#: classic/omp.xsl:5193 classic/omp.xsl:5195
+#: classic/omp.xsl:5110 classic/omp.xsl:5112
 msgid "Vulnerability count decreased"
 msgstr "Anzahl Schwachstellen hat abgenommen"
 
-#: classic/omp.xsl:5198 classic/omp.xsl:5200
+#: classic/omp.xsl:5115 classic/omp.xsl:5117
 msgid "Vulnerabilities did not change"
 msgstr "Schwachstellen haben sich nicht geändert"
 
-#: classic/omp.xsl:5273 classic/omp.xsl:5275 classic/omp.xsl:11028
+#: classic/omp.xsl:5186 classic/omp.xsl:5188 classic/omp.xsl:10844
 #: classic/dynamic_strings.xsl:914
 msgctxt "Status"
 msgid "Delete Requested"
 msgstr "Löschen Angefordert"
 
-#: classic/omp.xsl:5296
+#: classic/omp.xsl:5209
 msgctxt "Status"
 msgid " at "
 msgstr " bei "
 
-#: classic/omp.xsl:5412 classic/omp.xsl:5420 classic/omp.xsl:5421
-#: classic/omp.xsl:5862 classic/omp.xsl:5869 classic/omp.xsl:5870
-#: classic/omp.xsl:6308 classic/omp.xsl:6474 classic/wizard.xsl:153
-#: classic/dynamic_strings.xsl:391
+#: classic/omp.xsl:5325 classic/omp.xsl:5333 classic/omp.xsl:5334
+#: classic/omp.xsl:5775 classic/omp.xsl:5782 classic/omp.xsl:5783
+#: classic/omp.xsl:6331 classic/wizard.xsl:153 classic/dynamic_strings.xsl:391
 msgid "New Task"
 msgstr "Neue Aufgabe"
 
-#: classic/omp.xsl:5428 classic/omp.xsl:5429 classic/omp.xsl:5876
-#: classic/omp.xsl:5877 classic/omp.xsl:6307
+#: classic/omp.xsl:5341 classic/omp.xsl:5342 classic/omp.xsl:5789
+#: classic/omp.xsl:5790 classic/omp.xsl:6216
 msgid "New Container Task"
 msgstr "Neue Container-Aufgabe"
 
-#: classic/omp.xsl:5763 classic/omp.xsl:5766
+#: classic/omp.xsl:5676 classic/omp.xsl:5679
 msgid "Apply to page contents"
 msgstr "Auf Seiteninhalt anwenden"
 
-#: classic/omp.xsl:5771 classic/omp.xsl:5774
+#: classic/omp.xsl:5684 classic/omp.xsl:5687
 msgid "Apply to selection"
 msgstr "Auf Auswahl anwenden"
 
-#: classic/omp.xsl:5779 classic/omp.xsl:5782
+#: classic/omp.xsl:5692 classic/omp.xsl:5695
 msgid "Apply to all filtered"
 msgstr "Auf gesamte Filterauswahl anwenden"
 
-#: classic/omp.xsl:5793
+#: classic/omp.xsl:5706
 msgid "Applied filter"
 msgstr "Angewandter Filter"
 
-#: classic/omp.xsl:5897 classic/omp.xsl:28553 classic/omp.xsl:28579
+#: classic/omp.xsl:5810 classic/omp.xsl:27913 classic/omp.xsl:27939
 msgid "Import Port List"
 msgstr "Portliste importieren"
 
-#: classic/omp.xsl:5923 classic/omp.xsl:17845 classic/omp.xsl:30314
-#: classic/omp.xsl:30588
+#: classic/omp.xsl:5836 classic/omp.xsl:17736 classic/omp.xsl:29676
+#: classic/omp.xsl:29950
 msgid "Cloning..."
 msgstr "Klonen läuft …"
 
-#: classic/omp.xsl:5952 classic/omp.xsl:36558
+#: classic/omp.xsl:5865 classic/omp.xsl:36067
 msgid "Currently logged in as this user"
 msgstr "Momentan als dieser Benutzer eingeloggt"
 
-#: classic/omp.xsl:6050 classic/omp.xsl:17916 classic/omp.xsl:30759
-#: classic/omp.xsl:38962 classic/omp.xsl:39238
+#: classic/omp.xsl:5963 classic/omp.xsl:17809 classic/omp.xsl:30121
+#: classic/omp.xsl:38456 classic/omp.xsl:38739
 msgctxt "Action Verb"
 msgid "Export XML"
 msgstr "XML exportieren"
 
-#: classic/omp.xsl:6077
+#: classic/omp.xsl:5990
 msgctxt "Certificate"
 msgid "Activation"
 msgstr "Aktivierung"
 
-#: classic/omp.xsl:6082
+#: classic/omp.xsl:5995
 msgctxt "Certificate"
 msgid "not active yet"
 msgstr "noch nicht aktiv"
 
-#: classic/omp.xsl:6087
+#: classic/omp.xsl:6000
 msgctxt "Certificate"
 msgid "Expiration"
 msgstr "Ablaufdatum"
 
-#: classic/omp.xsl:6092
+#: classic/omp.xsl:6005
 msgctxt "Certificate"
 msgid "expired"
 msgstr "abgelaufen"
 
-#: classic/omp.xsl:6097
+#: classic/omp.xsl:6010
 msgid "MD5 Fingerprint"
 msgstr "MD5-Fingerabdruck"
 
-#: classic/omp.xsl:6101
+#: classic/omp.xsl:6014
 msgctxt "Certificate"
 msgid "Issued by"
 msgstr "Ausgestellt von"
 
-#: classic/omp.xsl:6112
+#: classic/omp.xsl:6025
 msgid "Certificate currently in use expired %1"
 msgstr "Aktuell verwendetes Zertifikat %1 abgelaufen"
 
-#: classic/omp.xsl:6115
+#: classic/omp.xsl:6028
 msgid "Certificate currently in use is not valid until %1"
 msgstr "Aktuell verwendetes Zertifikat ist nicht vor %1 gültig"
 
-#: classic/omp.xsl:6118
+#: classic/omp.xsl:6031
 msgid "Certificate currently in use will expire %1"
 msgstr "Aktuell verwendetes Zertifikat läuft %1 ab"
 
-#: classic/omp.xsl:6345
-msgid "Create Task"
-msgstr "Aufgabe erstellen"
-
-#: classic/omp.xsl:6412
-msgid "Create a new slave"
-msgstr "Neuen Slave erstellen"
-
-#: classic/omp.xsl:6447
+#: classic/omp.xsl:6304
 msgid "Maximum concurrently executed NVTs per host"
 msgstr "Maximal gleichzeitig ausgeführte NVT pro Host"
 
-#: classic/omp.xsl:6457
+#: classic/omp.xsl:6314
 msgid "Maximum concurrently scanned hosts"
 msgstr "Maximal gleichzeitig gescannte Hosts"
 
-#: classic/omp.xsl:6509 classic/omp.xsl:7165 classic/omp.xsl:7202
+#: classic/omp.xsl:6363 classic/omp.xsl:7019 classic/omp.xsl:7056
 msgid "Scan Targets"
 msgstr "Scan-Ziele"
 
-#: classic/omp.xsl:6529
+#: classic/omp.xsl:6383
 msgid "Create a new target"
 msgstr "Neues Ziel erstellen"
 
-#: classic/omp.xsl:6550 classic/omp.xsl:7246 classic/omp.xsl:34732
-#: classic/omp.xsl:34804
+#: classic/omp.xsl:6404 classic/omp.xsl:7100 classic/omp.xsl:34094
+#: classic/omp.xsl:34166
 msgid "Create a new alert"
 msgstr "Neue Benachrichtigung erstellen"
 
-#: classic/omp.xsl:6596
+#: classic/omp.xsl:6450
 msgid "Create a new schedule"
 msgstr "Neuen Zeitplan erstellen"
 
-#: classic/omp.xsl:6606
+#: classic/omp.xsl:6460
 msgid "Add results to Assets"
 msgstr "Ergebnisse zu Assets hinzufügen"
 
-#: classic/omp.xsl:6845 classic/omp.xsl:13182 classic/omp.xsl:13883
+#: classic/omp.xsl:6699 classic/omp.xsl:13085 classic/omp.xsl:13786
 #: classic/dynamic_strings.xsl:86
 msgid "Tag"
 msgstr "Tag"
 
-#: classic/omp.xsl:6977 classic/omp.xsl:8127 classic/omp.xsl:9096
-#: classic/omp.xsl:9692 classic/omp.xsl:12162 classic/omp.xsl:13234
-#: classic/omp.xsl:13831 classic/omp.xsl:15915 classic/omp.xsl:18420
-#: classic/omp.xsl:19244 classic/omp.xsl:20360 classic/omp.xsl:20758
-#: classic/omp.xsl:21177 classic/omp.xsl:21294 classic/omp.xsl:21407
-#: classic/omp.xsl:21519 classic/omp.xsl:21588 classic/omp.xsl:21642
-#: classic/omp.xsl:21718 classic/omp.xsl:24745 classic/omp.xsl:26047
-#: classic/omp.xsl:26493 classic/omp.xsl:27334 classic/omp.xsl:28148
-#: classic/omp.xsl:28912 classic/omp.xsl:32255 classic/omp.xsl:35212
-#: classic/omp.xsl:36549 classic/omp.xsl:39670 classic/omp.xsl:39805
+#: classic/omp.xsl:6831 classic/omp.xsl:7920 classic/omp.xsl:8891
+#: classic/omp.xsl:9437 classic/omp.xsl:12072 classic/omp.xsl:13137
+#: classic/omp.xsl:13734 classic/omp.xsl:15806 classic/omp.xsl:18313
+#: classic/omp.xsl:19139 classic/omp.xsl:20234 classic/omp.xsl:20504
+#: classic/omp.xsl:20621 classic/omp.xsl:20734 classic/omp.xsl:20846
+#: classic/omp.xsl:20915 classic/omp.xsl:20969 classic/omp.xsl:21045
+#: classic/omp.xsl:24101 classic/omp.xsl:25405 classic/omp.xsl:25853
+#: classic/omp.xsl:26691 classic/omp.xsl:27508 classic/omp.xsl:28272
+#: classic/omp.xsl:31619 classic/omp.xsl:34574 classic/omp.xsl:36058
+#: classic/omp.xsl:39182 classic/omp.xsl:39317
 msgid "Select for bulk action"
 msgstr "Für Mehrfachverabeitung auswählen"
 
-#: classic/omp.xsl:6985 classic/omp.xsl:6990 classic/omp.xsl:6996
-#: classic/omp.xsl:6998 classic/omp.xsl:7003 classic/omp.xsl:7005
+#: classic/omp.xsl:6839 classic/omp.xsl:6844 classic/omp.xsl:6850
+#: classic/omp.xsl:6852 classic/omp.xsl:6857 classic/omp.xsl:6859
 msgid "Compare"
 msgstr "Vergleichen"
 
-#: classic/omp.xsl:6986
+#: classic/omp.xsl:6840
 msgid "Report is already selected for delta"
 msgstr "Bericht ist bereits für Delta ausgewählt"
 
-#: classic/omp.xsl:6991
+#: classic/omp.xsl:6845
 msgid "Filter must be limited to a single Task to allow delta reports"
 msgstr ""
 "Filter muss auf eine einzige Aufgabe beschränkt sein, um Delta-Bereichte zu "
 "erlauben"
 
-#: classic/omp.xsl:7013
+#: classic/omp.xsl:6867
 msgid "Report is observed"
 msgstr "Bericht wird beobachtet"
 
-#: classic/omp.xsl:7019
+#: classic/omp.xsl:6873
 msgid "Scan is active"
 msgstr "Scan ist aktiv"
 
-#: classic/omp.xsl:7097
+#: classic/omp.xsl:6951
 msgid "Create a new scan config"
 msgstr "Neue Scan-Konfig erstellen"
 
-#: classic/omp.xsl:7109 classic/omp.xsl:7202 classic/omp.xsl:15256
-#: classic/omp.xsl:15292 classic/omp.xsl:15303 classic/omp.xsl:15330
-#: classic/omp.xsl:15358 classic/omp.xsl:15422
+#: classic/omp.xsl:6963 classic/omp.xsl:7056 classic/omp.xsl:15148
+#: classic/omp.xsl:15183 classic/omp.xsl:15194 classic/omp.xsl:15221
+#: classic/omp.xsl:15249 classic/omp.xsl:15313
 msgid "immutable"
 msgstr "nicht änderbar"
 
-#: classic/omp.xsl:7191
+#: classic/omp.xsl:7045
 msgid "Create a new scan target"
 msgstr "Neue Scan-Konfig erstellen"
 
-#: classic/omp.xsl:7329
-msgid "Create a slave"
-msgstr "Slave erstellen"
-
-#: classic/omp.xsl:7394
+#: classic/omp.xsl:7194
 msgctxt "Time"
 msgid "Periods"
 msgstr "Perioden"
 
-#: classic/omp.xsl:7407
+#: classic/omp.xsl:7207
 msgid "Create a schedule"
 msgstr "Zeitplan erstellen"
 
-#: classic/omp.xsl:7754 classic/dynamic_strings.xsl:604
+#: classic/omp.xsl:7580
+msgid "Edit Container Task"
+msgstr "Neue Container-Aufgabe"
+
+#: classic/omp.xsl:7583 classic/dynamic_strings.xsl:604
 msgid "Edit Task"
 msgstr "Aufgabe bearbeiten"
 
-#: classic/omp.xsl:7898
-msgid "Add Report"
-msgstr "Bericht hinzufügen"
-
-#: classic/omp.xsl:7957 classic/omp.xsl:7958
+#: classic/omp.xsl:7750 classic/omp.xsl:7751
 msgid "Task is alterable"
 msgstr "Aufgabe ist änderbar."
 
-#: classic/omp.xsl:7965 classic/omp.xsl:7966
-msgid "Task is configured to run on slave %1"
-msgstr "Aufgabe ist konfiguriert, um auf Slave %1 zu laufen"
+#: classic/omp.xsl:7758 classic/omp.xsl:7759
+msgid "Task is configured to run on slave scanner %1"
+msgstr "Aufgabe ist konfiguriert, auf Slave %1 zu laufen"
 
-#: classic/omp.xsl:7976
+#: classic/omp.xsl:7769
 msgid "Task made visible for Groups:"
 msgstr "Aufgabe sichtbar gemacht für die Gruppen:"
 
-#: classic/omp.xsl:7984
+#: classic/omp.xsl:7777
 msgid "Task made visible for Roles:"
 msgstr "Aufgabe sichtbar gemacht für die Rollen:"
 
-#: classic/omp.xsl:7991 classic/omp.xsl:7992
+#: classic/omp.xsl:7784 classic/omp.xsl:7785
 msgid "Task made visible for:"
 msgstr "Aufgabe sichtbar gemacht für:"
 
-#: classic/omp.xsl:8003 classic/omp.xsl:8004
+#: classic/omp.xsl:7796 classic/omp.xsl:7797
 msgid "Observing task owned by %1"
 msgstr "Beobachte Aufgabe von Besitzer %1"
 
-#: classic/omp.xsl:8035 classic/omp.xsl:8098
+#: classic/omp.xsl:7828 classic/omp.xsl:7891
 msgid "View last report for Task %1"
 msgstr "Letzten Bericht für Aufgabe %1"
 
-#: classic/omp.xsl:8054
+#: classic/omp.xsl:7847
 msgid "Go to the current report"
 msgstr "Zum aktuellen Bericht gehen"
 
-#: classic/omp.xsl:8085
+#: classic/omp.xsl:7878
 msgid "View list of all finished reports for Task %1"
 msgstr "Liste aller abgeschlossenen Berichte für Aufgabe %1"
 
-#: classic/omp.xsl:8089
+#: classic/omp.xsl:7882
 msgid "View list of all reports for Task %1, including unfinished ones"
 msgstr "Liste aller Berichte für Aufgabe %1, inklusive nicht abgeschlossener"
 
-#: classic/omp.xsl:8225 classic/omp.xsl:16068
+#: classic/omp.xsl:8018 classic/omp.xsl:15959
 msgid "and"
 msgstr "und"
 
-#: classic/omp.xsl:8230 classic/omp.xsl:12272 classic/omp.xsl:16071
-#: classic/omp.xsl:20432 classic/omp.xsl:20816
+#: classic/omp.xsl:8023 classic/omp.xsl:12182 classic/omp.xsl:15962
+#: classic/omp.xsl:20307
 msgctxt "Trashcan"
 msgid " must be restored first."
 msgstr " noch nicht wiederhergestellt."
 
-#: classic/omp.xsl:8319 classic/omp.xsl:35879
+#: classic/omp.xsl:8112 classic/omp.xsl:35404
 msgctxt "Task|Reports"
 msgid "Total"
 msgstr "Gesamt"
 
-#: classic/omp.xsl:8330 classic/omp.xsl:21957 classic/omp.xsl:22033
-#: classic/omp.xsl:22106 classic/omp.xsl:22183 classic/omp.xsl:22245
-#: classic/omp.xsl:22307 classic/omp.xsl:22369 classic/omp.xsl:29940
-#: classic/omp.xsl:32072
+#: classic/omp.xsl:8123 classic/omp.xsl:21287 classic/omp.xsl:21365
+#: classic/omp.xsl:21440 classic/omp.xsl:21519 classic/omp.xsl:21583
+#: classic/omp.xsl:21647 classic/omp.xsl:21711 classic/omp.xsl:29302
+#: classic/omp.xsl:31436
 msgctxt "Severity Short"
 msgid "Severity"
 msgstr "Schwereg."
 
-#: classic/omp.xsl:8390 classic/omp.xsl:17671 classic/omp.xsl:17765
-#: classic/omp.xsl:18267 classic/omp.xsl:18279 classic/omp.xsl:35719
-#: classic/omp.xsl:35721 classic/omp.xsl:35875
+#: classic/omp.xsl:8183 classic/omp.xsl:17562 classic/omp.xsl:17656
+#: classic/omp.xsl:18160 classic/omp.xsl:18172 classic/omp.xsl:35260
+#: classic/omp.xsl:35262 classic/omp.xsl:35400
 msgid "Trend"
 msgstr "Trend"
 
-#: classic/omp.xsl:8483 classic/dynamic_strings.xsl:396
+#: classic/omp.xsl:8278 classic/dynamic_strings.xsl:396
 msgid "New Credential"
 msgstr "Neue Anmeldedaten"
 
-#: classic/omp.xsl:8519 classic/omp.xsl:8774
+#: classic/omp.xsl:8314 classic/omp.xsl:8569
 msgid "Username + Password"
 msgstr "Benutzername + Passwort"
 
-#: classic/omp.xsl:8526 classic/omp.xsl:8779
+#: classic/omp.xsl:8321 classic/omp.xsl:8574
 msgid "Username + SSH Key"
 msgstr "Benutzername + SSH-Schlüssel"
 
-#: classic/omp.xsl:8533 classic/omp.xsl:8784 classic/omp.xsl:20179
+#: classic/omp.xsl:8328 classic/omp.xsl:8579 classic/omp.xsl:20053
 msgid "Client Certificate"
 msgstr "Client-Zertifikat"
 
-#: classic/omp.xsl:8540 classic/omp.xsl:8789 classic/omp.xsl:10402
-#: classic/omp.xsl:11274 classic/omp.xsl:11279 classic/omp.xsl:14846
-#: classic/omp.xsl:15218 classic/omp.xsl:15532 classic/omp.xsl:16286
+#: classic/omp.xsl:8335 classic/omp.xsl:8584 classic/omp.xsl:10151
+#: classic/omp.xsl:11103 classic/omp.xsl:11108 classic/omp.xsl:14739
+#: classic/omp.xsl:15110 classic/omp.xsl:15423 classic/omp.xsl:16177
 msgid "SNMP"
 msgstr "SNMP"
 
-#: classic/omp.xsl:8548 classic/omp.xsl:8693 classic/omp.xsl:8796
-#: classic/omp.xsl:9200 classic/omp.xsl:35750
+#: classic/omp.xsl:8343 classic/omp.xsl:8488 classic/omp.xsl:8591
+#: classic/omp.xsl:8995 classic/omp.xsl:35291
 msgid "Allow insecure use"
 msgstr "Unsichere Verwendung zulassen"
 
-#: classic/omp.xsl:8552 classic/omp.xsl:8567 classic/omp.xsl:8807
-#: classic/omp.xsl:9082 classic/omp.xsl:9128 classic/omp.xsl:9204
-#: classic/omp.xsl:13793 classic/omp.xsl:13943 classic/omp.xsl:13952
-#: classic/omp.xsl:14337 classic/omp.xsl:14493 classic/omp.xsl:14736
-#: classic/omp.xsl:14748 classic/omp.xsl:14979 classic/omp.xsl:14982
-#: classic/omp.xsl:15004 classic/omp.xsl:15007 classic/omp.xsl:15309
-#: classic/omp.xsl:15312 classic/omp.xsl:15336 classic/omp.xsl:15339
-#: classic/omp.xsl:16139 classic/omp.xsl:16148 classic/omp.xsl:37672
-#: classic/omp.xsl:38349
+#: classic/omp.xsl:8347 classic/omp.xsl:8362 classic/omp.xsl:8602
+#: classic/omp.xsl:8877 classic/omp.xsl:8923 classic/omp.xsl:8999
+#: classic/omp.xsl:13696 classic/omp.xsl:13846 classic/omp.xsl:13855
+#: classic/omp.xsl:14233 classic/omp.xsl:14389 classic/omp.xsl:14629
+#: classic/omp.xsl:14641 classic/omp.xsl:14871 classic/omp.xsl:14874
+#: classic/omp.xsl:14896 classic/omp.xsl:14899 classic/omp.xsl:15200
+#: classic/omp.xsl:15203 classic/omp.xsl:15227 classic/omp.xsl:15230
+#: classic/omp.xsl:16030 classic/omp.xsl:16039 classic/omp.xsl:37181
+#: classic/omp.xsl:37614 classic/omp.xsl:37849 classic/omp.xsl:38336
 msgid "Yes"
 msgstr "Ja"
 
-#: classic/omp.xsl:8556 classic/omp.xsl:8572 classic/omp.xsl:8818
-#: classic/omp.xsl:9085 classic/omp.xsl:9131 classic/omp.xsl:9207
-#: classic/omp.xsl:13790 classic/omp.xsl:13942 classic/omp.xsl:13951
-#: classic/omp.xsl:14348 classic/omp.xsl:14504 classic/omp.xsl:14740
-#: classic/omp.xsl:14752 classic/omp.xsl:14989 classic/omp.xsl:14992
-#: classic/omp.xsl:15014 classic/omp.xsl:15017 classic/omp.xsl:15319
-#: classic/omp.xsl:15322 classic/omp.xsl:15346 classic/omp.xsl:15349
-#: classic/omp.xsl:16140 classic/omp.xsl:16149 classic/omp.xsl:37671
-#: classic/omp.xsl:38344
+#: classic/omp.xsl:8351 classic/omp.xsl:8367 classic/omp.xsl:8613
+#: classic/omp.xsl:8880 classic/omp.xsl:8926 classic/omp.xsl:9002
+#: classic/omp.xsl:13693 classic/omp.xsl:13845 classic/omp.xsl:13854
+#: classic/omp.xsl:14244 classic/omp.xsl:14400 classic/omp.xsl:14633
+#: classic/omp.xsl:14645 classic/omp.xsl:14881 classic/omp.xsl:14884
+#: classic/omp.xsl:14906 classic/omp.xsl:14909 classic/omp.xsl:15210
+#: classic/omp.xsl:15213 classic/omp.xsl:15237 classic/omp.xsl:15240
+#: classic/omp.xsl:16031 classic/omp.xsl:16040 classic/omp.xsl:37180
+#: classic/omp.xsl:37611 classic/omp.xsl:37844 classic/omp.xsl:38341
 msgid "No"
 msgstr "Nein"
 
-#: classic/omp.xsl:8562
+#: classic/omp.xsl:8357
 msgid "Auto-generate"
 msgstr "Auto-generieren"
 
-#: classic/omp.xsl:8580 classic/omp.xsl:8824
+#: classic/omp.xsl:8375 classic/omp.xsl:8619
 msgid "SNMP Community"
 msgstr "SNMP-Community"
 
-#: classic/omp.xsl:8589 classic/omp.xsl:12647 classic/omp.xsl:12751
-#: classic/gsad.xsl:972
+#: classic/omp.xsl:8384 classic/omp.xsl:12557 classic/omp.xsl:12661
+#: classic/gsad.xsl:992
 msgid "Username"
 msgstr "Benutzername"
 
-#: classic/omp.xsl:8598 classic/omp.xsl:8854 classic/omp.xsl:36792
-#: classic/omp.xsl:37606 classic/omp.xsl:38222 classic/gsad.xsl:979
+#: classic/omp.xsl:8393 classic/omp.xsl:8649 classic/omp.xsl:36301
+#: classic/omp.xsl:37115 classic/omp.xsl:37722 classic/gsad.xsl:999
 msgid "Password"
 msgstr "Passwort"
 
-#: classic/omp.xsl:8607 classic/omp.xsl:8906
+#: classic/omp.xsl:8402 classic/omp.xsl:8701
 msgid "Passphrase"
 msgstr "Passphrase"
 
-#: classic/omp.xsl:8616 classic/omp.xsl:8872
+#: classic/omp.xsl:8411 classic/omp.xsl:8667
 msgid "Privacy Password"
 msgstr "Privacy-Passwort"
 
-#: classic/omp.xsl:8625 classic/omp.xsl:8890 classic/omp.xsl:9240
+#: classic/omp.xsl:8420 classic/omp.xsl:8685 classic/omp.xsl:9035
 msgid "Certificate"
 msgstr "Zertifikat"
 
-#: classic/omp.xsl:8632
+#: classic/omp.xsl:8427
 msgid "Private Key"
 msgstr "Privater Schlüssel"
 
-#: classic/omp.xsl:8639 classic/omp.xsl:8924 classic/omp.xsl:9220
+#: classic/omp.xsl:8434 classic/omp.xsl:8719 classic/omp.xsl:9015
 msgid "Auth Algorithm"
 msgstr "Auth-Algorithmus"
 
-#: classic/omp.xsl:8653 classic/omp.xsl:8953 classic/omp.xsl:9224
+#: classic/omp.xsl:8448 classic/omp.xsl:8748 classic/omp.xsl:9019
 msgid "Privacy Algorithm"
 msgstr "Privacy-Algorithmus"
 
-#: classic/omp.xsl:8665 classic/omp.xsl:8986 classic/omp.xsl:9231
+#: classic/omp.xsl:8460 classic/omp.xsl:8781 classic/omp.xsl:9026
 msgctxt "Privacy Algorithm"
 msgid "None"
 msgstr "Keiner"
 
-#: classic/omp.xsl:8697 classic/omp.xsl:8842 classic/omp.xsl:9214
-#: classic/omp.xsl:20574 classic/omp.xsl:20889 classic/omp.xsl:35751
-#: classic/omp.xsl:35828
+#: classic/omp.xsl:8492 classic/omp.xsl:8637 classic/omp.xsl:9009
+#: classic/omp.xsl:35292
 msgctxt "Auth Data"
 msgid "Login"
 msgstr "Anmeldename"
 
-#: classic/omp.xsl:8739 classic/dynamic_strings.xsl:609
+#: classic/omp.xsl:8534 classic/dynamic_strings.xsl:609
 msgid "Edit Credential"
 msgstr "Anmeldedaten bearbeiten"
 
-#: classic/omp.xsl:8829 classic/omp.xsl:8859 classic/omp.xsl:8877
-#: classic/omp.xsl:8911 classic/omp.xsl:16999
+#: classic/omp.xsl:8624 classic/omp.xsl:8654 classic/omp.xsl:8672
+#: classic/omp.xsl:8706 classic/omp.xsl:16890
 msgctxt "Auth Data|Password"
 msgid "Replace existing value with"
 msgstr "Vorhandenen Wert ersetzen durch"
 
-#: classic/omp.xsl:8898
+#: classic/omp.xsl:8693
 msgid "Private key"
 msgstr "Privater Schlüssel"
 
-#: classic/omp.xsl:9021
+#: classic/omp.xsl:8816
 msgctxt "Action Verb"
 msgid "Download RPM package"
 msgstr "RPM-Paket herunterladen"
 
-#: classic/omp.xsl:9023
+#: classic/omp.xsl:8818
 msgctxt "Action Verb"
 msgid "Download RPM"
 msgstr "RPM herunterladen"
 
-#: classic/omp.xsl:9028
+#: classic/omp.xsl:8823
 msgctxt "Action Verb"
 msgid "Download Debian package"
 msgstr "Debian-Paket herunterladen"
 
-#: classic/omp.xsl:9030
+#: classic/omp.xsl:8825
 msgctxt "Action Verb"
 msgid "Download Deb"
 msgstr "Deb herunterladen"
 
-#: classic/omp.xsl:9035
+#: classic/omp.xsl:8830
 msgctxt "Action Verb"
 msgid "Download Exe package"
 msgstr "Exe-Paket herunterladen"
 
-#: classic/omp.xsl:9037
+#: classic/omp.xsl:8832
 msgctxt "Action Verb"
 msgid "Download Exe"
 msgstr "Exe herunterladen"
 
-#: classic/omp.xsl:9042 classic/omp.xsl:9044
+#: classic/omp.xsl:8837 classic/omp.xsl:8839
 msgctxt "Action Verb"
 msgid "Download Public Key"
 msgstr "Öffentlichen Schlüssel herunterladen"
 
-#: classic/omp.xsl:9049 classic/omp.xsl:9051 classic/omp.xsl:34299
-#: classic/omp.xsl:34301 classic/omp.xsl:34325 classic/omp.xsl:34327
+#: classic/omp.xsl:8844 classic/omp.xsl:8846 classic/omp.xsl:33672
+#: classic/omp.xsl:33674 classic/omp.xsl:33698 classic/omp.xsl:33700
 msgctxt "Action Verb"
 msgid "Download Certificate"
 msgstr "Zertifikat herunterladen"
 
-#: classic/omp.xsl:9154 classic/dynamic_strings.xsl:419
+#: classic/omp.xsl:8949 classic/dynamic_strings.xsl:419
 msgid "Credential is still in use"
 msgstr "Anmeldedaten werden noch verwendet"
 
-#: classic/omp.xsl:9177 classic/omp.xsl:15661 classic/omp.xsl:16066
-#: classic/omp.xsl:35859 classic/omp.xsl:36098 classic/dynamic_strings.xsl:107
-#: classic/gsad.xsl:548
+#: classic/omp.xsl:8972 classic/omp.xsl:15552 classic/omp.xsl:15957
+#: classic/omp.xsl:35384 classic/omp.xsl:35616 classic/dynamic_strings.xsl:107
+#: classic/gsad.xsl:555
 msgid "Credentials"
 msgstr "Anmeldedaten"
 
-#: classic/omp.xsl:9180 classic/omp.xsl:10695 classic/omp.xsl:10801
-#: classic/omp.xsl:11685 classic/omp.xsl:11820 classic/omp.xsl:12638
-#: classic/omp.xsl:12742 classic/omp.xsl:13077 classic/omp.xsl:14068
-#: classic/omp.xsl:19560 classic/omp.xsl:19764 classic/omp.xsl:19776
-#: classic/omp.xsl:20075 classic/omp.xsl:20432 classic/omp.xsl:20511
-#: classic/omp.xsl:20570 classic/omp.xsl:20683 classic/omp.xsl:20816
-#: classic/omp.xsl:20874 classic/omp.xsl:35796 classic/omp.xsl:35827
-#: classic/dynamic_strings.xsl:75
+#: classic/omp.xsl:8975 classic/omp.xsl:10444 classic/omp.xsl:10550
+#: classic/omp.xsl:10630 classic/omp.xsl:11514 classic/omp.xsl:11649
+#: classic/omp.xsl:11791 classic/omp.xsl:12548 classic/omp.xsl:12652
+#: classic/omp.xsl:12987 classic/omp.xsl:13971 classic/omp.xsl:19455
+#: classic/omp.xsl:19649 classic/omp.xsl:19661 classic/omp.xsl:19949
+#: classic/omp.xsl:20307 classic/omp.xsl:35337 classic/dynamic_strings.xsl:75
 msgid "Credential"
 msgstr "Anmeldedaten"
 
-#: classic/omp.xsl:9256 classic/omp.xsl:20469 classic/omp.xsl:20470
-#: classic/omp.xsl:20850 classic/omp.xsl:20903 classic/omp.xsl:36197
-#: classic/dynamic_strings.xsl:114 classic/gsad.xsl:579
-msgid "Slaves"
-msgstr "Slaves"
-
-#: classic/omp.xsl:9259
-msgid "Slaves using this Credential"
-msgstr "Slaves, die diese Anmeldedaten verwenden"
-
-#: classic/omp.xsl:9266 classic/omp.xsl:9315 classic/omp.xsl:9364
-#: classic/omp.xsl:12935 classic/omp.xsl:13352 classic/omp.xsl:16332
-#: classic/omp.xsl:17988 classic/omp.xsl:18015 classic/omp.xsl:18042
-#: classic/omp.xsl:18075 classic/omp.xsl:19470 classic/omp.xsl:20214
-#: classic/omp.xsl:20913 classic/omp.xsl:28257 classic/omp.xsl:28301
-#: classic/omp.xsl:29263 classic/omp.xsl:29292
-msgid "none"
-msgstr "keine"
-
-#: classic/omp.xsl:9280 classic/omp.xsl:9330 classic/omp.xsl:9381
-#: classic/omp.xsl:12521 classic/omp.xsl:12541 classic/omp.xsl:12892
-#: classic/omp.xsl:12950 classic/omp.xsl:13367 classic/omp.xsl:16347
-#: classic/omp.xsl:18090 classic/omp.xsl:19485 classic/omp.xsl:20229
-#: classic/omp.xsl:20929 classic/omp.xsl:27403 classic/omp.xsl:27431
-#: classic/omp.xsl:28316 classic/omp.xsl:29307 classic/omp.xsl:36625
-#: classic/omp.xsl:36643
-msgid "UUID"
-msgstr "UUID"
-
-#: classic/omp.xsl:9285 classic/dynamic_strings.xsl:196
-msgid "Slave Details"
-msgstr "Slave-Details"
-
-#: classic/omp.xsl:9305 classic/omp.xsl:9354 classic/omp.xsl:14586
-#: classic/omp.xsl:14587 classic/omp.xsl:16112 classic/omp.xsl:28291
-#: classic/omp.xsl:36215 classic/dynamic_strings.xsl:105 classic/gsad.xsl:536
+#: classic/omp.xsl:9050 classic/omp.xsl:9099 classic/omp.xsl:14482
+#: classic/omp.xsl:14483 classic/omp.xsl:16003 classic/omp.xsl:27651
+#: classic/omp.xsl:35724 classic/dynamic_strings.xsl:105 classic/gsad.xsl:543
 msgid "Targets"
 msgstr "Ziele"
 
-#: classic/omp.xsl:9308
+#: classic/omp.xsl:9053
 msgid "Targets using this Credential"
 msgstr "Ziele, die diese Anmeldedaten verwenden"
 
-#: classic/omp.xsl:9335 classic/dynamic_strings.xsl:189
+#: classic/omp.xsl:9060 classic/omp.xsl:9109 classic/omp.xsl:12845
+#: classic/omp.xsl:13255 classic/omp.xsl:16223 classic/omp.xsl:17881
+#: classic/omp.xsl:17908 classic/omp.xsl:17935 classic/omp.xsl:17968
+#: classic/omp.xsl:19365 classic/omp.xsl:20088 classic/omp.xsl:27617
+#: classic/omp.xsl:27661 classic/omp.xsl:28623 classic/omp.xsl:28652
+msgid "none"
+msgstr "keine"
+
+#: classic/omp.xsl:9075 classic/omp.xsl:9126 classic/omp.xsl:12431
+#: classic/omp.xsl:12451 classic/omp.xsl:12802 classic/omp.xsl:12860
+#: classic/omp.xsl:13270 classic/omp.xsl:16238 classic/omp.xsl:17983
+#: classic/omp.xsl:19380 classic/omp.xsl:20103 classic/omp.xsl:26760
+#: classic/omp.xsl:26788 classic/omp.xsl:27676 classic/omp.xsl:28667
+#: classic/omp.xsl:36134 classic/omp.xsl:36152
+msgid "UUID"
+msgstr "UUID"
+
+#: classic/omp.xsl:9080 classic/dynamic_strings.xsl:189
 msgid "Target Details"
 msgstr "Ziel-Details"
 
-#: classic/omp.xsl:9357
+#: classic/omp.xsl:9102
 msgid "Scanners using this Credential"
 msgstr "Scanner, die diese Anmeldedaten verwenden"
 
-#: classic/omp.xsl:9386 classic/omp.xsl:17964 classic/dynamic_strings.xsl:198
+#: classic/omp.xsl:9131 classic/omp.xsl:17857 classic/dynamic_strings.xsl:198
 msgid "Scanner Details"
 msgstr "Scanner-Details"
 
-#: classic/omp.xsl:9456 classic/omp.xsl:9458 classic/dynamic_strings.xsl:402
+#: classic/omp.xsl:9201 classic/omp.xsl:9203 classic/dynamic_strings.xsl:402
 msgid "New Agent"
 msgstr "Neuer Agent"
 
-#: classic/omp.xsl:9464 classic/omp.xsl:9465 classic/omp.xsl:36071
-#: classic/dynamic_strings.xsl:115 classic/gsad.xsl:585
+#: classic/omp.xsl:9209 classic/omp.xsl:9210 classic/omp.xsl:35589
+#: classic/dynamic_strings.xsl:115 classic/gsad.xsl:586
 msgid "Agents"
 msgstr "Agenten"
 
-#: classic/omp.xsl:9491
+#: classic/omp.xsl:9236
 msgid "Installer"
 msgstr "Installationsprogramm"
 
-#: classic/omp.xsl:9495
+#: classic/omp.xsl:9240
 msgid "Installer signature"
 msgstr "Installationsprogramm-Signatur"
 
-#: classic/omp.xsl:9510
+#: classic/omp.xsl:9255
 msgid "Create Agent"
 msgstr "Agent erstellen"
 
-#: classic/omp.xsl:9541 classic/omp.xsl:9791 classic/omp.xsl:29223
-#: classic/omp.xsl:35700
+#: classic/omp.xsl:9286 classic/omp.xsl:9537 classic/omp.xsl:28583
+#: classic/omp.xsl:35241
 msgid "Trust"
 msgstr "Vertrauen"
 
-#: classic/omp.xsl:9555 classic/dynamic_strings.xsl:615
+#: classic/omp.xsl:9300 classic/dynamic_strings.xsl:615
 msgid "Edit Agent"
 msgstr "Agent bearbeiten"
 
-#: classic/omp.xsl:9591
+#: classic/omp.xsl:9336
 msgid "Save Agent"
 msgstr "Agent speichern"
 
-#: classic/omp.xsl:9704
+#: classic/omp.xsl:9449
 msgid "Download installer package"
 msgstr "Installationspaket herunterladen"
 
-#: classic/omp.xsl:9705
+#: classic/omp.xsl:9450
 msgid "Download Installer"
 msgstr "Installer herunterladen"
 
-#: classic/omp.xsl:9707
+#: classic/omp.xsl:9452
 msgid "Verifying Agent..."
 msgstr "Agent wird verifiziert..."
 
-#: classic/omp.xsl:9708
+#: classic/omp.xsl:9453
 msgid "Verify Agent"
 msgstr "Agent verifizieren"
 
-#: classic/omp.xsl:9716 classic/omp.xsl:12186 classic/omp.xsl:28935
-#: classic/omp.xsl:33921 classic/omp.xsl:33949 classic/omp.xsl:34286
+#: classic/omp.xsl:9462 classic/omp.xsl:12096 classic/omp.xsl:28295
+#: classic/omp.xsl:33288 classic/omp.xsl:33316 classic/omp.xsl:33659
 msgid "Success"
 msgstr "Erfolg"
 
-#: classic/omp.xsl:9718
+#: classic/omp.xsl:9464
 msgid "Agent has been verified."
 msgstr "Agent wurde verifiziert"
 
-#: classic/omp.xsl:9723
+#: classic/omp.xsl:9469
 msgid "Agent could not be verified."
 msgstr "Agent konnte nicht verifiziert werden."
 
-#: classic/omp.xsl:9773 classic/dynamic_strings.xsl:197
+#: classic/omp.xsl:9519 classic/dynamic_strings.xsl:197
 msgid "Agent Details"
 msgstr "Agenten-Details"
 
-#: classic/omp.xsl:10066 classic/omp.xsl:10074
+#: classic/omp.xsl:9812 classic/omp.xsl:9820
 msgid "Always"
 msgstr "Immer"
 
-#: classic/omp.xsl:10088
+#: classic/omp.xsl:9834
 msgid "Severity at least"
 msgstr "Schweregrad mindestens"
 
-#: classic/omp.xsl:10114
+#: classic/omp.xsl:9860
 msgid "Severity level"
 msgstr "Schwereniveau"
 
-#: classic/omp.xsl:10123
+#: classic/omp.xsl:9869
 msgctxt "Alert Condition|Severity"
 msgid "changed"
 msgstr "verändert"
 
-#: classic/omp.xsl:10128
+#: classic/omp.xsl:9874
 msgctxt "Alert Condition|Severity"
 msgid "increased"
 msgstr "gestiegen"
 
-#: classic/omp.xsl:10133
+#: classic/omp.xsl:9879
 msgctxt "Alert Condition|Severity"
 msgid "decreased"
 msgstr "gesunken"
 
-#: classic/omp.xsl:10145 classic/omp.xsl:10223
+#: classic/omp.xsl:9891 classic/omp.xsl:9969
 msgctxt "Alert Condition"
 msgid "Filter "
 msgstr "Filter "
 
-#: classic/omp.xsl:10186 classic/omp.xsl:10243
+#: classic/omp.xsl:9932 classic/omp.xsl:9989
 msgctxt "Alert Condition"
 msgid " matches at least "
 msgstr " passt zu mindestens "
 
-#: classic/omp.xsl:10207
+#: classic/omp.xsl:9953
 msgid "result(s)"
 msgstr "Ergebnis(sen)"
 
-#: classic/omp.xsl:10212
+#: classic/omp.xsl:9958
 msgid "NVT(s)"
 msgstr "NVT(s)"
 
-#: classic/omp.xsl:10260
+#: classic/omp.xsl:10006
 msgctxt "Alert Condition"
 msgid " result(s) more than previous scan"
 msgstr " Ergebnis(sen) mehr als der vorherige Scan"
 
-#: classic/omp.xsl:10271 classic/dynamic_strings.xsl:398
+#: classic/omp.xsl:10017 classic/dynamic_strings.xsl:398
 msgid "New Alert"
 msgstr "Neue Benachrichtigung"
 
-#: classic/omp.xsl:10297 classic/omp.xsl:10910 classic/omp.xsl:11000
-#: classic/omp.xsl:12410 classic/omp.xsl:35733
+#: classic/omp.xsl:10043 classic/omp.xsl:10726 classic/omp.xsl:10816
+#: classic/omp.xsl:12320 classic/omp.xsl:35274
 msgid "Event"
 msgstr "Ereignis"
 
-#: classic/omp.xsl:10304 classic/omp.xsl:11014
+#: classic/omp.xsl:10050 classic/omp.xsl:10830
 msgid "Task run status changed to"
 msgstr "Status der Aufgabe hat sich geändert zu"
 
-#: classic/omp.xsl:10309 classic/omp.xsl:11034 classic/dynamic_strings.xsl:916
+#: classic/omp.xsl:10055 classic/omp.xsl:10850 classic/dynamic_strings.xsl:916
 msgctxt "Status"
 msgid "Done"
 msgstr "Abgeschlossen"
 
-#: classic/omp.xsl:10310 classic/omp.xsl:10327 classic/omp.xsl:11039
-#: classic/omp.xsl:11076 classic/omp.xsl:11087 classic/omp.xsl:11098
+#: classic/omp.xsl:10056 classic/omp.xsl:10073 classic/omp.xsl:10855
+#: classic/omp.xsl:10892 classic/omp.xsl:10903 classic/omp.xsl:10914
 #: classic/dynamic_strings.xsl:917
 msgctxt "Status"
 msgid "New"
 msgstr "Neu"
 
-#: classic/omp.xsl:10311 classic/omp.xsl:11044
+#: classic/omp.xsl:10057 classic/omp.xsl:10860
 msgctxt "Status"
 msgid "Requested"
 msgstr "Angefordert"
 
-#: classic/omp.xsl:10312 classic/omp.xsl:11049 classic/dynamic_strings.xsl:918
+#: classic/omp.xsl:10058 classic/omp.xsl:10865 classic/dynamic_strings.xsl:918
 msgctxt "Status"
 msgid "Running"
 msgstr "Läuft gerade"
 
-#: classic/omp.xsl:10313 classic/omp.xsl:11054
+#: classic/omp.xsl:10059 classic/omp.xsl:10870
 msgctxt "Status"
 msgid "Stop Requested"
 msgstr "Stopp Angefordert"
 
-#: classic/omp.xsl:10314 classic/omp.xsl:11059 classic/dynamic_strings.xsl:919
+#: classic/omp.xsl:10060 classic/omp.xsl:10875 classic/dynamic_strings.xsl:919
 msgctxt "Status"
 msgid "Stopped"
 msgstr "Gestoppt"
 
-#: classic/omp.xsl:10328 classic/omp.xsl:11077 classic/omp.xsl:11088
-#: classic/omp.xsl:11099
+#: classic/omp.xsl:10074 classic/omp.xsl:10893 classic/omp.xsl:10904
+#: classic/omp.xsl:10915
 msgctxt "Status"
 msgid "Updated"
 msgstr "Aktualisiert"
 
-#: classic/omp.xsl:10333 classic/omp.xsl:11112 classic/omp.xsl:18272
-#: classic/omp.xsl:23861 classic/omp.xsl:23862 classic/omp.xsl:23903
-#: classic/omp.xsl:35714 classic/dynamic_strings.xsl:98 classic/gsad.xsl:497
+#: classic/omp.xsl:10079 classic/omp.xsl:10928 classic/omp.xsl:18165
+#: classic/omp.xsl:23217 classic/omp.xsl:23218 classic/omp.xsl:23259
+#: classic/omp.xsl:35255 classic/dynamic_strings.xsl:98 classic/gsad.xsl:504
 msgid "NVTs"
 msgstr "NVTs"
 
-#: classic/omp.xsl:10334 classic/omp.xsl:11117 classic/omp.xsl:21953
-#: classic/omp.xsl:22179 classic/omp.xsl:22241 classic/omp.xsl:22303
-#: classic/omp.xsl:22528 classic/omp.xsl:22529 classic/omp.xsl:22565
-#: classic/omp.xsl:29795 classic/dynamic_strings.xsl:99 classic/gsad.xsl:501
+#: classic/omp.xsl:10080 classic/omp.xsl:10933 classic/omp.xsl:21283
+#: classic/omp.xsl:21515 classic/omp.xsl:21579 classic/omp.xsl:21643
+#: classic/omp.xsl:21870 classic/omp.xsl:21871 classic/omp.xsl:21907
+#: classic/omp.xsl:29155 classic/dynamic_strings.xsl:99 classic/gsad.xsl:508
 msgid "CVEs"
 msgstr "CVEs"
 
-#: classic/omp.xsl:10335 classic/omp.xsl:11122 classic/omp.xsl:22820
-#: classic/omp.xsl:22821 classic/omp.xsl:22854 classic/dynamic_strings.xsl:100
-#: classic/gsad.xsl:505
+#: classic/omp.xsl:10081 classic/omp.xsl:10938 classic/omp.xsl:22162
+#: classic/omp.xsl:22163 classic/omp.xsl:22196 classic/dynamic_strings.xsl:100
+#: classic/gsad.xsl:512
 msgid "CPEs"
 msgstr "CPEs"
 
-#: classic/omp.xsl:10336 classic/omp.xsl:11127 classic/omp.xsl:23236
-#: classic/omp.xsl:23237 classic/omp.xsl:23262 classic/dynamic_strings.xsl:102
-#: classic/gsad.xsl:513
+#: classic/omp.xsl:10082 classic/omp.xsl:10943 classic/omp.xsl:22578
+#: classic/omp.xsl:22579 classic/omp.xsl:22604 classic/dynamic_strings.xsl:102
+#: classic/gsad.xsl:520
 msgid "CERT-Bund Advisories"
 msgstr "CERT-Bund-Advisories"
 
-#: classic/omp.xsl:10337 classic/omp.xsl:11132 classic/omp.xsl:23425
-#: classic/omp.xsl:23426 classic/omp.xsl:23451 classic/dynamic_strings.xsl:103
-#: classic/gsad.xsl:517
+#: classic/omp.xsl:10083 classic/omp.xsl:10948 classic/omp.xsl:22777
+#: classic/omp.xsl:22778 classic/omp.xsl:22803 classic/dynamic_strings.xsl:103
+#: classic/gsad.xsl:524
 msgid "DFN-CERT Advisories"
 msgstr "DFN-CERT-Advisories"
 
-#: classic/omp.xsl:10338 classic/omp.xsl:14124 classic/omp.xsl:23000
+#: classic/omp.xsl:10084 classic/omp.xsl:14027 classic/omp.xsl:22342
 #: classic/dynamic_strings.xsl:70
 msgid "OVAL Definition"
 msgstr "OVAL-Definition"
 
-#: classic/omp.xsl:10341 classic/omp.xsl:11142
+#: classic/omp.xsl:10087 classic/omp.xsl:10958
 msgctxt "Alert Condition"
 msgid "arrived"
 msgstr "eingetroffen"
 
-#: classic/omp.xsl:10347 classic/omp.xsl:10914 classic/omp.xsl:11149
-#: classic/omp.xsl:12404 classic/omp.xsl:35734
+#: classic/omp.xsl:10093 classic/omp.xsl:10730 classic/omp.xsl:10965
+#: classic/omp.xsl:12314 classic/omp.xsl:35275
 msgid "Condition"
 msgstr "Bedingung"
 
-#: classic/omp.xsl:10359 classic/omp.xsl:11171
+#: classic/omp.xsl:10105 classic/omp.xsl:10987
 msgid "Report Result Filter"
 msgstr "Ergebnisfilter für Bericht"
 
-#: classic/omp.xsl:10373 classic/omp.xsl:11192 classic/omp.xsl:12880
+#: classic/omp.xsl:10119 classic/omp.xsl:11008 classic/omp.xsl:12790
 msgid "Details URL"
 msgstr "Details-URL"
 
-#: classic/omp.xsl:10385 classic/omp.xsl:10918 classic/omp.xsl:11214
-#: classic/omp.xsl:12437 classic/omp.xsl:31530 classic/omp.xsl:35735
+#: classic/omp.xsl:10131 classic/omp.xsl:10734 classic/omp.xsl:11030
+#: classic/omp.xsl:12347 classic/omp.xsl:30892 classic/omp.xsl:35276
 msgid "Method"
 msgstr "Methode"
 
-#: classic/omp.xsl:10389 classic/omp.xsl:11220 classic/omp.xsl:11225
+#: classic/omp.xsl:10135 classic/omp.xsl:11036 classic/omp.xsl:11041
 msgid "Email"
 msgstr "E-Mail"
 
-#: classic/omp.xsl:10393 classic/omp.xsl:11234 classic/omp.xsl:11240
+#: classic/omp.xsl:10139 classic/omp.xsl:11050 classic/omp.xsl:11056
 msgid "HTTP Get"
 msgstr "HTTP-Get"
 
-#: classic/omp.xsl:10396 classic/omp.xsl:11248 classic/omp.xsl:11253
+#: classic/omp.xsl:10142 classic/omp.xsl:11064 classic/omp.xsl:11069
 msgid "SCP"
 msgstr "SCP"
 
-#: classic/omp.xsl:10399 classic/omp.xsl:10762 classic/omp.xsl:11261
-#: classic/omp.xsl:11266 classic/omp.xsl:11770
+#: classic/omp.xsl:10145 classic/omp.xsl:10511 classic/omp.xsl:11077
+#: classic/omp.xsl:11082 classic/omp.xsl:11599
 msgid "Send to host "
 msgstr "Sende an Host "
 
-#: classic/omp.xsl:10406 classic/omp.xsl:11288 classic/omp.xsl:11294
+#: classic/omp.xsl:10148 classic/omp.xsl:11090 classic/omp.xsl:11095
+#: classic/omp.xsl:14709 classic/omp.xsl:15046 classic/omp.xsl:15366
+#: classic/omp.xsl:16123
+msgid "SMB"
+msgstr "SMB"
+
+#: classic/omp.xsl:10155 classic/omp.xsl:11117 classic/omp.xsl:11123
 msgid "Sourcefire Connector"
 msgstr "Sourcefire-Schnittstelle"
 
-#: classic/omp.xsl:10410 classic/omp.xsl:10745 classic/omp.xsl:11303
-#: classic/omp.xsl:11309 classic/omp.xsl:11744
+#: classic/omp.xsl:10159 classic/omp.xsl:10494 classic/omp.xsl:11132
+#: classic/omp.xsl:11138 classic/omp.xsl:11573
 msgid "Start Task"
 msgstr "Aufgabe starten"
 
-#: classic/omp.xsl:10413 classic/omp.xsl:11317 classic/omp.xsl:11322
+#: classic/omp.xsl:10162 classic/omp.xsl:11146 classic/omp.xsl:11151
 msgid "System Logger"
 msgstr "System-Logger"
 
-#: classic/omp.xsl:10417 classic/omp.xsl:11331 classic/omp.xsl:11337
+#: classic/omp.xsl:10166 classic/omp.xsl:11160 classic/omp.xsl:11166
 msgid "verinice.PRO Connector"
 msgstr "verinice.PRO-Konnektor"
 
-#: classic/omp.xsl:10426 classic/omp.xsl:11348 classic/omp.xsl:12462
+#: classic/omp.xsl:10175 classic/omp.xsl:11177 classic/omp.xsl:12372
 msgctxt "Alert|Email"
 msgid "To Address"
 msgstr "An Adresse"
 
-#: classic/omp.xsl:10436 classic/omp.xsl:11359 classic/omp.xsl:12473
+#: classic/omp.xsl:10185 classic/omp.xsl:11188 classic/omp.xsl:12383
 msgctxt "Alert|Email"
 msgid "From Address"
 msgstr "Von Adresse"
 
-#: classic/omp.xsl:10446 classic/omp.xsl:11370 classic/omp.xsl:12558
+#: classic/omp.xsl:10195 classic/omp.xsl:11199 classic/omp.xsl:12468
 msgctxt "Alert|Email"
 msgid "Subject"
 msgstr "Subjekt"
 
-#: classic/omp.xsl:10468 classic/omp.xsl:11412 classic/omp.xsl:12486
-#: classic/omp.xsl:12505
+#: classic/omp.xsl:10217 classic/omp.xsl:11241 classic/omp.xsl:12396
+#: classic/omp.xsl:12415
 msgctxt "Alert|Email"
 msgid "Content"
 msgstr "Inhalt"
 
-#: classic/omp.xsl:10473 classic/omp.xsl:11417 classic/omp.xsl:12496
-#: classic/omp.xsl:12549
+#: classic/omp.xsl:10222 classic/omp.xsl:11246 classic/omp.xsl:12406
+#: classic/omp.xsl:12459
 msgctxt "Alert|Email"
 msgid "Simple notice"
 msgstr "Einfache Benachrichtigung"
 
-#: classic/omp.xsl:10483 classic/omp.xsl:11436 classic/omp.xsl:12509
+#: classic/omp.xsl:10232 classic/omp.xsl:11265 classic/omp.xsl:12419
 msgctxt "Alert|Email"
 msgid "Include report"
 msgstr "Bericht integrieren"
 
-#: classic/omp.xsl:10488 classic/omp.xsl:11441 classic/omp.xsl:12490
+#: classic/omp.xsl:10237 classic/omp.xsl:11270 classic/omp.xsl:12400
 msgctxt "Alert|Email"
 msgid "Include list of resources"
 msgstr "Ressourcenliste einbinden"
 
-#: classic/omp.xsl:10540 classic/omp.xsl:11513 classic/omp.xsl:12529
+#: classic/omp.xsl:10289 classic/omp.xsl:11342 classic/omp.xsl:12439
 msgctxt "Alert|Email"
 msgid "Attach report"
 msgstr "Bericht anhängen"
 
-#: classic/omp.xsl:10544 classic/omp.xsl:11517 classic/omp.xsl:12493
+#: classic/omp.xsl:10293 classic/omp.xsl:11346 classic/omp.xsl:12403
 msgctxt "Alert|Email"
 msgid "Attach list of resources"
 msgstr "Ressourcenliste anhängen"
 
-#: classic/omp.xsl:10602 classic/omp.xsl:11616
+#: classic/omp.xsl:10351 classic/omp.xsl:11445
 msgid "HTTP Get URL"
 msgstr "HTTP-Get-URL"
 
-#: classic/omp.xsl:10615 classic/omp.xsl:11918
+#: classic/omp.xsl:10364 classic/omp.xsl:11747
 msgctxt "SNMP"
 msgid "Community"
 msgstr "Community"
 
-#: classic/omp.xsl:10626 classic/omp.xsl:11930 classic/omp.xsl:13056
-#: classic/omp.xsl:14033 classic/dynamic_strings.xsl:83
+#: classic/omp.xsl:10375 classic/omp.xsl:11759 classic/omp.xsl:12966
+#: classic/omp.xsl:13936 classic/dynamic_strings.xsl:83
 msgid "Agent"
 msgstr "Agent"
 
-#: classic/omp.xsl:10637 classic/omp.xsl:11942 classic/omp.xsl:12569
+#: classic/omp.xsl:10386 classic/omp.xsl:11771 classic/omp.xsl:12479
 msgid "Message"
 msgstr "Nachricht"
 
-#: classic/omp.xsl:10649 classic/omp.xsl:11629 classic/omp.xsl:12603
+#: classic/omp.xsl:10398 classic/omp.xsl:11458 classic/omp.xsl:12513
 msgid "Defense Center IP"
 msgstr "Defense Center IP"
 
-#: classic/omp.xsl:10661 classic/omp.xsl:11642 classic/omp.xsl:12614
+#: classic/omp.xsl:10410 classic/omp.xsl:11471 classic/omp.xsl:12524
 msgid "Defense Center Port"
 msgstr "Defense Center Port"
 
-#: classic/omp.xsl:10672 classic/omp.xsl:11662
+#: classic/omp.xsl:10421 classic/omp.xsl:11491
 msgid "PKCS12 file"
 msgstr "PKCS12-Datei"
 
-#: classic/omp.xsl:10683 classic/omp.xsl:11673
+#: classic/omp.xsl:10432 classic/omp.xsl:11502
 msgid "verinice.PRO URL"
 msgstr "verinice.PRO-URL"
 
-#: classic/omp.xsl:10706 classic/omp.xsl:10812 classic/omp.xsl:11705
-#: classic/omp.xsl:11840 classic/omp.xsl:19572 classic/omp.xsl:19789
-#: classic/omp.xsl:20523 classic/omp.xsl:20695
+#: classic/omp.xsl:10455 classic/omp.xsl:10561 classic/omp.xsl:10641
+#: classic/omp.xsl:11534 classic/omp.xsl:11669 classic/omp.xsl:11811
+#: classic/omp.xsl:19467 classic/omp.xsl:19674
 msgid "Create a new Credential"
 msgstr "Neue Anmeldedaten erstellen"
 
-#: classic/omp.xsl:10715 classic/omp.xsl:11714
+#: classic/omp.xsl:10464 classic/omp.xsl:11543
 msgid "verinice.PRO Report"
 msgstr "verinice.PRO-Bericht"
 
-#: classic/omp.xsl:10771 classic/omp.xsl:11780
+#: classic/omp.xsl:10520 classic/omp.xsl:11609
 msgid " on port "
 msgstr " auf Port "
 
-#: classic/omp.xsl:10832 classic/omp.xsl:11861 classic/omp.xsl:12778
+#: classic/omp.xsl:10581 classic/omp.xsl:11690 classic/omp.xsl:12688
 msgid "Known Hosts"
 msgstr "Bekannte Hosts"
 
-#: classic/omp.xsl:10844 classic/omp.xsl:11874 classic/omp.xsl:12807
+#: classic/omp.xsl:10593 classic/omp.xsl:11703 classic/omp.xsl:12717
 msgid "Path"
 msgstr "Pfad"
 
-#: classic/omp.xsl:10962 classic/dynamic_strings.xsl:611
+#: classic/omp.xsl:10624 classic/omp.xsl:11785
+msgid ""
+"Security note: The SMB protocol does not offer a fingerprint to establish "
+"complete mutual trust. Thus a man-in-the-middle attack can not be fully "
+"prevented."
+msgstr ""
+"Sicherheitshinweis: Das SMB-Protokoll bietet keinen Fingerprint an, um "
+"komplettes gegenseitiges Vertrauen herzustellen. Ein Man-in-the-Middle-"
+"Angriff kann somit nicht völlig ausgeschlossen werden."
+
+#: classic/omp.xsl:10650 classic/omp.xsl:11820
+msgid "Share path"
+msgstr "Freigabepfad"
+
+#: classic/omp.xsl:10661
+msgid "File path"
+msgstr "Dateipfad"
+
+#: classic/omp.xsl:10672 classic/omp.xsl:11844 classic/omp.xsl:13043
+#: classic/omp.xsl:14062 classic/omp.xsl:28566 classic/dynamic_strings.xsl:81
+msgid "Report Format"
+msgstr "Berichtformat"
+
+#: classic/omp.xsl:10778 classic/dynamic_strings.xsl:611
 msgid "Edit Alert"
 msgstr "Benachrichtigung bearbeiten"
 
-#: classic/omp.xsl:11137 classic/omp.xsl:22971 classic/omp.xsl:22972
-#: classic/omp.xsl:22997 classic/dynamic_strings.xsl:101 classic/gsad.xsl:509
+#: classic/omp.xsl:10953 classic/omp.xsl:22313 classic/omp.xsl:22314
+#: classic/omp.xsl:22339 classic/dynamic_strings.xsl:101 classic/gsad.xsl:516
 msgid "OVAL Definitions"
 msgstr "OVAL-Definitionen"
 
-#: classic/omp.xsl:11592
+#: classic/omp.xsl:11421
 msgid "Log Level"
 msgstr "Log-Stufe"
 
-#: classic/omp.xsl:12075 classic/omp.xsl:12221 classic/omp.xsl:12429
+#: classic/omp.xsl:11832
+msgid "File Path"
+msgstr "Dateipfad"
+
+#: classic/omp.xsl:11985 classic/omp.xsl:12131 classic/omp.xsl:12339
 msgctxt "Status Change"
 msgid "to"
 msgstr "zu"
 
-#: classic/omp.xsl:12087
+#: classic/omp.xsl:11997
 msgid "SCP to "
 msgstr "SCP nach "
 
-#: classic/omp.xsl:12093 classic/omp.xsl:12653 classic/omp.xsl:12757
+#: classic/omp.xsl:12003 classic/omp.xsl:12563 classic/omp.xsl:12667
 msgid "Credential unavailable"
 msgstr "Anmeldedaten nicht verfügbar"
 
-#: classic/omp.xsl:12102
+#: classic/omp.xsl:12012
 msgid "Send to "
 msgstr "Senden an "
 
-#: classic/omp.xsl:12111
+#: classic/omp.xsl:12021
 msgid "SNMP to "
 msgstr "SNMP nach "
 
-#: classic/omp.xsl:12118 classic/omp.xsl:12247
+#: classic/omp.xsl:12028 classic/omp.xsl:12157
 msgctxt "Alert|Email"
 msgid "To"
 msgstr "An"
 
-#: classic/omp.xsl:12173
+#: classic/omp.xsl:12083
 msgid "Testing Alert..."
 msgstr "Teste Benachrichtigung..."
 
-#: classic/omp.xsl:12175
+#: classic/omp.xsl:12085
 msgctxt "Action Verb"
 msgid "Test Alert"
 msgstr "Benachrichtigung testen"
 
-#: classic/omp.xsl:12188
+#: classic/omp.xsl:12098
 msgid "Testing the alert %1 was successful."
 msgstr "Test der Benachrichtigung %1 war erfolgreich."
 
-#: classic/omp.xsl:12193
+#: classic/omp.xsl:12103
 msgid "Testing the alert %1 failed."
 msgstr "Test der Benachrichtigung %1 ist fehlgeschlagen. "
 
-#: classic/omp.xsl:12291 classic/dynamic_strings.xsl:421
+#: classic/omp.xsl:12201 classic/dynamic_strings.xsl:421
 msgid "Alert is still in use"
 msgstr " wird noch verwendet"
 
-#: classic/omp.xsl:12391 classic/omp.xsl:13063 classic/omp.xsl:14040
-#: classic/omp.xsl:34719 classic/omp.xsl:34791 classic/dynamic_strings.xsl:79
+#: classic/omp.xsl:12301 classic/omp.xsl:12973 classic/omp.xsl:13943
+#: classic/omp.xsl:34081 classic/omp.xsl:34153 classic/dynamic_strings.xsl:79
 msgid "Alert"
 msgstr "Benachrichtigung"
 
-#: classic/omp.xsl:12444
+#: classic/omp.xsl:12354
 msgid "Send list of resources to host"
 msgstr "Ressourcenliste an Host senden"
 
-#: classic/omp.xsl:12447
+#: classic/omp.xsl:12357
 msgid "Send report to host"
 msgstr "Sende Bericht an Host"
 
-#: classic/omp.xsl:12707 classic/omp.xsl:19625 classic/omp.xsl:19755
-#: classic/omp.xsl:19910 classic/omp.xsl:20053 classic/omp.xsl:20504
-#: classic/omp.xsl:20566 classic/omp.xsl:20676 classic/omp.xsl:20870
-#: classic/omp.xsl:24529 classic/omp.xsl:24910 classic/omp.xsl:25701
-#: classic/omp.xsl:26212 classic/omp.xsl:33246 classic/omp.xsl:34188
-#: classic/omp.xsl:34352 classic/omp.xsl:35794 classic/omp.xsl:35826
+#: classic/omp.xsl:12617 classic/omp.xsl:19520 classic/omp.xsl:19640
+#: classic/omp.xsl:19795 classic/omp.xsl:19927 classic/omp.xsl:23885
+#: classic/omp.xsl:24266 classic/omp.xsl:25059 classic/omp.xsl:25570
+#: classic/omp.xsl:32612 classic/omp.xsl:33561 classic/omp.xsl:33725
+#: classic/omp.xsl:35335
 msgid "Port"
 msgstr "Port"
 
-#: classic/omp.xsl:12908
+#: classic/omp.xsl:12818
 msgctxt "Alert|Filter"
 msgid "None"
 msgstr "Keiner"
 
-#: classic/omp.xsl:12928
+#: classic/omp.xsl:12838
 msgid "Tasks using this Alert"
 msgstr "Aufgaben, die diese Benachrichtigung verwenden"
 
-#: classic/omp.xsl:13070
+#: classic/omp.xsl:12980
 msgid "Asset"
 msgstr "Asset"
 
-#: classic/omp.xsl:13091 classic/omp.xsl:14103 classic/omp.xsl:26563
-#: classic/omp.xsl:26878 classic/omp.xsl:27747 classic/omp.xsl:35057
+#: classic/omp.xsl:13001 classic/omp.xsl:14006 classic/omp.xsl:25923
+#: classic/omp.xsl:26238 classic/omp.xsl:27110 classic/omp.xsl:34419
 #: classic/dynamic_strings.xsl:89
 msgid "Group"
 msgstr "Gruppe"
 
-#: classic/omp.xsl:13098 classic/omp.xsl:14110 classic/omp.xsl:30152
+#: classic/omp.xsl:13008 classic/omp.xsl:14013 classic/omp.xsl:29514
 #: classic/dynamic_strings.xsl:65
 msgid "Note"
 msgstr "Notiz"
 
-#: classic/omp.xsl:13105 classic/omp.xsl:14131 classic/dynamic_strings.xsl:66
+#: classic/omp.xsl:13015 classic/omp.xsl:14034 classic/dynamic_strings.xsl:66
 msgid "Override"
 msgstr "Übersteuerung"
 
-#: classic/omp.xsl:13112 classic/omp.xsl:14138 classic/omp.xsl:27371
+#: classic/omp.xsl:13022 classic/omp.xsl:14041 classic/omp.xsl:26728
 #: classic/dynamic_strings.xsl:87
 msgid "Permission"
 msgstr "Berechtigung"
 
-#: classic/omp.xsl:13119 classic/omp.xsl:14145 classic/omp.xsl:14758
-#: classic/omp.xsl:15025 classic/omp.xsl:15358 classic/omp.xsl:15657
-#: classic/omp.xsl:16070 classic/omp.xsl:16158 classic/omp.xsl:28216
-#: classic/omp.xsl:35858 classic/dynamic_strings.xsl:74
+#: classic/omp.xsl:13029 classic/omp.xsl:14048 classic/omp.xsl:14651
+#: classic/omp.xsl:14917 classic/omp.xsl:15249 classic/omp.xsl:15548
+#: classic/omp.xsl:15961 classic/omp.xsl:16049 classic/omp.xsl:27576
+#: classic/omp.xsl:35383 classic/dynamic_strings.xsl:74
 msgid "Port List"
 msgstr "Portliste"
 
-#: classic/omp.xsl:13133 classic/omp.xsl:14159 classic/omp.xsl:29206
-#: classic/dynamic_strings.xsl:81
-msgid "Report Format"
-msgstr "Berichtformat"
-
-#: classic/omp.xsl:13140 classic/omp.xsl:14166 classic/omp.xsl:24268
-#: classic/omp.xsl:24616 classic/omp.xsl:24964 classic/omp.xsl:25457
-#: classic/omp.xsl:25868 classic/omp.xsl:26293 classic/omp.xsl:30152
-#: classic/omp.xsl:30427 classic/omp.xsl:30809 classic/omp.xsl:31367
-#: classic/omp.xsl:31382 classic/omp.xsl:31592
+#: classic/omp.xsl:13050 classic/omp.xsl:14069 classic/omp.xsl:23624
+#: classic/omp.xsl:23972 classic/omp.xsl:24320 classic/omp.xsl:24815
+#: classic/omp.xsl:25226 classic/omp.xsl:25651 classic/omp.xsl:29514
+#: classic/omp.xsl:29789 classic/omp.xsl:30171 classic/omp.xsl:30729
+#: classic/omp.xsl:30744 classic/omp.xsl:30954
 msgid "Result"
 msgstr "Ergebnis"
 
-#: classic/omp.xsl:13147 classic/omp.xsl:14173 classic/omp.xsl:26856
-#: classic/omp.xsl:27719 classic/omp.xsl:35282 classic/dynamic_strings.xsl:90
+#: classic/omp.xsl:13057 classic/omp.xsl:14076 classic/omp.xsl:26216
+#: classic/omp.xsl:27082 classic/omp.xsl:34644 classic/dynamic_strings.xsl:90
 msgid "Role"
 msgstr "Rolle"
 
-#: classic/omp.xsl:13161 classic/gsad.xsl:528
+#: classic/omp.xsl:13071 classic/gsad.xsl:535
 msgid "SecInfo"
 msgstr "SecInfo"
 
-#: classic/omp.xsl:13203 classic/omp.xsl:14215 classic/omp.xsl:26834
-#: classic/omp.xsl:27691 classic/omp.xsl:36611 classic/dynamic_strings.xsl:88
+#: classic/omp.xsl:13106 classic/omp.xsl:14111 classic/omp.xsl:26194
+#: classic/omp.xsl:27054 classic/omp.xsl:36120 classic/dynamic_strings.xsl:88
 msgid "User"
 msgstr "Benutzer"
 
-#: classic/omp.xsl:13283 classic/dynamic_strings.xsl:427
+#: classic/omp.xsl:13186 classic/dynamic_strings.xsl:427
 msgid "Filter is still in use"
 msgstr "Filter wird noch verwendet"
 
-#: classic/omp.xsl:13303 classic/omp.xsl:13449 classic/omp.xsl:13451
-#: classic/omp.xsl:36107 classic/dynamic_strings.xsl:117 classic/gsad.xsl:598
+#: classic/omp.xsl:13206 classic/omp.xsl:13352 classic/omp.xsl:13354
+#: classic/omp.xsl:35625 classic/dynamic_strings.xsl:117 classic/gsad.xsl:599
 msgid "Filters"
 msgstr "Filter"
 
-#: classic/omp.xsl:13323 classic/omp.xsl:13400 classic/omp.xsl:13424
-#: classic/omp.xsl:13478 classic/omp.xsl:13553
+#: classic/omp.xsl:13226 classic/omp.xsl:13303 classic/omp.xsl:13327
+#: classic/omp.xsl:13381 classic/omp.xsl:13456
 msgid "Term"
 msgstr "Filterbefehl"
 
-#: classic/omp.xsl:13345
+#: classic/omp.xsl:13248
 msgid "Alerts using this Filter"
 msgstr "Benachrichtigungen, die diesen Filter verwenden"
 
-#: classic/omp.xsl:13493
+#: classic/omp.xsl:13396
 msgid "Create Filter"
 msgstr "Filter erstellen"
 
-#: classic/omp.xsl:13515 classic/dynamic_strings.xsl:617
+#: classic/omp.xsl:13418 classic/dynamic_strings.xsl:617
 msgid "Edit Filter"
 msgstr "Filter bearbeiten"
 
-#: classic/omp.xsl:13577
+#: classic/omp.xsl:13480
 msgid "Save Filter"
 msgstr "Filter speichern"
 
-#: classic/omp.xsl:13682 classic/omp.xsl:13688 classic/omp.xsl:24948
-#: classic/omp.xsl:26277 classic/omp.xsl:27292 classic/omp.xsl:27314
-#: classic/omp.xsl:27400 classic/omp.xsl:27428
+#: classic/omp.xsl:13585 classic/omp.xsl:13591 classic/omp.xsl:24304
+#: classic/omp.xsl:25635 classic/omp.xsl:26649 classic/omp.xsl:26671
+#: classic/omp.xsl:26757 classic/omp.xsl:26785
 msgctxt "Trashcan"
 msgid "in "
 msgstr "im "
 
-#: classic/omp.xsl:13683 classic/omp.xsl:13688 classic/omp.xsl:24948
-#: classic/omp.xsl:26277 classic/omp.xsl:27292 classic/omp.xsl:27314
-#: classic/omp.xsl:27400 classic/omp.xsl:27428
+#: classic/omp.xsl:13586 classic/omp.xsl:13591 classic/omp.xsl:24304
+#: classic/omp.xsl:25635 classic/omp.xsl:26649 classic/omp.xsl:26671
+#: classic/omp.xsl:26757 classic/omp.xsl:26785
 msgid "trashcan"
 msgstr "Mülleimer"
 
-#: classic/omp.xsl:13745 classic/omp.xsl:13939 classic/omp.xsl:14326
-#: classic/omp.xsl:14482
+#: classic/omp.xsl:13648 classic/omp.xsl:13842 classic/omp.xsl:14222
+#: classic/omp.xsl:14378
 msgctxt "Tag"
 msgid "Active"
 msgstr "Aktiv"
 
-#: classic/omp.xsl:13753 classic/omp.xsl:35843
+#: classic/omp.xsl:13656 classic/omp.xsl:35368
 msgid "Resource Name"
 msgstr "Ressourcen-Name"
 
-#: classic/omp.xsl:13774 classic/omp.xsl:13948
+#: classic/omp.xsl:13677 classic/omp.xsl:13851
 msgctxt "Tag"
 msgid "Orphan"
 msgstr "Verwaist"
 
-#: classic/omp.xsl:13902
+#: classic/omp.xsl:13805
 msgctxt "Tag"
 msgid "Attached to Resource"
 msgstr "Angehängt an Ressource"
 
-#: classic/omp.xsl:13935 classic/omp.xsl:14319 classic/omp.xsl:14475
-#: classic/omp.xsl:26992 classic/omp.xsl:27085 classic/omp.xsl:27771
-#: classic/omp.xsl:27885
+#: classic/omp.xsl:13838 classic/omp.xsl:14215 classic/omp.xsl:14371
+#: classic/omp.xsl:26352 classic/omp.xsl:26442 classic/omp.xsl:27134
+#: classic/omp.xsl:27245
 msgid "Resource ID"
 msgstr "Ressourcen-ID"
 
-#: classic/omp.xsl:14020 classic/dynamic_strings.xsl:428
+#: classic/omp.xsl:13923 classic/dynamic_strings.xsl:428
 msgid "Tag is still in use"
 msgstr "Tag wird noch verwendet"
 
-#: classic/omp.xsl:14054 classic/omp.xsl:33443 classic/omp.xsl:38932
-#: classic/omp.xsl:38974
+#: classic/omp.xsl:13957 classic/omp.xsl:32809 classic/omp.xsl:38426
+#: classic/omp.xsl:38468
 msgid "Operating System"
 msgstr "Betriebssystem"
 
-#: classic/omp.xsl:14061 classic/omp.xsl:22815 classic/omp.xsl:22857
-#: classic/omp.xsl:29772 classic/omp.xsl:33444 classic/dynamic_strings.xsl:69
+#: classic/omp.xsl:13964 classic/omp.xsl:22157 classic/omp.xsl:22199
+#: classic/omp.xsl:29132 classic/omp.xsl:32810 classic/dynamic_strings.xsl:69
 msgid "CPE"
 msgstr "CPE"
 
-#: classic/omp.xsl:14075 classic/omp.xsl:21013 classic/omp.xsl:22097
-#: classic/omp.xsl:22523 classic/omp.xsl:22568 classic/omp.xsl:29794
-#: classic/omp.xsl:34003 classic/omp.xsl:34080 classic/dynamic_strings.xsl:68
+#: classic/omp.xsl:13978 classic/omp.xsl:20340 classic/omp.xsl:21431
+#: classic/omp.xsl:21865 classic/omp.xsl:21910 classic/omp.xsl:29154
+#: classic/omp.xsl:33376 classic/omp.xsl:33453 classic/dynamic_strings.xsl:68
 msgid "CVE"
 msgstr "CVE"
 
-#: classic/omp.xsl:14082 classic/omp.xsl:23265 classic/dynamic_strings.xsl:71
+#: classic/omp.xsl:13985 classic/omp.xsl:22607 classic/dynamic_strings.xsl:71
 msgid "CERT-Bund Advisory"
 msgstr "CERT-Bund-Advisory"
 
-#: classic/omp.xsl:14089 classic/omp.xsl:23454 classic/dynamic_strings.xsl:72
+#: classic/omp.xsl:13992 classic/omp.xsl:22806 classic/dynamic_strings.xsl:72
 msgid "DFN-CERT Advisory"
 msgstr "DFN-CERT-Advisory"
 
-#: classic/omp.xsl:14117 classic/omp.xsl:17131 classic/omp.xsl:23906
-#: classic/omp.xsl:25025 classic/omp.xsl:25045 classic/omp.xsl:26354
-#: classic/omp.xsl:26382 classic/omp.xsl:34005 classic/omp.xsl:34350
-#: classic/omp.xsl:37323 classic/omp.xsl:37448 classic/dynamic_strings.xsl:67
+#: classic/omp.xsl:14020 classic/omp.xsl:17022 classic/omp.xsl:23262
+#: classic/omp.xsl:24381 classic/omp.xsl:24403 classic/omp.xsl:25712
+#: classic/omp.xsl:25742 classic/omp.xsl:33378 classic/omp.xsl:33723
+#: classic/omp.xsl:36832 classic/omp.xsl:36957 classic/dynamic_strings.xsl:67
 msgid "NVT"
 msgstr "NVT"
 
-#: classic/omp.xsl:14354
+#: classic/omp.xsl:14250
 msgid "Create Tag"
 msgstr "Tag erstellen"
 
-#: classic/omp.xsl:14510
+#: classic/omp.xsl:14406
 msgid "Save Tag"
 msgstr "Tag speichern"
 
-#: classic/omp.xsl:14578 classic/omp.xsl:14581 classic/dynamic_strings.xsl:394
+#: classic/omp.xsl:14474 classic/omp.xsl:14477 classic/dynamic_strings.xsl:394
 msgid "New Target"
 msgstr "Neues Ziel"
 
-#: classic/omp.xsl:14635 classic/omp.xsl:14941 classic/omp.xsl:15265
+#: classic/omp.xsl:14531 classic/omp.xsl:14834 classic/omp.xsl:15157
 msgctxt "Target Source"
 msgid "Manual"
 msgstr "Manuell"
 
-#: classic/omp.xsl:14655 classic/omp.xsl:14955 classic/omp.xsl:15280
+#: classic/omp.xsl:14549 classic/omp.xsl:14847 classic/omp.xsl:15171
 msgctxt "Target Source"
 msgid "From file"
 msgstr "Aus Datei"
 
-#: classic/omp.xsl:14686 classic/omp.xsl:14715
+#: classic/omp.xsl:14580 classic/omp.xsl:14609
 msgctxt "Target Source"
 msgid "From host assets"
 msgstr "Aus Host-Assets"
 
-#: classic/omp.xsl:14726 classic/omp.xsl:14966 classic/omp.xsl:15292
-#: classic/omp.xsl:16132
+#: classic/omp.xsl:14620 classic/omp.xsl:14858 classic/omp.xsl:15183
+#: classic/omp.xsl:16023
 msgid "Exclude Hosts"
 msgstr "Hosts ausschließen"
 
-#: classic/omp.xsl:14733 classic/omp.xsl:14974 classic/omp.xsl:15303
-#: classic/omp.xsl:16136
+#: classic/omp.xsl:14626 classic/omp.xsl:14866 classic/omp.xsl:15194
+#: classic/omp.xsl:16027
 msgid "Reverse Lookup Only"
 msgstr "Nur Invers-Lookup"
 
-#: classic/omp.xsl:14745 classic/omp.xsl:14999 classic/omp.xsl:15330
-#: classic/omp.xsl:16145
+#: classic/omp.xsl:14638 classic/omp.xsl:14891 classic/omp.xsl:15221
+#: classic/omp.xsl:16036
 msgid "Reverse Lookup Unify"
 msgstr "Invers-Lookup-Vereinheitlichung"
 
-#: classic/omp.xsl:14765 classic/omp.xsl:15042
+#: classic/omp.xsl:14658 classic/omp.xsl:14934
 msgid "Create a new port list"
 msgstr "Neue Portliste erstellen"
 
-#: classic/omp.xsl:14773 classic/omp.xsl:15050 classic/omp.xsl:15370
-#: classic/omp.xsl:16187
+#: classic/omp.xsl:14666 classic/omp.xsl:14942 classic/omp.xsl:15261
+#: classic/omp.xsl:16078
 msgid "Alive Test"
 msgstr "Erreichbarkeitstest"
 
-#: classic/omp.xsl:14776 classic/omp.xsl:15056 classic/omp.xsl:15376
+#: classic/omp.xsl:14669 classic/omp.xsl:14948 classic/omp.xsl:15267
 msgid "Scan Config Default"
 msgstr "Standard der Scankonfiguration"
 
-#: classic/omp.xsl:14792 classic/omp.xsl:15101 classic/omp.xsl:15421
-#: classic/omp.xsl:16195
+#: classic/omp.xsl:14685 classic/omp.xsl:14993 classic/omp.xsl:15312
+#: classic/omp.xsl:16086
 msgid "Credentials for authenticated checks"
 msgstr "Anmeldedaten für authentifizierte Prüfungen"
 
-#: classic/omp.xsl:14796 classic/omp.xsl:15105 classic/omp.xsl:15427
-#: classic/omp.xsl:16199
+#: classic/omp.xsl:14689 classic/omp.xsl:14997 classic/omp.xsl:15318
+#: classic/omp.xsl:16090
 msgid "SSH"
 msgstr "SSH"
 
-#: classic/omp.xsl:14805 classic/omp.xsl:15131 classic/omp.xsl:15454
-#: classic/omp.xsl:16223
+#: classic/omp.xsl:14698 classic/omp.xsl:15023 classic/omp.xsl:15345
+#: classic/omp.xsl:16114
 msgctxt "Target|Credential"
 msgid "on port"
 msgstr "auf Port"
 
-#: classic/omp.xsl:14809 classic/omp.xsl:14824 classic/omp.xsl:14839
-#: classic/omp.xsl:14854 classic/omp.xsl:15147 classic/omp.xsl:15179
-#: classic/omp.xsl:15211 classic/omp.xsl:15243
+#: classic/omp.xsl:14702 classic/omp.xsl:14717 classic/omp.xsl:14732
+#: classic/omp.xsl:14747 classic/omp.xsl:15039 classic/omp.xsl:15071
+#: classic/omp.xsl:15103 classic/omp.xsl:15135
 msgid "Create a credential"
 msgstr "Anmeldedaten erstellen"
 
-#: classic/omp.xsl:14816 classic/omp.xsl:15154 classic/omp.xsl:15475
-#: classic/omp.xsl:16232
-msgid "SMB"
-msgstr "SMB"
-
-#: classic/omp.xsl:14831 classic/omp.xsl:15186 classic/omp.xsl:15504
-#: classic/omp.xsl:16259
+#: classic/omp.xsl:14724 classic/omp.xsl:15078 classic/omp.xsl:15395
+#: classic/omp.xsl:16150
 msgid "ESXi"
 msgstr "ESXi"
 
-#: classic/omp.xsl:14863
+#: classic/omp.xsl:14756
 msgid "Create Target"
 msgstr "Ziel erstellen"
 
-#: classic/omp.xsl:15564
+#: classic/omp.xsl:15455
 msgid "Save Target"
 msgstr "Ziel speichern"
 
-#: classic/omp.xsl:15653 classic/omp.xsl:35857
+#: classic/omp.xsl:15544 classic/omp.xsl:35382
 msgid "IPs"
 msgstr "IPs"
 
-#: classic/omp.xsl:15668
+#: classic/omp.xsl:15559
 msgctxt "Target|Credential"
 msgid "sort by"
 msgstr "Sortieren nach"
 
-#: classic/omp.xsl:15712 classic/wizard.xsl:343
+#: classic/omp.xsl:15603 classic/wizard.xsl:344
 msgid "SSH Credential"
 msgstr "SSH-Anmeldedaten"
 
-#: classic/omp.xsl:15717 classic/wizard.xsl:366
+#: classic/omp.xsl:15608 classic/wizard.xsl:367
 msgid "SMB Credential"
 msgstr "SMB-Anmeldedaten"
 
-#: classic/omp.xsl:15722 classic/wizard.xsl:387
+#: classic/omp.xsl:15613 classic/wizard.xsl:388
 msgid "ESXi Credential"
 msgstr "ESXi-Anmeldedaten"
 
-#: classic/omp.xsl:15727
+#: classic/omp.xsl:15618
 msgid "SNMP Credential"
 msgstr "SNMP-Anmeldedaten"
 
-#: classic/omp.xsl:15952 classic/omp.xsl:15970 classic/omp.xsl:15994
-#: classic/omp.xsl:16018 classic/omp.xsl:16042 classic/omp.xsl:20412
-#: classic/omp.xsl:20795 classic/omp.xsl:27488
+#: classic/omp.xsl:15843 classic/omp.xsl:15861 classic/omp.xsl:15885
+#: classic/omp.xsl:15909 classic/omp.xsl:15933 classic/omp.xsl:20287
+#: classic/omp.xsl:26851
 msgid "in trashcan"
 msgstr "im Mülleimer"
 
-#: classic/omp.xsl:16092 classic/dynamic_strings.xsl:417
+#: classic/omp.xsl:15983 classic/dynamic_strings.xsl:417
 msgid "Target is still in use"
 msgstr "Ziel wird noch verwendet"
 
-#: classic/omp.xsl:16154
+#: classic/omp.xsl:16045
 msgid "Maximum number of hosts"
 msgstr "Maximale Anzahl Hosts"
 
-#: classic/omp.xsl:16325
+#: classic/omp.xsl:16216
 msgid "Tasks using this Target"
 msgstr "Aufgaben, die dieses Ziel verwenden"
 
-#: classic/omp.xsl:16436 classic/omp.xsl:17834 classic/dynamic_strings.xsl:397
+#: classic/omp.xsl:16327 classic/omp.xsl:17725 classic/dynamic_strings.xsl:397
 msgid "New Scan Config"
 msgstr "Neue Scan-Konfig"
 
-#: classic/omp.xsl:16465
+#: classic/omp.xsl:16356
 msgctxt "Scan Config"
 msgid "Base"
 msgstr "Basis"
 
-#: classic/omp.xsl:16473
+#: classic/omp.xsl:16364
 msgctxt "Scan Config"
 msgid "Empty, static and fast"
 msgstr "Leer, statisch und schnell (Empty)"
 
-#: classic/omp.xsl:16480
+#: classic/omp.xsl:16371
 msgctxt "Scan Config"
 msgid "Full and fast"
 msgstr "Vollständig und schnell (Full and fast)"
 
-#: classic/omp.xsl:16507 classic/omp.xsl:16510 classic/omp.xsl:16534
-#: classic/omp.xsl:17840
+#: classic/omp.xsl:16398 classic/omp.xsl:16401 classic/omp.xsl:16425
+#: classic/omp.xsl:17731
 msgid "Import Scan Config"
 msgstr "Scan-Konfig importieren"
 
-#: classic/omp.xsl:16515 classic/omp.xsl:16516 classic/omp.xsl:16662
-#: classic/omp.xsl:16690 classic/omp.xsl:17432 classic/omp.xsl:17460
-#: classic/omp.xsl:17871 classic/omp.xsl:17872 classic/omp.xsl:17946
-#: classic/omp.xsl:36089 classic/dynamic_strings.xsl:109 classic/gsad.xsl:554
+#: classic/omp.xsl:16406 classic/omp.xsl:16407 classic/omp.xsl:16553
+#: classic/omp.xsl:16581 classic/omp.xsl:17323 classic/omp.xsl:17351
+#: classic/omp.xsl:17762 classic/omp.xsl:17763 classic/omp.xsl:17839
+#: classic/omp.xsl:35607 classic/dynamic_strings.xsl:109 classic/gsad.xsl:561
 msgid "Scan Configs"
 msgstr "Scan-Konfigurationen"
 
-#: classic/omp.xsl:16528
+#: classic/omp.xsl:16419
 msgid "Import XML config"
 msgstr "XML-Konfig importieren"
 
-#: classic/omp.xsl:16560 classic/omp.xsl:17581
+#: classic/omp.xsl:16451 classic/omp.xsl:17472
 msgid "Edit Scan Config Family"
 msgstr "Scan-Konfig-Familie bearbeiten"
 
-#: classic/omp.xsl:16568 classic/omp.xsl:16702 classic/omp.xsl:17307
-#: classic/omp.xsl:23563 classic/dynamic_strings.xsl:76
+#: classic/omp.xsl:16459 classic/omp.xsl:16593 classic/omp.xsl:17198
+#: classic/omp.xsl:22919 classic/dynamic_strings.xsl:76
 msgid "Config"
 msgstr "Konfiguration"
 
-#: classic/omp.xsl:16569 classic/omp.xsl:16703 classic/omp.xsl:17308
-#: classic/omp.xsl:17651 classic/omp.xsl:17728 classic/omp.xsl:22079
-#: classic/omp.xsl:23075 classic/omp.xsl:23564
+#: classic/omp.xsl:16460 classic/omp.xsl:16594 classic/omp.xsl:17199
+#: classic/omp.xsl:17542 classic/omp.xsl:17619 classic/omp.xsl:21413
+#: classic/omp.xsl:22417 classic/omp.xsl:22920
 msgid "Family"
 msgstr "Familie"
 
-#: classic/omp.xsl:16572
+#: classic/omp.xsl:16463
 msgid "Edit Network Vulnerability Tests"
 msgstr "Network Vulnerability Tests bearbeiten"
 
-#: classic/omp.xsl:16583 classic/omp.xsl:16711 classic/omp.xsl:17309
-#: classic/omp.xsl:23565
+#: classic/omp.xsl:16474 classic/omp.xsl:16602 classic/omp.xsl:17200
+#: classic/omp.xsl:22921
 msgid "OID"
 msgstr "OID"
 
-#: classic/omp.xsl:16585 classic/omp.xsl:16713 classic/omp.xsl:17162
-#: classic/omp.xsl:17201
+#: classic/omp.xsl:16476 classic/omp.xsl:16604 classic/omp.xsl:17053
+#: classic/omp.xsl:17092
 msgid "Timeout"
 msgstr "Timeout"
 
-#: classic/omp.xsl:16586 classic/omp.xsl:16714
+#: classic/omp.xsl:16477 classic/omp.xsl:16605
 msgid "Prefs"
 msgstr "Vorgaben"
 
-#: classic/omp.xsl:16587
+#: classic/omp.xsl:16478
 msgctxt "NVTs"
 msgid "Selected"
 msgstr "Ausgewählt"
 
-#: classic/omp.xsl:16615 classic/omp.xsl:16740 classic/omp.xsl:17169
-#: classic/omp.xsl:17174
+#: classic/omp.xsl:16506 classic/omp.xsl:16631 classic/omp.xsl:17060
+#: classic/omp.xsl:17065
 msgctxt "Timeout"
 msgid "default"
 msgstr "Standard"
 
-#: classic/omp.xsl:16641
+#: classic/omp.xsl:16532
 msgid "Select and Edit NVT Details"
 msgstr "Auswählen und NVT-Details bearbeiten"
 
-#: classic/omp.xsl:16653
+#: classic/omp.xsl:16544
 msgid "Selected %1 of %2 total NVTs"
 msgstr "%1 von insgesamt %2 NVTs ausgewählt"
 
-#: classic/omp.xsl:16662 classic/omp.xsl:16693 classic/omp.xsl:17600
+#: classic/omp.xsl:16553 classic/omp.xsl:16584 classic/omp.xsl:17491
 msgid "Scan Config Family Details"
 msgstr "Scan-Konfig-Familien-Details"
 
-#: classic/omp.xsl:16675 classic/omp.xsl:17445
+#: classic/omp.xsl:16566 classic/omp.xsl:17336
 msgid "Config ID"
 msgstr "Konfig-ID"
 
-#: classic/omp.xsl:16706
+#: classic/omp.xsl:16597
 msgid "Network Vulnerability Tests"
 msgstr "Network Vulnerability Tests"
 
-#: classic/omp.xsl:16722 classic/omp.xsl:23856 classic/dynamic_strings.xsl:183
+#: classic/omp.xsl:16613 classic/omp.xsl:23212 classic/dynamic_strings.xsl:183
 msgid "NVT Details"
 msgstr "NVT-Details"
 
-#: classic/omp.xsl:16757 classic/omp.xsl:35720
+#: classic/omp.xsl:16648 classic/omp.xsl:35261
 msgctxt "NVTs"
 msgid "Total"
 msgstr "Gesamt"
 
-#: classic/omp.xsl:16784 classic/omp.xsl:16790 classic/omp.xsl:17301
-#: classic/omp.xsl:17432 classic/omp.xsl:17463
+#: classic/omp.xsl:16675 classic/omp.xsl:16681 classic/omp.xsl:17192
+#: classic/omp.xsl:17323 classic/omp.xsl:17354
 msgid "Scan Config NVT Details"
 msgstr "Scan-Konfig-NVT-Details"
 
-#: classic/omp.xsl:16805 classic/omp.xsl:16843 classic/omp.xsl:16872
+#: classic/omp.xsl:16696 classic/omp.xsl:16734 classic/omp.xsl:16763
 msgid "File attached."
 msgstr "Datei angehängt."
 
-#: classic/omp.xsl:16817
+#: classic/omp.xsl:16708
 msgid "Edit Scan Config NVT Details"
 msgstr "Scan-Konfig-NVT-Details bearbeiten"
 
-#: classic/omp.xsl:16823 classic/omp.xsl:16825 classic/omp.xsl:16886
-#: classic/omp.xsl:16888 classic/omp.xsl:17112 classic/omp.xsl:17114
+#: classic/omp.xsl:16714 classic/omp.xsl:16716 classic/omp.xsl:16777
+#: classic/omp.xsl:16779 classic/omp.xsl:17003 classic/omp.xsl:17005
 msgid "Export File"
 msgstr "Datei exportieren"
 
-#: classic/omp.xsl:16852 classic/omp.xsl:16954
+#: classic/omp.xsl:16743 classic/omp.xsl:16845
 msgid "Use target SSH credentials"
 msgstr "Benutze Ziel-SSH-Anmeldedaten"
 
-#: classic/omp.xsl:17011
+#: classic/omp.xsl:16902
 msgid "Replace existing file with"
 msgstr "Vorhandene Datei ersetzen durch"
 
-#: classic/omp.xsl:17014
+#: classic/omp.xsl:16905
 msgid "Upload file"
 msgstr "Datei hochladen"
 
-#: classic/omp.xsl:17104
+#: classic/omp.xsl:16995
 msgid "Edit NVT Details"
 msgstr "NVT-Details"
 
-#: classic/omp.xsl:17154 classic/omp.xsl:17258
+#: classic/omp.xsl:17045 classic/omp.xsl:17149
 msgid "Current Value"
 msgstr "Aktueller Wert"
 
-#: classic/omp.xsl:17156 classic/omp.xsl:17195 classic/omp.xsl:17259
-#: classic/omp.xsl:17275
+#: classic/omp.xsl:17047 classic/omp.xsl:17086 classic/omp.xsl:17150
+#: classic/omp.xsl:17166
 msgid "Default Value"
 msgstr "Standardwert"
 
-#: classic/omp.xsl:17194 classic/omp.xsl:17274
+#: classic/omp.xsl:17085 classic/omp.xsl:17165
 msgid "New Value"
 msgstr "Neuer Wert"
 
-#: classic/omp.xsl:17217
+#: classic/omp.xsl:17108
 msgid "Apply default timeout"
 msgstr "Standard-Timeout anwenden"
 
-#: classic/omp.xsl:17285 classic/omp.xsl:17286 classic/omp.xsl:17815
-#: classic/omp.xsl:17816
+#: classic/omp.xsl:17176 classic/omp.xsl:17177 classic/omp.xsl:17706
+#: classic/omp.xsl:17707
 msgid "Save Config"
 msgstr "Konfiguration speichern"
 
-#: classic/omp.xsl:17310 classic/omp.xsl:22093 classic/omp.xsl:22157
-#: classic/omp.xsl:23015 classic/omp.xsl:23277 classic/omp.xsl:23566
-#: classic/omp.xsl:37299
+#: classic/omp.xsl:17201 classic/omp.xsl:21427 classic/omp.xsl:21493
+#: classic/omp.xsl:22357 classic/omp.xsl:22619 classic/omp.xsl:22922
+#: classic/omp.xsl:36808
 msgid "Version"
 msgstr "Version"
 
-#: classic/omp.xsl:17327 classic/omp.xsl:23495 classic/omp.xsl:23499
-#: classic/omp.xsl:23595 classic/omp.xsl:28783 classic/omp.xsl:29240
-#: classic/omp.xsl:31353
+#: classic/omp.xsl:17218 classic/omp.xsl:22851 classic/omp.xsl:22855
+#: classic/omp.xsl:22951 classic/omp.xsl:28143 classic/omp.xsl:28600
+#: classic/omp.xsl:30715
 msgid "Summary"
 msgstr "Zusammenfassung"
 
-#: classic/omp.xsl:17342 classic/omp.xsl:23610 classic/omp.xsl:31431
+#: classic/omp.xsl:17233 classic/omp.xsl:22966 classic/omp.xsl:30793
 msgid "Affected Software/OS"
 msgstr "Betroffene Software/OS"
 
-#: classic/omp.xsl:17355 classic/omp.xsl:23623
+#: classic/omp.xsl:17246 classic/omp.xsl:22979
 msgid "Vulnerability Scoring"
 msgstr "Schwachstellen-Bewertung"
 
-#: classic/omp.xsl:17358 classic/omp.xsl:23626
+#: classic/omp.xsl:17249 classic/omp.xsl:22982
 msgid "CVSS base"
 msgstr "CVSS-Basisscore"
 
-#: classic/omp.xsl:17379 classic/omp.xsl:23647
+#: classic/omp.xsl:17270 classic/omp.xsl:23003
 msgid "CVSS base vector"
 msgstr "CVSS-Basisvektor"
 
-#: classic/omp.xsl:17397
+#: classic/omp.xsl:17288
 msgid "Edit Scan Config NVT"
 msgstr "Scan-Konfig-NVT bearbeiten"
 
-#: classic/omp.xsl:17404 classic/omp.xsl:17471 classic/omp.xsl:23916
+#: classic/omp.xsl:17295 classic/omp.xsl:17362 classic/omp.xsl:23272
 msgid "Preferences"
 msgstr "Vorgaben"
 
-#: classic/omp.xsl:17436 classic/omp.xsl:17438
+#: classic/omp.xsl:17327 classic/omp.xsl:17329
 msgid "Scan Config Family"
 msgstr "Scan-Konfig-Familie"
 
-#: classic/omp.xsl:17514 classic/omp.xsl:17617 classic/omp.xsl:17685
-#: classic/omp.xsl:17688 classic/omp.xsl:17786
+#: classic/omp.xsl:17405 classic/omp.xsl:17508 classic/omp.xsl:17576
+#: classic/omp.xsl:17579 classic/omp.xsl:17677
 msgctxt "Scan Config|NVTs"
 msgid " of "
 msgstr " von "
 
-#: classic/omp.xsl:17537 classic/omp.xsl:17626 classic/omp.xsl:17656
-#: classic/omp.xsl:17701 classic/omp.xsl:17734 classic/omp.xsl:17751
-#: classic/omp.xsl:17794 classic/omp.xsl:18373 classic/omp.xsl:18467
-#: classic/omp.xsl:18495
+#: classic/omp.xsl:17428 classic/omp.xsl:17517 classic/omp.xsl:17547
+#: classic/omp.xsl:17592 classic/omp.xsl:17625 classic/omp.xsl:17642
+#: classic/omp.xsl:17685 classic/omp.xsl:18266 classic/omp.xsl:18362
+#: classic/omp.xsl:18390
 msgctxt "Scan Config"
 msgid "Grows"
 msgstr "Wächst"
 
-#: classic/omp.xsl:17539 classic/omp.xsl:17628 classic/omp.xsl:17702
-#: classic/omp.xsl:17795
+#: classic/omp.xsl:17430 classic/omp.xsl:17519 classic/omp.xsl:17593
+#: classic/omp.xsl:17686
 msgid ""
 "The NVT selection is DYNAMIC. New NVTs will automatically be added and "
 "considered."
@@ -3055,16 +3025,16 @@ msgstr ""
 "Die NVT-Auswahl ist DYNAMISCH. Neue NVTs werden automatisch hinzugefügt und "
 "berücksichtigt."
 
-#: classic/omp.xsl:17561 classic/omp.xsl:17632 classic/omp.xsl:17662
-#: classic/omp.xsl:17707 classic/omp.xsl:17741 classic/omp.xsl:17758
-#: classic/omp.xsl:17800 classic/omp.xsl:18379 classic/omp.xsl:18408
-#: classic/omp.xsl:18473 classic/omp.xsl:18502
+#: classic/omp.xsl:17452 classic/omp.xsl:17523 classic/omp.xsl:17553
+#: classic/omp.xsl:17598 classic/omp.xsl:17632 classic/omp.xsl:17649
+#: classic/omp.xsl:17691 classic/omp.xsl:18272 classic/omp.xsl:18301
+#: classic/omp.xsl:18368 classic/omp.xsl:18397
 msgctxt "Scan Config"
 msgid "Static"
 msgstr "Statisch"
 
-#: classic/omp.xsl:17562 classic/omp.xsl:17634 classic/omp.xsl:17708
-#: classic/omp.xsl:17801 classic/omp.xsl:18409 classic/omp.xsl:18503
+#: classic/omp.xsl:17453 classic/omp.xsl:17525 classic/omp.xsl:17599
+#: classic/omp.xsl:17692 classic/omp.xsl:18302 classic/omp.xsl:18398
 msgid ""
 "The NVT selection is STATIC. New NVTs will NOT automatically be added or "
 "considered."
@@ -3072,8 +3042,8 @@ msgstr ""
 "Die NVT-Auswahl ist STATISCH. Neue NVTs werden NICHT automatisch hinzugefügt "
 "oder berücksichtigt."
 
-#: classic/omp.xsl:17657 classic/omp.xsl:17736 classic/omp.xsl:17752
-#: classic/omp.xsl:18374 classic/omp.xsl:18468
+#: classic/omp.xsl:17548 classic/omp.xsl:17627 classic/omp.xsl:17643
+#: classic/omp.xsl:18267 classic/omp.xsl:18363
 msgid ""
 "The family selection is DYNAMIC. New families will automatically be added "
 "and considered."
@@ -3081,8 +3051,8 @@ msgstr ""
 "Die Familien-Auswahl ist DYNAMISCH. Neue Familien werden automatisch "
 "hinzugefügt und berücksichtigt."
 
-#: classic/omp.xsl:17663 classic/omp.xsl:17743 classic/omp.xsl:17759
-#: classic/omp.xsl:18380 classic/omp.xsl:18474
+#: classic/omp.xsl:17554 classic/omp.xsl:17634 classic/omp.xsl:17650
+#: classic/omp.xsl:18273 classic/omp.xsl:18369
 msgid ""
 "The family selection is STATIC. New families will NOT automatically be added"
 " or considered."
@@ -3090,119 +3060,119 @@ msgstr ""
 "Die Familien-Auswahl ist STATISCH. Neue Familien werden NICHT automatisch "
 "hinzugefügt oder berücksichtigt."
 
-#: classic/omp.xsl:17670 classic/omp.xsl:17764
+#: classic/omp.xsl:17561 classic/omp.xsl:17655
 msgid "NVTs selected"
 msgstr "NVTs ausgewählt"
 
-#: classic/omp.xsl:17676 classic/omp.xsl:17782 classic/omp.xsl:35718
+#: classic/omp.xsl:17567 classic/omp.xsl:17673 classic/omp.xsl:35259
 msgctxt "Families"
 msgid "Total"
 msgstr "Gesamt"
 
-#: classic/omp.xsl:17687
+#: classic/omp.xsl:17578
 msgctxt "Scan Config|NVTs"
 msgid " in selected families"
 msgstr " in ausgewählten Familien"
 
-#: classic/omp.xsl:17690
+#: classic/omp.xsl:17581
 msgctxt "Scan Config|NVTs"
 msgid " in total"
 msgstr " insgesamt"
 
-#: classic/omp.xsl:17766
+#: classic/omp.xsl:17657
 msgid "Select all NVTs"
 msgstr "Alle NVTs auswählen"
 
-#: classic/omp.xsl:17830 classic/dynamic_strings.xsl:192
+#: classic/omp.xsl:17721 classic/dynamic_strings.xsl:192
 msgid "Scan Config Details"
 msgstr "Scan-Konfigurations-Details"
 
-#: classic/omp.xsl:17889 classic/omp.xsl:17890 classic/omp.xsl:17902
+#: classic/omp.xsl:17780 classic/omp.xsl:17781 classic/omp.xsl:17793
 #: classic/dynamic_strings.xsl:440
 msgid "Scan Config is not writable"
 msgstr "Scan-Konfiguration ist nicht beschreibbar"
 
-#: classic/omp.xsl:17891
+#: classic/omp.xsl:17782
 msgid "Cannot move Scan Config to trashcan"
 msgstr "Scan-Konfig kann nicht in den Mülleimer verschoben werden"
 
-#: classic/omp.xsl:17908 classic/omp.xsl:18130 classic/dynamic_strings.xsl:610
+#: classic/omp.xsl:17801 classic/omp.xsl:18023 classic/dynamic_strings.xsl:610
 msgid "Edit Scan Config"
 msgstr "Scan-Konfig bearbeiten"
 
-#: classic/omp.xsl:17914 classic/dynamic_strings.xsl:270
+#: classic/omp.xsl:17807 classic/dynamic_strings.xsl:270
 msgid "Export Scan Config as XML"
 msgstr "Scan-Konfig als XML exportieren"
 
-#: classic/omp.xsl:17920 classic/omp.xsl:17921
+#: classic/omp.xsl:17813 classic/omp.xsl:17814
 msgid "Sync Config"
 msgstr "Konfig synchronisieren"
 
-#: classic/omp.xsl:17981
+#: classic/omp.xsl:17874
 msgid "Network Vulnerability Test Families"
 msgstr "Familien von Network Vulnerability Tests"
 
-#: classic/omp.xsl:18006 classic/omp.xsl:18008
+#: classic/omp.xsl:17899 classic/omp.xsl:17901
 msgid "Scanner Preferences"
 msgstr "Scanner-Vorgaben"
 
-#: classic/omp.xsl:18033 classic/omp.xsl:18035 classic/omp.xsl:18203
-#: classic/omp.xsl:18227
+#: classic/omp.xsl:17926 classic/omp.xsl:17928 classic/omp.xsl:18096
+#: classic/omp.xsl:18120
 msgid "Network Vulnerability Test Preferences"
 msgstr "Vorgaben für Network Vulnerability Tests"
 
-#: classic/omp.xsl:18068
+#: classic/omp.xsl:17961
 msgid "Tasks using this Scan Config"
 msgstr "Aufgaben, die diese Konfiguration verwenden"
 
-#: classic/omp.xsl:18107 classic/omp.xsl:22802 classic/omp.xsl:22953
-#: classic/omp.xsl:23196 classic/omp.xsl:23405 classic/omp.xsl:23548
-#: classic/omp.xsl:23924
+#: classic/omp.xsl:18000 classic/omp.xsl:22144 classic/omp.xsl:22295
+#: classic/omp.xsl:22538 classic/omp.xsl:22757 classic/omp.xsl:22904
+#: classic/omp.xsl:23280
 msgid "User Tags for \"%1\""
 msgstr "Benutzer-Tags für \"%1\""
 
-#: classic/omp.xsl:18115
+#: classic/omp.xsl:18008
 msgid "User Permissions for Config \"%1\""
 msgstr "Berechtigungen für Konfiguration \"%1\""
 
-#: classic/omp.xsl:18187
+#: classic/omp.xsl:18080
 msgid "Edit Network Vulnerability Test Families"
 msgstr "Familien von Network Vulnerability Tests bearbeiten"
 
-#: classic/omp.xsl:18201 classic/omp.xsl:18214
+#: classic/omp.xsl:18094 classic/omp.xsl:18107
 msgid "Edit Scanner Preferences"
 msgstr "Scanner-Vorgaben bearbeiten"
 
-#: classic/omp.xsl:18201
+#: classic/omp.xsl:18094
 msgctxt "Scanner|Preferences"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:18203
+#: classic/omp.xsl:18096
 msgctxt "NVT|Preferences"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:18260 classic/omp.xsl:35713
+#: classic/omp.xsl:18153 classic/omp.xsl:35254
 msgid "Families"
 msgstr "Familien"
 
-#: classic/omp.xsl:18262
+#: classic/omp.xsl:18155
 msgctxt "Scan Config|Families"
 msgid "Total"
 msgstr "Gesamt"
 
-#: classic/omp.xsl:18274
+#: classic/omp.xsl:18167
 msgctxt "Scan Config|NVTs"
 msgid "Total"
 msgstr "Gesamt"
 
-#: classic/omp.xsl:18402
+#: classic/omp.xsl:18295
 msgctxt "Scan Config"
 msgid "Dynamic"
 msgstr "Dynamisch"
 
-#: classic/omp.xsl:18403 classic/omp.xsl:18497
+#: classic/omp.xsl:18296 classic/omp.xsl:18392
 msgid ""
 "The NVT selection is DYNAMIC. New NVTs of selected families will "
 "automatically be added and considered."
@@ -3210,392 +3180,368 @@ msgstr ""
 "Die NVT-Auswahl ist DYNAMISCH. Neue NVTs werden automatisch hinzugefügt und "
 "berücksichtigt. "
 
-#: classic/omp.xsl:18523 classic/dynamic_strings.xsl:420
+#: classic/omp.xsl:18418 classic/dynamic_strings.xsl:420
 msgid "Scan Config is still in use"
 msgstr "Scan-Konfiguration wird noch verwendet"
 
-#: classic/omp.xsl:18614 classic/dynamic_strings.xsl:399
+#: classic/omp.xsl:18509 classic/dynamic_strings.xsl:399
 msgid "New Schedule"
 msgstr "Neuer Zeitplan"
 
-#: classic/omp.xsl:18638 classic/omp.xsl:18893
+#: classic/omp.xsl:18533 classic/omp.xsl:18788
 msgctxt "Schedule"
 msgid "First Time"
 msgstr "Erster Zeitpunkt"
 
-#: classic/omp.xsl:18685 classic/omp.xsl:18766 classic/omp.xsl:18948
-#: classic/omp.xsl:19408 classic/omp.xsl:35811
+#: classic/omp.xsl:18580 classic/omp.xsl:18661 classic/omp.xsl:18843
+#: classic/omp.xsl:19303 classic/omp.xsl:35352
 msgctxt "Schedule"
 msgid "Period"
 msgstr "Periode"
 
-#: classic/omp.xsl:18699 classic/omp.xsl:18722 classic/omp.xsl:18994
-#: classic/omp.xsl:18997 classic/omp.xsl:19063 classic/omp.xsl:19066
+#: classic/omp.xsl:18594 classic/omp.xsl:18617 classic/omp.xsl:18889
+#: classic/omp.xsl:18892 classic/omp.xsl:18958 classic/omp.xsl:18961
 msgid "hour(s)"
 msgstr "Stunde(n)"
 
-#: classic/omp.xsl:18700 classic/omp.xsl:18723 classic/omp.xsl:19002
-#: classic/omp.xsl:19005 classic/omp.xsl:19071 classic/omp.xsl:19074
+#: classic/omp.xsl:18595 classic/omp.xsl:18618 classic/omp.xsl:18897
+#: classic/omp.xsl:18900 classic/omp.xsl:18966 classic/omp.xsl:18969
 msgid "day(s)"
 msgstr "Tag(e)"
 
-#: classic/omp.xsl:18701 classic/omp.xsl:18724 classic/omp.xsl:19010
-#: classic/omp.xsl:19013 classic/omp.xsl:19079 classic/omp.xsl:19082
+#: classic/omp.xsl:18596 classic/omp.xsl:18619 classic/omp.xsl:18905
+#: classic/omp.xsl:18908 classic/omp.xsl:18974 classic/omp.xsl:18977
 msgid "week(s)"
 msgstr "Woche(n)"
 
-#: classic/omp.xsl:18702 classic/omp.xsl:19018 classic/omp.xsl:19021
+#: classic/omp.xsl:18597 classic/omp.xsl:18913 classic/omp.xsl:18916
 msgid "month(s)"
 msgstr "Monat(e)"
 
-#: classic/omp.xsl:18708 classic/omp.xsl:18770 classic/omp.xsl:19031
-#: classic/omp.xsl:19433 classic/omp.xsl:35812
+#: classic/omp.xsl:18603 classic/omp.xsl:18665 classic/omp.xsl:18926
+#: classic/omp.xsl:19328 classic/omp.xsl:35353
 msgctxt "Schedule"
 msgid "Duration"
 msgstr "Dauer"
 
-#: classic/omp.xsl:18756 classic/omp.xsl:19376 classic/omp.xsl:35809
+#: classic/omp.xsl:18651 classic/omp.xsl:19271 classic/omp.xsl:35350
 msgctxt "Schedule"
 msgid "First Run"
 msgstr "Erster Lauf"
 
-#: classic/omp.xsl:18761 classic/omp.xsl:19384 classic/omp.xsl:35810
+#: classic/omp.xsl:18656 classic/omp.xsl:19279 classic/omp.xsl:35351
 msgctxt "Schedule"
 msgid "Next Run"
 msgstr "Nächster Lauf"
 
-#: classic/omp.xsl:18852 classic/dynamic_strings.xsl:612
+#: classic/omp.xsl:18747 classic/dynamic_strings.xsl:612
 msgid "Edit Schedule"
 msgstr "Zeitplan bearbeiten"
 
-#: classic/omp.xsl:18858
+#: classic/omp.xsl:18753
 msgid "Notice"
 msgstr "Hinweis"
 
-#: classic/omp.xsl:18963 classic/omp.xsl:19046
+#: classic/omp.xsl:18858 classic/omp.xsl:18941
 msgid "seconds"
 msgstr "Sekunden"
 
-#: classic/omp.xsl:18977 classic/omp.xsl:19215 classic/omp.xsl:19297
-#: classic/omp.xsl:19420
+#: classic/omp.xsl:18872 classic/omp.xsl:19110 classic/omp.xsl:19192
+#: classic/omp.xsl:19315
 msgid "months"
 msgstr "Monate"
 
-#: classic/omp.xsl:19112 classic/omp.xsl:35545 classic/omp.xsl:35548
+#: classic/omp.xsl:19007 classic/omp.xsl:35084
 msgid "week"
 msgstr "Woche"
 
-#: classic/omp.xsl:19115
+#: classic/omp.xsl:19010
 msgid "weeks"
 msgstr "Wochen"
 
-#: classic/omp.xsl:19124 classic/omp.xsl:35536 classic/omp.xsl:35539
+#: classic/omp.xsl:19019 classic/omp.xsl:35074
 msgid "day"
 msgstr "Tag"
 
-#: classic/omp.xsl:19127 classic/omp.xsl:24054 classic/omp.xsl:24439
-#: classic/omp.xsl:24463 classic/omp.xsl:24487 classic/omp.xsl:25207
-#: classic/omp.xsl:25615 classic/omp.xsl:25637 classic/omp.xsl:25659
+#: classic/omp.xsl:19022 classic/omp.xsl:23410 classic/omp.xsl:23795
+#: classic/omp.xsl:23819 classic/omp.xsl:23843 classic/omp.xsl:24565
+#: classic/omp.xsl:24973 classic/omp.xsl:24995 classic/omp.xsl:25017
 msgid "days"
 msgstr "Tage"
 
-#: classic/omp.xsl:19136 classic/omp.xsl:35527 classic/omp.xsl:35530
+#: classic/omp.xsl:19031 classic/omp.xsl:35064
 msgid "hour"
 msgstr "Stunde"
 
-#: classic/omp.xsl:19139
+#: classic/omp.xsl:19034
 msgid "hours"
 msgstr "Stunden"
 
-#: classic/omp.xsl:19148
+#: classic/omp.xsl:19043
 msgid "min"
 msgstr "Min."
 
-#: classic/omp.xsl:19151
+#: classic/omp.xsl:19046
 msgid "mins"
 msgstr "Min."
 
-#: classic/omp.xsl:19158
+#: classic/omp.xsl:19053
 msgid "sec"
 msgstr "Sek."
 
-#: classic/omp.xsl:19163
+#: classic/omp.xsl:19058
 msgid "secs"
 msgstr "Sek."
 
-#: classic/omp.xsl:19210 classic/omp.xsl:19292 classic/omp.xsl:19415
-#: classic/omp.xsl:35554 classic/omp.xsl:35557
+#: classic/omp.xsl:19105 classic/omp.xsl:19187 classic/omp.xsl:19310
+#: classic/omp.xsl:35094
 msgid "month"
 msgstr "Monat"
 
-#: classic/omp.xsl:19229 classic/omp.xsl:19311 classic/omp.xsl:19437
+#: classic/omp.xsl:19124 classic/omp.xsl:19206 classic/omp.xsl:19332
 msgctxt "Time"
 msgid "Entire Operation"
 msgstr "Gesamter Vorgang"
 
-#: classic/omp.xsl:19336 classic/dynamic_strings.xsl:422
+#: classic/omp.xsl:19231 classic/dynamic_strings.xsl:422
 msgid "Schedule is still in use"
 msgstr "Zeitplan wird noch verwendet"
 
-#: classic/omp.xsl:19356 classic/omp.xsl:36188 classic/dynamic_strings.xsl:112
-#: classic/gsad.xsl:567
+#: classic/omp.xsl:19251 classic/omp.xsl:35706 classic/dynamic_strings.xsl:112
+#: classic/gsad.xsl:574
 msgid "Schedules"
 msgstr "Zeitpläne"
 
-#: classic/omp.xsl:19463
+#: classic/omp.xsl:19358
 msgid "Tasks using this Schedule"
 msgstr "Aufgaben, die diesen Zeitplan verwenden"
 
-#: classic/omp.xsl:19586 classic/omp.xsl:19589 classic/dynamic_strings.xsl:403
+#: classic/omp.xsl:19481 classic/omp.xsl:19484 classic/dynamic_strings.xsl:403
 msgid "New Scanner"
 msgstr "Neuer Scanner"
 
-#: classic/omp.xsl:19594 classic/omp.xsl:19595 classic/omp.xsl:20023
-#: classic/omp.xsl:36179 classic/dynamic_strings.xsl:116 classic/gsad.xsl:592
+#: classic/omp.xsl:19489 classic/omp.xsl:19490 classic/omp.xsl:19897
+#: classic/omp.xsl:35697 classic/dynamic_strings.xsl:116 classic/gsad.xsl:593
 msgid "Scanners"
 msgstr "Scanner"
 
-#: classic/omp.xsl:19640 classic/omp.xsl:19648 classic/omp.xsl:19810
-#: classic/omp.xsl:20189 classic/omp.xsl:37123
+#: classic/omp.xsl:19535 classic/omp.xsl:19695 classic/omp.xsl:20063
+#: classic/omp.xsl:36632
 msgid "CA Certificate"
 msgstr "CA-Zertifikat"
 
-#: classic/omp.xsl:19681
+#: classic/omp.xsl:19566
 msgid "Create Scanner"
 msgstr "Scanner erstellen"
 
-#: classic/omp.xsl:19797 classic/omp.xsl:19799
+#: classic/omp.xsl:19682 classic/omp.xsl:19684
 msgctxt "Action Verb"
 msgid "Download Certificate currently in use"
 msgstr "Aktuell verwendetes Zertifikat herunterladen "
 
-#: classic/omp.xsl:19818
+#: classic/omp.xsl:19703
 msgctxt "Certificate"
 msgid "Existing"
 msgstr "Vorhandenes"
 
-#: classic/omp.xsl:19822 classic/omp.xsl:19828
+#: classic/omp.xsl:19707 classic/omp.xsl:19713
 msgctxt "Certificate"
 msgid "Default"
 msgstr "Standard"
 
-#: classic/omp.xsl:19834
+#: classic/omp.xsl:19719
 msgctxt "Certificate"
 msgid "New:"
 msgstr "Neu:"
 
-#: classic/omp.xsl:19840 classic/omp.xsl:19843
+#: classic/omp.xsl:19725 classic/omp.xsl:19728
 msgctxt "Action Verb"
 msgid "Download CA Certificate currently in use"
 msgstr "Aktuell verwendetes CA-Zertifikat herunterladen"
 
-#: classic/omp.xsl:19859 classic/dynamic_strings.xsl:616
+#: classic/omp.xsl:19744 classic/dynamic_strings.xsl:616
 msgid "Edit Scanner"
 msgstr "Scanner bearbeiten"
 
-#: classic/omp.xsl:19989
+#: classic/omp.xsl:19863
 msgid "Save Scanner"
 msgstr "Scanner speichern"
 
-#: classic/omp.xsl:20044 classic/omp.xsl:20057
+#: classic/omp.xsl:19918 classic/omp.xsl:19931
 msgid "builtin scanner"
 msgstr "integrierter Scanner"
 
-#: classic/omp.xsl:20097
+#: classic/omp.xsl:19971
 msgid "Online Response of Scanner"
 msgstr "Online-Antwort des Scanners"
 
-#: classic/omp.xsl:20101
+#: classic/omp.xsl:19975
 msgid "Scanner Name"
 msgstr "Scanner-Name"
 
-#: classic/omp.xsl:20105
+#: classic/omp.xsl:19979
 msgid "Scanner Version"
 msgstr "Scanner-Version"
 
-#: classic/omp.xsl:20109
+#: classic/omp.xsl:19983
 msgid "OSP Daemon"
 msgstr "OSP-Daemon"
 
-#: classic/omp.xsl:20117 classic/omp.xsl:28268 classic/omp.xsl:28415
-#: classic/omp.xsl:28516
+#: classic/omp.xsl:19991 classic/omp.xsl:27628 classic/omp.xsl:27775
+#: classic/omp.xsl:27876
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: classic/omp.xsl:20134
+#: classic/omp.xsl:20008
 msgid "Scanner parameters"
 msgstr "Scanner-Parameter"
 
-#: classic/omp.xsl:20141
+#: classic/omp.xsl:20015
 msgid "Default"
 msgstr "Standard"
 
-#: classic/omp.xsl:20142
+#: classic/omp.xsl:20016
 msgid "Mandatory"
 msgstr "Erforderlich"
 
-#: classic/omp.xsl:20173
+#: classic/omp.xsl:20047
 msgid "OSP Scanner is offline"
 msgstr "OSP-Scanner ist offline"
 
-#: classic/omp.xsl:20181 classic/omp.xsl:34299
+#: classic/omp.xsl:20055 classic/omp.xsl:33672
 msgid "from Credential"
 msgstr "aus Anmeldedaten"
 
-#: classic/omp.xsl:20207
+#: classic/omp.xsl:20081
 msgid "Tasks using this Scanner"
 msgstr "Aufgaben, die diesen Scanner verwenden"
 
-#: classic/omp.xsl:20416 classic/omp.xsl:20799 classic/dynamic_strings.xsl:191
+#: classic/omp.xsl:20291 classic/dynamic_strings.xsl:191
 msgid "Credential Details"
 msgstr "Anmeldedaten-Details"
 
-#: classic/omp.xsl:20446 classic/dynamic_strings.xsl:426
+#: classic/omp.xsl:20321 classic/dynamic_strings.xsl:426
 msgid "Scanner is still in use"
 msgstr "Scanner wird noch verwendet"
 
-#: classic/omp.xsl:20461 classic/omp.xsl:20464 classic/dynamic_strings.xsl:401
-msgid "New Slave"
-msgstr "Neuer Slave"
-
-#: classic/omp.xsl:20531
-msgid "Create Slave"
-msgstr "Slave erstellen"
-
-#: classic/omp.xsl:20632 classic/dynamic_strings.xsl:614
-msgid "Edit Slave"
-msgstr "Slave bearbeiten"
-
-#: classic/omp.xsl:20703
-msgid "Save Slave"
-msgstr "Slave speichern"
-
-#: classic/omp.xsl:20830 classic/dynamic_strings.xsl:424
-msgid "Slave is still in use"
-msgstr "Slave wird noch verwendet"
-
-#: classic/omp.xsl:20906
-msgid "Tasks using this Slave"
-msgstr "Aufgaben, die diesen Slave verwenden"
-
-#: classic/omp.xsl:21037
+#: classic/omp.xsl:20364
 msgid "BID"
 msgstr "BID"
 
-#: classic/omp.xsl:21058 classic/omp.xsl:21066 classic/omp.xsl:37514
+#: classic/omp.xsl:20385 classic/omp.xsl:20393 classic/omp.xsl:37023
 msgid "CERT"
 msgstr "CERT"
 
-#: classic/omp.xsl:21059 classic/omp.xsl:37361 classic/gsad.xsl:1114
+#: classic/omp.xsl:20386 classic/omp.xsl:36870 classic/gsad.xsl:1134
 msgid "Warning"
 msgstr "Warnung"
 
-#: classic/omp.xsl:21104
+#: classic/omp.xsl:20431
 msgctxt "SecInfo|References"
 msgid "Other"
 msgstr "Andere"
 
-#: classic/omp.xsl:21944 classic/omp.xsl:22232 classic/omp.xsl:22294
-#: classic/omp.xsl:22715 classic/omp.xsl:22867 classic/omp.xsl:23011
-#: classic/omp.xsl:23282 classic/omp.xsl:23465 classic/omp.xsl:38995
-#: classic/omp.xsl:39558
+#: classic/omp.xsl:21274 classic/omp.xsl:21570 classic/omp.xsl:21634
+#: classic/omp.xsl:22057 classic/omp.xsl:22209 classic/omp.xsl:22353
+#: classic/omp.xsl:22624 classic/omp.xsl:22817 classic/omp.xsl:38489
+#: classic/omp.xsl:39068
 msgid "Title"
 msgstr "Titel"
 
-#: classic/omp.xsl:22004
+#: classic/omp.xsl:21336
 msgctxt "CVSS Vector Short"
 msgid "Vector"
 msgstr "Vektor"
 
-#: classic/omp.xsl:22008
+#: classic/omp.xsl:21340
 msgctxt "CVSS Vector Short"
 msgid "Complexity"
 msgstr "Komplexität"
 
-#: classic/omp.xsl:22012
+#: classic/omp.xsl:21344
 msgctxt "CVSS Vector Short"
 msgid "Authentication"
 msgstr "Authentifiz."
 
-#: classic/omp.xsl:22016
+#: classic/omp.xsl:21348
 msgctxt "CVSS Vector Short"
 msgid "Confidentiality Impact"
 msgstr "Vertraulichkeits-​Ausw."
 
-#: classic/omp.xsl:22020
+#: classic/omp.xsl:21352
 msgctxt "CVSS Vector Short"
 msgid "Integrity Impact"
 msgstr "Integritäts-​Ausw."
 
-#: classic/omp.xsl:22024
+#: classic/omp.xsl:21356
 msgctxt "CVSS Vector Short"
 msgid "Availability Impact"
 msgstr "Verfügbarkeits-​Ausw."
 
-#: classic/omp.xsl:22028 classic/omp.xsl:22550
+#: classic/omp.xsl:21360 classic/omp.xsl:21892
 msgctxt "Date"
 msgid "Published"
 msgstr "Veröffentlicht"
 
-#: classic/omp.xsl:22165
+#: classic/omp.xsl:21501
 msgid "Class"
 msgstr "Klasse"
 
-#: classic/omp.xsl:22523 classic/dynamic_strings.xsl:184
+#: classic/omp.xsl:21865 classic/dynamic_strings.xsl:184
 msgid "CVE Details"
 msgstr "CVE-Details"
 
-#: classic/omp.xsl:22558 classic/omp.xsl:22847 classic/omp.xsl:22885
+#: classic/omp.xsl:21900 classic/omp.xsl:22189 classic/omp.xsl:22227
 msgctxt "Date"
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
 
-#: classic/omp.xsl:22577
+#: classic/omp.xsl:21919
 msgid "CWE ID"
 msgstr "CWE-ID"
 
-#: classic/omp.xsl:22592
+#: classic/omp.xsl:21934
 msgid "Base score"
 msgstr "Basisscore"
 
-#: classic/omp.xsl:22685 classic/omp.xsl:22688 classic/omp.xsl:23111
-#: classic/omp.xsl:23146 classic/omp.xsl:23798 classic/omp.xsl:31567
-#: classic/omp.xsl:31623
+#: classic/omp.xsl:22027 classic/omp.xsl:22030 classic/omp.xsl:22453
+#: classic/omp.xsl:22488 classic/omp.xsl:23154 classic/omp.xsl:30929
+#: classic/omp.xsl:30985
 msgid "References"
 msgstr "Verweise"
 
-#: classic/omp.xsl:22685 classic/omp.xsl:23146
+#: classic/omp.xsl:22027 classic/omp.xsl:22488
 msgctxt "SecInfo|References"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:22711
+#: classic/omp.xsl:22053
 msgid "CERT Advisories referencing this CVE"
 msgstr "CERT-Advisories, die auf diese CVE verweisen"
 
-#: classic/omp.xsl:22733
+#: classic/omp.xsl:22075
 msgid "Unknown CERT type!"
 msgstr "Unbekannter CERT-Typ!"
 
-#: classic/omp.xsl:22746 classic/omp.xsl:22749
+#: classic/omp.xsl:22088 classic/omp.xsl:22091
 msgid "Vulnerable products"
 msgstr "Verwundbare Produkte"
 
-#: classic/omp.xsl:22746
+#: classic/omp.xsl:22088
 msgctxt "CVE|Products"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:22771 classic/omp.xsl:22774
+#: classic/omp.xsl:22113 classic/omp.xsl:22116
 msgid "NVTs addressing this CVE"
 msgstr "NVTs, die diese CVE ansprechen"
 
-#: classic/omp.xsl:22771
+#: classic/omp.xsl:22113
 msgctxt "NVTs"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:22795
+#: classic/omp.xsl:22137
 msgid ""
 "This CVE was not found in the database.  This is not necessarily an error, "
 "because the CVE number might have been assigned for the issue, but the CVE "
@@ -3606,19 +3552,19 @@ msgstr ""
 "während die CVE noch nicht veröffentlicht wurde.  Der CVE-Inhalt wird "
 "beizeiten in der Datenbank erscheinen."
 
-#: classic/omp.xsl:22815 classic/dynamic_strings.xsl:185
+#: classic/omp.xsl:22157 classic/dynamic_strings.xsl:185
 msgid "CPE Details"
 msgstr "CPE-Details"
 
-#: classic/omp.xsl:22873
+#: classic/omp.xsl:22215
 msgid "NVD ID"
 msgstr "NVD-ID"
 
-#: classic/omp.xsl:22879
+#: classic/omp.xsl:22221
 msgid "Deprecated by"
 msgstr "Veraltet durch"
 
-#: classic/omp.xsl:22917
+#: classic/omp.xsl:22259
 msgid ""
 "This CPE does not appear in the CPE dictionary but is referenced by one or "
 "more CVE."
@@ -3626,91 +3572,91 @@ msgstr ""
 "Diese CPE ist nicht im CPE-Dictionary, wird aber von einem oder mehreren CVE "
 "referenziert."
 
-#: classic/omp.xsl:22923 classic/omp.xsl:22926
+#: classic/omp.xsl:22265 classic/omp.xsl:22268
 msgid "Reported vulnerabilites"
 msgstr "Gemeldete Schwachstellen"
 
-#: classic/omp.xsl:22923
+#: classic/omp.xsl:22265
 msgctxt "CPE|Vulnerabilities"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:22966 classic/dynamic_strings.xsl:186
+#: classic/omp.xsl:22308 classic/dynamic_strings.xsl:186
 msgid "OVAL Definition Details"
 msgstr "OVAL-Definitions-Details"
 
-#: classic/omp.xsl:23019
+#: classic/omp.xsl:22361
 msgid "Definition class"
 msgstr "Definitions-Klasse"
 
-#: classic/omp.xsl:23023 classic/omp.xsl:23366 classic/omp.xsl:23379
-#: classic/omp.xsl:23519 classic/omp.xsl:23536
+#: classic/omp.xsl:22365 classic/omp.xsl:22712 classic/omp.xsl:22725
+#: classic/omp.xsl:22875 classic/omp.xsl:22892
 msgid "Referenced CVEs"
 msgstr "CVE-Verweise"
 
-#: classic/omp.xsl:23048
+#: classic/omp.xsl:22390
 msgctxt "OVAL Definition"
 msgid "Deprecated"
 msgstr "Veraltet"
 
-#: classic/omp.xsl:23055
+#: classic/omp.xsl:22397
 msgid "File"
 msgstr "Datei"
 
-#: classic/omp.xsl:23066 classic/omp.xsl:23360
+#: classic/omp.xsl:22408 classic/omp.xsl:22706
 msgctxt "Resource Property|Description"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:23072 classic/omp.xsl:23093
+#: classic/omp.xsl:22414 classic/omp.xsl:22435
 msgctxt "OVAL Definition"
 msgid "Affected"
 msgstr "Betroffen"
 
-#: classic/omp.xsl:23093
+#: classic/omp.xsl:22435
 msgctxt "OVAL Definition|Affected"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:23099 classic/omp.xsl:23105
+#: classic/omp.xsl:22441 classic/omp.xsl:22447
 msgid "Criteria"
 msgstr "Kriterien"
 
-#: classic/omp.xsl:23105
+#: classic/omp.xsl:22447
 msgctxt "OVAL Definition|Criteria"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:23114 classic/omp.xsl:39352
+#: classic/omp.xsl:22456 classic/omp.xsl:38853
 msgid "Source"
 msgstr "Quelle"
 
-#: classic/omp.xsl:23115
+#: classic/omp.xsl:22457
 msgid "Ref.ID"
 msgstr "Verw.-ID"
 
-#: classic/omp.xsl:23152 classic/omp.xsl:23184
+#: classic/omp.xsl:22494 classic/omp.xsl:22526
 msgid "Repository history"
 msgstr "Repository-Verlauf"
 
-#: classic/omp.xsl:23159 classic/omp.xsl:29927
+#: classic/omp.xsl:22501 classic/omp.xsl:29289
 msgid "Date"
 msgstr "Datum"
 
-#: classic/omp.xsl:23160
+#: classic/omp.xsl:22502
 msgid "Contributors"
 msgstr "Beitragende"
 
-#: classic/omp.xsl:23184
+#: classic/omp.xsl:22526
 msgctxt "OVAL Definition|History"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:23189
+#: classic/omp.xsl:22531
 msgid "OVAL definition not found"
 msgstr "OVAL-Definition nicht gefunden"
 
-#: classic/omp.xsl:23190
+#: classic/omp.xsl:22532
 msgid ""
 "No OVAL definition with the requested ID could be found in the SCAP "
 "database."
@@ -3718,61 +3664,61 @@ msgstr ""
 "Es konnte keine OVAL-Definition mit der angefragten ID in der SCAP-Datenbank "
 "gefunden werden."
 
-#: classic/omp.xsl:23231
+#: classic/omp.xsl:22573
 msgid "CERT-Bund Details"
 msgstr "CERT-Bund-Advisory-Details"
 
-#: classic/omp.xsl:23288
+#: classic/omp.xsl:22630
 msgid "Software"
 msgstr "Software"
 
-#: classic/omp.xsl:23292
+#: classic/omp.xsl:22634
 msgid "Platform"
 msgstr "Plattform"
 
-#: classic/omp.xsl:23296
+#: classic/omp.xsl:22638
 msgid "Effect"
 msgstr "Auswirkung"
 
-#: classic/omp.xsl:23300
+#: classic/omp.xsl:22642
 msgid "Remote Attack"
 msgstr "Remoteangriff"
 
-#: classic/omp.xsl:23322
+#: classic/omp.xsl:22664
 msgid "CERT-Bund risk rating"
 msgstr "CERT-Bund-Risikobewertung"
 
-#: classic/omp.xsl:23328
+#: classic/omp.xsl:22670
 msgid "Reference"
 msgstr "Bezug"
 
-#: classic/omp.xsl:23333
+#: classic/omp.xsl:22675
 msgid "Reference URL"
 msgstr "Bezugs-URL"
 
-#: classic/omp.xsl:23340 classic/omp.xsl:23348
+#: classic/omp.xsl:22686 classic/omp.xsl:22694
 msgid "Categories"
 msgstr "Kategorien"
 
-#: classic/omp.xsl:23348
+#: classic/omp.xsl:22694
 msgctxt "CERT-Bund Advisory|Categories"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:23379
+#: classic/omp.xsl:22725
 msgctxt "CVEs"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:23385 classic/omp.xsl:23505
+#: classic/omp.xsl:22731 classic/omp.xsl:22861
 msgid "Other links"
 msgstr "Weitere Links"
 
-#: classic/omp.xsl:23398
+#: classic/omp.xsl:22750
 msgid "CERT-Bund advisory not found"
 msgstr "CERT-Bund-Advisory nicht gefunden"
 
-#: classic/omp.xsl:23399
+#: classic/omp.xsl:22751
 msgid ""
 "No CERT-Bund advisory with the requested ID could be found in the CERT "
 "database."
@@ -3780,24 +3726,24 @@ msgstr ""
 "Es wurde keine CERT-Bund-Meldung mit der angefragten ID in der CERT-"
 "Datenbank gefunden."
 
-#: classic/omp.xsl:23420 classic/dynamic_strings.xsl:188
+#: classic/omp.xsl:22772 classic/dynamic_strings.xsl:188
 msgid "DFN-CERT Advisory Details"
 msgstr "DFN-CERT-Advisory-Details"
 
-#: classic/omp.xsl:23471
+#: classic/omp.xsl:22823
 msgid "Advisory link"
 msgstr "Advisory-Link"
 
-#: classic/omp.xsl:23499
+#: classic/omp.xsl:22855
 msgctxt "Resource Property|Summary"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:23541
+#: classic/omp.xsl:22897
 msgid "DFN-CERT advisory not found"
 msgstr "DFN-CERT-Advisory nicht gefunden"
 
-#: classic/omp.xsl:23542
+#: classic/omp.xsl:22898
 msgid ""
 "No DFN-CERT advisory with the requested ID could be found in the CERT "
 "database."
@@ -3805,1374 +3751,1402 @@ msgstr ""
 "Es wurde keine DFN-CERT-Meldung mit der angefragten ID in der CERT-Datenbank "
 "gefunden."
 
-#: classic/omp.xsl:23571
+#: classic/omp.xsl:22927
 msgid "Notes on NVT %1"
 msgstr "Notizen für NVT %1"
 
-#: classic/omp.xsl:23580
+#: classic/omp.xsl:22936
 msgid "Overrides on NVT %1"
 msgstr "Übersteuerungen für NVT %1"
 
-#: classic/omp.xsl:23589
+#: classic/omp.xsl:22945
 msgid "Show scan results for this NVT"
 msgstr "Scanergebnisse für diesen NVT zeigen"
 
-#: classic/omp.xsl:23661 classic/omp.xsl:31440
+#: classic/omp.xsl:23017 classic/omp.xsl:30802
 msgid "Vulnerability Insight"
 msgstr "Schwachstellen-Einblick"
 
-#: classic/omp.xsl:23677 classic/omp.xsl:31450
+#: classic/omp.xsl:23033 classic/omp.xsl:30812
 msgid "Vulnerability Detection Method"
 msgstr "Methode zur Schwachstellenerkennung"
 
-#: classic/omp.xsl:23693
+#: classic/omp.xsl:23049
 msgid "Quality of Detection"
 msgstr "Qualität der Erkennung"
 
-#: classic/omp.xsl:23714 classic/omp.xsl:31403
+#: classic/omp.xsl:23070 classic/omp.xsl:30765
 msgid "Impact"
 msgstr "Auswirkungen"
 
-#: classic/omp.xsl:23731 classic/omp.xsl:31412
+#: classic/omp.xsl:23087 classic/omp.xsl:30774
 msgid "Solution"
 msgstr "Lösung"
 
-#: classic/omp.xsl:23762
+#: classic/omp.xsl:23118
 msgid "Other tags"
 msgstr "Weitere Tags"
 
-#: classic/omp.xsl:23866 classic/omp.xsl:23868 classic/omp.xsl:31257
-#: classic/omp.xsl:31260 classic/omp.xsl:31265 classic/omp.xsl:31268
-#: classic/omp.xsl:31273 classic/omp.xsl:31276 classic/omp.xsl:31281
-#: classic/omp.xsl:31284
+#: classic/omp.xsl:23222 classic/omp.xsl:23224 classic/omp.xsl:30619
+#: classic/omp.xsl:30622 classic/omp.xsl:30627 classic/omp.xsl:30630
+#: classic/omp.xsl:30635 classic/omp.xsl:30638 classic/omp.xsl:30643
+#: classic/omp.xsl:30646
 msgid "Add Note"
 msgstr "Notiz hinzufügen"
 
-#: classic/omp.xsl:23871 classic/omp.xsl:23873 classic/omp.xsl:31298
-#: classic/omp.xsl:31300 classic/omp.xsl:31305 classic/omp.xsl:31308
-#: classic/omp.xsl:31313 classic/omp.xsl:31316 classic/omp.xsl:31321
-#: classic/omp.xsl:31324
+#: classic/omp.xsl:23227 classic/omp.xsl:23229 classic/omp.xsl:30660
+#: classic/omp.xsl:30662 classic/omp.xsl:30667 classic/omp.xsl:30670
+#: classic/omp.xsl:30675 classic/omp.xsl:30678 classic/omp.xsl:30683
+#: classic/omp.xsl:30686
 msgid "Add Override"
 msgstr "Übersteuerung hinzufügen"
 
-#: classic/omp.xsl:23941 classic/dynamic_strings.xsl:392
+#: classic/omp.xsl:23297 classic/dynamic_strings.xsl:392
 msgid "New Note"
 msgstr "Neue Notiz"
 
-#: classic/omp.xsl:23988 classic/omp.xsl:24393 classic/omp.xsl:24845
-#: classic/omp.xsl:25144 classic/omp.xsl:25572 classic/omp.xsl:26147
+#: classic/omp.xsl:23344 classic/omp.xsl:23749 classic/omp.xsl:24201
+#: classic/omp.xsl:24502 classic/omp.xsl:24930 classic/omp.xsl:25505
 msgid "NVT Name"
 msgstr "NVT-Name"
 
-#: classic/omp.xsl:23995 classic/omp.xsl:24399 classic/omp.xsl:24830
-#: classic/omp.xsl:24850 classic/omp.xsl:25151 classic/omp.xsl:25578
-#: classic/omp.xsl:26132 classic/omp.xsl:26152
+#: classic/omp.xsl:23351 classic/omp.xsl:23755 classic/omp.xsl:24186
+#: classic/omp.xsl:24206 classic/omp.xsl:24509 classic/omp.xsl:24936
+#: classic/omp.xsl:25490 classic/omp.xsl:25510
 msgctxt "NVT"
 msgid "None.  Result was an open port."
 msgstr "Keiner.  Ergebnis war ein offener Port."
 
-#: classic/omp.xsl:24014 classic/omp.xsl:24866 classic/omp.xsl:25170
-#: classic/omp.xsl:26168
+#: classic/omp.xsl:23370 classic/omp.xsl:24222 classic/omp.xsl:24528
+#: classic/omp.xsl:25526
 msgid "NVT OID"
 msgstr "NVT-OID"
 
-#: classic/omp.xsl:24032 classic/omp.xsl:24415 classic/omp.xsl:24877
-#: classic/omp.xsl:25029
+#: classic/omp.xsl:23388 classic/omp.xsl:23771 classic/omp.xsl:24233
+#: classic/omp.xsl:24385
 msgctxt "Note"
 msgid "Active"
 msgstr "Aktiv"
 
-#: classic/omp.xsl:24038 classic/omp.xsl:24422 classic/omp.xsl:24453
-#: classic/omp.xsl:24477 classic/omp.xsl:25193 classic/omp.xsl:25601
-#: classic/omp.xsl:25629 classic/omp.xsl:25651
+#: classic/omp.xsl:23394 classic/omp.xsl:23778 classic/omp.xsl:23809
+#: classic/omp.xsl:23833 classic/omp.xsl:24551 classic/omp.xsl:24959
+#: classic/omp.xsl:24987 classic/omp.xsl:25009
 msgid "always"
 msgstr "immer"
 
-#: classic/omp.xsl:24046 classic/omp.xsl:24435 classic/omp.xsl:24459
-#: classic/omp.xsl:24483 classic/omp.xsl:25200 classic/omp.xsl:25613
-#: classic/omp.xsl:25635 classic/omp.xsl:25657
+#: classic/omp.xsl:23402 classic/omp.xsl:23791 classic/omp.xsl:23815
+#: classic/omp.xsl:23839 classic/omp.xsl:24558 classic/omp.xsl:24971
+#: classic/omp.xsl:24993 classic/omp.xsl:25015
 msgctxt "Time"
 msgid "for the next"
 msgstr "für die nächsten"
 
-#: classic/omp.xsl:24076 classic/omp.xsl:24094 classic/omp.xsl:24510
-#: classic/omp.xsl:24516 classic/omp.xsl:24904 classic/omp.xsl:25229
-#: classic/omp.xsl:25247 classic/omp.xsl:25682 classic/omp.xsl:25688
-#: classic/omp.xsl:26206
+#: classic/omp.xsl:23432 classic/omp.xsl:23450 classic/omp.xsl:23866
+#: classic/omp.xsl:23872 classic/omp.xsl:24260 classic/omp.xsl:24587
+#: classic/omp.xsl:24605 classic/omp.xsl:25040 classic/omp.xsl:25046
+#: classic/omp.xsl:25564
 msgctxt "Hosts"
 msgid "Any"
 msgstr "Beliebig"
 
-#: classic/omp.xsl:24112 classic/omp.xsl:25267 classic/omp.xsl:31014
-#: classic/omp.xsl:31018 classic/omp.xsl:32141
+#: classic/omp.xsl:23468 classic/omp.xsl:24625 classic/omp.xsl:30376
+#: classic/omp.xsl:30380 classic/omp.xsl:31505
 msgctxt "Result"
 msgid "Location"
 msgstr "Ort"
 
-#: classic/omp.xsl:24121 classic/omp.xsl:24139 classic/omp.xsl:25276
-#: classic/omp.xsl:25294
+#: classic/omp.xsl:23477 classic/omp.xsl:23495 classic/omp.xsl:24634
+#: classic/omp.xsl:24652
 msgctxt "Result|Location"
 msgid "Any"
 msgstr "Beliebig"
 
-#: classic/omp.xsl:24166 classic/omp.xsl:24192 classic/omp.xsl:24563
-#: classic/omp.xsl:24569 classic/omp.xsl:24933 classic/omp.xsl:25323
-#: classic/omp.xsl:25349 classic/omp.xsl:25735 classic/omp.xsl:25741
-#: classic/omp.xsl:26005 classic/omp.xsl:26235 classic/omp.xsl:26247
-#: classic/omp.xsl:30417
+#: classic/omp.xsl:23522 classic/omp.xsl:23548 classic/omp.xsl:23919
+#: classic/omp.xsl:23925 classic/omp.xsl:24289 classic/omp.xsl:24681
+#: classic/omp.xsl:24707 classic/omp.xsl:25093 classic/omp.xsl:25099
+#: classic/omp.xsl:25363 classic/omp.xsl:25593 classic/omp.xsl:25605
+#: classic/omp.xsl:29779
 msgctxt "Severity"
 msgid "Any"
 msgstr "Beliebig"
 
-#: classic/omp.xsl:24227 classic/omp.xsl:24246 classic/omp.xsl:24597
-#: classic/omp.xsl:24603 classic/omp.xsl:24958 classic/omp.xsl:25416
-#: classic/omp.xsl:25435 classic/omp.xsl:25849 classic/omp.xsl:25855
-#: classic/omp.xsl:26287
+#: classic/omp.xsl:23583 classic/omp.xsl:23602 classic/omp.xsl:23953
+#: classic/omp.xsl:23959 classic/omp.xsl:24314 classic/omp.xsl:24774
+#: classic/omp.xsl:24793 classic/omp.xsl:25207 classic/omp.xsl:25213
+#: classic/omp.xsl:25645
 msgctxt "Task"
 msgid "Any"
 msgstr "Beliebig"
 
-#: classic/omp.xsl:24275 classic/omp.xsl:24624 classic/omp.xsl:24630
-#: classic/omp.xsl:24656 classic/omp.xsl:24974 classic/omp.xsl:25464
-#: classic/omp.xsl:25876 classic/omp.xsl:25882 classic/omp.xsl:25903
-#: classic/omp.xsl:26303
+#: classic/omp.xsl:23631 classic/omp.xsl:23980 classic/omp.xsl:23986
+#: classic/omp.xsl:24012 classic/omp.xsl:24330 classic/omp.xsl:24822
+#: classic/omp.xsl:25234 classic/omp.xsl:25240 classic/omp.xsl:25261
+#: classic/omp.xsl:25661
 msgctxt "Result"
 msgid "Any"
 msgstr "Beliebig"
 
-#: classic/omp.xsl:24285 classic/omp.xsl:25474
+#: classic/omp.xsl:23641 classic/omp.xsl:24832
 msgctxt "Note or Override|Result"
 msgid "Only the selected one"
 msgstr "Nur das ausgewählte"
 
-#: classic/omp.xsl:24310 classic/omp.xsl:24642 classic/omp.xsl:25021
-#: classic/omp.xsl:25046 classic/omp.xsl:25894 classic/omp.xsl:26350
-#: classic/omp.xsl:26383
+#: classic/omp.xsl:23666 classic/omp.xsl:23998 classic/omp.xsl:24377
+#: classic/omp.xsl:24404 classic/omp.xsl:25252 classic/omp.xsl:25708
+#: classic/omp.xsl:25743
 msgid "Text"
 msgstr "Text"
 
-#: classic/omp.xsl:24320 classic/omp.xsl:24656 classic/omp.xsl:24660
-#: classic/omp.xsl:25499 classic/omp.xsl:25903 classic/omp.xsl:25907
+#: classic/omp.xsl:23676 classic/omp.xsl:24012 classic/omp.xsl:24016
+#: classic/omp.xsl:24857 classic/omp.xsl:25261 classic/omp.xsl:25265
 msgid "Associated Result"
 msgstr "Zugehöriges Ergebnis"
 
-#: classic/omp.xsl:24348 classic/omp.xsl:30271 classic/omp.xsl:30278
-#: classic/omp.xsl:30285 classic/omp.xsl:30292 classic/omp.xsl:30299
-#: classic/omp.xsl:30306 classic/dynamic_strings.xsl:605
+#: classic/omp.xsl:23704 classic/omp.xsl:29633 classic/omp.xsl:29640
+#: classic/omp.xsl:29647 classic/omp.xsl:29654 classic/omp.xsl:29661
+#: classic/omp.xsl:29668 classic/dynamic_strings.xsl:605
 msgid "Edit Note"
 msgstr "Notiz bearbeiten"
 
-#: classic/omp.xsl:24428 classic/omp.xsl:24884 classic/omp.xsl:25607
-#: classic/omp.xsl:26186
+#: classic/omp.xsl:23784 classic/omp.xsl:24240 classic/omp.xsl:24965
+#: classic/omp.xsl:25544
 msgctxt "Time"
 msgid "until"
 msgstr "bis"
 
-#: classic/omp.xsl:24537 classic/omp.xsl:24543 classic/omp.xsl:24917
-#: classic/omp.xsl:25709 classic/omp.xsl:25715 classic/omp.xsl:26219
+#: classic/omp.xsl:23893 classic/omp.xsl:23899 classic/omp.xsl:24273
+#: classic/omp.xsl:25067 classic/omp.xsl:25073 classic/omp.xsl:25577
 msgctxt "Port"
 msgid "Any"
 msgstr "Beliebig"
 
-#: classic/omp.xsl:24649
+#: classic/omp.xsl:24005
 msgid "Save Note"
 msgstr "Notiz speichern"
 
-#: classic/omp.xsl:24706 classic/omp.xsl:24788 classic/omp.xsl:24943
-#: classic/omp.xsl:24968
+#: classic/omp.xsl:24062 classic/omp.xsl:24144 classic/omp.xsl:24299
+#: classic/omp.xsl:24324
 msgctxt "Note"
 msgid "Orphan"
 msgstr "Verwaist"
 
-#: classic/omp.xsl:24721 classic/omp.xsl:24777 classic/omp.xsl:25992
-#: classic/omp.xsl:26079
+#: classic/omp.xsl:24077 classic/omp.xsl:24133 classic/omp.xsl:25350
+#: classic/omp.xsl:25437
 msgid "Result was an open port."
 msgstr "Ergebnis war ein offener Port"
 
-#: classic/omp.xsl:24721 classic/omp.xsl:24777 classic/omp.xsl:25992
-#: classic/omp.xsl:26079
+#: classic/omp.xsl:24077 classic/omp.xsl:24133 classic/omp.xsl:25350
+#: classic/omp.xsl:25437
 msgctxt "NVT"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:24825
+#: classic/omp.xsl:24181
 msgid "Note for NVT"
 msgstr "Notiz für NVT"
 
-#: classic/omp.xsl:24894 classic/omp.xsl:26196
+#: classic/omp.xsl:24250 classic/omp.xsl:25554
 msgctxt "Note or Override"
 msgid "Application"
 msgstr "Anwendung"
 
-#: classic/omp.xsl:24983
+#: classic/omp.xsl:24339
 msgctxt "Note"
 msgid "Appearance when active"
 msgstr "Aussehen, wenn aktiv"
 
-#: classic/omp.xsl:24986 classic/omp.xsl:26315
+#: classic/omp.xsl:24342 classic/omp.xsl:25673
 msgid "Appearance"
 msgstr "Aussehen"
 
-#: classic/omp.xsl:24996
+#: classic/omp.xsl:24352
 msgid "User Tags for this Note"
 msgstr "Benutzer-Tags für diese Notiz"
 
-#: classic/omp.xsl:25002
+#: classic/omp.xsl:24358
 msgid "Permissions for this Note"
 msgstr "Berechtigungen für diese Notiz"
 
-#: classic/omp.xsl:25097 classic/dynamic_strings.xsl:393
+#: classic/omp.xsl:24455 classic/dynamic_strings.xsl:393
 msgid "New Override"
 msgstr "Neue Übersteuerung"
 
-#: classic/omp.xsl:25187 classic/omp.xsl:25594 classic/omp.xsl:26179
-#: classic/omp.xsl:26366
+#: classic/omp.xsl:24545 classic/omp.xsl:24952 classic/omp.xsl:25537
+#: classic/omp.xsl:25724
 msgctxt "Override"
 msgid "Active"
 msgstr "Aktiv"
 
-#: classic/omp.xsl:25375 classic/omp.xsl:25761 classic/omp.xsl:26241
+#: classic/omp.xsl:24733 classic/omp.xsl:25119 classic/omp.xsl:25599
 msgid "New Severity"
 msgstr "Neuer Schweregrad"
 
-#: classic/omp.xsl:25388 classic/omp.xsl:25811
+#: classic/omp.xsl:24746 classic/omp.xsl:25169
 msgctxt "Severity"
 msgid "False Positive"
 msgstr "Falsch Positiv"
 
-#: classic/omp.xsl:25396 classic/omp.xsl:25827
+#: classic/omp.xsl:24754 classic/omp.xsl:25185
 msgctxt "Override|Severity"
 msgid "Other"
 msgstr "Anderer"
 
-#: classic/omp.xsl:25527 classic/omp.xsl:30545 classic/omp.xsl:30552
-#: classic/omp.xsl:30559 classic/omp.xsl:30566 classic/omp.xsl:30573
-#: classic/omp.xsl:30580 classic/dynamic_strings.xsl:606
+#: classic/omp.xsl:24885 classic/omp.xsl:29907 classic/omp.xsl:29914
+#: classic/omp.xsl:29921 classic/omp.xsl:29928 classic/omp.xsl:29935
+#: classic/omp.xsl:29942 classic/dynamic_strings.xsl:606
 msgid "Edit Override"
 msgstr "Übersteuerung bearbeiten"
 
-#: classic/omp.xsl:25974 classic/omp.xsl:26090 classic/omp.xsl:26272
-#: classic/omp.xsl:26297
+#: classic/omp.xsl:25332 classic/omp.xsl:25448 classic/omp.xsl:25630
+#: classic/omp.xsl:25655
 msgctxt "Override"
 msgid "Orphan"
 msgstr "Verwaist"
 
-#: classic/omp.xsl:26127
+#: classic/omp.xsl:25485
 msgid "Override for NVT"
 msgstr "Übersteuerung für NVT"
 
-#: classic/omp.xsl:26312
+#: classic/omp.xsl:25670
 msgctxt "Override"
 msgid "Appearance when active"
 msgstr "Aussehen, wenn aktiv"
 
-#: classic/omp.xsl:26325
+#: classic/omp.xsl:25683
 msgid "User Tags for this Override"
 msgstr "Benutzer-Tags für diese Übersteuerung"
 
-#: classic/omp.xsl:26331
+#: classic/omp.xsl:25689
 msgid "Permissions for this Override"
 msgstr "Berechtigungen für diese Übersteuerung"
 
-#: classic/omp.xsl:26358
+#: classic/omp.xsl:25716
 msgctxt "Override|Severity"
 msgid "From"
 msgstr "Von"
 
-#: classic/omp.xsl:26362
+#: classic/omp.xsl:25720
 msgctxt "Override|Severity"
 msgid "To"
 msgstr "Nach"
 
-#: classic/omp.xsl:26540 classic/dynamic_strings.xsl:431
+#: classic/omp.xsl:25900 classic/dynamic_strings.xsl:431
 msgid "Group is still in use"
 msgstr "Gruppe wird noch verwendet"
 
-#: classic/omp.xsl:26560 classic/omp.xsl:26638 classic/omp.xsl:26639
-#: classic/omp.xsl:36116 classic/omp.xsl:36321 classic/omp.xsl:36398
-#: classic/omp.xsl:36638 classic/omp.xsl:36866 classic/dynamic_strings.xsl:121
-#: classic/gsad.xsl:666
+#: classic/omp.xsl:25920 classic/omp.xsl:25998 classic/omp.xsl:25999
+#: classic/omp.xsl:35634 classic/omp.xsl:35830 classic/omp.xsl:35907
+#: classic/omp.xsl:36147 classic/omp.xsl:36375 classic/dynamic_strings.xsl:121
+#: classic/gsad.xsl:667
 msgid "Groups"
 msgstr "Gruppen"
 
-#: classic/omp.xsl:26576 classic/omp.xsl:26668 classic/omp.xsl:26746
-#: classic/omp.xsl:34907 classic/omp.xsl:34972 classic/omp.xsl:35295
-#: classic/omp.xsl:36608 classic/dynamic_strings.xsl:120 classic/gsad.xsl:660
+#: classic/omp.xsl:25936 classic/omp.xsl:26028 classic/omp.xsl:26106
+#: classic/omp.xsl:34269 classic/omp.xsl:34334 classic/omp.xsl:34657
+#: classic/omp.xsl:36117 classic/dynamic_strings.xsl:120 classic/gsad.xsl:661
 msgid "Users"
 msgstr "Benutzer"
 
-#: classic/omp.xsl:26630 classic/omp.xsl:26633 classic/dynamic_strings.xsl:408
+#: classic/omp.xsl:25990 classic/omp.xsl:25993 classic/dynamic_strings.xsl:408
 msgid "New Group"
 msgstr "Neue Gruppe"
 
-#: classic/omp.xsl:26675
+#: classic/omp.xsl:26035
 msgid "Special Groups"
 msgstr "Spezielle Gruppen"
 
-#: classic/omp.xsl:26680
+#: classic/omp.xsl:26040
 msgid ""
 "Create permission to grant full read and write access among all group "
 "members and across any resources"
 msgstr "Spezielle Gruppen"
 
-#: classic/omp.xsl:26686
+#: classic/omp.xsl:26046
 msgid "Create Group"
 msgstr "Gruppe erstellen"
 
-#: classic/omp.xsl:26708 classic/dynamic_strings.xsl:621
+#: classic/omp.xsl:26068 classic/dynamic_strings.xsl:621
 msgid "Edit Group"
 msgstr "Gruppe bearbeiten"
 
-#: classic/omp.xsl:26756
+#: classic/omp.xsl:26116
 msgid "Save Group"
 msgstr "Gruppe speichern"
 
-#: classic/omp.xsl:26893 classic/omp.xsl:34982 classic/dynamic_strings.xsl:406
+#: classic/omp.xsl:26253 classic/omp.xsl:34344 classic/dynamic_strings.xsl:406
 msgid "New Permission"
 msgstr "Neue Berechtigung"
 
-#: classic/omp.xsl:26923 classic/omp.xsl:27636 classic/dynamic_strings.xsl:631
+#: classic/omp.xsl:26283 classic/omp.xsl:26999 classic/dynamic_strings.xsl:631
 msgid "has super access"
 msgstr "hat Super-Zugriff"
 
-#: classic/omp.xsl:26924 classic/omp.xsl:27637
+#: classic/omp.xsl:26284 classic/omp.xsl:27000
 msgid "Super (Has super access)"
 msgstr "Super (hat Super-Zugriff)"
 
-#: classic/omp.xsl:26932 classic/omp.xsl:27643 classic/omp.xsl:27653
+#: classic/omp.xsl:26292 classic/omp.xsl:27006 classic/omp.xsl:27016
 msgid "%1 ID"
 msgstr "%1-ID"
 
-#: classic/omp.xsl:26993 classic/omp.xsl:27774 classic/omp.xsl:27777
+#: classic/omp.xsl:26353 classic/omp.xsl:27137 classic/omp.xsl:27140
 msgid "User ID"
 msgstr "Benutzer-ID"
 
-#: classic/omp.xsl:26994 classic/omp.xsl:27782 classic/omp.xsl:27785
+#: classic/omp.xsl:26354 classic/omp.xsl:27145 classic/omp.xsl:27148
 msgid "Role ID"
 msgstr "Rollen-ID"
 
-#: classic/omp.xsl:26995 classic/omp.xsl:27790 classic/omp.xsl:27793
+#: classic/omp.xsl:26355 classic/omp.xsl:27153 classic/omp.xsl:27156
 msgid "Group ID"
 msgstr "Gruppen-ID"
 
-#: classic/omp.xsl:27140
+#: classic/omp.xsl:26497
 msgctxt "Permission|Grant"
 msgid "Grant "
 msgstr "Vergebe "
 
-#: classic/omp.xsl:27144
+#: classic/omp.xsl:26501
 msgctxt "Permission"
 msgid "read"
 msgstr "Lese"
 
-#: classic/omp.xsl:27145
+#: classic/omp.xsl:26502
 msgctxt "Permission"
 msgid "proxy"
 msgstr "Stellvertreter"
 
-#: classic/omp.xsl:27147
+#: classic/omp.xsl:26504
 msgctxt "Permission|Grant"
 msgid " permissions"
 msgstr "-Rechte"
 
-#: classic/omp.xsl:27152
+#: classic/omp.xsl:26509
 msgctxt "Permission|Grant"
 msgid " to "
 msgstr " an "
 
-#: classic/omp.xsl:27160
+#: classic/omp.xsl:26517
 msgctxt "Permission|Grant"
 msgid " on "
 msgstr " für "
 
-#: classic/omp.xsl:27183
+#: classic/omp.xsl:26540
 msgctxt "Permission"
 msgid "including related resources"
 msgstr "inklusive verwandter Ressourcen"
 
-#: classic/omp.xsl:27186
+#: classic/omp.xsl:26543
 msgctxt "Permission"
 msgid "for current resource only"
 msgstr "nur für aktuelles Ressource"
 
-#: classic/omp.xsl:27189
+#: classic/omp.xsl:26546
 msgctxt "Permission"
 msgid "for related resources only"
 msgstr "nur für verwandte Ressourcen"
 
-#: classic/omp.xsl:27257 classic/omp.xsl:27258 classic/omp.xsl:27461
-#: classic/omp.xsl:27462
+#: classic/omp.xsl:26614 classic/omp.xsl:26615 classic/omp.xsl:26824
+#: classic/omp.xsl:26825
 msgid "Permission made visible for:"
 msgstr "Berechtigung sichtbar gemacht für:"
 
-#: classic/omp.xsl:27289 classic/omp.xsl:27425
+#: classic/omp.xsl:26646 classic/omp.xsl:26782
 msgctxt "Permission"
 msgid "Orphan"
 msgstr "Verwaist"
 
-#: classic/omp.xsl:27518 classic/omp.xsl:35123 classic/dynamic_strings.xsl:429
+#: classic/omp.xsl:26881 classic/omp.xsl:34485 classic/dynamic_strings.xsl:429
 msgid "Permission is still in use"
 msgstr "Berechtigung wird noch verwendet"
 
-#: classic/omp.xsl:27609 classic/dynamic_strings.xsl:619
+#: classic/omp.xsl:26972 classic/dynamic_strings.xsl:619
 msgid "Edit Permission"
 msgstr "Berechtigung bearbeiten"
 
-#: classic/omp.xsl:27963 classic/omp.xsl:27966 classic/omp.xsl:28556
+#: classic/omp.xsl:27323 classic/omp.xsl:27326 classic/omp.xsl:27916
 #: classic/dynamic_strings.xsl:395
 msgid "New Port List"
 msgstr "Neue Portliste"
 
-#: classic/omp.xsl:27971 classic/omp.xsl:27972 classic/omp.xsl:28213
-#: classic/omp.xsl:28562 classic/omp.xsl:36152 classic/dynamic_strings.xsl:106
-#: classic/gsad.xsl:542
+#: classic/omp.xsl:27331 classic/omp.xsl:27332 classic/omp.xsl:27573
+#: classic/omp.xsl:27922 classic/omp.xsl:35670 classic/dynamic_strings.xsl:106
+#: classic/gsad.xsl:549
 msgid "Port Lists"
 msgstr "Portlisten"
 
-#: classic/omp.xsl:27999 classic/omp.xsl:28250 classic/omp.xsl:28409
+#: classic/omp.xsl:27359 classic/omp.xsl:27610 classic/omp.xsl:27769
 msgid "Port Ranges"
 msgstr "Portbereiche"
 
-#: classic/omp.xsl:28011
+#: classic/omp.xsl:27371
 msgctxt "Port List"
 msgid "From file"
 msgstr "Aus Datei"
 
-#: classic/omp.xsl:28020
+#: classic/omp.xsl:27380
 msgid "Create Port List"
 msgstr "Portliste erstellen"
 
-#: classic/omp.xsl:28044
+#: classic/omp.xsl:27404
 msgid "Port Counts"
 msgstr "Portanzahlen"
 
-#: classic/omp.xsl:28046
+#: classic/omp.xsl:27406
 msgctxt "Port Counts"
 msgid "Total"
 msgstr "Gesamt"
 
-#: classic/omp.xsl:28051
+#: classic/omp.xsl:27411
 msgid "TCP"
 msgstr "TCP"
 
-#: classic/omp.xsl:28056
+#: classic/omp.xsl:27416
 msgid "UDP"
 msgstr "UDP"
 
-#: classic/omp.xsl:28193 classic/omp.xsl:28445 classic/dynamic_strings.xsl:418
+#: classic/omp.xsl:27553 classic/omp.xsl:27805 classic/dynamic_strings.xsl:418
 msgid "Port List is still in use"
 msgstr "Portliste wird noch verwendet"
 
-#: classic/omp.xsl:28229
+#: classic/omp.xsl:27589
 msgid "Port count"
 msgstr "Anzahl Ports"
 
-#: classic/omp.xsl:28233
+#: classic/omp.xsl:27593
 msgid "TCP Port count"
 msgstr "Anzahl TCP-Ports"
 
-#: classic/omp.xsl:28237
+#: classic/omp.xsl:27597
 msgid "UDP Port count"
 msgstr "Anzahl UDP-Ports"
 
-#: classic/omp.xsl:28266 classic/omp.xsl:28413 classic/omp.xsl:28502
+#: classic/omp.xsl:27626 classic/omp.xsl:27773 classic/omp.xsl:27862
 msgctxt "Port Range"
 msgid "Start"
 msgstr "Anfang"
 
-#: classic/omp.xsl:28267 classic/omp.xsl:28414 classic/omp.xsl:28509
+#: classic/omp.xsl:27627 classic/omp.xsl:27774 classic/omp.xsl:27869
 msgctxt "Port Range"
 msgid "End"
 msgstr "Ende"
 
-#: classic/omp.xsl:28294
+#: classic/omp.xsl:27654
 msgid "Targets using this Port List"
 msgstr "Ziele, die diese Portliste verwenden"
 
-#: classic/omp.xsl:28349 classic/dynamic_strings.xsl:608
+#: classic/omp.xsl:27709 classic/dynamic_strings.xsl:608
 msgid "Edit Port List"
 msgstr "Portliste bearbeiten"
 
-#: classic/omp.xsl:28392
+#: classic/omp.xsl:27752
 msgid "Save Port List"
 msgstr "Portliste bearbeiten"
 
-#: classic/omp.xsl:28401 classic/omp.xsl:28405
+#: classic/omp.xsl:27761 classic/omp.xsl:27765
 msgid "Add Port Range"
 msgstr "Neuen Portbereich hinzufügen"
 
-#: classic/omp.xsl:28489
+#: classic/omp.xsl:27849
 msgid "New Port Range"
 msgstr "Neuer Portbereich"
 
-#: classic/omp.xsl:28573
+#: classic/omp.xsl:27933
 msgid "Import XML Port List"
 msgstr "XML-Portliste importieren"
 
-#: classic/omp.xsl:28648 classic/omp.xsl:29215 classic/omp.xsl:35777
+#: classic/omp.xsl:28008 classic/omp.xsl:28575 classic/omp.xsl:35318
 msgctxt "File"
 msgid "Extension"
 msgstr "Erweiterung"
 
-#: classic/omp.xsl:28652 classic/omp.xsl:29219 classic/omp.xsl:35778
+#: classic/omp.xsl:28012 classic/omp.xsl:28579 classic/omp.xsl:35319
 msgid "Content Type"
 msgstr "Inhaltstyp"
 
-#: classic/omp.xsl:28656 classic/omp.xsl:35779
+#: classic/omp.xsl:28016 classic/omp.xsl:35320
 msgid "Trust (Last Verified)"
 msgstr "Vertrauen (Zuletzt Verifiziert)"
 
-#: classic/omp.xsl:28660 classic/omp.xsl:28791 classic/omp.xsl:29227
-#: classic/omp.xsl:35780
+#: classic/omp.xsl:28020 classic/omp.xsl:28151 classic/omp.xsl:28587
+#: classic/omp.xsl:35321
 msgctxt "Report Format"
 msgid "Active"
 msgstr "Aktiv"
 
-#: classic/omp.xsl:28673 classic/omp.xsl:28676 classic/dynamic_strings.xsl:400
+#: classic/omp.xsl:28033 classic/omp.xsl:28036 classic/dynamic_strings.xsl:400
 msgid "New Report Format"
 msgstr "Neues Berichtformat"
 
-#: classic/omp.xsl:28681 classic/omp.xsl:28682 classic/omp.xsl:29203
-#: classic/omp.xsl:36161 classic/dynamic_strings.xsl:113 classic/gsad.xsl:573
+#: classic/omp.xsl:28041 classic/omp.xsl:28042 classic/omp.xsl:28563
+#: classic/omp.xsl:35679 classic/dynamic_strings.xsl:113 classic/gsad.xsl:580
 msgid "Report Formats"
 msgstr "Berichtformate"
 
-#: classic/omp.xsl:28696
+#: classic/omp.xsl:28056
 msgid "Import XML report format"
 msgstr "XML-Berichtformat importieren"
 
-#: classic/omp.xsl:28702
+#: classic/omp.xsl:28062
 msgid "Import Report Format"
 msgstr "Berichtformat importieren"
 
-#: classic/omp.xsl:28756 classic/dynamic_strings.xsl:613
+#: classic/omp.xsl:28116 classic/dynamic_strings.xsl:613
 msgid "Edit Report Format"
 msgstr "Berichtformat bearbeiten"
 
-#: classic/omp.xsl:28832 classic/omp.xsl:28835 classic/omp.xsl:29256
+#: classic/omp.xsl:28192 classic/omp.xsl:28195 classic/omp.xsl:28616
 msgid "Parameters"
 msgstr "Parameter"
 
-#: classic/omp.xsl:28832
+#: classic/omp.xsl:28192
 msgctxt "Report Format|Parameters"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:28925
+#: classic/omp.xsl:28285
 msgid "Verifying Report Format..."
 msgstr "Berichtformat wird verifiziert..."
 
-#: classic/omp.xsl:28926 classic/omp.xsl:28949
+#: classic/omp.xsl:28286 classic/omp.xsl:28309
 msgid "Verify Report Format"
 msgstr "Berichtformat verifizieren"
 
-#: classic/omp.xsl:28937
+#: classic/omp.xsl:28297
 msgid "Report Format has been verified."
 msgstr "Berichtformat wurde verfiziert."
 
-#: classic/omp.xsl:28942
+#: classic/omp.xsl:28302
 msgid "Report Format could not be verified."
 msgstr "Berichtformat konnte nicht verifiziert werden."
 
-#: classic/omp.xsl:28950
+#: classic/omp.xsl:28310
 msgid "Permission to verify Report Format denied"
 msgstr "Keine Berechtigung, Berichtformat zu verifizieren"
 
-#: classic/omp.xsl:29009 classic/dynamic_strings.xsl:423
+#: classic/omp.xsl:28369 classic/dynamic_strings.xsl:423
 msgid "Report Format is still in use"
 msgstr "Berichtformats wird noch verwendet"
 
-#: classic/omp.xsl:29285
+#: classic/omp.xsl:28645
 msgid "Alerts using this Report Format"
 msgstr "Benachrichtigungen, die dieses Berichtformat verwenden"
 
-#: classic/omp.xsl:29442
+#: classic/omp.xsl:28802
 msgid "Host Details (Classic)"
 msgstr "Host-Details (klassisch)"
 
-#: classic/omp.xsl:29445 classic/omp.xsl:39174 classic/dynamic_strings.xsl:179
+#: classic/omp.xsl:28805 classic/omp.xsl:38675 classic/dynamic_strings.xsl:179
 msgid "Host Details"
 msgstr "Host-Details"
 
-#: classic/omp.xsl:29530 classic/omp.xsl:32354 classic/omp.xsl:32495
-#: classic/omp.xsl:33043
+#: classic/omp.xsl:28890 classic/omp.xsl:31718 classic/omp.xsl:31861
+#: classic/omp.xsl:32409
 msgctxt "Report"
 msgid "not finished"
 msgstr "nicht abgeschlossen"
 
-#: classic/omp.xsl:29578 classic/omp.xsl:32292 classic/omp.xsl:32462
-#: classic/omp.xsl:32913 classic/omp.xsl:39275 classic/omp.xsl:39519
+#: classic/omp.xsl:28938 classic/omp.xsl:31656 classic/omp.xsl:31828
+#: classic/omp.xsl:32279 classic/omp.xsl:38776 classic/omp.xsl:39027
 msgid "OS"
 msgstr "OS"
 
-#: classic/omp.xsl:29590
+#: classic/omp.xsl:28950
 msgid "Open Ports"
 msgstr "Offene Ports"
 
-#: classic/omp.xsl:29596
+#: classic/omp.xsl:28956
 msgid "Open TCP Ports"
 msgstr "Offene TCP-Ports"
 
-#: classic/omp.xsl:29605
+#: classic/omp.xsl:28965
 msgid "Open UDP Ports"
 msgstr "Offene UDP-Ports"
 
-#: classic/omp.xsl:29614 classic/omp.xsl:29766 classic/omp.xsl:32915
+#: classic/omp.xsl:28974 classic/omp.xsl:29126 classic/omp.xsl:32281
 msgid "Apps"
 msgstr "Anw."
 
-#: classic/omp.xsl:29620 classic/omp.xsl:32295 classic/omp.xsl:32466
-#: classic/omp.xsl:32916 classic/omp.xsl:33179
+#: classic/omp.xsl:28980 classic/omp.xsl:31659 classic/omp.xsl:31832
+#: classic/omp.xsl:32282 classic/omp.xsl:32545
 msgctxt "Host"
 msgid "Distance"
 msgstr "Distanz"
 
-#: classic/omp.xsl:29634
+#: classic/omp.xsl:28994
 msgid "Host Identification"
 msgstr "Host-Identifizierung"
 
-#: classic/omp.xsl:29637
+#: classic/omp.xsl:28997
 msgid "Identifier"
 msgstr "Bezeichner"
 
-#: classic/omp.xsl:29657
+#: classic/omp.xsl:29017
 msgid "Scanned IP"
 msgstr "Gescannte IP"
 
-#: classic/omp.xsl:29662 classic/omp.xsl:29668 classic/omp.xsl:29674
-#: classic/omp.xsl:29680 classic/omp.xsl:39263 classic/omp.xsl:39511
+#: classic/omp.xsl:29022 classic/omp.xsl:29028 classic/omp.xsl:29034
+#: classic/omp.xsl:29040 classic/omp.xsl:38764 classic/omp.xsl:39019
 msgid "Hostname"
 msgstr "Hostname"
 
-#: classic/omp.xsl:29662
+#: classic/omp.xsl:29022
 msgid "target definition"
 msgstr "Ziel-Definition"
 
-#: classic/omp.xsl:29668
+#: classic/omp.xsl:29028
 msgid "reverse lookup"
 msgstr "Invers-Lookup"
 
-#: classic/omp.xsl:29674
+#: classic/omp.xsl:29034
 msgid "WMI, Standalone"
 msgstr "WMI, Standalone"
 
-#: classic/omp.xsl:29680
+#: classic/omp.xsl:29040
 msgid "WMI, Domain"
 msgstr "WMI, Domain"
 
-#: classic/omp.xsl:29693 classic/omp.xsl:29696
+#: classic/omp.xsl:29053 classic/omp.xsl:29056
 msgid "Hardware"
 msgstr "Hardware"
 
-#: classic/omp.xsl:29693
+#: classic/omp.xsl:29053
 msgid "Information not available"
 msgstr "Informationen nicht verfügbar"
 
-#: classic/omp.xsl:29699
+#: classic/omp.xsl:29059
 msgctxt "Hardware"
 msgid "Component"
 msgstr "Komponente"
 
-#: classic/omp.xsl:29700
+#: classic/omp.xsl:29060
 msgid "Values"
 msgstr "Werte"
 
-#: classic/omp.xsl:29704
+#: classic/omp.xsl:29064
 msgid "CPU"
 msgstr "CPU"
 
-#: classic/omp.xsl:29710
+#: classic/omp.xsl:29070
 msgctxt "Hardware"
 msgid "Memory"
 msgstr "Speicher"
 
-#: classic/omp.xsl:29716
+#: classic/omp.xsl:29076
 msgid "Target-Interface"
 msgstr "Ziel-Interface"
 
-#: classic/omp.xsl:29738
+#: classic/omp.xsl:29098
 msgid "Other MACs"
 msgstr "Weitere MACs"
 
-#: classic/omp.xsl:29750
+#: classic/omp.xsl:29110
 msgid "Netinfo dump"
 msgstr "Netinfo-Dump"
 
-#: classic/omp.xsl:29766
+#: classic/omp.xsl:29126
 msgctxt "Apps"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:29769
+#: classic/omp.xsl:29129
 msgid "Detected Applications"
 msgstr "Gefundene Anwendungen"
 
-#: classic/omp.xsl:29775 classic/omp.xsl:32296
+#: classic/omp.xsl:29135 classic/omp.xsl:31660
 msgid "Prognosis"
 msgstr "Vorhersage"
 
-#: classic/omp.xsl:30001
+#: classic/omp.xsl:29363
 msgid "Scan Results"
 msgstr "Scan-Ergebnisse"
 
-#: classic/omp.xsl:30160
+#: classic/omp.xsl:29522
 msgctxt "Note"
 msgid "Active until"
 msgstr "Aktiv bis"
 
-#: classic/omp.xsl:30171 classic/omp.xsl:30249 classic/omp.xsl:30445
-#: classic/omp.xsl:30523
+#: classic/omp.xsl:29533 classic/omp.xsl:29611 classic/omp.xsl:29807
+#: classic/omp.xsl:29885
 msgctxt "Action Verb"
 msgid "Move to Trashcan"
 msgstr "In den Mülleimer verschieben"
 
-#: classic/omp.xsl:30172 classic/dynamic_strings.xsl:498
+#: classic/omp.xsl:29534 classic/dynamic_strings.xsl:498
 msgid "Permission to move Note to trashcan denied"
 msgstr "Keine Berechtigung, Notiz in den Mülleimer zu verschieben"
 
-#: classic/omp.xsl:30250
+#: classic/omp.xsl:29612
 msgid "Note cannot be moved to trashcan"
 msgstr "Notiz kann nicht in den Mülleimer verschoben werden"
 
-#: classic/omp.xsl:30255 classic/dynamic_strings.xsl:181
+#: classic/omp.xsl:29617 classic/dynamic_strings.xsl:181
 msgid "Note Details"
 msgstr "Notiz-Details"
 
-#: classic/omp.xsl:30261 classic/dynamic_strings.xsl:519
+#: classic/omp.xsl:29623 classic/dynamic_strings.xsl:519
 msgid "Permission to edit Note denied"
 msgstr "Keine Berechtigung, Notiz zu bearbeiten"
 
-#: classic/omp.xsl:30266 classic/dynamic_strings.xsl:435
+#: classic/omp.xsl:29628 classic/dynamic_strings.xsl:435
 msgid "Note is not writable"
 msgstr "Notiz ist nicht beschreibbar"
 
-#: classic/omp.xsl:30392 classic/dynamic_strings.xsl:242
+#: classic/omp.xsl:29754 classic/dynamic_strings.xsl:242
 msgid "Export Note"
 msgstr "Notiz exportieren"
 
-#: classic/omp.xsl:30414
+#: classic/omp.xsl:29776
 msgid "Override from "
 msgstr "Übersteuerung von "
 
-#: classic/omp.xsl:30426
+#: classic/omp.xsl:29788
 msgctxt "Override"
 msgid " to "
 msgstr " nach "
 
-#: classic/omp.xsl:30434
+#: classic/omp.xsl:29796
 msgctxt "Override"
 msgid "Active until"
 msgstr "Aktiv bis"
 
-#: classic/omp.xsl:30446 classic/dynamic_strings.xsl:499
+#: classic/omp.xsl:29808 classic/dynamic_strings.xsl:499
 msgid "Permission to move Override to trashcan denied"
 msgstr "Keine Berechtigung, Übersteuerung in den Mülleimer zu verschieben"
 
-#: classic/omp.xsl:30524
+#: classic/omp.xsl:29886
 msgid "Override cannot be moved to trashcan"
 msgstr "Übersteuerung kann nicht in den Mülleimer verschoben werden"
 
-#: classic/omp.xsl:30529 classic/dynamic_strings.xsl:182
+#: classic/omp.xsl:29891 classic/dynamic_strings.xsl:182
 msgid "Override Details"
 msgstr "Übersteuerungs-Details"
 
-#: classic/omp.xsl:30535 classic/dynamic_strings.xsl:520
+#: classic/omp.xsl:29897 classic/dynamic_strings.xsl:520
 msgid "Permission to edit Override denied"
 msgstr "Keine Berechtigung, Übersteuerung zu bearbeiten"
 
-#: classic/omp.xsl:30540 classic/dynamic_strings.xsl:436
+#: classic/omp.xsl:29902 classic/dynamic_strings.xsl:436
 msgid "Override is not writable"
 msgstr "Übersteuerung ist nicht beschreibbar"
 
-#: classic/omp.xsl:30666 classic/dynamic_strings.xsl:243
+#: classic/omp.xsl:30028 classic/dynamic_strings.xsl:243
 msgid "Export Override"
 msgstr "Übersteuerung exportieren"
 
-#: classic/omp.xsl:30692
+#: classic/omp.xsl:30054
 msgid "All Assets with this IP"
 msgstr "Alle Assets mit dieser IP"
 
-#: classic/omp.xsl:30698
+#: classic/omp.xsl:30060
 msgid "The Asset recorded from this report"
 msgstr "Das Asset aus diesem Bericht"
 
-#: classic/omp.xsl:30751 classic/dynamic_strings.xsl:180
+#: classic/omp.xsl:30113 classic/dynamic_strings.xsl:180
 msgid "Result Details"
 msgstr "Ergebnis-Details"
 
-#: classic/omp.xsl:30757
+#: classic/omp.xsl:30119
 msgid "Export Result as XML"
 msgstr "Ergebnis als XML exportieren"
 
-#: classic/omp.xsl:30781 classic/omp.xsl:33974
+#: classic/omp.xsl:30143 classic/omp.xsl:33344
 msgid "Corresponding Task (%1)"
 msgstr "Zugehörige Aufgabe (%1) "
 
-#: classic/omp.xsl:30788 classic/omp.xsl:30789 classic/omp.xsl:30794
-#: classic/omp.xsl:30796
+#: classic/omp.xsl:30150 classic/omp.xsl:30151 classic/omp.xsl:30156
+#: classic/omp.xsl:30158
 msgid "Corresponding Report"
 msgstr "Zugehöriger Bericht"
 
-#: classic/omp.xsl:30829
+#: classic/omp.xsl:30191
 msgid "User Tags for this Result"
 msgstr "Benutzer-Tags für dieses Ergebnis"
 
-#: classic/omp.xsl:31165 classic/omp.xsl:32188
+#: classic/omp.xsl:30527 classic/omp.xsl:31552
 msgctxt "Result"
 msgid "Overridden from "
 msgstr "Übersteuert von "
 
-#: classic/omp.xsl:31346
+#: classic/omp.xsl:30708
 msgid "Result Tags"
 msgstr "Ergebnis-Tags"
 
-#: classic/omp.xsl:31386
+#: classic/omp.xsl:30748
 msgid "Vulnerability Detection Result"
 msgstr "Ergebnis zur Schwachstellenerkennung"
 
-#: classic/omp.xsl:31390
+#: classic/omp.xsl:30752
 msgid ""
 "Vulnerability was detected according to the Vulnerability Detection Method."
 msgstr ""
 "Schwachstelle wurde entsprechend der Schwachstellen-Erkennungsmethode "
 "erkannt."
 
-#: classic/omp.xsl:31453
+#: classic/omp.xsl:30815
 msgid "Log Method"
 msgstr "Log-Methode"
 
-#: classic/omp.xsl:31502
+#: classic/omp.xsl:30864
 msgid "Version used"
 msgstr "Benutzte Version"
 
-#: classic/omp.xsl:31521
+#: classic/omp.xsl:30883
 msgid "Product Detection Result"
 msgstr "Ergebnis zur Produkterkennung"
 
-#: classic/omp.xsl:31524
+#: classic/omp.xsl:30886
 msgid "Product"
 msgstr "Produkt"
 
-#: classic/omp.xsl:31536
+#: classic/omp.xsl:30898
 msgctxt "Result"
 msgid "Log"
 msgstr "Log"
 
-#: classic/omp.xsl:31539
+#: classic/omp.xsl:30901
 msgid "Product detection results"
 msgstr "Ergebnisse zur Produkterkennung"
 
-#: classic/omp.xsl:31540
+#: classic/omp.xsl:30902
 msgid "View details of product detection"
 msgstr "Details der Produkterkennung anzeigen"
 
-#: classic/omp.xsl:31643
+#: classic/omp.xsl:31005
 msgid "Different Lines"
 msgstr "Zeilen mit Unterschieden"
 
-#: classic/omp.xsl:31877 classic/omp.xsl:31879 classic/omp.xsl:31882
-#: classic/omp.xsl:31884 classic/omp.xsl:31961 classic/omp.xsl:31963
-#: classic/omp.xsl:31966 classic/omp.xsl:31968
+#: classic/omp.xsl:31239 classic/omp.xsl:31241 classic/omp.xsl:31244
+#: classic/omp.xsl:31246 classic/omp.xsl:31323 classic/omp.xsl:31325
+#: classic/omp.xsl:31328 classic/omp.xsl:31330
 msgid "OS conflict"
 msgstr "OS-Konflikt"
 
-#: classic/omp.xsl:31900
+#: classic/omp.xsl:31262
 msgid "No information on Operating System."
 msgstr "Keine Informationen zum Betriebssystem."
 
-#: classic/omp.xsl:31984
+#: classic/omp.xsl:31346
 msgid "No information on Operating System was gathered during scan."
 msgstr ""
 "Während des Scans wurden keine Informationen zum Betriebssystem gesammelt."
 
-#: classic/omp.xsl:32270 classic/omp.xsl:32445 classic/omp.xsl:39269
-#: classic/omp.xsl:39515
+#: classic/omp.xsl:31634 classic/omp.xsl:31811 classic/omp.xsl:38770
+#: classic/omp.xsl:39023
 msgid "IP"
 msgstr "IP"
 
-#: classic/omp.xsl:32291
+#: classic/omp.xsl:31655
 msgid "Last Report"
 msgstr "Letzter Bericht"
 
-#: classic/omp.xsl:32293 classic/omp.xsl:32463 classic/omp.xsl:32914
-#: classic/omp.xsl:33178
+#: classic/omp.xsl:31657 classic/omp.xsl:31829 classic/omp.xsl:32280
+#: classic/omp.xsl:32544
 msgid "Ports"
 msgstr "Ports"
 
-#: classic/omp.xsl:32294 classic/omp.xsl:32464
+#: classic/omp.xsl:31658 classic/omp.xsl:31830
 msgctxt "Apps short"
 msgid "Apps"
 msgstr "Anw."
 
-#: classic/omp.xsl:32350
+#: classic/omp.xsl:31714
 msgid "View Report %1"
 msgstr "Bericht %1 anzeigen"
 
-#: classic/omp.xsl:32409
+#: classic/omp.xsl:31773
 msgid "No Apps detected for Prognostic Report"
 msgstr "Keine Anwendungen für Vorhersage-Bericht erkannt"
 
-#: classic/omp.xsl:32427 classic/omp.xsl:32527 classic/omp.xsl:33103
+#: classic/omp.xsl:31791 classic/omp.xsl:31893 classic/omp.xsl:32469
 msgctxt "Hosts"
 msgid "Total"
 msgstr "Gesamt"
 
-#: classic/omp.xsl:32461
+#: classic/omp.xsl:31827
 msgid "Current Report"
 msgstr "Aktueller Bericht"
 
-#: classic/omp.xsl:32917
+#: classic/omp.xsl:32283
 msgid "Auth"
 msgstr "Auth."
 
-#: classic/omp.xsl:32918
+#: classic/omp.xsl:32284
 msgctxt "Time"
 msgid "Start"
 msgstr "Starten"
 
-#: classic/omp.xsl:32919
+#: classic/omp.xsl:32285
 msgctxt "Time"
 msgid "End"
 msgstr "Ende"
 
-#: classic/omp.xsl:32945 classic/omp.xsl:34648
+#: classic/omp.xsl:32311 classic/omp.xsl:34010
 msgctxt "Results"
 msgid "Total"
 msgstr "Gesamt"
 
-#: classic/omp.xsl:33247
+#: classic/omp.xsl:32613
 msgid "IANA"
 msgstr "IANA"
 
-#: classic/omp.xsl:33333 classic/omp.xsl:33589 classic/omp.xsl:33686
-#: classic/omp.xsl:34082
+#: classic/omp.xsl:32699 classic/omp.xsl:32955 classic/omp.xsl:33052
+#: classic/omp.xsl:33455
 msgid "Occurrences"
 msgstr "Vorkommen"
 
-#: classic/omp.xsl:33484 classic/omp.xsl:33484 classic/omp.xsl:33485
+#: classic/omp.xsl:32850 classic/omp.xsl:32850 classic/omp.xsl:32851
 msgctxt "Report"
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: classic/omp.xsl:33526 classic/omp.xsl:33554
+#: classic/omp.xsl:32892 classic/omp.xsl:32920
 msgctxt "Result"
 msgid "None"
 msgstr "Keines"
 
-#: classic/omp.xsl:33587 classic/omp.xsl:33684
+#: classic/omp.xsl:32953 classic/omp.xsl:33050
 msgid "Application CPE"
 msgstr "Anwendungs-CPE"
 
-#: classic/omp.xsl:33609
+#: classic/omp.xsl:32975
 msgctxt "Result"
 msgid "for App"
 msgstr "für Anwendung"
 
-#: classic/omp.xsl:33723
+#: classic/omp.xsl:33089
 msgid "View Report"
 msgstr "Bericht anzeigen"
 
-#: classic/omp.xsl:33737 classic/omp.xsl:33828
+#: classic/omp.xsl:33103 classic/omp.xsl:33194
 msgctxt "Property"
 msgid "Download Format"
 msgstr "Download-Format"
 
-#: classic/omp.xsl:33791
+#: classic/omp.xsl:33157
 msgid "Download full Report"
 msgstr "Vollständigen Bericht herunterladen"
 
-#: classic/omp.xsl:33795 classic/omp.xsl:33872 classic/omp.xsl:34651
-#: classic/omp.xsl:34654 classic/omp.xsl:34658
+#: classic/omp.xsl:33161 classic/omp.xsl:33238 classic/omp.xsl:34013
+#: classic/omp.xsl:34016 classic/omp.xsl:34020
 msgctxt "Action Verb"
 msgid "Download"
 msgstr "Herunterladen"
 
-#: classic/omp.xsl:33869
+#: classic/omp.xsl:33235
 msgid "Download filtered Report"
 msgstr "Gefilterten Bericht herunterladen"
 
-#: classic/omp.xsl:33885
+#: classic/omp.xsl:33252
 msgid "Adding Report to Assets..."
 msgstr "Füge zu Assets hinzu..."
 
-#: classic/omp.xsl:33903
+#: classic/omp.xsl:33270
 msgid "Add to Assets with QoD>=%1%% and Overrides disabled"
 msgstr ""
 "Zu den Assets mit QoD>=%1%% und deaktivierten Übersteuerungen hinzufügen"
 
-#: classic/omp.xsl:33910
+#: classic/omp.xsl:33277
 msgid "Report content added to Assets with QoD>=%1%% and Overrides enabled."
 msgstr ""
 "Berichtinhalt mit QoD>=%1%% und aktivierten Übersteuerungen hinzugefügt."
 
-#: classic/omp.xsl:33913
+#: classic/omp.xsl:33280
 msgid "Report content added to Assets with QoD>=%1%% and Overrides disabled."
 msgstr ""
 "Berichtinhalt mit QoD>=%1%% und deaktivierten Übersteuerungen hinzugefügt."
 
-#: classic/omp.xsl:33928
+#: classic/omp.xsl:33295
 msgid "Report content could not be added to Assets."
 msgstr "Bericht konnte nicht zu Assets hinzugefügt werden."
 
-#: classic/omp.xsl:33945
+#: classic/omp.xsl:33312
 msgid "Removing Report from Assets..."
 msgstr "Bericht wird aus Assets entfernt..."
 
-#: classic/omp.xsl:33946 classic/omp.xsl:33948
+#: classic/omp.xsl:33313 classic/omp.xsl:33315
 msgid "Remove from Assets"
 msgstr "Aus Assets entfernen"
 
-#: classic/omp.xsl:33951
+#: classic/omp.xsl:33318
 msgid "Report content removed from Assets."
 msgstr "Berichtinhalt wurde aus Assets entfernt."
 
-#: classic/omp.xsl:33956
+#: classic/omp.xsl:33323
 msgid "Report content could not be removed from Assets."
 msgstr "Berichtinhalt konnte nicht aus Assets entfernt werden."
 
-#: classic/omp.xsl:33979
+#: classic/omp.xsl:33351
 msgid "Corresponding Results"
 msgstr "Entsprechende Ergebnisse"
 
-#: classic/omp.xsl:34006
+#: classic/omp.xsl:33379
 msgid "NVT Severity"
 msgstr "NVT-Schweregrad"
 
-#: classic/omp.xsl:34135
+#: classic/omp.xsl:33508
 msgid "ERROR: List of available report formats missing!"
 msgstr "FEHLER: Liste der verfügbaren Berichtformate fehlt!"
 
-#: classic/omp.xsl:34140
+#: classic/omp.xsl:33513
 msgid "Cannot find report format %1"
 msgstr "Kann Berichtformat %1 nicht finden"
 
-#: classic/omp.xsl:34145
+#: classic/omp.xsl:33518
 msgid "Report format %1 is not trusted"
 msgstr "Berichtformat %1 wird nicht vertraut"
 
-#: classic/omp.xsl:34150
+#: classic/omp.xsl:33523
 msgid "Report format %1 is not active"
 msgstr "Berichtformat %1 ist nicht aktiv"
 
-#: classic/omp.xsl:34183
+#: classic/omp.xsl:33556
 msgid "DN"
 msgstr "DN"
 
-#: classic/omp.xsl:34184
+#: classic/omp.xsl:33557
 msgid "Serial"
 msgstr "Seriennummer"
 
-#: classic/omp.xsl:34185
+#: classic/omp.xsl:33558
 msgid "Not valid before"
 msgstr "Nicht gültig vor"
 
-#: classic/omp.xsl:34186
+#: classic/omp.xsl:33559
 msgid "Not valid after"
 msgstr "Nicht gültig nach"
 
-#: classic/omp.xsl:34264 classic/omp.xsl:34265
+#: classic/omp.xsl:33637 classic/omp.xsl:33638
 msgid "Download SSL Cert"
 msgstr "SSL-Zertifikat herunterladen"
 
-#: classic/omp.xsl:34275
+#: classic/omp.xsl:33648
 msgid "Verifying Scanner..."
 msgstr "Scanner wird verifiziert..."
 
-#: classic/omp.xsl:34276 classic/omp.xsl:34277
+#: classic/omp.xsl:33649 classic/omp.xsl:33650
 msgid "Verify Scanner"
 msgstr "Scanner verifizieren"
 
-#: classic/omp.xsl:34288
+#: classic/omp.xsl:33661
 msgid "Scanner has been verified."
 msgstr "Scanner wurde verifiziert."
 
-#: classic/omp.xsl:34291
+#: classic/omp.xsl:33664
 msgid "Verification failed"
 msgstr "Verifizierung fehlgeschlagen"
 
-#: classic/omp.xsl:34293
+#: classic/omp.xsl:33666
 msgid "Scanner could not be verified."
 msgstr "Scanner konnte nicht verifiziert werden."
 
-#: classic/omp.xsl:34306 classic/omp.xsl:34309
+#: classic/omp.xsl:33679 classic/omp.xsl:33682
 msgctxt "Action Verb"
 msgid "Download CA Certificate"
 msgstr "CA-Zertifikat herunterladen"
 
-#: classic/omp.xsl:34349
+#: classic/omp.xsl:33722
 msgid "Error Message"
 msgstr "Fehlermeldung"
 
-#: classic/omp.xsl:34400
+#: classic/omp.xsl:33773
 msgid "User Tags for Report \"%1\" (%2)"
 msgstr "Benutzer-Tags für Bericht \"%1\" (%2)"
 
-#: classic/omp.xsl:34441
+#: classic/omp.xsl:33814
 msgid "Multiple hosts"
 msgstr "Mehrere Hosts"
 
-#: classic/omp.xsl:34447
+#: classic/omp.xsl:33820
 msgid "Result of Task"
 msgstr "Ergebnis für Aufgabe"
 
-#: classic/omp.xsl:34465
+#: classic/omp.xsl:33838
 msgid "Scan 1 started"
 msgstr "Scan 1 gestartet"
 
-#: classic/omp.xsl:34469
+#: classic/omp.xsl:33842
 msgid "Scan 1 ended"
 msgstr "Scan 1 beendet"
 
-#: classic/omp.xsl:34473
+#: classic/omp.xsl:33846
 msgid "Scan 1 status"
 msgstr "Status Scan 1"
 
-#: classic/omp.xsl:34502
+#: classic/omp.xsl:33875
 msgid "Scan 2 started"
 msgstr "Scan 2 gestartet"
 
-#: classic/omp.xsl:34506
+#: classic/omp.xsl:33879
 msgid "Scan 2 ended"
 msgstr "Scan 2 beendet"
 
-#: classic/omp.xsl:34510
+#: classic/omp.xsl:33883
 msgid "Scan 2 status"
 msgstr "Status Scan 2"
 
-#: classic/omp.xsl:34535
+#: classic/omp.xsl:33908
 msgid "Scan initiated"
 msgstr "Scan eingeleitet"
 
-#: classic/omp.xsl:34543
+#: classic/omp.xsl:33916
 msgid "Scan started"
 msgstr "Scan gestartet"
 
-#: classic/omp.xsl:34551
+#: classic/omp.xsl:33924
 msgid "Scan ended"
 msgstr "Scan beendet"
 
-#: classic/omp.xsl:34559
+#: classic/omp.xsl:33932
 msgid "Scan duration"
 msgstr "Scan-Dauer"
 
-#: classic/omp.xsl:34567
+#: classic/omp.xsl:33940
 msgid "Scan status"
 msgstr "Scan-Status"
 
-#: classic/omp.xsl:34657 classic/omp.xsl:34726 classic/omp.xsl:34729
-#: classic/omp.xsl:34799 classic/omp.xsl:34802
+#: classic/omp.xsl:34019 classic/omp.xsl:34088 classic/omp.xsl:34091
+#: classic/omp.xsl:34161 classic/omp.xsl:34164
 msgctxt "Action Verb"
 msgid "Run Alert"
 msgstr "Benachrichtigung ausführen"
 
-#: classic/omp.xsl:34669
+#: classic/omp.xsl:34031
 msgid "Full report"
 msgstr "Vollständiger Bericht"
 
-#: classic/omp.xsl:34690 classic/omp.xsl:34774
+#: classic/omp.xsl:34052 classic/omp.xsl:34136
 msgid "Running Alert..."
 msgstr "Benachrichtigung wird ausgeführt"
 
-#: classic/omp.xsl:34747
+#: classic/omp.xsl:34109
 msgid "Filtered report"
 msgstr "Gefilterter Bericht"
 
-#: classic/omp.xsl:34873 classic/omp.xsl:34875 classic/dynamic_strings.xsl:409
+#: classic/omp.xsl:34235 classic/omp.xsl:34237 classic/dynamic_strings.xsl:409
 msgid "New Role"
 msgstr "Neue Rolle"
 
-#: classic/omp.xsl:34880 classic/omp.xsl:34882 classic/omp.xsl:35279
-#: classic/omp.xsl:36170 classic/omp.xsl:36309 classic/omp.xsl:36394
-#: classic/omp.xsl:36620 classic/omp.xsl:36842 classic/dynamic_strings.xsl:122
-#: classic/gsad.xsl:672
+#: classic/omp.xsl:34242 classic/omp.xsl:34244 classic/omp.xsl:34641
+#: classic/omp.xsl:35688 classic/omp.xsl:35818 classic/omp.xsl:35903
+#: classic/omp.xsl:36129 classic/omp.xsl:36351 classic/dynamic_strings.xsl:122
+#: classic/gsad.xsl:673
 msgid "Roles"
 msgstr "Rollen"
 
-#: classic/omp.xsl:34914
+#: classic/omp.xsl:34276
 msgid "Create Role"
 msgstr "Rolle erstellen"
 
-#: classic/omp.xsl:34934 classic/dynamic_strings.xsl:622
+#: classic/omp.xsl:34296 classic/dynamic_strings.xsl:622
 msgid "Edit Role"
 msgstr "Rolle bearbeiten"
 
-#: classic/omp.xsl:35028 classic/omp.xsl:35033 classic/omp.xsl:35072
-#: classic/omp.xsl:35077
+#: classic/omp.xsl:34390 classic/omp.xsl:34395 classic/omp.xsl:34434
+#: classic/omp.xsl:34439
 msgid "Create Permission"
 msgstr "Berechtigung erstellen"
 
-#: classic/omp.xsl:35042
+#: classic/omp.xsl:34404
 msgid "New Super Permission"
 msgstr "Neue Super-Berechtigung"
 
-#: classic/omp.xsl:35086 classic/omp.xsl:35311 classic/omp.xsl:35314
-#: classic/omp.xsl:35317
+#: classic/omp.xsl:34448 classic/omp.xsl:34673 classic/omp.xsl:34676
+#: classic/omp.xsl:34679
 msgid "General Command Permissions"
 msgstr "Generelle Berechtigungen für Befehle"
 
-#: classic/omp.xsl:35259 classic/dynamic_strings.xsl:432
+#: classic/omp.xsl:34621 classic/dynamic_strings.xsl:432
 msgid "Role is still in use"
 msgstr "Rolle wird noch verwendet"
 
-#: classic/omp.xsl:35311
+#: classic/omp.xsl:34673
 msgctxt "Permissions"
 msgid "None"
 msgstr "Keine"
 
-#: classic/omp.xsl:35314
+#: classic/omp.xsl:34676
 msgid "Role has Everything"
 msgstr "Rolle hat alle (Everything)"
 
-#: classic/omp.xsl:35503 classic/omp.xsl:35511 classic/omp.xsl:35514
-#: classic/gsad.xsl:636
+#: classic/omp.xsl:34891 classic/omp.xsl:34954 classic/omp.xsl:34957
+#: classic/gsad.xsl:637
 msgid "Performance"
 msgstr "Leistung"
 
-#: classic/omp.xsl:35522
-msgid "Reports span the last"
-msgstr "Bericht über die Zeitspanne:"
+#: classic/omp.xsl:34903
+msgid "Report for last hour"
+msgstr "Bericht über letzte Stunde"
 
-#: classic/omp.xsl:35563 classic/omp.xsl:35566
+#: classic/omp.xsl:34913
+msgid "Report for last day"
+msgstr "Bericht über letzten Tag"
+
+#: classic/omp.xsl:34923
+msgid "Report for last week"
+msgstr "Bericht über letzte Woche"
+
+#: classic/omp.xsl:34933
+msgid "Report for last month"
+msgstr "Bericht über letzten Monat"
+
+#: classic/omp.xsl:34943
+msgid "Report for last year"
+msgstr "Bericht über letztes Jahr"
+
+#: classic/omp.xsl:34971 classic/wizard.xsl:258 classic/wizard.xsl:525
+msgid "Start time"
+msgstr "Startzeit"
+
+#: classic/omp.xsl:35012
+msgid "End time"
+msgstr "Endzeit"
+
+#: classic/omp.xsl:35054
+msgid "Report for last"
+msgstr "Berichte für letzte(n/s)"
+
+#: classic/omp.xsl:35104
 msgid "year"
 msgstr "Jahr"
 
-#: classic/omp.xsl:35574
-msgid "Reports for slave"
-msgstr "Berichte für Slave"
+#: classic/omp.xsl:35115
+msgid "Reports for slave scanner"
+msgstr "Bericht für Slave-Scanner"
 
-#: classic/omp.xsl:35620
+#: classic/omp.xsl:35161
 msgid ""
-"The selected Scan Slave can currently not be reached for retrieval of "
+"The selected Slave Scanner can currently not be reached for retrieval of "
 "performance data."
 msgstr ""
-"Der ausgewählte Scan-Slave ist momentan nicht erreichbar, um Performance-"
-"Daten abzurufen."
+"Der gewählte Slave-Scanner kann aktuell nicht erreicht werden, um "
+"Performancedaten abzurufen."
 
-#: classic/omp.xsl:35623
+#: classic/omp.xsl:35164
 msgid ""
-"Please check network connection or Slave configuration.  The problem may "
+"Please check network connection or Scanner configuration.  The problem may "
 "also be temporary, so you could try again at a later time."
 msgstr ""
-"Bitte überprüfen Sie die Netzwerkverbindung oder Slave-Konfiguration. Das "
-"Problem könnte auch nur vorübergehend bestehen, so dass sie es später noch "
-"einmal versuchen können."
+"Bitte Netzwerkverbindung oder Scannerkonfiguration überprüfen.  Das Problem "
+"könnte auch nur vorübergehend bestehen, so dass Sie es später erneut "
+"versuchen können."
 
-#: classic/omp.xsl:35880
+#: classic/omp.xsl:35405
 msgctxt "Task|Report"
 msgid "First"
 msgstr "Erster"
 
-#: classic/omp.xsl:35914 classic/omp.xsl:35922 classic/omp.xsl:35925
-#: classic/gsad.xsl:624
+#: classic/omp.xsl:35438 classic/omp.xsl:35446 classic/omp.xsl:35449
+#: classic/gsad.xsl:625
 msgid "Trashcan"
 msgstr "Mülleimer"
 
-#: classic/omp.xsl:35938 classic/omp.xsl:35939
+#: classic/omp.xsl:35462 classic/omp.xsl:35463
 msgctxt "Action Verb"
 msgid "Empty Trashcan"
 msgstr "Mülleimer leeren"
 
-#: classic/omp.xsl:35944
+#: classic/omp.xsl:35468
 msgctxt "Trashcan"
 msgid "Contents"
 msgstr "Inhalt"
 
-#: classic/omp.xsl:35948
+#: classic/omp.xsl:35472
 msgctxt "Trashcan"
 msgid "Items"
 msgstr "Objekte"
 
-#: classic/omp.xsl:36238 classic/dynamic_strings.xsl:407
+#: classic/omp.xsl:35747 classic/dynamic_strings.xsl:407
 msgid "New User"
 msgstr "Neuer Benutzer"
 
-#: classic/omp.xsl:36250 classic/omp.xsl:36763
+#: classic/omp.xsl:35759 classic/omp.xsl:36272
 msgid "Login Name"
 msgstr "Loginname"
 
-#: classic/omp.xsl:36260 classic/omp.xsl:36783
+#: classic/omp.xsl:35769 classic/omp.xsl:36292
 msgid "Authentication"
 msgstr "Authentifiz."
 
-#: classic/omp.xsl:36270 classic/omp.xsl:36278
+#: classic/omp.xsl:35779 classic/omp.xsl:35787
 msgid "Password:"
 msgstr "Passwort:"
 
-#: classic/omp.xsl:36293 classic/omp.xsl:36820
+#: classic/omp.xsl:35802 classic/omp.xsl:36329
 msgctxt "Auth Method"
 msgid "LDAP Authentication Only"
 msgstr "Nur LDAP-Authentifizierung"
 
-#: classic/omp.xsl:36301 classic/omp.xsl:36835
+#: classic/omp.xsl:35810 classic/omp.xsl:36344
 msgctxt "Auth Method"
 msgid "RADIUS Authentication Only"
 msgstr "Nur RADIUS-Authentifizierung"
 
-#: classic/omp.xsl:36332 classic/omp.xsl:36402 classic/omp.xsl:36656
-#: classic/omp.xsl:36884
+#: classic/omp.xsl:35841 classic/omp.xsl:35911 classic/omp.xsl:36165
+#: classic/omp.xsl:36393
 msgid "Host Access"
 msgstr "Host-Zugriff"
 
-#: classic/omp.xsl:36337 classic/omp.xsl:36358 classic/omp.xsl:36523
-#: classic/omp.xsl:36660 classic/omp.xsl:36675 classic/omp.xsl:36909
-#: classic/omp.xsl:36945
+#: classic/omp.xsl:35846 classic/omp.xsl:35867 classic/omp.xsl:36032
+#: classic/omp.xsl:36169 classic/omp.xsl:36184 classic/omp.xsl:36418
+#: classic/omp.xsl:36454
 msgid "Allow all and deny"
 msgstr "Erlaube alle und verweigere"
 
-#: classic/omp.xsl:36343 classic/omp.xsl:36364 classic/omp.xsl:36527
-#: classic/omp.xsl:36664 classic/omp.xsl:36679 classic/omp.xsl:36896
-#: classic/omp.xsl:36932
+#: classic/omp.xsl:35852 classic/omp.xsl:35873 classic/omp.xsl:36036
+#: classic/omp.xsl:36173 classic/omp.xsl:36188 classic/omp.xsl:36405
+#: classic/omp.xsl:36441
 msgid "Deny all and allow"
 msgstr "Verweigere alle und erlaube"
 
-#: classic/omp.xsl:36353 classic/omp.xsl:36671 classic/omp.xsl:36920
+#: classic/omp.xsl:35862 classic/omp.xsl:36180 classic/omp.xsl:36429
 msgid "Interface Access"
 msgstr "Interface-Zugriff"
 
-#: classic/omp.xsl:36406 classic/omp.xsl:36686
+#: classic/omp.xsl:35915 classic/omp.xsl:36195
 msgid "Authentication Type"
 msgstr "Authentifizierungsart"
 
-#: classic/omp.xsl:36535 classic/omp.xsl:36690 classic/gsad.xsl:679
+#: classic/omp.xsl:36044 classic/omp.xsl:36199 classic/gsad.xsl:680
 msgctxt "Auth Method"
 msgid "LDAP"
 msgstr "LDAP"
 
-#: classic/omp.xsl:36538 classic/omp.xsl:36693
+#: classic/omp.xsl:36047 classic/omp.xsl:36202
 msgctxt "Auth Method"
 msgid "RADIUS"
 msgstr "RADIUS"
 
-#: classic/omp.xsl:36541 classic/omp.xsl:36696
+#: classic/omp.xsl:36050 classic/omp.xsl:36205
 msgctxt "Auth Method"
 msgid "Local"
 msgstr "Lokal"
 
-#: classic/omp.xsl:36578 classic/dynamic_strings.xsl:471
+#: classic/omp.xsl:36087 classic/dynamic_strings.xsl:471
 msgid "User cannot be deleted"
 msgstr "Benutzer kann nicht gelöscht werden"
 
-#: classic/omp.xsl:36752 classic/dynamic_strings.xsl:620
+#: classic/omp.xsl:36261 classic/dynamic_strings.xsl:620
 msgid "Edit User"
 msgstr "Benutzer bearbeiten"
 
-#: classic/omp.xsl:36792
+#: classic/omp.xsl:36301
 msgid "Use existing value"
 msgstr "Existierenden Wert verwenden"
 
-#: classic/omp.xsl:36801
+#: classic/omp.xsl:36310
 msgid "New Password"
 msgstr "Neues Passwort"
 
-#: classic/omp.xsl:36964 classic/omp.xsl:39912
+#: classic/omp.xsl:36473 classic/omp.xsl:39424
 msgid "Confirm action"
 msgstr "Aktion bestätigen"
 
-#: classic/omp.xsl:36977
+#: classic/omp.xsl:36486
 msgid "User \"%1\" will be deleted."
 msgstr "Benutzer \"%1\" wird gelöscht."
 
-#: classic/omp.xsl:36981 classic/omp.xsl:39936
+#: classic/omp.xsl:36490 classic/omp.xsl:39448
 msgid ""
 "If no inheriting user is selected, all owned resources will be deleted as "
 "well."
@@ -5180,529 +5154,525 @@ msgstr ""
 "Wenn kein erbender Benutzer gewählt wird, werden alle Ressourcen, die der "
 "Benutzer besitzt, ebenfalls gelöscht."
 
-#: classic/omp.xsl:36987 classic/omp.xsl:39939
+#: classic/omp.xsl:36496 classic/omp.xsl:39451
 msgid "Inheriting user"
 msgstr "Erbender Benutzer"
 
-#: classic/omp.xsl:36999 classic/omp.xsl:39950
+#: classic/omp.xsl:36508 classic/omp.xsl:39462
 msgid "Current User"
 msgstr "Aktueller Benutzer"
 
-#: classic/omp.xsl:37085 classic/omp.xsl:37157
+#: classic/omp.xsl:36594 classic/omp.xsl:36666
 msgid "Setting"
 msgstr "Einstellung"
 
-#: classic/omp.xsl:37089 classic/omp.xsl:37161
+#: classic/omp.xsl:36598 classic/omp.xsl:36670
 msgid "Enable"
 msgstr "Aktivieren"
 
-#: classic/omp.xsl:37116
+#: classic/omp.xsl:36625
 msgid "Auth. DN"
 msgstr "Auth. DN"
 
-#: classic/omp.xsl:37137 classic/omp.xsl:37189
+#: classic/omp.xsl:36646 classic/omp.xsl:36698
 msgid "Save"
 msgstr "Speichern"
 
-#: classic/omp.xsl:37183
+#: classic/omp.xsl:36692
 msgid "Secret Key"
 msgstr "Geheimer Schlüssel"
 
-#: classic/omp.xsl:37206 classic/omp.xsl:37213
+#: classic/omp.xsl:36715 classic/omp.xsl:36722
 msgctxt "Auth Method"
 msgid "LDAP per-User Authentication"
 msgstr "LDAP-Authentifizierung pro Benutzer"
 
-#: classic/omp.xsl:37221
+#: classic/omp.xsl:36730
 msgctxt "Auth Method"
 msgid "LDAP per-User Authentication not available"
 msgstr "LDAP-per-User-Authentifizierung nicht verfügbar"
 
-#: classic/omp.xsl:37230 classic/omp.xsl:37237
+#: classic/omp.xsl:36739 classic/omp.xsl:36746
 msgctxt "Auth Method"
 msgid "RADIUS Authentication"
 msgstr "RADIUS-Authentifizierung"
 
-#: classic/omp.xsl:37246
+#: classic/omp.xsl:36755
 msgctxt "Auth Method"
 msgid "RADIUS Authentication not available"
 msgstr "RADIUS-Authentifizierung nicht verfügbar "
 
-#: classic/omp.xsl:37279 classic/omp.xsl:37287
+#: classic/omp.xsl:36788 classic/omp.xsl:36796
 msgid "Feed"
 msgstr "Feed"
 
-#: classic/omp.xsl:37290 classic/gsad.xsl:646
+#: classic/omp.xsl:36799 classic/gsad.xsl:647
 msgid "Feed Status"
 msgstr "Feed-Status"
 
-#: classic/omp.xsl:37297
+#: classic/omp.xsl:36806
 msgctxt "Feed"
 msgid "Content"
 msgstr "Inhalt"
 
-#: classic/omp.xsl:37298
+#: classic/omp.xsl:36807
 msgid "Origin"
 msgstr "Ursprung"
 
-#: classic/omp.xsl:37363
+#: classic/omp.xsl:36872
 msgid "Synchronization with this feed is currently not possible."
 msgstr "Synchonisierung mit diesem Feed ist momentan nicht möglich."
 
-#: classic/omp.xsl:37366
+#: classic/omp.xsl:36875
 msgid "The synchronization script returned the following error message:"
 msgstr "Das Synchronisierungsscript gab folgende Fehlermeldung zurück:"
 
-#: classic/omp.xsl:37375
+#: classic/omp.xsl:36884
 msgctxt "Feed Sync"
 msgid "Synchronization"
 msgstr "Synchonisierung"
 
-#: classic/omp.xsl:37376
+#: classic/omp.xsl:36885
 msgctxt "Feed Sync"
 msgid " in progress"
 msgstr " läuft gerade"
 
-#: classic/omp.xsl:37378
+#: classic/omp.xsl:36887
 msgctxt "Feed Sync"
 msgid "Started "
 msgstr "Gestartet: "
 
-#: classic/omp.xsl:37382
+#: classic/omp.xsl:36891
 msgctxt "Feed Sync"
 msgid " by "
 msgstr "  von "
 
-#: classic/omp.xsl:37395
+#: classic/omp.xsl:36904
 msgid "Please check the automatic synchronization of your system"
 msgstr "Bitte überprüfen Sie die automatische Synchronisation Ihres Systems"
 
-#: classic/omp.xsl:37401
-msgid "Less than 1 day old"
-msgstr "Weniger als 1 Tag alt"
+#: classic/omp.xsl:36910
+msgid "Current"
+msgstr "Aktueller"
 
-#: classic/omp.xsl:37406
+#: classic/omp.xsl:36915
 msgid "No status info available"
 msgstr "Keine Statusinfo verfügbar"
 
-#: classic/omp.xsl:37412
+#: classic/omp.xsl:36921
 msgid "OMP Error"
 msgstr "OMP-Fehler"
 
-#: classic/omp.xsl:37477
+#: classic/omp.xsl:36986
 msgid "SCAP"
 msgstr "SCAP"
 
-#: classic/omp.xsl:37564 classic/omp.xsl:37579 classic/omp.xsl:37582
-#: classic/omp.xsl:38191 classic/omp.xsl:38196 classic/omp.xsl:38197
-#: classic/gsad.xsl:630
+#: classic/omp.xsl:37073 classic/omp.xsl:37088 classic/omp.xsl:37091
+#: classic/omp.xsl:37691 classic/omp.xsl:37696 classic/omp.xsl:37697
+#: classic/gsad.xsl:631
 msgid "My Settings"
 msgstr "Eigene Einstellungen"
 
-#: classic/omp.xsl:37569 classic/omp.xsl:38188
+#: classic/omp.xsl:37078 classic/omp.xsl:37688
 msgid "Edit My Settings"
 msgstr "Eigene Einstellungen bearbeiten"
 
-#: classic/omp.xsl:37611 classic/omp.xsl:38245
+#: classic/omp.xsl:37120 classic/omp.xsl:37745
 msgid "User Interface Language"
 msgstr "Sprache der Benutzeroberfläche"
 
-#: classic/omp.xsl:37638 classic/omp.xsl:38296
+#: classic/omp.xsl:37147 classic/omp.xsl:37796
 msgid "Rows Per Page"
 msgstr "Zeilen pro Seite"
 
-#: classic/omp.xsl:37642
+#: classic/omp.xsl:37151
 msgid "Max Rows Per Page (immutable)"
 msgstr "Max. Zeilen pro Seite (nicht änderbar)"
 
-#: classic/omp.xsl:37646 classic/omp.xsl:38304
+#: classic/omp.xsl:37155 classic/omp.xsl:37804
 msgid "Details Export File Name"
 msgstr "Details-Export-Dateiname"
 
-#: classic/omp.xsl:37650 classic/omp.xsl:38312
+#: classic/omp.xsl:37159 classic/omp.xsl:37812
 msgid "List Export File Name"
 msgstr "Listen-Export-Dateiname"
 
-#: classic/omp.xsl:37654 classic/omp.xsl:38320
+#: classic/omp.xsl:37163 classic/omp.xsl:37820
 msgid "Report Export File Name"
 msgstr "Bericht-Export-Dateiname"
 
-#: classic/omp.xsl:37658 classic/omp.xsl:38328
+#: classic/omp.xsl:37167 classic/omp.xsl:37828
 msgid "Severity Class"
 msgstr "Schweregrad-Klasse"
 
-#: classic/omp.xsl:37667 classic/omp.xsl:38337
+#: classic/omp.xsl:37176 classic/omp.xsl:37837
 msgid "Dynamic Severity"
 msgstr "Dynamischer Schweregrad"
 
-#: classic/omp.xsl:37680 classic/omp.xsl:38356
+#: classic/omp.xsl:37189 classic/omp.xsl:37856
 msgid "Default Severity"
 msgstr "Standard-Schweregrad"
 
-#: classic/omp.xsl:37686 classic/omp.xsl:38366
+#: classic/omp.xsl:37195 classic/omp.xsl:37866
 msgid "Default Alert"
 msgstr "Standard-Benachrichtigung"
 
-#: classic/omp.xsl:37700 classic/omp.xsl:38381
+#: classic/omp.xsl:37209 classic/omp.xsl:37881
 msgid "Default OpenVAS Scan Config"
 msgstr "Standard OpenVAS-Scan-Konfig"
 
-#: classic/omp.xsl:37712 classic/omp.xsl:38394
+#: classic/omp.xsl:37221 classic/omp.xsl:37894
 msgid "Default OSP Scan Config"
 msgstr "Standard OSP-Scan-Konfig"
 
-#: classic/omp.xsl:37726 classic/omp.xsl:38409
+#: classic/omp.xsl:37235 classic/omp.xsl:37909
 msgid "Default SSH Credential"
 msgstr "Standard-SSH-Anmeldedaten"
 
-#: classic/omp.xsl:37738 classic/omp.xsl:38422
+#: classic/omp.xsl:37247 classic/omp.xsl:37922
 msgid "Default SMB Credential"
 msgstr "Standard-SMB-Anmeldedaten"
 
-#: classic/omp.xsl:37750 classic/omp.xsl:38435
+#: classic/omp.xsl:37259 classic/omp.xsl:37935
 msgid "Default ESXi Credential"
 msgstr "Standard-ESXi-Anmeldedaten"
 
-#: classic/omp.xsl:37762 classic/omp.xsl:38448
+#: classic/omp.xsl:37271 classic/omp.xsl:37948
 msgid "Default SNMP Credential"
 msgstr "Standard-SNMP-Anmeldedaten"
 
-#: classic/omp.xsl:37776 classic/omp.xsl:38463
+#: classic/omp.xsl:37285 classic/omp.xsl:37963
 msgid "Default Port List"
 msgstr "Standard-Portliste"
 
-#: classic/omp.xsl:37790 classic/omp.xsl:38493
+#: classic/omp.xsl:37299 classic/omp.xsl:37993
 msgid "Default OpenVAS Scanner"
 msgstr "Standard-OpenVAS-Scanner"
 
-#: classic/omp.xsl:37802 classic/omp.xsl:38506
+#: classic/omp.xsl:37311 classic/omp.xsl:38006
 msgid "Default OSP Scanner"
 msgstr "Standard-OSP-Scanner"
 
-#: classic/omp.xsl:37816 classic/omp.xsl:38478
+#: classic/omp.xsl:37325 classic/omp.xsl:37978
 msgid "Default Report Format"
 msgstr "Standard-Berichtformat"
 
-#: classic/omp.xsl:37830 classic/omp.xsl:38521
+#: classic/omp.xsl:37339 classic/omp.xsl:38021
 msgid "Default Schedule"
 msgstr "Standard-Zeitplan"
 
-#: classic/omp.xsl:37844 classic/omp.xsl:38536
-msgid "Default Slave"
-msgstr "Standard-Slave"
-
-#: classic/omp.xsl:37858 classic/omp.xsl:38551
+#: classic/omp.xsl:37353 classic/omp.xsl:38036
 msgid "Default Target"
 msgstr "Standard-Ziel"
 
-#: classic/omp.xsl:37872 classic/omp.xsl:38566
+#: classic/omp.xsl:37367 classic/omp.xsl:38051
 msgid "Agents Filter"
 msgstr "Agenten-Filter"
 
-#: classic/omp.xsl:37881 classic/omp.xsl:38577
+#: classic/omp.xsl:37376 classic/omp.xsl:38062
 msgid "Alerts Filter"
 msgstr "Benachrichtigungen-Filter"
 
-#: classic/omp.xsl:37890 classic/omp.xsl:38588
+#: classic/omp.xsl:37385 classic/omp.xsl:38073
 msgid "Assets Filter"
 msgstr "Assets-Filter"
 
-#: classic/omp.xsl:37899 classic/omp.xsl:38599
+#: classic/omp.xsl:37394 classic/omp.xsl:38084
 msgid "Configs Filter"
 msgstr "Konfigurationen-Filter"
 
-#: classic/omp.xsl:37908 classic/omp.xsl:38610
+#: classic/omp.xsl:37403 classic/omp.xsl:38095
 msgid "Credentials Filter"
 msgstr "Anmeldedaten-Filter"
 
-#: classic/omp.xsl:37917 classic/omp.xsl:38621
+#: classic/omp.xsl:37412 classic/omp.xsl:38106
 msgid "Filters Filter"
 msgstr "Filter-Filter"
 
-#: classic/omp.xsl:37926 classic/omp.xsl:38632
+#: classic/omp.xsl:37421 classic/omp.xsl:38117
 msgid "Notes Filter"
 msgstr "Notizen-Filter"
 
-#: classic/omp.xsl:37935 classic/omp.xsl:38643
+#: classic/omp.xsl:37430 classic/omp.xsl:38128
 msgid "Overrides Filter"
 msgstr "Übersteuerungen-Filter"
 
-#: classic/omp.xsl:37944 classic/omp.xsl:38654
+#: classic/omp.xsl:37439 classic/omp.xsl:38139
 msgid "Permissions Filter"
 msgstr "Berechtigungen-Filter"
 
-#: classic/omp.xsl:37953 classic/omp.xsl:38665
+#: classic/omp.xsl:37448 classic/omp.xsl:38150
 msgid "Port Lists Filter"
 msgstr "Portlisten-Filter"
 
-#: classic/omp.xsl:37962 classic/omp.xsl:38676
+#: classic/omp.xsl:37457 classic/omp.xsl:38161
 msgid "Reports Filter"
 msgstr "Berichte-Filter"
 
-#: classic/omp.xsl:37971 classic/omp.xsl:38687
+#: classic/omp.xsl:37466 classic/omp.xsl:38172
 msgid "Report Formats Filter"
 msgstr "Berichtformate-Filter"
 
-#: classic/omp.xsl:37980 classic/omp.xsl:38698
+#: classic/omp.xsl:37475 classic/omp.xsl:38183
 msgid "Results Filter"
 msgstr "Ergebnisse-Filter"
 
-#: classic/omp.xsl:37989 classic/omp.xsl:38709
+#: classic/omp.xsl:37484 classic/omp.xsl:38194
 msgid "Roles Filter"
 msgstr "Rollen-Filter"
 
-#: classic/omp.xsl:37998 classic/omp.xsl:38720
+#: classic/omp.xsl:37493 classic/omp.xsl:38205
 msgid "Schedules Filter"
 msgstr "Zeitpläne-Filter"
 
-#: classic/omp.xsl:38007 classic/omp.xsl:38731
-msgid "Slaves Filter"
-msgstr "Slaves-Filter"
-
-#: classic/omp.xsl:38016 classic/omp.xsl:38742
+#: classic/omp.xsl:37502 classic/omp.xsl:38216
 msgid "Tags Filter"
 msgstr "Tags-Filter"
 
-#: classic/omp.xsl:38025 classic/omp.xsl:38753
+#: classic/omp.xsl:37511 classic/omp.xsl:38227
 msgid "Targets Filter"
 msgstr "Ziele-Filter"
 
-#: classic/omp.xsl:38034 classic/omp.xsl:38764
+#: classic/omp.xsl:37520 classic/omp.xsl:38238
 msgid "Tasks Filter"
 msgstr "Aufgaben-Filter"
 
-#: classic/omp.xsl:38043 classic/omp.xsl:38775 classic/dynamic_strings.xsl:317
+#: classic/omp.xsl:37529 classic/omp.xsl:38249 classic/dynamic_strings.xsl:317
 msgid "CPE Filter"
 msgstr "CPE-Filter"
 
-#: classic/omp.xsl:38052 classic/omp.xsl:38786 classic/dynamic_strings.xsl:316
+#: classic/omp.xsl:37538 classic/omp.xsl:38260 classic/dynamic_strings.xsl:316
 msgid "CVE Filter"
 msgstr "CVE-Filter"
 
-#: classic/omp.xsl:38061 classic/omp.xsl:38797 classic/dynamic_strings.xsl:315
+#: classic/omp.xsl:37547 classic/omp.xsl:38271 classic/dynamic_strings.xsl:315
 msgid "NVT Filter"
 msgstr "NVT-Filter"
 
-#: classic/omp.xsl:38070 classic/omp.xsl:38808 classic/dynamic_strings.xsl:318
+#: classic/omp.xsl:37556 classic/omp.xsl:38282 classic/dynamic_strings.xsl:318
 msgid "OVAL Filter"
 msgstr "OVAL-Filter"
 
-#: classic/omp.xsl:38079 classic/omp.xsl:38819 classic/dynamic_strings.xsl:319
+#: classic/omp.xsl:37565 classic/omp.xsl:38293 classic/dynamic_strings.xsl:319
 msgid "CERT-Bund Filter"
 msgstr "CERT-Bund-Filter"
 
-#: classic/omp.xsl:38088 classic/omp.xsl:38830 classic/dynamic_strings.xsl:320
+#: classic/omp.xsl:37574 classic/omp.xsl:38304 classic/dynamic_strings.xsl:320
 msgid "DFN-CERT Filter"
 msgstr "DFN-CERT-Filter"
 
-#: classic/omp.xsl:38097 classic/omp.xsl:38842 classic/dynamic_strings.xsl:322
+#: classic/omp.xsl:37583 classic/omp.xsl:38316 classic/dynamic_strings.xsl:322
 msgid "All SecInfo Filter"
 msgstr "Alle-Sicherheitsinfos-Filter"
 
-#: classic/omp.xsl:38108
+#: classic/omp.xsl:37594
 msgid "Default CA Cert (immutable)"
 msgstr "Standard CA-Zert. (nicht änderbar)"
 
-#: classic/omp.xsl:38226
+#: classic/omp.xsl:37607 classic/omp.xsl:38329
+msgid "Auto Cache Rebuild"
+msgstr "Automatische Cache-Neuerstellung"
+
+#: classic/omp.xsl:37726
 msgctxt "Auth Data|Password"
 msgid "Old"
 msgstr "Altes"
 
-#: classic/omp.xsl:38234
+#: classic/omp.xsl:37734
 msgctxt "Auth Data|Password"
 msgid "New"
 msgstr "Neues"
 
-#: classic/omp.xsl:38856
+#: classic/omp.xsl:38350
 msgid "Save My Settings"
 msgstr "Eigene Einstellungen speichern"
 
-#: classic/omp.xsl:38875 classic/omp.xsl:38878 classic/omp.xsl:39178
+#: classic/omp.xsl:38369 classic/omp.xsl:38372 classic/omp.xsl:38679
 msgid "New Host"
 msgstr "Neuer Host"
 
-#: classic/omp.xsl:38912
+#: classic/omp.xsl:38406
 msgid "Create Host"
 msgstr "Host erstellen"
 
-#: classic/omp.xsl:38932
+#: classic/omp.xsl:38426
 msgid "Operating System Details"
 msgstr "Betriebssystem-Details"
 
-#: classic/omp.xsl:38936 classic/omp.xsl:38938
+#: classic/omp.xsl:38430 classic/omp.xsl:38432
 msgid "OSs"
 msgstr "OSs"
 
-#: classic/omp.xsl:38956 classic/omp.xsl:39825
+#: classic/omp.xsl:38450 classic/omp.xsl:39337
 msgid "OS is in use"
 msgstr "Os wird verwendet"
 
-#: classic/omp.xsl:38960 classic/omp.xsl:39236
+#: classic/omp.xsl:38454 classic/omp.xsl:38737
 msgid "Export Asset as XML"
 msgstr "Asset als XML exportieren"
 
-#: classic/omp.xsl:38971 classic/gsad.xsl:472
+#: classic/omp.xsl:38465 classic/gsad.xsl:477
 msgid "Operating Systems"
 msgstr "Betriebssysteme"
 
-#: classic/omp.xsl:38999
+#: classic/omp.xsl:38493
 msgid "Latest Severity"
 msgstr "Neuester Schweregrad"
 
-#: classic/omp.xsl:39009
+#: classic/omp.xsl:38503
 msgid "Highest Severity"
 msgstr "Höchster Schweregrad"
 
-#: classic/omp.xsl:39019
+#: classic/omp.xsl:38513
 msgid "Average Severity"
 msgstr "Durchschnittsschweregrad"
 
-#: classic/omp.xsl:39079
+#: classic/omp.xsl:38580
 msgid "Edit Asset"
 msgstr "Asset bearbeiten"
 
-#: classic/omp.xsl:39136
+#: classic/omp.xsl:38637
 msgid "Save Asset"
 msgstr "Asset speichern"
 
-#: classic/omp.xsl:39203 classic/omp.xsl:39692
+#: classic/omp.xsl:38704 classic/omp.xsl:39204
 msgid "Host is in use"
 msgstr "Host wird benutzt"
 
-#: classic/omp.xsl:39210 classic/omp.xsl:39700
+#: classic/omp.xsl:38711 classic/omp.xsl:39212
 msgid "Edit Host"
 msgstr "Host bearbeiten"
 
-#: classic/omp.xsl:39220 classic/omp.xsl:39710
+#: classic/omp.xsl:38721 classic/omp.xsl:39222
 msgid "Host is not writable"
 msgstr "Host ist nicht beschreibbar"
 
-#: classic/omp.xsl:39223 classic/omp.xsl:39713
+#: classic/omp.xsl:38724 classic/omp.xsl:39225
 msgid "Permission to edit Host denied"
 msgstr "Keine Berechtigung, Host zu bearbeiten"
 
-#: classic/omp.xsl:39226 classic/omp.xsl:39716
+#: classic/omp.xsl:38727 classic/omp.xsl:39228
 msgid "Cannot modify Host"
 msgstr "Kann Host nicht ändern"
 
-#: classic/omp.xsl:39283
+#: classic/omp.xsl:38784
 msgid "Route"
 msgstr "Route"
 
-#: classic/omp.xsl:39322
+#: classic/omp.xsl:38823
 msgid "Show scan results for this host"
 msgstr "Scanergebnisse für diesen Host zeigen"
 
-#: classic/omp.xsl:39335
+#: classic/omp.xsl:38836
 msgid "All Identifiers"
 msgstr "Alle Identifikatoren"
 
-#: classic/omp.xsl:39338
+#: classic/omp.xsl:38839
 msgid "Latest Identifiers"
 msgstr "Neueste Identifikatoren"
 
-#: classic/omp.xsl:39447
+#: classic/omp.xsl:38948
 msgid "Show only latest Identifiers"
 msgstr "Nur neueste Identifikatoren zeigen"
 
-#: classic/omp.xsl:39462
+#: classic/omp.xsl:38963
 msgid "Show all Identifiers"
 msgstr "Alle Identifikatoren anzeigen"
 
-#: classic/omp.xsl:39527 classic/omp.xsl:39586
+#: classic/omp.xsl:39035 classic/omp.xsl:39096
 msgctxt "Date"
 msgid "Updated"
 msgstr "Aktualisiert"
 
-#: classic/omp.xsl:39565
+#: classic/omp.xsl:39075
 msgid "Latest"
 msgstr "Neueste"
 
-#: classic/omp.xsl:39570
+#: classic/omp.xsl:39080
 msgid "Highest"
 msgstr "Höchster"
 
-#: classic/omp.xsl:39575
+#: classic/omp.xsl:39085
 msgid "Average"
 msgstr "Durchschnitt"
 
-#: classic/omp.xsl:39735
+#: classic/omp.xsl:39247
 msgid "Create Target from host"
 msgstr "Ziel aus Host erstellen"
 
-#: classic/omp.xsl:39739
+#: classic/omp.xsl:39251
 msgid "Export Host"
 msgstr "Host exportieren"
 
-#: classic/omp.xsl:39830
+#: classic/omp.xsl:39342
 msgid "Export Operating System"
 msgstr "Betriebssystem exportieren"
 
-#: classic/omp.xsl:40017 classic/omp.xsl:40020
+#: classic/omp.xsl:39529 classic/omp.xsl:39532
 msgid "Help: OMP"
 msgstr "Hilfe: OMP"
 
-#: classic/omp.xsl:40081 classic/omp.xsl:40089 classic/omp.xsl:40092
+#: classic/omp.xsl:39593 classic/omp.xsl:39601 classic/omp.xsl:39604
 msgctxt "CVSS Calculator"
 msgid "CVSS Base Score Calculator"
 msgstr "CVSS-Basisscore-Rechner"
 
-#: classic/omp.xsl:40097
+#: classic/omp.xsl:39609
 msgctxt "CVSS Calculator"
 msgid "From Metrics"
 msgstr "Aus Metriken"
 
-#: classic/omp.xsl:40101
+#: classic/omp.xsl:39613
 msgctxt "CVSS Vector"
 msgid "Access Vector"
 msgstr "Zugriffsvektor"
 
-#: classic/omp.xsl:40123
+#: classic/omp.xsl:39635
 msgctxt "CVSS Vector"
 msgid "Access Complexity"
 msgstr "Zugriffskomplexität"
 
-#: classic/omp.xsl:40145
+#: classic/omp.xsl:39657
 msgctxt "CVSS Vector"
 msgid "Authentication"
 msgstr "Authentifizierung"
 
-#: classic/omp.xsl:40167
+#: classic/omp.xsl:39679
 msgctxt "CVSS Vector"
 msgid "Confidentiality"
 msgstr "Vertraulichkeit"
 
-#: classic/omp.xsl:40189
+#: classic/omp.xsl:39701
 msgctxt "CVSS Vector"
 msgid "Integrity"
 msgstr "Intergrität"
 
-#: classic/omp.xsl:40211
+#: classic/omp.xsl:39723
 msgctxt "CVSS Vector"
 msgid "Availability"
 msgstr "Verfügbarkeit"
 
-#: classic/omp.xsl:40236 classic/omp.xsl:40255
+#: classic/omp.xsl:39748 classic/omp.xsl:39767
 msgctxt "CVSS Calculator"
 msgid "Calculate"
 msgstr "Berechnen"
 
-#: classic/omp.xsl:40241
+#: classic/omp.xsl:39753
 msgctxt "CVSS Calculator"
 msgid "From Vector"
 msgstr "Aus Vektor"
 
-#: classic/omp.xsl:40264
+#: classic/omp.xsl:39776
 msgctxt "CVSS Calculator"
 msgid "Base Vector"
 msgstr "Basisvektor"
 
-#: classic/omp.xsl:40270
+#: classic/omp.xsl:39782
 msgctxt "CVSS Calculator"
 msgid "Base Score"
 msgstr "Basisscore"
 
-#: classic/omp.xsl:40281
+#: classic/omp.xsl:39793
 msgid ""
 "Invalid CVSS Base Vector value provided.  Use back button of your browser to"
 " edit the vector."
@@ -5734,7 +5704,7 @@ msgid_plural "%1 seconds"
 msgstr[0] "%1 Sekunde"
 msgstr[1] "%1 Sekunden"
 
-#: classic/omp.xsl:18860
+#: classic/omp.xsl:18755
 msgid "A Task using this schedule will be affected by changes made here."
 msgid_plural ""
 "%1 Tasks using this schedule will be affected by changes made here."
@@ -5745,7 +5715,7 @@ msgstr[1] ""
 "%1 Aufgaben, die diesen Zeitplan verwenden werden von Änderungen hier "
 "betroffen sein."
 
-#: classic/omp.xsl:33613
+#: classic/omp.xsl:32979
 msgid ""
 "Includes %1 host where CPE was found in inventory, but number of "
 "installations could not be determined"
@@ -5759,13 +5729,13 @@ msgstr[1] ""
 "Beinhaltet %1 Hosts für den die CPE gefunden, aber die Anzahl der "
 "Installationen nicht festgestellt werden konnte"
 
-#: classic/omp.xsl:37393
+#: classic/omp.xsl:36902
 msgid "Too old (%1 day)"
 msgid_plural "Too old (%1 days)"
 msgstr[0] "Zu alt (%1 Tag)"
 msgstr[1] "Zu alt (%1 Tage)"
 
-#: classic/omp.xsl:37398
+#: classic/omp.xsl:36907
 msgid "%1 day old"
 msgid_plural "%1 days old"
 msgstr[0] "%1 Tag alt"
@@ -5784,11 +5754,11 @@ msgstr "Scan starten"
 msgid "Task Wizard"
 msgstr "Aufgaben-Wizard"
 
-#: classic/wizard.xsl:66 classic/wizard.xsl:451
+#: classic/wizard.xsl:66 classic/wizard.xsl:452
 msgid "Advanced Task Wizard"
 msgstr "Erweiterter Aufgaben-Wizard"
 
-#: classic/wizard.xsl:73 classic/wizard.xsl:618
+#: classic/wizard.xsl:73 classic/wizard.xsl:621
 msgid "Modify Task Wizard"
 msgstr "Aufgabe-Bearbeiten-Wizard"
 
@@ -5942,27 +5912,27 @@ msgstr "Name der Aufgabe"
 msgid "Target Host(s)"
 msgstr "Ziel-Host(s)"
 
-#: classic/wizard.xsl:258 classic/wizard.xsl:523
-msgid "Start time"
-msgstr "Startzeit"
-
 #: classic/wizard.xsl:264
 msgid "Start immediately"
 msgstr "Sofort starten"
 
-#: classic/wizard.xsl:270 classic/wizard.xsl:535
+#: classic/wizard.xsl:271 classic/wizard.xsl:537
 msgid "Create Schedule"
 msgstr "Zeitplan erstellen"
 
-#: classic/wizard.xsl:335
+#: classic/wizard.xsl:336
 msgid "Do not start automatically"
 msgstr "Nicht automatisch starten"
 
-#: classic/wizard.xsl:410 classic/wizard.xsl:601
+#: classic/wizard.xsl:411 classic/wizard.xsl:604
 msgid "Email report to"
 msgstr "Email-Bericht an"
 
-#: classic/wizard.xsl:479
+#: classic/wizard.xsl:422 classic/dynamic_strings.xsl:82
+msgid "Slave"
+msgstr "Slave"
+
+#: classic/wizard.xsl:480
 msgid ""
 "I will modify an existing task for you. The difference to the Edit Task "
 "dialog is that here you can enter values for associated objects directly. I "
@@ -5974,15 +5944,15 @@ msgstr ""
 "eingeben. Ich werde diese dann automatisch erstellen und der ausgewählten "
 "Aufgabe zuweisen."
 
-#: classic/wizard.xsl:483
+#: classic/wizard.xsl:484
 msgid "Please be aware that"
 msgstr "Bitte beachten Sie, dass"
 
-#: classic/wizard.xsl:486
+#: classic/wizard.xsl:487
 msgid "setting a start time overwrites a possibly already existing one,"
 msgstr "das Setzen einer Startzeit eine möglicherweise vorhandene überschreibt,"
 
-#: classic/wizard.xsl:489
+#: classic/wizard.xsl:490
 msgid ""
 "setting an Email Address means adding an additional Alert, not replacing an "
 "existing one."
@@ -5990,11 +5960,11 @@ msgstr ""
 "wenn Sie eine EMail-Adresse hier einstellen wird eine zusätzliche "
 "Benachrichtigung erstellt. Eine vorhandene wird dabei nicht ersetzt."
 
-#: classic/wizard.xsl:500
+#: classic/wizard.xsl:501
 msgid "Quick edit: Modify a task"
 msgstr "Schnell-Bearbeiten: Aufgabe ändern"
 
-#: classic/wizard.xsl:529
+#: classic/wizard.xsl:531
 msgid "Do not change"
 msgstr "Nicht ändern"
 
@@ -6049,6 +6019,10 @@ msgstr "Konfigurationen"
 #: classic/dynamic_strings.xsl:110
 msgid "Scan Configurations"
 msgstr "Scan-Konfigurationen"
+
+#: classic/dynamic_strings.xsl:114
+msgid "Slaves"
+msgstr "Slaves"
 
 #: classic/dynamic_strings.xsl:127
 msgid "Global Task"
@@ -6241,6 +6215,10 @@ msgstr "Benachrichtigungs-Details"
 #: classic/dynamic_strings.xsl:195
 msgid "Report Format Details"
 msgstr "Berichtformats-Details"
+
+#: classic/dynamic_strings.xsl:196
+msgid "Slave Details"
+msgstr "Slave-Details"
 
 #: classic/dynamic_strings.xsl:201
 msgid "Permission Details"
@@ -6758,6 +6736,10 @@ msgstr "Neuen Gruppen-Filter aus aktuellem Suchausdruck erstellen"
 msgid "New Role Filter from current term"
 msgstr "Neuen Rollen-Filter aus aktuellem Suchausdruck erstellen"
 
+#: classic/dynamic_strings.xsl:401
+msgid "New Slave"
+msgstr "Neuer Slave"
+
 #: classic/dynamic_strings.xsl:414
 msgid "Task is still in use"
 msgstr "Aufgabe wird noch verwendet"
@@ -6769,6 +6751,10 @@ msgstr "Notiz wird noch verwendet"
 #: classic/dynamic_strings.xsl:416
 msgid "Override is still in use"
 msgstr "Übersteuerung wird noch verwendet"
+
+#: classic/dynamic_strings.xsl:424
+msgid "Slave is still in use"
+msgstr "Slave wird noch verwendet"
 
 #: classic/dynamic_strings.xsl:425
 msgid "Agent is still in use"
@@ -7382,6 +7368,10 @@ msgstr "Gruppe muss aktuellem Benutzer gehören oder global sein"
 msgid "Role must be owned or global"
 msgstr "Rolle muss aktuellem Benutzer gehören oder global sein"
 
+#: classic/dynamic_strings.xsl:614
+msgid "Edit Slave"
+msgstr "Slave bearbeiten"
+
 #: classic/dynamic_strings.xsl:635
 msgid "may run multiple OMP commands as one"
 msgstr "darf mehrere OMP-Befehle als einen ausführen"
@@ -7769,6 +7759,10 @@ msgstr "hat Lesezugriff auf NVTs"
 #: classic/dynamic_strings.xsl:746
 msgid "has read access to NVT families"
 msgstr "hat Lesezugriff auf NVT-Familien"
+
+#: classic/dynamic_strings.xsl:747
+msgid "may get NVT feed version information"
+msgstr "darf Versionsinformationen des NVT-Feeds abrufen"
 
 #: classic/dynamic_strings.xsl:748
 msgid "has read access to overrides"
@@ -8467,104 +8461,181 @@ msgid_plural "%1 Roles will be moved to the trashcan"
 msgstr[0] "%1 Rolle wird in den Mülleimer verschoben"
 msgstr[1] "%1 Rollen werden in den Mülleimer verschoben"
 
-#: classic/gsad.xsl:211
+#: classic/gsad.xsl:214
 msgid "Logged in as"
 msgstr "Angemeldet als"
 
-#: classic/gsad.xsl:225 classic/gsad.xsl:226
+#: classic/gsad.xsl:228 classic/gsad.xsl:229
 msgctxt "Action Verb"
 msgid "Logout"
 msgstr "Abmelden"
 
-#: classic/gsad.xsl:232
+#: classic/gsad.xsl:235
 msgid "No auto-refresh"
 msgstr "Kein Auto-Refresh"
 
-#: classic/gsad.xsl:233
+#: classic/gsad.xsl:236
 msgid "Refresh every 30 Sec."
 msgstr "Alle 30 Sek. aktualisieren"
 
-#: classic/gsad.xsl:234
+#: classic/gsad.xsl:237
 msgid "Refresh every 60 Sec."
 msgstr "Alle 60 Sek. aktualisieren"
 
-#: classic/gsad.xsl:235
+#: classic/gsad.xsl:238
 msgid "Refresh every 2 Min."
 msgstr "Alle 2 Min. aktualisieren"
 
-#: classic/gsad.xsl:236
+#: classic/gsad.xsl:239
 msgid "Refresh every 5 Min."
 msgstr "Alle 5 Min. aktualisieren"
 
-#: classic/gsad.xsl:279
+#: classic/gsad.xsl:282
 msgctxt "Performance Timing"
 msgid "Backend operation"
 msgstr "Backend-Tätigkeit"
 
-#: classic/gsad.xsl:455
+#: classic/gsad.xsl:458
 msgid "Scans"
 msgstr "Scans"
 
-#: classic/gsad.xsl:478
+#: classic/gsad.xsl:483
 msgid "Hosts (Classic)"
 msgstr "Hosts (Klassisch)"
 
-#: classic/gsad.xsl:484
+#: classic/gsad.xsl:489
 msgid "Assets"
 msgstr "Assets"
 
-#: classic/gsad.xsl:522
+#: classic/gsad.xsl:529
 msgid "All SecInfo"
 msgstr "Alle Sicherheitsinfos"
 
-#: classic/gsad.xsl:616
+#: classic/gsad.xsl:617
 msgid "Configuration"
 msgstr "Konfiguration"
 
-#: classic/gsad.xsl:641
+#: classic/gsad.xsl:642
 msgid "CVSS Calculator"
 msgstr "CVSS-Rechner"
 
-#: classic/gsad.xsl:652
+#: classic/gsad.xsl:653
 msgid "Extras"
 msgstr "Extras"
 
-#: classic/gsad.xsl:683
+#: classic/gsad.xsl:684
 msgctxt "Auth Method"
 msgid "Radius"
 msgstr "Radius"
 
-#: classic/gsad.xsl:689
+#: classic/gsad.xsl:690
 msgid "Administration"
 msgstr "Administration"
 
-#: classic/gsad.xsl:696
+#: classic/gsad.xsl:697
 msgctxt "Help"
 msgid "Contents"
 msgstr "Inhalt"
 
-#: classic/gsad.xsl:700
+#: classic/gsad.xsl:701
 msgctxt "Help"
 msgid "About"
 msgstr "Über GSA"
 
-#: classic/gsad.xsl:916
+#: classic/gsad.xsl:917
 msgid "Greenbone Security Assistant"
 msgstr "Greenbone Security Assistant"
 
-#: classic/gsad.xsl:988
+#: classic/gsad.xsl:955
+msgid "Warning: Connection unencrypted"
+msgstr "Warnung: Verbindung unverschlüsselt"
+
+#: classic/gsad.xsl:958
+msgid ""
+"The connection to this GSA is not encrypted, allowing anyone listening to "
+"the traffic to steal your credentials."
+msgstr ""
+"Die Verbindung zu diesem GSA ist nicht verschlüsselt, so dass jeder, der den "
+"Datenverkehr mitverfolgt, Ihre Anmeldedaten stehlen kann."
+
+#: classic/gsad.xsl:961
+msgid ""
+"Please configure a TLS certificate for the HTTPS service or ask your "
+"administrator to do so as soon as possible."
+msgstr ""
+"Bitte konfigurieren Sie so bald wie möglich ein TLS-Zertifikat für den HTTPS-"
+"Dienst oder bitten Sie Ihren Administrator, dies zu tun."
+
+#: classic/gsad.xsl:1008
 msgctxt "Action Verb"
 msgid "Login"
 msgstr "Anmelden"
 
-#: classic/gsad.xsl:1000 classic/gsad.xsl:1005
+#: classic/gsad.xsl:1020 classic/gsad.xsl:1025
 msgctxt "Action Verb"
 msgid "Login as a guest"
 msgstr "Als Gast anmelden"
 
-#: classic/gsad.xsl:1118
+#: classic/gsad.xsl:1138
 msgid "Your current password does not comply with the password policy:"
 msgstr "Ihr aktuelles Passwort hält nicht die Passwortrichlinien ein:"
+
+#~ msgid "Create Task"
+#~ msgstr "Aufgabe erstellen"
+
+#~ msgid "Create a new slave"
+#~ msgstr "Neuen Slave erstellen"
+
+#~ msgid "Create a slave"
+#~ msgstr "Slave erstellen"
+
+#~ msgid "Add Report"
+#~ msgstr "Bericht hinzufügen"
+
+#~ msgid "Task is configured to run on slave %1"
+#~ msgstr "Aufgabe ist konfiguriert, um auf Slave %1 zu laufen"
+
+#~ msgid "Slaves using this Credential"
+#~ msgstr "Slaves, die diese Anmeldedaten verwenden"
+
+#~ msgid "Create Slave"
+#~ msgstr "Slave erstellen"
+
+#~ msgid "Save Slave"
+#~ msgstr "Slave speichern"
+
+#~ msgid "Tasks using this Slave"
+#~ msgstr "Aufgaben, die diesen Slave verwenden"
+
+#~ msgid "Reports span the last"
+#~ msgstr "Berichte über die Zeitspanne"
+
+#~ msgid "Reports for slave"
+#~ msgstr "Berichte für Slave"
+
+#~ msgid ""
+#~ "The selected Scan Slave can currently not be reached for retrieval of "
+#~ "performance data."
+#~ msgstr ""
+#~ "Der ausgewählte Scan-Slave ist momentan nicht erreichbar, um Performance-"
+#~ "Daten abzurufen."
+
+#~ msgid ""
+#~ "Please check network connection or Slave configuration.  The problem may "
+#~ "also be temporary, so you could try again at a later time."
+#~ msgstr ""
+#~ "Bitte überprüfen Sie die Netzwerkverbindung oder Slave-Konfiguration. Das "
+#~ "Problem könnte auch nur vorübergehend bestehen, so dass sie es später noch "
+#~ "einmal versuchen können."
+
+#~ msgid "Less than 1 day old"
+#~ msgstr "Weniger als 1 Tag alt"
+
+#~ msgid "Default Slave"
+#~ msgstr "Standard-Slave"
+
+#~ msgid "Slaves Filter"
+#~ msgstr "Slaves-Filter"
 
 #~ msgid "may get details about the CERT feed"
 #~ msgstr "darf Details über den CERT-Feed abrufen"


### PR DESCRIPTION
The labels in the "Duration Timeline" chart and a few other elements were lacking German translations,
 which should be fixed with these changes.