### PR TITLE
Allow to add query params to Link components

### DIFF
--- a/ng/src/web/components/link/link.js
+++ b/ng/src/web/components/link/link.js
@@ -69,6 +69,7 @@ let Link = ({
   anchor,
   to,
   filter,
+  query,
   ...other
 }) => {
 
@@ -83,7 +84,7 @@ let Link = ({
 
   const location = {
     pathname,
-    query: {},
+    query: is_defined(query) ? {...query} : {},
     hash: is_defined(anchor) ? '#' + anchor : undefined,
   };
 
@@ -96,6 +97,7 @@ let Link = ({
 Link.propTypes = {
   anchor: PropTypes.string,
   filter: PropTypes.string,
+  query: PropTypes.object,
   to: PropTypes.string.isRequired,
 };
 


### PR DESCRIPTION
We need to be able to pass query params ?name=value to links to be able
to pass additional data to pages.