### PR TITLE
Use react-popper for Select and MultiSelect

### DIFF
--- a/ng/src/web/components/form/multiselect.js
+++ b/ng/src/web/components/form/multiselect.js
@@ -29,6 +29,8 @@ import glamorous from 'glamorous';
 
 import Downshift from 'downshift';
 
+import {Manager, Target, Popper} from 'react-popper';
+
 import {arrays_equal, is_array, is_defined, is_empty} from 'gmp/utils';
 
 import ArrowIcon from '../icon/arrowicon.js';
@@ -191,6 +193,11 @@ class MultiSelect extends React.Component {
       items = option_items(children);
     }
 
+    let popperPlacement = 'bottom-start';
+    if (is_defined(menuPosition) && menuPosition === 'right') {
+      popperPlacement = 'bottom-end';
+    }
+
     disabled = disabled || !is_defined(items) || items.length === 0;
 
     const displayedItems = is_defined(items) ?
@@ -217,56 +224,63 @@ class MultiSelect extends React.Component {
               flex="column"
               width={width}
             >
-              <Box
-                isOpen={isOpen}
-                disabled={disabled}
-              >
-                <Layout grow="1" wrap>
-                  {!is_empty(selectedItems) && selectedItems.map(
-                      item => this.renderItem(item, items)
-                    )
-                  }
-                </Layout>
-                <Layout align={['center', 'center']}>
-                  <ArrowIcon
-                    {...getButtonProps({
-                      disabled,
-                      down: !isOpen,
-                      onClick: isOpen ? undefined : event => {
-                        event.preventDefault(); // don't call default handler from downshift
-                        openMenu(() => is_defined(this.input) && this.input.focus()); // set focus to input field after menu is opened
-                      },
-                    })}
-                    size="small"
-                  />
-                </Layout>
-              </Box>
-              {isOpen && !disabled &&
-                <Menu position={menuPosition}>
-                  <Input
-                    {...getInputProps({
-                      value: search,
-                      onChange: this.handleSearch,
-                    })}
+              <Manager>
+                <Target>
+                  <Box
+                    isOpen={isOpen}
                     disabled={disabled}
-                    innerRef={ref => this.input = ref}
-                  />
-                  <ItemContainer>
-                    {displayedItems
-                      .map(({label: itemLabel, value: itemValue}, i) => (
-                        <Item
-                          {...getItemProps({item: itemValue})}
-                          isSelected={selectedItems.includes(itemValue)}
-                          isActive={i === highlightedIndex}
-                          key={itemValue}
-                        >
-                          {itemLabel}
-                        </Item>
-                      ))
-                    }
-                  </ItemContainer>
-                </Menu>
-              }
+                  >
+                    <Layout grow="1" wrap>
+                      {!is_empty(selectedItems) && selectedItems.map(
+                          item => this.renderItem(item, items)
+                        )
+                      }
+                    </Layout>
+                    <Layout align={['center', 'center']}>
+                      <ArrowIcon
+                        {...getButtonProps({
+                          disabled,
+                          down: !isOpen,
+                          onClick: isOpen ? undefined : event => {
+                            event.preventDefault(); // don't call default handler from downshift
+                            openMenu(() => is_defined(this.input) &&
+                              this.input.focus()); // set focus to input field after menu is opened
+                          },
+                        })}
+                        size="small"
+                      />
+                    </Layout>
+                  </Box>
+                </Target>
+                {isOpen && !disabled &&
+                  <Popper placement={popperPlacement}>
+                    <Menu position={menuPosition} width={width}>
+                      <Input
+                        {...getInputProps({
+                          value: search,
+                          onChange: this.handleSearch,
+                        })}
+                        disabled={disabled}
+                        innerRef={ref => this.input = ref}
+                      />
+                      <ItemContainer>
+                        {displayedItems
+                          .map(({label: itemLabel, value: itemValue}, i) => (
+                            <Item
+                              {...getItemProps({item: itemValue})}
+                              isSelected={selectedItems.includes(itemValue)}
+                              isActive={i === highlightedIndex}
+                              key={itemValue}
+                            >
+                              {itemLabel}
+                            </Item>
+                          ))
+                        }
+                      </ItemContainer>
+                    </Menu>
+                  </Popper>
+                }
+              </Manager>
             </SelectContainer>
           );
         }}

--- a/ng/src/web/components/form/select.js
+++ b/ng/src/web/components/form/select.js
@@ -26,6 +26,8 @@ import React from 'react';
 
 import Downshift from 'downshift';
 
+import {Manager, Target, Popper} from 'react-popper';
+
 import {is_defined} from 'gmp/utils';
 
 import PropTypes from '../../utils/proptypes.js';
@@ -121,6 +123,11 @@ class Select extends React.Component {
       items = option_items(children);
     }
 
+    let popperPlacement = 'bottom-start';
+    if (is_defined(menuPosition) && menuPosition === 'right') {
+      popperPlacement = 'bottom-end';
+    }
+
     check_value(items, value); // raise warning in dev mode
 
     disabled = disabled || !is_defined(items) || items.length === 0;
@@ -152,57 +159,63 @@ class Select extends React.Component {
               flex="column"
               width={width}
             >
-              <Box
-                {...getButtonProps({
-                  disabled,
-                  onClick: isOpen ? undefined : event => {
-                    event.preventDefault(); // don't call default handler from downshift
-                    openMenu(() =>
-                      is_defined(this.input) && this.input.focus()); // set focus to input field after menu is opened
-                  },
-                })}
-                isOpen={isOpen}
-              >
-                <SelectedValue
-                  disabled={disabled}
-                  title={label}
-                >
-                  {label}
-                </SelectedValue>
-                <Layout align={['center', 'center']}>
-                  <ArrowIcon
-                    disabled={disabled}
-                    down={!isOpen}
-                    size="small"
-                  />
-                </Layout>
-              </Box>
-              {isOpen && !disabled &&
-                <Menu position={menuPosition}>
-                  <Input
-                    {...getInputProps({
-                      value: search,
-                      onChange: this.handleSearch,
+              <Manager>
+                <Target>
+                  <Box
+                    {...getButtonProps({
+                      disabled,
+                      onClick: isOpen ? undefined : event => {
+                        event.preventDefault(); // don't call default handler from downshift
+                        openMenu(() =>
+                          is_defined(this.input) && this.input.focus()); // set focus to input field after menu is opened
+                      },
                     })}
-                    disabled={disabled}
-                    innerRef={ref => this.input = ref}
-                  />
-                  <ItemContainer>
-                    {displayedItems
-                      .map(({label: itemLabel, value: itemValue}, i) => (
-                        <Item
-                          {...getItemProps({item: itemValue})}
-                          isSelected={itemValue === selectedItem}
-                          isActive={i === highlightedIndex}
-                          key={itemValue}
-                        >
-                          {itemLabel}
-                        </Item>
-                      ))
-                    }
-                  </ItemContainer>
-                </Menu>
-              }
+                    isOpen={isOpen}
+                  >
+                    <SelectedValue
+                      disabled={disabled}
+                      title={label}
+                    >
+                      {label}
+                    </SelectedValue>
+                    <Layout align={['center', 'center']}>
+                      <ArrowIcon
+                        disabled={disabled}
+                        down={!isOpen}
+                        size="small"
+                      />
+                    </Layout>
+                  </Box>
+                </Target>
+                {isOpen && !disabled &&
+                  <Popper placement={popperPlacement}>
+                    <Menu position={menuPosition} width={width}>
+                      <Input
+                        {...getInputProps({
+                          value: search,
+                          onChange: this.handleSearch,
+                        })}
+                        disabled={disabled}
+                        innerRef={ref => this.input = ref}
+                      />
+                      <ItemContainer>
+                        {displayedItems
+                          .map(({label: itemLabel, value: itemValue}, i) => (
+                            <Item
+                              {...getItemProps({item: itemValue})}
+                              isSelected={itemValue === selectedItem}
+                              isActive={i === highlightedIndex}
+                              key={itemValue}
+                            >
+                              {itemLabel}
+                            </Item>
+                          ))
+                        }
+                      </ItemContainer>
+                    </Menu>
+                  </Popper>
+                }
+              </Manager>
             </SelectContainer>
           );
         }}

--- a/ng/src/web/components/form/selectelements.js
+++ b/ng/src/web/components/form/selectelements.js
@@ -85,14 +85,16 @@ export const Menu = glamorous.div({
   display: 'flex',
   flexDirection: 'column',
   position: 'absolute',
-  top: '100%', // move below Box
   zIndex: 5,
   marginTop: '-1px', // collapse top border
   boxSizing: 'border-box',
-}, ({position}) => {
+}, ({position, width}) => {
   switch (position) {
     case 'adjust':
-      return {width: '100%'};
+      return {
+        left: 0,
+        width,
+      };
     case 'right':
       return {
         right: 0,
@@ -109,7 +111,6 @@ export const Menu = glamorous.div({
 export const SelectContainer = glamorous.div({
   display: 'flex',
   flexDirection: 'column',
-  position: 'relative',
 }, ({width}) => ({
   width,
 }));


### PR DESCRIPTION
Opened drop-downs from Select and MultiSelect now _pop_ out of context
and can thereby break the "overflow:hidden" from the dialog contents
(just as DatePicker does, which uses react-popper as well).
While making these changes, another issue came up, which I couldn't
solve: Spinners and some icons are not overlayed by the drop-down but
show through.
Using react-popper seems to be a better basis for fixing the issues with
(Multi)Select, though.