### PR TITLE
responseType arraybuffer for Agents / Credentials

### DIFF
--- a/ng/src/gmp/commands/agents.js
+++ b/ng/src/gmp/commands/agents.js
@@ -76,7 +76,7 @@ class AgentCommand extends EntityCommand {
       cmd: 'download_agent',
       agent_format: 'installer',
       agent_id: id,
-    }, {transform: DefaultTransform});
+    }, {transform: DefaultTransform, responseType: 'arraybuffer'});
   }
 }
 

--- a/ng/src/gmp/commands/credentials.js
+++ b/ng/src/gmp/commands/credentials.js
@@ -123,7 +123,7 @@ class CredentialCommand extends EntityCommand {
       cmd: 'download_credential',
       package_format: format,
       credential_id: id,
-    }, {transform: DefaultTransform});
+    }, {transform: DefaultTransform, responseType: 'arraybuffer'});
   }
 
   getElementFromRoot(root) {


### PR DESCRIPTION
The downloads for Agents and Credentials now use "arraybuffer" as the
response type so binary files are handled correctly.