### PR TITLE
Fix rendering charts

### DIFF
--- a/gsa/package.json
+++ b/gsa/package.json
@@ -46,10 +46,10 @@
     "moment": "^2.22.2",
     "moment-timezone": "^0.5.21",
     "prop-types": "^15.6.2",
-    "react": "^16.4.1",
+    "react": "^16.3.1",
     "react-beautiful-dnd": "^7.1.3",
     "react-datepicker": "^1.4.1",
-    "react-dom": "^16.4.1",
+    "react-dom": "^16.3.1",
     "react-redux": "^5.0.7",
     "react-router": "^3.2.1",
     "react-scripts": "^1.1.4",
@@ -75,7 +75,7 @@
     "@storybook/react": "^3.4.8",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
-    "react-test-renderer": "^16.4.1"
+    "react-test-renderer": "^16.3.1"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/gsa/src/web/components/chart/wordcloud.js
+++ b/gsa/src/web/components/chart/wordcloud.js
@@ -51,6 +51,12 @@ class WordCloudChart extends React.Component {
     super(...args);
 
     this.state = {};
+
+    this.cloud = d3cloud()
+      .fontSize(d => d.size)
+      .rotate(0)
+      .padding(2)
+      .font('Sans');
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -116,12 +122,9 @@ class WordCloudChart extends React.Component {
     const maxWidth = width - margin.left - margin.right;
     const maxHeight = height - margin.top - margin.bottom;
 
-    d3cloud()
+    this.cloud.stop();
+    this.cloud
       .size([maxWidth, maxHeight])
-      .fontSize(d => d.size)
-      .rotate(0)
-      .padding(2)
-      .font('Sans')
       .words(origWords)
       .on('end', words => this.setState({words}))
       .start();

--- a/gsa/yarn.lock
+++ b/gsa/yarn.lock
@@ -6930,9 +6930,9 @@ react-docgen@^3.0.0-beta11:
     node-dir "^0.1.10"
     recast "^0.12.6"
 
-react-dom@^16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
+react-dom@16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.1.tgz#6a3c90a4fb62f915bdbcf6204422d93a7d4ca573"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -6981,7 +6981,7 @@ react-inspector@^2.2.2:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
-react-is@^16.4.1:
+react-is@^16.3.1:
   version "16.4.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.4.1.tgz#d624c4650d2c65dbd52c72622bbf389435d9776e"
 
@@ -7103,6 +7103,15 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
+react-test-renderer@16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.1.tgz#d9257936d8535bd40f57f3d5a84e7b0452fb17f2"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.3.1"
+
 react-test-renderer@^16.0.0-0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
@@ -7110,15 +7119,6 @@ react-test-renderer@^16.0.0-0:
     fbjs "^0.8.16"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
-
-react-test-renderer@^16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.4.1.tgz#f2fb30c2c7b517db6e5b10ed20bb6b0a7ccd8d70"
-  dependencies:
-    fbjs "^0.8.16"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-    react-is "^16.4.1"
 
 react-transition-group@^1.1.2:
   version "1.2.1"
@@ -7141,9 +7141,9 @@ react-treebeard@^2.1.0:
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-react@^16.4.1:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
+react@16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.3.1.tgz#4a2da433d471251c69b6033ada30e2ed1202cfd8"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
Temporarily downgrade to react 16.3. to fix rendering issues caused by https://reactjs.org/blog/2018/05/23/react-v-16-4.html#bugfix-for-getderivedstatefromprops