### PR TITLE
Add usersettings to menubar

### DIFF
--- a/ng/src/web/components/bar/menubar.js
+++ b/ng/src/web/components/bar/menubar.js
@@ -277,9 +277,8 @@ const MenuBar = (props, {gmp, capabilities}) => {
             to="trashcan"
           />
           <MenuEntry
-            legacy title={_('My Settings')}
-            cmd="get_my_settings"
-            caps="get_settings"
+            title={_('My Settings')}
+            to="usersettings"
           />
           <MenuEntry
             legacy


### PR DESCRIPTION
Update the menubar to link to the new user settings page instead of using legacy.