### PR TITLE
Overwrite default filters when loading entities in user settings

### DIFF
--- a/gsa/src/gmp/models/scanconfig.js
+++ b/gsa/src/gmp/models/scanconfig.js
@@ -46,6 +46,11 @@ export const parse_count = count => {
 export const filterEmptyScanConfig = config =>
   config.id !== EMPTY_SCAN_CONFIG_ID;
 
+export const openVasScanConfigsFilter = config =>
+  config.scan_config_type === OPENVAS_SCAN_CONFIG_TYPE;
+export const ospScanConfigsFilter = config =>
+  config.scan_config_type === OSP_SCAN_CONFIG_TYPE;
+
 class ScanConfig extends Model {
 
   static entityType = 'scanconfig';

--- a/gsa/src/gmp/models/scanner.js
+++ b/gsa/src/gmp/models/scanner.js
@@ -44,6 +44,11 @@ export const PARAM_TYPE_OVALDEF_FILE = 'osp_ovaldef_file';
 export const PARAM_TYPE_SELECTION = 'osp_selection';
 export const PARAM_TYPE_BOOLEAN = 'osp_boolean';
 
+export const openVasScannersFilter = config =>
+  config.scanner_type === OPENVAS_SCANNER_TYPE;
+export const ospScannersFilter = config =>
+  config.scanner_type === OSP_SCANNER_TYPE;
+
 export function scanner_type_name(scanner_type) {
   scanner_type = parseInt(scanner_type);
   if (scanner_type === OSP_SCANNER_TYPE) {

--- a/gsa/src/web/pages/usersettings/defaultspart.js
+++ b/gsa/src/web/pages/usersettings/defaultspart.js
@@ -35,8 +35,10 @@ import withCapabilities from 'web/utils/withCapabilities';
 const DefaultsPart = ({
   alerts,
   credentials,
-  scanConfigs,
-  scanners,
+  openVasScanConfigs,
+  ospScanConfigs,
+  openVasScanners,
+  ospScanners,
   portLists,
   reportFormats,
   schedules,
@@ -84,7 +86,7 @@ const DefaultsPart = ({
           <Select
             name="defaultOspScanConfig"
             value={defaultOspScanConfig}
-            items={renderSelectItems(scanConfigs, UNSET_VALUE)}
+            items={renderSelectItems(ospScanConfigs, UNSET_VALUE)}
             onChange={onChange}
           />
         </FormGroup>
@@ -94,7 +96,7 @@ const DefaultsPart = ({
           <Select
             name="defaultOspScanner"
             value={defaultOspScanner}
-            items={renderSelectItems(scanners, UNSET_VALUE)}
+            items={renderSelectItems(ospScanners, UNSET_VALUE)}
             onChange={onChange}
           />
         </FormGroup>
@@ -104,7 +106,7 @@ const DefaultsPart = ({
           <Select
             name="defaultOpenvasScanConfig"
             value={defaultOpenvasScanConfig}
-            items={renderSelectItems(scanConfigs, UNSET_VALUE)}
+            items={renderSelectItems(openVasScanConfigs, UNSET_VALUE)}
             onChange={onChange}
           />
         </FormGroup>
@@ -114,7 +116,7 @@ const DefaultsPart = ({
           <Select
             name="defaultOpenvasScanner"
             value={defaultOpenvasScanner}
-            items={renderSelectItems(scanners, UNSET_VALUE)}
+            items={renderSelectItems(openVasScanners, UNSET_VALUE)}
             onChange={onChange}
           />
         </FormGroup>
@@ -210,10 +212,12 @@ DefaultsPart.propTypes = {
   defaultSnmpCredential: PropTypes.string,
   defaultSshCredential: PropTypes.string,
   defaultTarget: PropTypes.string,
+  openVasScanConfigs: PropTypes.array,
+  openVasScanners: PropTypes.array,
+  ospScanConfigs: PropTypes.array,
+  ospScanners: PropTypes.array,
   portLists: PropTypes.array,
   reportFormats: PropTypes.array,
-  scanConfigs: PropTypes.array,
-  scanners: PropTypes.array,
   schedules: PropTypes.array,
   targets: PropTypes.array,
   onChange: PropTypes.func,

--- a/gsa/src/web/pages/usersettings/dialog.js
+++ b/gsa/src/web/pages/usersettings/dialog.js
@@ -54,8 +54,10 @@ let UserSettingsDialog = ({
     alerts,
     credentials,
     filters,
-    scanConfigs,
-    scanners,
+    openVasScanConfigs,
+    ospScanConfigs,
+    openVasScanners,
+    ospScanners,
     portLists,
     reportFormats,
     schedules,
@@ -215,8 +217,10 @@ let UserSettingsDialog = ({
                 <DefaultsPart
                   alerts={alerts}
                   credentials={credentials}
-                  scanConfigs={scanConfigs}
-                  scanners={scanners}
+                  openVasScanConfigs={openVasScanConfigs}
+                  ospScanConfigs={ospScanConfigs}
+                  openVasScanners={openVasScanners}
+                  ospScanners={ospScanners}
                   portLists={portLists}
                   reportFormats={reportFormats}
                   schedules={schedules}
@@ -316,6 +320,10 @@ UserSettingsDialog.propTypes = {
   maxRowsPerPage: PropTypes.string,
   notesFilter: PropTypes.string,
   nvtFilter: PropTypes.string,
+  openVasScanConfigs: PropTypes.array,
+  openVasScanners: PropTypes.array,
+  ospScanConfigs: PropTypes.array,
+  ospScanners: PropTypes.array,
   ovalFilter: PropTypes.string,
   overridesFilter: PropTypes.string,
   permissionsFilter: PropTypes.string,
@@ -328,8 +336,6 @@ UserSettingsDialog.propTypes = {
   resultsFilter: PropTypes.string,
   rolesFilter: PropTypes.string,
   rowsPerPage: PropTypes.string,
-  scanConfigs: PropTypes.array,
-  scanners: PropTypes.array,
   schedules: PropTypes.array,
   schedulesFilter: PropTypes.string,
   secInfoFilter: PropTypes.string,

--- a/gsa/src/web/pages/usersettings/usersettingspage.js
+++ b/gsa/src/web/pages/usersettings/usersettingspage.js
@@ -28,7 +28,16 @@ import {connect} from 'react-redux';
 
 import _ from 'gmp/locale';
 
-import {filterEmptyScanConfig} from 'gmp/models/scanconfig';
+import {ALL_FILTER} from 'gmp/models/filter';
+import {
+  filterEmptyScanConfig,
+  openVasScanConfigsFilter,
+  ospScanConfigsFilter,
+} from 'gmp/models/scanconfig';
+import {
+  openVasScannersFilter,
+  ospScannersFilter,
+} from 'gmp/models/scanner';
 
 import {YES_VALUE, parseYesNo} from 'gmp/parser';
 
@@ -258,8 +267,8 @@ class UserSettings extends React.Component {
       filters,
       alerts,
       credentials,
-      scanconfigs,
-      scanners,
+      scanconfigs = [],
+      scanners = [],
       portlists,
       reportformats,
       schedules,
@@ -319,6 +328,12 @@ class UserSettings extends React.Component {
     if (isLoading) {
       return <Loading/>;
     };
+
+    const openVasScanConfigs = scanconfigs.filter(openVasScanConfigsFilter);
+    const ospScanConfigs = scanconfigs.filter(ospScanConfigsFilter);
+    const openVasScanners = scanners.filter(openVasScannersFilter);
+    const ospScanners = scanners.filter(ospScannersFilter);
+
     return (
       <Layout flex="column">
         <ToolBarIcons
@@ -687,8 +702,10 @@ class UserSettings extends React.Component {
             alerts={alerts}
             filters={filters}
             credentials={credentials}
-            scanConfigs={scanconfigs}
-            scanners={scanners}
+            openVasScanConfigs={openVasScanConfigs}
+            ospScanConfigs={ospScanConfigs}
+            openVasScanners={openVasScanners}
+            ospScanners={ospScanners}
             portLists={portlists}
             reportFormats={reportformats}
             schedules={schedules}
@@ -966,21 +983,21 @@ const mapStateToProps = rootState => {
   const ovalFilter = filtersSel.getEntity(ovalFilterId);
   const secInfoFilter = filtersSel.getEntity(secInfoFilterId);
 
-  let scanconfigs = scanConfigsSel.getEntities();
+  let scanconfigs = scanConfigsSel.getEntities(ALL_FILTER);
   if (isDefined(scanconfigs)) {
     scanconfigs = scanconfigs.filter(filterEmptyScanConfig);
   }
 
   return {
-    alerts: alertsSel.getEntities(),
-    credentials: credentialsSel.getEntities(),
-    filters: filtersSel.getEntities(),
-    portlists: portListsSel.getEntities(),
-    reportformats: reportFormatsSel.getEntities(),
+    alerts: alertsSel.getEntities(ALL_FILTER),
+    credentials: credentialsSel.getEntities(ALL_FILTER),
+    filters: filtersSel.getEntities(ALL_FILTER),
+    portlists: portListsSel.getEntities(ALL_FILTER),
+    reportformats: reportFormatsSel.getEntities(ALL_FILTER),
     scanconfigs,
-    scanners: scannersSel.getEntities(),
-    schedules: schedulesSel.getEntities(),
-    targets: targetsSel.getEntities(),
+    scanners: scannersSel.getEntities(ALL_FILTER),
+    schedules: schedulesSel.getEntities(ALL_FILTER),
+    targets: targetsSel.getEntities(ALL_FILTER),
     timezone: getTimezone(rootState),
     userInterfaceLanguage,
     rowsPerPage,
@@ -1035,16 +1052,18 @@ const mapStateToProps = rootState => {
 };
 
 const mapDispatchToProps = (dispatch, {gmp}) => ({
-  loadAlerts: () => dispatch(loadAlerts({gmp})),
-  loadCredentials: () => dispatch(loadCredentials({gmp})),
-  loadFilters: () => dispatch(loadFilters({gmp})),
-  loadPortLists: () => dispatch(loadPortLists({gmp})),
-  loadReportFormats: () => dispatch(loadReportFormats({gmp})),
-  loadScanConfigs: () => dispatch(loadScanConfigs({gmp})),
-  loadScanners: () => dispatch(loadScanners({gmp})),
-  loadSchedules: () => dispatch(loadSchedules({gmp})),
-  loadSettings: () => dispatch(loadUserSettingDefaults({gmp})),
-  loadTargets: () => dispatch(loadTargets({gmp})),
+  loadAlerts: () => dispatch(loadAlerts({gmp, filter: ALL_FILTER})),
+  loadCredentials: () => dispatch(loadCredentials({gmp, filter: ALL_FILTER})),
+  loadFilters: () => dispatch(loadFilters({gmp, filter: ALL_FILTER})),
+  loadPortLists: () => dispatch(loadPortLists({gmp, filter: ALL_FILTER})),
+  loadReportFormats: () =>
+    dispatch(loadReportFormats({gmp, filter: ALL_FILTER})),
+  loadScanConfigs: () => dispatch(loadScanConfigs({gmp, filter: ALL_FILTER})),
+  loadScanners: () => dispatch(loadScanners({gmp, filter: ALL_FILTER})),
+  loadSchedules: () => dispatch(loadSchedules({gmp, filter: ALL_FILTER})),
+  loadSettings: () =>
+    dispatch(loadUserSettingDefaults({gmp, filter: ALL_FILTER})),
+  loadTargets: () => dispatch(loadTargets({gmp, filter: ALL_FILTER})),
   loadAlert: id => dispatch(loadAlert({gmp, id})),
   setLocale: locale => gmp.setLocale(locale),
   setTimezone: timezone => dispatch(updateTimezone({gmp, timezone})),


### PR DESCRIPTION
Also split scanconfigs and scanners into openvas and osp options.