### PR TITLE
Fix resizing of dialogs in firefox

### DIFF
--- a/ng/src/web/components/dialog/scrollablecontent.js
+++ b/ng/src/web/components/dialog/scrollablecontent.js
@@ -40,11 +40,15 @@ const ScrollableContent = glamorous.div(
   ({maxHeight}) => ({maxHeight}),
 );
 
+const StyledLayout = glamorous(Layout)({
+  overflow: 'hidden', // fix for adjusting the content while resizing in firefox
+});
+
 const ScrollableContentLayout = ({
   children,
   maxHeight,
 }) => (
-  <Layout
+  <StyledLayout
     flex="column"
     align={['center', 'start']}
     grow="1"
@@ -52,7 +56,7 @@ const ScrollableContentLayout = ({
     <ScrollableContent maxHeight={maxHeight}>
       {children}
     </ScrollableContent>
-  </Layout>
+  </StyledLayout>
 );
 
 ScrollableContentLayout.propTypes = {


### PR DESCRIPTION
Firefox has a different behavior when calulating the height of the
scrollable content flexbox automatically compared to chrome. Therefore
resizing the dialogs caused rendering the content with full height.
Setting overflow to hidden fixes this behavior and the height is
adjusted to the max. possible height for the flexbox content and shows
the scrollbars instead.