### PR TITLE
Fix confirmation button labels in Wizards

### DIFF
--- a/src/html/classic/js/greenbone.js
+++ b/src/html/classic/js/greenbone.js
@@ -490,7 +490,7 @@
       var button = $(this);
       if (button.button('option', 'label') !== 'Close') {
         this.label = button.button('option', 'label');
-        if (this.label !== 'OK') {
+        if (this.label === 'Create' || this.label === 'Save') {
           button.button('option', 'label', this.label.substring(
                 0, this.label.length - 1) + 'ing ...');
         }

--- a/src/html/classic/wizard.xsl
+++ b/src/html/classic/wizard.xsl
@@ -68,7 +68,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           </li>
           <li>
             <a href="/omp?cmd=wizard&amp;name=modify_task&amp;filter={/envelope/params/filter}&amp;filt_id={/envelope/params/filt_id}&amp;token={/envelope/token}"
-              data-dialog-id="modify_task_wizard"
+              data-dialog-id="modify_task_wizard" data-button="{gsa:i18n ('Save', 'Action Verb')}"
                class="wizard-action-icon" data-name="modify_task">
               <xsl:value-of select="gsa:i18n ('Modify Task Wizard')"/>
             </a>


### PR DESCRIPTION
The label of the confirmation button of dialogs will now only change on
 clicking if labeled "Create" and "Save" as the automatic change only
 makes sense for these cases.
The label for the "Modify Task Wizard" has been changed to "Save" as
 it is on other edit dialogs.