### PR TITLE
Remove drop-down when auto-refresh is disabled.

### DIFF
--- a/src/html/classic/js/greenbone.js
+++ b/src/html/classic/js/greenbone.js
@@ -1706,9 +1706,7 @@
         start_auto_refresh();
       });
       if (!global.autorefresh_enabled) {
-        var autorefresh_off = autorefresh.find('option[value="0"]');
-        autorefresh.prop('disabled', 'disabled');
-        autorefresh_off.prop ('selected', 'selected');
+        autorefresh.remove();
       }
     }
 


### PR DESCRIPTION
To make it clearer when auto-refresh is disabled, remove the drop-down
 list completely instead of just graying it out.