### PR TITLE
Allow colon in optional hosts parameters.

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -1359,7 +1359,7 @@ init_validator ()
   openvas_validator_add (validator, "hostpath",   "^[-[:alnum:]\\. :/]{1,80}$");
   openvas_validator_add (validator, "hosts",      "^[-[:alnum:],: \\./]+$");
   openvas_validator_add (validator, "hosts_allow", "^(0|1)$");
-  openvas_validator_add (validator, "hosts_opt",  "^[-[:alnum:], \\./]*$");
+  openvas_validator_add (validator, "hosts_opt",  "^[-[:alnum:],: \\./]*$");
   openvas_validator_add (validator, "hosts_ordering", "^(sequential|random|reverse)$");
   openvas_validator_add (validator, "hour",        "^([01]?[0-9]|2[0-3])$");
   openvas_validator_add (validator, "howto_use",   "(?s)^.*$");


### PR DESCRIPTION
The parameters for optional lists of hosts like the host access fields
in the user editing and creation now also allow colons.
Without this it wasn't possible to enter IPv6 addresses.