### PR TITLE
Skip result counts for new override / note

### DIFF
--- a/src/gsad_omp.c
+++ b/src/gsad_omp.c
@@ -15350,6 +15350,7 @@ new_note (openvas_connection_t *connection, credentials_t *credentials,
   if (openvas_connection_sendf (connection,
                                 "<get_results"
                                 " result_id=\"%s\""
+                                " get_counts=\"0\""
                                 " task_id=\"%s\""
                                 " notes_details=\"1\""
                                 " notes=\"1\""
@@ -16031,6 +16032,7 @@ new_override (openvas_connection_t *connection, credentials_t *credentials,
   if (openvas_connection_sendf (connection,
                                 "<get_results"
                                 " result_id=\"%s\""
+                                " get_counts=\"0\""
                                 " task_id=\"%s\""
                                 " notes_details=\"1\""
                                 " notes=\"1\""


### PR DESCRIPTION
When getting a result for the new override or note dialog, skip counting
all the results to make the OMP request faster when opening the dialog
from a report results page.