### PR TITLE
Don't crash if items are an empty array

### DIFF
--- a/ng/src/web/components/dashboard2/controls.js
+++ b/ng/src/web/components/dashboard2/controls.js
@@ -26,7 +26,7 @@ import {connect} from 'react-redux';
 
 import _ from 'gmp/locale';
 
-import {is_defined, has_value} from 'gmp/utils/identity';
+import {is_defined, is_array} from 'gmp/utils/identity';
 
 import compose from '../../utils/compose.js';
 import withGmp from '../../utils/withGmp.js';
@@ -93,7 +93,8 @@ DashboardControls.propTypes = {
 };
 
 const canAdd = (items, {maxItemsPerRow, maxRows}) => {
-  if (has_value(items) && is_defined(maxItemsPerRow) && is_defined(maxRows)) {
+  if (is_array(items) && items.length > 0 &&
+    is_defined(maxItemsPerRow) && is_defined(maxRows)) {
     const lastRow = items[items.length - 1];
     return lastRow.items.length < maxItemsPerRow || items.length < maxRows;
   }

--- a/ng/src/web/components/dashboard2/settings/actions.js
+++ b/ng/src/web/components/dashboard2/settings/actions.js
@@ -20,7 +20,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-import {is_defined} from 'gmp/utils/identity';
+import {is_defined, is_array} from 'gmp/utils/identity';
 
 import getDashboardSettings from './selectors';
 import {createRow, createItem} from '../../sortable/grid';
@@ -152,14 +152,15 @@ export const addDefaultDisplay = ({gmp}) => id => (dispatch, getState) => {
   const rootState = getState();
   const settings = getDashboardSettings(rootState);
   const defaults = settings.getDefaultsById(id);
-  const currentItems = settings.getItemsById(id);
+  const currentItems = settings.getItemsById(id) || [];
   const {defaultDisplay, maxItemsPerRow, maxRows} = defaults;
 
   if (!is_defined(defaultDisplay)) {
     return;
   }
 
-  const lastRow = currentItems[currentItems.length - 1];
+  const lastRow = is_array(currentItems) && currentItems.length > 0 ?
+    currentItems[currentItems.length - 1] : {items: []};
 
   let items;
   if (is_defined(maxItemsPerRow) && lastRow.items.length >= maxItemsPerRow) {


### PR DESCRIPTION
Normally this should not happen but it is more safe to ensure we don't
crash if the items array is actually empty.