### PR TITLE
Rename module xslt_i18n to gsad_i18n.

### DIFF
--- a/gsad/src/CMakeLists.txt
+++ b/gsad/src/CMakeLists.txt
@@ -102,7 +102,7 @@ target_link_libraries (gsad_gmp ${LIBMICROHTTPD_LDFLAGS} ${LIBXML_LDFLAGS}
                        ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
                        ${LIBGVM_GMP_LDFLAGS} ${GNUTLS_LDFLAGS})
 
-add_library (gsad_xslt_ext STATIC xslt_i18n.c)
+add_library (gsad_i18n_ext STATIC gsad_i18n.c)
 target_link_libraries (gsad_gmp ${LIBMICROHTTPD_LDFLAGS} ${LIBXML_LDFLAGS}
                        ${GLIB_LDFLAGS} ${GTHREAD_LDFLAGS}
                        ${LIBGVM_GMP_LDFLAGS} ${GNUTLS_LDFLAGS})
@@ -118,7 +118,7 @@ add_executable (gsad
                 gsad_http_handler.c
                 validator.c)
 
-target_link_libraries (gsad gsad_gmp gsad_base gsad_xslt_ext ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBGVM_GMP_LDFLAGS} ${LIBGCRYPT_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT} ${LINKER_HARDENING_FLAGS})
+target_link_libraries (gsad gsad_gmp gsad_base gsad_i18n_ext ${LIBGVM_BASE_LDFLAGS} ${LIBGVM_UTIL_LDFLAGS} ${LIBGVM_GMP_LDFLAGS} ${LIBGCRYPT_LDFLAGS} ${CMAKE_THREAD_LIBS_INIT} ${LINKER_HARDENING_FLAGS})
 set_target_properties (gsad PROPERTIES LINKER_LANGUAGE C)
 
 if (SERVE_STATIC_ASSETS)

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -104,7 +104,7 @@
 #include "gsad_settings.h"
 #include "gsad_user.h"
 #include "validator.h"
-#include "xslt_i18n.h"
+#include "gsad_i18n.h"
 
 #undef G_LOG_DOMAIN
 /**

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -57,7 +57,7 @@
 #include "gsad_settings.h" /* for vendor_version_get */
 #include "gsad_http.h" /* for gsad_message, logout_xml */
 #include "gsad_base.h" /* for set_language_code */
-#include "xslt_i18n.h"
+#include "gsad_i18n.h"
 
 #include <gvm/base/cvss.h>
 #include <gvm/util/fileutils.h>

--- a/gsad/src/gsad_http.c
+++ b/gsad/src/gsad_http.c
@@ -41,7 +41,7 @@
 #include <gvm/base/networking.h> /* for sockaddr_as_str */
 #include <gvm/util/xmlutils.h>   /* for xml_string_append */
 
-#include "xslt_i18n.h" /* for accept_language_to_env_fmt */
+#include "gsad_i18n.h" /* for accept_language_to_env_fmt */
 #include "gsad_settings.h"
 #include "gsad_base.h" /* for ctime_r_strip_newline */
 

--- a/gsad/src/gsad_http_handler.c
+++ b/gsad/src/gsad_http_handler.c
@@ -30,7 +30,7 @@
 #include "gsad_http_handler.h"
 #include "gsad_gmp.h" /* for get_system_report_gmp */
 #include "validator.h" /* for openvas_validate */
-#include "xslt_i18n.h" /* for accept_language_to_env_fmt */
+#include "gsad_i18n.h" /* for accept_language_to_env_fmt */
 #include "gsad_settings.h" /* for get_guest_usernmae */
 #include "gsad_base.h" /* for ctime_r_strip_newline */
 

--- a/gsad/src/gsad_i18n.c
+++ b/gsad/src/gsad_i18n.c
@@ -1,6 +1,6 @@
 /* Greenbone Security Assistant
  * $Id$
- * Description: Translation libxslt extension of Greenbone Security Assistant.
+ * Description: I18n support for Greenbone Security Assistant.
  *
  * Authors:
  * Timo Pollmeier <timo.pollmeier@greenbone.net>
@@ -25,7 +25,7 @@
 
 #define _GNU_SOURCE
 
-#include "xslt_i18n.h"
+#include "gsad_i18n.h"
 #include "gsad_base.h"
 #include <assert.h>
 #include <dirent.h>
@@ -43,7 +43,7 @@
 /**
  * @brief GLib log domain.
  */
-#define G_LOG_DOMAIN "gsad xslt"
+#define G_LOG_DOMAIN "gsad i18n"
 
 #ifndef GETTEXT_CONTEXT_GLUE
 #define GETTEXT_CONTEXT_GLUE "\004"

--- a/gsad/src/gsad_i18n.h
+++ b/gsad/src/gsad_i18n.h
@@ -1,6 +1,6 @@
 /* Greenbone Security Assistant
  * $Id$
- * Description: Translation libxslt extension of Greenbone Security Assistant.
+ * Description: I18n support for Greenbone Security Assistant.
  *
  * Authors:
  * Timo Pollmeier <timo.pollmeier@greenbone.net>
@@ -23,8 +23,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef _XSLT_I18N_H
-#define _XSLT_I18N_H
+#ifndef _GSAD_I18N_H
+#define _GSAD_I18N_H
 
 #include <glib.h>
 
@@ -43,4 +43,4 @@ void buffer_languages_xml (GString *);
 
 gchar* accept_language_to_env_fmt (const char*);
 
-#endif /* not _XSLT_I18N_H */
+#endif /* not _GSAD_I18N_H */

--- a/gsad/src/gsad_log_conf.cmake_in
+++ b/gsad/src/gsad_log_conf.cmake_in
@@ -15,7 +15,7 @@ prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=${GVM_LOG_DIR}/gsad.log
 level=127
 
-[gsad xslt]
+[gsad i18n]
 prepend=%t %p
 prepend_time_format=%Y-%m-%d %Hh%M.%S %Z
 file=${GVM_LOG_DIR}/gsad.log


### PR DESCRIPTION
Since the module is not about xslt anymore, just about i18n,
the renaming makes sense.
Along with the plain renaming in the source code, also the log
domain is renamed from xslt to i18n.