### PR TITLE
Add #include for string.h to utils.c

### DIFF
--- a/gsad/src/utils.c
+++ b/gsad/src/utils.c
@@ -34,6 +34,7 @@
  * @return TRUE if string are equal
  */
 
+#include <string.h>  // For strcmp
 #include "utils.h"
 
 gboolean


### PR DESCRIPTION
The standard string.h header file is needed for strcmp.