### PR TITLE
Allow binary file uploads in validator (7.0)

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -1382,7 +1382,6 @@ init_validator ()
   openvas_validator_add (validator, "ifaces_allow", "^(0|1)$");
   openvas_validator_add (validator, "include_id_list:name",  "^[[:alnum:]\\-_ ]+$");
   openvas_validator_add (validator, "include_id_list:value", "^(0|1)$");
-  openvas_validator_add (validator, "installer",      "(?s)^.*$");
   openvas_validator_add (validator, "installer_sig",  "(?s)^.*$");
   openvas_validator_add (validator, "lang",
                          "^(Browser Language|"
@@ -1509,6 +1508,10 @@ init_validator ()
   openvas_validator_add (validator, "z_fields:value", "^[\\[\\]_[:alnum:]]{1,80}$");
   openvas_validator_add (validator, "calendar_unit", "^(second|minute|hour|day|week|month|year|decade)$");
   openvas_validator_add (validator, "chart_title", "(?s)^.*$");
+
+  /* Binary data params that should not use no UTF-8 validation */
+  openvas_validator_add_binary (validator, "installer");
+  openvas_validator_add_binary (validator, "method_data:pkcs12:");
 
   /* Beware, the rule must be defined before the alias. */
 
@@ -2016,9 +2019,7 @@ params_mhd_validate_values (const char *parent_name, void *params)
     {
       gchar *item_name;
 
-      /* Item specific value validator like "method_data:to_adddress:". */
-      if ((g_utf8_validate (name, -1, NULL) == FALSE)
-          || (g_utf8_validate (param->value, -1, NULL) == FALSE))
+      if ((g_utf8_validate (name, -1, NULL) == FALSE))
         {
           param->original_value = param->value;
           param->value = NULL;
@@ -2027,6 +2028,7 @@ params_mhd_validate_values (const char *parent_name, void *params)
           param->valid_utf8 = 0;
           item_name = NULL;
         }
+      /* Item specific value validator like "method_data:to_adddress:". */
       else switch (openvas_validate (validator,
                                      (item_name = g_strdup_printf ("%s%s:",
                                                                    parent_name,
@@ -2034,6 +2036,7 @@ params_mhd_validate_values (const char *parent_name, void *params)
                                      param->value))
         {
           case 0:
+            param->valid_utf8 = g_utf8_validate (param->value, -1, NULL);
             break;
           case 1:
             /* General name validator for collection like "method_data:name". */
@@ -2059,7 +2062,7 @@ params_mhd_validate_values (const char *parent_name, void *params)
                 const gchar *alias_for;
 
                 param->valid = 1;
-                param->valid_utf8 = 1;
+                param->valid_utf8 = g_utf8_validate (param->value, -1, NULL);
 
                 alias_for = openvas_validator_alias_for (validator, name);
                 if ((param->value && (strcmp ((gchar*) name, "number") == 0))
@@ -2113,6 +2116,7 @@ params_mhd_validate (void *params)
           param->original_value = param->value;
           param->value = NULL;
           param->valid = 0;
+          param->valid_utf8 = 0;
         }
       else
         {

--- a/src/validator.c
+++ b/src/validator.c
@@ -51,7 +51,7 @@
  *
  * The validator must be freed with \ref openvas_validator_rule_free.
  *
- * @return A newly allocated validator.
+ * @return A newly allocated validator rule.
  */
 validator_rule_t *
 openvas_validator_rule_new (const char *regex)
@@ -60,9 +60,27 @@ openvas_validator_rule_new (const char *regex)
   rule = g_malloc (sizeof (validator_rule_t));
   rule->regex = g_strdup (regex);
   rule->alias_for = NULL;
+  rule->is_binary = FALSE;
   return rule;
 }
 
+/**
+ * @brief Create a new validator rule for a binary parameter.
+ *
+ * The validator must be freed with \ref openvas_validator_rule_free.
+ *
+ * @return A newly allocated validator rule.
+ */
+validator_rule_t *
+openvas_validator_rule_new_binary ()
+{
+  validator_rule_t *rule;
+  rule = g_malloc (sizeof (validator_rule_t));
+  rule->regex = NULL;
+  rule->alias_for = NULL;
+  rule->is_binary = TRUE;
+  return rule;
+}
 
 /**
  * @brief Free a validator rule.
@@ -110,6 +128,21 @@ openvas_validator_add (validator_t validator,
   g_hash_table_insert (validator,
                        (gpointer) g_strdup (name),
                        (gpointer) openvas_validator_rule_new (regex));
+}
+
+/**
+ * @brief Add or overwrite a validation rule for a binary data param.
+ *
+ * @param  validator  Validator to add rule to.
+ * @param  name       Name of the rule.
+ */
+void
+openvas_validator_add_binary (validator_t validator,
+                              const char *name)
+{
+  g_hash_table_insert (validator,
+                       (gpointer) g_strdup (name),
+                       (gpointer) openvas_validator_rule_new_binary ());
 }
 
 /**
@@ -188,11 +221,6 @@ openvas_validate (validator_t validator, const char *name, const char *value)
       g_debug ("%s: name is not valid UTF-8", __FUNCTION__);
       return 1;
     }
-  else if (value != NULL && g_utf8_validate (value, -1, NULL) == FALSE)
-    {
-      g_debug ("%s: value is not valid UTF-8", __FUNCTION__);
-      return 2;
-    }
 
   g_debug ("%s: name %s value %s", __FUNCTION__, name, value);
 
@@ -203,6 +231,18 @@ openvas_validate (validator_t validator, const char *name, const char *value)
       assert (value_rule);
 
       rule = (validator_rule_t*) value_rule;
+
+      if (rule->is_binary)
+        {
+          // Skip UTF-8 and regex validation for binary data
+          return 0;
+        }
+
+      if (value != NULL && g_utf8_validate (value, -1, NULL) == FALSE)
+        {
+          g_debug ("%s: value is not valid UTF-8", __FUNCTION__);
+          return 2;
+        }
 
       if (rule->regex == NULL)
         {

--- a/src/validator.h
+++ b/src/validator.h
@@ -46,6 +46,7 @@ struct validator_rule
 {
   gchar *alias_for;   ///< Name of the rule for which this is an alias.
   gchar *regex;       ///< Regular expression.
+  gboolean is_binary; ///< Whether to expect raw byte data, skip UTF-8 checks.
 };
 
 /**
@@ -55,6 +56,7 @@ typedef struct validator_rule validator_rule_t;
 
 validator_t openvas_validator_new ();
 void openvas_validator_add (validator_t, const char *, const char *);
+void openvas_validator_add_binary (validator_t, const char *);
 int openvas_validator_alias (validator_t, const char *, const char *);
 gchar *openvas_validator_alias_for (validator_t, const char *);
 int openvas_validate (validator_t, const char *, const char *);


### PR DESCRIPTION
Add an is_binary flag to validator rules to skip checks like UTF-8
validation and the regex test.
Apply those to allow non-text files as the installer param for agents
and as method_data:pkcs12 for alerts.