### PR TITLE
Allow to filter results on report pages

### DIFF
--- a/ng/src/gmp/commands/entity.js
+++ b/ng/src/gmp/commands/entity.js
@@ -44,7 +44,7 @@ class EntityCommand extends GmpCommand {
   }
 
   getParams(params, extra_params = {}) {
-    const {id, filter, ...other} = params;
+    const {id, ...other} = params;
     const rparams = super.getParams(other, extra_params);
 
     if (is_defined(id)) {


### PR DESCRIPTION
Not explicitly excluding the filter param for EntityCommand.getParams()
allows to apply filters to the results on report details pages such als
including Log-results, min_qod settings etc.