### PR TITLE
Remove optional use of xsltproc command line tool.

### DIFF
--- a/gsad/CMakeLists.txt
+++ b/gsad/CMakeLists.txt
@@ -24,25 +24,8 @@
 
 ## Check existence required tools
 
-set (MANDATORY_TOOL_MISSING FALSE)
-
-if (NOT USE_LIBXSLT EQUAL 0)
-  set (USE_LIBXSLT 1)
-endif (NOT USE_LIBXSLT EQUAL 0)
-
 find_program (PATH_TO_XSLTPROC xsltproc DOC "xsltproc command line "
               "xslt processor.")
-if (NOT USE_LIBXSLT AND NOT PATH_TO_XSLTPROC)
-  set (MANDATORY_TOOL_MISSING TRUE)
-endif (NOT USE_LIBXSLT AND NOT PATH_TO_XSLTPROC)
-
-if (MANDATORY_TOOL_MISSING)
-  if (NOT USE_LIBXSLT AND NOT PATH_TO_XSLTPROC)
-    message ("The xsltproc tool or libxslt is required.")
-  endif (NOT USE_LIBXSLT AND NOT PATH_TO_XSLTPROC)
-  message (FATAL_ERROR "One or more tools or libraries could not be found on "
-                      "your system. Please check the logs above.")
-endif (MANDATORY_TOOL_MISSING)
 
 ## Files generated on installation
 

--- a/gsad/src/CMakeLists.txt
+++ b/gsad/src/CMakeLists.txt
@@ -134,13 +134,6 @@ else (SERVE_STATIC_ASSETS)
   message (STATUS "Static asset serving not builtin, use an external server")
 endif (SERVE_STATIC_ASSETS)
 
-if (USE_LIBXSLT)
-  message (STATUS "Internal XSL transformations, with libxslt.")
-  add_definitions (-DUSE_LIBXSLT)
-else (USE_LIBXSLT)
-  message (STATUS "External XSL transformations, with xsltproc.")
-endif (USE_LIBXSLT)
-
 if (GSAD_VERSION)
   add_definitions (-DGSAD_VERSION="${GSAD_VERSION}")
 endif (GSAD_VERSION)

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -2814,11 +2814,7 @@ register_signal_handlers ()
       || signal (SIGINT, handle_signal_exit) == SIG_ERR
       || signal (SIGHUP, SIG_IGN) == SIG_ERR
       || signal (SIGPIPE, SIG_IGN) == SIG_ERR
-#ifdef USE_LIBXSLT
       || signal (SIGCHLD, SIG_IGN) == SIG_ERR)
-#else
-      || signal (SIGCHLD, SIG_DFL) == SIG_ERR)
-#endif
     return -1;
   return 0;
 }


### PR DESCRIPTION
The code had an optional method to use the xsltproc command line tool.
By default it was not used and rather the xslt library was used.
This patch make the use of the library mandatory and removes any
code path for the xsltproc tool.

Note that the tool is still in use for build-time to check validity
of the installed xsl-files.

* gsad/CMakeLists.txt: Drop handling of USE_LIBXSLT. Since it was the
  last element to determine about MANDATORY_TOOL_MISSING, the handling
  of this variable is also removed entirely.

* gsad/src/CMakeLists.txt: Drop handling og USE_LIBXSLT.

* gsad/src/gsad.c (register_signal_handlers): Make the code path for
  USE_LIBXSLT the only one.

* gsad/src/gsad_base.c (gsad_base_init, gsad_base_cleanup,
  xsl_transform_with_stylesheet): Make the code path for
  USE_LIBXSLT the only one.