### PR TITLE
Remove fields from hidden divs in OMP POST.

### DIFF
--- a/src/html/classic/js/greenbone.js
+++ b/src/html/classic/js/greenbone.js
@@ -1254,7 +1254,30 @@
       };
     }
     else if (this.method === 'POST') {
-      var data = new FormData(this.form);
+      var data = new FormData();
+
+      var elem_i;
+      for (elem_i = 0; elem_i < this.form.length; elem_i++) {
+        var elem = this.form[elem_i];
+
+        if (! elem.matches ('div[style*="display: none"] *')) {
+          if (elem.matches ('select')) {
+            var val_i;
+            for (val_i = 0; val_i < elem.length; val_i++)
+              {
+                if (elem[val_i].selected) {
+                  data.append(elem.name, elem[val_i].value);
+                }
+              }
+          }
+          else if (elem.matches ('input')) {
+            if ((elem.type !== 'checkbox' && elem.type !== 'radio')
+                || elem.checked === true) {
+              data.append (elem.name, elem.value);
+            }
+          }
+        }
+      }
 
       for (var param in this.params) {
         if (this.xml && param === 'no_redirect') {

--- a/src/html/classic/js/gsa_polyfill.js
+++ b/src/html/classic/js/gsa_polyfill.js
@@ -59,6 +59,21 @@
     });
   }
 
+  if (!Element.prototype.matches) {
+    Element.prototype.matches =
+        Element.prototype.matchesSelector ||
+        Element.prototype.mozMatchesSelector ||
+        Element.prototype.msMatchesSelector ||
+        Element.prototype.oMatchesSelector ||
+        Element.prototype.webkitMatchesSelector ||
+        function(s) {
+            var matches = (this.document || this.ownerDocument).querySelectorAll(s),
+                i = matches.length;
+            while (--i >= 0 && matches.item(i) !== this) {}
+            return i > -1;
+        };
+  }
+
   /*
    * Polyfills for string functions
    *  by Mathias Bynens <https://mathiasbynens.be/>


### PR DESCRIPTION
When preparing a POST request in OMPRequest.do, simply passing the form
 element to the FormData constructor could include duplicate fields,
 so the function will now add the data by itself, excluding fields
 contained in a div hidden with an inline "display: none".
A polyfill for the Element.matches function used is also added.