### PR TITLE
Make resource_ids:value an alias of info_id

### DIFF
--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -875,7 +875,7 @@ init_validator ()
   openvas_validator_alias (validator, "radiushost",     "hostport");
   openvas_validator_alias (validator, "restrict_type", "resource_type");
   openvas_validator_alias (validator, "resource_ids:name",     "number");
-  openvas_validator_alias (validator, "resource_ids:value",    "id_optional");
+  openvas_validator_alias (validator, "resource_ids:value",    "info_id");
   openvas_validator_alias (validator, "result_hosts_only", "boolean");
   openvas_validator_alias (validator, "result_task_id", "optional_task_id");
   openvas_validator_alias (validator, "result_uuid", "optional_id");


### PR DESCRIPTION
This allows using SecInfo ids like NVT OIDs and CVE IDs for actions on
generic resources like adding them to tags.