### PR TITLE
Update handling of data display title

### DIFF
--- a/ng/src/web/components/dashboard2/display/datadisplay.js
+++ b/ng/src/web/components/dashboard2/display/datadisplay.js
@@ -106,7 +106,11 @@ class DataDisplay extends React.Component {
       return {
         data,
         originalData: nextProps.data,
-        title: nextProps.title({data, id: nextProps.id}),
+        title: nextProps.title({
+          data,
+          id: nextProps.id,
+          isLoading: nextProps.isLoading,
+        }),
       };
     }
     return null;
@@ -337,7 +341,7 @@ class DataDisplay extends React.Component {
               }
             </DisplayMenu> : null
         }
-        title={isLoading ? _('Loading') : title}
+        title={title}
         onRemoveClick={onRemoveClick}
         {...otherProps}
       >


### PR DESCRIPTION
Pass isLoading prop to title func and always display title string
instead of "Loading". Now it's possible to adjust the title in the
loading case by the title function itself.