### PR TITLE
Add create_tags GMP command.

### DIFF
--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -296,6 +296,7 @@ init_validator ()
                          "|(create_scanner)"
                          "|(create_schedule)"
                          "|(create_tag)"
+                         "|(create_tags)"
                          "|(create_target)"
                          "|(create_task)"
                          "|(cvss_calculator)"
@@ -901,6 +902,8 @@ init_validator ()
   openvas_validator_alias (validator, "privacy_password", "lsc_password");
   openvas_validator_alias (validator, "radiushost",     "hostport");
   openvas_validator_alias (validator, "restrict_type", "resource_type");
+  openvas_validator_alias (validator, "resource_ids:name",     "number");
+  openvas_validator_alias (validator, "resource_ids:value",    "id_optional");
   openvas_validator_alias (validator, "result_hosts_only", "boolean");
   openvas_validator_alias (validator, "result_task_id", "optional_task_id");
   openvas_validator_alias (validator, "result_uuid", "optional_id");
@@ -1130,7 +1133,8 @@ params_append_mhd (params_t *params,
   if ((strcmp (name, "alert_ids:") == 0)
       || (strcmp(name, "role_ids:") == 0)
       || (strcmp(name, "group_ids:") == 0)
-      || (strcmp(name, "id_list:") == 0))
+      || (strcmp(name, "id_list:") == 0)
+      || (strcmp(name, "resource_ids:") == 0))
     {
       param_t *param;
       gchar *index_str;
@@ -1531,6 +1535,7 @@ exec_gmp_post (http_connection_t *con,
   ELSE (create_scanner)
   ELSE (create_schedule)
   ELSE (create_tag)
+  ELSE (create_tags)
   ELSE (create_target)
   ELSE (create_config)
   ELSE (create_note)

--- a/gsad/src/gsad_gmp.h
+++ b/gsad/src/gsad_gmp.h
@@ -251,6 +251,8 @@ char * export_schedules_gmp (gvm_connection_t *, credentials_t *,
 
 char * create_tag_gmp (gvm_connection_t *, credentials_t *, params_t *,
                        cmd_response_data_t*);
+char * create_tags_gmp (gvm_connection_t *, credentials_t *, params_t *,
+                        cmd_response_data_t*);
 char * delete_tag_gmp (gvm_connection_t *, credentials_t *, params_t *,
                        cmd_response_data_t*);
 char * delete_trash_tag_gmp (gvm_connection_t *, credentials_t *,


### PR DESCRIPTION
This adds the back-end functionality to create multiple tags in one request
with the new create_tags GMP command.