### PR TITLE
Allow for easier debugging at entites pages

### DIFF
--- a/ng/src/web/entities/container.js
+++ b/ng/src/web/entities/container.js
@@ -157,6 +157,8 @@ class EntitiesContainer extends React.Component {
           loading: false,
         });
 
+        log.debug('Loaded entities', entities);
+
         if (meta.fromcache && (meta.dirty || reload)) {
           log.debug('Forcing reload of entities', meta.dirty, reload);
           refresh = 1;


### PR DESCRIPTION
Log the loaded entities object. It should always be a CollectionList.