### PR TITLE
Fix getting the allowed displays for a Dashboard

### DIFF
--- a/gsa/src/web/components/dashboard/controls.js
+++ b/gsa/src/web/components/dashboard/controls.js
@@ -166,7 +166,7 @@ DashboardControls.propTypes = {
 
 const mapStateToProps = (rootState, {dashboardId}) => {
   const settingsSelector = getDashboardSettings(rootState);
-  const settings = settingsSelector.getById(dashboardId);
+  const settings = settingsSelector.getDefaultsById(dashboardId);
   const {permittedDisplays: displayIds} = settings || {};
   return {
     canAdd: canAddDisplay(settings),


### PR DESCRIPTION
The state layout for the dashboard settings has been changed. The
defaults (including the permittedDisplays setting) aren't put in the
same state object as the loaded settings anymore.