### PR TITLE
Don't crash if reference is not set in Badge component

### DIFF
--- a/gsa/src/web/components/badge/badge.js
+++ b/gsa/src/web/components/badge/badge.js
@@ -25,10 +25,10 @@ import React from 'react';
 
 import glamorous from 'glamorous';
 
-import {is_defined} from 'gmp/utils';
+import {is_defined, has_value} from 'gmp/utils/identity';
 
-import PropTypes from '../../utils/proptypes.js';
-import Theme from '../../utils/theme.js';
+import PropTypes from 'web/utils/proptypes';
+import Theme from 'web/utils/theme';
 
 const BadgeContainer = glamorous.div({
   position: 'relative',
@@ -92,7 +92,7 @@ class Badge extends React.Component {
   }
 
   calcMargin() {
-    if (is_defined(this.icon)) {
+    if (has_value(this.icon)) {
       const {width} = this.icon.getBoundingClientRect();
       this.setState({margin: width / 2});
     }


### PR DESCRIPTION
icon is set via react reference. The reference is set to null if it
isn't available. Therefore checking only for undefined when calculating
the margins did crash.

Also update the imports to use full paths and no .js ending.