### PR TITLE
Fix array-mapping for reports-array

### DIFF
--- a/ng/src/gmp/commands/performance.js
+++ b/ng/src/gmp/commands/performance.js
@@ -20,7 +20,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-import {is_defined} from '../utils.js';
+import {
+  is_defined,
+  is_array,
+} from '../utils.js';
 
 import HttpCommand from './http.js';
 
@@ -45,7 +48,7 @@ class PerformanceCommand extends HttpCommand {
         throw new Error('Invalid response data for system reports');
       }
 
-      return response.setData(reports);
+      return response.setData(is_array(reports) ? reports : [reports]);
     });
   }
 }


### PR DESCRIPTION
Use own gmp/utils.js map() to map through array of reports. The previous
usage of Array.prototype.map() threw a "map is not a function" error.