### PR TITLE
Fixes for building .pot files

### DIFF
--- a/gsad/src/po/CMakeLists.txt
+++ b/gsad/src/po/CMakeLists.txt
@@ -152,9 +152,9 @@ if (GETTEXT_FOUND)
 
     add_custom_command (OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/gsad_xsl.pot
                         COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_SOURCE_DIR}/tools/xsl2pot"
-                        ARGS    "${CMAKE_SOURCE_DIR}/src/html/classic"
+                        ARGS    "${CMAKE_SOURCE_DIR}/gsad/src/html/classic"
                                 "${CMAKE_CURRENT_BINARY_DIR}/gsad_xsl.pot"
-                        DEPENDS ${CMAKE_SOURCE_DIR}/src/html/classic/*.xsl
+                        DEPENDS ${CMAKE_SOURCE_DIR}/gsad/src/html/classic/*.xsl
                         COMMENT "Creating translation template (.pot) file from XSLT")
 
   else (PY_POLIB_FOUND)

--- a/tools/js2pot
+++ b/tools/js2pot
@@ -35,6 +35,15 @@ SOURCE_DIR=$3
 mkdir -p `dirname $POT_FILE`
 
 cd "$SOURCE_BASEDIR" || exit 2
-SOURCES=`find $SOURCE_DIR -name "*.js" -not -path "*/node_modules/*" -not -path "*/build/*"`
+SOURCES_ABS=`find -L $SOURCE_DIR -name "*.js" -not -path "*/node_modules/*" -not -path "*/build/*"`
+
+SOURCES=""
+for SOURCE_FILE in $SOURCES_ABS
+do
+  REL_FILE=$(realpath --relative-to "$SOURCE_BASEDIR" "$SOURCE_FILE")
+  echo "$REL_FILE"
+  SOURCES="${SOURCES}${REL_FILE}
+"
+done
 
 xgettext --from-code=UTF-8 -o "$POT_FILE" -L JavaScript $SOURCES


### PR DESCRIPTION
Building the .pot files from XSLT didn't work for me and the file from JS was missing the old scripts
 because js2pot did not follow the symlinks to them.