### PR TITLE
Quick fix for linking to ng from charts

### DIFF
--- a/gsad/src/html/classic/js/gsa_bar_chart.js
+++ b/gsad/src/html/classic/js/gsa_bar_chart.js
@@ -234,7 +234,7 @@
         });
     }
 
-    var generateLink = self.createGenerateLinkFunc(
+    var handler = self.createGenerateLinkFunc(
         data.column_info.columns.value.column,
         data.column_info.columns.value.type, data.filter_info);
 
@@ -242,7 +242,6 @@
     this.svg.selectAll('.bar')
       .data(records).enter().insert('a')
         .attr('class', 'bar')
-        .attr('xlink:href', generateLink)
         .insert('rect', '.x.axis')
           .attr('x', function(d) { return self.x_scale(d[self.x_field]); })
           .attr('y', function(d) { return self.y_scale(0); })
@@ -250,6 +249,7 @@
           .attr('height', function(d) {
             return height - self.y_scale(0);
           })
+          .on('click', handler)
           .on('mouseover', this.tip.show)
           .on('mouseout', this.tip.hide);
 
@@ -314,9 +314,9 @@
     var value = d.value;
 
     if (column === 'uuid') {
-      return gsa.charts.details_page_url(type, value, filter_info);
+      return gsa.charts.goto_details_page(type, value);
     } else {
-      return gsa.charts.filtered_list_url(type, column, value, filter_info);
+      return gsa.charts.goto_list_page(type, column, value, filter_info);
     }
   };
 

--- a/gsad/src/html/classic/js/gsa_bubble_chart.js
+++ b/gsad/src/html/classic/js/gsa_bubble_chart.js
@@ -252,7 +252,7 @@
       })
       .append('a');
 
-    new_node_a.attr('xlink:href', function(d) {
+    new_node_a.on('click', function(d) {
       if (no_chart_links === true) {
         return null;
       }

--- a/gsad/src/html/classic/js/gsa_chart_helpers.js
+++ b/gsad/src/html/classic/js/gsa_chart_helpers.js
@@ -2536,26 +2536,27 @@
    * @return {string} The resource type as used in cmd=get_[...].
    */
   gch.cmd_type = function(type) {
-    var get_type;
-    if (type === 'host' || type === 'os') {
-      get_type = 'asset';
+    switch (type) {
+      case 'allinfo':
+        type = 'secinfo';
+        break;
+      case 'dfn_cert_adv':
+        type = 'dfncertadv';
+        break;
+      case 'cert_bund_adv':
+        type = 'certbundadv';
+        break;
+      case 'os':
+        type = 'operatingsystem';
+        break;
+      default:
+        break;
     }
-    else if (type === 'allinfo' || type === 'nvt' || type === 'cve' ||
-        type === 'cpe' || type === 'ovaldef' || type === 'cert_bund_adv' ||
-        type === 'dfn_cert_adv') {
-      get_type = 'info';
-    }
-    else {
-      get_type = type;
-    }
-    return get_type;
+    return type;
   };
 
-  function is_ng(type) {
-    return type === 'task' || type === 'result';
-  }
   /**
-   * @summary Generates a filtered list page URL
+   * @summary Changes location to a list page
    *
    * @param {string}  type         Resource type or subtype
    * @param {string}  column       Column name
@@ -2565,7 +2566,7 @@
    *
    * @return {string} The page URL.
    */
-  gch.filtered_list_url = function(type, column, value, filter_info, relation) {
+  gch.goto_list_page = function(type, column, value, filter_info, relation) {
     var result;
     var get_type;
     var get_type_plural;
@@ -2577,28 +2578,7 @@
     // Get "real" type and plural
     get_type = gch.cmd_type(type);
 
-    if (get_type === 'info') {
-      get_type_plural = get_type;
-    }
-    else {
-      get_type_plural = get_type + 's';
-    }
-
-    if (is_ng(get_type)) {
-      result = '/ng/' + get_type_plural + '?';
-    }
-    else {
-
-      // Add command and (if needed) subtype
-      result = '/omp?cmd=get_' + get_type_plural + '&';
-
-      if (get_type !== type) {
-        result += get_type + '_type=' + type + '&';
-      }
-    }
-
-    // Add existing extra options from filter
-    result += 'filter=' + filter_info.extra_options_str + ' ';
+    result = '/ng/' + get_type + 's?filter=';
 
     // Create new column filter keyword(s)
     var criteria_addition = '';
@@ -2688,46 +2668,21 @@
 
     result += new_criteria;
 
-    if (!is_ng(get_type)) {
-      // Add token
-      result += '&token=' + gsa.token;
-    }
-
-    return result;
+    gsa.history.push(result);
   };
 
   /**
-   * @summary Generates a details page URL
+   * @summary Changes location to a details page
    *
    * @param {string}  type         Resource type or subtype
    * @param {string}  id           id of the resource to get
-   * @param {Object}  filter_info  filter_info from generator
-   * @param {string}  relation     The relation to use
    *
    * @return {string} the page URL
    */
-  gch.details_page_url = function(type, id, filter_info) {
-    var result = '/omp?';
+  gch.goto_details_page = function(type, id) {
     var get_type = gch.cmd_type(type);
 
-    // Add command and (if needed) subtype
-    result += ('cmd=get_' + get_type);
-
-    if (get_type !== type) {
-      result += ('&' + get_type + '_type=' + type);
-    }
-
-    // Add resource id
-    result += ('&' + get_type + '_id=' + id);
-
-    // Add filter
-    result += ('&filter=' + filter_info.term);
-    result += ('&filt_id=' + filter_info.id);
-
-    // Add token
-    result += ('&token=' + gsa.token);
-
-    return result;
+    gsa.history.push('/ng/' + get_type + '/' + id);
   };
 
   /*

--- a/gsad/src/html/classic/js/gsa_cloud_chart.js
+++ b/gsad/src/html/classic/js/gsa_cloud_chart.js
@@ -126,7 +126,7 @@
 
     this.color_scale.domain(words);
 
-    var generate_link = this.createGenerateLinkFunc(
+    var handler = this.createGenerateLinkFunc(
         data.column_info.group_column,
         data.column_info.columns[self.x_field].type,
         data.filter_info);
@@ -141,7 +141,7 @@
         self.svg.selectAll('text')
           .data(words)
           .enter().append('a')
-            .attr('xlink:href', generate_link)
+            .on('click', handler)
             .append('text')
               .style('font-size', function(d) { return d.size + 'px'; })
               .style('font-family', function(d) { return d.font; })
@@ -181,7 +181,7 @@
   CloudChartGenerator.prototype.generateLink = function(d, i, column, type,
       filter_info) {
     var value = d.text;
-    return gch.filtered_list_url(type, column, value, filter_info, '~');
+    return gch.goto_list_page(type, column, value, filter_info, '~');
   };
 
 })(window, window, window.d3, window.console, window.gsa);

--- a/gsad/src/html/classic/js/gsa_donut_chart.js
+++ b/gsad/src/html/classic/js/gsa_donut_chart.js
@@ -213,8 +213,8 @@
     }
 
     var legend_y = 0;
-    for (i = 0; i < slices.length; i++) {
-      var d = slices[i];
+    for (let i = 0; i < slices.length; i++) {
+      let d = slices[i];
       var color = self.scaleColor(d.data[self.x_field]);
       if (!gsa.is_defined(color)) {
         color = self.scaleColor(d.data[self.x_field + '~original']);
@@ -226,7 +226,9 @@
         .on('mouseout', this.tip.hide);
 
       var legend_item = legend_group.insert('a')
-        .attr('xlink:href', generate_link(d, i));
+        .on('click', function() {
+          generate_link(d, i);
+        });
 
       legend_item.insert('rect')
         .attr('height', '15')
@@ -276,7 +278,7 @@
       .enter()
       .insert('a')
         .attr('class', 'slice')
-        .attr('xlink:href', generate_link)
+        .on('click', generate_link)
         .on('mouseover', set_tooltip_title)
         .on('mouseout', this.tip.hide)
         .each(function(d, i) {
@@ -375,7 +377,7 @@
       .data(slices)
       .enter()
       .insert('a')
-        .attr('xlink:href', generate_link)
+        .on('click', generate_link)
         .insert('text')
           .classed('slice_label', true)
           .classed('empty', function(d) {
@@ -547,7 +549,7 @@
       value = d.data[self.x_field];
     }
 
-    return gch.filtered_list_url(type, column, value, filter_info);
+    return gch.goto_list_page(type, column, value, filter_info);
   };
 
   /*

--- a/gsad/src/html/classic/js/gsa_gantt_chart.js
+++ b/gsad/src/html/classic/js/gsa_gantt_chart.js
@@ -253,15 +253,15 @@
       .attr('x', width / 2)
       .attr('y', height / 2);
 
-    // Function to generate link URLs
-    function generate_link(d, i) {
+    // Function to generate click handler
+    function handler(d, i) {
       if (self.noChartLinks) {
         return null;
       }
       var type = data.column_info.columns.id.type;
       var value = d.id;
 
-      return gch.details_page_url(type, value, data.filter_info);
+      return gch.goto_details_page(type, value);
     }
 
     // Update chart
@@ -282,7 +282,7 @@
       .insert('g')
       .attr('class', 'bar-group')
       .insert('a')
-        .attr('xlink:href', generate_link);
+        .on('click', handler);
 
     this.svg.selectAll('.bar-label-shadow')
       .data(display_records)

--- a/gsad/src/html/classic/js/gsa_h_bar_chart.js
+++ b/gsad/src/html/classic/js/gsa_h_bar_chart.js
@@ -365,7 +365,7 @@
       .attr('x', width / 2)
       .attr('y', height / 2);
 
-    var generateLink = self.createGenerateLinkFunc(
+    var handler = self.createGenerateLinkFunc(
         data.column_info.columns.value.column,
         data.column_info.columns.value.type, data.filter_info);
 
@@ -381,7 +381,7 @@
     this.svg.selectAll('.bar')
       .data(records).enter().insert('a')
         .attr('class', 'bar')
-        .attr('xlink:href', generateLink)
+        .on('click', handler)
         .insert('rect', '.x.axis')
           .attr('class', 'bar-rect')
           .attr('x', this.y_scale(0))

--- a/gsad/src/html/classic/js/gsa_line_chart.js
+++ b/gsad/src/html/classic/js/gsa_line_chart.js
@@ -269,7 +269,7 @@
       var type = data.column_info.columns[self.x_field].type;
       var column = data.column_info.columns[self.x_field].column;
       var value;
-      var url;
+      var handler;
 
       if (self.is_timeline) {
         if (self.range_marker_start.getTime() >=
@@ -296,16 +296,10 @@
       }
 
       if (self.range_marker_resize) {
-        url = gch.filtered_list_url(
+        handler = gch.goto_list_page(
             type, column, value, data.filter_info, 'range');
 
-        self.range_marker_elem.attr('xlink:href', url);
-
-        if (d3.event.button === 1 || d3.event.ctrlKey || d3.event.shiftKey) {
-          window.open(url, '_blank');
-        } else {
-          window.location = url;
-        }
+        self.range_marker_elem.on('click', handler);
       }
 
       self.range_marker_resize = false;

--- a/gsad/src/html/classic/js/gsa_topology_chart.js
+++ b/gsad/src/html/classic/js/gsa_topology_chart.js
@@ -238,11 +238,11 @@
     this.graph.selectAll('.node').data(this.layout.nodes()).enter()
       .append('a')
         .classed('node', true)
-        .attr('xlink:href', function(d) {
+        .on('click', function(d) {
           if (d.id === null) {
             return null;
           }
-          return gch.details_page_url('host', d.id, data.filter_info);
+          return gch.goto_details_page('host', d.id, data.filter_info);
         })
         .append('circle')
           .classed('node-marker', true)
@@ -339,9 +339,9 @@
     var value = d.value;
 
     if (column === 'uuid') {
-      return gsa.details_page_url(type, value, filter_info);
+      return gsa.goto_details_page(type, value);
     } else {
-      return gsa.filtered_list_url(type, column, value, filter_info);
+      return gsa.goto_list_page(type, column, value, filter_info);
     }
   };
 

--- a/ng/src/web/app.js
+++ b/ng/src/web/app.js
@@ -154,6 +154,8 @@ if (!is_defined(window.gsa.severity_levels)) {
   window.gsa.severity_levels = get_severity_levels(); // TODO pass type
 }
 
+window.gsa.history = browserHistory;
+
 class AppHttpInterceptor extends HttpInterceptor {
 
   constructor(app) {


### PR DESCRIPTION
Use react routers history api to change locations to the ng details or
list pages when clicking at a chart.