### PR TITLE
Get rid of react warning

### DIFF
--- a/ng/src/web/components/dashboard/withDashboard.js
+++ b/ng/src/web/components/dashboard/withDashboard.js
@@ -29,25 +29,17 @@ import Dashboard from './dashboard.js';
 
 const withDashboard = (options = {}) => Charts => {
 
-  class DashboardWrapper extends React.Component {
-
-    reload() {
-      this.dashboard.reload();
-    }
-
-    render() {
-      const {filter, ...other} = this.props;
-      return (
-        <Dashboard
-          {...options}
-          {...other}
-          ref={ref => this.dashboard = ref}
-        >
-          <Charts filter={filter}/>
-        </Dashboard>
-      );
-    }
-  };
+  const DashboardWrapper = ({
+    filter,
+    ...props,
+  }) => (
+    <Dashboard
+      {...options}
+      {...props}
+    >
+      <Charts filter={filter}/>
+    </Dashboard>
+  );
 
   DashboardWrapper.propTypes = {
     filter: PropTypes.filter,


### PR DESCRIPTION
Get rid of the "Stateless function components cannot be given refs"
warning. The Dashboard is a composed component which root component is a
function component. Therefore it's not possible to use the ref here. To
avoid this all used HOCs of Dashboard would have to implement the
innerRef pattern to be able to get the ref to the actual Dashboard
component.

But here we can avoid that because calling the reload method of
Dashboard wasn't used at all. Therefore we can remove the ref and
convert the DashboardWrapper also to a stateless function component.