### PR TITLE
Fix host count of checkbox selection for target

### DIFF
--- a/src/html/classic/omp.xsl
+++ b/src/html/classic/omp.xsl
@@ -14859,7 +14859,7 @@ should not have received it.
                 </tr>
                 <xsl:variable name="host_count">
                   <xsl:choose>
-                    <xsl:when test="/envelope/params/host_count = 0">
+                    <xsl:when test="not (/envelope/params/host_count != 0)">
                       <xsl:value-of select="count (/envelope/params/_param[substring (name, 1, 13) = 'bulk_selected'])"/>
                     </xsl:when>
                     <xsl:otherwise>


### PR DESCRIPTION
The "New Target" dialog will now properly recognize if the parameter
host_count is missing, so it will count the bulk_selected parameters
instead, making the selection of hosts by checkboxes work.