### PR TITLE
Fix rendering of empty toplogy charts

### DIFF
--- a/ng/src/web/components/dashboard/legacy/chart/topology.js
+++ b/ng/src/web/components/dashboard/legacy/chart/topology.js
@@ -306,7 +306,7 @@ class TopologyChartGenerator extends BaseChartController {
     const width = svg.attr('width');
 
     if (topology.nodes.length === 0) {
-      return this.renderEmptyText();
+      return this.renderEmptyText(svg);
     }
 
     if (is_defined(this.empty_text)) {


### PR DESCRIPTION
Pass the expected svg element to the renderEmptyText method.