### PR TITLE
Fix loginpage for Internet Explorer

### DIFF
--- a/ng/src/web/pages/loginpage.js
+++ b/ng/src/web/pages/loginpage.js
@@ -112,7 +112,7 @@ class LoginForm extends React.Component {
     const {username, password} = this.state;
     const protocol_insecure = window.location.protocol !== 'https:';
     return (
-      <Layout flex="column">
+      <Layout flex="column" shrink="0">
         {protocol_insecure &&
           <Panel>
             <Error>{_('Warning: Connection unencrypted')}</Error>
@@ -176,7 +176,10 @@ LoginForm.propTypes = {
 };
 
 const GreenboneIcon = glamorous(GBIcon)({
+  minWidth: '60px',
+  width: '100%',
   minHeight: '60px',
+  height: '100%', // for IE11 fix
   maxHeight: '315px',
   margin: '40px 0px',
 });
@@ -208,7 +211,6 @@ const StyledLayout = glamorous(Layout)({
 const MenuSpacer = glamorous.div({
   minHeight: '35px',
   background: '#393637',
-  zIndex: '1000',
 });
 
 class LoginPage extends React.Component {
@@ -271,7 +273,7 @@ class LoginPage extends React.Component {
             grow="1"
             position="relative">
             <StyledIcon img="login-label.png" size="default"/>
-            <GreenboneIcon width="350px"/>
+            <GreenboneIcon/>
             <LoginForm onSubmit={this.onSubmit} error={message}/>
           </StyledLayout>
         </LoginMain>

--- a/ng/src/web/pages/loginpage.js
+++ b/ng/src/web/pages/loginpage.js
@@ -183,6 +183,7 @@ const GreenboneIcon = glamorous(GBIcon)({
 
 const LoginMain = glamorous(Main)({
   background: '#fefefe',
+  height: '100%',
 });
 
 const LoginLayout = glamorous(Layout)({
@@ -201,7 +202,7 @@ const StyledIcon = glamorous(Icon)({
 
 const StyledLayout = glamorous(Layout)({
   margin: '0 auto',
-  height: '1vh',
+  height: '100%',
 });
 
 const MenuSpacer = glamorous.div({


### PR DESCRIPTION
The aspect ratio of the Icon was broken in IE, so size calculation had
to be changed mainly relying in width instead of height.
Additionally, IE11 moved the "insecure"-message flush to the username
input field when the browser height was decreased. A spacer is only
added in IE to prevent this.