### PR TITLE
Rework user session handling

### DIFF
--- a/gsad/src/CMakeLists.txt
+++ b/gsad/src/CMakeLists.txt
@@ -90,10 +90,12 @@ add_executable (gsad
                 gsad.c
                 gsad_base.c
                 gsad_cmd.c
+                gsad_credentials.c
                 gsad_gmp.c
                 gsad_http.c
                 gsad_http_handler.c
                 gsad_i18n.c
+                gsad_session.c
                 gsad_settings.c
                 gsad_user.c
                 utils.c

--- a/gsad/src/gsad_base.c
+++ b/gsad/src/gsad_base.c
@@ -129,29 +129,6 @@ set_http_only (int state)
 }
 
 /**
- * @brief Set language code of user.
- *
- * Caller must handle locking.
- *
- * @param[in]   lang      Language slot. May be a language name or code
- * @param[in]   language  User Interface Language.
- */
-void
-set_language_code (gchar **lang, const gchar *language)
-{
-  if (language == NULL || strcmp (language, "Browser Language") == 0)
-    *lang = NULL;
-  else if (strcmp (language, "Chinese") == 0)
-    *lang = g_strdup ("zh_CN");
-  else if (strcmp (language, "English") == 0)
-    *lang = g_strdup ("en");
-  else if (strcmp (language, "German") == 0)
-    *lang = g_strdup ("de");
-  else
-    *lang = g_strdup (language);
-}
-
-/**
  * @brief Return string from ctime_r with newline replaces with terminator.
  *
  * @param[in]  time    Time.

--- a/gsad/src/gsad_credentials.c
+++ b/gsad/src/gsad_credentials.c
@@ -1,0 +1,110 @@
+/* Greenbone Security Assistant
+ *
+ * Description: GSAD credentials handling
+ *
+ * Authors:
+ * Björn Ricks <bjoern.ricks@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2018 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <glib.h>
+
+#include "gsad_credentials.h"
+#include "gsad_user.h"
+
+/**
+ *  @brief Structure of credential related information.
+ */
+struct credentials
+{
+  struct timeval cmd_start; ///< Seconds since command page handler started.
+  gchar *caller;            ///< Caller URL, for POST relogin.
+  gchar *current_page;      ///< Current page URL, for refresh.
+  gchar *language;          ///< Language for this request
+  user_t *user;             ///< Current user
+};
+
+credentials_t *
+credentials_new (user_t *user,
+                 const gchar *language,
+                 const gchar *caller)
+{
+  credentials_t *credentials;
+
+  credentials = g_malloc0 (sizeof (credentials_t));
+  credentials->user = user_copy (user);
+  credentials->language = g_strdup (language);
+  credentials->caller = g_strdup (caller);
+
+  return credentials;
+}
+
+void
+credentials_free (credentials_t *creds)
+{
+  if (!creds)
+    return;
+
+  g_free (creds->caller);
+  g_free (creds->current_page);
+  g_free (creds->language);
+
+  user_free (creds->user);
+
+  g_free (creds);
+}
+
+user_t *
+credentials_get_user (credentials_t *cred)
+{
+  return cred->user;
+}
+
+const gchar *
+credentials_get_caller (credentials_t *cred)
+{
+  return cred->caller;
+}
+
+const gchar *
+credentials_get_current_page (credentials_t *cred)
+{
+  return cred->current_page;
+}
+
+const gchar *
+credentials_get_language (credentials_t *cred)
+{
+  return cred->language;
+}
+
+void
+credentials_start_cmd (credentials_t *creds)
+{
+  gettimeofday (&creds->cmd_start, NULL);
+}
+
+double
+credentials_get_cmd_duration (credentials_t *cred)
+{
+  struct timeval tv;
+  gettimeofday (&tv, NULL);
+  return ((double) ((tv.tv_sec - cred->cmd_start.tv_sec) * 1000000L
+                    + tv.tv_usec - cred->cmd_start.tv_usec) / 1000000.0);
+}

--- a/gsad/src/gsad_credentials.h
+++ b/gsad/src/gsad_credentials.h
@@ -1,0 +1,52 @@
+/* Greenbone Security Assistant
+ *
+ * Description: GSAD credentials handling
+ *
+ * Authors:
+ * Björn Ricks <bjoern.ricks@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2018 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+#ifndef _GSAD_CREDENTIALS_H
+#define _GSAD_CREDENTIALS_H
+
+#include <glib.h>
+
+#include "gsad_user.h"
+
+typedef struct credentials credentials_t;
+
+credentials_t *credentials_new (user_t *user,
+                                const gchar *language,
+                                const gchar *caller);
+
+void credentials_free (credentials_t *creds);
+
+user_t *credentials_get_user (credentials_t *creds);
+
+const gchar *credentials_get_caller (credentials_t *creds);
+
+const gchar *credentials_get_current_page (credentials_t *creds);
+
+const gchar *credentials_get_language (credentials_t *creds);
+
+void credentials_start_cmd (credentials_t *creds);
+
+double credentials_get_cmd_duration (credentials_t *creds);
+
+#endif /* _GSAD_CREDENTIALS_H */

--- a/gsad/src/gsad_gmp.h
+++ b/gsad/src/gsad_gmp.h
@@ -528,7 +528,7 @@ char * get_user_gmp (gvm_connection_t *, credentials_t *, params_t *,
 char * get_users_gmp (gvm_connection_t *, credentials_t *, params_t *,
                       cmd_response_data_t*);
 char * save_user_gmp (gvm_connection_t *, credentials_t *, params_t *,
-                      char **, char **, int *, cmd_response_data_t*);
+                      cmd_response_data_t*);
 char * get_vulns_gmp (gvm_connection_t *, credentials_t *, params_t *,
                       cmd_response_data_t*);
 char * save_auth_gmp (gvm_connection_t *, credentials_t *, params_t *,
@@ -574,8 +574,7 @@ char * edit_my_settings_gmp (gvm_connection_t *, credentials_t *,
 char * get_my_settings_gmp (gvm_connection_t *, credentials_t *, params_t *,
                             cmd_response_data_t*);
 char * save_my_settings_gmp (gvm_connection_t *, credentials_t *,
-                             params_t *, const char *, char **, char **,
-                             char **, char **, cmd_response_data_t*);
+                             params_t *, const gchar *, cmd_response_data_t*);
 
 char * get_info_gmp (gvm_connection_t *, credentials_t *, params_t *,
                      cmd_response_data_t*);

--- a/gsad/src/gsad_http.h
+++ b/gsad/src/gsad_http.h
@@ -30,8 +30,9 @@
 #include <glib.h>
 
 #include "gsad_content_type.h" /* for content_type_t */
-#include "gsad_user.h"
+#include "gsad_user.h" /* for user_t */
 #include "gsad_cmd.h" /* for cmd_response_data_t */
+#include "gsad_credentials.h" /* for credentials_t */
 
 /**
  * @brief At least maximum length of rfc2822 format date.

--- a/gsad/src/gsad_session.c
+++ b/gsad/src/gsad_session.c
@@ -1,0 +1,209 @@
+/* Greenbone Security Assistant
+
+ * Description: GSAD user session handling
+ *
+ * Authors:
+ * Björn Ricks <bjoern.ricks@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2018 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "gsad_session.h"
+#include "gsad_user.h"
+#include "utils.h" /* for str_equal */
+
+
+#undef G_LOG_DOMAIN
+/**
+ * @brief GLib log domain.
+ */
+#define G_LOG_DOMAIN "gsad session"
+
+/**
+ * @brief User session data.
+ */
+GPtrArray *users = NULL;
+
+/**
+ * @brief Mutex to prevent concurrent access to the session.
+ */
+static GMutex *mutex = NULL;
+
+user_t *
+session_get_user_by_id_internal (const gchar *id)
+{
+  int index;
+  for (index = 0; index < users->len; index++)
+    {
+      user_t *item = (user_t*) g_ptr_array_index (users, index);
+      const gchar *token = user_get_token (item);
+
+      if (str_equal (id, token))
+        {
+          return item;
+        }
+    }
+
+  return NULL;
+}
+
+void
+session_remove_user_internal (const gchar *id)
+{
+  user_t *user = session_get_user_by_id_internal (id);
+
+  if (user)
+    {
+      g_ptr_array_remove(users, (gpointer)user);
+
+      user_free(user);
+    }
+}
+
+void
+session_add_user_internal (user_t *user)
+{
+  g_ptr_array_add (users, (gpointer) user_copy (user));
+}
+
+void
+session_init ()
+{
+  mutex = g_malloc (sizeof (GMutex));
+  g_mutex_init (mutex);
+  users = g_ptr_array_new ();
+}
+
+/**
+ * Find a user by a session identifier
+ *
+ * @return Return a copy of the user or NULL if not found
+ */
+user_t *
+session_get_user_by_id (const gchar *id)
+{
+  user_t * user;
+
+  g_mutex_lock (mutex);
+
+  user = user_copy (session_get_user_by_id_internal (id));
+
+  g_mutex_unlock (mutex);
+
+  return user;
+}
+
+/**
+ * Find the first user with the username
+ *
+ * @return Return a copy of the user or NULL if not found
+ */
+user_t *
+session_get_user_by_username (const gchar *username)
+{
+  int index;
+  user_t * user = NULL;
+
+  g_mutex_lock (mutex);
+
+  for (index = 0; index < users->len; index++)
+    {
+      user_t *item = (user_t*) g_ptr_array_index (users, index);
+      const gchar *name = user_get_username (item);
+
+      if (str_equal (name, username))
+        {
+          user = user_copy(item);
+          break;
+        }
+    }
+
+  g_mutex_unlock (mutex);
+
+  return user;
+}
+
+/**
+ * @brief Add user to the session "database"
+ *
+ * @param[in]  id     Unique identifier.
+ * @param[in]  user   User.
+ */
+void
+session_add_user (const gchar *id, user_t *user)
+{
+  g_mutex_lock (mutex);
+
+  session_remove_user_internal (id);
+
+  session_add_user_internal (user);
+
+  g_mutex_unlock (mutex);
+}
+
+/**
+ * @brief Remove a user from the session "database"
+ *
+ * @param[in]  id  Unique identifier.
+ */
+void
+session_remove_user (const gchar *id)
+{
+  g_mutex_lock (mutex);
+
+  session_remove_user_internal (id);
+
+  g_mutex_unlock (mutex);
+}
+
+/**
+ * @brief Removes all session of the user, except the one with the passed id.
+ *
+ * @param[in] id    ID of the session to keep
+ * @param[in] user  The user to logout.
+ *
+ */
+void
+session_remove_other_sessions (const gchar *id, user_t *user)
+{
+  int index;
+
+  g_mutex_lock (mutex);
+
+  for (index = 0; index < users->len; index++)
+    {
+      user_t *item = (user_t*) g_ptr_array_index (users, index);
+
+      const gchar *itemtoken = user_get_token(item);
+      const gchar *itemname = user_get_username(item);
+      const gchar *username = user_get_username(user);
+
+      if (str_equal (itemname, username) && !str_equal (id, itemtoken))
+        {
+          g_debug ("%s: logging out user '%s', token '%s'",
+                   __FUNCTION__, itemname, itemtoken);
+          g_ptr_array_remove (users, (gpointer) item);
+
+          user_free (item);
+
+          index --;
+        }
+    }
+
+  g_mutex_unlock (mutex);
+}

--- a/gsad/src/gsad_session.h
+++ b/gsad/src/gsad_session.h
@@ -1,13 +1,12 @@
 /* Greenbone Security Assistant
- * $Id$
- * Description: Headers/structs used generally in GSA
+
+ * Description: GSAD user session handling
  *
  * Authors:
- * Matthew Mundell <matthew.mundell@greenbone.net>
- * Jan-Oliver Wagner <jan-oliver.wagner@greenbone.net>
+ * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2009, 2018 Greenbone Networks GmbH
+ * Copyright (C) 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,26 +23,23 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-/**
- * @file gsad_base.h
- * @brief Headers/structs used generally in GSA.
- */
-
-#ifndef _GSAD_BASE_H
-#define _GSAD_BASE_H
+#ifndef _GSAD_SESSION_H
+#define _GSAD_SESSION_H
 
 #include <glib.h>
-#include <sys/time.h>
 
-#include "gsad_cmd.h" /* for cmd_response_data_t */
-#include "gsad_user.h" /* for credentials_t */
+#include "gsad_user.h"
 
-int gsad_base_init ();
-int gsad_base_cleanup ();
-int get_chroot_state ();
-void set_chroot_state (int);
-int get_http_only ();
-void set_http_only (int);
-char *ctime_r_strip_newline (time_t *, char *);
+void session_add_user (const gchar *id, user_t *user);
 
-#endif /* not _GSAD_BASE_H */
+void session_remove_user (const gchar *id);
+
+user_t *session_get_user_by_id (const gchar *id);
+
+user_t *session_get_user_by_username (const gchar *username);
+
+void session_remove_other_sessions (const gchar *id, user_t *user);
+
+void session_init ();
+
+#endif

--- a/gsad/src/gsad_user.h
+++ b/gsad/src/gsad_user.h
@@ -41,70 +41,60 @@
 #define USER_GUEST_LOGIN_ERROR -1
 
 /**
- *  @brief Structure of credential related information.
- */
-typedef struct
-{
-  struct timeval cmd_start; ///< Seconds since command page handler started.
-  char *username;     ///< Name of user.
-  char *password;     ///< User's password.
-  char *role;         ///< User's role.
-  char *timezone;     ///< User's timezone.
-  char *token;        ///< Session token.
-  char *caller;       ///< Caller URL, for POST relogin.
-  char *current_page; ///< Current page URL, for refresh.
-  char *capabilities; ///< Capabilites of manager.
-  char *language;     ///< Accept-Language browser header.
-  char *severity;     ///< Severity class.
-  char *pw_warning;   ///< Password policy warning message
-  char *client_address; ///< Client's address.
-  GTree *last_filt_ids; ///< Last filter ids.
-  params_t *params;   ///< Request parameters.
-  int guest;          ///< Whether the user is a guest user.
-  char *sid;          ///< Session ID of the user.
-} credentials_t;
-
-/**
  * @brief User information type, for sessions.
  */
 typedef struct user user_t;
 
+void user_free (user_t *user);
+
+user_t *user_copy (user_t *user);
+
 int user_find (const gchar *cookie, const gchar *token, const char *address,
                user_t **user_return);
 
-void user_remove (user_t *user);
+user_t *user_add (const gchar *username, const gchar *password,
+                  const gchar *timezone, const gchar *severity,
+                  const gchar *role, const gchar *capabilities,
+                  const gchar *language, const gchar *pw_warning,
+                  const char *address);
 
-void user_free (user_t *user);
 
-user_t *
-user_add (const gchar *username, const gchar *password, const gchar *timezone,
-          const gchar *severity, const gchar *role, const gchar *capabilities,
-          const gchar *language, const gchar *pw_warning, const char *address);
+void user_set_timezone (user_t *user, const gchar *timezone);
 
-int user_set_timezone (const gchar *token, const gchar *timezone);
+void user_set_username (user_t *user, const gchar *username);
 
-int user_set_password (const gchar *token, const gchar *password);
+void user_set_password (user_t *user, const gchar *password);
 
-int user_set_severity (const gchar *token, const gchar *severity);
+void user_set_severity (user_t *user, const gchar *severity);
 
-int user_set_language (const gchar *token, const gchar *language);
+void user_set_language (user_t *user, const gchar *language);
 
-int user_logout_all_sessions (const gchar *username,
-                              credentials_t *credentials);
 
-gchar * user_get_username (user_t *user);
+const gchar *user_get_username (user_t *user);
 
-gchar * user_get_language (user_t *user);
+const gchar *user_get_password (user_t *user);
 
-gchar * user_get_cookie (user_t *user);
+const gchar *user_get_language (user_t *user);
 
-credentials_t * credentials_new (user_t *user, const char *language,
-                                 const char *client_address);
+const gchar *user_get_cookie (user_t *user);
 
-void credentials_free (credentials_t *creds);
+const gchar *user_get_token (user_t *user);
 
-int logout (credentials_t *);
+const gchar *user_get_timezone (user_t *user);
 
-void init_users ();
+gboolean user_get_guest (user_t *user);
+
+const gchar *user_get_client_address (user_t *user);
+
+const gchar *user_get_role (user_t *user);
+
+const gchar *user_get_severity (user_t *user);
+
+const gchar *user_get_password_warning (user_t *user);
+
+const gchar *user_get_capabilities (user_t *user);
+
+
+int user_logout (user_t *user);
 
 #endif /* _GSAD_USER_H_ */


### PR DESCRIPTION
* Move credentials and users/session list into own c modules.
* Shrink credentials. Credentials are only containing request specific
  data now.
* Don't allow direct access on credential members. Use accessor
  functions instead.
* Rework the session/users list out of the user module.
* Always work on a copy of a user. Don't access the user object in the
  session directly. This avoids having to block the thread when
  accessing user data.
* Actually only block a thread when accessing the session for reading
  and writing users. This should improve concurrent http requests a lot.
  Before nearly only one thread could run simultaneously because they
  have been blocked for user access.