### PR TITLE
Fix icon size for upload report at report list page

### DIFF
--- a/ng/src/web/pages/reports/listpage.js
+++ b/ng/src/web/pages/reports/listpage.js
@@ -64,7 +64,6 @@ const ToolBarIcons = ({onUploadReportClick}) => (
       title={_('Help: Reports')}
     />
     <Icon
-      size="small"
       title={_('Upload report')}
       img="upload.svg"
       onClick={onUploadReportClick}/>


### PR DESCRIPTION
Use default icon size for the upload report icon. This allows to use a
IconProvider to change its size.