### PR TITLE
Add a github CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# default reviewers
+*                 @greenbone/gsa-dev
+
+# cmake files
+*/CMakeLists.txt  @bjoernricks @wiegandm
+*.cmake           @bjoernricks @wiegandm
+
+# web dev files
+*.js              @bjoernricks @swaterkamp
+*.css             @bjoernricks @swaterkamp
+
+# all gsad files
+/gsad/            @bjoernricks @timopollmeier
+# tools
+/tools/           @bjoernricks @timopollmeier
+
+# licenses
+COPYING*          @wiegandm
+LICENSE           @wiegandm


### PR DESCRIPTION
The CODEOWNERS file is used to add reviewers in pull requests
automatically.

For details see https://help.github.com/articles/about-codeowners/