### PR TITLE
Don't display severity and trend for container tasks

### DIFF
--- a/ng/src/web/pages/tasks/row.js
+++ b/ng/src/web/pages/tasks/row.js
@@ -179,12 +179,14 @@ const Row = ({
         {render_report(entity.last_report, links)}
       </TableData>
       <TableData flex align="center">
-        {entity.last_report &&
+        {!entity.isContainer() && is_defined(entity.last_report) &&
           <SeverityBar severity={entity.last_report.severity}/>
         }
       </TableData>
       <TableData flex align="center">
-        <Trend name={entity.trend}/>
+        {!entity.isContainer() &&
+          <Trend name={entity.trend} />
+        }
       </TableData>
       {render_component(actions, {
         links,


### PR DESCRIPTION
At the task list don't display severity and trend for container tasks.
This reproduces the same behavior as in gsa 7 with openvas 9.