### PR TITLE
Entity tags edit

### DIFF
--- a/ng/src/web/entity/container.js
+++ b/ng/src/web/entity/container.js
@@ -237,6 +237,7 @@ class EntityContainer extends React.Component {
 }
 
 EntityContainer.propTypes = {
+  children: PropTypes.func.isRequired,
   gmp: PropTypes.gmp.isRequired,
   loaders: PropTypes.array,
   name: PropTypes.string.isRequired,

--- a/ng/src/web/entity/container.js
+++ b/ng/src/web/entity/container.js
@@ -24,11 +24,14 @@
 import React from 'react';
 
 import logger from 'gmp/log.js';
+
 import Promise from 'gmp/promise.js';
+
 import {is_defined} from 'gmp/utils.js';
 
 import compose from '../utils/compose.js';
 import PropTypes from '../utils/proptypes.js';
+import withGmp from '../utils/withGmp.js';
 
 import withDownload from '../components/form/withDownload.js';
 
@@ -39,7 +42,7 @@ import TagsHandler from './tagshandler.js';
 const log = logger.getLogger('web.entity.container');
 
 export const loader = (type, filter_func, name = type) => function(id) {
-  const {gmp} = this.context;
+  const {gmp} = this.props;
 
   log.debug('Loading', name, 'for entity', id);
 
@@ -84,7 +87,7 @@ class EntityContainer extends React.Component {
     super(...args);
 
     const {name} = this.props;
-    const {gmp} = this.context;
+    const {gmp} = this.props;
 
     this.name = name;
 
@@ -118,8 +121,7 @@ class EntityContainer extends React.Component {
   }
 
   load(id) {
-    const {gmp} = this.context;
-    const {loaders} = this.props;
+    const {loaders, gmp} = this.props;
 
     const all_loaders = [this.loadEntity];
 
@@ -176,7 +178,7 @@ class EntityContainer extends React.Component {
   }
 
   startTimer(refresh) {
-    const {gmp} = this.context;
+    const {gmp} = this.props;
 
     refresh = is_defined(refresh) ? refresh : gmp.autorefresh;
 
@@ -230,12 +232,12 @@ class EntityContainer extends React.Component {
           ...this.state,
         })}
       </TagsHandler>
-
     );
   }
 }
 
 EntityContainer.propTypes = {
+  gmp: PropTypes.gmp.isRequired,
   loaders: PropTypes.array,
   name: PropTypes.string.isRequired,
   params: PropTypes.object.isRequired,
@@ -245,11 +247,8 @@ EntityContainer.propTypes = {
   onDownload: PropTypes.func.isRequired,
 };
 
-EntityContainer.contextTypes = {
-  gmp: PropTypes.gmp.isRequired,
-};
-
 export default compose(
+  withGmp,
   withDialogNotification,
   withDownload,
 )(EntityContainer);

--- a/ng/src/web/entity/container.js
+++ b/ng/src/web/entity/container.js
@@ -217,20 +217,31 @@ class EntityContainer extends React.Component {
     } = this.props;
     return (
       <TagsHandler
-        resourceType={resourceType}
+        onChanged={this.handleChanged}
         onError={this.handleError}
-        onSuccess={this.handleChanged}
-      >
-        {tprops => children({
-          entityCommand: this.entity_command,
-          resourceType,
-          onDownloaded: onDownload,
-          onChanged: this.handleChanged,
-          onSuccess: this.handleChanged,
-          onError: this.handleError,
-          ...tprops,
-          ...this.state,
-        })}
+      >{({
+          add,
+          create,
+          delete: delete_func,
+          disable,
+          edit,
+          enable,
+        }) => children({
+            resourceType,
+            entityCommand: this.entity_command,
+            onChanged: this.handleChanged,
+            onSuccess: this.handleChanged,
+            onError: this.handleError,
+            onDownloaded: onDownload,
+            onTagAddClick: add,
+            onTagCreateClick: create,
+            onTagDeleteClick: delete_func,
+            onTagDisableClick: disable,
+            onTagEditClick: edit,
+            onTagEnableClick: enable,
+            ...this.state,
+          })
+        }
       </TagsHandler>
     );
   }

--- a/ng/src/web/entity/page.js
+++ b/ng/src/web/entity/page.js
@@ -117,12 +117,12 @@ class EntityPage extends React.Component {
     const {
       entity,
       tagsComponent: TagsComponent = EntityTags,
-      onAddTag,
-      onDeleteTag,
-      onDisableTag,
-      onEditTagClick,
-      onEnableTag,
-      onNewTagClick,
+      onTagAddClick,
+      onTagDeleteClick,
+      onTagDisableClick,
+      onTagEditClick,
+      onTagEnableClick,
+      onTagCreateClick,
     } = this.props;
     if (TagsComponent === false) {
       return null;
@@ -131,12 +131,12 @@ class EntityPage extends React.Component {
     return (
       <TagsComponent
         entity={entity}
-        onAddTag={onAddTag}
-        onDeleteTag={onDeleteTag}
-        onDisableTag={onDisableTag}
-        onEditTagClick={onEditTagClick}
-        onEnableTag={onEnableTag}
-        onNewTagClick={onNewTagClick}
+        onTagAddClick={onTagAddClick}
+        onTagDeleteClick={onTagDeleteClick}
+        onTagDisableClick={onTagDisableClick}
+        onTagEditClick={onTagEditClick}
+        onTagEnableClick={onTagEnableClick}
+        onTagCreateClick={onTagCreateClick}
       />
     );
   }
@@ -205,15 +205,15 @@ EntityPage.propTypes = {
   tagsComponent: PropTypes.componentOrFalse,
   title: PropTypes.string,
   toolBarIcons: PropTypes.component,
-  onAddTag: PropTypes.func.isRequired,
-  onDeleteTag: PropTypes.func.isRequired,
-  onDisableTag: PropTypes.func.isRequired,
-  onEditTagClick: PropTypes.func.isRequired,
-  onEnableTag: PropTypes.func.isRequired,
-  onNewTagClick: PropTypes.func.isRequired,
   onPermissionChanged: PropTypes.func,
   onPermissionDownloadError: PropTypes.func,
   onPermissionDownloaded: PropTypes.func,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
 };
 
 export default EntityPage;

--- a/ng/src/web/entity/tags.js
+++ b/ng/src/web/entity/tags.js
@@ -168,20 +168,20 @@ const SectionElementDivider = glamorous(Divider)({
 
 const SectionElements = ({
   entity,
-  onAddTag,
-  onNewTagClick,
+  onTagAddClick,
+  onTagCreateClick,
 }) => {
   return (
     <SectionElementDivider margin="10px">
       <AddTag
         entity={entity}
-        onAddTag={onAddTag}
+        onAddTag={onTagAddClick}
       />
       <IconDivider>
         <NewIcon
           title={_('New Tag')}
           value={entity}
-          onClick={onNewTagClick}
+          onClick={onTagCreateClick}
         />
         <HelpIcon
           page="user-tags"
@@ -194,24 +194,24 @@ const SectionElements = ({
 
 SectionElements.propTypes = {
   entity: PropTypes.model.isRequired,
-  onAddTag: PropTypes.func.isRequired,
-  onNewTagClick: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
 };
 
 const EntityTags = ({
   entity,
   foldable = true,
-  onAddTag,
-  onDeleteTag,
-  onDisableTag,
-  onEditTagClick,
-  onNewTagClick,
+  onTagAddClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagCreateClick,
 }) => {
   const extra = (
     <SectionElements
       entity={entity}
-      onAddTag={onAddTag}
-      onNewTagClick={onNewTagClick}
+      onTagAddClick={onTagAddClick}
+      onTagCreateClick={onTagCreateClick}
     />
   );
   const tags = entity.user_tags;
@@ -268,17 +268,17 @@ const EntityTags = ({
                           img="disable.svg"
                           value={tag}
                           title={_('Disable Tag')}
-                          onClick={onDisableTag}
+                          onClick={onTagDisableClick}
                         />
                         <TrashIcon
                           value={tag}
                           title={_('Move Tag to Trashcan')}
-                          onClick={onDeleteTag}
+                          onClick={onTagDeleteClick}
                         />
                         <EditIcon
                           value={tag}
                           title={_('Edit Tag')}
-                          onClick={onEditTagClick}
+                          onClick={onTagEditClick}
                         />
                       </IconDivider>
                     </TableData>
@@ -296,11 +296,11 @@ const EntityTags = ({
 EntityTags.propTypes = {
   entity: PropTypes.model.isRequired,
   foldable: PropTypes.bool,
-  onAddTag: PropTypes.func.isRequired,
-  onDeleteTag: PropTypes.func.isRequired,
-  onDisableTag: PropTypes.func.isRequired,
-  onEditTagClick: PropTypes.func.isRequired,
-  onNewTagClick: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
 };
 
 export default EntityTags;

--- a/ng/src/web/entity/tags.js
+++ b/ng/src/web/entity/tags.js
@@ -250,7 +250,6 @@ const EntityTags = ({
                     key={tag.id}>
                     <TableData>
                       <DetailsLink
-                        legacy
                         id={tag.id}
                         type="tag">
                         {tag.name}

--- a/ng/src/web/pages/reports/detailscontent.js
+++ b/ng/src/web/pages/reports/detailscontent.js
@@ -407,8 +407,8 @@ const PageContent = ({
             <TabPanel>
               <Summary
                 report={report}
-                onSuccess={onTagSuccess}
                 onError={onError}
+                onTagChanged={onTagSuccess}
               />
             </TabPanel>
             <TabPanel>

--- a/ng/src/web/pages/reports/summary.js
+++ b/ng/src/web/pages/reports/summary.js
@@ -36,8 +36,7 @@ import ScanInfo from './scaninfo.js';
 const Summary = ({
   report,
   onError,
-  onSuccess,
-  ...props
+  onTagChanged,
 }) => (
   <Layout flex="column">
     <ScanInfo
@@ -45,14 +44,25 @@ const Summary = ({
     />
     <TagsHandler
       onError={onError}
-      onSuccess={onSuccess}
+      onChanged={onTagChanged}
       resourceType="report"
     >
-      {tprops => (
+      {({
+        add,
+        create,
+        delete: delete_func,
+        disable,
+        enable,
+        edit,
+      }) => (
         <EntityTags
-          {...props}
-          {...tprops}
           entity={report}
+          onTagAddClick={add}
+          onTagCreateClick={create}
+          onTagDeleteClick={delete_func}
+          onTagDisableClick={disable}
+          onTagEditClick={edit}
+          onTagEndableClick={enable}
         />
       )}
     </TagsHandler>
@@ -62,7 +72,7 @@ const Summary = ({
 Summary.propTypes = {
   report: PropTypes.model.isRequired,
   onError: PropTypes.func.isRequired,
-  onSuccess: PropTypes.func.isRequired,
+  onTagChanged: PropTypes.func.isRequired,
 };
 
 export default Summary;

--- a/ng/src/web/pages/tags/component.js
+++ b/ng/src/web/pages/tags/component.js
@@ -44,6 +44,7 @@ class TagComponent extends React.Component {
 
     this.handleEnableTag = this.handleEnableTag.bind(this);
     this.handleDisableTag = this.handleDisableTag.bind(this);
+    this.handleAddTag = this.handleAddTag.bind(this);
     this.openTagDialog = this.openTagDialog.bind(this);
     this.openCreateTagDialog = this.openCreateTagDialog.bind(this);
   }
@@ -58,6 +59,18 @@ class TagComponent extends React.Component {
     const {gmp, onDisabled, onDisableError} = this.props;
 
     gmp.tag.disable(tag).then(onDisabled, onDisableError);
+  }
+
+  handleAddTag({name, value, entity}) {
+    const {gmp, onAdded, onAddError} = this.props;
+
+    return gmp.tag.create({
+      name,
+      value,
+      active: 1,
+      resource_id: entity.id,
+      resource_type: entity.entity_type,
+    }).then(onAdded, onAddError);
   }
 
   getResourceTypes() {
@@ -217,6 +230,7 @@ class TagComponent extends React.Component {
           <Wrapper>
             {children({
               ...other,
+              add: this.handleAddTag,
               create: this.openCreateTagDialog,
               edit: this.openTagDialog,
               enable: this.handleEnableTag,
@@ -237,6 +251,8 @@ TagComponent.propTypes = {
   capabilities: PropTypes.capabilities.isRequired,
   children: PropTypes.func.isRequired,
   gmp: PropTypes.gmp.isRequired,
+  onAddError: PropTypes.func,
+  onAdded: PropTypes.func,
   onCloneError: PropTypes.func,
   onCloned: PropTypes.func,
   onCreateError: PropTypes.func,

--- a/ng/src/web/pages/tags/component.js
+++ b/ng/src/web/pages/tags/component.js
@@ -157,13 +157,14 @@ class TagComponent extends React.Component {
     return resource_types;
   }
 
-  openTagDialog(tag) {
+  openTagDialog(tag, options = {}) {
     const resource_types = this.getResourceTypes();
 
     if (is_defined(tag)) {
       const {resource = {}} = tag;
 
       this.tag_dialog.show({
+        ...options,
         id: tag.id,
         tag,
         name: tag.name,

--- a/ng/src/web/pages/tags/component.js
+++ b/ng/src/web/pages/tags/component.js
@@ -45,6 +45,7 @@ class TagComponent extends React.Component {
     this.handleEnableTag = this.handleEnableTag.bind(this);
     this.handleDisableTag = this.handleDisableTag.bind(this);
     this.openTagDialog = this.openTagDialog.bind(this);
+    this.openCreateTagDialog = this.openCreateTagDialog.bind(this);
   }
 
   handleEnableTag(tag) {
@@ -59,7 +60,7 @@ class TagComponent extends React.Component {
     gmp.tag.disable(tag).then(onDisabled, onDisableError);
   }
 
-  openTagDialog(tag) {
+  getResourceTypes() {
     const {capabilities} = this.props;
     const resource_types = [];
     if (capabilities.mayAccess('agents')) {
@@ -140,6 +141,12 @@ class TagComponent extends React.Component {
     if (capabilities.mayAccess('users')) {
       resource_types.push(['user', _('User')]);
     }
+    return resource_types;
+  }
+
+  openTagDialog(tag) {
+    const resource_types = this.getResourceTypes();
+
     if (is_defined(tag)) {
       const {resource = {}} = tag;
 
@@ -164,6 +171,15 @@ class TagComponent extends React.Component {
         resource_types,
       });
     }
+  }
+
+  openCreateTagDialog(options = {}) {
+    const resource_types = this.getResourceTypes();
+
+    this.tag_dialog.show({
+      ...options,
+      resource_types,
+    });
   }
 
   render() {
@@ -201,7 +217,7 @@ class TagComponent extends React.Component {
           <Wrapper>
             {children({
               ...other,
-              create: this.openTagDialog,
+              create: this.openCreateTagDialog,
               edit: this.openTagDialog,
               enable: this.handleEnableTag,
               disable: this.handleDisableTag,


### PR DESCRIPTION
Cleanup the tag handling for details pages. Most detail pages contain a tag list. Reuse more code by using the TagComponent in the TagHandler. The TagHandler is now only responsible for passing the right params to TagComponets handlers.