### PR TITLE
Update resources-list in Tags detailspages

### DIFF
--- a/gsa/src/gmp/models/tag.js
+++ b/gsa/src/gmp/models/tag.js
@@ -34,7 +34,8 @@ class Tag extends Model {
   parseProperties(elem) {
     const ret = super.parseProperties(elem);
     if (is_defined(elem.resources)) {
-      ret.resources = map(ret.resources.resource, res => new Model(res));
+      ret.resources = map(ret.resources.resource,
+        res => new Model(res, elem.resources.type));
       ret.resource_type = elem.resources.type;
       ret.resource_count = elem.resources.count.total;
     }


### PR DESCRIPTION
Resources under the "Assigned Resources" tab are now limited to 40 items
being listed.
To list all resources a link will be shown (in case there is more than
40) that leads to the respective resource-entities listpage filtered
with the new tag_id filter keyword.