### PR TITLE
Fix deleting a report at the report list page

### DIFF
--- a/ng/src/web/pages/reports/listpage.js
+++ b/ng/src/web/pages/reports/listpage.js
@@ -81,6 +81,7 @@ class Page extends React.Component {
     this.handleDialogSave = this.handleDialogSave.bind(this);
     this.handleCreateContainerTask = this.handleCreateContainerTask.bind(this);
     this.handleReportDeltaSelect = this.handleReportDeltaSelect.bind(this);
+    this.handleReportDeleteClick = this.handleReportDeleteClick.bind(this);
     this.openImportDialog = this.openImportDialog.bind(this);
     this.openCreateTaskDialog = this.openCreateTaskDialog.bind(this);
   }
@@ -117,8 +118,9 @@ class Page extends React.Component {
   }
 
   handleDialogSave(data) {
-    const {entityCommand, onChanged} = this.props;
-    return entityCommand.import(data).then(() => onChanged());
+    const {gmp} = this.context;
+    const {onChanged, onError} = this.props;
+    return gmp.report.import(data).then(onChanged, onError);
   }
 
   handleCreateContainerTask(data) {
@@ -144,6 +146,12 @@ class Page extends React.Component {
     }
   }
 
+  handleReportDeleteClick(report) {
+    const {gmp} = this.context;
+    const {onChanged, onError} = this.props;
+    return gmp.report.delete(report).then(onChanged, onError);
+  }
+
   render() {
     return (
       <Wrapper>
@@ -152,6 +160,7 @@ class Page extends React.Component {
           {...this.state}
           onUploadReportClick={this.openImportDialog}
           onReportDeltaSelect={this.handleReportDeltaSelect}
+          onReportDeleteClick={this.handleReportDeleteClick}
         />
         <ImportReportDialog
           ref={ref => this.import_dialog = ref}
@@ -166,10 +175,10 @@ class Page extends React.Component {
 }
 
 Page.propTypes = {
-  entityCommand: PropTypes.entitycommand.isRequired,
   filter: PropTypes.filter,
   router: PropTypes.object.isRequired,
   onChanged: PropTypes.func.isRequired,
+  onError: PropTypes.func.isRequired,
   onFilterChanged: PropTypes.func.isRequired,
 };
 

--- a/ng/src/web/pages/reports/row.js
+++ b/ng/src/web/pages/reports/row.js
@@ -48,7 +48,7 @@ import TableRow from '../../components/table/row.js';
 const IconActions = ({
   entity,
   selectedDeltaReport,
-  onEntityDelete,
+  onReportDeleteClick,
   onReportDeltaSelect,
 }) => {
   const {report} = entity;
@@ -87,7 +87,7 @@ const IconActions = ({
         active={active}
         value={entity}
         title={title}
-        onClick={active ? onEntityDelete : undefined}
+        onClick={active ? onReportDeleteClick : undefined}
       />
     </IconDivider>
   );
@@ -96,7 +96,7 @@ const IconActions = ({
 IconActions.propTypes = {
   entity: PropTypes.model.isRequired,
   selectedDeltaReport: PropTypes.model,
-  onEntityDelete: PropTypes.func.isRequired,
+  onReportDeleteClick: PropTypes.func.isRequired,
   onReportDeltaSelect: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
The former onEntityDelete handler got removed from the entites container
component. Therefore the reports page must provide an own implementation
of the handler.

Also add error handlers to get notified about occuring errors. Don't use
entityCommand prop anymore. This prop should also no longer be provided
by the entities container in future.