### PR TITLE
Add years 2018 to 2020 on New/Edit Schedule page

### DIFF
--- a/src/html/classic/omp.xsl
+++ b/src/html/classic/omp.xsl
@@ -15755,6 +15755,18 @@ should not have received it.
                   <xsl:with-param name="value" select="'2017'"/>
                   <xsl:with-param name="select-value" select="time/year"/>
                 </xsl:call-template>
+                <xsl:call-template name="opt">
+                  <xsl:with-param name="value" select="'2018'"/>
+                  <xsl:with-param name="select-value" select="time/year"/>
+                </xsl:call-template>
+                <xsl:call-template name="opt">
+                  <xsl:with-param name="value" select="'2019'"/>
+                  <xsl:with-param name="select-value" select="time/year"/>
+                </xsl:call-template>
+                <xsl:call-template name="opt">
+                  <xsl:with-param name="value" select="'2020'"/>
+                  <xsl:with-param name="select-value" select="time/year"/>
+                </xsl:call-template>
               </select>
             </td>
           </tr>
@@ -16317,7 +16329,7 @@ should not have received it.
               <select name="year">
                 <xsl:variable name="year"
                               select="date:year (commands_response/get_schedules_response/schedule/first_time)"/>
-                <xsl:if test="$year &lt; 2012 or $year &gt; 2017">
+                <xsl:if test="$year &lt; 2012 or $year &gt; 2020">
                   <option value="{$year}"><xsl:value-of select="$year"/></option>
                 </xsl:if>
                 <xsl:call-template name="opt">
@@ -16342,6 +16354,18 @@ should not have received it.
                 </xsl:call-template>
                 <xsl:call-template name="opt">
                   <xsl:with-param name="value" select="'2017'"/>
+                  <xsl:with-param name="select-value" select="$year"/>
+                </xsl:call-template>
+                <xsl:call-template name="opt">
+                  <xsl:with-param name="value" select="'2018'"/>
+                  <xsl:with-param name="select-value" select="$year"/>
+                </xsl:call-template>
+                <xsl:call-template name="opt">
+                  <xsl:with-param name="value" select="'2019'"/>
+                  <xsl:with-param name="select-value" select="$year"/>
+                </xsl:call-template>
+                <xsl:call-template name="opt">
+                  <xsl:with-param name="value" select="'2020'"/>
                   <xsl:with-param name="select-value" select="$year"/>
                 </xsl:call-template>
               </select>


### PR DESCRIPTION
The New/Edit Schedule page only allowed years up to 2017, so the years
 2018 to 2020 have been added to the drop-down selection.