### PR TITLE
Always pass children to Loader components

### DIFF
--- a/ng/src/web/pages/tasks/dashboard/loaders.js
+++ b/ng/src/web/pages/tasks/dashboard/loaders.js
@@ -44,7 +44,9 @@ export const tasksSchedulesLoader = loadFunc(
   }).then(r => r.data),
   TASKS_SCHEDULES);
 
-export const TaskStatusLoader = props => (
+export const TaskStatusLoader = ({
+  children,
+}) => (
   <Loader
     dataId={TASKS_STATUS}
     load={tasksStatusLoader}
@@ -52,10 +54,15 @@ export const TaskStatusLoader = props => (
       'tasks.timer',
       'tasks.changed',
     ]}
-  />
+    children={children}
+  >
+    {children}
+  </Loader>
 );
 
-export const TasksSchedulesLoader = props => (
+export const TasksSchedulesLoader = ({
+  children,
+}) => (
   <Loader
     dataId={TASKS_SCHEDULES}
     load={tasksSchedulesLoader}
@@ -63,10 +70,14 @@ export const TasksSchedulesLoader = props => (
       'tasks.timer',
       'tasks.changed',
     ]}
-  />
+  >
+    {children}
+  </Loader>
 );
 
-export const TasksSeverityLoader = props => (
+export const TasksSeverityLoader = ({
+  children,
+}) => (
   <Loader
     dataId={TASKS_SEVERITY}
     load={tasksSeverityLoader}
@@ -74,7 +85,9 @@ export const TasksSeverityLoader = props => (
       'tasks.timer',
       'tasks.changed',
     ]}
-  />
+  >
+    {children}
+  </Loader>
 );
 
 // vim: set ts=2 sw=2 tw=80:

--- a/ng/src/web/pages/vulns/dashboard/loaders.js
+++ b/ng/src/web/pages/vulns/dashboard/loaders.js
@@ -30,15 +30,18 @@ export const vulnsSeverityLoader = loadFunc(
   ({gmp}) => gmp.vulns.getSeverityAggregates().then(r => r.data),
   VULNS_SEVERITY);
 
-export const VulnsSeverityLoader = props => (
+export const VulnsSeverityLoader = ({
+  children,
+}) => (
   <Loader
-    {...props}
     dataId={VULNS_SEVERITY}
     load={vulnsSeverityLoader}
     subscriptions={[
       'vulns.timer',
       'vulns.changed',
     ]}
-  />
+  >
+    {children}
+  </Loader>
 );
 // vim: set ts=2 sw=2 tw=80:


### PR DESCRIPTION
Fix displaying the charts at the tasks dashboard by always passing the
children to the Loader components.