### PR TITLE
Fix propType warning for entitiesSelected

### DIFF
--- a/gsa/src/web/entities/container.js
+++ b/gsa/src/web/entities/container.js
@@ -467,7 +467,7 @@ class EntitiesContainer extends React.Component {
       loaded_filter,
       loading,
       newTag,
-      selected = {},
+      selected,
       selection_type,
       sortBy,
       sortDir,


### PR DESCRIPTION
entitiesSelected must be undefined or a Set. Therefore don't initialize
them as an object.