### PR TITLE
Transfrom delta report response to a Report model

### DIFF
--- a/ng/src/gmp/commands/reports.js
+++ b/ng/src/gmp/commands/reports.js
@@ -127,7 +127,7 @@ class ReportCommand extends EntityCommand {
       id,
       delta_report_id,
       filter,
-    }, options);
+    }, options).then(this.transformResponse);
   }
 
   getElementFromRoot(root) {


### PR DESCRIPTION
The http get request for a delta report must be transformed into an
actual Report model instance.

Seems to have been broken due to some refactoring some time ago.