### PR TITLE
Use an interval of five seconds for the autorefresh interval

### DIFF
--- a/gsa/public/config.js
+++ b/gsa/public/config.js
@@ -1,6 +1,8 @@
-window.config = {
+const FIVE_SECONDS = 5;
+
+config = {
   loglevel: 'warn',
-  autorefresh: 2,
+  autorefresh: FIVE_SECONDS,
   manualurl: 'http://docs.greenbone.net/GSM-Manual/gos-4/',
   protocoldocurl: 'http://docs.greenbone.net/API/OMP/omp-7.0.html',
 };


### PR DESCRIPTION
By default use an autorefresh interval of five seconds now. Two seconds
is a way to fast when some pages need 200 ms and more for rendering.