### PR TITLE
Fix parsing App and Os data from reports

### DIFF
--- a/gsa/src/gmp/models/report/app.js
+++ b/gsa/src/gmp/models/report/app.js
@@ -22,9 +22,14 @@
  */
 import {isDefined} from 'gmp/utils/identity';
 
-import {parseSeverity} from 'gmp/parser';
+import {parseSeverity, setProperties} from 'gmp/parser';
 
 class App {
+
+  constructor(elem) {
+    const properties = this.parseProperties(elem);
+    setProperties(properties, this);
+  }
 
   addHost(host) {
     if (!(host.ip in this.hosts.hosts_by_ip)) {

--- a/gsa/src/gmp/models/report/os.js
+++ b/gsa/src/gmp/models/report/os.js
@@ -20,10 +20,16 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-
 import {isDefined} from 'gmp/utils/identity';
 
+import {setProperties} from 'gmp/parser';
+
 class OperatingSystem {
+
+  constructor(elem) {
+    const properties = this.parseProperties(elem);
+    setProperties(properties, this);
+  }
 
   addHost(host) {
     if (!(host.ip in this.hosts.hosts_by_ip)) {


### PR DESCRIPTION
By removing the parent class asset from App and OperatingSystem the
parsing code wasn't called anymore. This code re-introduces parsing of
the properties from the passed response element again.

This bug got introduced with f5f4bdc22bdb191a9d03edc66606b521107fd123