### PR TITLE
Fix crashes for single values

### DIFF
--- a/ng/src/gmp/commands/entities.js
+++ b/ng/src/gmp/commands/entities.js
@@ -21,7 +21,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import {is_defined, is_string} from '../utils/identity';
+import {is_defined, is_string, is_array} from '../utils/identity';
 import {map} from '../utils/array';
 
 import logger from '../log.js';
@@ -147,8 +147,24 @@ class EntitiesCommand extends HttpCommand {
   }
 
   transformAggregates(response) {
-    return response.setData(
-      response.data.get_aggregate.get_aggregates_response.aggregate);
+    const {aggregate} = response.data.get_aggregate.get_aggregates_response;
+
+    const ret = {
+      ...aggregate,
+    };
+
+    // ensure groups is always an array
+    let {group: groups = []} = aggregate;
+
+    if (!is_array(groups)) {
+       groups = [groups];
+    }
+
+    ret.groups = groups;
+
+    delete ret.group;
+
+    return response.setData(ret);
   }
 
   getAggregates(params = {}) {

--- a/ng/src/web/components/dashboard2/display/cvssdisplay.js
+++ b/ng/src/web/components/dashboard2/display/cvssdisplay.js
@@ -22,8 +22,6 @@
  */
 import React from 'react';
 
-import {is_defined} from 'gmp/utils/identity';
-import {for_each} from 'gmp/utils/array';
 import {is_empty} from 'gmp/utils/string';
 
 import {parse_int, parse_float} from 'gmp/parser';
@@ -46,7 +44,7 @@ import BarChart from '../../chart/bar';
 
 import DataDisplay from './datadisplay';
 
-import {EMPTY, totalCount, percent, riskFactorColorScale} from './utils';
+import {totalCount, percent, riskFactorColorScale} from './utils';
 
 const getSeverityClassLabel = value => {
   switch (value) {
@@ -64,13 +62,10 @@ const getSeverityClassLabel = value => {
 };
 
 const transformCvssData = (data = {}, {severityClass}) => {
-  const {group: groups} = data;
-
-  if (!is_defined(groups)) {
-    return EMPTY;
-  };
+  const {groups = []} = data;
 
   const sum = totalCount(groups);
+
   const cvssData = {
     [NA_VALUE]: 0,
     [LOG_VALUE]: 0,
@@ -86,7 +81,7 @@ const transformCvssData = (data = {}, {severityClass}) => {
     10: 0,
   };
 
-  for_each(groups, group => {
+  groups.forEach(group => {
     let {value, count = 0} = group;
     if (is_empty(value)) {
       value = NA_VALUE;

--- a/ng/src/web/components/dashboard2/display/severityclassdisplay.js
+++ b/ng/src/web/components/dashboard2/display/severityclassdisplay.js
@@ -39,7 +39,6 @@ import DonutChart from '../../chart/donut3d';
 import DataDisplay from './datadisplay';
 
 import {
-  EMPTY,
   totalCount,
   percent,
   riskFactorColorScale,
@@ -49,11 +48,7 @@ const transformSeverityData = (
   data = {},
   {severityClass: severityClassType}
 ) => {
-  const {group: groups} = data;
-
-  if (!is_defined(groups)) {
-    return EMPTY;
-  };
+  const {groups = []} = data;
 
   const sum = totalCount(groups);
 

--- a/ng/src/web/components/dashboard2/display/utils.js
+++ b/ng/src/web/components/dashboard2/display/utils.js
@@ -43,9 +43,6 @@ export const totalCount = (groups = []) => {
     .reduce((prev, cur) => prev + cur);
 };
 
-export const EMPTY = [];
-EMPTY.total = 0;
-
 export const percent = (count, sum) =>
   (parse_int(count) / sum * 100).toFixed(1);
 

--- a/ng/src/web/pages/tasks/dashboard/statusdisplay.js
+++ b/ng/src/web/pages/tasks/dashboard/statusdisplay.js
@@ -28,14 +28,11 @@ import {interpolateHcl} from 'd3-interpolate';
 
 import _ from 'gmp/locale';
 
-import {is_defined} from 'gmp/utils/identity';
-import {map} from 'gmp/utils/array';
 
 import DonutChart from '../../../components/chart/donut3d';
 
 import DataDisplay from '../../../components/dashboard2/display/datadisplay';
 import {
-  EMPTY,
   totalCount,
   percent,
 } from '../../../components/dashboard2/display/utils';
@@ -74,15 +71,11 @@ const taskStatusColorScale = scaleOrdinal()
   ]);
 
 const transformStatusData = (data = {}) => {
-  const {group: groups} = data;
-
-  if (!is_defined(groups)) {
-    return EMPTY;
-  };
+  const {groups = []} = data;
 
   const sum = totalCount(groups);
 
-  const tdata = map(groups, group => {
+  const tdata = groups.map(group => {
     const {count, value} = group;
     const perc = percent(count, sum);
     return {


### PR DESCRIPTION
Don't crash charts if the aggregates response only returns a single value and not an array for the groups property. Ensure aggregates.groups is always an array now.