### PR TITLE
Fix array_equals for IE11

### DIFF
--- a/ng/src/gmp/utils/array.js
+++ b/ng/src/gmp/utils/array.js
@@ -22,6 +22,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 import 'core-js/fn/array/includes';
+import 'core-js/fn/object/is';
 import 'core-js/fn/symbol';
 
 import {has_value, is_defined, is_array} from './identity';


### PR DESCRIPTION
Import required polyfill for Object.is in IE11