### PR TITLE
Action creator function signature changes

### DIFF
--- a/gsa/src/web/entities/page.js
+++ b/gsa/src/web/entities/page.js
@@ -338,7 +338,7 @@ const mapStateToProps = (state, {filtersFilter}) => {
 };
 
 const mapDispatchToProps = (dispatch, {gmp, filtersFilter}) => ({
-  loadFilters: () => dispatch(loadEntities({gmp, filter: filtersFilter})),
+  loadFilters: () => dispatch(loadEntities(gmp)(filtersFilter)),
 });
 
 export default compose(

--- a/gsa/src/web/entities/withEntitiesContainer.js
+++ b/gsa/src/web/entities/withEntitiesContainer.js
@@ -76,7 +76,7 @@ const withEntitiesContainer = (gmpname, {
   };
 
   const mapDispatchToProps = (dispatch, {gmp}) => ({
-    loadEntities: filter => dispatch(loadEntities({gmp, filter})),
+    loadEntities: filter => dispatch(loadEntities(gmp)(filter)),
     updateFilter: filter => dispatch(pageFilter(gmpname, filter)),
     renewSessionTimeout: () => dispatch(renewSessionTimeout({gmp})),
   });

--- a/gsa/src/web/pages/login/loginpage.js
+++ b/gsa/src/web/pages/login/loginpage.js
@@ -188,7 +188,7 @@ LoginPage.propTypes = {
 };
 
 const mapDispatchToProps = (dispatch, {gmp}) => ({
-  setTimezone: timezone => dispatch(updateTimezone({gmp, timezone})),
+  setTimezone: timezone => dispatch(updateTimezone(gmp)(timezone)),
   setLocale: locale => gmp.setLocale(locale),
   setSessionTimeout: timeout => dispatch(setSessionTimeout(timeout)),
   setUsername: username => dispatch(setUsername(username)),

--- a/gsa/src/web/pages/tasks/details.js
+++ b/gsa/src/web/pages/tasks/details.js
@@ -395,7 +395,7 @@ const mapStateToProps = (rootState, {entity = {}}) => {
 };
 
 const mapDispatchToProps = (dispatch, {gmp}) => ({
-  loadSchedule: id => dispatch(loadSchedule({id, gmp})),
+  loadSchedule: id => dispatch(loadSchedule(gmp)(id)),
 });
 
 export default compose(

--- a/gsa/src/web/pages/usersettings/usersettingspage.js
+++ b/gsa/src/web/pages/usersettings/usersettingspage.js
@@ -1064,7 +1064,7 @@ const mapDispatchToProps = (dispatch, {gmp}) => ({
   loadSettings: () =>
     dispatch(loadUserSettingDefaults({gmp, filter: ALL_FILTER})),
   loadTargets: () => dispatch(loadTargets({gmp, filter: ALL_FILTER})),
-  loadAlert: id => dispatch(loadAlert({gmp, id})),
+  loadAlert: id => dispatch(loadAlert(gmp)(id)),
   setLocale: locale => gmp.setLocale(locale),
   setTimezone: timezone => dispatch(updateTimezone({gmp, timezone})),
 });

--- a/gsa/src/web/pages/usersettings/usersettingspage.js
+++ b/gsa/src/web/pages/usersettings/usersettingspage.js
@@ -1066,7 +1066,7 @@ const mapDispatchToProps = (dispatch, {gmp}) => ({
   loadTargets: () => dispatch(loadTargets({gmp, filter: ALL_FILTER})),
   loadAlert: id => dispatch(loadAlert(gmp)(id)),
   setLocale: locale => gmp.setLocale(locale),
-  setTimezone: timezone => dispatch(updateTimezone({gmp, timezone})),
+  setTimezone: timezone => dispatch(updateTimezone(gmp)(timezone)),
 });
 
 export default compose(

--- a/gsa/src/web/pages/usersettings/usersettingspage.js
+++ b/gsa/src/web/pages/usersettings/usersettingspage.js
@@ -1052,17 +1052,16 @@ const mapStateToProps = rootState => {
 };
 
 const mapDispatchToProps = (dispatch, {gmp}) => ({
-  loadAlerts: () => dispatch(loadAlerts({gmp, filter: ALL_FILTER})),
-  loadCredentials: () => dispatch(loadCredentials({gmp, filter: ALL_FILTER})),
-  loadFilters: () => dispatch(loadFilters({gmp, filter: ALL_FILTER})),
-  loadPortLists: () => dispatch(loadPortLists({gmp, filter: ALL_FILTER})),
-  loadReportFormats: () =>
-    dispatch(loadReportFormats({gmp, filter: ALL_FILTER})),
-  loadScanConfigs: () => dispatch(loadScanConfigs({gmp, filter: ALL_FILTER})),
-  loadScanners: () => dispatch(loadScanners({gmp, filter: ALL_FILTER})),
-  loadSchedules: () => dispatch(loadSchedules({gmp, filter: ALL_FILTER})),
+  loadAlerts: () => dispatch(loadAlerts(gmp)(ALL_FILTER)),
+  loadCredentials: () => dispatch(loadCredentials(gmp)(ALL_FILTER)),
+  loadFilters: () => dispatch(loadFilters(gmp)(ALL_FILTER)),
+  loadPortLists: () => dispatch(loadPortLists(gmp)(ALL_FILTER)),
+  loadReportFormats: () => dispatch(loadReportFormats(gmp)(ALL_FILTER)),
+  loadScanConfigs: () => dispatch(loadScanConfigs(gmp)(ALL_FILTER)),
+  loadScanners: () => dispatch(loadScanners(gmp)(ALL_FILTER)),
+  loadSchedules: () => dispatch(loadSchedules(gmp)(ALL_FILTER)),
   loadSettings: () => dispatch(loadUserSettingDefaults(gmp)(ALL_FILTER)),
-  loadTargets: () => dispatch(loadTargets({gmp, filter: ALL_FILTER})),
+  loadTargets: () => dispatch(loadTargets(gmp)(ALL_FILTER)),
   loadAlert: id => dispatch(loadAlert(gmp)(id)),
   setLocale: locale => gmp.setLocale(locale),
   setTimezone: timezone => dispatch(updateTimezone(gmp)(timezone)),

--- a/gsa/src/web/pages/usersettings/usersettingspage.js
+++ b/gsa/src/web/pages/usersettings/usersettingspage.js
@@ -1061,8 +1061,7 @@ const mapDispatchToProps = (dispatch, {gmp}) => ({
   loadScanConfigs: () => dispatch(loadScanConfigs({gmp, filter: ALL_FILTER})),
   loadScanners: () => dispatch(loadScanners({gmp, filter: ALL_FILTER})),
   loadSchedules: () => dispatch(loadSchedules({gmp, filter: ALL_FILTER})),
-  loadSettings: () =>
-    dispatch(loadUserSettingDefaults({gmp, filter: ALL_FILTER})),
+  loadSettings: () => dispatch(loadUserSettingDefaults(gmp)(ALL_FILTER)),
   loadTargets: () => dispatch(loadTargets({gmp, filter: ALL_FILTER})),
   loadAlert: id => dispatch(loadAlert(gmp)(id)),
   setLocale: locale => gmp.setLocale(locale),

--- a/gsa/src/web/store/entities/utils/__tests__/actions.js
+++ b/gsa/src/web/store/entities/utils/__tests__/actions.js
@@ -391,7 +391,7 @@ describe('entities actions tests', () => {
       expect(loadEntity).toBeDefined();
       expect(isFunction(loadEntity)).toBe(true);
 
-      return loadEntity({gmp, id})(dispatch, getState).then(() => {
+      return loadEntity(gmp)(id)(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(selector).toBeCalledWith({foo: 'bar'});
         expect(isLoadingEntity).toBeCalledWith(id);
@@ -441,7 +441,7 @@ describe('entities actions tests', () => {
       expect(loadEntity).toBeDefined();
       expect(isFunction(loadEntity)).toBe(true);
 
-      return loadEntity({gmp, id})(dispatch, getState).then(() => {
+      return loadEntity(gmp)(id)(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(selector).toBeCalledWith({foo: 'bar'});
         expect(isLoadingEntity).toBeCalledWith(id);
@@ -493,7 +493,7 @@ describe('entities actions tests', () => {
       expect(loadEntity).toBeDefined();
       expect(isFunction(loadEntity)).toBe(true);
 
-      return loadEntity({gmp, id})(dispatch, getState).then(() => {
+      return loadEntity(gmp)(id)(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(selector).toBeCalledWith({foo: 'bar'});
         expect(isLoadingEntity).toBeCalledWith(id);

--- a/gsa/src/web/store/entities/utils/__tests__/actions.js
+++ b/gsa/src/web/store/entities/utils/__tests__/actions.js
@@ -218,7 +218,7 @@ describe('entities actions tests', () => {
       expect(loadEntities).toBeDefined();
       expect(isFunction(loadEntities)).toBe(true);
 
-      return loadEntities({gmp})(dispatch, getState).then(() => {
+      return loadEntities(gmp)()(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(selector).toBeCalledWith({foo: 'bar'});
         expect(isLoadingEntities).toBeCalled();
@@ -269,16 +269,12 @@ describe('entities actions tests', () => {
         entityType: 'foo',
       });
 
-      const props = {
-        gmp,
-        filter: 'myfilter',
-        other: 3,
-      };
+      const filter = 'myfilter';
 
       expect(loadEntities).toBeDefined();
       expect(isFunction(loadEntities)).toBe(true);
 
-      return loadEntities(props)(dispatch, getState).then(() => {
+      return loadEntities(gmp)(filter)(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(selector).toBeCalledWith({foo: 'bar'});
         expect(isLoadingEntities).toBeCalledWith('myfilter');
@@ -327,16 +323,12 @@ describe('entities actions tests', () => {
         entityType: 'foo',
       });
 
-      const props = {
-        gmp,
-        filter: 'myfilter',
-        other: 3,
-      };
+      const filter = 'myfilter';
 
       expect(loadEntities).toBeDefined();
       expect(isFunction(loadEntities)).toBe(true);
 
-      return loadEntities(props)(dispatch, getState).then(() => {
+      return loadEntities(gmp)(filter)(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(selector).toBeCalledWith({foo: 'bar'});
         expect(isLoadingEntities).toBeCalledWith('myfilter');

--- a/gsa/src/web/store/entities/utils/actions.js
+++ b/gsa/src/web/store/entities/utils/actions.js
@@ -102,7 +102,7 @@ export const createLoadEntity = ({
   selector,
   actions,
   entityType,
-}) => ({gmp, id}) => (dispatch, getState) => {
+}) => gmp => id => (dispatch, getState) => {
     const rootState = getState();
     const state = selector(rootState);
 

--- a/gsa/src/web/store/entities/utils/actions.js
+++ b/gsa/src/web/store/entities/utils/actions.js
@@ -77,7 +77,7 @@ export const createLoadEntities = ({
   selector,
   actions,
   entityType,
-}) => ({gmp, filter, ...props}) => (dispatch, getState) => {
+}) => gmp => filter => (dispatch, getState) => {
   const rootState = getState();
   const state = selector(rootState);
 

--- a/gsa/src/web/store/entities/utils/testing.js
+++ b/gsa/src/web/store/entities/utils/testing.js
@@ -243,16 +243,10 @@ export const testLoadEntities = (entityType, loadEntities) => {
         },
       };
 
-      const props = {
-        gmp,
-        filter,
-        other: 3,
-      };
-
       expect(loadEntities).toBeDefined();
       expect(isFunction(loadEntities)).toBe(true);
 
-      return loadEntities(props)(dispatch, getState).then(() => {
+      return loadEntities(gmp)(filter)(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(get).toBeCalledWith({filter});
         expect(dispatch).toHaveBeenCalledTimes(2);
@@ -296,7 +290,7 @@ export const testLoadEntities = (entityType, loadEntities) => {
         },
       };
 
-      return loadEntities({gmp, filter})(dispatch, getState).then(() => {
+      return loadEntities(gmp)(filter)(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(dispatch).not.toBeCalled();
         expect(get).not.toBeCalled();
@@ -327,7 +321,7 @@ export const testLoadEntities = (entityType, loadEntities) => {
         },
       };
 
-      return loadEntities({gmp, filter})(dispatch, getState).then(() => {
+      return loadEntities(gmp)(filter)(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(get).toBeCalledWith({filter});
         expect(dispatch).toHaveBeenCalledTimes(2);

--- a/gsa/src/web/store/entities/utils/testing.js
+++ b/gsa/src/web/store/entities/utils/testing.js
@@ -482,16 +482,10 @@ export const testLoadEntity = (entityType, loadEntity) => {
         },
       };
 
-      const props = {
-        id,
-        gmp,
-        other: 3,
-      };
-
       expect(loadEntity).toBeDefined();
       expect(isFunction(loadEntity)).toBe(true);
 
-      return loadEntity(props)(dispatch, getState).then(() => {
+      return loadEntity(gmp)(id)(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(get).toBeCalledWith({id});
         expect(dispatch).toHaveBeenCalledTimes(2);
@@ -533,7 +527,7 @@ export const testLoadEntity = (entityType, loadEntity) => {
         },
       };
 
-      return loadEntity({gmp, id})(dispatch, getState).then(() => {
+      return loadEntity(gmp)(id)(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(dispatch).not.toBeCalled();
         expect(get).not.toBeCalled();
@@ -564,7 +558,7 @@ export const testLoadEntity = (entityType, loadEntity) => {
         },
       };
 
-      return loadEntity({gmp, id})(dispatch, getState).then(() => {
+      return loadEntity(gmp)(id)(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(get).toBeCalledWith({id});
         expect(dispatch).toHaveBeenCalledTimes(2);

--- a/gsa/src/web/store/usersettings/__tests__/actions.js
+++ b/gsa/src/web/store/usersettings/__tests__/actions.js
@@ -70,7 +70,7 @@ describe('settings actions tests', () => {
     const gmp = {
       setTimezone: jest.fn(),
     };
-    return updateTimezone({gmp, timezone: 'cet'})(dispatch).then(() => {
+    return updateTimezone(gmp)('cet')(dispatch).then(() => {
       expect(dispatch).toBeCalledWith({
         type: USER_SETTINGS_SET_TIMEZONE,
         timezone: 'cet',

--- a/gsa/src/web/store/usersettings/actions.js
+++ b/gsa/src/web/store/usersettings/actions.js
@@ -51,10 +51,7 @@ export const renewSessionTimeout = ({gmp}) => dispatch =>
   gmp.user.renewSession().then(response =>
     dispatch(setSessionTimeout(response.data)));
 
-export const updateTimezone = ({
-  gmp,
-  timezone,
-}) => dispatch => {
+export const updateTimezone = gmp => timezone => dispatch => {
   gmp.setTimezone(timezone);
   return Promise.resolve(dispatch(setTimezone(timezone)));
 };

--- a/gsa/src/web/store/usersettings/defaults/__tests__/actions.js
+++ b/gsa/src/web/store/usersettings/defaults/__tests__/actions.js
@@ -81,7 +81,7 @@ describe('UserSettings Defaults action tests', () => {
 
       expect(isFunction(loadUserSettingDefaults)).toBe(true);
 
-      return loadUserSettingDefaults({gmp})(dispatch, getState).then(() => {
+      return loadUserSettingDefaults(gmp)(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(dispatch).not.toBeCalled();
         expect(currentSettings).not.toBeCalled();
@@ -110,7 +110,7 @@ describe('UserSettings Defaults action tests', () => {
 
       expect(isFunction(loadUserSettingDefaults)).toBe(true);
 
-      return loadUserSettingDefaults({gmp})(dispatch, getState).then(() => {
+      return loadUserSettingDefaults(gmp)(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(currentSettings).toBeCalled();
         expect(dispatch).toHaveBeenCalledTimes(2);
@@ -145,7 +145,7 @@ describe('UserSettings Defaults action tests', () => {
 
       expect(isFunction(loadUserSettingDefaults)).toBe(true);
 
-      return loadUserSettingDefaults({gmp})(dispatch, getState).then(() => {
+      return loadUserSettingDefaults(gmp)(dispatch, getState).then(() => {
         expect(getState).toBeCalled();
         expect(currentSettings).toBeCalled();
         expect(dispatch).toHaveBeenCalledTimes(2);

--- a/gsa/src/web/store/usersettings/defaults/actions.js
+++ b/gsa/src/web/store/usersettings/defaults/actions.js
@@ -44,7 +44,7 @@ export const loadingActions = {
   }),
 };
 
-export const loadUserSettingDefaults = ({gmp}) => (dispatch, getState) => {
+export const loadUserSettingDefaults = gmp => (dispatch, getState) => {
   const rootState = getState();
   const selector = getUserSettingsDefaults(rootState);
 


### PR DESCRIPTION
All action creators should now have one of the following signatures

```js
actionCreator(configureParams)(params)(dispatch, getState)
```

or

```js
actionCreator(params)(dispatch, getState)
```

or

```js
actionCreator(params)
```