### PR TITLE
Fix dialog resizing in Chrome

### DIFF
--- a/ng/src/web/components/dialog/scrollablecontent.js
+++ b/ng/src/web/components/dialog/scrollablecontent.js
@@ -43,6 +43,7 @@ const ScrollableContent = glamorous.div(
 
 const StyledLayout = glamorous(Layout)({
   overflow: 'hidden', // fix for adjusting the content while resizing in firefox
+  height: '100%', // needs to be set for Chrome
 });
 
 const ScrollableContentLayout = ({


### PR DESCRIPTION
A Layout within the hierarchy from ScrollableContent to root was not set
100%. Chrome's default behavior prevented correct display of resized
dialog contents.