### PR TITLE
Fix bulk actions delete and export

### DIFF
--- a/gsa/src/gmp/commands/entities.js
+++ b/gsa/src/gmp/commands/entities.js
@@ -141,8 +141,8 @@ class EntitiesCommand extends HttpCommand {
     // FIXME change gmp to allow deletion by filter
     let deleted;
     return this.get({filter}).then(entities => {
-      deleted = entities.getEntries();
-      return this.delete(entities, extra_params);
+      deleted = entities.data;
+      return this.delete(deleted, extra_params);
     }).then(response => response.setData(deleted));
   }
 

--- a/gsa/src/gmp/commands/entities.js
+++ b/gsa/src/gmp/commands/entities.js
@@ -97,7 +97,7 @@ class EntitiesCommand extends HttpCommand {
 
   exportByIds(ids) {
     const params = {
-      cmd: 'process_bulk',
+      cmd: 'bulk_export',
       resource_type: this.name,
       bulk_select: 1,
       'bulk_export.x': 1,
@@ -110,7 +110,7 @@ class EntitiesCommand extends HttpCommand {
 
   exportByFilter(filter) {
     const params = {
-      cmd: 'process_bulk',
+      cmd: 'bulk_export',
       resource_type: this.name,
       bulk_select: 0,
       'bulk_export.x': 1,


### PR DESCRIPTION
In order to fully function the previously deleted process_bulk in gsad needs to be restored and renamed to bulk_export.