### PR TITLE
Fix z-Index of link targets to work in Firefox

### DIFF
--- a/ng/src/web/components/link/target.js
+++ b/ng/src/web/components/link/target.js
@@ -36,8 +36,9 @@ const Target = glamorous.div({
   content: '',
   display: 'block',
   height: '35px',
-  margin: '-35px 0 0',
   zIndex: '-100',
+  margin: '-35px 0 0 0',
+  position: 'relative', // needs to be set for z-index to work in Firefox
 });
 
 export default Target;


### PR DESCRIPTION
In Firefox the link target overlayed the content below it, making e.g.
links not clickable. With a set position this issue can be avoided
(position: relative;).