### PR TITLE
Remove folding prop where not needed

### DIFF
--- a/ng/src/web/entities/page.js
+++ b/ng/src/web/entities/page.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -78,7 +78,6 @@ class EntitiesPage extends React.Component {
     const {
       entities,
       filter,
-      foldable,
       loading,
       sectionIcon,
       dashboard: DashboardComponent,
@@ -101,7 +100,6 @@ class EntitiesPage extends React.Component {
         title={this.getSectionTitle()}
         className="entities-section"
         img={sectionIcon}
-        foldable={foldable}
         extra={DashboardComponent ? <DashboardControls/> : null}>
         <Layout
           flex="column"
@@ -253,7 +251,6 @@ EntitiesPage.propTypes = {
   filter: PropTypes.filter,
   filterEditDialog: PropTypes.component,
   filters: PropTypes.array,
-  foldable: PropTypes.bool,
   loading: PropTypes.bool,
   powerfilter: PropTypes.componentOrFalse,
   section: PropTypes.componentOrFalse,

--- a/ng/src/web/entity/page.js
+++ b/ng/src/web/entity/page.js
@@ -93,7 +93,6 @@ class EntityPage extends React.Component {
       detailsComponent: Details,
       children,
       entity,
-      foldable,
       sectionIcon,
       permissionsComponent: PermissionsComponent = EntityPermissions,
       sectionComponent: SectionComponent = Section,
@@ -141,7 +140,6 @@ class EntityPage extends React.Component {
         title={section_title}
         className="entity-section"
         img={sectionIcon}
-        foldable={foldable}
         extra={this.renderInfo()}
       >
         {children({
@@ -266,7 +264,6 @@ class EntityPage extends React.Component {
 EntityPage.propTypes = {
   detailsComponent: PropTypes.component.isRequired,
   entity: PropTypes.model,
-  foldable: PropTypes.bool,
   infoComponent: PropTypes.componentOrFalse,
   loading: PropTypes.bool,
   permissions: PropTypes.object,

--- a/ng/src/web/entity/permissions.js
+++ b/ng/src/web/entity/permissions.js
@@ -193,7 +193,6 @@ class EntityPermissions extends React.Component {
 
 EntityPermissions.propTypes = {
   entity: PropTypes.model.isRequired,
-  foldable: PropTypes.bool,
   permissions: PropTypes.array,
   relatedResourcesLoaders: PropTypes.arrayOf(PropTypes.func),
   onChanged: PropTypes.func.isRequired,

--- a/ng/src/web/entity/tags.js
+++ b/ng/src/web/entity/tags.js
@@ -205,7 +205,6 @@ SectionElements.propTypes = {
 
 const EntityTags = ({
   entity,
-  foldable = true,
   onTagAddClick,
   onTagDeleteClick,
   onTagDisableClick,
@@ -301,7 +300,6 @@ const EntityTags = ({
 
 EntityTags.propTypes = {
   entity: PropTypes.model.isRequired,
-  foldable: PropTypes.bool,
   onTagAddClick: PropTypes.func.isRequired,
   onTagCreateClick: PropTypes.func.isRequired,
   onTagDeleteClick: PropTypes.func.isRequired,

--- a/ng/src/web/pages/scanconfigs/listpage.js
+++ b/ng/src/web/pages/scanconfigs/listpage.js
@@ -105,7 +105,6 @@ const ScanConfigsPage = ({
     }) => (
       <EntitiesPage
         {...props}
-        foldable={true}
         filterEditDialog={ScanConfigFilterDialog}
         sectionIcon="config.svg"
         table={Table}


### PR DESCRIPTION
Most of the sections that are foldable got replaced by tabs. Therefore,
remove the foldable prop where it is not needed anymore.
The last remaining instance, in which foldable is used, is for the scan
configs edit dialog.