### PR TITLE
Fix building the js translations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,9 +176,9 @@ set (CMAKE_C_FLAGS_DEBUG        "${CMAKE_C_FLAGS_DEBUG} -Werror")
 set (CMAKE_C_FLAGS_RELEASE      "${CMAKE_C_FLAGS_RELEASE} ${HARDENING_FLAGS}")
 
 if (NOT SKIP_SRC)
-  add_subdirectory (gsad)
   # ng has no documentation to build so skip if src should not be build
   add_subdirectory (ng)
+  add_subdirectory (gsad)
 endif (NOT SKIP_SRC)
 
 ## Documentation

--- a/gsad/src/po/CMakeLists.txt
+++ b/gsad/src/po/CMakeLists.txt
@@ -142,9 +142,8 @@ if (GETTEXT_FOUND)
                         COMMAND "${CMAKE_SOURCE_DIR}/tools/js2pot"
                         ARGS    "${CMAKE_SOURCE_DIR}"
                                 "${CMAKE_CURRENT_BINARY_DIR}/gsad_js.pot"
-                                "src/html/classic/"
-                        DEPENDS ${CMAKE_SOURCE_DIR}/src/html/classic/js/*.js
-                                ${NG_JS_SRC_FILES}
+                                "${CMAKE_SOURCE_DIR}/ng"
+                        DEPENDS ${NG_JS_SRC_FILES}
                         COMMENT "Creating translation template (.pot) file from JS")
 
     # XSL template files


### PR DESCRIPTION
Include ng before gsad in the main CMakeLists.txt file to defines
NG_JS_SRC_FILES variable which is used in gsad/po/CMakeLists.txt. Adjust
path to the js source files for building the gsad_js.pot file.