### PR TITLE
Make Grid items draggable at header only

### DIFF
--- a/ng/src/web/components/dashboard2/dashboard.js
+++ b/ng/src/web/components/dashboard2/dashboard.js
@@ -105,11 +105,12 @@ class Dashboard extends React.Component {
         maxItemsPerRow={maxItemsPerRow}
         onChange={this.handleItemsChange}
       >
-        {({id, props, height, width, remove}) => {
+        {({dragHandleProps, id, props, height, width, remove}) => {
           const {id: elementId} = props;
           const Component = components[elementId];
           return is_defined(Component) ? (
             <Component
+              dragHandleProps={dragHandleProps}
               height={height}
               width={width}
               id={id}
@@ -128,4 +129,3 @@ export default compose(
 )(Dashboard);
 
 // vim: set ts=2 sw=2 tw=80:
-

--- a/ng/src/web/components/dashboard2/data/display.js
+++ b/ng/src/web/components/dashboard2/data/display.js
@@ -47,6 +47,7 @@ let DataDisplay = ({
   title,
   width,
   onRemoveClick,
+  ...props
 }) => {
   height = height - DISPLAY_HEADER_HEIGHT;
   return (
@@ -54,6 +55,7 @@ let DataDisplay = ({
       menu={menu}
       title={isLoading ? _('Loading') : title({data, id})}
       onRemoveClick={onRemoveClick}
+      {...props}
     >
       {isLoading ?
         <Loading/> :

--- a/ng/src/web/components/dashboard2/display.js
+++ b/ng/src/web/components/dashboard2/display.js
@@ -99,13 +99,14 @@ const DisplayTitle = glamorous.div('display-title', {
 
 const Display = ({
   children,
+  dragHandleProps,
   menu,
   title,
   onRemoveClick,
 }) => {
   return (
     <DisplayView>
-      <HeaderContainer>
+      <HeaderContainer {...dragHandleProps}>
         <Header>
           {menu}
           <HeaderContent>
@@ -128,6 +129,7 @@ const Display = ({
 };
 
 Display.propTypes = {
+  dragHandleProps: PropTypes.object,
   menu: PropTypes.element,
   title: PropTypes.string,
   onRemoveClick: PropTypes.func.isRequired,

--- a/ng/src/web/components/sortable/grid.js
+++ b/ng/src/web/components/sortable/grid.js
@@ -237,14 +237,12 @@ class Grid extends React.Component {
                         key={item.id}
                         id={item.id}
                         index={index}
+                        props={item.props}
+                        height={itemHeight}
+                        width={itemWidth}
+                        remove={() => this.handleRemoveItem(item.id)}
                       >
-                        {children({
-                          id: item.id,
-                          props: item.props,
-                          height: itemHeight,
-                          width: itemWidth,
-                          remove: () => this.handleRemoveItem(item.id),
-                        })}
+                        {children}
                       </Item>
                     ))}
                   </Row>
@@ -265,4 +263,3 @@ class Grid extends React.Component {
 export default Grid;
 
 // vim: set ts=2 sw=2 tw=80:
-

--- a/ng/src/web/components/sortable/item.js
+++ b/ng/src/web/components/sortable/item.js
@@ -2,6 +2,7 @@
  *
  * Authors:
  * Björn Ricks <bjoern.ricks@greenbone.net>
+ * Steffen Waterkamp <steffen.waterkamp@greenbone.net>
  *
  * Copyright:
  * Copyright (C) 2018 Greenbone Networks GmbH
@@ -52,6 +53,7 @@ const Item = ({
   children,
   index,
   id,
+  ...props
 }) => (
   <Draggable
     draggableId={id}
@@ -62,11 +64,14 @@ const Item = ({
         <GridItem
           innerRef={provided.innerRef}
           {...provided.draggableProps}
-          {...provided.dragHandleProps}
           isDragging={snapshot.isDragging}
           style={provided.draggableProps.style}
         >
-          {children}
+          {children({
+            ...props,
+            id,
+            dragHandleProps: provided.dragHandleProps,
+          })}
         </GridItem>
         {provided.placeholder}
       </React.Fragment>
@@ -75,6 +80,7 @@ const Item = ({
 );
 
 Item.propTypes = {
+  children: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,
 };


### PR DESCRIPTION
Items in the grid can now be dragged with the header only.