### PR TITLE
Simplify table header sort

### DIFF
--- a/ng/src/web/components/table/head.js
+++ b/ng/src/web/components/table/head.js
@@ -42,6 +42,7 @@ const TableHead = ({
     rowSpan,
     currentSortBy,
     currentSortDir,
+    sort = true,
     sortBy,
     width,
     onSortChange,
@@ -76,7 +77,7 @@ const TableHead = ({
       className={className}
       rowSpan={rowSpan}
       colSpan={colSpan}>
-      {sortBy && is_defined(onSortChange) ?
+      {sort && sortBy && is_defined(onSortChange) ?
         <Sort by={sortBy} onClick={onSortChange}>
           <Layout {...other}>
             {children}
@@ -97,6 +98,7 @@ TableHead.propTypes = {
   currentSortBy: PropTypes.string,
   currentSortDir: PropTypes.string,
   rowSpan: PropTypes.numberString,
+  sort: PropTypes.bool,
   sortBy: PropTypes.stringOrFalse,
   width: PropTypes.string,
   onSortChange: PropTypes.func,

--- a/ng/src/web/pages/tasks/table.js
+++ b/ng/src/web/pages/tasks/table.js
@@ -48,60 +48,60 @@ const Header = ({
   currentSortDir,
   onSortChange,
 }) => {
+  const sortProps = {
+    currentSortBy,
+    currentSortDir,
+    sort,
+    onSortChange,
+  };
   return (
     <TableHeader>
       <TableRow>
         <TableHead
+          {...sortProps}
           rowSpan="2"
-          currentSortDir={currentSortDir}
-          currentSortBy={currentSortBy}
-          sortBy={sort ? 'name' : false}
-          onSortChange={onSortChange}>
+          sortBy="name"
+        >
           {_('Name')}
         </TableHead>
         <TableHead
+          {...sortProps}
           rowSpan="2"
           width="10em"
-          currentSortDir={currentSortDir}
-          currentSortBy={currentSortBy}
-          sortBy={sort ? 'status' : false}
-          onSortChange={onSortChange}>
+          sortBy="status"
+        >
           {_('Status')}
         </TableHead>
         <TableHead colSpan="2">{_('Reports')}</TableHead>
         <TableHead
+          {...sortProps}
           rowSpan="2"
           width="10em"
-          currentSortDir={currentSortDir}
-          currentSortBy={currentSortBy}
-          sortBy={sort ? 'severity' : false}
-          onSortChange={onSortChange}>
+          sortBy="severity"
+        >
           {_('Severity')}
         </TableHead>
         <TableHead
+          {...sortProps}
           rowSpan="2"
           width="6em"
-          currentSortDir={currentSortDir}
-          currentSortBy={currentSortBy}
-          sortBy={sort ? 'trend' : false}
-          onSortChange={onSortChange}>
+          sortBy="trend"
+        >
           {_('Trend')}
         </TableHead>
         {actionsColumn}
       </TableRow>
       <TableRow>
         <TableHead
-          currentSortDir={currentSortDir}
-          currentSortBy={currentSortBy}
-          sortBy={sort ? 'total' : false}
-          onSortChange={onSortChange}>
+          {...sortProps}
+          sortBy="total"
+        >
           {_('Total')}
         </TableHead>
         <TableHead
-          currentSortDir={currentSortDir}
-          currentSortBy={currentSortBy}
-          sortBy={sort ? 'last' : false}
-          onSortChange={onSortChange}>
+          {...sortProps}
+          sortBy="last"
+        >
           {_('Last')}
         </TableHead>
       </TableRow>


### PR DESCRIPTION
Reduce necessary codelines for setting sorting on TableHeaders. Pass common props of all headers via an object. All table can now be refactored to use this new pattern.