### PR TITLE
Languages #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ config.local.js
 # directory files for image previews
 .directory
 coverage/
+/ng/public/locales/

--- a/gsad/src/gsad_http_handler.c
+++ b/gsad/src/gsad_http_handler.c
@@ -810,6 +810,8 @@ init_http_handlers()
                    handle_static_ng_file);
   url_handler_add (anon_url_handlers, "^/robots.txt$",
                    handle_static_file);
+  url_handler_add (anon_url_handlers, "^/locales/.+$",
+                   handle_static_file);
 #endif
 
   url_handler_add (anon_url_handlers, "^/login/?$", handle_index_ng);

--- a/gsad/src/gsad_http_handler.c
+++ b/gsad/src/gsad_http_handler.c
@@ -806,11 +806,9 @@ init_http_handlers()
   anon_url_handlers = url_handler_new ("^/$", handle_redirect_to_login_page);
 
 #ifdef SERVE_STATIC_ASSETS
-  url_handler_add (anon_url_handlers, "^/(img|js|css)/.+$",
+  url_handler_add (anon_url_handlers, "^/(img|js|css|locales)/.+$",
                    handle_static_ng_file);
   url_handler_add (anon_url_handlers, "^/robots.txt$",
-                   handle_static_file);
-  url_handler_add (anon_url_handlers, "^/locales/.+$",
                    handle_static_file);
 #endif
 

--- a/ng/CMakeLists.txt
+++ b/ng/CMakeLists.txt
@@ -750,8 +750,8 @@ install (FILES public/robots.txt
 install (CODE "file(REMOVE_RECURSE ${NG_DEST_DIR}/static)")
 
 install (DIRECTORY
-         build/static
-         build/img
+         ${NG_BUILD_DIR}/static
+         ${NG_BUILD_DIR}/img
          DESTINATION ${NG_DEST_DIR})
 
 ## Translations

--- a/ng/po/CMakeLists.txt
+++ b/ng/po/CMakeLists.txt
@@ -41,7 +41,7 @@ macro (MAKE_TRANSLATION _LANG)
                       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/gsad_js-${_LANG}.po
                       ${CMAKE_CURRENT_BINARY_DIR}/gsad-${_LANG}.json)
   install (FILES ${CMAKE_CURRENT_BINARY_DIR}/gsad-${_LANG}.json
-          DESTINATION ${GSA_DATA_DIR}/classic/js/locales)
+          DESTINATION ${GSA_DATA_DIR}/classic/locales)
 
   add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gsad_js-${_LANG}-merged.po
                       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gsad_js.pot

--- a/ng/po/CMakeLists.txt
+++ b/ng/po/CMakeLists.txt
@@ -29,19 +29,17 @@ include (FindPythonModule)
 
 find_python_module(polib)
 
+set (NG_LOCALE_DIR ${NG_SRC_DIR}/public/locales)
+
 # Create targets for a language _LANG
 macro (MAKE_TRANSLATION _LANG)
-  file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${_LANG})
-
   # Files for installation
   # .json for JS
-  add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gsad-${_LANG}.json
+  add_custom_command (OUTPUT ${NG_LOCALE_DIR}/gsad-${_LANG}.json
                       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gsad_js-${_LANG}.po
                       COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_SOURCE_DIR}/tools/po2json"
                       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/gsad_js-${_LANG}.po
-                      ${CMAKE_CURRENT_BINARY_DIR}/gsad-${_LANG}.json)
-  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/gsad-${_LANG}.json
-          DESTINATION ${GSA_DATA_DIR}/classic/locales)
+                      ${NG_LOCALE_DIR}/gsad-${_LANG}.json)
 
   add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/gsad_js-${_LANG}-merged.po
                       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gsad_js.pot
@@ -53,6 +51,9 @@ endmacro ()
 
 if (GETTEXT_FOUND)
   if (PY_POLIB_FOUND)
+
+    file (MAKE_DIRECTORY ${NG_LOCALE_DIR})
+
     MAKE_TRANSLATION (ar)
     MAKE_TRANSLATION (de)
     MAKE_TRANSLATION (fr)
@@ -64,13 +65,13 @@ if (GETTEXT_FOUND)
     # Installed files
     add_custom_target (gettext-json
                        ALL
-                       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gsad-ar.json
-                       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gsad-de.json
-                       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gsad-fr.json
-                       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gsad-pt_BR.json
-                       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gsad-ru.json
-                       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gsad-tr.json
-                       DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/gsad-zh_CN.json
+                       DEPENDS ${NG_LOCALE_DIR}/gsad-ar.json
+                       DEPENDS ${NG_LOCALE_DIR}/gsad-de.json
+                       DEPENDS ${NG_LOCALE_DIR}/gsad-fr.json
+                       DEPENDS ${NG_LOCALE_DIR}/gsad-pt_BR.json
+                       DEPENDS ${NG_LOCALE_DIR}/gsad-ru.json
+                       DEPENDS ${NG_LOCALE_DIR}/gsad-tr.json
+                       DEPENDS ${NG_LOCALE_DIR}/gsad-zh_CN.json
                        COMMENT "Created translation .json files")
 
     # Merged .po files
@@ -105,6 +106,10 @@ if (GETTEXT_FOUND)
                                 "${CMAKE_SOURCE_DIR}/ng"
                         DEPENDS ${NG_JS_SRC_FILES}
                         COMMENT "Creating translation template (.pot) file from JS")
+
+    install (DIRECTORY
+             ${NG_BUILD_DIR}/locales
+             DESTINATION ${NG_DEST_DIR})
 
   else (PY_POLIB_FOUND)
     message (WARNING "Could not build translation files: Python interpreter or polib Python module not found.")

--- a/ng/src/gmp/locale.js
+++ b/ng/src/gmp/locale.js
@@ -57,7 +57,7 @@ i18next
     defaultNS: 'gsad',
     fallbackNS: 'gsad',
     backend: {
-      loadPath: '/js/locales/{{ns}}-{{lng}}.json', // e.g. /js/locales/gsad-en.json
+      loadPath: '/locales/{{ns}}-{{lng}}.json', // e.g. /locales/gsad-en.json
     },
     detection: {
       // only use url querystring and browser settings for language detection

--- a/ng/src/gmp/locale.js
+++ b/ng/src/gmp/locale.js
@@ -72,7 +72,11 @@ i18next
   });
 
 export const get_language = () => i18next.language;
-export const set_language = lang => i18next.changeLanguage(lang);
+export const set_language = lang => i18next.changeLanguage(lang, err => {
+  if (is_defined(err)) {
+    log.error('Could not set language to', lang, err);
+  }
+});
 
 export function translate(key, options) {
   return i18next.t(key, options);


### PR DESCRIPTION
Allow to use the localization files from the development web server. Therefore generate them into ng/public/locales dir. 

With `yarn build` they will be copied into _build/locales_ automatically. This dir is picked up by `make install`.