### PR TITLE
Set MHD_USE_INTERNAL_POLLING_THREAD explicitly

### DIFF
--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -2845,8 +2845,9 @@ start_unix_http_daemon (const char *unix_socket_path,
     }
 
   return MHD_start_daemon
-          (MHD_USE_THREAD_PER_CONNECTION | MHD_USE_DEBUG, 0,
-           NULL, NULL, handler, http_handlers, MHD_OPTION_NOTIFY_COMPLETED,
+          (MHD_USE_THREAD_PER_CONNECTION | MHD_USE_INTERNAL_POLLING_THREAD
+           | MHD_USE_DEBUG, 0, NULL, NULL, handler, http_handlers,
+           MHD_OPTION_NOTIFY_COMPLETED,
            free_resources, NULL, MHD_OPTION_LISTEN_SOCKET, unix_socket,
            MHD_OPTION_PER_IP_CONNECTION_LIMIT, 30,
            MHD_OPTION_EXTERNAL_LOGGER, mhd_logger, NULL, MHD_OPTION_END);
@@ -2872,7 +2873,8 @@ start_http_daemon (int port,
   else
     ipv6_flag = MHD_NO_FLAG;
   return MHD_start_daemon
-          (MHD_USE_THREAD_PER_CONNECTION | MHD_USE_DEBUG | ipv6_flag, port,
+          (MHD_USE_THREAD_PER_CONNECTION | MHD_USE_INTERNAL_POLLING_THREAD
+           | MHD_USE_DEBUG | ipv6_flag, port,
            NULL, NULL, handler, http_handlers, MHD_OPTION_NOTIFY_COMPLETED,
            free_resources, NULL, MHD_OPTION_SOCK_ADDR, address,
            MHD_OPTION_PER_IP_CONNECTION_LIMIT, 30,
@@ -2897,8 +2899,9 @@ start_https_daemon (int port, const char *key, const char *cert,
   else
     ipv6_flag = MHD_NO_FLAG;
   return MHD_start_daemon
-          (MHD_USE_THREAD_PER_CONNECTION | MHD_USE_DEBUG | MHD_USE_SSL
-           | ipv6_flag, port, NULL, NULL, &handle_request, http_handlers,
+          (MHD_USE_THREAD_PER_CONNECTION | MHD_USE_INTERNAL_POLLING_THREAD
+           | MHD_USE_DEBUG | MHD_USE_SSL | ipv6_flag,
+           port, NULL, NULL, &handle_request, http_handlers,
            MHD_OPTION_HTTPS_MEM_KEY, key,
            MHD_OPTION_HTTPS_MEM_CERT, cert,
            MHD_OPTION_NOTIFY_COMPLETED, free_resources, NULL,

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -115,6 +115,13 @@
 #undef G_LOG_FATAL_MASK
 #define G_LOG_FATAL_MASK G_LOG_LEVEL_ERROR
 
+/*
+* define MHD_USE_INTERNAL_POLLING_THREAD for libmicrohttp < 0.9.53
+*/
+#if MHD_VERSION < 0x00095300
+#define MHD_USE_INTERNAL_POLLING_THREAD 0
+#endif
+
 /**
  * @brief Fallback GSAD port for HTTPS.
  */


### PR DESCRIPTION
Fix displaying warnings with newer libmicrohttp versions:

"MHD_USE_THREAD_PER_CONNECTION must be used only
with MHD_USE_INTERNAL_POLLING_THREAD. Flag
MHD_USE_INTERNAL_POLLING_THREAD was added. Consider setting
MHD_USE_INTERNAL_POLLING_THREAD explicitly."