### PR TITLE
Remove handling of refresh interval.

### DIFF
--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -839,7 +839,6 @@ init_validator ()
   openvas_validator_alias (validator, "include_related",   "number");
   openvas_validator_alias (validator, "inheritor_id",       "id");
   openvas_validator_alias (validator, "ignore_pagination",   "boolean");
-  openvas_validator_alias (validator, "refresh_interval", "number");
   openvas_validator_alias (validator, "event",        "condition");
   openvas_validator_alias (validator, "access_hosts", "hosts_opt");
   openvas_validator_alias (validator, "access_ifaces", "hosts_opt");
@@ -1343,7 +1342,7 @@ exec_gmp_post (http_connection_t *con,
           && password)
         {
           gchar *timezone, *role, *capabilities, *severity, *language;
-          gchar *pw_warning, *autorefresh;
+          gchar *pw_warning;
           GTree *chart_prefs;
           ret = authenticate_gmp (params_value (con_info->params, "login"),
                                   password,
@@ -1353,8 +1352,7 @@ exec_gmp_post (http_connection_t *con,
                                   &capabilities,
                                   &language,
                                   &pw_warning,
-                                  &chart_prefs,
-                                  &autorefresh);
+                                  &chart_prefs);
           if (ret)
             {
               int status;
@@ -1381,8 +1379,7 @@ exec_gmp_post (http_connection_t *con,
               user_t *user;
               user = user_add (params_value (con_info->params, "login"),
                                password, timezone, severity, role, capabilities,
-                               language, pw_warning, chart_prefs, autorefresh,
-                               client_address);
+                               language, pw_warning, chart_prefs, client_address);
               /* Redirect to get_tasks. */
               url = g_strdup_printf ("%s&token=%s",
                                      params_value (con_info->params, "text"),
@@ -1401,7 +1398,6 @@ exec_gmp_post (http_connection_t *con,
               g_free (language);
               g_free (role);
               g_free (pw_warning);
-              g_free (autorefresh);
               return ret;
             }
         }

--- a/gsad/src/gsad_gmp_auth.h
+++ b/gsad/src/gsad_gmp_auth.h
@@ -29,7 +29,6 @@
 #include <glib.h> /* for gchar */
 
 int authenticate_gmp (const gchar *, const gchar *, gchar **, gchar **,
-                      gchar **, gchar **, gchar **, gchar **, GTree **,
-                      gchar **);
+                      gchar **, gchar **, gchar **, gchar **, GTree **);
 
 #endif /* _GSAD_GMP_AUTH_H */

--- a/gsad/src/gsad_user.h
+++ b/gsad/src/gsad_user.h
@@ -59,7 +59,6 @@ typedef struct
   char *pw_warning;   ///< Password policy warning message
   char *client_address; ///< Client's address.
   GTree *chart_prefs; ///< Chart preferences.
-  char *autorefresh;  ///< Auto-refresh interval.
   GTree *last_filt_ids; ///< Last filter ids.
   params_t *params;   ///< Request parameters.
   int charts;         ///< Whether to show charts for this user.
@@ -91,7 +90,6 @@ struct user
   time_t time;         ///< Login time.
   int charts;          ///< Whether to show charts for this user.
   GTree *chart_prefs;  ///< Chart preferences.
-  gchar *autorefresh; ///< Auto-Refresh interval
   GTree *last_filt_ids;///< Last used filter ids.
   int guest;           ///< Whether the user is a guest.
 };
@@ -107,7 +105,7 @@ user_t *
 user_add (const gchar *username, const gchar *password, const gchar *timezone,
           const gchar *severity, const gchar *role, const gchar *capabilities,
           const gchar *language, const gchar *pw_warning, GTree *chart_prefs,
-          const gchar *autorefresh, const char *address);
+          const char *address);
 
 int user_set_timezone (const gchar *token, const gchar *timezone);
 
@@ -120,8 +118,6 @@ int user_set_language (const gchar *token, const gchar *language);
 int user_set_charts (const gchar *token, const int charts);
 
 int user_set_chart_pref (const gchar *token, gchar* pref_id, gchar *pref_value);
-
-int user_set_autorefresh (const gchar *token, const gchar *autorefresh);
 
 int user_logout_all_sessions (const gchar *username,
                               credentials_t *credentials);


### PR DESCRIPTION
The refresh interval is meanwhile fully and automatically handled in the client.

* gsad/src/gsad.c: (init_validator): drop validator for referesh_interval.
  (exec_gmp_post): drop the parameter for autorefresh and do not handle
  autorefresh anymore.

* gsad/src/gsad_gmp.c (envelope_gmp): Don't add refresh_interval to the
  envelope anymore.
  (edit_task, openvas_connection_open): Don't handle refresh_interval anymore.
  (authenticate_gmp): Remove parameter "autorefresh".

* gsad/src/gsad_gmp_auth-.h: Update header accordingly.

* gsad/src/gsad_user.c (user_add, user_find): Remove parameter "autorefresh".
  (user_set_autorefresh): Removed.
  (credentials_new, credentials_free): Remove handling of autrefesh in the credentials structure.

* gsad/src/gsad_user.h: Update headers and struct accordingly.