### PR TITLE
Remove obsolete PropType of App component

### DIFF
--- a/gsa/src/web/app.js
+++ b/gsa/src/web/app.js
@@ -33,7 +33,6 @@ import {is_defined} from 'gmp/utils/identity';
 import CacheFactoryProvider from './components/provider/cachefactoryprovider';
 import GmpProvider from './components/provider/gmpprovider';
 
-import PropTypes from './utils/proptypes';
 import globalcss from './utils/globalcss';
 
 import configureStore from './store';
@@ -90,10 +89,6 @@ class App extends React.Component {
     );
   }
 }
-
-App.contextTypes = {
-  router: PropTypes.object.isRequired,
-};
 
 export default App;
 


### PR DESCRIPTION
Drop the proptype to remove the warning from the console.