### PR TITLE
Pass MenuEntry props to Layout

### DIFF
--- a/ng/src/web/components/menu/menuentry.js
+++ b/ng/src/web/components/menu/menuentry.js
@@ -70,7 +70,11 @@ const MenuEntry = ({
   }
 
   return (
-    <Layout grow="1" align={['start', 'stretch']}>
+    <Layout
+      {...props}
+      grow="1"
+      align={['start', 'stretch']}
+    >
       {entry}
     </Layout>
   );


### PR DESCRIPTION
This fixes setting the onClick handler e.g. for the wizard icon menu
entries.