### PR TITLE
Ignore empty files in OMP dialogs.

### DIFF
--- a/src/html/classic/js/greenbone.js
+++ b/src/html/classic/js/greenbone.js
@@ -1279,7 +1279,7 @@
               }
             }
             else if (elem.matches('input') || elem.matches('textarea')) {
-              if (elem.type === 'file') {
+              if (elem.type === 'file' && gsa.is_defined (elem.files[0])) {
                 data.append(elem.name, elem.files[0]);
               }
               else if ((elem.type !== 'checkbox' && elem.type !== 'radio') ||


### PR DESCRIPTION
In OMP dialogs, add content of file input fields to the request only if
the file content is defined, i.e. the user has actually chosen a file to
upload, otherwise ignore the field.
This prevents "undefined" being sent as the file content if no file is
selected.