### PR TITLE
Test whether xsl_filename is NULL in help handler (GSA 7.0)

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -5187,9 +5187,12 @@ handle_request (void *cls, struct MHD_Connection *connection,
               g_hash_table_insert (template_attributes, "mode", "help");
 
               // Try to find the requested page template
-              template_found
-                = find_element_in_xml_file (xsl_filename, "xsl:template",
-                                            template_attributes);
+              if (xsl_filename)
+                {
+                  template_found
+                    = find_element_in_xml_file (xsl_filename, "xsl:template",
+                                                template_attributes);
+                }
 
               if (template_found == 0)
                 {


### PR DESCRIPTION
To avoid warning messages when handling help pages that do not have
 a language specific .xsl file, find_element_in_xml_file is only
 called if xsl_filename is not NULL.