### PR TITLE
Update state only if necessary for svgRef

### DIFF
--- a/ng/src/web/components/dashboard2/display/datadisplay.js
+++ b/ng/src/web/components/dashboard2/display/datadisplay.js
@@ -226,9 +226,11 @@ class DataDisplay extends React.Component {
   }
 
   setHasSvg() {
-    const {current: svg} = this.svgRef;
-
-    this.setState({hasSvg: svg !== null});
+    this.setState(prevState => {
+      const {current: svg} = this.svgRef;
+      const hasSvg = svg !== null;
+      return prevState.hasSvg === hasSvg ? null : {hasSvg};
+    });
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
Calling setState with the same data as before seems to issue re-renders
despite nothing has changed. Therefore avoid re-renders if the hasSvg
variable in the state doesn't change. This fixes an infinite loop
(render -> componentDidUpdate -> render -> componentDirUpdate -> ...).