### PR TITLE
Fix Toggle All Details

### DIFF
--- a/ng/src/web/entities/table.js
+++ b/ng/src/web/entities/table.js
@@ -95,7 +95,11 @@ class EntitiesTable extends React.Component {
     const {entities} = this.props;
     let {details, allToggled} = this.state;
 
-    allToggled = !allToggled && untoggle;
+    allToggled = !allToggled;
+
+    if (untoggle) {
+      allToggled = false;
+    }
 
     if (allToggled) {
       for_each(entities, entity => details[entity.id] = true);


### PR DESCRIPTION
The logic in handleToggleAllDetails() was broken after the last revision
and is now reset to a working state.