### PR TITLE
Remove support for severity class OpenVAS Classic

### DIFF
--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -761,7 +761,7 @@ init_validator ()
   openvas_validator_add (validator, "osp_scanner_id", "^[a-z0-9\\-]+$");
   openvas_validator_add (validator, "schedule_id", "^[a-z0-9\\-]+$");
   openvas_validator_add (validator, "severity", "^(-1(\\.0)?|[0-9](\\.[0-9])?|10(\\.0)?)$");
-  openvas_validator_add (validator, "severity_class", "^(classic|nist|bsi|pci\\-dss)$");
+  openvas_validator_add (validator, "severity_class", "^(nist|bsi|pci\\-dss)$");
   openvas_validator_add (validator, "severity_optional", "^(-1(\\.0)?|[0-9](\\.[0-9])?|10(\\.0)?)?$");
   openvas_validator_add (validator, "source_iface", "^(.*){1,16}$");
   openvas_validator_add (validator, "uuid",       "^[0-9abcdefABCDEF\\-]{1,40}$");

--- a/ng/src/web/pages/usersettings/usersettingspage.js
+++ b/ng/src/web/pages/usersettings/usersettingspage.js
@@ -52,7 +52,6 @@ import Languages, {BROWSER_LANGUAGE} from '../../utils/languages';
 import {
   SEVERITY_CLASS_NIST,
   SEVERITY_CLASS_BSI,
-  SEVERITY_CLASS_CLASSIC,
   SEVERITY_CLASS_PCI_DSS,
 } from '../../utils/severity';
 
@@ -66,7 +65,6 @@ const CA_CERT_ID = '9ac801ea-39f8-11e6-bbaa-28d24461215b';
 const SEVERITY_CLASSES = [
   {id: SEVERITY_CLASS_NIST, name: 'NVD Vulnerability Severity Ratings'},
   {id: SEVERITY_CLASS_BSI, name: 'BSI Schwachstellenampel (Germany)'},
-  {id: SEVERITY_CLASS_CLASSIC, name: 'OpenVAS Classic'},
   {id: SEVERITY_CLASS_PCI_DSS, name: 'PCI-DSS'},
 ];
 

--- a/ng/src/web/utils/proptypes.js
+++ b/ng/src/web/utils/proptypes.js
@@ -41,7 +41,6 @@ import Settings from 'gmp/models/settings.js';
 
 import {
   SEVERITY_CLASS_BSI,
-  SEVERITY_CLASS_CLASSIC,
   SEVERITY_CLASS_NIST,
   SEVERITY_CLASS_PCI_DSS,
 } from './severity';
@@ -173,7 +172,6 @@ const toString = mayRequire(toStringValidator);
 
 const severityClass = ReactPropTypes.objectOf([
   SEVERITY_CLASS_BSI,
-  SEVERITY_CLASS_CLASSIC,
   SEVERITY_CLASS_NIST,
   SEVERITY_CLASS_PCI_DSS,
 ]);

--- a/ng/src/web/utils/severity.js
+++ b/ng/src/web/utils/severity.js
@@ -115,7 +115,6 @@ export const translateRiskFactor = factor => TRANSLATED_RISK_FACTORS[factor];
 export const translatedResultSeverityRiskFactor = value =>
   translateRiskFactor(resultSeverityRiskFactor(value));
 
-export const SEVERITY_CLASS_CLASSIC = 'classic';
 export const SEVERITY_CLASS_PCI_DSS = 'pci-dss';
 export const SEVERITY_CLASS_NIST = 'nist';
 export const SEVERITY_CLASS_BSI = 'bsi';
@@ -137,11 +136,6 @@ export const SEVERITY_CLASS_BSI = 'bsi';
  *  - medium range from 3.0 to 6.5 including 3.0 and excluding 6.5 => [3.0, 6.5[
  *  - high range from 6.5 to 10 [6.5, 10]
  */
-const SEVERITY_LEVELS_CLASSIC = {
-  high: 5.1,
-  medium: 2.1,
-  low: 0.1,
-};
 
 /*
  The original version form xslt used
@@ -166,8 +160,6 @@ const SEVERITY_LEVELS_DEFAULT = {
 
 export const getSeverityLevels = type => {
   switch (type) {
-    case SEVERITY_CLASS_CLASSIC:
-      return SEVERITY_LEVELS_CLASSIC;
     case SEVERITY_CLASS_PCI_DSS:
       return SEVERITY_LEVELS_PCI_DSS;
     default:
@@ -176,17 +168,6 @@ export const getSeverityLevels = type => {
 };
 
 export const getSeverityLevelsOld = type => {
-  if (type === SEVERITY_CLASS_CLASSIC) {
-    return {
-      max_high: 10.0,
-      min_high: 5.1,
-      max_medium: 5.0,
-      min_medium: 2.1,
-      max_low: 2.0,
-      min_low: 0.1,
-      max_log: 0.0,
-    };
-  }
   if (type === SEVERITY_CLASS_PCI_DSS) {
     return {
       max_high: 10.0,


### PR DESCRIPTION
This severity class is no longer used provided by Manager.