### PR TITLE
Add CI job for checking documentation coverage of gsad

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,21 @@ jobs:
           key: v1-deps-{{ checksum "./ng/yarn.lock"  }}
           paths:
             - ./ng/node_modules
+  doc_coverage:
+    docker:
+      - image: greenbone/code-metrics-doxy-coverage-debian-stretch
+    steps:
+      - checkout
+      - run:
+          name: Generate documentation (XML)
+          command: mkdir build && cd build/ && cmake -DSKIP_SRC=1 .. && make doc-xml 2> ~/doxygen-stderr.txt
+      - run:
+          name: Establish coverage
+          command: ~/doxy-coverage/doxy-coverage.py ~/project/build/gsad/doc/generated/xml/ > ~/documentation-coverage.txt
+      - store_artifacts:
+          path: ~/doxygen-stderr.txt
+      - store_artifacts:
+          path: ~/documentation-coverage.txt
 workflows:
   version: 2
   build_and_test:
@@ -67,3 +82,5 @@ workflows:
       - build_gsad
       - build_ng
       - js_test
+      - doc_coverage
+


### PR DESCRIPTION
This commit adds a CI job which generates the source code documentation
with Doxygen as XML and then analyzes the documentation coverage with
doxy-coverage.

Errors reported during the Doxygen run and the coverage results
themselves are stored as build artifacts.

Should the job name be more precise?