### PR TITLE
Fix button-text alignment

### DIFF
--- a/ng/src/web/components/form/button.js
+++ b/ng/src/web/components/form/button.js
@@ -91,7 +91,7 @@ const Button = glamorous(({
 });
 
 export default compose(
-  withLayout(),
+  withLayout({align: ['center', 'center']}),
   withClickHandler(),
 )(Button);
 


### PR DESCRIPTION
The x in the close-buttons for dialogs is now centered by using
justifyContent: 'center'.