### PR TITLE
Add TippingPoint alert method data in gsad.

### DIFF
--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -7937,6 +7937,11 @@ append_alert_method_data (GString *xml, params_t *data, const char *method)
                 && (strcmp (name, "snmp_community") == 0
                     || strcmp (name, "snmp_agent") == 0
                     || strcmp (name, "snmp_message") == 0))
+            || (strcmp (method, "TippingPoint SMS") == 0
+                && (strcmp (name, "tp_sms_credential") == 0
+                    || strcmp (name, "tp_sms_hostname") == 0
+                    || strcmp (name, "tp_sms_tls_certificate") == 0
+                    || strcmp (name, "tp_sms_tls_workaround") == 0))
             || (strcmp (method, "verinice Connector") == 0
                 && (strcmp (name, "verinice_server_credential") == 0
                     || strcmp (name, "verinice_server_url") == 0


### PR DESCRIPTION
In the gsad function append_alert_method_data, add the method
"TippingPoint SMS" and the corresponding data items so the method data
can be sent to the manager when creating or modifying an alert with that
method.