### PR TITLE
Extended schedules

### DIFF
--- a/ng/CMakeLists.txt
+++ b/ng/CMakeLists.txt
@@ -237,6 +237,7 @@ set (NG_JS_SRC_FILES
      ${NG_SRC_DIR}/src/web/components/form/textarea.js
      ${NG_SRC_DIR}/src/web/components/form/textfield.js
      ${NG_SRC_DIR}/src/web/components/form/timezoneselect.js
+     ${NG_SRC_DIR}/src/web/components/form/togglebutton.js
      ${NG_SRC_DIR}/src/web/components/form/withChangeHandler.js
      ${NG_SRC_DIR}/src/web/components/form/withClickHandler.js
      ${NG_SRC_DIR}/src/web/components/form/withDownload.js

--- a/ng/CMakeLists.txt
+++ b/ng/CMakeLists.txt
@@ -669,6 +669,7 @@ set (NG_JS_SRC_FILES
      ${NG_SRC_DIR}/src/web/pages/schedules/row.js
      ${NG_SRC_DIR}/src/web/pages/schedules/render.js
      ${NG_SRC_DIR}/src/web/pages/schedules/table.js
+     ${NG_SRC_DIR}/src/web/pages/schedules/timeunitselect.js
      ${NG_SRC_DIR}/src/web/pages/secinfo/details.js
      ${NG_SRC_DIR}/src/web/pages/secinfo/filterdialog.js
      ${NG_SRC_DIR}/src/web/pages/secinfo/listpage.js

--- a/ng/CMakeLists.txt
+++ b/ng/CMakeLists.txt
@@ -670,6 +670,7 @@ set (NG_JS_SRC_FILES
      ${NG_SRC_DIR}/src/web/pages/schedules/render.js
      ${NG_SRC_DIR}/src/web/pages/schedules/table.js
      ${NG_SRC_DIR}/src/web/pages/schedules/timeunitselect.js
+     ${NG_SRC_DIR}/src/web/pages/schedules/weekdayselect.js
      ${NG_SRC_DIR}/src/web/pages/secinfo/details.js
      ${NG_SRC_DIR}/src/web/pages/secinfo/filterdialog.js
      ${NG_SRC_DIR}/src/web/pages/secinfo/listpage.js

--- a/ng/CMakeLists.txt
+++ b/ng/CMakeLists.txt
@@ -662,6 +662,7 @@ set (NG_JS_SRC_FILES
      ${NG_SRC_DIR}/src/web/pages/scans/page.js
      ${NG_SRC_DIR}/src/web/pages/scans/dashboard.js
      ${NG_SRC_DIR}/src/web/pages/schedules/component.js
+     ${NG_SRC_DIR}/src/web/pages/schedules/dayselect.js
      ${NG_SRC_DIR}/src/web/pages/schedules/details.js
      ${NG_SRC_DIR}/src/web/pages/schedules/detailspage.js
      ${NG_SRC_DIR}/src/web/pages/schedules/dialog.js

--- a/ng/CMakeLists.txt
+++ b/ng/CMakeLists.txt
@@ -667,6 +667,7 @@ set (NG_JS_SRC_FILES
      ${NG_SRC_DIR}/src/web/pages/schedules/detailspage.js
      ${NG_SRC_DIR}/src/web/pages/schedules/dialog.js
      ${NG_SRC_DIR}/src/web/pages/schedules/listpage.js
+     ${NG_SRC_DIR}/src/web/pages/schedules/monthdaysselect.js
      ${NG_SRC_DIR}/src/web/pages/schedules/row.js
      ${NG_SRC_DIR}/src/web/pages/schedules/render.js
      ${NG_SRC_DIR}/src/web/pages/schedules/table.js

--- a/ng/src/gmp/models/date.js
+++ b/ng/src/gmp/models/date.js
@@ -35,6 +35,7 @@ export const {
   isMoment: isDate,
   locale: setLocale,
   duration,
+  localeData: _localeData,
 } = moment;
 
 export default moment;

--- a/ng/src/gmp/models/event.js
+++ b/ng/src/gmp/models/event.js
@@ -308,6 +308,17 @@ class Event {
     return byday.length > 0 ? WeekDays.fromByDay(byday) : undefined;
   }
 
+  get monthdays() {
+    const {recurrence} = this;
+
+    if (!is_defined(recurrence)) {
+      return undefined;
+    }
+
+    const bymonthday = recurrence.getComponent('bymonthday');
+    return bymonthday.length > 0 ? bymonthday : undefined;
+  }
+
   get nextDate() {
     if (this.isRecurring()) {
       const now = ical.Time.now();

--- a/ng/src/gmp/models/event.js
+++ b/ng/src/gmp/models/event.js
@@ -21,6 +21,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 import 'core-js/fn/object/entries';
+import 'core-js/fn/object/values';
 
 import ical from 'ical.js';
 
@@ -111,13 +112,15 @@ export class WeekDays {
     saturday = false,
     sunday = false,
   } = {}) {
-    this.monday = monday;
-    this.tuesday = tuesday;
-    this.wednesday = wednesday;
-    this.thursday = thursday;
-    this.friday = friday;
-    this.saturday = saturday;
-    this.sunday = sunday;
+    this._weekdays = {
+      monday,
+      tuesday,
+      wednesday,
+      thursday,
+      friday,
+      saturday,
+      sunday,
+    };
   }
 
   static fromByDay(bydate = []) {
@@ -139,59 +142,33 @@ export class WeekDays {
   }
 
   _setWeekDay(weekday, value = true) {
-    this[weekday] = value;
+    this._weekdays[weekday] = value;
     return this;
   }
 
   isDefault() {
-    return this.monday === false && this.tuesday === false &&
-      this.wednesday === false && this.thursday === false &&
-      this.friday === false && this.saturday === false &&
-      this.sunday === false;
+    return this.values().some(value => !value);
   }
 
   copy() {
-    return new WeekDays({...this});
+    return new WeekDays({...this._weekdays});
   }
 
   entries() {
-    return [
-      ['monday', this.monday],
-      ['tuesday', this.tuesday],
-      ['wednesday', this.wednesday],
-      ['thursday', this.thursday],
-      ['friday', this.friday],
-      ['saturday', this.saturday],
-      ['sunday', this.sunday],
-    ];
+    return Object.entries(this._weekdays);
+  }
+
+  values() {
+    return Object.values(this._weekdays);
   }
 
   getSelectedWeekDay() {
-    if (this.monday) {
-      return 'monday';
-    }
-    if (this.tuesday) {
-      return 'tuesday';
-    }
-    if (this.wednesday) {
-      return 'wednesday';
-    }
-    if (this.thursday) {
-      return 'thursday';
-    }
-    if (this.friday) {
-      return 'friday';
-    }
-    if (this.saturday) {
-      return 'saturday';
-    }
-    if (this.sunday) {
-      return 'sunday';
-    }
+    const ret = this.entries().find(([, value]) => value);
+    return is_defined(ret) ? ret[0] : undefined;
   }
 
   get(weekday) {
-    return this[weekday];
+    return this._weekdays[weekday];
   }
 
   setWeekDay(weekday, value = true) {
@@ -208,7 +185,7 @@ export class WeekDays {
     const byday = [];
 
     for (const [abbr, weekday] of Object.entries(ABR_TO_WEEKDAY)) {
-      const value = this[weekday];
+      const value = this.get(weekday);
       if (value) {
         if (value === true) {
           byday.push(abbr.toUpperCase());
@@ -220,6 +197,34 @@ export class WeekDays {
     }
 
     return byday;
+  }
+
+  get monday() {
+    return this.get('monday');
+  }
+
+  get tuesday() {
+    return this.get('tuesday');
+  }
+
+  get wednesday() {
+    return this.get('wednesday');
+  }
+
+  get thursday() {
+    return this.get('thursday');
+  }
+
+  get friday() {
+    return this.get('friday');
+  }
+
+  get saturday() {
+    return this.get('saturday');
+  }
+
+  get sunday() {
+    return this.get('sunday');
   }
 }
 

--- a/ng/src/gmp/models/event.js
+++ b/ng/src/gmp/models/event.js
@@ -136,6 +136,34 @@ export class WeekDays {
     return new WeekDays({...this});
   }
 
+  getSelectedWeekDay() {
+    if (this.monday) {
+      return 'monday';
+    }
+    if (this.tuesday) {
+      return 'tuesday';
+    }
+    if (this.wednesday) {
+      return 'wednesday';
+    }
+    if (this.thursday) {
+      return 'thursday';
+    }
+    if (this.friday) {
+      return 'friday';
+    }
+    if (this.saturday) {
+      return 'saturday';
+    }
+    if (this.sunday) {
+      return 'sunday';
+    }
+  }
+
+  get(weekday) {
+    return this[weekday];
+  }
+
   setWeekDay(weekday, value = true) {
     const copy = this.copy();
     return copy._setWeekDay(weekday, value);

--- a/ng/src/gmp/models/event.js
+++ b/ng/src/gmp/models/event.js
@@ -241,7 +241,7 @@ class Event {
       eventRecur.freq = freq;
       eventRecur.interval = interval;
 
-      const icalweekdays = weekdays.toByDate();
+      const icalweekdays = is_defined(weekdays) ? weekdays.toByDate() : [];
 
       if (icalweekdays.length > 0) {
         eventRecur.setComponent('byday', icalweekdays);

--- a/ng/src/gmp/models/event.js
+++ b/ng/src/gmp/models/event.js
@@ -300,7 +300,7 @@ class Event {
     }
 
     const byday = recurrence.getComponent('byday');
-    return WeekDays.fromByDay(byday);
+    return byday.length > 0 ? WeekDays.fromByDay(byday) : undefined;
   }
 
   get nextDate() {

--- a/ng/src/gmp/models/event.js
+++ b/ng/src/gmp/models/event.js
@@ -154,6 +154,18 @@ export class WeekDays {
     return new WeekDays({...this});
   }
 
+  entries() {
+    return [
+      ['monday', this.monday],
+      ['tuesday', this.tuesday],
+      ['wednesday', this.wednesday],
+      ['thursday', this.thursday],
+      ['friday', this.friday],
+      ['saturday', this.saturday],
+      ['sunday', this.sunday],
+    ];
+  }
+
   getSelectedWeekDay() {
     if (this.monday) {
       return 'monday';

--- a/ng/src/gmp/models/event.js
+++ b/ng/src/gmp/models/event.js
@@ -52,10 +52,6 @@ const setEventRecurrence = (event, recurrence) => {
 const PROD_ID = '-//Greenbone.net//NONSGML Greenbone Security Assistent';
 const ICAL_VERSION = '2.0';
 
-const DAYS = 'day';
-const WEEKS = 'week';
-const MONTHS = 'month';
-
 export const ReccurenceFrequency = {
   YEARLY: 'YEARLY',
   MONTHLY: 'MONTHLY',
@@ -186,11 +182,12 @@ class Event {
 
   static fromData({
     description,
-    startDate,
     duration,
-    period = 0,
-    periodUnit,
+    freq,
+    interval,
+    startDate,
     summary,
+    weekdays,
   }, timezone) {
 
     const event = new ical.Event();
@@ -210,21 +207,17 @@ class Event {
       setEventDuration(event, eventDuration);
     }
 
-    if (period > 0) {
+    if (is_defined(freq)) {
       const eventRecur = new ical.Recur();
-      if (periodUnit === MONTHS) {
-        eventRecur.freq = ReccurenceFrequency.MONTHLY;
+
+      eventRecur.freq = freq;
+      eventRecur.interval = interval;
+
+      const icalweekdays = weekdays.toByDate();
+
+      if (icalweekdays.length > 0) {
+        eventRecur.setComponent('byday', icalweekdays);
       }
-      else if (periodUnit === WEEKS) {
-        eventRecur.freq = ReccurenceFrequency.WEEKLY;
-      }
-      else if (periodUnit === DAYS) {
-        eventRecur.freq = ReccurenceFrequency.WEEKLY;
-      }
-      else {
-        eventRecur.freq = ReccurenceFrequency.HOURLY;
-      }
-      eventRecur.interval = period;
 
       setEventRecurrence(event, eventRecur);
     }
@@ -232,6 +225,7 @@ class Event {
     if (!is_empty(summary)) {
       event.summary = summary;
     }
+
     if (!is_empty(description)) {
       event.description = description;
     }

--- a/ng/src/gmp/models/event.js
+++ b/ng/src/gmp/models/event.js
@@ -82,6 +82,24 @@ const ABR_TO_WEEKDAY = {
   su: 'sunday',
 };
 
+const getWeekDaysFromRRule = rrule => {
+    if (!is_defined(rrule)) {
+      return undefined;
+    }
+
+    const byday = rrule.getComponent('byday');
+    return byday.length > 0 ? WeekDays.fromByDay(byday) : undefined;
+};
+
+const getMonthDaysFromRRule = rrule => {
+  if (!is_defined(rrule)) {
+    return undefined;
+  }
+
+  const bymonthday = rrule.getComponent('bymonthday');
+  return bymonthday.length > 0 ? bymonthday.sort() : undefined;
+};
+
 export class WeekDays {
 
   constructor({
@@ -266,6 +284,14 @@ class Event {
     return new Event(event, timezone);
   }
 
+  _getReccurenceRule() {
+    if (this.isRecurring()) {
+      const rrule = this.event.component.getFirstPropertyValue('rrule');
+      return rrule === null ? undefined : rrule;
+    }
+    return undefined;
+  }
+
   get startDate() {
     return convertIcalDate(this.event.startDate, this.timezone);
   }
@@ -290,33 +316,13 @@ class Event {
   }
 
   get recurrence() {
-    if (this.isRecurring()) {
-      const rrule = this.event.component.getFirstPropertyValue('rrule');
-      return rrule === null ? undefined : rrule;
-    }
-    return undefined;
-  }
+    const rrule = this._getReccurenceRule();
 
-  get weekdays() {
-    const {recurrence} = this;
-
-    if (!is_defined(recurrence)) {
-      return undefined;
-    }
-
-    const byday = recurrence.getComponent('byday');
-    return byday.length > 0 ? WeekDays.fromByDay(byday) : undefined;
-  }
-
-  get monthdays() {
-    const {recurrence} = this;
-
-    if (!is_defined(recurrence)) {
-      return undefined;
-    }
-
-    const bymonthday = recurrence.getComponent('bymonthday');
-    return bymonthday.length > 0 ? bymonthday : undefined;
+    return {
+      ...rrule,
+      weekdays: getWeekDaysFromRRule(rrule),
+      monthdays: getMonthDaysFromRRule(rrule),
+    };
   }
 
   get nextDate() {

--- a/ng/src/gmp/models/event.js
+++ b/ng/src/gmp/models/event.js
@@ -20,6 +20,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+import 'core-js/fn/object/entries';
+
 import ical from 'ical.js';
 
 import uuid from 'uuid/v4';
@@ -63,6 +65,109 @@ export const ReccurenceFrequency = {
   MINUTELY: 'MINUTELY',
   SECONDLY: 'SECONDLY',
 };
+
+const ISOWEEKDAY_TO_WEEKDAY = {
+  1: 'monday',
+  2: 'tuesday',
+  3: 'wednesday',
+  4: 'thursday',
+  5: 'friday',
+  6: 'saturday',
+  7: 'sunday',
+};
+
+const ABR_TO_WEEKDAY = {
+  mo: 'monday',
+  tu: 'tuesday',
+  we: 'wednesday',
+  th: 'thursday',
+  fr: 'friday',
+  sa: 'saturday',
+  su: 'sunday',
+};
+
+export class WeekDays {
+
+  constructor({
+    monday = false,
+    tuesday = false,
+    wednesday = false,
+    thursday = false,
+    friday = false,
+    saturday = false,
+    sunday = false,
+  } = {}) {
+    this.monday = monday;
+    this.tuesday = tuesday;
+    this.wednesday = wednesday;
+    this.thursday = thursday;
+    this.friday = friday;
+    this.saturday = saturday;
+    this.sunday = sunday;
+  }
+
+  static fromByDay(bydate = []) {
+    const weekdays = new WeekDays();
+
+    for (const part of bydate) {
+      const pday = part.slice(-2).toLowerCase();
+      const pval = part.slice(0, -2);
+
+      const wday = ABR_TO_WEEKDAY[pday];
+      const val = pval.length === 0 ? true : pval;
+
+      if (is_defined(wday)) {
+        weekdays._setWeekDay(wday, val);
+      }
+    }
+
+    return weekdays;
+  }
+
+  _setWeekDay(weekday, value = true) {
+    this[weekday] = value;
+    return this;
+  }
+
+  isDefault() {
+    return this.monday === false && this.tuesday === false &&
+      this.wednesday === false && this.thursday === false &&
+      this.friday === false && this.saturday === false &&
+      this.sunday === false;
+  }
+
+  copy() {
+    return new WeekDays({...this});
+  }
+
+  setWeekDay(weekday, value = true) {
+    const copy = this.copy();
+    return copy._setWeekDay(weekday, value);
+  }
+
+  setWeekDayFromDate(curdate, value = true) {
+    const wday = ISOWEEKDAY_TO_WEEKDAY[curdate.isoWeekday()];
+    return this.setWeekDay(wday, value);
+  }
+
+  toByDate() {
+    const byday = [];
+
+    for (const [abbr, weekday] of Object.entries(ABR_TO_WEEKDAY)) {
+      const value = this[weekday];
+      if (value) {
+        if (value === true) {
+          byday.push(abbr.toUpperCase());
+        }
+        else {
+          byday.push('' + value + abbr.toUpperCase());
+        }
+      }
+    }
+
+    return byday;
+  }
+}
 
 class Event {
 

--- a/ng/src/gmp/models/event.js
+++ b/ng/src/gmp/models/event.js
@@ -213,6 +213,7 @@ class Event {
     duration,
     freq,
     interval,
+    monthdays = [],
     startDate,
     summary,
     weekdays,
@@ -245,6 +246,10 @@ class Event {
 
       if (icalweekdays.length > 0) {
         eventRecur.setComponent('byday', icalweekdays);
+      }
+
+      if (monthdays.length > 0) {
+        eventRecur.setComponent('bymonthday', monthdays);
       }
 
       setEventRecurrence(event, eventRecur);

--- a/ng/src/gmp/models/event.js
+++ b/ng/src/gmp/models/event.js
@@ -270,6 +270,17 @@ class Event {
     return undefined;
   }
 
+  get weekdays() {
+    const {recurrence} = this;
+
+    if (!is_defined(recurrence)) {
+      return undefined;
+    }
+
+    const byday = recurrence.getComponent('byday');
+    return WeekDays.fromByDay(byday);
+  }
+
   get nextDate() {
     if (this.isRecurring()) {
       const now = ical.Time.now();

--- a/ng/src/web/components/form/togglebutton.js
+++ b/ng/src/web/components/form/togglebutton.js
@@ -30,34 +30,55 @@ import PropTypes from 'web/utils/proptypes';
 import Theme from 'web/utils/theme';
 
 const Styled = glamorous.div({
-  borderRadius: '25%',
-  cursor: 'pointer',
+  borderRadius: '8px',
   padding: '5px',
-  width: '32px',
   userSelect: 'none',
-}, ({checked}) => ({
-  backgroundColor: checked ? Theme.lightGreen : Theme.lightGray,
-  color: checked ? Theme.white : Theme.black,
-}));
+}, ({
+  checked = false,
+  disabled = false,
+  width = '32px',
+}) => {
+  let color;
+  let backgroundColor;
+  if (disabled) {
+    backgroundColor = Theme.lightGray;
+    color = Theme.mediumGray;
+  }
+  else if (checked) {
+    backgroundColor = Theme.lightGreen;
+    color = Theme.white;
+  }
+  else {
+    backgroundColor = Theme.lightGray;
+    color = Theme.darkGray;
+  }
+  return {
+    backgroundColor,
+    color,
+    cursor: disabled ? 'default' : 'pointer',
+    width,
+  };
+});
 
 const ToggleButton = ({
   name,
   checked = false,
-  children,
-  title,
+  disabled,
   onToggle,
+  ...props
 }) => (
   <Styled
-    title={title}
+    {...props}
     checked={checked}
-    onClick={is_defined(onToggle) ? () => onToggle(!checked, name) : undefined}
-  >
-    {children}
-  </Styled>
+    disabled={disabled}
+    onClick={!disabled && is_defined(onToggle) ?
+      () => onToggle(!checked, name) : undefined}
+  />
 );
 
 ToggleButton.propTypes = {
   checked: PropTypes.bool,
+  disabled: PropTypes.bool,
   name: PropTypes.string,
   title: PropTypes.string,
   onToggle: PropTypes.func,

--- a/ng/src/web/components/form/togglebutton.js
+++ b/ng/src/web/components/form/togglebutton.js
@@ -1,0 +1,68 @@
+/* Greenbone Security Assistant
+ *
+ * Authors:
+ * Björn Ricks <bjoern.ricks@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2018 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import React from 'react';
+
+import glamorous from 'glamorous';
+
+import {is_defined} from 'gmp/utils/identity';
+
+import PropTypes from 'web/utils/proptypes';
+import Theme from 'web/utils/theme';
+
+const Styled = glamorous.div({
+  borderRadius: '25%',
+  cursor: 'pointer',
+  padding: '5px',
+  width: '32px',
+  userSelect: 'none',
+}, ({checked}) => ({
+  backgroundColor: checked ? Theme.lightGreen : Theme.lightGray,
+  color: checked ? Theme.white : Theme.black,
+}));
+
+const ToggleButton = ({
+  name,
+  checked = false,
+  children,
+  title,
+  onToggle,
+}) => (
+  <Styled
+    title={title}
+    checked={checked}
+    onClick={is_defined(onToggle) ? () => onToggle(!checked, name) : undefined}
+  >
+    {children}
+  </Styled>
+);
+
+ToggleButton.propTypes = {
+  checked: PropTypes.bool,
+  name: PropTypes.string,
+  title: PropTypes.string,
+  onToggle: PropTypes.func,
+};
+
+export default ToggleButton;
+
+// vim: set ts=2 sw=2 tw=80:

--- a/ng/src/web/pages/schedules/component.js
+++ b/ng/src/web/pages/schedules/component.js
@@ -58,11 +58,9 @@ class ScheduleComponent extends React.Component {
         recurrence = {},
         duration,
         durationInSeconds,
-        monthdays,
-        weekdays,
       } = event;
 
-      const {interval, freq} = recurrence;
+      const {interval, freq, monthdays, weekdays} = recurrence;
 
       this.setState({
         comment: schedule.comment,

--- a/ng/src/web/pages/schedules/component.js
+++ b/ng/src/web/pages/schedules/component.js
@@ -58,6 +58,7 @@ class ScheduleComponent extends React.Component {
         recurrence = {},
         duration,
         durationInSeconds,
+        monthdays,
         weekdays,
       } = event;
 
@@ -71,6 +72,7 @@ class ScheduleComponent extends React.Component {
         freq,
         id: schedule.id,
         interval,
+        monthdays,
         name: schedule.name,
         title: _('Edit Schedule {{name}}', {name: schedule.name}),
         timezone: schedule.timezone,
@@ -86,6 +88,7 @@ class ScheduleComponent extends React.Component {
         freq: undefined,
         id: undefined,
         interval: undefined,
+        monthdays: undefined,
         name: undefined,
         startDate: undefined,
         timezone,

--- a/ng/src/web/pages/schedules/component.js
+++ b/ng/src/web/pages/schedules/component.js
@@ -28,8 +28,6 @@ import _ from 'gmp/locale';
 
 import {is_defined} from 'gmp/utils';
 
-import {ReccurenceFrequency} from 'gmp/models/event';
-
 import PropTypes from '../../utils/proptypes.js';
 import withGmp from '../../utils/withGmp.js';
 
@@ -38,14 +36,6 @@ import Wrapper from '../../components/layout/wrapper.js';
 import EntityComponent from '../../entity/component.js';
 
 import ScheduleDialog from './dialog.js';
-
-const PERIOD_UNIT = {
-  [ReccurenceFrequency.MINUTELY]: 'minute',
-  [ReccurenceFrequency.HOURLY]: 'hour',
-  [ReccurenceFrequency.DAILY]: 'day',
-  [ReccurenceFrequency.WEEKLY]: 'week',
-  [ReccurenceFrequency.MONTHLY]: 'month',
-};
 
 class ScheduleComponent extends React.Component {
 
@@ -63,20 +53,28 @@ class ScheduleComponent extends React.Component {
 
     if (is_defined(schedule)) {
       const {event} = schedule;
-      const {startDate, recurrence = {}, duration, durationInSeconds} = event;
-      const {freq, interval = 1} = recurrence;
+      const {
+        startDate,
+        recurrence = {},
+        duration,
+        durationInSeconds,
+        weekdays,
+      } = event;
+
+      const {interval, freq} = recurrence;
 
       this.setState({
         comment: schedule.comment,
         startDate,
         dialogVisible: true,
         duration: durationInSeconds > 0 ? duration : undefined,
+        freq,
         id: schedule.id,
+        interval,
         name: schedule.name,
-        period: is_defined(freq) ? interval : undefined,
-        period_unit: is_defined(freq) ? PERIOD_UNIT[freq] : 'hour',
         title: _('Edit Schedule {{name}}', {name: schedule.name}),
         timezone: schedule.timezone,
+        weekdays,
       });
     }
     else {
@@ -85,14 +83,14 @@ class ScheduleComponent extends React.Component {
         comment: undefined,
         dialogVisible: true,
         duration: undefined,
-        duration_unit: undefined,
+        freq: undefined,
         id: undefined,
+        interval: undefined,
         name: undefined,
-        period: undefined,
-        period_unit: undefined,
         startDate: undefined,
         timezone,
         title: undefined,
+        weekdays: undefined,
       });
     }
   }
@@ -117,16 +115,8 @@ class ScheduleComponent extends React.Component {
     } = this.props;
 
     const {
-      comment,
-      startDate,
       dialogVisible,
-      duration,
-      id,
-      name,
-      period,
-      period_unit,
-      timezone,
-      title,
+      ...dialogProps
     } = this.state;
 
     return (
@@ -155,15 +145,7 @@ class ScheduleComponent extends React.Component {
             })}
             {dialogVisible &&
               <ScheduleDialog
-                comment={comment}
-                startDate={startDate}
-                duration={duration}
-                id={id}
-                name={name}
-                period={period}
-                period_unit={period_unit}
-                timezone={timezone}
-                title={title}
+                {...dialogProps}
                 onClose={this.closeScheduleDialog}
                 onSave={save}
               />

--- a/ng/src/web/pages/schedules/dayselect.js
+++ b/ng/src/web/pages/schedules/dayselect.js
@@ -1,0 +1,79 @@
+/* Greenbone Security Assistant
+ *
+ * Authors:
+ * Björn Ricks <bjoern.ricks@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2018 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import React from 'react';
+
+import _ from 'gmp/locale';
+
+import PropTyes from 'web/utils/proptypes';
+
+import Select from 'web/components/form/select';
+
+const DAY_SELECT_ITEMS = [{
+  label: _('Monday'),
+  value: 'monday',
+}, {
+  label: _('Tuesday'),
+  value: 'tuesday',
+}, {
+  label: _('Wednesday'),
+  value: 'wednesday',
+}, {
+  label: _('Thursday'),
+  value: 'thursday',
+}, {
+  label: _('Friday'),
+  value: 'friday',
+}, {
+  label: _('Saturday'),
+  value: 'saturday',
+}, {
+  label: _('Sunday'),
+  value: 'sunday',
+}];
+
+const DaySelect = ({
+  value,
+  ...props
+}) => (
+  <Select
+    {...props}
+    value={value}
+    items={DAY_SELECT_ITEMS}
+  />
+);
+
+DaySelect.propTypes = {
+  value: PropTyes.oneOf([
+    'monday',
+    'tuesday',
+    'wednesday',
+    'thursday',
+    'friday',
+    'saturday',
+    'sunday',
+  ]),
+};
+
+export default DaySelect;
+
+// vim: set ts=2 sw=2 tw=80:

--- a/ng/src/web/pages/schedules/details.js
+++ b/ng/src/web/pages/schedules/details.js
@@ -107,7 +107,7 @@ const ScheduleDetails = ({
 
           <TableRow>
             <TableData>
-              {_('Period')}
+              {_('Recurrence')}
             </TableData>
             <TableData>
               {renderRecurrence(recurrence)}

--- a/ng/src/web/pages/schedules/dialog.js
+++ b/ng/src/web/pages/schedules/dialog.js
@@ -476,7 +476,7 @@ ScheduleDialog.propTypes = {
     ReccurenceFrequency.HOURLY,
     ReccurenceFrequency.DAILY,
     ReccurenceFrequency.WEEKLY,
-    ReccurenceFrequency.MINUTELY,
+    ReccurenceFrequency.MONTHLY,
     ReccurenceFrequency.YEARLY,
   ]),
   id: PropTypes.string,

--- a/ng/src/web/pages/schedules/dialog.js
+++ b/ng/src/web/pages/schedules/dialog.js
@@ -232,6 +232,12 @@ class ScheduleDialog extends React.Component {
         .seconds(0)
         .hours(endHour)
         .minutes(endMinute);
+
+      if (endDate.isSameOrBefore(startDate)) {
+        return Promise.reject(new Error(_(
+          'End date is same or before start date. Please adjust you start ' +
+          'and/or end date.')));
+      }
     }
 
     if (recurrenceType === RECURRENCE_WORKWEEK) {

--- a/ng/src/web/pages/schedules/dialog.js
+++ b/ng/src/web/pages/schedules/dialog.js
@@ -30,24 +30,24 @@ import {is_defined} from 'gmp/utils/identity';
 import date, {duration as createDuration} from 'gmp/models/date';
 import Event, {ReccurenceFrequency, WeekDays} from 'gmp/models/event';
 
-import PropTypes from '../../utils/proptypes.js';
+import PropTypes from 'web/utils/proptypes';
 
-import SaveDialog from '../../components/dialog/savedialog.js';
+import SaveDialog from 'web/components/dialog/savedialog';
 
-import Select from '../../components/form/select.js';
-import Spinner from '../../components/form/spinner.js';
-import FormGroup from '../../components/form/formgroup.js';
-import TextField from '../../components/form/textfield.js';
-import DatePicker from '../../components/form/datepicker.js';
-import TimeZoneSelect from '../../components/form/timezoneselect.js';
-import CheckBox from '../../components/form/checkbox.js';
+import Select from 'web/components/form/select';
+import Spinner from 'web/components/form/spinner';
+import FormGroup from 'web/components/form/formgroup';
+import TextField from 'web/components/form/textfield';
+import DatePicker from 'web/components/form/datepicker';
+import TimeZoneSelect from 'web/components/form/timezoneselect';
+import CheckBox from 'web/components/form/checkbox';
 
-import Divider from '../../components/layout/divider.js';
-import Layout from '../../components/layout/layout.js';
+import Divider from 'web/components/layout/divider';
+import Layout from 'web/components/layout/layout';
 
 import TimeUnitSelect from './timeunitselect';
 import WeekDaySelect, {WeekDaysPropType} from './weekdayselect';
-import {renderDuration} from './render.js';
+import {renderDuration} from './render';
 
 const RECURRENCE_ONCE = 'once';
 const RECURRENCE_HOURLY = ReccurenceFrequency.HOURLY;

--- a/ng/src/web/pages/schedules/dialog.js
+++ b/ng/src/web/pages/schedules/dialog.js
@@ -47,31 +47,7 @@ import CheckBox from '../../components/form/checkbox.js';
 import Divider from '../../components/layout/divider.js';
 import Layout from '../../components/layout/layout.js';
 
-const TimeUnitSelect = ({
-  month = false,
-  ...props
- }) => {
-  const unitOptions = [
-    {value: 'hour', label: _('hour(s)')},
-    {value: 'day', label: _('day(s)')},
-    {value: 'week', label: _('week(s)')},
-  ];
-
-  if (month) {
-    unitOptions.push({value: 'month', label: _('month(s)')});
-  }
-
-  return (
-    <Select
-      {...props}
-      items={unitOptions}
-    />
-  );
-};
-
-TimeUnitSelect.propTypes = {
-  month: PropTypes.bool,
-};
+import TimeUnitSelect from './timeunitselect';
 
 class ScheduleDialog extends React.Component {
 

--- a/ng/src/web/pages/schedules/monthdaysselect.js
+++ b/ng/src/web/pages/schedules/monthdaysselect.js
@@ -1,0 +1,152 @@
+/* Greenbone Security Assistant
+ *
+ * Authors:
+ * Björn Ricks <bjoern.ricks@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2018 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import 'core-js/fn/array/includes';
+
+import React from 'react';
+
+import _ from 'gmp/locale';
+
+import {is_defined} from 'gmp/utils/identity';
+
+import {parse_int} from 'gmp/parser';
+
+import Divider from 'web/components/layout/divider';
+
+import ToggleButton from 'web/components/form/togglebutton';
+
+import PropTypes from 'web/utils/proptypes';
+
+const RANGE = [1, 2, 3, 4, 5, 6, 7];
+const ROWS = [0, 1, 2, 3];
+
+class MonthDaysSelect extends React.Component {
+
+  constructor(...args) {
+    super(...args);
+
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(val, valname) {
+    const {onChange, value = [], name} = this.props;
+
+    if (!is_defined(onChange)) {
+      return;
+    }
+
+    const day = parse_int(valname);
+
+    let newValue;
+    if (val && !value.includes(day)) {
+      newValue = [
+        ...value,
+        day,
+      ];
+    }
+    else if (!val && value.includes(day)) {
+      newValue = value.filter(v => v !== day);
+    }
+    else {
+      newValue = value;
+    }
+
+    if (newValue.length > 0) { // at least one day must be still selected
+      onChange(newValue, name);
+    }
+  }
+
+  render() {
+    const {
+      value = [],
+      disabled,
+    } = this.props;
+    return (
+      <Divider flex="column">
+        {ROWS.map(j => (
+          <Divider key={j}>
+            {RANGE.map(i => {
+              const k = j * 7 + i;
+              return (
+                <ToggleButton
+                  name={'' + k}
+                  key={k}
+                  checked={value.includes(k)}
+                  disabled={disabled}
+                  onToggle={this.handleChange}
+                >
+                  {k}
+                </ToggleButton>
+              );
+            })}
+          </Divider>
+        ))}
+        <Divider>
+          <ToggleButton
+            name="29"
+            checked={value.includes(29)}
+            disabled={disabled}
+            onToggle={this.handleChange}
+          >
+            29
+          </ToggleButton>
+          <ToggleButton
+            name="30"
+            checked={value.includes(30)}
+            disabled={disabled}
+            onToggle={this.handleChange}
+          >
+            30
+          </ToggleButton>
+          <ToggleButton
+            name="31"
+            checked={value.includes(31)}
+            disabled={disabled}
+            onToggle={this.handleChange}
+          >
+            31
+          </ToggleButton>
+          <ToggleButton
+            name="-1"
+            checked={value.includes(-1)}
+            disabled={disabled}
+            width="64px"
+            onToggle={this.handleChange}
+          >
+            {_('Last Day')}
+          </ToggleButton>
+        </Divider>
+      </Divider>
+    );
+  }
+}
+
+MonthDaysSelect.propTypes = {
+  disabled: PropTypes.bool,
+  name: PropTypes.string,
+  value: PropTypes.arrayOf(PropTypes.number).isRequired,
+  onChange: PropTypes.func,
+};
+
+export default MonthDaysSelect;
+
+// vim: set ts=2 sw=2 tw=80:

--- a/ng/src/web/pages/schedules/render.js
+++ b/ng/src/web/pages/schedules/render.js
@@ -24,45 +24,101 @@ import _ from 'gmp/locale';
 
 import {is_defined} from 'gmp/utils/identity';
 
+import {_localeData} from 'gmp/models/date';
 import {ReccurenceFrequency} from 'gmp/models/event';
 
-export const renderRecurrence = ({freq, interval = 1} = {}) => {
+const WEEKDAY = {
+  monday: _('Monday'),
+  tuesday: _('Tuesday'),
+  wednesday: _('Wednesday'),
+  thursday: _('Thursday'),
+  friday: _('Friday'),
+  saturday: _('Saturday'),
+  sunday: _('Sunday'),
+};
+
+export const renderRecurrence = ({
+  freq,
+  interval = 1,
+  weekdays,
+  monthdays,
+} = {}) => {
   switch (freq) {
     case ReccurenceFrequency.YEARLY:
       if (interval === 1) {
-        return _('One year');
+        return _('Every year');
       }
-      return _('{{interval}} years', {interval});
+      return _('Every {{interval}} years', {interval});
+
     case ReccurenceFrequency.MONTHLY:
-      if (interval === 1) {
-        return _('One month');
+      if (is_defined(monthdays)) {
+        if (interval === 1) {
+          return _('Every month at days {{days}}',
+            {days: monthdays.join(', ')});
+        }
+        return _('Every {{interval}} month at days {{days}}',
+          {interval, days: monthdays.join(', ')});
       }
-      return _('{{interval}} months', {interval});
+      else if (is_defined(weekdays)) {
+        const weekday = weekdays.getSelectedWeekDay();
+        const nth = weekdays.get(weekday);
+        const localeData = _localeData();
+        if (interval === 1) {
+          return _('{{nth}} {{weekday}} every month',
+            {nth: localeData.ordinal(nth), weekday: WEEKDAY[weekday]});
+        }
+        return _('{{nth}} {{weekday}} every {{interval}} month', {
+          nth: localeData.ordinal(nth),
+          weekday: WEEKDAY[weekday],
+          interval,
+        });
+      }
+      else if (interval === 1) {
+        return _('Every month');
+      }
+      return _('Every {{interval}} months', {interval});
+
     case ReccurenceFrequency.WEEKLY:
-      if (interval === 1) {
-        return _('One week');
+      if (is_defined(weekdays)) {
+        const days = weekdays.entries()
+          .filter(([, value]) => value)
+          .map(([day]) => WEEKDAY[day]);
+
+        if (interval === 1) {
+          return _('Every week on {{days}}', {days: days.join(', ')});
+        }
+        return _('Every {{interval}} weeks on {{days}}',
+          {interval, days: days.join(', ')});
       }
-      return _('{{interval}} weeks', {interval});
+      if (interval === 1) {
+        return _('Every week');
+      }
+      return _('Every {{interval}} weeks', {interval});
+
     case ReccurenceFrequency.DAILY:
       if (interval === 1) {
-        return _('One day');
+        return _('Every day');
       }
-      return _('{{interval}} days', {interval});
+      return _('Every {{interval}} days', {interval});
+
     case ReccurenceFrequency.HOURLY:
       if (interval === 1) {
-        return _('One hour');
+        return _('Every hour');
       }
-      return _('{{interval}} hours', {interval});
+      return _('Every {{interval}} hours', {interval});
+
     case ReccurenceFrequency.MINUTELY:
       if (interval === 1) {
-        return _('One minute');
+        return _('Every minute');
       }
-      return _('{{interval}} minutes', {interval});
+      return _('Every {{interval}} minutes', {interval});
+
     case ReccurenceFrequency.SECONDLY:
       if (interval === 1) {
-        return _('One second');
+        return _('Every second');
       }
-      return _('{{interval}} seconds', {interval});
+      return _('Every {{interval}} seconds', {interval});
+
     default:
       return _('Once');
   }

--- a/ng/src/web/pages/schedules/table.js
+++ b/ng/src/web/pages/schedules/table.js
@@ -34,7 +34,7 @@ export const SORT_FIELDS = [
   ['name', _('Name'), '30%'],
   ['first_run', _('First Run'), '20%'],
   ['next_run', _('Next Run'), '20%'],
-  ['period', _('Period'), '11%'],
+  ['period', _('Recurrence'), '11%'],
   ['duration', _('Duration'), '11%'],
 ];
 

--- a/ng/src/web/pages/schedules/timeunitselect.js
+++ b/ng/src/web/pages/schedules/timeunitselect.js
@@ -1,0 +1,49 @@
+/* Greenbone Security Assistant
+ *
+ * Authors:
+ * Björn Ricks <bjoern.ricks@greenbone.net>
+ * Steffen Waterkamp <steffen.waterkamp@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2016 - 2018 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import React from 'react';
+
+import _ from 'gmp/locale';
+
+import {ReccurenceFrequency} from 'gmp/models/event';
+
+import Select from 'web/components/form/select.js';
+
+const TIME_UNIT_ITEMS = [
+  {value: ReccurenceFrequency.HOURLY, label: _('hour(s)')},
+  {value: ReccurenceFrequency.DAILY, label: _('day(s)')},
+  {value: ReccurenceFrequency.WEEKLY, label: _('week(s)')},
+  {value: ReccurenceFrequency.MONTHLY, label: _('month(s)')},
+  {value: ReccurenceFrequency.YEARLY, label: _('years(s)')},
+];
+
+const TimeUnitSelect = props => (
+  <Select
+    {...props}
+    items={TIME_UNIT_ITEMS}
+  />
+);
+
+export default TimeUnitSelect;
+
+// vim: set ts=2 sw=2 tw=80:

--- a/ng/src/web/pages/schedules/weekdayselect.js
+++ b/ng/src/web/pages/schedules/weekdayselect.js
@@ -1,0 +1,139 @@
+/* Greenbone Security Assistant
+ *
+ * Authors:
+ * Björn Ricks <bjoern.ricks@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2018 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import 'core-js/fn/array/some';
+import 'core-js/fn/object/values';
+
+import React from 'react';
+
+import _ from 'gmp/locale';
+
+import {is_defined} from 'gmp/utils/identity';
+
+import {WeekDays} from 'gmp/models/event';
+
+import Divider from 'web/components/layout/divider';
+
+import ToggleButton from 'web/components/form/togglebutton';
+
+import PropTypes from 'web/utils/proptypes';
+
+export const WeekDaysPropType = PropTypes.instanceOf(WeekDays);
+
+class WeekDaySelect extends React.Component {
+
+  constructor(...args) {
+    super(...args);
+
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(val, valname) {
+    const {onChange, value, name} = this.props;
+
+    if (!is_defined(onChange)) {
+      return;
+    }
+
+    const newValue = value.setWeekDay(valname, val);
+
+    if (!newValue.isDefault()) { // at least one day must be still selected
+      onChange(newValue, name);
+    }
+  }
+
+  render() {
+    const {
+      value,
+    } = this.props;
+    return (
+      <Divider>
+        <ToggleButton
+          name="monday"
+          title={_('Monday')}
+          checked={value.monday}
+          onToggle={this.handleChange}
+        >
+          {_('Mo.')}
+        </ToggleButton>
+        <ToggleButton
+          name="tuesday"
+          title={_('Tuesday')}
+          checked={value.tuesday}
+          onToggle={this.handleChange}
+        >
+          {_('Tu.')}
+        </ToggleButton>
+        <ToggleButton
+          name="wednesday"
+          title={_('Wednesday')}
+          checked={value.wednesday}
+          onToggle={this.handleChange}
+        >
+          {_('We.')}
+        </ToggleButton>
+        <ToggleButton
+          name="thursday"
+          title={_('Thursday')}
+          checked={value.thursday}
+          onToggle={this.handleChange}
+        >
+          {_('Th.')}
+        </ToggleButton>
+        <ToggleButton
+          name="friday"
+          title={_('Friday')}
+          checked={value.friday}
+          onToggle={this.handleChange}
+        >
+          {_('Fr.')}
+        </ToggleButton>
+        <ToggleButton
+          name="saturday"
+          title={_('Saturday')}
+          checked={value.saturday}
+          onToggle={this.handleChange}
+        >
+          {_('Sa.')}
+        </ToggleButton>
+        <ToggleButton
+          name="sunday"
+          title={_('Sunday')}
+          checked={value.sunday}
+          onToggle={this.handleChange}
+        >
+          {_('Su.')}
+        </ToggleButton>
+      </Divider>
+    );
+  }
+}
+
+WeekDaySelect.propTypes = {
+  name: PropTypes.string,
+  value: WeekDaysPropType,
+  onChange: PropTypes.func,
+};
+
+export default WeekDaySelect;
+
+// vim: set ts=2 sw=2 tw=80:


### PR DESCRIPTION
Part 5
* Parse ical rrule bydate as weekdays
* Use rrule weekdays, interval and freq for modifying and creating Schedules
* Update the ScheduleDialog to support more ical recurrence options

**UPDATE**

Part 6
* Parse ical rrule bymonthday as monthdays
* Update ScheduleDialog to support more options for custom weekly recurrence
* Don't allow to save a Schedule with end date before or same as start date

**UPDATE2**

Part 7
* Update renderRecurrence to reflect weekdays and monthdays of rrules
* Update schedule list and details page to use term Recurrence instead of Period

The extended schedules feature should be complete now.