### PR TITLE
Allow Filter model and String as filter for Link components

### DIFF
--- a/gsa/src/web/components/link/link.js
+++ b/gsa/src/web/components/link/link.js
@@ -98,7 +98,10 @@ let Link = ({
 
 Link.propTypes = {
   anchor: PropTypes.string,
-  filter: PropTypes.filter,
+  filter: PropTypes.oneOfType([
+    PropTypes.filter,
+    PropTypes.string,
+  ]),
   query: PropTypes.object,
   to: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
It seems to much efford to convert all Link component occurences to pass
a Filter instance to Link. Also most of the filter strings are very
simple so it's an overhead to parse them in a Filter before.