### PR TITLE
added systemd units

### DIFF
--- a/systemd/gsad.default
+++ b/systemd/gsad.default
@@ -1,0 +1,35 @@
+OPTIONS=""
+
+#
+# The address the Greenbone Security Assistant will listen on.
+#
+
+GSA_ADDRESS=127.0.0.1
+
+#
+# The port the Greenbone Security Assistant will listen on.
+#
+
+GSA_PORT=9392
+R_PORT=80 # redirect from port
+
+# NOT USED BY DEFAULT IN OpenVAS 9
+#
+# The address the OpenVAS Manager is listening on.
+#
+
+#MANAGER_ADDRESS=127.0.0.1
+
+#
+# The port the OpenVAS Manager is listening on.
+#
+
+#MANAGER_PORT=9390
+
+## Determines ciphers that GSAD will use with TLS and their order.
+# Work around with gnutls prorities not working
+GNUTLS_PRIORITIES="NORMAL"
+
+# This is the new standard. DOES NOT WORK BECASUE OF BUG
+#GNUTLS_PRIORITIES="NONE:+SECURE256:+SECURE192:+SUITEB192:+VERS-TLS1.2"
+

--- a/systemd/gsad.logrotate
+++ b/systemd/gsad.logrotate
@@ -1,0 +1,9 @@
+/var/log/openvas/gsad.log {
+	daily
+	rotate 7
+	compress
+	missingok
+	notifempty
+	sharedscripts
+}
+

--- a/systemd/gsad.service
+++ b/systemd/gsad.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=OpenVAS Manager
+After=network.target
+After=openvas-scanner.service
+After=openvas-manager.service
+
+[Service]
+Type=forking
+EnvironmentFile=-/etc/sysconfig/gsad
+#ExecStart=/usr/sbin/gsad --listen $GSA_ADDRESS --port $GSA_PORT --mlisten $MANAGER_ADDRESS --mport $MANAGER_PORT --gnutls-priorities $GNUTLS_PRIORITIES $OPTIONS
+ExecStart=/usr/sbin/gsad --listen $GSA_ADDRESS --port $GSA_PORT --rport $R_PORT --gnutls-priorities $GNUTLS_PRIORITIES $OPTIONS
+Restart=always
+RestartSec=1
+User=root
+Group=root
+TimeoutSec=1200
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
Systemd UNIX for gsad.

gsad.default gets moved to /etc/default/gsad

gsad.logrotate goes to /etc/logrotate.d/gsad

systemd service is self explanatory.