### PR TITLE
Fix setting password in user dialog

### DIFF
--- a/ng/src/gmp/commands/users.js
+++ b/ng/src/gmp/commands/users.js
@@ -167,7 +167,7 @@ class UserCommand extends EntityCommand {
     ifaces_allow,
     name,
     old_name,
-    password,
+    password = '', // needs to be included in httpPost, should be optional in gsad
     role_ids,
   }) {
     if (auth_method === AUTH_METHOD_LDAP) {


### PR DESCRIPTION
The password field must not be undefined.