### PR TITLE
Revert update of fast-deep-equal dependency

### DIFF
--- a/gsa/package.json
+++ b/gsa/package.json
@@ -35,7 +35,7 @@
     "d3-scale": "^2.1.0",
     "d3-shape": "^1.2.0",
     "downshift": "^1.31.6",
-    "fast-deep-equal": "^2.0.1",
+    "fast-deep-equal": "^1.1.0",
     "glamor": "^2.20.40",
     "glamorous": "^4.13.1",
     "hoist-non-react-statics": "^2.5.5",

--- a/gsa/yarn.lock
+++ b/gsa/yarn.lock
@@ -3558,9 +3558,9 @@ fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
 
-fast-deep-equal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+fast-deep-equal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The 2.0.0 version breaks our comparison for the chart data. It seems to
compare something recursively which causes a js stack error.