### PR TITLE
Indicate updating of entities tables

### DIFF
--- a/ng/src/web/entities/container.js
+++ b/ng/src/web/entities/container.js
@@ -2,6 +2,7 @@
  *
  * Authors:
  * Björn Ricks <bjoern.ricks@greenbone.net>
+ * Steffen Waterkamp <steffen.waterkamp@greenbone.net>
  *
  * Copyright:
  * Copyright (C) 2017 Greenbone Networks GmbH
@@ -67,6 +68,7 @@ class EntitiesContainer extends React.Component {
 
     this.state = {
       loading: false,
+      updating: false,
       selection_type: SelectionType.SELECTION_PAGE_CONTENTS,
     };
 
@@ -133,10 +135,19 @@ class EntitiesContainer extends React.Component {
     const {entities_command} = this;
     const {force = false, reload = false} = options;
     const {cache, extraLoadParams = {}} = this.props;
+    const {loaded_filter} = this.state;
 
     this.cancelLoading();
 
-    this.setState({loading: true});
+    if (is_defined(loaded_filter) && !loaded_filter.equals(filter)) {
+      this.setState({
+        loading: true,
+        updating: true,
+      });
+    }
+    else {
+      this.setState({loading: true});
+    }
 
     const token = new CancelToken(cancel => this.cancel = cancel);
 
@@ -159,6 +170,7 @@ class EntitiesContainer extends React.Component {
           filter,
           loaded_filter,
           loading: false,
+          updating: false,
         });
 
         log.debug('Loaded entities', response);
@@ -399,6 +411,7 @@ class EntitiesContainer extends React.Component {
       loading,
       selected,
       selection_type,
+      updating,
     } = this.state;
     const {
       onDownload,
@@ -437,6 +450,7 @@ class EntitiesContainer extends React.Component {
           onPreviousClick={this.handlePrevious}
           showError={showErrorMessage}
           showSuccess={showSuccessMessage}
+          updating={updating}
         />
       </Wrapper>
     );

--- a/ng/src/web/entities/table.js
+++ b/ng/src/web/entities/table.js
@@ -2,6 +2,7 @@
  *
  * Authors:
  * Björn Ricks <bjoern.ricks@greenbone.net>
+ * Steffen Waterkamp <steffen.waterkamp@greenbone.net>
  *
  * Copyright:
  * Copyright (C) 2016 - 2017 Greenbone Networks GmbH
@@ -22,6 +23,7 @@
  */
 
 import React from 'react';
+import glamorous from 'glamorous';
 
 import _ from 'gmp/locale.js';
 import {is_defined, for_each, exclude_object_props} from 'gmp/utils.js';
@@ -47,6 +49,14 @@ const exclude_props = [
   'emptyTitle',
   'children',
 ];
+
+const UpdatingStripedTable = glamorous(StripedTable)(
+  ({updating}) => {
+    return {
+      opacity: updating ? '0.2' : '1.0',
+    };
+  },
+);
 
 class EntitiesTable extends React.Component {
 
@@ -77,6 +87,7 @@ class EntitiesTable extends React.Component {
       entitiesCounts,
       filter,
       footnote = true,
+      updating,
     } = props;
 
     if (!is_defined(entities)) {
@@ -163,9 +174,13 @@ class EntitiesTable extends React.Component {
         grow="1"
         className="entities-table">
         {pagination}
-        <StripedTable header={header} footer={footer}>
+        <UpdatingStripedTable
+          header={header}
+          footer={footer}
+          updating={updating}
+        >
           {body}
-        </StripedTable>
+        </UpdatingStripedTable>
         {footnote ?
           <Layout flex align="space-between">
             <FootNote>


### PR DESCRIPTION
Entities tables become transparent while they are updating to a new
page. This gives users feedback that their page change request or filter
query was registered.