### PR TITLE
Only raise warning if the prop has a value

### DIFF
--- a/ng/src/web/utils/proptypes.js
+++ b/ng/src/web/utils/proptypes.js
@@ -148,7 +148,7 @@ export const iconSize = ReactPropTypes.oneOfType([
 
 const toStringValidator = (props, prop_name, component_name) => {
   const value = props[prop_name];
-  if (!is_defined(value) || !is_defined(value.toString)) {
+  if (is_defined(value) && !is_defined(value.toString)) {
     return new Error('Invalid prop `' + prop_name + '` supplied to' +
       ' `' + component_name + '`. Prop ' + prop_name + ' can not be ' +
       'converted to String. Value is `' + value + '`.');


### PR DESCRIPTION
Raising an error if no value is set for the prop is done by additonal
isRequired.