### PR TITLE
Fix TagDialog

### DIFF
--- a/gsa/src/web/pages/tags/component.js
+++ b/gsa/src/web/pages/tags/component.js
@@ -33,16 +33,16 @@ import {getEntityType, typeName} from 'gmp/utils/entitytype';
 
 import {YES_VALUE} from 'gmp/parser';
 
-import PropTypes from '../../utils/proptypes.js';
-import compose from '../../utils/compose';
-import withGmp from '../../utils/withGmp.js';
-import withCapabilities from '../../utils/withCapabilities.js';
+import PropTypes from 'web/utils/proptypes';
+import compose from 'web/utils/compose';
+import withGmp from 'web/utils/withGmp';
+import withCapabilities from 'web/utils/withCapabilities';
 
-import Wrapper from '../../components/layout/wrapper.js';
+import Wrapper from 'web/components/layout/wrapper';
 
-import EntityComponent from '../../entity/component.js';
+import EntityComponent from 'web/entity/component';
 
-import TagDialog from './dialog.js';
+import TagDialog from 'web/apges/tags/dialog';
 
 const TYPES = [
   'agent',

--- a/gsa/src/web/pages/tags/dialog.js
+++ b/gsa/src/web/pages/tags/dialog.js
@@ -51,6 +51,8 @@ import YesNoRadio from 'web/components/form/yesnoradio';
 
 import Layout from 'web/components/layout/layout';
 
+import {SELECT_MAX_RESOURCES} from 'web/pages/tags/component';
+
 const Divider = glamorous.div({
   margin: '0 5px',
 });
@@ -191,6 +193,7 @@ class TagDialog extends React.Component {
       comment = '',
       fixed = false,
       name = _('default:unnamed'),
+      resourceCount,
       resource_types = [],
       title = _('New Tag'),
       value = '',
@@ -213,6 +216,7 @@ class TagDialog extends React.Component {
     };
 
     const typeIsChosen = isDefined(this.state.resourceType);
+    const showResourceSelection = resourceCount < SELECT_MAX_RESOURCES;
 
     const controlledData = {
       resource_ids: this.state.resourceIdsSelected,
@@ -265,39 +269,48 @@ class TagDialog extends React.Component {
                 />
               </FormGroup>
 
-              <FormGroup title={_('Resource Type')}>
-                <Select
-                  name="resource_type"
-                  items={resourceTypesOptions}
-                  value={this.state.resourceType}
-                  disabled={fixed || resourceTypesOptions.length === 0}
-                  onChange={type => this.handleResourceTypeChange(
-                    type, onValueChange)}
-                />
-              </FormGroup>
-
-              <FormGroup title={_('Resources')}>
-                <ScrollableContent>
-                  <MultiSelect
-                    name="resource_ids"
-                    items={renderSelectItems(this.state.resourceOptions)}
-                    value={this.state.resourceIdsSelected}
-                    disabled={!typeIsChosen || fixed ||
-                      resourceTypesOptions.length === 0}
-                    onChange={ids => this.handleIdChange(ids, onValueChange)}
+              {showResourceSelection &&
+                <FormGroup title={_('Resource Type')}>
+                  <Select
+                    name="resource_type"
+                    items={resourceTypesOptions}
+                    value={this.state.resourceType}
+                    disabled={fixed || resourceTypesOptions.length === 0}
+                    onChange={type => this.handleResourceTypeChange(
+                      type, onValueChange)}
                   />
-                </ScrollableContent>
-                <Divider>
-                  {_('or add by ID:')}
-                </Divider>
-                <TextField
-                  name="resource_id_text"
-                  value={this.state.resourceIdText}
-                  grow="1"
-                  disabled={!typeIsChosen || fixed}
-                  onChange={id => this.handleIdChangeByText(id, onValueChange)}
-                />
-              </FormGroup>
+                </FormGroup>
+              }
+              {showResourceSelection &&
+                <FormGroup title={_('Resources')}>
+                  <ScrollableContent>
+                    <MultiSelect
+                      name="resource_ids"
+                      items={renderSelectItems(this.state.resourceOptions)}
+                      value={this.state.resourceIdsSelected}
+                      disabled={!typeIsChosen || fixed ||
+                        resourceTypesOptions.length === 0}
+                      onChange={ids => this.handleIdChange(ids, onValueChange)}
+                    />
+                  </ScrollableContent>
+                  <Divider>
+                    {_('or add by ID:')}
+                  </Divider>
+                  <TextField
+                    name="resource_id_text"
+                    value={this.state.resourceIdText}
+                    grow="1"
+                    disabled={!typeIsChosen || fixed}
+                    onChange={id =>
+                      this.handleIdChangeByText(id, onValueChange)}
+                  />
+                </FormGroup>
+              }
+              {!showResourceSelection &&
+                <FormGroup title={_('Resources')}>
+                  <span>{_('Too many resources to list.')}</span>
+                </FormGroup>
+              }
               <FormGroup title={_('Active')}>
                 <YesNoRadio
                   name="active"
@@ -320,6 +333,7 @@ TagDialog.propTypes = {
   fixed: PropTypes.bool,
   gmp: PropTypes.gmp.isRequired,
   name: PropTypes.string,
+  resourceCount: PropTypes.number.isRequired,
   resource_ids: PropTypes.arrayOf(PropTypes.id),
   resource_type: PropTypes.string,
   resource_types: PropTypes.array.isRequired,

--- a/gsa/src/web/pages/tags/resourcelist.js
+++ b/gsa/src/web/pages/tags/resourcelist.js
@@ -40,7 +40,7 @@ import Layout from 'web/components/layout/layout';
 import DetailsLink from 'web/components/link/detailslink';
 import Loading from 'web/components/loading/loading';
 
-const MAX_RESOURCES = 40;
+import {MAX_RESOURCES} from 'web/pages/tags/component';
 
 const Spacer = styled.div`
   height: 12px,


### PR DESCRIPTION
Fixing and changing include:
- Load resources according to new API (resources are no longer listed in the Tag-object)
- Change behavior of TagDialog concerning Resource selection:
-- as a get... command yields max. 1000 elements, the resource list of tags with more than 1000 resources was cut when editing/saving. Also: manual selection of resources for tags of a certain size, does not really make sense.
-- The new concept: For tags with just a few resources (<200 atm) don't change behavior. For more than a few resources, do not show the resource selection elements and thereby don't override the original list when saving. If users want to change resources of a huge bulk tag, it is easier to delete the old tag and create a new one with adjusted resources.