### PR TITLE
Fix syntax error in french translation

### DIFF
--- a/src/po/gsad_js-fr.po
+++ b/src/po/gsad_js-fr.po
@@ -427,7 +427,7 @@ msgstr "Histogramme horizontal"
 
 #: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_h_bar_chart.js:275
 msgid "<br/>({{assets}} Host(s) with average severity {{severity}})"
-msgid "<br/>({{assets}} Hôte(s) avec une moyenne de sévérité {{severity}})"
+msgstr "<br/>({{assets}} Hôte(s) avec une moyenne de sévérité {{severity}})"
 
 #: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_line_chart.js:79
 msgid "Loading line chart ..."


### PR DESCRIPTION
Build of the translations will currently fail with the following error:

```
Traceback (most recent call last):
  File "/usr/src/gsa-7.0.3/tools/po2json", line 66, in <module>
    main()
  File "/usr/src/gsa-7.0.3/tools/po2json", line 62, in main
    convert(sys.argv[1], sys.argv[2])
  File "/usr/src/gsa-7.0.3/tools/po2json", line 45, in convert
    po_f = polib.pofile(in_name)
  File "/usr/lib/python2.7/dist-packages/polib.py", line 138, in pofile
    return _pofile_or_mofile(pofile, 'pofile', **kwargs)
  File "/usr/lib/python2.7/dist-packages/polib.py", line 86, in _pofile_or_mofile
    instance = parser.parse()
  File "/usr/lib/python2.7/dist-packages/polib.py", line 1320, in parse
    self.process(keywords[tokens[0]])
  File "/usr/lib/python2.7/dist-packages/polib.py", line 1464, in process
    self.current_line)
IOError: Syntax error in po file (line 430)
src/po/CMakeFiles/gettext-json.dir/build.make:74: recipe for target 'src/po/gsad-fr.json' failed
make[2]: *** [src/po/gsad-fr.json] Error 1
CMakeFiles/Makefile2:1020: recipe for target 'src/po/CMakeFiles/gettext-json.dir/all' failed
make[1]: *** [src/po/CMakeFiles/gettext-json.dir/all] Error 2
Makefile:149: recipe for target 'all' failed
make: *** [all] Error 2
```