### PR TITLE
Fix Menu in IE11

### DIFF
--- a/gsa/src/web/components/menu/menu.js
+++ b/gsa/src/web/components/menu/menu.js
@@ -83,6 +83,7 @@ export const StyledMenuEntry = styled.li`
   font-weight: bold;
 
   & a {
+    line-height: 22px;
     color: ${Theme.darkGray};
   };
 


### PR DESCRIPTION
Links in the first (and only first) menu sections were not high enough 
and not centered vertically.