### PR TITLE
Fix copy and paster mistake

### DIFF
--- a/ng/src/web/components/provider/gmpprovider.js
+++ b/ng/src/web/components/provider/gmpprovider.js
@@ -48,7 +48,7 @@ GmpProvider.propTypes = {
 };
 
 GmpProvider.childContextTypes = {
-  gmp: PropTypes.capabilities,
+  gmp: PropTypes.gmp,
 };
 
 export default GmpProvider;


### PR DESCRIPTION
Get rid of proptype warning in GmpProvider.