### PR TITLE
Fix toolbar icon margins

### DIFF
--- a/ng/src/web/pages/groups/listpage.js
+++ b/ng/src/web/pages/groups/listpage.js
@@ -33,7 +33,7 @@ import withEntitiesContainer from '../../entities/withEntitiesContainer.js';
 import HelpIcon from '../../components/icon/helpicon.js';
 import NewIcon from '../../components/icon/newicon.js';
 
-import Layout from '../../components/layout/layout.js';
+import IconDivider from '../../components/layout/icondivider.js';
 
 import {createFilterDialog} from '../../components/powerfilter/dialog.js';
 
@@ -46,7 +46,7 @@ const ToolBarIcons = ({
   onGroupCreateClick,
 }, {capabilities}) => {
   return (
-    <Layout flex box>
+    <IconDivider>
       <HelpIcon
         page="groups"
         title={_('Help: Groups')}/>
@@ -55,7 +55,7 @@ const ToolBarIcons = ({
           title={_('New Group')}
           onClick={onGroupCreateClick}/>
       }
-    </Layout>
+    </IconDivider>
   );
 };
 

--- a/ng/src/web/pages/portlists/listpage.js
+++ b/ng/src/web/pages/portlists/listpage.js
@@ -25,7 +25,7 @@ import React from 'react';
 
 import _ from 'gmp/locale.js';
 
-import Layout from '../../components/layout/layout.js';
+import IconDivider from '../../components/layout/icondivider.js';
 
 import PropTypes from '../../utils/proptypes.js';
 import withCapabilities from '../../utils/withCapabilities.js';
@@ -48,7 +48,7 @@ const ToolBarIcons = withCapabilities(({
   onPortListCreateClick,
   onPortListImportClick,
 }) => (
-  <Layout flex box>
+  <IconDivider>
     <HelpIcon
       page="port_lists"
       title={_('Help: Port Lists')}/>
@@ -61,7 +61,7 @@ const ToolBarIcons = withCapabilities(({
       img="upload.svg"
       title={_('Import Port List')}
       onClick={onPortListImportClick}/>
-  </Layout>
+  </IconDivider>
 ));
 
 ToolBarIcons.propTypes = {

--- a/ng/src/web/pages/roles/listpage.js
+++ b/ng/src/web/pages/roles/listpage.js
@@ -33,6 +33,7 @@ import withEntitiesContainer from '../../entities/withEntitiesContainer.js';
 import HelpIcon from '../../components/icon/helpicon.js';
 import NewIcon from '../../components/icon/newicon.js';
 
+import IconDivider from '../../components/layout/icondivider.js';
 import Layout from '../../components/layout/layout.js';
 
 import {createFilterDialog} from '../../components/powerfilter/dialog.js';
@@ -45,7 +46,7 @@ import Table, {SORT_FIELDS} from './table.js';
 const ToolBarIcons = ({
   onRoleCreateClick,
 }, {capabilities}) => (
-  <Layout flex box>
+  <IconDivider>
     <HelpIcon
       page="roles"
       title={_('Help: Roles')}/>
@@ -54,7 +55,7 @@ const ToolBarIcons = ({
         title={_('New Role')}
         onClick={onRoleCreateClick}/>
     }
-  </Layout>
+  </IconDivider>
 );
 
 ToolBarIcons.propTypes = {


### PR DESCRIPTION
Added IconDivider to toolbars for roles, groups, and port lists.