### PR TITLE
Do not store filt_id in last_filt_ids if it is -2 (GSA 7.0)

### DIFF
--- a/src/gsad_omp.c
+++ b/src/gsad_omp.c
@@ -2086,7 +2086,8 @@ get_many (openvas_connection_t *connection, const char *type,
 
   if (given_filt_id)
     {
-      if (no_filter_history == 0 && strcmp (given_filt_id, "0"))
+      if (no_filter_history == 0
+          && strcmp (given_filt_id, "0") && strcmp (given_filt_id, "-2"))
         g_tree_replace (credentials->last_filt_ids, filter_type,
                         g_strdup (given_filt_id));
       filt_id = given_filt_id;


### PR DESCRIPTION
The value -2 should be ignored like 0 when storing the filt_id in the
last_filt_ids field of the current user credentials.
Otherwise it would cause problems where pages revert to a built in
filter selecting all items when they should not.