### PR TITLE
Include only specific polyfills for es6+ features

### DIFF
--- a/ng/package.json
+++ b/ng/package.json
@@ -20,7 +20,7 @@
     "extends": "react-app"
   },
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
+    "core-js": "^2.5.3",
     "d3": "^3.5.17",
     "glamor": "^2.20.40",
     "glamorous": "^4.7.0",

--- a/ng/src/gmp/http.js
+++ b/ng/src/gmp/http.js
@@ -20,6 +20,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+import 'core-js/fn/object/entries';
 
 import logger from './log.js';
 

--- a/ng/src/gmp/models/alert.js
+++ b/ng/src/gmp/models/alert.js
@@ -20,6 +20,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+import 'core-js/fn/object/entries';
 
 import {is_defined, is_empty, is_object, for_each, map} from '../utils.js';
 

--- a/ng/src/gmp/models/cve.js
+++ b/ng/src/gmp/models/cve.js
@@ -20,6 +20,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+import 'core-js/fn/object/entries';
 
 import moment from 'moment';
 

--- a/ng/src/gmp/models/ovaldef.js
+++ b/ng/src/gmp/models/ovaldef.js
@@ -20,6 +20,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+import 'core-js/fn/object/entries';
 
 import moment from 'moment';
 

--- a/ng/src/gmp/models/report/parser.js
+++ b/ng/src/gmp/models/report/parser.js
@@ -20,8 +20,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-
-import 'babel-polyfill'; // required for Object.entries, Object.values
+import 'core-js/fn/object/entries';
+import 'core-js/fn/object/values';
 
 import moment from 'moment';
 

--- a/ng/src/gmp/models/report/tlscertificate.js
+++ b/ng/src/gmp/models/report/tlscertificate.js
@@ -20,6 +20,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+import 'core-js/fn/object/entries';
 
 import {is_defined} from '../../utils.js';
 

--- a/ng/src/gmp/parser.js
+++ b/ng/src/gmp/parser.js
@@ -20,6 +20,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+import 'core-js/fn/object/entries';
 
 import moment from 'moment';
 

--- a/ng/src/gmp/utils.js
+++ b/ng/src/gmp/utils.js
@@ -20,8 +20,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-
-import 'babel-polyfill'; // required for Object.entries, Object.values
+import 'core-js/fn/object/assign';
+import 'core-js/fn/object/keys';
 
 export const is_array = Array.isArray;
 

--- a/ng/src/web/pages/cves/details.js
+++ b/ng/src/web/pages/cves/details.js
@@ -20,6 +20,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+import 'core-js/fn/object/entries';
 
 import React from 'react';
 

--- a/ng/src/web/pages/usersettings/usersettingspage.js
+++ b/ng/src/web/pages/usersettings/usersettingspage.js
@@ -20,6 +20,7 @@
 * along with this program; if not, write to the Free Software
 * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 */
+import 'core-js/fn/object/entries';
 
 import React from 'react';
 import glamorous, {Col} from 'glamorous';

--- a/ng/src/web/utils/withCache.js
+++ b/ng/src/web/utils/withCache.js
@@ -20,6 +20,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+import 'core-js/fn/object/entries';
 
 import React from 'react';
 

--- a/ng/yarn.lock
+++ b/ng/yarn.lock
@@ -893,14 +893,6 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
-  dependencies:
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    regenerator-runtime "^0.10.5"
-
 babel-preset-env@1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.5.2.tgz#cd4ae90a6e94b709f97374b33e5f8b983556adef"
@@ -988,7 +980,7 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@6.26.0, babel-runtime@^6.26.0:
+babel-runtime@6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -1681,9 +1673,9 @@ core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
-core-js@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.0.tgz#569c050918be6486b3837552028ae0466b717086"
+core-js@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -5774,10 +5766,6 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz#257f41961ce44558b18f7814af48c17559f9faeb"
-
-regenerator-runtime@^0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 regenerator-runtime@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
For browsers not supporting es6+ features (especially ie11) we need polyfills. Using babel-polyfill did include all polyfills in our bundle. We are currently only using some specific es6 features which aren't transpiled with babel like Object.entries and Object.values. Therefore there is no need to use babel-polyfill.