### PR TITLE
Improve loading of dashboard charts

### DIFF
--- a/gsa/src/web/components/dashboard/dashboard.js
+++ b/gsa/src/web/components/dashboard/dashboard.js
@@ -214,9 +214,19 @@ export class Dashboard extends React.Component {
 const mapStateToProps = (rootState, {id}) => {
   const settingsSelector = DashboardSettings(rootState);
   const settings = settingsSelector.getById(id);
+  const hasLoaded = settingsSelector.hasSettings(id);
+  const defaults = settingsSelector.getDefaultsById(id);
+
+  let items;
+  if (hasLoaded && is_defined(settings.rows)) {
+    items = settings.rows;
+  }
+  else if (hasLoaded) {
+    items = defaults.rows;
+  }
   return {
-    isLoading: settingsSelector.getIsLoading(),
-    items: has_value(settings) ? settings.rows : undefined,
+    isLoading: settingsSelector.getIsLoading() || !hasLoaded,
+    items,
   };
 };
 

--- a/gsa/src/web/components/dashboard/dashboard.js
+++ b/gsa/src/web/components/dashboard/dashboard.js
@@ -125,8 +125,15 @@ export class Dashboard extends React.Component {
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    return prevState.items === nextProps.items ?
-      null : {items: nextProps.items};
+    // try to synchronize external and internal state
+    // update state items only if prop items have changed or
+    // prop items are different then already set items
+    return prevState.propItems === nextProps.items ||
+      prevState.propItems === nextProps.items ?
+      null : {
+        items: nextProps.items,
+        propItems: nextProps.items,
+      };
   }
 
   componentDidMount() {

--- a/gsa/src/web/components/dashboard/dashboard.js
+++ b/gsa/src/web/components/dashboard/dashboard.js
@@ -26,6 +26,8 @@ import React from 'react';
 
 import {connect} from 'react-redux';
 
+import glamorous from 'glamorous';
+
 import Logger from 'gmp/log';
 
 import {is_defined, has_value} from 'gmp/utils/identity';
@@ -38,7 +40,14 @@ import {
 } from 'web/store/dashboard/settings/actions';
 import DashboardSettings from 'web/store/dashboard/settings/selectors';
 
-import Grid, {createRow, createItem, itemsPropType} from '../sortable/grid.js';
+import Loading from 'web/components/loading/loading';
+
+import Grid, {
+  createRow,
+  createItem,
+  itemsPropType,
+  DEFAULT_ROW_HEIGHT,
+} from 'web/components/sortable/grid';
 
 import PropTypes from '../../utils/proptypes';
 import withGmp from '../../utils/withGmp';
@@ -55,6 +64,7 @@ const ownPropNames = [
   'defaultContent',
   'gmp',
   'id',
+  'isLoading',
   'items',
   'loadSettings',
   'maxItemsPerRow',
@@ -62,6 +72,12 @@ const ownPropNames = [
   'permittedDisplays',
   'saveSettings',
 ];
+
+const RowPlaceHolder = glamorous.div({
+  display: 'flex',
+  grow: 1,
+  height: DEFAULT_ROW_HEIGHT,
+});
 
 const convertDefaultContent = defaultContent =>
   defaultContent.map(row => createRow(
@@ -73,6 +89,7 @@ export class Dashboard extends React.Component {
     defaultContent: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
     filter: PropTypes.filter,
     id: PropTypes.id.isRequired,
+    isLoading: PropTypes.bool.isRequired,
     items: itemsPropType,
     loadSettings: PropTypes.func.isRequired,
     maxItemsPerRow: PropTypes.number,
@@ -150,8 +167,13 @@ export class Dashboard extends React.Component {
     const {
       maxItemsPerRow = DEFAULT_MAX_ITEMS_PER_ROW,
       maxRows = DEFAULT_MAX_ROWS,
+      isLoading,
       ...props
     } = this.props;
+
+    if (!is_defined(items) && isLoading) {
+      return <RowPlaceHolder><Loading/></RowPlaceHolder>;
+    }
 
     const other = exclude_object_props(props, ownPropNames);
     return (

--- a/gsa/src/web/components/dashboard/dashboard.js
+++ b/gsa/src/web/components/dashboard/dashboard.js
@@ -30,7 +30,7 @@ import glamorous from 'glamorous';
 
 import Logger from 'gmp/log';
 
-import {is_defined, has_value} from 'gmp/utils/identity';
+import {is_defined} from 'gmp/utils/identity';
 import {debounce} from 'gmp/utils/event';
 import {exclude_object_props} from 'gmp/utils/object';
 
@@ -99,8 +99,8 @@ export class Dashboard extends React.Component {
     onFilterChanged: PropTypes.func,
   }
 
-  constructor(props) {
-    super(props);
+  constructor(...args) {
+    super(...args);
 
     const {permittedDisplays = []} = this.props;
 
@@ -185,7 +185,7 @@ export class Dashboard extends React.Component {
     const other = exclude_object_props(props, ownPropNames);
     return (
       <Grid
-        items={has_value(items) ? items : []}
+        items={is_defined(items) ? items : []}
         maxItemsPerRow={maxItemsPerRow}
         maxRows={maxRows}
         onChange={this.handleItemsChange}

--- a/gsa/src/web/components/sortable/grid.js
+++ b/gsa/src/web/components/sortable/grid.js
@@ -43,7 +43,7 @@ import AutoSize from '../layout/autosize.js';
 
 const findRowIndex = (rows, rowid) => rows.findIndex(row => row.id === rowid);
 
-const DEFAULT_ROW_HEIGHT = 250;
+export const DEFAULT_ROW_HEIGHT = 250;
 
 export const createRow = (items, height = DEFAULT_ROW_HEIGHT) => ({
   id: uuid(),

--- a/gsa/src/web/store/dashboard/settings/__tests__/actions.js
+++ b/gsa/src/web/store/dashboard/settings/__tests__/actions.js
@@ -38,32 +38,18 @@ import {
   saveDashboardSettingsError,
 } from '../actions';
 
-describe('receive settings action tests', () => {
+describe('dashboard settings action tests', () => {
 
   test('should create an action to request dashboard settings', () => {
-    expect(requestDashboardSettings()).toEqual({
+    const id = 'a1';
+    const defaults = {abc: 'def'};
+
+    expect(requestDashboardSettings(id, defaults)).toEqual({
+      defaults,
+      id,
       type: DASHBOARD_SETTINGS_LOADING_REQUEST,
     });
   });
-
-  test('should create an action to receive dashboard settings with defaults', () => {
-    const id = 'a1';
-    const data = {foo: 'bar'};
-    const defaults = {abc: 'def'};
-    const settings = {
-      items: data,
-    };
-
-    expect(receivedDashboardSettings(id, settings, defaults)).toEqual({
-      settings,
-      defaults,
-      id,
-      type: DASHBOARD_SETTINGS_LOADING_SUCCESS,
-    });
-  });
-});
-
-describe('received settings action tests', () => {
 
   test('should create an action after receiving dashboard settings', () => {
     const id = 'a1';
@@ -78,21 +64,17 @@ describe('received settings action tests', () => {
       type: DASHBOARD_SETTINGS_LOADING_SUCCESS,
     });
   });
-});
-
-describe('received settings loading error action tests', () => {
 
   test('should create an action to receive an error during loading', () => {
     const error = 'An error occured';
+    const id = 'a1';
 
-    expect(receivedDashboardSettingsLoadingError(error)).toEqual({
+    expect(receivedDashboardSettingsLoadingError(id, error)).toEqual({
       error,
+      id,
       type: DASHBOARD_SETTINGS_LOADING_ERROR,
     });
   });
-});
-
-describe('save settings action tests', () => {
 
   test('should create an action to save dashboard settings', () => {
     const id = 'a1';
@@ -107,18 +89,12 @@ describe('save settings action tests', () => {
       settings,
     });
   });
-});
-
-describe('saved settings action tests', () => {
 
   test('should create an action after dashboard settings have been saved', () => {
     expect(savedDashboardSettings()).toEqual({
       type: DASHBOARD_SETTINGS_SAVING_SUCCESS,
     });
   });
-});
-
-describe('save settings error action tests', () => {
 
   test('should create an action if an error has occurred during saving', () => {
     const error = 'An error';
@@ -128,6 +104,7 @@ describe('save settings error action tests', () => {
       error,
     });
   });
+
 });
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/store/dashboard/settings/__tests__/reducers.js
+++ b/gsa/src/web/store/dashboard/settings/__tests__/reducers.js
@@ -52,9 +52,7 @@ describe('dashboard settings reducers tests for loading requests', () => {
     const action = requestDashboardSettings(id);
 
     expect(dashboardSettings({}, action)).toEqual({
-      byId: {
-        a1: {},
-      },
+      byId: {},
       isLoading: true,
       error: null,
       defaults: {
@@ -69,11 +67,7 @@ describe('dashboard settings reducers tests for loading requests', () => {
     const action = requestDashboardSettings(id, defaults);
 
     expect(dashboardSettings({}, action)).toEqual({
-      byId: {
-        a1: {
-          foo: 'bar',
-        },
-      },
+      byId: {},
       isLoading: true,
       error: null,
       defaults: {
@@ -87,18 +81,48 @@ describe('dashboard settings reducers tests for loading requests', () => {
   test('should reset isLoading and error in request dashboard settings', () => {
     const id = 'a1';
     const action = requestDashboardSettings(id);
-
-    expect(dashboardSettings({
+    const state = {
       isLoading: false,
       error: 'an previous error',
-    }, action)).toEqual({
-      byId: {
-        a1: {},
-      },
+    };
+
+    expect(dashboardSettings(state, action)).toEqual({
+      byId: {},
       isLoading: true,
       error: null,
       defaults: {
         a1: undefined,
+      },
+    });
+  });
+
+  test('should override defaults', () => {
+    const id = 'a1';
+    const state = {
+      defaults: {
+        [id]: {
+          width: 200,
+        },
+      },
+    };
+    const defaults = {
+      other: 'ipsum',
+      data: ['abc', 'def'],
+      width: 100,
+    };
+
+    const action = requestDashboardSettings(id, defaults);
+
+    expect(dashboardSettings(state, action)).toEqual({
+      isLoading: true,
+      error: null,
+      byId: {},
+      defaults: {
+        [id]: {
+          other: 'ipsum',
+          data: ['abc', 'def'],
+          width: 100,
+        },
       },
     });
   });
@@ -139,13 +163,13 @@ describe('dashboard settings reducers tests for loading success', () => {
         rows: ['foo', 'bar'],
       },
     };
-
-    const action = receivedDashboardSettings(id, settings);
-
-    expect(dashboardSettings({
+    const state = {
       isLoading: true,
       error: 'an previous error',
-    }, action)).toEqual({
+    };
+    const action = receivedDashboardSettings(id, settings);
+
+    expect(dashboardSettings(state, action)).toEqual({
       byId: {
         a1: {
           height: 100,
@@ -158,11 +182,8 @@ describe('dashboard settings reducers tests for loading success', () => {
     });
   });
 
-  test('should handle receive dashboard settings with defaults', () => {
+  test('should handle receive dashboard settings', () => {
     const id = 'a2';
-    const defaults = {
-      items: ['abc', 'def'],
-    };
 
     const settings = {
       a1: {
@@ -170,7 +191,7 @@ describe('dashboard settings reducers tests for loading success', () => {
         items: ['foo', 'bar'],
       },
     };
-    const action = receivedDashboardSettings(id, settings, defaults);
+    const action = receivedDashboardSettings(id, settings);
 
     expect(dashboardSettings({}, action)).toEqual({
       isLoading: false,
@@ -181,42 +202,11 @@ describe('dashboard settings reducers tests for loading success', () => {
           height: 100,
           items: ['foo', 'bar'],
         },
-        a2: {
-          items: ['abc', 'def'],
-        },
+        a2: {},
       },
     });
   });
 
-  test('should handle receive dashboard settings and merge defaults', () => {
-    const id = 'a1';
-    const defaults = {
-      other: 'ipsum',
-      data: ['abc', 'def'],
-    };
-
-    const settings = {
-      [id]: {
-        height: 100,
-        data: ['foo', 'bar'],
-      },
-    };
-
-    const action = receivedDashboardSettings(id, settings, defaults);
-
-    expect(dashboardSettings({}, action)).toEqual({
-      isLoading: false,
-      error: null,
-      byId: {
-        a1: {
-          other: 'ipsum',
-          height: 100,
-          data: ['foo', 'bar'],
-        },
-      },
-      defaults: {},
-    });
-  });
 
   test('should handle receive dashboard settings and keep state', () => {
     const id = 'a1';
@@ -290,11 +280,14 @@ describe('dashboard settings reducers tests for loading success', () => {
   });
 
   test('should handle receive dashboard error', () => {
+    const id = 'a1';
     const error = 'An error occured';
-    const action = receivedDashboardSettingsLoadingError(error);
+    const action = receivedDashboardSettingsLoadingError(id, error);
 
     expect(dashboardSettings({}, action)).toEqual({
-      byId: {},
+      byId: {
+        [id]: {},
+      },
       isLoading: false,
       error,
       defaults: {},
@@ -302,13 +295,17 @@ describe('dashboard settings reducers tests for loading success', () => {
   });
 
   test('should reset isLoading in receive dashboard error', () => {
+    const id = 'a1';
     const error = 'An error occured';
-    const action = receivedDashboardSettingsLoadingError(error);
-
-    expect(dashboardSettings({
+    const action = receivedDashboardSettingsLoadingError(id, error);
+    const state = {
       isLoading: true,
-    }, action)).toEqual({
-      byId: {},
+    };
+
+    expect(dashboardSettings(state, action)).toEqual({
+      byId: {
+        [id]: {},
+      },
       isLoading: false,
       error,
       defaults: {},
@@ -316,13 +313,17 @@ describe('dashboard settings reducers tests for loading success', () => {
   });
 
   test('should reset old error in receive dashboard error', () => {
+    const id = 'a1';
     const error = 'An error occured';
-    const action = receivedDashboardSettingsLoadingError(error);
-
-    expect(dashboardSettings({
+    const action = receivedDashboardSettingsLoadingError(id, error);
+    const state = {
       error: 'An old error',
-    }, action)).toEqual({
-      byId: {},
+    };
+
+    expect(dashboardSettings(state, action)).toEqual({
+      byId: {
+        [id]: {},
+      },
       isLoading: false,
       error,
       defaults: {},
@@ -330,23 +331,28 @@ describe('dashboard settings reducers tests for loading success', () => {
   });
 
   test('should keep state in receive dashboard error', () => {
+    const id = 'a1';
     const error = 'An error occured';
-    const action = receivedDashboardSettingsLoadingError(error);
+    const action = receivedDashboardSettingsLoadingError(id, error);
 
     const state = {
       byId: {
-        a1: {},
-        a2: {
+        a1: {
           rows: ['foo', 'bar'],
+        },
+        a2: {
+          width: 100,
         },
       },
     };
 
     expect(dashboardSettings(state, action)).toEqual({
       byId: {
-        a1: {},
-        a2: {
+        a1: {
           rows: ['foo', 'bar'],
+        },
+        a2: {
+          width: 100,
         },
       },
       isLoading: false,

--- a/gsa/src/web/store/dashboard/settings/__tests__/selectors.js
+++ b/gsa/src/web/store/dashboard/settings/__tests__/selectors.js
@@ -25,6 +25,12 @@
 
 import getDashboardSettings from '../selectors';
 
+const createState = state => ({
+  dashboardSettings: {
+    ...state,
+  },
+});
+
 describe('dashboard settings selector init tests', () => {
   test('should not crash with undefined state', () => {
     const selector = getDashboardSettings();
@@ -33,6 +39,7 @@ describe('dashboard settings selector init tests', () => {
     expect(selector.getIsLoading()).toEqual(false);
     expect(selector.getError()).toBeUndefined();
     expect(selector.getDefaultsById('a')).toEqual({});
+    expect(selector.hasSettings('a')).toBe(false);
   });
 
   test('should not crash with empty state', () => {
@@ -42,12 +49,11 @@ describe('dashboard settings selector init tests', () => {
     expect(selector.getIsLoading()).toEqual(false);
     expect(selector.getError()).toBeUndefined();
     expect(selector.getDefaultsById('a')).toEqual({});
+    expect(selector.hasSettings('a')).toBe(false);
   });
 
   test('should not crash with empty dashboadSettings', () => {
-    const rootState = {
-      dashboardSettings: {},
-    };
+    const rootState = createState({});
 
     const selector = getDashboardSettings(rootState);
 
@@ -55,17 +61,16 @@ describe('dashboard settings selector init tests', () => {
     expect(selector.getIsLoading()).toBeUndefined();
     expect(selector.getError()).toBeUndefined();
     expect(selector.getDefaultsById('a')).toEqual({});
+    expect(selector.hasSettings('a')).toBe(false);
   });
 });
 
 describe('dashboard setting selector isLoading tests', () => {
 
   test('should return isLoading', () => {
-    const rootState = {
-      dashboardSettings: {
-        isLoading: true,
-      },
-    };
+    const rootState = createState({
+      isLoading: true,
+    });
 
     const selector = getDashboardSettings(rootState);
 
@@ -76,11 +81,9 @@ describe('dashboard setting selector isLoading tests', () => {
 describe('dashboard setting selector getItemsById tests', () => {
 
   test('should return error', () => {
-    const rootState = {
-      dashboardSettings: {
-        error: 'An error',
-      },
-    };
+    const rootState = createState({
+      error: 'An error',
+    });
 
     const selector = getDashboardSettings(rootState);
 
@@ -92,15 +95,13 @@ describe('dashboard setting selector getById tests', () => {
 
   test('should return settings', () => {
     const id = 'a1';
-    const rootState = {
-      dashboardSettings: {
-        byId: {
-          [id]: {
-            foo: 'bar',
-          },
+    const rootState = createState({
+      byId: {
+        [id]: {
+          foo: 'bar',
         },
       },
-    };
+    });
 
     const selector = getDashboardSettings(rootState);
 
@@ -108,12 +109,10 @@ describe('dashboard setting selector getById tests', () => {
   });
 
   test('should return undefined if unknown id is passed', () => {
-    const rootState = {
-      dashboardSettings: {
-        byId: {
-        },
+    const rootState = createState({
+      byId: {
       },
-    };
+    });
 
     const selector = getDashboardSettings(rootState);
 
@@ -124,13 +123,11 @@ describe('dashboard setting selector getById tests', () => {
 describe('dashboard setting selector getDefaultsById tests', () => {
   test('should return defaults', () => {
     const id = 'a1';
-    const rootState = {
-      dashboardSettings: {
-        defaults: {
-          [id]: ['a', 'b'],
-        },
+    const rootState = createState({
+      defaults: {
+        [id]: ['a', 'b'],
       },
-    };
+    });
 
     const selector = getDashboardSettings(rootState);
 
@@ -138,16 +135,71 @@ describe('dashboard setting selector getDefaultsById tests', () => {
   });
 
   test('should return null for items if unknown id is passed', () => {
-    const rootState = {
-      dashboardSettings: {
-        defaults: {
-        },
+    const rootState = createState({
+      defaults: {
       },
-    };
+    });
 
     const selector = getDashboardSettings(rootState);
 
     expect(selector.getDefaultsById('a')).toEqual({});
+  });
+});
+
+describe('dashboard setting selector hasSettings tests', () => {
+
+  test('should return false for undefined state', () => {
+    const selector = getDashboardSettings();
+
+    expect(selector.hasSettings('a')).toBe(false);
+  });
+
+  test('should return false for empty state', () => {
+    const selector = getDashboardSettings({});
+
+    expect(selector.hasSettings('a')).toBe(false);
+  });
+
+  test('should return false for empty byId', () => {
+    const rootState = createState({
+      byId: {},
+    });
+    const selector = getDashboardSettings(rootState);
+
+    expect(selector.hasSettings('a')).toBe(false);
+  });
+
+  test('should return false for undefined id in byId', () => {
+    const rootState = createState({
+      byId: {
+        a: undefined,
+      },
+    });
+    const selector = getDashboardSettings(rootState);
+
+    expect(selector.hasSettings('a')).toBe(false);
+  });
+
+  test('should return true for empty id in byId', () => {
+    const rootState = createState({
+      byId: {
+        a: {},
+      },
+    });
+    const selector = getDashboardSettings(rootState);
+
+    expect(selector.hasSettings('a')).toBe(true);
+  });
+
+  test('should return false for other id in byId', () => {
+    const rootState = createState({
+      byId: {
+        a: {},
+      },
+    });
+    const selector = getDashboardSettings(rootState);
+
+    expect(selector.hasSettings('b')).toBe(false);
   });
 });
 

--- a/gsa/src/web/store/dashboard/settings/actions.js
+++ b/gsa/src/web/store/dashboard/settings/actions.js
@@ -42,15 +42,15 @@ export const DASHBOARD_SETTINGS_SAVING_ERROR =
 export const DASHBOARD_SETTINGS_SAVING_REQUEST =
   'DASHBOARD_SETTINGS_SAVING_REQUEST';
 
-export const receivedDashboardSettings = (id, settings, defaults) => ({
+export const receivedDashboardSettings = (id, settings) => ({
   type: DASHBOARD_SETTINGS_LOADING_SUCCESS,
   id,
   settings,
-  defaults,
 });
 
-export const receivedDashboardSettingsLoadingError = error => ({
+export const receivedDashboardSettingsLoadingError = (id, error) => ({
   type: DASHBOARD_SETTINGS_LOADING_ERROR,
+  id,
   error,
 });
 
@@ -90,9 +90,8 @@ export const loadSettings = ({gmp}) => (id, defaults) =>
 
   const promise = gmp.dashboards.currentSettings();
   return promise.then(
-    response => dispatch(receivedDashboardSettings(
-      id, response.data, defaults)),
-    error => dispatch(receivedDashboardSettingsLoadingError(error)),
+    response => dispatch(receivedDashboardSettings(id, response.data)),
+    error => dispatch(receivedDashboardSettingsLoadingError(id, error)),
   );
 };
 

--- a/gsa/src/web/store/dashboard/settings/reducers.js
+++ b/gsa/src/web/store/dashboard/settings/reducers.js
@@ -46,26 +46,16 @@ const defaults = (state = {}, action) => {
 const byId = (state = {}, action) => {
   const {
     id,
-    defaults: actionDefaults = {},
     settings = {},
   } = action;
 
   switch (action.type) {
-    case DASHBOARD_SETTINGS_LOADING_REQUEST:
-      return {
-        ...state,
-        [id]: {
-          ...state[id],
-          ...actionDefaults,
-        },
-      };
     case DASHBOARD_SETTINGS_LOADING_SUCCESS:
       return {
         ...state,
         ...settings,
         [id]: {
           ...state[id],
-          ...actionDefaults,
           ...settings[id],
         },
       };
@@ -75,6 +65,13 @@ const byId = (state = {}, action) => {
         [id]: {
           ...state[id],
           ...settings,
+        },
+      };
+    case DASHBOARD_SETTINGS_LOADING_ERROR:
+      return {
+        ...state,
+        [id]: { // ensure id is set in state
+          ...state[id],
         },
       };
     default:

--- a/gsa/src/web/store/dashboard/settings/selectors.js
+++ b/gsa/src/web/store/dashboard/settings/selectors.js
@@ -43,6 +43,10 @@ class DashboardSetting {
     return {};
   }
 
+  hasSettings(id) {
+    return is_defined(this.getById(id));
+  }
+
   getError() {
     return is_defined(this.state) ? this.state.error : undefined;
   }

--- a/gsa/src/web/store/dashboard/settings/selectors.js
+++ b/gsa/src/web/store/dashboard/settings/selectors.js
@@ -20,7 +20,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-import {is_defined, has_value} from 'gmp/utils/index';
+import {is_defined} from 'gmp/utils/identity';
 
 class DashboardSetting {
 
@@ -29,14 +29,14 @@ class DashboardSetting {
   }
 
   getById(id) {
-    if (is_defined(this.state) && has_value(this.state.byId)) {
+    if (is_defined(this.state) && is_defined(this.state.byId)) {
       return this.state.byId[id];
     }
     return undefined;
   }
 
   getDefaultsById(id) {
-    if (is_defined(this.state) && has_value(this.state.defaults)) {
+    if (is_defined(this.state) && is_defined(this.state.defaults)) {
       const defaults = this.state.defaults[id];
       return is_defined(defaults) ? defaults : {};
     }


### PR DESCRIPTION
* Only fallback to defaults if no dashboard settings aren't available
* Show loading indicator if the settings aren't loaded yet
* Separate the defaults from the loaded settings in the store 