### PR TITLE
Don't crash if asset is not available

### DIFF
--- a/ng/src/web/pages/reports/hoststable.js
+++ b/ng/src/web/pages/reports/hoststable.js
@@ -143,7 +143,7 @@ const Row = ({
   entity,
   links = true,
 }) => {
-  const {ip, details = {}, result_counts = {}, severity, asset} = entity;
+  const {ip, details = {}, result_counts = {}, severity, asset = {}} = entity;
   const {best_os_cpe, best_os_txt} = details;
   return (
     <TableRow>


### PR DESCRIPTION
If the parsed host has no asset rendering the report hosts table should
not crash.