### PR TITLE
Include textarea elements in OMP POST requests

### DIFF
--- a/src/html/classic/js/greenbone.js
+++ b/src/html/classic/js/greenbone.js
@@ -1270,7 +1270,7 @@
                 }
               }
           }
-          else if (elem.matches ('input')) {
+          else if (elem.matches ('input') || elem.matches ('textarea')) {
             if ((elem.type !== 'checkbox' && elem.type !== 'radio')
                 || elem.checked === true) {
               data.append (elem.name, elem.value);


### PR DESCRIPTION
The custom FormData in OMPRequest.prototype.do was not including textarea
 elements before, so they are now handled together with input elements.