### PR TITLE
Skip result counts for new override / note

### DIFF
--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -15281,6 +15281,7 @@ new_note (gvm_connection_t *connection, credentials_t *credentials,
   if (gvm_connection_sendf (connection,
                             "<get_results"
                             " result_id=\"%s\""
+                            " get_counts=\"0\""
                             " task_id=\"%s\""
                             " notes_details=\"1\""
                             " notes=\"1\""
@@ -16013,6 +16014,7 @@ new_override (gvm_connection_t *connection, credentials_t *credentials,
   if (gvm_connection_sendf (connection,
                             "<get_results"
                             " result_id=\"%s\""
+                            " get_counts=\"0\""
                             " task_id=\"%s\""
                             " notes_details=\"1\""
                             " notes=\"1\""


### PR DESCRIPTION
When getting a result for the new override or note dialog, skip counting
all the results to make the GMP request faster when opening the dialog
from a report results page.