### PR TITLE
Show busy indicator on save button while loading

### DIFF
--- a/ng/src/web/components/dialog/button.js
+++ b/ng/src/web/components/dialog/button.js
@@ -2,6 +2,7 @@
  *
  * Authors:
  * Björn Ricks <bjoern.ricks@greenbone.net>
+ * Steffen Waterkamp <steffen.waterkamp@greenbone.net>
  *
  * Copyright:
  * Copyright (C) 2017 Greenbone Networks GmbH
@@ -23,7 +24,9 @@
 
 import glamorous from 'glamorous';
 
-const DialogButton = glamorous.button({
+import Button from '../form/button.js';
+
+const DialogButton = glamorous(Button)({
   border: '1px solid #519032',
   fontWeight: 'bold',
   color: '#519032',
@@ -37,7 +40,22 @@ const DialogButton = glamorous.button({
     color: '#fff',
     background: '#519032',
   },
-});
+},
+  ({loading}) => {
+    if (loading) {
+      return {
+        background: '#87d050 url(/img/loading.gif) center center no-repeat',
+        color: 'rgba(0, 0, 0, 0.0)',
+
+        // when loading, :hover needs to be overwritten explicitly
+        ':hover': {
+          background: '#87d050 url(/img/loading.gif) center center no-repeat',
+          color: 'rgba(0, 0, 0, 0.0)',
+        },
+      };
+    }
+  }
+);
 
 export default DialogButton;
 

--- a/ng/src/web/components/dialog/footer.js
+++ b/ng/src/web/components/dialog/footer.js
@@ -2,6 +2,7 @@
  *
  * Authors:
  * Björn Ricks <bjoern.ricks@greenbone.net>
+ * Steffen Waterkamp <steffen.waterkamp@greenbone.net>
  *
  * Copyright:
  * Copyright (C) 2017 Greenbone Networks GmbH
@@ -39,18 +40,21 @@ const StyledLayout = glamorous(Layout)({
   padding: '10px 15px 10px 15px',
 });
 
-const DialogFooter = ({title, onClick}) => (
+const DialogFooter = ({title, onClick, loading = false}) => (
   <StyledLayout
     align={['end', 'center']}>
     <Button
       onClick={onClick}
-      title={title}>
+      title={title}
+      loading={loading}
+    >
       {title}
     </Button>
   </StyledLayout>
 );
 
 DialogFooter.propTypes = {
+  loading: PropTypes.bool,
   title: PropTypes.string.isRequired,
   onClick: PropTypes.func,
 };
@@ -58,4 +62,3 @@ DialogFooter.propTypes = {
 export default DialogFooter;
 
 // vim: set ts=2 sw=2 tw=80:
-

--- a/ng/src/web/components/dialog/savedialog.js
+++ b/ng/src/web/components/dialog/savedialog.js
@@ -2,6 +2,7 @@
  *
  * Authors:
  * Björn Ricks <bjoern.ricks@greenbone.net>
+ * Steffen Waterkamp <steffen.waterkamp@greenbone.net>
  *
  * Copyright:
  * Copyright (C) 2017 Greenbone Networks GmbH
@@ -42,7 +43,9 @@ class SaveDialogContent extends React.Component {
   constructor(...args) {
     super(...args);
 
-    this.state = {};
+    this.state = {
+      loading: false,
+    };
 
     this.handleSaveClick = this.handleSaveClick.bind(this);
     this.handleClose = this.handleClose.bind(this);
@@ -52,9 +55,10 @@ class SaveDialogContent extends React.Component {
   handleSaveClick(state) {
     const {onSave} = this.props;
 
-    if (onSave) {
+    if (onSave && !this.state.loading) {
       const promise = onSave(state);
       if (is_defined(promise)) {
+        this.setState({loading: true});
         promise.then(
           () => this.handleClose(),
           error => this.setError(error)
@@ -72,12 +76,18 @@ class SaveDialogContent extends React.Component {
 
   handleClose() {
     const {close} = this.props;
-    this.setState({error: undefined});
+    this.setState({
+      error: undefined,
+      loading: false,
+    });
     close();
   }
 
   setError(error) {
-    this.setState({error: error.message});
+    this.setState({
+      error: error.message,
+      loading: false,
+    });
   }
 
   render() {
@@ -116,6 +126,7 @@ class SaveDialogContent extends React.Component {
             </ScrollableContent>
             <DialogFooter
               title={_('Save')}
+              loading={this.state.loading}
               onClick={() => this.handleSaveClick(state)}
             />
           </DialogContent>

--- a/ng/src/web/components/dialog/withDialog.js
+++ b/ng/src/web/components/dialog/withDialog.js
@@ -2,6 +2,7 @@
  *
  * Authors:
  * Björn Ricks <bjoern.ricks@greenbone.net>
+ * Steffen Waterkamp <steffen.waterkamp@greenbone.net>
  *
  * Copyright:
  * Copyright (C) 2017 Greenbone Networks GmbH
@@ -107,7 +108,10 @@ const withDialog = (options = {}) => Component => {
     }
 
     setErrorMessage(message) {
-      this.setState({error: message});
+      this.setState({
+        error: message,
+        loading: false,
+      });
     }
 
     setValues(new_data) {
@@ -139,6 +143,7 @@ const withDialog = (options = {}) => Component => {
         footer,
         title,
         visible: true,
+        loading: false,
       });
     }
 
@@ -156,7 +161,7 @@ const withDialog = (options = {}) => Component => {
       const {onClose} = this.props;
 
       this.close();
-
+      this.setState({loading: false});
       if (onClose) {
         onClose();
       }
@@ -169,6 +174,7 @@ const withDialog = (options = {}) => Component => {
       if (onSave) {
         const promise = onSave(data);
         if (is_defined(promise)) {
+          this.setState({loading: true});
           promise.then(
             () => this.close(),
             error => this.setError(error)
@@ -238,10 +244,21 @@ const withDialog = (options = {}) => Component => {
     }
 
     renderFooter() {
-      const {footer} = {...this.state, ...this.props};
+      const {
+        footer,
+        loading
+      } = {...this.state, ...this.props};
 
       if (!is_defined(footer)) {
         return null;
+      }
+      if (loading) {
+        return (
+          <DialogFooter
+            title={footer}
+            loading={loading}
+          />
+        );
       }
       return (
         <DialogFooter


### PR DESCRIPTION
Note: The button has not been set to "disabled" explicitly. I tested clicking it several times while it was in "loading-mode" and it did not create new queries in the network-tab in the browser's Dev-Tools.