### PR TITLE
Limit width of progress bar to 100%

### DIFF
--- a/ng/src/web/components/bar/progressbar.js
+++ b/ng/src/web/components/bar/progressbar.js
@@ -85,6 +85,9 @@ const Progress = glamorous.div(
       background = 'gray';
     }
 
+    if (progress > 100) {
+      progress = 100;
+    }
     return {
       width: progress + '%',
       background,


### PR DESCRIPTION
Avoid longer progress bars then 100% if a progress bigger then 100 is
reported by gvmd.