### PR TITLE
Removing ESLint warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ config.local.js
 # directory files for image previews
 .directory
 coverage/
-/ng/public/locales/
+/gsa/public/locales/

--- a/gsa/src/gmp/log.js
+++ b/gsa/src/gmp/log.js
@@ -46,7 +46,7 @@ export class Logger {
 
   setLevel(level) {
     level = isString(level) ? level.toLowerCase() : undefined;
-    let loglevel = LogLevels[level];
+    const loglevel = LogLevels[level];
 
     if (isDefined(loglevel)) {
       this.level = level;
@@ -57,8 +57,8 @@ export class Logger {
       this.level = 'silent';
     }
 
-    for (let logname in LogLevels) { // eslint-disable-line guard-for-in
-      this[logname] = (LogLevels[logname] < loglevel) ? noop : (...args) => {
+    for (const logname in LogLevels) { // eslint-disable-line guard-for-in
+      this[logname] = LogLevels[logname] < loglevel ? noop : (...args) => {
         return console[logname]('%c' + this.name, 'color: ' + GREENBONE_GREEN,
           ...args);
       };

--- a/gsa/src/gmp/models/host.js
+++ b/gsa/src/gmp/models/host.js
@@ -65,7 +65,7 @@ class Host extends Asset {
   static asset_type = 'host';
 
   parseProperties(elem) {
-    let ret = super.parseProperties(elem);
+    const ret = super.parseProperties(elem);
 
     if (isDefined(ret.host) && isDefined(ret.host.severity)) {
       ret.severity = parseSeverity(ret.host.severity.value);

--- a/gsa/src/web/components/dialog/savedialog.js
+++ b/gsa/src/web/components/dialog/savedialog.js
@@ -217,7 +217,8 @@ SaveDialog.propTypes = {
   buttonTitle: PropTypes.string,
   defaultValues: PropTypes.object, // default values for uncontrolled values
   externalError: PropTypes.object, // for errors from outside SaveDialog
-  initialData: deprecated(PropTypes.object, 'Please use \'defaultValues\' instead.'), // should not be used anymore. use defaultValues instead.
+  initialData:
+    deprecated(PropTypes.object, 'Please use \'defaultValues\' instead.'), // should not be used anymore. use defaultValues instead.
   minHeight: PropTypes.numberOrNumberString,
   minWidth: PropTypes.numberOrNumberString,
   title: PropTypes.string.isRequired,

--- a/gsa/src/web/components/icon/deleteicon.js
+++ b/gsa/src/web/components/icon/deleteicon.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -36,7 +36,7 @@ const DeleteIcon = ({
   active = true,
   selectionType,
   title,
-  ...other,
+  ...other
 }) => {
   if (!isDefined(title)) {
     if (selectionType === SelectionType.SELECTION_PAGE_CONTENTS) {
@@ -50,7 +50,8 @@ const DeleteIcon = ({
     }
   }
   return (
-    <Icon  {...other}
+    <Icon
+      {...other}
       img={active ? 'delete.svg' : 'delete_inactive.svg'}
       title={title}/>
   );
@@ -58,8 +59,8 @@ const DeleteIcon = ({
 
 DeleteIcon.propTypes = {
   active: PropTypes.bool,
-  title: PropTypes.string,
   selectionType: PropTypes.string,
+  title: PropTypes.string,
   onClick: PropTypes.func,
 };
 

--- a/gsa/src/web/components/icon/editicon.js
+++ b/gsa/src/web/components/icon/editicon.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -29,7 +29,7 @@ import Icon from './icon.js';
 
 const EditIcon = ({
   active = true,
-  ...props,
+  ...props
 }) => {
   return (
     <Icon {...props} img={active ? 'edit.svg' : 'edit_inactive.svg'}/>

--- a/gsa/src/web/components/icon/exporticon.js
+++ b/gsa/src/web/components/icon/exporticon.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2016 - 2017 Greenbone Networks GmbH
+ * Copyright (C) 2016 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -43,14 +43,15 @@ export const ExportIcon = ({selectionType, title, ...other}) => {
     download_title = _('Export all filtered');
   }
   return (
-    <Icon img="download.svg"
+    <Icon
+      img="download.svg"
       title={download_title} {...other}/>
   );
 };
 
 ExportIcon.propTypes = {
-  title: PropTypes.string,
   selectionType: PropTypes.string,
+  title: PropTypes.string,
   onClick: PropTypes.func,
 };
 

--- a/gsa/src/web/components/icon/foldicon.js
+++ b/gsa/src/web/components/icon/foldicon.js
@@ -4,7 +4,7 @@
  * Timo Pollmeier <timo.pollmeier@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -35,12 +35,12 @@ import Icon from './icon.js';
 export const FoldIcon = ({
     foldState,
     title,
-    ...other,
+    ...other
   }) => {
-  let folded = foldState === FoldState.FOLDED ||
+  const folded = foldState === FoldState.FOLDED ||
       foldState === FoldState.FOLDING ||
       foldState === FoldState.FOLDING_START;
-  let img = folded ? 'unfold.svg' : 'fold.svg';
+  const img = folded ? 'unfold.svg' : 'fold.svg';
 
   if (!isDefined(title)) {
     title = folded ? _('Unfold') : _('Fold');
@@ -62,4 +62,3 @@ FoldIcon.propTypes = {
 export default FoldIcon;
 
 // vim: set ts=2 sw=2 tw=80:
-

--- a/gsa/src/web/components/icon/osicon.js
+++ b/gsa/src/web/components/icon/osicon.js
@@ -42,7 +42,7 @@ const OsIcon = ({
   displayOsName = false,
   osTxt,
   osCpe,
-  ...props,
+  ...props
 }) => {
   const os = isDefined(osCpe) ?
     OperatingSystems.find(osCpe) : undefined;
@@ -98,10 +98,10 @@ const OsIcon = ({
 };
 
 OsIcon.propTypes = {
-  displayOsName: PropTypes.bool,
   displayOsCpe: PropTypes.bool,
-  osTxt: PropTypes.string,
+  displayOsName: PropTypes.bool,
   osCpe: PropTypes.string,
+  osTxt: PropTypes.string,
 };
 
 

--- a/gsa/src/web/components/icon/solutiontypeicon.js
+++ b/gsa/src/web/components/icon/solutiontypeicon.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2016 - 2017 Greenbone Networks GmbH
+ * Copyright (C) 2016 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -69,7 +69,7 @@ const SolutionType = ({
 
   if (displayTitleText) {
     return (
-      <Divider flex align={["start", "center"]}>
+      <Divider flex align={['start', 'center']}>
         <Icon
           img={img}
           title={title}
@@ -90,8 +90,8 @@ const SolutionType = ({
 };
 
 SolutionType.propTypes = {
-  type: PropTypes.string,
   displayTitleText: PropTypes.bool,
+  type: PropTypes.string,
 };
 
 

--- a/gsa/src/web/components/icon/trashicon.js
+++ b/gsa/src/web/components/icon/trashicon.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2016 - 2017 Greenbone Networks GmbH
+ * Copyright (C) 2016 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -36,7 +36,7 @@ const TrashIcon = ({
   active = true,
   selectionType,
   title,
-  ...other,
+  ...other
 }) => {
   if (!isDefined(title)) {
     if (selectionType === SelectionType.SELECTION_PAGE_CONTENTS) {
@@ -50,7 +50,8 @@ const TrashIcon = ({
     }
   }
   return (
-    <Icon  {...other}
+    <Icon
+      {...other}
       img={active ? 'trashcan.svg' : 'trashcan_inactive.svg'}
       title={title}/>
   );
@@ -58,8 +59,8 @@ const TrashIcon = ({
 
 TrashIcon.propTypes = {
   active: PropTypes.bool,
-  title: PropTypes.string,
   selectionType: PropTypes.string,
+  title: PropTypes.string,
   onClick: PropTypes.func,
 };
 

--- a/gsa/src/web/components/img/img.js
+++ b/gsa/src/web/components/img/img.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2016 - 2017 Greenbone Networks GmbH
+ * Copyright (C) 2016 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -30,9 +30,9 @@ import {get_img_url} from '../../utils/urls.js';
 const Img = ({
   alt = '',
   src,
-  ...other,
+  ...other
 }) => {
-  let img_path = get_img_url(src);
+  const img_path = get_img_url(src);
   return (
     <img
       {...other}

--- a/gsa/src/web/components/link/innerlink.js
+++ b/gsa/src/web/components/link/innerlink.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,7 +28,7 @@ import PropTypes from '../../utils/proptypes.js';
 const InnerLink = ({
   children,
   to,
-  ...props,
+  ...props
 }) => {
   return (
     <a {...props} href={'#' + to}>

--- a/gsa/src/web/components/powerfilter/firstresultgroup.js
+++ b/gsa/src/web/components/powerfilter/firstresultgroup.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -48,9 +48,9 @@ const FirstResultGroup = ({first, filter, onChange, name = 'first'}) => {
 };
 
 FirstResultGroup.propTypes = {
-  name: PropTypes.string,
-  first: PropTypes.number,
   filter: PropTypes.filter,
+  first: PropTypes.number,
+  name: PropTypes.string,
   onChange: PropTypes.func,
 };
 

--- a/gsa/src/web/components/powerfilter/sortbygroup.js
+++ b/gsa/src/web/components/powerfilter/sortbygroup.js
@@ -39,8 +39,7 @@ class SortByGroup extends React.Component {
   renderSortFieldOptions() {
     const {fields} = this.props;
     return map(fields, field => {
-      const value = field[0];
-      const title = field[1];
+      const [value, title] = field;
       return <option key={value} value={value}>{title}</option>;
     });
   }
@@ -79,9 +78,9 @@ class SortByGroup extends React.Component {
 
 SortByGroup.propTypes = {
   by: PropTypes.string,
-  order: PropTypes.oneOf(['sort', 'sort-reverse']),
-  filter: PropTypes.filter,
   fields: PropTypes.array,
+  filter: PropTypes.filter,
+  order: PropTypes.oneOf(['sort', 'sort-reverse']),
   onSortByChange: PropTypes.func,
   onSortOrderChange: PropTypes.func,
 };

--- a/gsa/src/web/components/table/header.js
+++ b/gsa/src/web/components/table/header.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -40,8 +40,8 @@ const TableHeader = glamorous.thead({
     '& a, & a:hover': {
       textDecoration: 'none',
       color: 'black',
-    }
-  }
+    },
+  },
 });
 
 export default TableHeader;

--- a/gsa/src/web/components/table/row.js
+++ b/gsa/src/web/components/table/row.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2016 - 2017 Greenbone Networks GmbH
+ * Copyright (C) 2016 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,7 +26,7 @@ import React from 'react';
 import PropTypes from '../../utils/proptypes.js';
 
 const TableRow = ({items = [], children, ...other}) => {
-  let data = items.map((item, i) => {
+  const data = items.map((item, i) => {
     return <th key={i}>{item}</th>;
   });
   return (

--- a/gsa/src/web/entities/selection.js
+++ b/gsa/src/web/entities/selection.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -36,7 +36,11 @@ export class EntitySelection extends React.Component {
   }
 
   handleSelection(value) {
-    let {onDeselected, onSelected, entity} = this.props;
+    const {
+      onDeselected,
+      onSelected,
+      entity,
+    } = this.props;
 
     if (value) {
       if (onSelected) {
@@ -57,10 +61,9 @@ export class EntitySelection extends React.Component {
 
 EntitySelection.propTypes = {
   entity: PropTypes.model,
-  onSelected: PropTypes.func,
   onDeselected: PropTypes.func,
+  onSelected: PropTypes.func,
 };
-
 
 export default EntitySelection;
 

--- a/gsa/src/web/entity/container.js
+++ b/gsa/src/web/entity/container.js
@@ -42,7 +42,7 @@ import TagsHandler from './tagshandler.js';
 const log = logger.getLogger('web.entity.container');
 
 export const loader = (type, filter_func, name = type) =>
-  function (id, cancel_token) {
+  function(id, cancel_token) {
     const {gmp} = this.props;
 
     log.debug('Loading', name, 'for entity', id);

--- a/gsa/src/web/entity/icon/observericon.js
+++ b/gsa/src/web/entity/icon/observericon.js
@@ -5,7 +5,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -60,8 +60,8 @@ const ObserverIcon = ({
 };
 
 ObserverIcon.propTypes = {
-  entity: PropTypes.model.isRequired,
   displayName: PropTypes.string,
+  entity: PropTypes.model.isRequired,
   userName: PropTypes.string.isRequired,
 };
 

--- a/gsa/src/web/pages/alerts/details.js
+++ b/gsa/src/web/pages/alerts/details.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -102,7 +102,8 @@ const AlertDetails = ({
             </TableData>
           </TableRow>
 
-          {capabilities.mayAccess('report') && isDefined(method.data.delta_type) &&
+          {capabilities.mayAccess('report') &&
+            isDefined(method.data.delta_type) &&
             method.data.delta_type.value === DELTA_TYPE_PREVIOUS &&
             <TableRow>
               <TableData>
@@ -114,7 +115,8 @@ const AlertDetails = ({
             </TableRow>
           }
 
-          {capabilities.mayAccess('report') && isDefined(method.data.delta_type) &&
+          {capabilities.mayAccess('report') &&
+            isDefined(method.data.delta_type) &&
             isDefined(method.data.delta_report_id) &&
             method.data.delta_type.value === DELTA_TYPE_REPORT &&
             <TableRow>

--- a/gsa/src/web/pages/alerts/dialog.js
+++ b/gsa/src/web/pages/alerts/dialog.js
@@ -521,7 +521,8 @@ class AlertDialog extends React.Component {
                       title={_('None')}
                       name="method_data_delta_type"
                       value={DELTA_TYPE_NONE}
-                      checked={values.method_data_delta_type === DELTA_TYPE_NONE}
+                      checked={
+                        values.method_data_delta_type === DELTA_TYPE_NONE}
                       onChange={onValueChange}
                     />
 
@@ -529,7 +530,8 @@ class AlertDialog extends React.Component {
                       title={_('Previous completed report of the same task')}
                       name="method_data_delta_type"
                       value={DELTA_TYPE_PREVIOUS}
-                      checked={values.method_data_delta_type === DELTA_TYPE_PREVIOUS}
+                      checked={
+                        values.method_data_delta_type === DELTA_TYPE_PREVIOUS}
                       onChange={onValueChange}
                     />
 
@@ -538,7 +540,8 @@ class AlertDialog extends React.Component {
                         title={_('Report with ID')}
                         name="method_data_delta_type"
                         value={DELTA_TYPE_REPORT}
-                        checked={values.method_data_delta_type === DELTA_TYPE_REPORT}
+                        checked={
+                          values.method_data_delta_type === DELTA_TYPE_REPORT}
                         onChange={onValueChange}
                       />
                       <TextField
@@ -721,10 +724,10 @@ AlertDialog.propTypes = {
   filter_id: PropTypes.idOrZero,
   method: PropTypes.string,
   method_data_URL: PropTypes.string,
-  method_data_delta_type: PropTypes.string,
-  method_data_delta_report_id: PropTypes.string,
   method_data_defense_center_ip: PropTypes.string,
   method_data_defense_center_port: PropTypes.numberOrNumberString,
+  method_data_delta_report_id: PropTypes.string,
+  method_data_delta_type: PropTypes.string,
   method_data_details_url: PropTypes.string,
   method_data_from_address: PropTypes.string,
   method_data_message: PropTypes.string,

--- a/gsa/src/web/pages/alerts/httpmethodpart.js
+++ b/gsa/src/web/pages/alerts/httpmethodpart.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2016 - 2017 Greenbone Networks GmbH
+ * Copyright (C) 2016 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -49,8 +49,8 @@ const HttpMethodPart = ({
 };
 
 HttpMethodPart.propTypes = {
-  prefix: PropTypes.string,
   URL: PropTypes.string.isRequired,
+  prefix: PropTypes.string,
   onChange: PropTypes.func,
 };
 

--- a/gsa/src/web/pages/hosts/row.js
+++ b/gsa/src/web/pages/hosts/row.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -58,7 +58,7 @@ const Actions = ({
   }, {capabilities}) => {
 
   let new_title;
-  let can_create_target = capabilities.mayCreate('target');
+  const can_create_target = capabilities.mayCreate('target');
   if (can_create_target) {
     new_title = _('Create Target from Host');
   }
@@ -98,8 +98,8 @@ Actions.propTypes = {
   entity: PropTypes.model,
   onHostDeleteClick: PropTypes.func,
   onHostDownloadClick: PropTypes.func,
-  onTargetCreateFromHostClick: PropTypes.func,
   onHostEditClick: PropTypes.func,
+  onTargetCreateFromHostClick: PropTypes.func,
 };
 
 Actions.contextTypes = {
@@ -111,7 +111,7 @@ const Row = ({
   links = true,
   actions,
   onToggleDetailsClick,
-  ...props,
+  ...props
 }) => {
   const {details = {}} = entity;
   const os_cpe = isDefined(details.best_os_cpe) ? details.best_os_cpe.value :

--- a/gsa/src/web/pages/notes/details.js
+++ b/gsa/src/web/pages/notes/details.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -102,11 +102,11 @@ const NoteDetails = ({
                 {_('Severity')}
               </TableData>
               <TableData>
-                {isDefined(severity) ? (
+                {isDefined(severity) ?
                   severity > LOG_VALUE ?
                     _('> 0.0') :
-                    translatedResultSeverityRiskFactor(severity)
-                ) : _('Any')
+                    translatedResultSeverityRiskFactor(severity) :
+                 _('Any')
                 }
               </TableData>
             </TableRow>
@@ -117,13 +117,12 @@ const NoteDetails = ({
               </TableData>
               <TableData>
                 {entity.isOrphan() ?
-                  <b>{_('Orphan')}</b> : (
+                  <b>{_('Orphan')}</b> :
                   isDefined(task) ?
                     <EntityLink
                       entity={task}
                     /> :
                     _('Any')
-                  )
                 }
               </TableData>
             </TableRow>
@@ -134,13 +133,12 @@ const NoteDetails = ({
               </TableData>
               <TableData>
                 {entity.isOrphan() ?
-                  <b>{_('Orphan')}</b> : (
+                  <b>{_('Orphan')}</b> :
                   isDefined(result) ?
                     <EntityLink
                       entity={result}
                     /> :
                     _('Any')
-                  )
                 }
               </TableData>
             </TableRow>

--- a/gsa/src/web/pages/notes/row.js
+++ b/gsa/src/web/pages/notes/row.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -91,7 +91,7 @@ const Row = ({
   links = true,
   actions,
   onToggleDetailsClick,
-  ...props,
+  ...props
 }) => {
   const text = (
     <div>
@@ -111,7 +111,7 @@ const Row = ({
         </RowDetailsToggle>
       </TableData>
       <TableData>
-        {entity.nvt ? entity.nvt.name : ""}
+        {entity.nvt ? entity.nvt.name : ''}
       </TableData>
       <TableData title={entity.hosts}>
         {shorten(entity.hosts.join(', '))}

--- a/gsa/src/web/pages/overrides/details.js
+++ b/gsa/src/web/pages/overrides/details.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -102,11 +102,11 @@ const OverrideDetails = ({
                 {_('Severity')}
               </TableData>
               <TableData>
-                {isDefined(severity) ? (
+                {isDefined(severity) ?
                   severity > LOG_VALUE ?
                     _('> 0.0') :
-                    translatedResultSeverityRiskFactor(severity)
-                ) : _('Any')
+                    translatedResultSeverityRiskFactor(severity) :
+                 _('Any')
                 }
               </TableData>
             </TableRow>
@@ -117,13 +117,12 @@ const OverrideDetails = ({
               </TableData>
               <TableData>
                 {entity.isOrphan() ?
-                  <b>{_('Orphan')}</b> : (
+                  <b>{_('Orphan')}</b> :
                   isDefined(task) ?
                     <EntityLink
                       entity={task}
                     /> :
                     _('Any')
-                  )
                 }
               </TableData>
             </TableRow>
@@ -134,13 +133,12 @@ const OverrideDetails = ({
               </TableData>
               <TableData>
                 {entity.isOrphan() ?
-                  <b>{_('Orphan')}</b> : (
+                  <b>{_('Orphan')}</b> :
                   isDefined(result) ?
                     <EntityLink
                       entity={result}
                     /> :
                     _('Any')
-                  )
                 }
               </TableData>
             </TableRow>

--- a/gsa/src/web/pages/overrides/row.js
+++ b/gsa/src/web/pages/overrides/row.js
@@ -109,7 +109,7 @@ const Row = ({
   links = true,
   actions,
   onToggleDetailsClick,
-  ...props,
+  ...props
 }) => {
   return (
     <TableRow>
@@ -121,7 +121,7 @@ const Row = ({
         </RowDetailsToggle>
       </TableData>
       <TableData>
-        {entity.nvt ? entity.nvt.name : ""}
+        {entity.nvt ? entity.nvt.name : ''}
       </TableData>
       <TableData title={entity.hosts}>
         {shorten(entity.hosts.join(', '))}

--- a/gsa/src/web/pages/portlists/portrangedialog.js
+++ b/gsa/src/web/pages/portlists/portrangedialog.js
@@ -113,6 +113,7 @@ const PortRangeDialog = ({
 };
 
 PortRangeDialog.propTypes = {
+  id: PropTypes.id.isRequired,
   port_list: PropTypes.model,
   port_type: PropTypes.string,
   title: PropTypes.string,

--- a/gsa/src/web/pages/results/row.js
+++ b/gsa/src/web/pages/results/row.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -94,11 +94,11 @@ const Row = ({
         >
           {host.name}
         </DetailsLink>
-        {host.hostname.length > 0
-          ? <span title={host.hostname}>
-              ({shorten (host.hostname, 40)})
-            </span>
-          : false}
+        {host.hostname.length > 0 ?
+          <span title={host.hostname}>
+              ({shorten(host.hostname, 40)})
+            </span> :
+          false}
       </TableData>
       <TableData>
         {entity.port}

--- a/gsa/src/web/pages/results/table.js
+++ b/gsa/src/web/pages/results/table.js
@@ -105,7 +105,8 @@ const Header = ({
           onSortChange={onSortChange}>
           {_('QoD')}
         </TableHead>
-        <TableHead colSpan="2"
+        <TableHead
+          colSpan="2"
           width="13%">
           {_('Host')}
         </TableHead>

--- a/gsa/src/web/pages/scanconfigs/trend.js
+++ b/gsa/src/web/pages/scanconfigs/trend.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -32,7 +32,7 @@ const Trend = ({
     trend,
     titleDynamic,
     titleStatic,
-    ...props,
+    ...props
   }) => {
   if (trend === '1') {
     return (
@@ -60,9 +60,9 @@ const Trend = ({
 };
 
 Trend.propTypes = {
-  trend: PropTypes.string,
-  titleStatic: PropTypes.string,
   titleDynamic: PropTypes.string,
+  titleStatic: PropTypes.string,
+  trend: PropTypes.string,
 };
 
 export default Trend;

--- a/gsa/src/web/pages/tasks/icons/importreporticon.js
+++ b/gsa/src/web/pages/tasks/icons/importreporticon.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -28,10 +28,10 @@ import PropTypes from '../../../utils/proptypes.js';
 
 import Icon from '../../../components/icon/icon.js';
 
-const  ImportIcon = ({
+const ImportIcon = ({
   size,
   task,
-  onClick
+  onClick,
 }, {capabilities}) => {
 
   if (!task.isContainer() || !capabilities.mayCreate('report')) {

--- a/gsa/src/web/pages/tasks/icons/newiconmenu.js
+++ b/gsa/src/web/pages/tasks/icons/newiconmenu.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2016 - 2017 Greenbone Networks GmbH
+ * Copyright (C) 2016 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -36,9 +36,11 @@ const NewIcon = ({
   if (capabilities.mayCreate('task')) {
     return (
       <IconMenu img="new.svg" onClick={onNewClick}>
-        <MenuEntry title={_('New Task')}
+        <MenuEntry
+          title={_('New Task')}
           onClick={onNewClick}/>
-        <MenuEntry title={_('New Container Task')}
+        <MenuEntry
+          title={_('New Container Task')}
           onClick={onNewContainerClick}/>
       </IconMenu>
     );

--- a/gsa/src/web/pages/tasks/icons/starticon.js
+++ b/gsa/src/web/pages/tasks/icons/starticon.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -31,7 +31,7 @@ import Icon from '../../../components/icon/icon.js';
 const StartIcon = ({
   task,
   size,
-  onClick
+  onClick,
 }, {capabilities}) => {
 
   if (task.isRunning() || task.isContainer()) {

--- a/gsa/src/web/pages/vulns/filterdialog.js
+++ b/gsa/src/web/pages/vulns/filterdialog.js
@@ -4,7 +4,7 @@
  * Björn Ricks <bjoern.ricks@greenbone.net>
  *
  * Copyright:
- * Copyright (C) 2017 Greenbone Networks GmbH
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -20,7 +20,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-import  _ from 'gmp/locale';
+import _ from 'gmp/locale';
 
 import {createFilterDialog} from '../../components/powerfilter/dialog.js';
 

--- a/gsa/src/web/utils/os.js
+++ b/gsa/src/web/utils/os.js
@@ -46,1002 +46,1002 @@ const operating_systems = [
   {
     pattern: 'cpe:/o:microsoft:windows_nt:4.0:sp5',
     title: 'Microsoft Windows 4.0 sp5',
-    icon: 'os_windows.svg'
+    icon: 'os_windows.svg',
   },
   {
     pattern: 'cpe:/o:microsoft:windows_nt:4.0:sp6',
     title: 'Microsoft Windows 4.0 sp6',
-    icon: 'os_windows.svg'
+    icon: 'os_windows.svg',
   },
   {
     pattern: 'cpe:/o:microsoft:windows_xp::sp1',
     title: 'Microsoft windows xp_sp1',
-    icon: 'os_windows.svg'
+    icon: 'os_windows.svg',
   },
   {
     pattern: 'cpe:/o:microsoft:windows_xp::sp2',
     title: 'Microsoft Windows XP Service Pack 2',
-    icon: 'os_windows.svg'
+    icon: 'os_windows.svg',
   },
   {
     pattern: 'cpe:/o:microsoft:windows_xp::sp3',
     title: 'Microsoft Windows XP Service Pack 3',
-    icon: 'os_windows.svg'
+    icon: 'os_windows.svg',
   },
   {
     pattern: 'cpe:/o:microsoft:windows_server_2003::sp1',
     title: 'Microsoft Windows Server 2003 Service Pack 1',
-    icon: 'os_windows.svg'
+    icon: 'os_windows.svg',
   },
   {
     pattern: 'cpe:/o:microsoft:windows_server_2003::sp2',
     title: 'Microsoft Windows Server 2003 Service Pack 2',
-    icon: 'os_windows.svg'
+    icon: 'os_windows.svg',
   },
   {
     pattern: 'cpe:/o:microsoft:windows_nt',
     title: 'Microsoft Windows NT',
-    icon: 'os_windows.svg'
+    icon: 'os_windows.svg',
   },
   {
     pattern: 'cpe:/o:microsoft:windows_2000',
     title: 'Microsoft Windows 2000',
-    icon: 'os_windows.svg'
+    icon: 'os_windows.svg',
   },
   {
     pattern: 'cpe:/o:microsoft:windows_server_2000',
     title: 'Microsoft Windows Server 2000',
-    icon: 'os_windows.svg'
+    icon: 'os_windows.svg',
   },
   {
     pattern: 'cpe:/o:microsoft:windows_xp',
     title: 'Microsoft Windows XP',
-    icon: 'os_windows.svg'
+    icon: 'os_windows.svg',
   },
   {
     pattern: 'cpe:/o:microsoft:windows_server_2003',
     title: 'Microsoft Windows Server 2003',
-    icon: 'os_windows.svg'
+    icon: 'os_windows.svg',
   },
   {
     pattern: 'cpe:/o:microsoft:windows_embedded',
     title: 'Microsoft Windows Embedded',
-    icon: 'os_windows.svg'
+    icon: 'os_windows.svg',
   },
   {
     pattern: 'cpe:/o:microsoft:windows',
     title: 'Microsoft Windows',
-    icon: 'os_windows.svg'
+    icon: 'os_windows.svg',
   },
   {
     pattern: 'cpe:/o:redhat:linux:7.3',
     title: 'Red Hat Linux 7.3',
-    icon: 'os_redhat.svg'
+    icon: 'os_redhat.svg',
   },
   {
     pattern: 'cpe:/o:redhat:linux:8.0',
     title: 'Red Hat Linux 8.0',
-    icon: 'os_redhat.svg'
+    icon: 'os_redhat.svg',
   },
   {
     pattern: 'cpe:/o:redhat:linux:9',
     title: 'Red Hat Linux 9.0',
-    icon: 'os_redhat.svg'
+    icon: 'os_redhat.svg',
   },
   {
     pattern: 'cpe:/o:redhat:linux',
     title: 'Red Hat Linux',
-    icon: 'os_redhat.svg'
+    icon: 'os_redhat.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora_core:1',
     title: 'Fedora Core 1',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora_core:2',
     title: 'Fedora Core 2',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora_core:3',
     title: 'Fedora Core 3',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora_core:4',
     title: 'Fedora Core 4',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora_core:5',
     title: 'Fedora Core 5',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora_core:6',
     title: 'Fedora Core 6',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:7',
     title: 'Fedora 7',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:8',
     title: 'Fedora 8',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:9',
     title: 'Fedora 9',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:10',
     title: 'Fedora 10',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:11',
     title: 'Fedora 11',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:12',
     title: 'Fedora 12',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:13',
     title: 'Fedora 13',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:14',
     title: 'Fedora 14',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:15',
     title: 'Fedora 15',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:16',
     title: 'Fedora 16',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:17',
     title: 'Fedora 17',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:18',
     title: 'Fedora 18',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:19',
     title: 'Fedora 19',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:20',
     title: 'Fedora 20',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:21',
     title: 'Fedora 21',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:22',
     title: 'Fedora 22',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora:23',
     title: 'Fedora 23',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:fedoraproject:fedora',
     title: 'Fedora',
-    icon: 'os_fedora.svg'
+    icon: 'os_fedora.svg',
   },
   {
     pattern: 'cpe:/o:redhat:enterprise_linux:2.1',
     title: 'Red Hat Enterprise Linux 2.1',
-    icon: 'os_redhat.svg'
+    icon: 'os_redhat.svg',
   },
   {
     pattern: 'cpe:/o:redhat:enterprise_linux:3',
     title: 'Red Hat Enterprise Linux 3',
-    icon: 'os_redhat.svg'
+    icon: 'os_redhat.svg',
   },
   {
     pattern: 'cpe:/o:redhat:enterprise_linux:4',
     title: 'Red Hat Enterprise Linux 4',
-    icon: 'os_redhat.svg'
+    icon: 'os_redhat.svg',
   },
   {
     pattern: 'cpe:/o:redhat:enterprise_linux:5',
     title: 'Red Hat Enterprise Linux 5',
-    icon: 'os_redhat.svg'
+    icon: 'os_redhat.svg',
   },
   {
     pattern: 'cpe:/o:redhat:enterprise_linux:6',
     title: 'Red Hat Enterprise Linux 6',
-    icon: 'os_redhat.svg'
+    icon: 'os_redhat.svg',
   },
   {
     pattern: 'cpe:/o:redhat:enterprise_linux:7',
     title: 'Red Hat Enterprise Linux 7',
-    icon: 'os_redhat.svg'
+    icon: 'os_redhat.svg',
   },
   {
     pattern: 'cpe:/o:redhat',
     title: 'Red Hat',
-    icon: 'os_redhat.svg'
+    icon: 'os_redhat.svg',
   },
   {
     pattern: 'cpe:/o:mandriva:linux:2010.0',
     title: 'Mandriva Linux 2010.0',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandriva:linux:2010.1',
     title: 'Mandriva Linux 2010.1',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandriva:linux:2011.0',
     title: 'Mandriva Linux 2011.0',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandriva:linux:2009.0',
     title: 'Mandriva Linux 2009.0',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandriva:linux:2009.1',
     title: 'Mandriva Linux 2009.1',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandriva:linux:2008.1',
     title: 'Mandrake Linux 2008.1',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandriva:linux:2008.0',
     title: 'Mandriva Linux 2008.0',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandriva:linux:2007.1',
     title: 'Mandriva Linux 2007.1',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandriva:linux:2007.0',
     title: 'Mandriva Linux 2007.0',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandriva:linux:2006.0',
     title: 'Mandriva Linux 2006.0',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandriva:linux',
     title: 'Mandriva Linux',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandrakesoft:mandrake_linux:10.2',
     title: 'MandrakeSoft Mandrake Linux 10.2',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandrakesoft:mandrake_linux:10.1',
     title: 'MandrakeSoft Mandrake Linux 10.1',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandrakesoft:mandrake_linux:10.0',
     title: 'MandrakeSoft Mandrake Linux 10.0',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandrakesoft:mandrake_linux:9.2',
     title: 'MandrakeSoft Mandrake Linux 9.2',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandrakesoft:mandrake_linux:9.1',
     title: 'MandrakeSoft Mandrake Linux 9.1',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandrakesoft:mandrake_linux:8.1',
     title: 'MandrakeSoft Mandrake Linux 8.1',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandrakesoft:mandrake_linux:8.0',
     title: 'MandrakeSoft Mandrake Linux 8.0',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandrakesoft:mandrake_linux:7.2',
     title: 'MandrakeSoft Mandrake Linux 7.2',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:mandrakesoft:mandrake_linux',
     title: 'MandrakeSoft Mandrake Linux',
-    icon: 'os_mandriva.svg'
+    icon: 'os_mandriva.svg',
   },
   {
     pattern: 'cpe:/o:centos:centos:7',
     title: 'CentOS-7',
-    icon: 'os_centos.svg'
+    icon: 'os_centos.svg',
   },
   {
     pattern: 'cpe:/o:centos:centos:6',
     title: 'CentOS-6',
-    icon: 'os_centos.svg'
+    icon: 'os_centos.svg',
   },
   {
     pattern: 'cpe:/o:centos:centos:5',
     title: 'CentOS-5',
-    icon: 'os_centos.svg'
+    icon: 'os_centos.svg',
   },
   {
     pattern: 'cpe:/o:centos:centos:4',
     title: 'CentOS-4',
-    icon: 'os_centos.svg'
+    icon: 'os_centos.svg',
   },
   {
     pattern: 'cpe:/o:centos:centos:3',
     title: 'CentOS-3',
-    icon: 'os_centos.svg'
+    icon: 'os_centos.svg',
   },
   {
     pattern: 'cpe:/o:centos:centos:2',
     title: 'CentOS-2',
-    icon: 'os_centos.svg'
+    icon: 'os_centos.svg',
   },
   {
     pattern: 'cpe:/o:centos:centos',
     title: 'CentOS',
-    icon: 'os_centos.svg'
+    icon: 'os_centos.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:2.2',
     title: 'Debian Debian Linux 2.2',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:3.0',
     title: 'Debian Debian Linux 3.0',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:3.1',
     title: 'Debian Debian Linux 3.1',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:4.0',
     title: 'Debian GNU/Linux 4.0',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:5.0',
     title: 'Debian GNU/Linux 5.0',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:6.0',
     title: 'Debian GNU/Linux 6.0',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:7.0',
     title: 'Debian GNU/Linux 7.0',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:7.1',
     title: 'Debian GNU/Linux 7.1',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:7.2',
     title: 'Debian GNU/Linux 7.2',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:7.3',
     title: 'Debian GNU/Linux 7.3',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:7.4',
     title: 'Debian GNU/Linux 7.4',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:7.5',
     title: 'Debian GNU/Linux 7.5',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:7.6',
     title: 'Debian GNU/Linux 7.6',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:7.7',
     title: 'Debian GNU/Linux 7.7',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:7.8',
     title: 'Debian GNU/Linux 7.8',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:7.9',
     title: 'Debian GNU/Linux 7.9',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:8.0',
     title: 'Debian GNU/Linux 8.0',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:8.1',
     title: 'Debian GNU/Linux 8.1',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:8.2',
     title: 'Debian GNU/Linux 8.2',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:8.3',
     title: 'Debian GNU/Linux 8.3',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux:8.4',
     title: 'Debian GNU/Linux 8.4',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:debian:debian_linux',
     title: 'Debian GNU/Linux',
-    icon: 'os_debian.svg'
+    icon: 'os_debian.svg',
   },
   {
     pattern: 'cpe:/o:suse:linux_enterprise_server:12',
     title: 'SuSE Linux Enterprise Server 12',
-    icon: 'os_suse.svg'
+    icon: 'os_suse.svg',
   },
   {
     pattern: 'cpe:/o:suse:linux_enterprise_server:11',
     title: 'SuSE Linux Enterprise Server 11',
-    icon: 'os_suse.svg'
+    icon: 'os_suse.svg',
   },
   {
     pattern: 'cpe:/o:suse:linux_enterprise_server:10',
     title: 'SuSE Linux Enterprise Server 10',
-    icon: 'os_suse.svg'
+    icon: 'os_suse.svg',
   },
   {
     pattern: 'cpe:/o:suse:linux_enterprise_server:9',
     title: 'SuSE Linux Enterprise Server 9',
-    icon: 'os_suse.svg'
+    icon: 'os_suse.svg',
   },
   {
     pattern: 'cpe:/o:suse:linux_enterprise_server',
     title: 'SuSE Linux Enterprise Server',
-    icon: 'os_suse.svg'
+    icon: 'os_suse.svg',
   },
   {
     pattern: 'cpe:/o:novell:opensuse:11.3',
     title: 'Novell openSUSE 11.3',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:opensuse:11.4',
     title: 'Novell openSUSE 11.4',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:opensuse:12.1',
     title: 'Novell openSUSE 12.1',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:opensuse:12.2',
     title: 'Novell openSUSE 12.2',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:opensuse:12.3',
     title: 'Novell openSUSE 12.3',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:opensuse:13.1',
     title: 'Novell openSUSE 13.1',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:opensuse:13.2',
     title: 'Novell openSUSE 13.2',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:opensuse:42.1',
     title: 'Novell openSUSE Leap 42.1',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:opensuse:11.2',
     title: 'Novell openSUSE 11.2',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:opensuse:11.1',
     title: 'Novell openSUSE 11.1',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:opensuse:11.0',
     title: 'Novell opensuse 11.0',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:opensuse:10.3',
     title: 'Novell opensuse 10.3',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:opensuse:10.2',
     title: 'Novell openSUSE 10.2',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:opensuse',
     title: 'Novell openSUSE',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:suse_linux:11.0',
     title: 'Novell SUSE Linux 11.0',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:suse_linux:10.3',
     title: 'Novell SUSE Linux 10.3',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:suse_linux:10.2',
     title: 'Novell SUSE Linux 10.2',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:suse_linux:10.1',
     title: 'Novell SUSE Linux 10.1',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:suse_linux:9.3',
     title: 'Novell SUSE Linux 9.3',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:suse_linux:9.2',
     title: 'Novell SUSE Linux 9.2',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:suse_linux:9.1',
     title: 'Novell SUSE Linux 9.1',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:suse_linux:9.0',
     title: 'Novell SUSE Linux 9.0',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:suse_linux:8.2',
     title: 'Novell SUSE Linux 8.2',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:suse_linux:8.1',
     title: 'Novell SUSE Linux 8.1',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:suse_linux:8.0',
     title: 'Novell SUSE Linux 8.0',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:suse_linux:7.3',
     title: 'Novell SUSE Linux 7.3',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:novell:suse_linux',
     title: 'Novell SUSE Linux',
-    icon: 'os_novell.svg'
+    icon: 'os_novell.svg',
   },
   {
     pattern: 'cpe:/o:trustix:secure_linux:3.0.5',
     title: 'Trustix Secure Linux 3.0.5',
-    icon: 'os_trustix.svg'
+    icon: 'os_trustix.svg',
   },
   {
     pattern: 'cpe:/o:trustix:secure_linux:3.0',
     title: 'Trustix Secure Linux 3.0',
-    icon: 'os_trustix.svg'
+    icon: 'os_trustix.svg',
   },
   {
     pattern: 'cpe:/o:trustix:secure_linux:2.2',
     title: 'Trustix Secure Linux 2.2',
-    icon: 'os_trustix.svg'
+    icon: 'os_trustix.svg',
   },
   {
     pattern: 'cpe:/o:trustix:secure_linux:2.1',
     title: 'Trustix Secure Linux 2.1',
-    icon: 'os_trustix.svg'
+    icon: 'os_trustix.svg',
   },
   {
     pattern: 'cpe:/o:trustix:secure_linux:2.0',
     title: 'Trustix Secure Linux 2.0',
-    icon: 'os_trustix.svg'
+    icon: 'os_trustix.svg',
   },
   {
     pattern: 'cpe:/o:trustix:secure_linux:1.5',
     title: 'Trustix Secure Linux 1.5',
-    icon: 'os_trustix.svg'
+    icon: 'os_trustix.svg',
   },
   {
     pattern: 'cpe:/o:trustix:secure_linux:1.2',
     title: 'Trustix Secure Linux 1.2',
-    icon: 'os_trustix.svg'
+    icon: 'os_trustix.svg',
   },
   {
     pattern: 'cpe:/o:trustix:secure_linux:1.1',
     title: 'Trustix Secure Linux 1.1',
-    icon: 'os_trustix.svg'
+    icon: 'os_trustix.svg',
   },
   {
     pattern: 'cpe:/o:trustix:secure_linux',
     title: 'Trustix Secure Linux',
-    icon: 'os_trustix.svg'
+    icon: 'os_trustix.svg',
   },
   {
     pattern: 'cpe:/o:gentoo:linux',
     title: 'Gentoo Linux',
-    icon: 'os_gentoo.svg'
+    icon: 'os_gentoo.svg',
   },
   {
     pattern: 'cpe:/o:hp:hp-ux:10.01',
     title: 'HP HP-UX 10.01',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:hp:hp-ux:10.10',
     title: 'HP HP-UX 10.10',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:hp:hp-ux:10.20',
     title: 'HP HP-UX 10.20',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:hp:hp-ux:10.24',
     title: 'HP HP-UX 10.24',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:hp:hp-ux:10.26',
     title: 'HP HP-UX 10.26',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:hp:hp-ux:11.00',
     title: 'HP-UX 11.00',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:hp:hp-ux:11.0.4',
     title: 'HP HP-UX 11.0.4',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:hp:hp-ux:11.11',
     title: 'HP-UX 11.11',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:hp:hp-ux:11.20',
     title: 'HP-UX 11i v1.5',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:hp:hp-ux:11.22',
     title: 'HP-UX 11i v1.6',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:hp:hp-ux:11.23',
     title: 'HP-UX 11i v2',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:hp:hp-ux:11.31',
     title: 'HP-UX 11i v3',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:hp:hp-ux',
     title: 'HP-UX',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:hp:integrated_lights-out',
     title: 'HP Integrated Lights-Out',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:sun:solaris',
     title: 'Sun Solaris',
-    icon: 'os_sun.svg'
+    icon: 'os_sun.svg',
   },
   {
     pattern: 'cpe:/o:sun:sunos',
     title: 'Sun Solaris',
-    icon: 'os_sun.svg'
+    icon: 'os_sun.svg',
   },
   {
     pattern: 'cpe:/o:apple:mac_os_x',
     title: 'Apple Mac OS X',
-    icon: 'os_apple.svg'
+    icon: 'os_apple.svg',
   },
   {
     pattern: 'cpe:/o:ibm:aix',
     title: 'IBM AIX',
-    icon: 'os_aix.svg'
+    icon: 'os_aix.svg',
   },
   {
     pattern: 'cpe:/o:cisco:nx-os',
     title: 'Cisco NX-OS',
-    icon: 'os_cisco.svg'
+    icon: 'os_cisco.svg',
   },
   {
     pattern: 'cpe:/o:cisco:ios_xr',
     title: 'Cisco IOS XR',
-    icon: 'os_cisco.svg'
+    icon: 'os_cisco.svg',
   },
   {
     pattern: 'cpe:/o:cisco:ios',
     title: 'Cisco IOS',
-    icon: 'os_cisco.svg'
+    icon: 'os_cisco.svg',
   },
   {
     pattern: 'cpe:/o:cisco:asyncos',
     title: 'Cisco AsyncOS',
-    icon: 'os_cisco.svg'
+    icon: 'os_cisco.svg',
   },
   {
     pattern: 'cpe:/o:cisco:cnu-os',
     title: 'Cisco CNU-OS',
-    icon: 'os_cisco.svg'
+    icon: 'os_cisco.svg',
   },
   {
     pattern: 'cpe:/o:cisco:ucos',
     title: 'Cisco UCOS',
-    icon: 'os_cisco.svg'
+    icon: 'os_cisco.svg',
   },
   {
     pattern: 'cpe:/o:cisco:application_deployment_engine',
     title: 'Cisco ADE-OS',
-    icon: 'os_cisco.svg'
+    icon: 'os_cisco.svg',
   },
   {
     pattern: 'cpe:/o:cisco:wireless_lan_controller_software',
     title: 'Cisco Wireless LAN Controller Software',
-    icon: 'os_cisco.svg'
+    icon: 'os_cisco.svg',
   },
   {
     pattern: 'cpe:/o:cisco:fire_linux_os',
     title: 'Cisco Fire Linux OS',
-    icon: 'os_cisco.svg'
+    icon: 'os_cisco.svg',
   },
   {
     pattern: 'cpe:/o:cisco',
     title: 'Cisco',
-    icon: 'os_cisco.svg'
+    icon: 'os_cisco.svg',
   },
   {
     pattern: 'cpe:/o:cyclades',
     title: 'Cyclades',
-    icon: 'os_cyclades.svg'
+    icon: 'os_cyclades.svg',
   },
   {
     pattern: 'cpe:/o:juniper',
     title: 'Juniper',
-    icon: 'os_junos.svg'
+    icon: 'os_junos.svg',
   },
   {
     pattern: 'cpe:/o:fortinet:fortios',
     title: 'Fortinet',
-    icon: 'os_fortinet.svg'
+    icon: 'os_fortinet.svg',
   },
   {
     pattern: 'cpe:/o:freebsd:freebsd',
     title: 'FreeBSD',
-    icon: 'os_freebsd.svg'
+    icon: 'os_freebsd.svg',
   },
   {
     pattern: 'cpe:/h:hp:jetdirect',
     title: 'HP Jetdirect',
-    icon: 'os_hp.svg'
+    icon: 'os_hp.svg',
   },
   {
     pattern: 'cpe:/o:linux:kernel',
     title: 'Linux Kernel',
-    icon: 'os_linux.svg'
+    icon: 'os_linux.svg',
   },
   {
     pattern: 'cpe:/o:linux:linux_kernel',
     title: 'Linux Kernel',
-    icon: 'os_linux.svg'
+    icon: 'os_linux.svg',
   },
   {
     pattern: 'cpe:/o:netbsd:netbsd',
     title: 'NetBSD',
-    icon: 'os_netbsd.svg'
+    icon: 'os_netbsd.svg',
   },
   {
     pattern: 'cpe:/o:netgear',
     title: 'Netgear',
-    icon: 'os_netgear.svg'
+    icon: 'os_netgear.svg',
   },
   {
     pattern: 'cpe:/o:openbsd:openbsd',
     title: 'OpenBSD',
-    icon: 'os_openbsd.svg'
+    icon: 'os_openbsd.svg',
   },
   {
     pattern: 'cpe:/o:altaware:palo_alto_networks_panos',
     title: 'PaloAlto',
-    icon: 'os_paloalto.svg'
+    icon: 'os_paloalto.svg',
   },
   {
     pattern: 'cpe:/o:univention:univention_corporate_server:2.2',
     title: 'Univention Corporate Server (UCS) 2.2',
-    icon: 'os_ucs.svg'
+    icon: 'os_ucs.svg',
   },
   {
     pattern: 'cpe:/o:univention:univention_corporate_server:2.3',
     title: 'Univention Corporate Server (UCS) 2.3',
-    icon: 'os_ucs.svg'
+    icon: 'os_ucs.svg',
   },
   {
     pattern: 'cpe:/o:univention:univention_corporate_server:2.4',
     title: 'Univention Corporate Server (UCS) 2.4',
-    icon: 'os_ucs.svg'
+    icon: 'os_ucs.svg',
   },
   {
     pattern: 'cpe:/o:univention:univention_corporate_server',
     title: 'Univention Corporate Server (UCS)',
-    icon: 'os_ucs.svg'
+    icon: 'os_ucs.svg',
   },
   {
     pattern: 'cpe:/o:univention:ucs',
     title: 'Univention Corporate Server (UCS)',
-    icon: 'os_ucs.svg'
+    icon: 'os_ucs.svg',
   },
   {
     pattern: 'cpe:/o:canonical:ubuntu_linux',
     title: 'Canonical Ubuntu Linux',
-    icon: 'os_ubuntu.svg'
+    icon: 'os_ubuntu.svg',
   },
   {
     pattern: 'cpe:/o:greenbone:greenbone_os:1.6.0',
     title: 'Greenbone OS 1.6',
-    icon: 'os_gos.svg'
+    icon: 'os_gos.svg',
   },
   {
     pattern: 'cpe:/o:greenbone:greenbone_os:1.7.0',
     title: 'Greenbone OS 1.7',
-    icon: 'os_gos.svg'
+    icon: 'os_gos.svg',
   },
   {
     pattern: 'cpe:/o:greenbone:greenbone_os:2.0.0',
     title: 'Greenbone OS 2.0',
-    icon: 'os_gos.svg'
+    icon: 'os_gos.svg',
   },
   {
     pattern: 'cpe:/o:greenbone:greenbone_os:2.1.0',
     title: 'Greenbone OS 2.1',
-    icon: 'os_gos.svg'
+    icon: 'os_gos.svg',
   },
   {
     pattern: 'cpe:/o:greenbone:greenbone_os:2.2.0',
     title: 'Greenbone OS 2.2',
-    icon: 'os_gos.svg'
+    icon: 'os_gos.svg',
   },
   {
     pattern: 'cpe:/o:greenbone:greenbone_os:3.0',
     title: 'Greenbone OS 3.0',
-    icon: 'os_gos.svg'
+    icon: 'os_gos.svg',
   },
   {
     pattern: 'cpe:/o:greenbone:greenbone_os',
     title: 'Greenbone OS',
-    icon: 'os_gos.svg'
+    icon: 'os_gos.svg',
   },
   {
     pattern: 'cpe:/o:ruggedcom:ros',
     title: 'Ruggedcom ROS',
-    icon: 'os_ruggedcom.svg'
+    icon: 'os_ruggedcom.svg',
   },
   {
     pattern: 'cpe:/o:synology:dsm',
     title: 'Synology DSM',
-    icon: 'os_synology.svg'
+    icon: 'os_synology.svg',
   },
   {
     pattern: 'cpe:/o:arubanetworks:arubaos',
     title: 'Arubanetworks Arubaos',
-    icon: 'os_arubanetworks.svg'
+    icon: 'os_arubanetworks.svg',
   },
   {
     pattern: 'cpe:/o:huawei',
     title: 'Huawei',
-    icon: 'os_huawai.svg'
+    icon: 'os_huawai.svg',
   },
   {
     pattern: 'cpe:/o:sourcefire:linux_os',
     title: 'Sourcefire Linux',
-    icon: 'os_sourcefire.svg'
+    icon: 'os_sourcefire.svg',
   },
   {
     pattern: 'cpe:/o:checkpoint:gaia_os',
     title: 'Checkpoint Gaia Os',
-    icon: 'os_checkpoint.svg'
+    icon: 'os_checkpoint.svg',
   },
   {
     pattern: 'cpe:/o:ipfire:linux',
     title: 'Ipfire Linux',
-    icon: 'os_ipfire.svg'
+    icon: 'os_ipfire.svg',
   },
   {
     pattern: 'cpe:/o:mcafee:linux_operating_system',
     title: 'McAfee Linux',
-    icon: 'os_mcafee.svg'
+    icon: 'os_mcafee.svg',
   },
   {
     pattern: 'cpe:/o:slackware:slackware_linux:8.1',


### PR DESCRIPTION
All files in /web and /gmp have been rid of ESLint warnings

Also .gitignore is updated to use /gsa/ instead of /ng/