### PR TITLE
Fix warning for tab titles

### DIFF
--- a/ng/src/web/pages/reports/detailscontent.js
+++ b/ng/src/web/pages/reports/detailscontent.js
@@ -114,7 +114,7 @@ const TabTitleForUserTags = ({title, count}) => (
 );
 
 TabTitleForUserTags.propTypes = {
-  count: PropTypes.counts.isRequired,
+  count: PropTypes.number.isRequired,
   title: PropTypes.string.isRequired,
 };
 


### PR DESCRIPTION
Change required proptype to 'number' instead of the 2-part (x of y)
collection counts.