### PR TITLE
Add result hostname to list pages

### DIFF
--- a/gsa/src/gmp/models/result.js
+++ b/gsa/src/gmp/models/result.js
@@ -77,12 +77,14 @@ class Result extends Model {
       copy.host = {
         name: host,
         id: host,
+        hostname: '',
       };
     }
     else {
       copy.host = {
         name: host.__text,
         id: is_defined(host.asset) ? host.asset._asset_id : host.__text,
+        hostname: is_defined(host.hostname) ? host.hostname : '',
       };
     }
 

--- a/gsa/src/web/pages/reports/detailsfilterdialog.js
+++ b/gsa/src/web/pages/reports/detailsfilterdialog.js
@@ -53,7 +53,7 @@ const SORT_FIELDS = [
   ['severity', _('Severity')],
   ['qod', _('Quality of Detection')],
   ['host', _('Host (IP)')],
-  ['hostname', _('Hostname')],
+  ['hostname', _('Host (Name)')],
   ['location', _('Location')],
 ];
 

--- a/gsa/src/web/pages/reports/detailsfilterdialog.js
+++ b/gsa/src/web/pages/reports/detailsfilterdialog.js
@@ -52,7 +52,8 @@ const SORT_FIELDS = [
   ['solution_type', _('Solution Type')],
   ['severity', _('Severity')],
   ['qod', _('Quality of Detection')],
-  ['host', _('Host')],
+  ['host', _('Host (IP)')],
+  ['hostname', _('Hostname')],
   ['location', _('Location')],
 ];
 

--- a/gsa/src/web/pages/reports/sort.js
+++ b/gsa/src/web/pages/reports/sort.js
@@ -89,6 +89,7 @@ export const results_sort_functions = {
   delta: make_compare_string(entity => entity.delta.delta_type),
   created: make_compare_date('creation_time'),
   host: make_compare_ip(entity => entity.host.name),
+  hostname: make_compare_string(entity => entity.host.hostname),
   location: make_compare_string('port'),
   qod: make_compare_number(entity => entity.qod.value),
   severity: make_compare_severity(),

--- a/gsa/src/web/pages/results/filterdialog.js
+++ b/gsa/src/web/pages/results/filterdialog.js
@@ -48,7 +48,7 @@ const SORT_FIELDS = [
   ['severity', _('Severity')],
   ['qod', _('QoD')],
   ['host', _('Host (IP)')],
-  ['hostname', _('Hostname')],
+  ['hostname', _('Host (Name)')],
   ['location', _('Location')],
   ['created', _('Created')],
 ];

--- a/gsa/src/web/pages/results/filterdialog.js
+++ b/gsa/src/web/pages/results/filterdialog.js
@@ -47,7 +47,8 @@ const SORT_FIELDS = [
   ['solution_type', _('Solution type')],
   ['severity', _('Severity')],
   ['qod', _('QoD')],
-  ['host', _('Host')],
+  ['host', _('Host (IP)')],
+  ['hostname', _('Hostname')],
   ['location', _('Location')],
   ['created', _('Created')],
 ];

--- a/gsa/src/web/pages/results/row.js
+++ b/gsa/src/web/pages/results/row.js
@@ -23,6 +23,8 @@
 
 import React from 'react';
 
+import glamorous from 'glamorous';
+
 import {longDate} from 'gmp/locale/date';
 
 import {is_defined} from 'gmp/utils/identity';
@@ -42,6 +44,10 @@ import TableRow from '../../components/table/row.js';
 import TableData from '../../components/table/data.js';
 
 import ResultDelta from './delta.js';
+
+const Hostname = glamorous.span({
+  fontSize: '10px',
+});
 
 const Row = ({
   actions,
@@ -83,7 +89,7 @@ const Row = ({
       <TableData flex align="center">
         {entity.qod.value} %
       </TableData>
-      <TableData flex align="center">
+      <TableData colSpan="2">
         <DetailsLink
           type="host"
           id={host.id}
@@ -91,6 +97,9 @@ const Row = ({
         >
           {host.name}
         </DetailsLink>
+        {host.hostname &&
+          <Hostname>({host.hostname})</Hostname>
+        }
       </TableData>
       <TableData>
         {entity.port}

--- a/gsa/src/web/pages/results/row.js
+++ b/gsa/src/web/pages/results/row.js
@@ -23,11 +23,11 @@
 
 import React from 'react';
 
-import glamorous from 'glamorous';
-
 import {longDate} from 'gmp/locale/date';
 
 import {is_defined} from 'gmp/utils/identity';
+
+import {shorten} from 'gmp/utils/string';
 
 import PropTypes from '../../utils/proptypes.js';
 import {render_component} from '../../utils/render.js';
@@ -45,10 +45,6 @@ import TableData from '../../components/table/data.js';
 
 import ResultDelta from './delta.js';
 
-const Hostname = glamorous.span({
-  fontSize: '0.8em',
-});
-
 const Row = ({
   actions,
   delta = false,
@@ -60,6 +56,16 @@ const Row = ({
   const {host} = entity;
   const shown_name = is_defined(entity.name) ? entity.name : entity.nvt.oid;
   const has_tags = is_defined(entity.nvt) && is_defined(entity.nvt.tags);
+  var hostname_elem;
+  if (host.hostname.length > 40)
+    hostname_elem = <span title={host.hostname}>
+                      ({shorten (host.hostname, 40)})
+                    </span>
+  else if (host.hostname.length > 0)
+    hostname_elem = <span>{host.hostname}</span>
+  else
+    hostname_elem = false
+
   return (
     <TableRow>
       {delta &&
@@ -97,9 +103,7 @@ const Row = ({
         >
           {host.name}
         </DetailsLink>
-        {host.hostname.length > 0 &&
-          <Hostname>({host.hostname})</Hostname>
-        }
+        {hostname_elem}
       </TableData>
       <TableData>
         {entity.port}

--- a/gsa/src/web/pages/results/row.js
+++ b/gsa/src/web/pages/results/row.js
@@ -46,7 +46,7 @@ import TableData from '../../components/table/data.js';
 import ResultDelta from './delta.js';
 
 const Hostname = glamorous.span({
-  fontSize: '10px',
+  fontSize: '0.8em',
 });
 
 const Row = ({
@@ -97,7 +97,7 @@ const Row = ({
         >
           {host.name}
         </DetailsLink>
-        {host.hostname &&
+        {host.hostname.length > 0 &&
           <Hostname>({host.hostname})</Hostname>
         }
       </TableData>

--- a/gsa/src/web/pages/results/row.js
+++ b/gsa/src/web/pages/results/row.js
@@ -56,15 +56,6 @@ const Row = ({
   const {host} = entity;
   const shown_name = is_defined(entity.name) ? entity.name : entity.nvt.oid;
   const has_tags = is_defined(entity.nvt) && is_defined(entity.nvt.tags);
-  var hostname_elem;
-  if (host.hostname.length > 40)
-    hostname_elem = <span title={host.hostname}>
-                      ({shorten (host.hostname, 40)})
-                    </span>
-  else if (host.hostname.length > 0)
-    hostname_elem = <span>{host.hostname}</span>
-  else
-    hostname_elem = false
 
   return (
     <TableRow>
@@ -103,7 +94,11 @@ const Row = ({
         >
           {host.name}
         </DetailsLink>
-        {hostname_elem}
+        {host.hostname.length > 0
+          ? <span title={host.hostname}>
+              ({shorten (host.hostname, 40)})
+            </span>
+          : false}
       </TableData>
       <TableData>
         {entity.port}

--- a/gsa/src/web/pages/results/table.js
+++ b/gsa/src/web/pages/results/table.js
@@ -143,7 +143,7 @@ const Header = ({
           currentSortBy={currentSortBy}
           sortBy={sort ? 'hostname' : false}
           onSortChange={onSortChange}>
-          {_('Hostname')}
+          {_('Name')}
         </TableHead>
       </TableRow>
     </TableHeader>

--- a/gsa/src/web/pages/results/table.js
+++ b/gsa/src/web/pages/results/table.js
@@ -61,6 +61,7 @@ const Header = ({
         {delta &&
           <TableHead
             width="4%"
+            rowSpan="2"
             currentSortDir={currentSortDir}
             currentSortBy={currentSortBy}
             sortBy={sort ? 'delta' : false}
@@ -69,14 +70,15 @@ const Header = ({
           </TableHead>
         }
         <TableHead
-          width="57%"
+          width="55%"
+          rowSpan="2"
           currentSortDir={currentSortDir}
           currentSortBy={currentSortBy}
           sortBy={sort ? 'vulnerability' : false}
           onSortChange={onSortChange}>
           {_('Vulnerability')}
         </TableHead>
-        <TableHead width="2%">
+        <TableHead width="2%" rowSpan="2">
           <Layout flex align="center">
             {sort ?
               <Sort by="solution_type" onClick={onSortChange}>
@@ -88,6 +90,7 @@ const Header = ({
         </TableHead>
         <TableHead
           width="8%"
+          rowSpan="2"
           currentSortDir={currentSortDir}
           currentSortBy={currentSortBy}
           sortBy={sort ? 'severity' : false}
@@ -96,22 +99,20 @@ const Header = ({
         </TableHead>
         <TableHead
           width="3%"
+          rowSpan="2"
           currentSortDir={currentSortDir}
           currentSortBy={currentSortBy}
           sortBy={sort ? 'qod' : false}
           onSortChange={onSortChange}>
           {_('QoD')}
         </TableHead>
-        <TableHead
-          width="7%"
-          currentSortDir={currentSortDir}
-          currentSortBy={currentSortBy}
-          sortBy={sort ? 'host' : false}
-          onSortChange={onSortChange}>
+        <TableHead colSpan="2"
+          width="13%">
           {_('Host')}
         </TableHead>
         <TableHead
-          width="13%"
+          width="9%"
+          rowSpan="2"
           currentSortDir={currentSortDir}
           currentSortBy={currentSortBy}
           sortBy={sort ? 'location' : false}
@@ -120,6 +121,7 @@ const Header = ({
         </TableHead>
         <TableHead
           width="10%"
+          rowSpan="2"
           currentSortDir={currentSortDir}
           currentSortBy={currentSortBy}
           sortBy={sort ? 'created' : false}
@@ -127,6 +129,22 @@ const Header = ({
           {_('Created')}
         </TableHead>
         {actionsColumn}
+      </TableRow>
+      <TableRow>
+        <TableHead
+          currentSortDir={currentSortDir}
+          currentSortBy={currentSortBy}
+          sortBy={sort ? 'host' : false}
+          onSortChange={onSortChange}>
+          {_('IP')}
+        </TableHead>
+        <TableHead
+          currentSortDir={currentSortDir}
+          currentSortBy={currentSortBy}
+          sortBy={sort ? 'hostname' : false}
+          onSortChange={onSortChange}>
+          {_('Hostname')}
+        </TableHead>
       </TableRow>
     </TableHeader>
   );


### PR DESCRIPTION
This adds the hostname to the "Host" column of the results list and the
report details and a new filter option for it.
The column header now has two subcolumns: IP and Hostname to easily sort
by both.