### PR TITLE
Use common function to parse qod

### DIFF
--- a/ng/src/gmp/models/report/vulnerability.js
+++ b/ng/src/gmp/models/report/vulnerability.js
@@ -23,7 +23,7 @@
 
 import {is_defined} from 'gmp/utils.js';
 
-import {parse_float} from 'gmp/parser.js';
+import {parse_qod} from 'gmp/parser.js';
 
 import Vulnerability from 'gmp/models/vulnerability.js';
 
@@ -54,7 +54,7 @@ class RfpVulnerabilty extends Vulnerability {
 
     copy.id = oid;
     copy.name = name;
-    copy.qod = parse_float(qod.value);
+    copy.qod = parse_qod(qod);
 
     copy.hosts = {
       hosts_by_ip: {},

--- a/ng/src/gmp/models/result.js
+++ b/ng/src/gmp/models/result.js
@@ -24,7 +24,7 @@
 import {for_each, is_defined, is_string} from '../utils.js';
 
 import Model from '../model.js';
-import {parse_severity} from '../parser.js';
+import {parse_severity, parse_qod} from '../parser.js';
 
 import Nvt from './nvt.js';
 
@@ -68,6 +68,7 @@ class Result extends Model {
       severity,
       task,
       delta,
+      qod = {},
     } = elem;
 
     if (is_string(host)) {
@@ -125,6 +126,8 @@ class Result extends Model {
     if (is_defined(original_severity)) {
       copy.original_severity = parse_severity(original_severity);
     }
+
+    copy.qod = parse_qod(qod);
 
     copy.notes = parse_notes(notes);
     copy.overrides = parse_overrides(overrides);

--- a/ng/src/gmp/parser.js
+++ b/ng/src/gmp/parser.js
@@ -79,6 +79,11 @@ export function parse_csv(value) {
   return value.split(',').map(val => val.trim());
 }
 
+export const parse_qod = qod => ({
+  type: qod.type,
+  value: parse_float(qod.value),
+});
+
 export function parse_envelope_meta(envelope) {
   const meta = {};
 

--- a/ng/src/web/pages/reports/vulnerabilitiestable.js
+++ b/ng/src/web/pages/reports/vulnerabilitiestable.js
@@ -58,7 +58,7 @@ const Row = ({
         <SeverityBar severity={entity.severity}/>
       </TableData>
       <TableData flex align="center">
-        {entity.qod} %
+        {entity.qod.value} %
       </TableData>
       <TableData flex align="center">
         <Link


### PR DESCRIPTION
The qod (quality of detection) consists of a type and value field. We
should always parse both. Before the report vulnerabilities only had the
value as vuln.qod which did broke the sorting. On the opposite report
results didn't parse the value as a float.