### PR TITLE
Fix setting the default font family

### DIFF
--- a/ng/src/web/utils/globalcss.js
+++ b/ng/src/web/utils/globalcss.js
@@ -43,7 +43,7 @@ css({
 
   body: {
     margin: '0',
-    font: Theme.Font.default,
+    fontFamily: Theme.Font.default,
     fontSize: '12px',
     color: Theme.black,
   },


### PR DESCRIPTION
Now it's obvious where the small did come from. The font css property
was used in the global css for the body content and not the font-family.