### PR TITLE
Show error message if target doesn't exist (empty report)

### DIFF
--- a/gsa/src/web/pages/reports/detailspage.js
+++ b/gsa/src/web/pages/reports/detailspage.js
@@ -35,22 +35,22 @@ import {isDefined} from 'gmp/utils/identity';
 
 import {RESULTS_FILTER_FILTER} from 'gmp/models/filter';
 
-import PropTypes from '../../utils/proptypes.js';
-import {create_pem_certificate} from '../../utils/cert.js';
-import withCache from '../../utils/withCache.js';
-import withGmp from '../../utils/withGmp.js';
-import compose from '../../utils/compose.js';
+import PropTypes from 'web/utils/proptypes';
+import {create_pem_certificate} from 'web/utils/cert';
+import withCache from 'web/utils/withCache';
+import withGmp from 'web/utils/withGmp';
+import compose from 'web/utils/compose';
 
-import withDownload from '../../components/form/withDownload.js';
+import withDownload from 'web/components/form/withDownload';
 
-import Wrapper from '../../components/layout/wrapper.js';
+import Wrapper from 'web/components/layout/wrapper';
 
-import withDialogNotification from '../../components/notification/withDialogNotifiaction.js'; // eslint-disable-line max-len
+import withDialogNotification from 'web/components/notification/withDialogNotifiaction'; // eslint-disable-line max-len
 
-import TargetComponent from '../targets/component.js';
+import TargetComponent from '../targets/component';
 
-import Page from './detailscontent.js';
-import FilterDialog from './detailsfilterdialog.js';
+import Page from './detailscontent';
+import FilterDialog from './detailsfilterdialog';
 
 const log = logger.getLogger('web.pages.report.details');
 

--- a/gsa/src/web/pages/reports/detailspage.js
+++ b/gsa/src/web/pages/reports/detailspage.js
@@ -445,9 +445,14 @@ class ReportDetails extends React.Component {
     const {gmp} = this.props;
     const {report} = entity;
     const {task} = report;
-    const {target} = task;
+    const {target = {}} = task;
 
-    return gmp.target.get(target).then(response => response.data);
+    return gmp.target.get(target)
+      .then(response => response.data)
+      .catch(err => {
+        this.props.showError(err);
+        throw err;
+      });
   }
 
   render() {


### PR DESCRIPTION
Before this commit the link to editing a target crashed the GUI when
clicked and the target ID doesn't exist. Now there will be a small
dialog showing an error to increase UX. However, the problem behind this
error should be fixed as well (Issue #835)!