### PR TITLE
Remove Apache License Version 2 from COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -5,12 +5,10 @@ The effective license of the module as a whole is the GNU General Public
 License Version 2 or any later version (GNU GPLv2+).
 
 Most files, are licensed under GNU General Public License Version 2
-or any later version (GNU GPLv2+). Some files have a different licenses
-(Apache Version 2 and MIT).
+or any later version (GNU GPLv2+). Some files have a different licenses (MIT).
 
 GPLv2: See file COPYING.GPL
 MIT: See file COPYING.MIT
-APLv2: See http://www.apache.org/licenses/LICENSE-2.0
 
 These are the files that are not licensed GPLv2+, any others
 are licensed under GPLv2+:


### PR DESCRIPTION
No file shipped with gsa repo has APLv2 anymore.