### PR TITLE
Fix creating of new tags for secinfo

### DIFF
--- a/ng/src/web/entity/container.js
+++ b/ng/src/web/entity/container.js
@@ -89,8 +89,6 @@ class EntityContainer extends React.Component {
     const {name} = this.props;
     const {gmp} = this.props;
 
-    this.name = name;
-
     this.entity_command = gmp[name];
 
     this.state = {
@@ -215,11 +213,14 @@ class EntityContainer extends React.Component {
   render() {
     const {
       children,
-      resourceType = this.name,
+      name,
+      resourceType = name,
       onDownload,
     } = this.props;
     return (
       <TagsHandler
+        name={name}
+        resourceType={resourceType}
         onChanged={this.handleChanged}
         onError={this.handleError}
       >{({

--- a/ng/src/web/entity/tagshandler.js
+++ b/ng/src/web/entity/tagshandler.js
@@ -25,6 +25,8 @@ import React from 'react';
 
 import _ from 'gmp/locale.js';
 
+import {is_defined} from 'gmp/utils.js';
+
 import PropTypes from '../utils/proptypes.js';
 import withGmp from '../utils/withGmp.js';
 
@@ -51,13 +53,15 @@ class TagsHandler extends React.Component {
   }
 
   openCreateTagDialog(entity, create) {
-    const resourceType = entity.entity_type;
+    const resourceType = is_defined(this.props.resourceType) ?
+      this.props.resourceType : entity.entity_type;
+    const name = is_defined(this.props.name) ? this.props.name : resourceType;
 
     create({
       fixed: true,
       resource_id: entity.id,
       resource_type: resourceType,
-      name: _('{{type}}:unnamed', {type: resourceType}),
+      name: _('{{type}}:unnamed', {type: name}),
     });
   }
 
@@ -104,6 +108,8 @@ class TagsHandler extends React.Component {
 
 TagsHandler.propTypes = {
   gmp: PropTypes.gmp.isRequired,
+  name: PropTypes.string,
+  resourceType: PropTypes.string,
   onChanged: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
 };

--- a/ng/src/web/pages/certbund/detailspage.js
+++ b/ng/src/web/pages/certbund/detailspage.js
@@ -146,6 +146,7 @@ const CertBundAdvPage = props => (
   <EntityContainer
     {...props}
     name="certbundadv"
+    resourceType="cert_bund_adv"
   >
     {({
       onChanged,

--- a/ng/src/web/pages/dfncert/detailspage.js
+++ b/ng/src/web/pages/dfncert/detailspage.js
@@ -131,6 +131,7 @@ const DfnCertAdvPage = props => (
   <EntityContainer
     {...props}
     name="dfncertadv"
+    resourceType="dfn_cert_adv"
   >
     {({
       onChanged,


### PR DESCRIPTION
Allow to set resource type to be able to create new tags for dfn cert
advs and cert bund advs because name differs for them compared to the
resource type.