### PR TITLE
Don't crash if items are null or undefined

### DIFF
--- a/ng/src/web/components/dashboard2/controls.js
+++ b/ng/src/web/components/dashboard2/controls.js
@@ -26,7 +26,7 @@ import {connect} from 'react-redux';
 
 import _ from 'gmp/locale';
 
-import {is_defined} from 'gmp/utils/identity';
+import {is_defined, has_value} from 'gmp/utils/identity';
 
 import compose from '../../utils/compose.js';
 import withGmp from '../../utils/withGmp.js';
@@ -93,7 +93,7 @@ DashboardControls.propTypes = {
 };
 
 const canAdd = (items, {maxItemsPerRow, maxRows}) => {
-  if (is_defined(maxItemsPerRow) && is_defined(maxRows)) {
+  if (has_value(items) && is_defined(maxItemsPerRow) && is_defined(maxRows)) {
     const lastRow = items[items.length - 1];
     return lastRow.items.length < maxItemsPerRow || items.length < maxRows;
   }


### PR DESCRIPTION
If the dashboard items couldn't be loaded because e.g. of an error don't
crash the app.