### PR TITLE
Fix content growth in dialogs

### DIFF
--- a/ng/src/web/components/dialog/scrollablecontent.js
+++ b/ng/src/web/components/dialog/scrollablecontent.js
@@ -5,7 +5,7 @@
  * Steffen Waterkamp <steffen.waterkamp@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2016 - 2017 Greenbone Networks GmbH
+ * Copyright (C) 2016 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -36,6 +36,7 @@ const ScrollableContent = glamorous.div(
     background: '#eee',
     padding: '0 15px',
     width: '100%',
+    height: '100%',
   },
   ({maxHeight}) => ({maxHeight}),
 );


### PR DESCRIPTION
ScrollableContent is now 100% height of its parent and e.g. opened Selects
may use the free space of enlarged dialogs. Before this change, they were basically
"overflow: auto"-hidden behind the dialog footer.