### PR TITLE
Remove unnecessary prop(-types) from EntityTags

### DIFF
--- a/gsa/src/web/entity/tags.js
+++ b/gsa/src/web/entity/tags.js
@@ -90,7 +90,6 @@ SectionElements.propTypes = {
 
 const EntityTags = ({
   entity,
-  onTagDeleteClick,
   onTagDisableClick,
   onTagEditClick,
   onTagCreateClick,
@@ -186,9 +185,7 @@ const EntityTags = ({
 
 EntityTags.propTypes = {
   entity: PropTypes.model.isRequired,
-  gmp: PropTypes.gmp.isRequired,
   onTagCreateClick: PropTypes.func.isRequired,
-  onTagDeleteClick: PropTypes.func.isRequired,
   onTagDisableClick: PropTypes.func.isRequired,
   onTagEditClick: PropTypes.func.isRequired,
   onTagRemoveClick: PropTypes.func.isRequired,


### PR DESCRIPTION
onTagDeleteClick was replaces by onTagRemoveClick therefore it is
unused. gmp prop was never used. Therefore it is removed to fix all prop
type warnings.