### PR TITLE
Fix adding tags

### DIFF
--- a/ng/src/web/pages/scanconfigs/detailspage.js
+++ b/ng/src/web/pages/scanconfigs/detailspage.js
@@ -501,6 +501,7 @@ const ScanConfigPage = props => (
   <EntityContainer
     {...props}
     name="scanconfig"
+    resourceType="config"
     loaders={[
       permissions_resource_loader,
     ]}


### PR DESCRIPTION
When adding a tag for an entity on its details page, port lists and scan
configs yielded an error message "invalid resource type"). The
TagsHandler set the resourceType for its render-method to the name of
the entity by default. Removing this default fixes the bug.