### PR TITLE
Entity page updates

### DIFF
--- a/gsa/CMakeLists.txt
+++ b/gsa/CMakeLists.txt
@@ -369,6 +369,7 @@ set (GSA_JS_SRC_FILES
      ${GSA_SRC_DIR}/src/web/entity/tab.js
      ${GSA_SRC_DIR}/src/web/entity/tags.js
      ${GSA_SRC_DIR}/src/web/entity/tagshandler.js
+     ${GSA_SRC_DIR}/src/web/entity/withEntityContainer.js
      ${GSA_SRC_DIR}/src/web/pages/agents/component.js
      ${GSA_SRC_DIR}/src/web/pages/agents/details.js
      ${GSA_SRC_DIR}/src/web/pages/agents/detailspage.js

--- a/gsa/CMakeLists.txt
+++ b/gsa/CMakeLists.txt
@@ -366,6 +366,7 @@ set (GSA_JS_SRC_FILES
      ${GSA_SRC_DIR}/src/web/entity/override.js
      ${GSA_SRC_DIR}/src/web/entity/page.js
      ${GSA_SRC_DIR}/src/web/entity/permissions.js
+     ${GSA_SRC_DIR}/src/web/entity/tab.js
      ${GSA_SRC_DIR}/src/web/entity/tags.js
      ${GSA_SRC_DIR}/src/web/entity/tagshandler.js
      ${GSA_SRC_DIR}/src/web/pages/agents/component.js

--- a/gsa/src/web/components/tab/tablist.js
+++ b/gsa/src/web/components/tab/tablist.js
@@ -27,8 +27,6 @@ import PropTypes from '../../utils/proptypes.js';
 
 import Layout from '../layout/layout.js';
 
-import Tab from './tab.js';
-
 const TabList = ({
   active = 0,
   children,
@@ -36,7 +34,7 @@ const TabList = ({
   ...props
 }) => {
   children = React.Children.map(children, (child, index) => {
-    if (child !== null && child.type === Tab) {
+    if (child !== null) {
       return React.cloneElement(child, {
         isActive: active === index,
         onActivate: () => onActivateTab(index),

--- a/gsa/src/web/entity/container.js
+++ b/gsa/src/web/entity/container.js
@@ -126,10 +126,10 @@ class EntityContainer extends React.Component {
     this.cancelLoading();
   }
 
-  componentWillReceiveProps(next) {
+  componentDidUpdate() {
     const {id} = this.props.match.params;
-    if (id !== next.match.params.id) {
-      this.load(next.match.params.id);
+    if (id !== this.state.id) {
+      this.load(id);
     }
   }
 
@@ -149,7 +149,10 @@ class EntityContainer extends React.Component {
     const promises = all_loaders.map(loader_func =>
       loader_func.call(this, id, token));
 
-    this.setState({loading: true});
+    this.setState({
+      id,
+      loading: true,
+    });
 
     Promise.all(promises)
       .then(values => {

--- a/gsa/src/web/entity/container.js
+++ b/gsa/src/web/entity/container.js
@@ -59,13 +59,10 @@ export const loader = (type, filter_func, name = type) =>
 
       log.debug('Loaded', name, response);
 
-      const {meta} = response;
+      const {meta, data} = response;
 
       this.setState({
-        [name]: {
-          counts: meta.counts,
-          entities: response.data,
-        },
+        [name]: data,
       });
 
       if (meta.fromcache && meta.dirty) {

--- a/gsa/src/web/entity/container.js
+++ b/gsa/src/web/entity/container.js
@@ -23,89 +23,22 @@
  */
 import React from 'react';
 
-import {connect} from 'react-redux';
-
-import {withRouter} from 'react-router-dom';
-
 import logger from 'gmp/log';
-
-import CancelToken from 'gmp/cancel';
 
 import {isDefined} from 'gmp/utils/identity';
 
-import withDownload from 'web/components/form/withDownload';
-
-import {renewSessionTimeout} from 'web/store/usersettings/actions';
-
-import compose from 'web/utils/compose';
 import PropTypes from 'web/utils/proptypes';
-import withGmp from 'web/utils/withGmp';
-
-import withDialogNotification from 'web/components/notification/withDialogNotifiaction'; // eslint-disable-line max-len
 
 import TagsHandler from './tagshandler';
 
 const log = logger.getLogger('web.entity.container');
-
-export const loader = (type, filter_func, name = type) =>
-  function(id, cancel_token) {
-    const {gmp} = this.props;
-
-    log.debug('Loading', name, 'for entity', id);
-
-    return gmp[type].getAll({
-      filter: filter_func(id),
-    }, {cancel_token}).then(response => {
-
-      log.debug('Loaded', name, response);
-
-      const {meta, data} = response;
-
-      this.setState({
-        [name]: data,
-      });
-
-      if (meta.fromcache && meta.dirty) {
-        log.debug('Forcing reload of', name, meta.dirty);
-        return true;
-      }
-
-      return false;
-    }).catch(err => {
-      if (isDefined(err.isCancel) && err.isCancel()) {
-        return;
-      }
-      // call handleError before setting state. setting state may hide the root
-      // error
-      const rej = this.handleError(err);
-      this.setState({[name]: undefined});
-      return rej;
-    });
-  };
-
-// load permissions assigned to the entity as resource
-export const permissions_resource_loader = loader('permissions',
-  id => 'resource_uuid=' + id);
-
-// load permissions assigned for the entity as subject or resource but not
-// permissions with empty resources
-export const permissions_subject_loader = loader('permissions',
-  id => 'subject_uuid=' + id + ' and not resource_uuid=""' +
-    ' or resource_uuid=' + id);
 
 class EntityContainer extends React.Component {
 
   constructor(...args) {
     super(...args);
 
-    const {name} = this.props;
-    const {gmp} = this.props;
-
-    this.entity_command = gmp[name];
-
-    this.state = {
-      loading: true,
-    };
+    this.state = {};
 
     this.reload = this.reload.bind(this);
 
@@ -115,104 +48,34 @@ class EntityContainer extends React.Component {
   }
 
   componentDidMount() {
-    const {id} = this.props.match.params;
+    const {id} = this.props;
     this.load(id);
   }
 
-  componentWillUnmount() {
-    this.cancelLoading();
-  }
-
   componentDidUpdate() {
-    const {id} = this.props.match.params;
+    const {id} = this.props;
     if (id !== this.state.id) {
       this.load(id);
     }
   }
 
   load(id) {
-    const {loaders} = this.props;
-
-    const all_loaders = [this.loadEntity];
-
-    if (isDefined(loaders)) {
-      all_loaders.push(...this.props.loaders);
-    }
-
-    this.cancelLoading();
-
-    const token = new CancelToken(cancel => this.cancel = cancel);
-
-    const promises = all_loaders.map(loader_func =>
-      loader_func.call(this, id, token));
-
-    this.setState({
-      id,
-      loading: true,
-    });
-
-    Promise.all(promises)
-      .then(values => {
-        this.cancel = undefined;
-        return values.reduce((sum, cur) => sum || cur, false);
-      })
-      .then(refresh => this.startTimer(refresh))
-      .catch(err => {
-        log.error('Error while loading data', err);
-        this.setState({loading: false});
-      });
+    this.props.load(id);
+    this.setState({id});
   }
 
   reload() {
-    const {id} = this.props.match.params;
+    const {id} = this.props;
     this.load(id);
-  }
-
-  loadEntity(id, cancel_token) {
-    log.debug('Loading entity', id);
-
-    return this.entity_command.get({id}, {cancel_token}).then(response => {
-
-      const {data: entity, meta} = response;
-
-      log.debug('Loaded entity', entity);
-
-      this.setState({entity, loading: false});
-
-      if (meta.fromcache && meta.dirty) {
-        log.debug('Forcing reload of entity', meta.dirty);
-        return true;
-      }
-      return false;
-    })
-      .catch(err => {
-        if (isDefined(err.isCancel) && err.isCancel()) {
-          return;
-        }
-        this.handleError(err);
-        return Promise.reject(err);
-      });
   }
 
   handleChanged() {
     this.reload();
-    this.props.renewSessionTimeout();
   }
 
   getRefreshInterval() {
     const {gmp} = this.props;
     return gmp.autorefresh * 1000;
-  }
-
-  cancelLastRequest() {
-    if (isDefined(this.cancel)) {
-      this.cancel();
-    }
-  }
-
-  cancelLoading() {
-    this.cancelLastRequest();
-    this.clearTimer(); // remove possible running timer
   }
 
   startTimer(immediate = false) {
@@ -248,41 +111,40 @@ class EntityContainer extends React.Component {
   render() {
     const {
       children,
-      name,
-      resourceType = name,
+      entityType,
       onDownload,
+      onInteraction,
     } = this.props;
     return (
       <TagsHandler
-        name={name}
-        resourceType={resourceType}
+        resourceType={entityType}
         onChanged={this.handleChanged}
         onError={this.handleError}
-      >{({
-        add,
-        create,
-        delete: delete_func,
-        disable,
-        edit,
-        enable,
-        remove,
-      }) => children({
-        resourceType,
-        entityCommand: this.entity_command,
-        onChanged: this.handleChanged,
-        onSuccess: this.handleChanged,
-        onError: this.handleError,
-        onDownloaded: onDownload,
-        onTagAddClick: add,
-        onTagCreateClick: create,
-        onTagDeleteClick: delete_func,
-        onTagDisableClick: disable,
-        onTagEditClick: edit,
-        onTagEnableClick: enable,
-        onTagRemoveClick: remove,
-        ...this.state,
-      })
-        }
+        onInteraction={onInteraction}
+      >
+        {({
+          add,
+          create,
+          delete: delete_func,
+          disable,
+          edit,
+          enable,
+          remove,
+        }) => children({
+          onChanged: this.handleChanged,
+          onSuccess: this.handleChanged,
+          onError: this.handleError,
+          onDownloaded: onDownload,
+          onInteraction: this.handleInteraction,
+          onTagAddClick: add,
+          onTagCreateClick: create,
+          onTagDeleteClick: delete_func,
+          onTagDisableClick: disable,
+          onTagEditClick: edit,
+          onTagEnableClick: enable,
+          onTagRemoveClick: remove,
+          ...this.props,
+        })}
       </TagsHandler>
     );
   }
@@ -290,25 +152,16 @@ class EntityContainer extends React.Component {
 
 EntityContainer.propTypes = {
   children: PropTypes.func.isRequired,
+  entityType: PropTypes.string.isRequired,
   gmp: PropTypes.gmp.isRequired,
-  loaders: PropTypes.array,
-  match: PropTypes.object.isRequired,
-  name: PropTypes.string.isRequired,
-  renewSessionTimeout: PropTypes.func.isRequired,
-  resourceType: PropTypes.string,
+  id: PropTypes.id.isRequired,
+  load: PropTypes.func.isRequired,
   showError: PropTypes.func.isRequired,
   showSuccessMessage: PropTypes.func.isRequired,
   onDownload: PropTypes.func.isRequired,
+  onInteraction: PropTypes.func.isRequired,
 };
 
-export default compose(
-  withGmp,
-  withDialogNotification,
-  withDownload,
-  withRouter,
-  connect(undefined, (dispatch, {gmp}) => ({
-    renewSessionTimeout: () => dispatch(renewSessionTimeout({gmp})),
-  }))
-)(EntityContainer);
+export default EntityContainer;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/entity/page.js
+++ b/gsa/src/web/entity/page.js
@@ -130,13 +130,13 @@ class EntityPage extends React.Component {
   render() {
     const {
       entity,
-      loading,
+      isLoading = true,
     } = this.props;
 
     if (!isDefined(entity)) {
-      if (loading) {
+      if (isLoading) {
         return (
-          <Loading loading={loading}/>
+          <Loading />
         );
       }
       return null;
@@ -160,7 +160,7 @@ class EntityPage extends React.Component {
 EntityPage.propTypes = {
   entity: PropTypes.model,
   infoComponent: PropTypes.componentOrFalse,
-  loading: PropTypes.bool,
+  isLoading: PropTypes.bool,
   sectionComponent: PropTypes.componentOrFalse,
   sectionIcon: PropTypes.icon,
   title: PropTypes.string,

--- a/gsa/src/web/entity/page.js
+++ b/gsa/src/web/entity/page.js
@@ -92,7 +92,6 @@ class EntityPage extends React.Component {
 
   renderSection() {
     const {
-      detailsComponent: Details,
       children,
       entity,
       sectionIcon,
@@ -223,7 +222,6 @@ class EntityPage extends React.Component {
 }
 
 EntityPage.propTypes = {
-  detailsComponent: PropTypes.component.isRequired,
   entity: PropTypes.model,
   infoComponent: PropTypes.componentOrFalse,
   loading: PropTypes.bool,

--- a/gsa/src/web/entity/page.js
+++ b/gsa/src/web/entity/page.js
@@ -40,7 +40,6 @@ import Loading from '../components/loading/loading.js';
 import Section from '../components/section/section.js';
 
 import EntityInfo from './info.js';
-import EntityPermissions from './permissions.js';
 
 export const Col = glamorous.col(
   ({width}) => ({width})
@@ -95,10 +94,8 @@ class EntityPage extends React.Component {
       children,
       entity,
       sectionIcon,
-      permissionsComponent: PermissionsComponent = EntityPermissions,
       sectionComponent: SectionComponent = Section,
       title,
-      permissions,
     } = this.props;
 
     const {activeTab} = this.state;
@@ -112,18 +109,6 @@ class EntityPage extends React.Component {
       section_title = title + ': ' + entity.name;
     }
 
-    let hasPermissions = false;
-    if (isDefined(permissions)) {
-      hasPermissions = isDefined(permissions.entities);
-    }
-    const permissionsCount = hasPermissions ? permissions.entities.length : 0;
-    const permissionsTitle = (
-      <TabTitle
-        title={_('Permissions')}
-        count={permissionsCount}
-      />
-    );
-
     return (
       <SectionComponent
         title={section_title}
@@ -133,9 +118,6 @@ class EntityPage extends React.Component {
       >
         {children({
           activeTab,
-          permissionsComponent: PermissionsComponent ?
-            this.renderPermissions() : undefined,
-          permissionsTitle,
           onActivateTab: this.handleActivateTab,
         })}
       </SectionComponent>
@@ -160,31 +142,6 @@ class EntityPage extends React.Component {
           entity={entity}
         />
       </Layout>
-    );
-  }
-
-  renderPermissions() {
-    const {
-      entity,
-      permissions,
-      permissionsComponent: PermissionsComponent = EntityPermissions,
-      onPermissionChanged,
-      onPermissionDownloaded,
-      onPermissionDownloadError,
-    } = this.props;
-
-    if (PermissionsComponent === false) {
-      return null;
-    }
-
-    return (
-      <PermissionsComponent
-        entity={entity}
-        permissions={isDefined(permissions) ? permissions.entities : undefined}
-        onChanged={onPermissionChanged}
-        onDownloaded={onPermissionDownloaded}
-        onError={onPermissionDownloadError}
-      />
     );
   }
 
@@ -222,15 +179,10 @@ EntityPage.propTypes = {
   entity: PropTypes.model,
   infoComponent: PropTypes.componentOrFalse,
   loading: PropTypes.bool,
-  permissions: PropTypes.object,
-  permissionsComponent: PropTypes.componentOrFalse,
   sectionComponent: PropTypes.componentOrFalse,
   sectionIcon: PropTypes.icon,
   title: PropTypes.string,
   toolBarIcons: PropTypes.component,
-  onPermissionChanged: PropTypes.func,
-  onPermissionDownloadError: PropTypes.func,
-  onPermissionDownloaded: PropTypes.func,
 };
 
 export default EntityPage;

--- a/gsa/src/web/entity/page.js
+++ b/gsa/src/web/entity/page.js
@@ -116,14 +116,6 @@ class EntityPage extends React.Component {
       section_title = title + ': ' + entity.name;
     }
 
-    const {userTags} = entity;
-    const tagsTitle = (
-      <TabTitle
-        title={_('User Tags')}
-        count={userTags.length}
-      />
-    );
-
     let hasPermissions = false;
     if (isDefined(permissions)) {
       hasPermissions = isDefined(permissions.entities);
@@ -148,7 +140,6 @@ class EntityPage extends React.Component {
           activeTab,
           entity,
           tagsComponent: TagsComponent ? this.renderUserTags() : undefined,
-          tagsTitle,
           permissionsComponent: PermissionsComponent ?
             this.renderPermissions() : undefined,
           permissionsTitle,

--- a/gsa/src/web/entity/page.js
+++ b/gsa/src/web/entity/page.js
@@ -99,7 +99,6 @@ class EntityPage extends React.Component {
       sectionComponent: SectionComponent = Section,
       title,
       permissions,
-      ...other
     } = this.props;
 
     const {activeTab} = this.state;
@@ -133,9 +132,7 @@ class EntityPage extends React.Component {
         extra={this.renderInfo()}
       >
         {children({
-          ...other,
           activeTab,
-          entity,
           permissionsComponent: PermissionsComponent ?
             this.renderPermissions() : undefined,
           permissionsTitle,

--- a/gsa/src/web/entity/page.js
+++ b/gsa/src/web/entity/page.js
@@ -41,7 +41,6 @@ import Section from '../components/section/section.js';
 
 import EntityInfo from './info.js';
 import EntityPermissions from './permissions.js';
-import EntityTags from './tags.js';
 
 export const Col = glamorous.col(
   ({width}) => ({width})
@@ -99,7 +98,6 @@ class EntityPage extends React.Component {
       sectionIcon,
       permissionsComponent: PermissionsComponent = EntityPermissions,
       sectionComponent: SectionComponent = Section,
-      tagsComponent: TagsComponent = EntityTags,
       title,
       permissions,
       ...other
@@ -139,7 +137,6 @@ class EntityPage extends React.Component {
           ...other,
           activeTab,
           entity,
-          tagsComponent: TagsComponent ? this.renderUserTags() : undefined,
           permissionsComponent: PermissionsComponent ?
             this.renderPermissions() : undefined,
           permissionsTitle,
@@ -167,36 +164,6 @@ class EntityPage extends React.Component {
           entity={entity}
         />
       </Layout>
-    );
-  }
-
-  renderUserTags() {
-    const {
-      entity,
-      tagsComponent: TagsComponent = EntityTags,
-      onTagAddClick,
-      onTagDeleteClick,
-      onTagDisableClick,
-      onTagEditClick,
-      onTagEnableClick,
-      onTagCreateClick,
-      onTagRemoveClick,
-    } = this.props;
-    if (TagsComponent === false) {
-      return null;
-    }
-
-    return (
-      <TagsComponent
-        entity={entity}
-        onTagAddClick={onTagAddClick}
-        onTagDeleteClick={onTagDeleteClick}
-        onTagDisableClick={onTagDisableClick}
-        onTagEditClick={onTagEditClick}
-        onTagEnableClick={onTagEnableClick}
-        onTagCreateClick={onTagCreateClick}
-        onTagRemoveClick={onTagRemoveClick}
-      />
     );
   }
 
@@ -264,19 +231,11 @@ EntityPage.propTypes = {
   permissionsComponent: PropTypes.componentOrFalse,
   sectionComponent: PropTypes.componentOrFalse,
   sectionIcon: PropTypes.icon,
-  tagsComponent: PropTypes.componentOrFalse,
   title: PropTypes.string,
   toolBarIcons: PropTypes.component,
   onPermissionChanged: PropTypes.func,
   onPermissionDownloadError: PropTypes.func,
   onPermissionDownloaded: PropTypes.func,
-  onTagAddClick: PropTypes.func.isRequired,
-  onTagCreateClick: PropTypes.func.isRequired,
-  onTagDeleteClick: PropTypes.func.isRequired,
-  onTagDisableClick: PropTypes.func.isRequired,
-  onTagEditClick: PropTypes.func.isRequired,
-  onTagEnableClick: PropTypes.func.isRequired,
-  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 export default EntityPage;

--- a/gsa/src/web/entity/page.js
+++ b/gsa/src/web/entity/page.js
@@ -23,9 +23,7 @@
  */
 import React from 'react';
 
-import glamorous from 'glamorous';
-
-import _ from 'gmp/locale';
+import styled from 'styled-components';
 
 import {isDefined} from 'gmp/utils/identity';
 
@@ -41,25 +39,9 @@ import Section from '../components/section/section.js';
 
 import EntityInfo from './info.js';
 
-export const Col = glamorous.col(
-  ({width}) => ({width})
-);
-
-const TabTitleCounts = glamorous.span({
-  fontSize: '0.7em',
-});
-
-const TabTitle = ({title, count}) => (
-  <Layout flex="column" align={['center', 'center']}>
-    <span>{title}</span>
-    <TabTitleCounts>(<i>{(count)}</i>)</TabTitleCounts>
-  </Layout>
-);
-
-TabTitle.propTypes = {
-  count: PropTypes.number.isRequired,
-  title: PropTypes.string.isRequired,
-};
+export const Col = styled.col`
+  width: ${props => props.width};
+`;
 
 class EntityPage extends React.Component {
 

--- a/gsa/src/web/entity/tab.js
+++ b/gsa/src/web/entity/tab.js
@@ -38,18 +38,20 @@ const TabTitleCounts = styled.span`
 const EntitiesTab = ({
   children,
   entities = [],
+  count = entities.length,
   ...props
 }) => (
   <Tab {...props}>
     <Layout flex="column" align={['center', 'center']}>
       <span>{children}</span>
-      <TabTitleCounts>(<i>{(entities.length)}</i>)</TabTitleCounts>
+      <TabTitleCounts>(<i>{(count)}</i>)</TabTitleCounts>
     </Layout>
   </Tab>
 );
 
 EntitiesTab.propTypes = {
-  entities: PropTypes.array.isRequired,
+  count: PropTypes.number,
+  entities: PropTypes.array,
 };
 
 export default EntitiesTab;

--- a/gsa/src/web/entity/tab.js
+++ b/gsa/src/web/entity/tab.js
@@ -1,0 +1,57 @@
+/* Greenbone Security Assistant
+ *
+ * Authors:
+ * Björn Ricks <bjoern.ricks@greenbone.net>
+ * Steffen Waterkamp <steffen.waterkamp@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2017 - 2018 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import React from 'react';
+
+import styled from 'styled-components';
+
+import Layout from 'web/components/layout/layout';
+
+import Tab from 'web/components/tab/tab';
+
+import PropTypes from 'web/utils/proptypes';
+
+const TabTitleCounts = styled.span`
+  font-size: 0.7em;
+`;
+
+const EntitiesTab = ({
+  children,
+  entities = [],
+  ...props
+}) => (
+  <Tab {...props}>
+    <Layout flex="column" align={['center', 'center']}>
+      <span>{children}</span>
+      <TabTitleCounts>(<i>{(entities.length)}</i>)</TabTitleCounts>
+    </Layout>
+  </Tab>
+);
+
+EntitiesTab.propTypes = {
+  entities: PropTypes.array.isRequired,
+};
+
+export default EntitiesTab;
+
+// vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/entity/tagshandler.js
+++ b/gsa/src/web/entity/tagshandler.js
@@ -56,13 +56,12 @@ class TagsHandler extends React.Component {
   openCreateTagDialog(entity, create) {
     const {
       resourceType = getEntityType(entity),
-      name = resourceType,
     } = this.props;
     create({
       fixed: true,
       resource_ids: [entity.id],
       resource_type: resourceType,
-      name: _('{{type}}:unnamed', {type: name}),
+      name: _('{{type}}:unnamed', {type: resourceType}),
     });
   }
 
@@ -113,7 +112,6 @@ class TagsHandler extends React.Component {
 
 TagsHandler.propTypes = {
   gmp: PropTypes.gmp.isRequired,
-  name: PropTypes.string,
   resourceType: PropTypes.string,
   onChanged: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/entity/withEntityContainer.js
+++ b/gsa/src/web/entity/withEntityContainer.js
@@ -1,0 +1,109 @@
+
+/* Greenbone Security Assistant
+ *
+ * Authors:
+ * Björn Ricks <bjoern.ricks@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2018 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import React from 'react';
+
+import {connect} from 'react-redux';
+
+import {withRouter} from 'react-router-dom';
+
+import Filter from 'gmp/models/filter';
+
+import {isDefined} from 'gmp/utils/identity';
+
+import withDownload from 'web/components/form/withDownload';
+
+import withDialogNotification from 'web/components/notification/withDialogNotifiaction'; // eslint-disable-line max-len
+
+import {renewSessionTimeout} from 'web/store/usersettings/actions';
+
+import compose from 'web/utils/compose';
+import PropTypes from 'web/utils/proptypes';
+import withGmp from 'web/utils/withGmp';
+
+import EntityContainer from './container';
+
+// get permissions assigned to the entity as resource
+export const permissionsResourceFilter = id =>
+  Filter.fromString('resource_uuid=' + id).all();
+
+export const permissionsSubjectFilter = id =>
+  Filter.fromString('subject_uuid=' + id + ' and not resource_uuid=""' +
+    ' or resource_uuid=' + id).all();
+
+const withEntityContainer = (entityType, {
+  load,
+  entitySelector,
+  mapStateToProps: componentMapStateToProps,
+}) => Component => {
+  const EntityContainerWrapper = ({id, ...props}) => (
+    <EntityContainer
+      {...props}
+      id={id}
+      entityType={entityType}
+    >
+      {cprops => <Component {...cprops} />}
+    </EntityContainer>
+  );
+
+  EntityContainerWrapper.propTypes = {
+    id: PropTypes.id.isRequired,
+    match: PropTypes.object.isRequired,
+  };
+
+  const mapDispatchToProps = (dispatch, {gmp}) => {
+    return {
+      onInteraction: () => dispatch(renewSessionTimeout({gmp})),
+      load: id => dispatch(load(gmp)(id)),
+    };
+  };
+
+  const mapStateToProps = (rootState, {gmp, match, ...props}) => {
+    const {id} = match.params;
+    const entitySel = entitySelector(rootState);
+    const otherProps = isDefined(componentMapStateToProps) ?
+      componentMapStateToProps(rootState, {
+        gmp,
+        id,
+        ...props,
+      }) : undefined;
+    return {
+      isLoading: entitySel.isLoadingEntity(id),
+      ...otherProps,
+      id,
+      entity: entitySel.getEntity(id),
+    };
+  };
+
+  return compose(
+    withGmp,
+    withRouter,
+    withDialogNotification,
+    withDownload,
+    connect(mapStateToProps, mapDispatchToProps),
+  )(EntityContainerWrapper);
+};
+
+export default withEntityContainer;
+
+// vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/agents/detailspage.js
+++ b/gsa/src/web/pages/agents/detailspage.js
@@ -41,19 +41,29 @@ import TabPanel from 'web/components/tab/tabpanel';
 import TabPanels from 'web/components/tab/tabpanels';
 import Tabs from 'web/components/tab/tabs';
 
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPage from 'web/entity/page';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsResourceFilter,
+} from 'web/entity/withEntityContainer';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/agents';
+
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 import withCapabilities from 'web/utils/withCapabilities';
@@ -266,18 +276,26 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-const AgentPage = props => (
-  <EntityContainer
-    {...props}
-    name="agent"
-    loaders={[
-      permissions_resource_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const load = gmp => {
+  const loadEntityFunc = loadEntity(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  return id => dispatch => {
+    dispatch(loadEntityFunc(id));
+    dispatch(loadPermissionsFunc(permissionsResourceFilter(id)));
+  };
+};
 
-export default AgentPage;
+const mapStateToProps = (rootState, {id}) => {
+  const permissionsSel = permissionsSelector(rootState);
+  return {
+    permissions: permissionsSel.getEntities(permissionsResourceFilter(id)),
+  };
+};
+
+export default withEntityContainer('agent', {
+  entitySelector: selector,
+  load,
+  mapStateToProps,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/agents/detailspage.js
+++ b/gsa/src/web/pages/agents/detailspage.js
@@ -172,7 +172,6 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
-        detailsComponent={AgentDetails}
         sectionIcon="agent.svg"
         toolBarIcons={ToolBarIcons}
         title={_('Agent')}

--- a/gsa/src/web/pages/agents/detailspage.js
+++ b/gsa/src/web/pages/agents/detailspage.js
@@ -47,6 +47,7 @@ import EntityContainer, {
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPage from 'web/entity/page';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -136,6 +137,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => (
   <AgentComponent
@@ -184,7 +192,6 @@ const Page = ({
           activeTab = 0,
           permissionsComponent,
           permissionsTitle,
-          tagsComponent,
           onActivateTab,
           entity,
           ...other
@@ -220,7 +227,16 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {tagsComponent}
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
                   </TabPanel>
                   <TabPanel>
                     {permissionsComponent}
@@ -239,6 +255,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const AgentPage = props => (

--- a/gsa/src/web/pages/agents/detailspage.js
+++ b/gsa/src/web/pages/agents/detailspage.js
@@ -134,6 +134,7 @@ ToolBarIcons.propTypes = {
 };
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -172,6 +173,7 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
+        entity={entity}
         sectionIcon="agent.svg"
         toolBarIcons={ToolBarIcons}
         title={_('Agent')}
@@ -192,8 +194,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           onActivateTab,
-          entity,
-          ...other
         }) => (
           <Layout grow="1" flex="column">
             <TabLayout
@@ -249,6 +249,7 @@ const Page = ({
 );
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/agents/detailspage.js
+++ b/gsa/src/web/pages/agents/detailspage.js
@@ -195,57 +195,55 @@ const Page = ({
           onActivateTab,
           entity,
           ...other
-        }) => {
-          return (
-            <Layout grow="1" flex="column">
-              <TabLayout
-                grow="1"
-                align={['start', 'end']}
+        }) => (
+          <Layout grow="1" flex="column">
+            <TabLayout
+              grow="1"
+              align={['start', 'end']}
+            >
+              <TabList
+                active={activeTab}
+                align={['start', 'stretch']}
+                onActivateTab={onActivateTab}
               >
-                <TabList
-                  active={activeTab}
-                  align={['start', 'stretch']}
-                  onActivateTab={onActivateTab}
-                >
-                  <Tab>
-                    {_('Information')}
-                  </Tab>
-                  <EntitiesTab entities={entity.userTags}>
-                    {_('User Tags')}
-                  </EntitiesTab>
-                  <Tab>
-                    {permissionsTitle}
-                  </Tab>
-                </TabList>
-              </TabLayout>
+                <Tab>
+                  {_('Information')}
+                </Tab>
+                <EntitiesTab entities={entity.userTags}>
+                  {_('User Tags')}
+                </EntitiesTab>
+                <Tab>
+                  {permissionsTitle}
+                </Tab>
+              </TabList>
+            </TabLayout>
 
-              <Tabs active={activeTab}>
-                <TabPanels>
-                  <TabPanel>
-                    <AgentDetails
-                      entity={entity}
-                    />
-                  </TabPanel>
-                  <TabPanel>
-                    <EntityTags
-                      entity={entity}
-                      onTagAddClick={onTagAddClick}
-                      onTagDeleteClick={onTagDeleteClick}
-                      onTagDisableClick={onTagDisableClick}
-                      onTagEditClick={onTagEditClick}
-                      onTagEnableClick={onTagEnableClick}
-                      onTagCreateClick={onTagCreateClick}
-                      onTagRemoveClick={onTagRemoveClick}
-                    />
-                  </TabPanel>
-                  <TabPanel>
-                    {permissionsComponent}
-                  </TabPanel>
-                </TabPanels>
-              </Tabs>
-            </Layout>
-          );
-        }}
+            <Tabs active={activeTab}>
+              <TabPanels>
+                <TabPanel>
+                  <AgentDetails
+                    entity={entity}
+                  />
+                </TabPanel>
+                <TabPanel>
+                  <EntityTags
+                    entity={entity}
+                    onTagAddClick={onTagAddClick}
+                    onTagDeleteClick={onTagDeleteClick}
+                    onTagDisableClick={onTagDisableClick}
+                    onTagEditClick={onTagEditClick}
+                    onTagEnableClick={onTagEnableClick}
+                    onTagCreateClick={onTagCreateClick}
+                    onTagRemoveClick={onTagRemoveClick}
+                  />
+                </TabPanel>
+                <TabPanel>
+                  {permissionsComponent}
+                </TabPanel>
+              </TabPanels>
+            </Tabs>
+          </Layout>
+        )}
       </EntityPage>
     )}
   </AgentComponent>

--- a/gsa/src/web/pages/agents/detailspage.js
+++ b/gsa/src/web/pages/agents/detailspage.js
@@ -25,8 +25,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from '../../utils/proptypes.js';
 import withCapabilities from '../../utils/withCapabilities.js';
 
@@ -205,16 +203,12 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  {isDefined(tagsComponent) &&
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
-                  }
+                  <Tab>
+                    {tagsTitle}
+                  </Tab>
+                  <Tab>
+                    {permissionsTitle}
+                  </Tab>
                 </TabList>
               </TabLayout>
 
@@ -225,16 +219,12 @@ const Page = ({
                       entity={entity}
                     />
                   </TabPanel>
-                  {isDefined(tagsComponent) &&
-                    <TabPanel>
-                      {tagsComponent}
-                    </TabPanel>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <TabPanel>
-                      {permissionsComponent}
-                    </TabPanel>
-                  }
+                  <TabPanel>
+                    {tagsComponent}
+                  </TabPanel>
+                  <TabPanel>
+                    {permissionsComponent}
+                  </TabPanel>
                 </TabPanels>
               </Tabs>
             </Layout>

--- a/gsa/src/web/pages/agents/detailspage.js
+++ b/gsa/src/web/pages/agents/detailspage.js
@@ -25,39 +25,39 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from '../../utils/proptypes.js';
-import withCapabilities from '../../utils/withCapabilities.js';
+import Icon from 'web/components/icon/icon';
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
+
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
+
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
 
 import EntityContainer, {
   permissions_resource_loader,
-} from '../../entity/container.js';
-import {goto_details, goto_list} from '../../entity/component.js';
-import EntityPage from '../../entity/page.js';
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
+import EntityPage from 'web/entity/page';
 import EntitiesTab from 'web/entity/tab';
 
-import CloneIcon from '../../entity/icon/cloneicon.js';
-import CreateIcon from '../../entity/icon/createicon.js';
-import EditIcon from '../../entity/icon/editicon.js';
-import TrashIcon from '../../entity/icon/trashicon.js';
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
 
-import Icon from '../../components/icon/icon.js';
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import PropTypes from 'web/utils/proptypes';
+import withCapabilities from 'web/utils/withCapabilities';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
-
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
-
-import AgentComponent from './component.js';
-import AgentDetails from './details.js';
+import AgentComponent from './component';
+import AgentDetails from './details';
 
 const ToolBarIcons = withCapabilities(({
   capabilities,

--- a/gsa/src/web/pages/agents/detailspage.js
+++ b/gsa/src/web/pages/agents/detailspage.js
@@ -46,6 +46,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPage from 'web/entity/page';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -135,6 +136,7 @@ ToolBarIcons.propTypes = {
 
 const Page = ({
   entity,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -185,14 +187,9 @@ const Page = ({
         onAgentInstallerDownloadClick={downloadinstaller}
         onAgentSaveClick={save}
         onAgentVerifyClick={verify}
-        onPermissionChanged={onChanged}
-        onPermissionDownloaded={onDownloaded}
-        onPermissionDownloadError={onError}
       >
         {({
           activeTab = 0,
-          permissionsComponent,
-          permissionsTitle,
           onActivateTab,
         }) => (
           <Layout grow="1" flex="column">
@@ -211,9 +208,9 @@ const Page = ({
                 <EntitiesTab entities={entity.userTags}>
                   {_('User Tags')}
                 </EntitiesTab>
-                <Tab>
-                  {permissionsTitle}
-                </Tab>
+                <EntitiesTab entities={permissions}>
+                  {_('Permissions')}
+                </EntitiesTab>
               </TabList>
             </TabLayout>
 
@@ -237,7 +234,13 @@ const Page = ({
                   />
                 </TabPanel>
                 <TabPanel>
-                  {permissionsComponent}
+                  <EntityPermissions
+                    entity={entity}
+                    permissions={permissions}
+                    onChanged={onChanged}
+                    onDownloaded={onDownloaded}
+                    onError={onError}
+                  />
                 </TabPanel>
               </TabPanels>
             </Tabs>
@@ -250,6 +253,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/agents/detailspage.js
+++ b/gsa/src/web/pages/agents/detailspage.js
@@ -33,6 +33,7 @@ import EntityContainer, {
 } from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
 import EntityPage from '../../entity/page.js';
+import EntitiesTab from 'web/entity/tab';
 
 import CloneIcon from '../../entity/icon/cloneicon.js';
 import CreateIcon from '../../entity/icon/createicon.js';
@@ -184,7 +185,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           tagsComponent,
-          tagsTitle,
           onActivateTab,
           entity,
           ...other
@@ -203,9 +203,9 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <Tab>
-                    {tagsTitle}
-                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
                   <Tab>
                     {permissionsTitle}
                   </Tab>

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -25,8 +25,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from '../../utils/proptypes.js';
 
 import EntityPage from '../../entity/page.js';
@@ -177,16 +175,12 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  {isDefined(tagsComponent) &&
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
-                  }
+                  <Tab>
+                    {tagsTitle}
+                  </Tab>
+                  <Tab>
+                    {permissionsTitle}
+                  </Tab>
                 </TabList>
               </TabLayout>
               <Tabs active={activeTab}>
@@ -196,16 +190,12 @@ const Page = ({
                       entity={entity}
                     />
                   </TabPanel>
-                  {isDefined(tagsComponent) &&
-                    <TabPanel>
-                      {tagsComponent}
-                    </TabPanel>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <TabPanel>
-                      {permissionsComponent}
-                    </TabPanel>
-                  }
+                  <TabPanel>
+                    {tagsComponent}
+                  </TabPanel>
+                  <TabPanel>
+                    {permissionsComponent}
+                  </TabPanel>
                 </TabPanels>
               </Tabs>
             </Layout>

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -32,6 +32,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
+import EntitiesTab from 'web/entity/tab';
 
 import ExportIcon from '../../components/icon/exporticon.js';
 import CloneIcon from '../../entity/icon/cloneicon.js';
@@ -156,7 +157,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           tagsComponent,
-          tagsTitle,
           onActivateTab,
           entity,
           ...other
@@ -175,9 +175,9 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <Tab>
-                    {tagsTitle}
-                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
                   <Tab>
                     {permissionsTitle}
                   </Tab>

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -25,37 +25,37 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from '../../utils/proptypes.js';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
 
-import EntityPage from '../../entity/page.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
+
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
+
+import EntityPage from 'web/entity/page';
 import EntityContainer, {
   permissions_resource_loader,
-} from '../../entity/container.js';
-import {goto_details, goto_list} from '../../entity/component.js';
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import CloneIcon from '../../entity/icon/cloneicon.js';
-import CreateIcon from '../../entity/icon/createicon.js';
-import EditIcon from '../../entity/icon/editicon.js';
-import TrashIcon from '../../entity/icon/trashicon.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
 
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import PropTypes from 'web/utils/proptypes';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
-
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
-
-import AlertComponent from './component.js';
-import AlertDetails from './details.js';
+import AlertComponent from './component';
+import AlertDetails from './details';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -40,19 +40,29 @@ import TabPanels from 'web/components/tab/tabpanels';
 import Tabs from 'web/components/tab/tabs';
 
 import EntityPage from 'web/entity/page';
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsResourceFilter,
+} from 'web/entity/withEntityContainer';
 
 import ExportIcon from 'web/components/icon/exporticon';
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/alerts';
+
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -239,18 +249,26 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-const AlertPage = props => (
-  <EntityContainer
-    {...props}
-    name="alert"
-    loaders={[
-      permissions_resource_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const load = gmp => {
+  const loadEntityFunc = loadEntity(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  return id => dispatch => {
+    dispatch(loadEntityFunc(id));
+    dispatch(loadPermissionsFunc(permissionsResourceFilter(id)));
+  };
+};
 
-export default AlertPage;
+const mapStateToProps = (rootState, {id}) => {
+  const permissionsSel = permissionsSelector(rootState);
+  return {
+    permissions: permissionsSel.getEntities(permissionsResourceFilter(id)),
+  };
+};
+
+export default withEntityContainer('alert', {
+  entitySelector: selector,
+  load,
+  mapStateToProps,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -44,6 +44,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -115,6 +116,7 @@ ToolBarIcons.propTypes = {
 
 const Page = ({
   entity,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -157,14 +159,9 @@ const Page = ({
         onAlertDownloadClick={download}
         onAlertEditClick={edit}
         onAlertSaveClick={save}
-        onPermissionChanged={onChanged}
-        onPermissionDownloaded={onDownloaded}
-        onPermissionDownloadError={onError}
       >
         {({
           activeTab = 0,
-          permissionsComponent,
-          permissionsTitle,
           onActivateTab,
         }) => {
           return (
@@ -184,9 +181,9 @@ const Page = ({
                   <EntitiesTab entities={entity.userTags}>
                     {_('User Tags')}
                   </EntitiesTab>
-                  <Tab>
-                    {permissionsTitle}
-                  </Tab>
+                  <EntitiesTab entities={permissions}>
+                    {_('Permissions')}
+                  </EntitiesTab>
                 </TabList>
               </TabLayout>
               <Tabs active={activeTab}>
@@ -209,7 +206,13 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {permissionsComponent}
+                    <EntityPermissions
+                      entity={entity}
+                      permissions={permissions}
+                      onChanged={onChanged}
+                      onDownloaded={onDownloaded}
+                      onError={onError}
+                    />
                   </TabPanel>
                 </TabPanels>
               </Tabs>
@@ -223,6 +226,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -45,6 +45,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import ExportIcon from 'web/components/icon/exporticon';
 import CloneIcon from 'web/entity/icon/cloneicon';
@@ -116,6 +117,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => (
   <AlertComponent
@@ -156,7 +164,6 @@ const Page = ({
           activeTab = 0,
           permissionsComponent,
           permissionsTitle,
-          tagsComponent,
           onActivateTab,
           entity,
           ...other
@@ -191,7 +198,16 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {tagsComponent}
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
                   </TabPanel>
                   <TabPanel>
                     {permissionsComponent}
@@ -210,6 +226,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const AlertPage = props => (

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -114,6 +114,7 @@ ToolBarIcons.propTypes = {
 };
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -146,6 +147,7 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
+        entity={entity}
         sectionIcon="alert.svg"
         title={_('Alert')}
         toolBarIcons={ToolBarIcons}
@@ -164,8 +166,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           onActivateTab,
-          entity,
-          ...other
         }) => {
           return (
             <Layout grow="1" flex="column">
@@ -222,6 +222,7 @@ const Page = ({
 );
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -148,7 +148,6 @@ const Page = ({
         {...props}
         sectionIcon="alert.svg"
         title={_('Alert')}
-        detailsComponent={AlertDetails}
         toolBarIcons={ToolBarIcons}
         onAlertCloneClick={clone}
         onAlertCreateClick={create}

--- a/gsa/src/web/pages/certbund/detailspage.js
+++ b/gsa/src/web/pages/certbund/detailspage.js
@@ -27,8 +27,6 @@ import React from 'react';
 import _ from 'gmp/locale';
 import {longDate} from 'gmp/locale/date';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from '../../utils/proptypes.js';
 
 import DetailsBlock from '../../entity/block.js';
@@ -243,14 +241,11 @@ const CertBundAdvPage = props => (
             sectionIcon="cert_bund_adv.svg"
             title={_('CERT-Bund Advisory')}
             detailsComponent={Details}
-            permissionsComponent={false}
             toolBarIcons={ToolBarIcons}
             onCertBundAdvDownloadClick={download}
           >
             {({
               activeTab = 0,
-              permissionsComponent,
-              permissionsTitle,
               tagsComponent,
               tagsTitle,
               onActivateTab,
@@ -271,16 +266,9 @@ const CertBundAdvPage = props => (
                       <Tab>
                         {_('Information')}
                       </Tab>
-                      {isDefined(tagsComponent) &&
-                        <Tab>
-                          {tagsTitle}
-                        </Tab>
-                      }
-                      {isDefined(permissionsComponent) &&
-                        <Tab>
-                          {permissionsTitle}
-                        </Tab>
-                      }
+                      <Tab>
+                        {tagsTitle}
+                      </Tab>
                     </TabList>
                   </TabLayout>
 
@@ -291,16 +279,9 @@ const CertBundAdvPage = props => (
                           entity={entity}
                         />
                       </TabPanel>
-                      {isDefined(tagsComponent) &&
-                        <TabPanel>
-                          {tagsComponent}
-                        </TabPanel>
-                      }
-                      {isDefined(permissionsComponent) &&
-                        <TabPanel>
-                          {permissionsComponent}
-                        </TabPanel>
-                      }
+                      <TabPanel>
+                        {tagsComponent}
+                      </TabPanel>
                     </TabPanels>
                   </Tabs>
                 </Layout>

--- a/gsa/src/web/pages/certbund/detailspage.js
+++ b/gsa/src/web/pages/certbund/detailspage.js
@@ -53,6 +53,7 @@ import EntityPage from 'web/entity/page';
 import EntityComponent from 'web/entity/component';
 import EntityContainer from 'web/entity/container';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import ExportIcon from 'web/components/icon/exporticon';
 import ManualIcon from 'web/components/icon/manualicon';
@@ -228,6 +229,13 @@ const CertBundAdvPage = props => (
       onChanged,
       onDownloaded,
       onError,
+      onTagAddClick,
+      onTagCreateClick,
+      onTagDeleteClick,
+      onTagDisableClick,
+      onTagEditClick,
+      onTagEnableClick,
+      onTagRemoveClick,
       ...cprops
     }) => (
       <EntityComponent
@@ -247,7 +255,6 @@ const CertBundAdvPage = props => (
           >
             {({
               activeTab = 0,
-              tagsComponent,
               onActivateTab,
               entity,
               ...other
@@ -280,7 +287,16 @@ const CertBundAdvPage = props => (
                         />
                       </TabPanel>
                       <TabPanel>
-                        {tagsComponent}
+                        <EntityTags
+                          entity={entity}
+                          onTagAddClick={onTagAddClick}
+                          onTagDeleteClick={onTagDeleteClick}
+                          onTagDisableClick={onTagDisableClick}
+                          onTagEditClick={onTagEditClick}
+                          onTagEnableClick={onTagEnableClick}
+                          onTagCreateClick={onTagCreateClick}
+                          onTagRemoveClick={onTagRemoveClick}
+                        />
                       </TabPanel>
                     </TabPanels>
                   </Tabs>

--- a/gsa/src/web/pages/certbund/detailspage.js
+++ b/gsa/src/web/pages/certbund/detailspage.js
@@ -249,7 +249,6 @@ const CertBundAdvPage = props => (
             {...cprops}
             sectionIcon="cert_bund_adv.svg"
             title={_('CERT-Bund Advisory')}
-            detailsComponent={Details}
             toolBarIcons={ToolBarIcons}
             onCertBundAdvDownloadClick={download}
           >

--- a/gsa/src/web/pages/certbund/detailspage.js
+++ b/gsa/src/web/pages/certbund/detailspage.js
@@ -27,40 +27,40 @@ import React from 'react';
 import _ from 'gmp/locale';
 import {longDate} from 'gmp/locale/date';
 
-import PropTypes from '../../utils/proptypes.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
 
-import DetailsBlock from '../../entity/block.js';
-import EntityPage from '../../entity/page.js';
-import EntityComponent from '../../entity/component.js';
-import EntityContainer from '../../entity/container.js';
-import EntitiesTab from 'web/entity/tab.js';
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import DetailsLink from 'web/components/link/detailslink';
+import ExternalLink from 'web/components/link/externallink';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
+import InfoTable from 'web/components/table/infotable';
+import TableBody from 'web/components/table/body';
+import TableData from 'web/components/table/data';
+import TableHeader from 'web/components/table/header';
+import TableHead from 'web/components/table/head';
+import TableRow from 'web/components/table/row';
 
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
+import DetailsBlock from 'web/entity/block';
+import EntityPage from 'web/entity/page';
+import EntityComponent from 'web/entity/component';
+import EntityContainer from 'web/entity/container';
+import EntitiesTab from 'web/entity/tab';
 
-import DetailsLink from '../../components/link/detailslink.js';
-import ExternalLink from '../../components/link/externallink.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
 
-import InfoTable from '../../components/table/infotable.js';
-import TableBody from '../../components/table/body.js';
-import TableData from '../../components/table/data.js';
-import TableHeader from '../../components/table/header.js';
-import TableHead from '../../components/table/head.js';
-import TableRow from '../../components/table/row.js';
+import PropTypes from 'web/utils/proptypes';
 
-import CertBundAdvDetails from './details.js';
+import CertBundAdvDetails from './details';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/certbund/detailspage.js
+++ b/gsa/src/web/pages/certbund/detailspage.js
@@ -226,6 +226,7 @@ const CertBundAdvPage = props => (
     resourceType="cert_bund_adv"
   >
     {({
+      entity,
       onChanged,
       onDownloaded,
       onError,
@@ -247,6 +248,7 @@ const CertBundAdvPage = props => (
           <EntityPage
             {...props}
             {...cprops}
+            entity={entity}
             sectionIcon="cert_bund_adv.svg"
             title={_('CERT-Bund Advisory')}
             toolBarIcons={ToolBarIcons}
@@ -255,8 +257,6 @@ const CertBundAdvPage = props => (
             {({
               activeTab = 0,
               onActivateTab,
-              entity,
-              ...other
             }) => {
               return (
                 <Layout grow="1" flex="column">

--- a/gsa/src/web/pages/certbund/detailspage.js
+++ b/gsa/src/web/pages/certbund/detailspage.js
@@ -51,9 +51,14 @@ import TableRow from 'web/components/table/row';
 import DetailsBlock from 'web/entity/block';
 import EntityPage from 'web/entity/page';
 import EntityComponent from 'web/entity/component';
-import EntityContainer from 'web/entity/container';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer from 'web/entity/withEntityContainer';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/certbund';
 
 import ExportIcon from 'web/components/icon/exporticon';
 import ManualIcon from 'web/components/icon/manualicon';
@@ -219,96 +224,104 @@ Details.propTypes = {
   entity: PropTypes.model.isRequired,
 };
 
-const CertBundAdvPage = props => (
-  <EntityContainer
-    {...props}
+const CertBundAdvPage = ({
+  entity,
+  onChanged,
+  onDownloaded,
+  onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
+  ...props
+}) => (
+  <EntityComponent
     name="certbund"
-    resourceType="cert_bund_adv"
+    onDownloaded={onDownloaded}
+    onDownloadError={onError}
   >
-    {({
-      entity,
-      onChanged,
-      onDownloaded,
-      onError,
-      onTagAddClick,
-      onTagCreateClick,
-      onTagDeleteClick,
-      onTagDisableClick,
-      onTagEditClick,
-      onTagEnableClick,
-      onTagRemoveClick,
-      ...cprops
-    }) => (
-      <EntityComponent
-        name="certbund"
-        onDownloaded={onDownloaded}
-        onDownloadError={onError}
+    {({download}) => (
+      <EntityPage
+        {...props}
+        entity={entity}
+        sectionIcon="cert_bund_adv.svg"
+        title={_('CERT-Bund Advisory')}
+        toolBarIcons={ToolBarIcons}
+        onCertBundAdvDownloadClick={download}
       >
-        {({download}) => (
-          <EntityPage
-            {...props}
-            {...cprops}
-            entity={entity}
-            sectionIcon="cert_bund_adv.svg"
-            title={_('CERT-Bund Advisory')}
-            toolBarIcons={ToolBarIcons}
-            onCertBundAdvDownloadClick={download}
-          >
-            {({
-              activeTab = 0,
-              onActivateTab,
-            }) => {
-              return (
-                <Layout grow="1" flex="column">
-                  <TabLayout
-                    grow="1"
-                    align={['start', 'end']}
-                  >
-                    <TabList
-                      active={activeTab}
-                      align={['start', 'stretch']}
-                      onActivateTab={onActivateTab}
-                    >
-                      <Tab>
-                        {_('Information')}
-                      </Tab>
-                      <EntitiesTab entities={entity.userTags}>
-                        {_('User Tags')}
-                      </EntitiesTab>
-                    </TabList>
-                  </TabLayout>
+        {({
+          activeTab = 0,
+          onActivateTab,
+        }) => {
+          return (
+            <Layout grow="1" flex="column">
+              <TabLayout
+                grow="1"
+                align={['start', 'end']}
+              >
+                <TabList
+                  active={activeTab}
+                  align={['start', 'stretch']}
+                  onActivateTab={onActivateTab}
+                >
+                  <Tab>
+                    {_('Information')}
+                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
+                </TabList>
+              </TabLayout>
 
-                  <Tabs active={activeTab}>
-                    <TabPanels>
-                      <TabPanel>
-                        <Details
-                          entity={entity}
-                        />
-                      </TabPanel>
-                      <TabPanel>
-                        <EntityTags
-                          entity={entity}
-                          onTagAddClick={onTagAddClick}
-                          onTagDeleteClick={onTagDeleteClick}
-                          onTagDisableClick={onTagDisableClick}
-                          onTagEditClick={onTagEditClick}
-                          onTagEnableClick={onTagEnableClick}
-                          onTagCreateClick={onTagCreateClick}
-                          onTagRemoveClick={onTagRemoveClick}
-                        />
-                      </TabPanel>
-                    </TabPanels>
-                  </Tabs>
-                </Layout>
-              );
-            }}
-          </EntityPage>
-        )}
-      </EntityComponent>
+              <Tabs active={activeTab}>
+                <TabPanels>
+                  <TabPanel>
+                    <Details
+                      entity={entity}
+                    />
+                  </TabPanel>
+                  <TabPanel>
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
+                  </TabPanel>
+                </TabPanels>
+              </Tabs>
+            </Layout>
+          );
+        }}
+      </EntityPage>
     )}
-  </EntityContainer>
+  </EntityComponent>
 );
 
-export default CertBundAdvPage;
+CertBundAdvPage.propTypes = {
+  entity: PropTypes.model,
+  onChanged: PropTypes.func.isRequired,
+  onDownloaded: PropTypes.func.isRequired,
+  onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
+};
+
+export default withEntityContainer('certbund', {
+  load: loadEntity,
+  entitySelector: selector,
+})(CertBundAdvPage);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/certbund/detailspage.js
+++ b/gsa/src/web/pages/certbund/detailspage.js
@@ -33,6 +33,7 @@ import DetailsBlock from '../../entity/block.js';
 import EntityPage from '../../entity/page.js';
 import EntityComponent from '../../entity/component.js';
 import EntityContainer from '../../entity/container.js';
+import EntitiesTab from 'web/entity/tab.js';
 
 import ExportIcon from '../../components/icon/exporticon.js';
 import ManualIcon from '../../components/icon/manualicon.js';
@@ -247,7 +248,6 @@ const CertBundAdvPage = props => (
             {({
               activeTab = 0,
               tagsComponent,
-              tagsTitle,
               onActivateTab,
               entity,
               ...other
@@ -266,9 +266,9 @@ const CertBundAdvPage = props => (
                       <Tab>
                         {_('Information')}
                       </Tab>
-                      <Tab>
-                        {tagsTitle}
-                      </Tab>
+                      <EntitiesTab entities={entity.userTags}>
+                        {_('User Tags')}
+                      </EntitiesTab>
                     </TabList>
                   </TabLayout>
 

--- a/gsa/src/web/pages/cpes/detailspage.js
+++ b/gsa/src/web/pages/cpes/detailspage.js
@@ -58,6 +58,7 @@ import EntityComponent from 'web/entity/component';
 import EntityContainer from 'web/entity/container';
 import {InfoLayout} from 'web/entity/info';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -181,6 +182,13 @@ const CpePage = props => (
       onChanged,
       onDownloaded,
       onError,
+      onTagAddClick,
+      onTagCreateClick,
+      onTagDeleteClick,
+      onTagDisableClick,
+      onTagEditClick,
+      onTagEnableClick,
+      onTagRemoveClick,
       ...cprops
     }) => (
       <EntityComponent
@@ -201,7 +209,6 @@ const CpePage = props => (
           >
             {({
               activeTab = 0,
-              tagsComponent,
               onActivateTab,
               entity,
               ...other
@@ -234,7 +241,16 @@ const CpePage = props => (
                         />
                       </TabPanel>
                       <TabPanel>
-                        {tagsComponent}
+                        <EntityTags
+                          entity={entity}
+                          onTagAddClick={onTagAddClick}
+                          onTagDeleteClick={onTagDeleteClick}
+                          onTagDisableClick={onTagDisableClick}
+                          onTagEditClick={onTagEditClick}
+                          onTagEnableClick={onTagEnableClick}
+                          onTagCreateClick={onTagCreateClick}
+                          onTagRemoveClick={onTagRemoveClick}
+                        />
                       </TabPanel>
                     </TabPanels>
                   </Tabs>

--- a/gsa/src/web/pages/cpes/detailspage.js
+++ b/gsa/src/web/pages/cpes/detailspage.js
@@ -33,6 +33,7 @@ import EntityPage from '../../entity/page.js';
 import EntityComponent from '../../entity/component.js';
 import EntityContainer from '../../entity/container.js';
 import {InfoLayout} from '../../entity/info.js';
+import EntitiesTab from 'web/entity/tab.js';
 
 import SeverityBar from '../../components/bar/severitybar.js';
 
@@ -201,7 +202,6 @@ const CpePage = props => (
             {({
               activeTab = 0,
               tagsComponent,
-              tagsTitle,
               onActivateTab,
               entity,
               ...other
@@ -220,9 +220,9 @@ const CpePage = props => (
                       <Tab>
                         {_('Information')}
                       </Tab>
-                      <Tab>
-                        {tagsTitle}
-                      </Tab>
+                      <EntitiesTab entities={entity.userTags}>
+                        {_('User Tags')}
+                      </EntitiesTab>
                     </TabList>
                   </TabLayout>
 

--- a/gsa/src/web/pages/cpes/detailspage.js
+++ b/gsa/src/web/pages/cpes/detailspage.js
@@ -26,8 +26,6 @@ import React from 'react';
 import _ from 'gmp/locale';
 import {dateTimeWithTimeZone} from 'gmp/locale/date';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from '../../utils/proptypes.js';
 
 import DetailsBlock from '../../entity/block.js';
@@ -197,14 +195,11 @@ const CpePage = props => (
             title={_('CPE')}
             detailsComponent={Details}
             infoComponent={EntityInfo}
-            permissionsComponent={false}
             toolBarIcons={ToolBarIcons}
             onCpeDownloadClick={download}
           >
             {({
               activeTab = 0,
-              permissionsComponent,
-              permissionsTitle,
               tagsComponent,
               tagsTitle,
               onActivateTab,
@@ -225,16 +220,9 @@ const CpePage = props => (
                       <Tab>
                         {_('Information')}
                       </Tab>
-                      {isDefined(tagsComponent) &&
-                        <Tab>
-                          {tagsTitle}
-                        </Tab>
-                      }
-                      {isDefined(permissionsComponent) &&
-                        <Tab>
-                          {permissionsTitle}
-                        </Tab>
-                      }
+                      <Tab>
+                        {tagsTitle}
+                      </Tab>
                     </TabList>
                   </TabLayout>
 
@@ -245,16 +233,9 @@ const CpePage = props => (
                           entity={entity}
                         />
                       </TabPanel>
-                      {isDefined(tagsComponent) &&
-                        <TabPanel>
-                          {tagsComponent}
-                        </TabPanel>
-                      }
-                      {isDefined(permissionsComponent) &&
-                        <TabPanel>
-                          {permissionsComponent}
-                        </TabPanel>
-                      }
+                      <TabPanel>
+                        {tagsComponent}
+                      </TabPanel>
                     </TabPanels>
                   </Tabs>
                 </Layout>

--- a/gsa/src/web/pages/cpes/detailspage.js
+++ b/gsa/src/web/pages/cpes/detailspage.js
@@ -55,10 +55,15 @@ import TableRow from 'web/components/table/row';
 import DetailsBlock from 'web/entity/block';
 import EntityPage from 'web/entity/page';
 import EntityComponent from 'web/entity/component';
-import EntityContainer from 'web/entity/container';
 import {InfoLayout} from 'web/entity/info';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer from 'web/entity/withEntityContainer';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/cpes';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -173,96 +178,105 @@ Details.propTypes = {
   links: PropTypes.bool,
 };
 
-const CpePage = props => (
-  <EntityContainer
-    {...props}
+const CpePage = ({
+  entity,
+  onChanged,
+  onDownloaded,
+  onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
+  ...props
+}) => (
+  <EntityComponent
     name="cpe"
+    onDownloaded={onDownloaded}
+    onDownloadError={onError}
   >
-    {({
-      entity,
-      onChanged,
-      onDownloaded,
-      onError,
-      onTagAddClick,
-      onTagCreateClick,
-      onTagDeleteClick,
-      onTagDisableClick,
-      onTagEditClick,
-      onTagEnableClick,
-      onTagRemoveClick,
-      ...cprops
-    }) => (
-      <EntityComponent
-        name="cpe"
-        onDownloaded={onDownloaded}
-        onDownloadError={onError}
+    {({download}) => (
+      <EntityPage
+        {...props}
+        entity={entity}
+        sectionIcon="cpe.svg"
+        title={_('CPE')}
+        infoComponent={EntityInfo}
+        toolBarIcons={ToolBarIcons}
+        onCpeDownloadClick={download}
       >
-        {({download}) => (
-          <EntityPage
-            {...props}
-            {...cprops}
-            entity={entity}
-            sectionIcon="cpe.svg"
-            title={_('CPE')}
-            infoComponent={EntityInfo}
-            toolBarIcons={ToolBarIcons}
-            onCpeDownloadClick={download}
-          >
-            {({
-              activeTab = 0,
-              onActivateTab,
-            }) => {
-              return (
-                <Layout grow="1" flex="column">
-                  <TabLayout
-                    grow="1"
-                    align={['start', 'end']}
-                  >
-                    <TabList
-                      active={activeTab}
-                      align={['start', 'stretch']}
-                      onActivateTab={onActivateTab}
-                    >
-                      <Tab>
-                        {_('Information')}
-                      </Tab>
-                      <EntitiesTab entities={entity.userTags}>
-                        {_('User Tags')}
-                      </EntitiesTab>
-                    </TabList>
-                  </TabLayout>
+        {({
+          activeTab = 0,
+          onActivateTab,
+        }) => {
+          return (
+            <Layout grow="1" flex="column">
+              <TabLayout
+                grow="1"
+                align={['start', 'end']}
+              >
+                <TabList
+                  active={activeTab}
+                  align={['start', 'stretch']}
+                  onActivateTab={onActivateTab}
+                >
+                  <Tab>
+                    {_('Information')}
+                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
+                </TabList>
+              </TabLayout>
 
-                  <Tabs active={activeTab}>
-                    <TabPanels>
-                      <TabPanel>
-                        <Details
-                          entity={entity}
-                        />
-                      </TabPanel>
-                      <TabPanel>
-                        <EntityTags
-                          entity={entity}
-                          onTagAddClick={onTagAddClick}
-                          onTagDeleteClick={onTagDeleteClick}
-                          onTagDisableClick={onTagDisableClick}
-                          onTagEditClick={onTagEditClick}
-                          onTagEnableClick={onTagEnableClick}
-                          onTagCreateClick={onTagCreateClick}
-                          onTagRemoveClick={onTagRemoveClick}
-                        />
-                      </TabPanel>
-                    </TabPanels>
-                  </Tabs>
-                </Layout>
-              );
-            }}
-          </EntityPage>
-        )}
-      </EntityComponent>
+              <Tabs active={activeTab}>
+                <TabPanels>
+                  <TabPanel>
+                    <Details
+                      entity={entity}
+                    />
+                  </TabPanel>
+                  <TabPanel>
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
+                  </TabPanel>
+                </TabPanels>
+              </Tabs>
+            </Layout>
+          );
+        }}
+      </EntityPage>
     )}
-  </EntityContainer>
+  </EntityComponent>
 );
 
-export default CpePage;
+CpePage.propTypes = {
+  entity: PropTypes.model,
+  onChanged: PropTypes.func.isRequired,
+  onDownloaded: PropTypes.func.isRequired,
+  onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
+};
+
+export default withEntityContainer('cpe', {
+  load: loadEntity,
+  entitySelector: selector,
+})(CpePage);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/cpes/detailspage.js
+++ b/gsa/src/web/pages/cpes/detailspage.js
@@ -26,42 +26,42 @@ import React from 'react';
 import _ from 'gmp/locale';
 import {dateTimeWithTimeZone} from 'gmp/locale/date';
 
-import PropTypes from '../../utils/proptypes.js';
+import SeverityBar from 'web/components/bar/severitybar';
 
-import DetailsBlock from '../../entity/block.js';
-import EntityPage from '../../entity/page.js';
-import EntityComponent from '../../entity/component.js';
-import EntityContainer from '../../entity/container.js';
-import {InfoLayout} from '../../entity/info.js';
-import EntitiesTab from 'web/entity/tab.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
 
-import SeverityBar from '../../components/bar/severitybar.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
+import DetailsLink from 'web/components/link/detailslink';
 
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
+import Table from 'web/components/table/stripedtable';
+import TableHeader from 'web/components/table/header';
+import TableHead from 'web/components/table/head';
+import TableBody from 'web/components/table/body';
+import TableData from 'web/components/table/data';
+import TableRow from 'web/components/table/row';
 
-import DetailsLink from '../../components/link/detailslink.js';
+import DetailsBlock from 'web/entity/block';
+import EntityPage from 'web/entity/page';
+import EntityComponent from 'web/entity/component';
+import EntityContainer from 'web/entity/container';
+import {InfoLayout} from 'web/entity/info';
+import EntitiesTab from 'web/entity/tab';
 
-import Table from '../../components/table/stripedtable.js';
-import TableHeader from '../../components/table/header.js';
-import TableHead from '../../components/table/head.js';
-import TableBody from '../../components/table/body.js';
-import TableData from '../../components/table/data.js';
-import TableRow from '../../components/table/row.js';
+import PropTypes from 'web/utils/proptypes';
 
-import CpeDetails from './details.js';
+import CpeDetails from './details';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/cpes/detailspage.js
+++ b/gsa/src/web/pages/cpes/detailspage.js
@@ -202,7 +202,6 @@ const CpePage = props => (
             {...cprops}
             sectionIcon="cpe.svg"
             title={_('CPE')}
-            detailsComponent={Details}
             infoComponent={EntityInfo}
             toolBarIcons={ToolBarIcons}
             onCpeDownloadClick={download}

--- a/gsa/src/web/pages/cpes/detailspage.js
+++ b/gsa/src/web/pages/cpes/detailspage.js
@@ -179,6 +179,7 @@ const CpePage = props => (
     name="cpe"
   >
     {({
+      entity,
       onChanged,
       onDownloaded,
       onError,
@@ -200,6 +201,7 @@ const CpePage = props => (
           <EntityPage
             {...props}
             {...cprops}
+            entity={entity}
             sectionIcon="cpe.svg"
             title={_('CPE')}
             infoComponent={EntityInfo}
@@ -209,8 +211,6 @@ const CpePage = props => (
             {({
               activeTab = 0,
               onActivateTab,
-              entity,
-              ...other
             }) => {
               return (
                 <Layout grow="1" flex="column">

--- a/gsa/src/web/pages/credentials/detailspage.js
+++ b/gsa/src/web/pages/credentials/detailspage.js
@@ -65,6 +65,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -219,6 +220,7 @@ Details.propTypes = {
 
 const Page = ({
   entity,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -266,14 +268,9 @@ const Page = ({
           onCredentialEditClick={edit}
           onCredentialInstallerDownloadClick={downloadinstaller}
           onCredentialSaveClick={save}
-          onPermissionChanged={onChanged}
-          onPermissionDownloadError={onError}
-          onPermissionDownloaded={onDownloaded}
         >
           {({
             activeTab = 0,
-            permissionsComponent,
-            permissionsTitle,
             onActivateTab,
           }) => {
             return (
@@ -293,9 +290,9 @@ const Page = ({
                     <EntitiesTab entities={entity.userTags}>
                       {_('User Tags')}
                     </EntitiesTab>
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
+                    <EntitiesTab entities={permissions}>
+                      {_('Permissions')}
+                    </EntitiesTab>
                   </TabList>
                 </TabLayout>
 
@@ -319,7 +316,13 @@ const Page = ({
                       />
                     </TabPanel>
                     <TabPanel>
-                      {permissionsComponent}
+                      <EntityPermissions
+                        entity={entity}
+                        permissions={permissions}
+                        onChanged={onChanged}
+                        onDownloaded={onDownloaded}
+                        onError={onError}
+                      />
                     </TabPanel>
                   </TabPanels>
                 </Tabs>
@@ -334,6 +337,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/credentials/detailspage.js
+++ b/gsa/src/web/pages/credentials/detailspage.js
@@ -61,13 +61,23 @@ import TrashIcon from 'web/entity/icon/trashicon';
 
 import DetailsBlock from 'web/entity/block';
 import EntityPage from 'web/entity/page';
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsResourceFilter,
+} from 'web/entity/withEntityContainer';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/credentials';
+
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -350,18 +360,26 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-const CredentialPage = props => (
-  <EntityContainer
-    {...props}
-    name="credential"
-    loaders={[
-      permissions_resource_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const load = gmp => {
+  const loadEntityFunc = loadEntity(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  return id => dispatch => {
+    dispatch(loadEntityFunc(id));
+    dispatch(loadPermissionsFunc(permissionsResourceFilter(id)));
+  };
+};
 
-export default CredentialPage;
+const mapStateToProps = (rootState, {id}) => {
+  const permissionsSel = permissionsSelector(rootState);
+  return {
+    permissions: permissionsSel.getEntities(permissionsResourceFilter(id)),
+  };
+};
+
+export default withEntityContainer('credential', {
+  entitySelector: selector,
+  load,
+  mapStateToProps,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/credentials/detailspage.js
+++ b/gsa/src/web/pages/credentials/detailspage.js
@@ -66,6 +66,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -220,6 +221,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => {
   return (
@@ -265,7 +273,6 @@ const Page = ({
             activeTab = 0,
             permissionsComponent,
             permissionsTitle,
-            tagsComponent,
             onActivateTab,
             entity,
             ...other
@@ -301,7 +308,16 @@ const Page = ({
                       />
                     </TabPanel>
                     <TabPanel>
-                      {tagsComponent}
+                      <EntityTags
+                        entity={entity}
+                        onTagAddClick={onTagAddClick}
+                        onTagDeleteClick={onTagDeleteClick}
+                        onTagDisableClick={onTagDisableClick}
+                        onTagEditClick={onTagEditClick}
+                        onTagEnableClick={onTagEnableClick}
+                        onTagCreateClick={onTagCreateClick}
+                        onTagRemoveClick={onTagRemoveClick}
+                      />
                     </TabPanel>
                     <TabPanel>
                       {permissionsComponent}
@@ -321,6 +337,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const CredentialPage = props => (

--- a/gsa/src/web/pages/credentials/detailspage.js
+++ b/gsa/src/web/pages/credentials/detailspage.js
@@ -34,44 +34,44 @@ import {
   CERTIFICATE_STATUS_EXPIRED,
 } from 'gmp/models/credential';
 
-import PropTypes from '../../utils/proptypes.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
 
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
+import InfoTable from 'web/components/table/infotable';
+import TableBody from 'web/components/table/body';
+import TableData from 'web/components/table/data';
+import TableRow from 'web/components/table/row';
 
-import InfoTable from '../../components/table/infotable.js';
-import TableBody from '../../components/table/body.js';
-import TableData from '../../components/table/data.js';
-import TableRow from '../../components/table/row.js';
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
 
-import CloneIcon from '../../entity/icon/cloneicon.js';
-import CreateIcon from '../../entity/icon/createicon.js';
-import EditIcon from '../../entity/icon/editicon.js';
-import TrashIcon from '../../entity/icon/trashicon.js';
-
-import DetailsBlock from '../../entity/block.js';
-import EntityPage from '../../entity/page.js';
+import DetailsBlock from 'web/entity/block';
+import EntityPage from 'web/entity/page';
 import EntityContainer, {
   permissions_resource_loader,
-} from '../../entity/container.js';
-import {goto_details, goto_list} from '../../entity/component.js';
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
 
-import CredentialDetails from './details.js';
-import CredentialComponent from './component.js';
-import CredentialDownloadIcon from './downloadicon.js';
+import PropTypes from 'web/utils/proptypes';
+
+import CredentialDetails from './details';
+import CredentialComponent from './component';
+import CredentialDownloadIcon from './downloadicon';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/credentials/detailspage.js
+++ b/gsa/src/web/pages/credentials/detailspage.js
@@ -67,6 +67,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
+import EntitiesTab from 'web/entity/tab';
 
 import CredentialDetails from './details.js';
 import CredentialComponent from './component.js';
@@ -265,7 +266,6 @@ const Page = ({
             permissionsComponent,
             permissionsTitle,
             tagsComponent,
-            tagsTitle,
             onActivateTab,
             entity,
             ...other
@@ -284,9 +284,9 @@ const Page = ({
                     <Tab>
                       {_('Information')}
                     </Tab>
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
+                    <EntitiesTab entities={entity.userTags}>
+                      {_('User Tags')}
+                    </EntitiesTab>
                     <Tab>
                       {permissionsTitle}
                     </Tab>

--- a/gsa/src/web/pages/credentials/detailspage.js
+++ b/gsa/src/web/pages/credentials/detailspage.js
@@ -284,16 +284,12 @@ const Page = ({
                     <Tab>
                       {_('Information')}
                     </Tab>
-                    {isDefined(tagsComponent) &&
-                      <Tab>
-                        {tagsTitle}
-                      </Tab>
-                    }
-                    {isDefined(permissionsComponent) &&
-                      <Tab>
-                        {permissionsTitle}
-                      </Tab>
-                    }
+                    <Tab>
+                      {tagsTitle}
+                    </Tab>
+                    <Tab>
+                      {permissionsTitle}
+                    </Tab>
                   </TabList>
                 </TabLayout>
 
@@ -304,16 +300,12 @@ const Page = ({
                         entity={entity}
                       />
                     </TabPanel>
-                    {isDefined(tagsComponent) &&
-                      <TabPanel>
-                        {tagsComponent}
-                      </TabPanel>
-                    }
-                    {isDefined(permissionsComponent) &&
-                      <TabPanel>
-                        {permissionsComponent}
-                      </TabPanel>
-                    }
+                    <TabPanel>
+                      {tagsComponent}
+                    </TabPanel>
+                    <TabPanel>
+                      {permissionsComponent}
+                    </TabPanel>
                   </TabPanels>
                 </Tabs>
               </Layout>

--- a/gsa/src/web/pages/credentials/detailspage.js
+++ b/gsa/src/web/pages/credentials/detailspage.js
@@ -254,7 +254,6 @@ const Page = ({
       }) => (
         <EntityPage
           {...props}
-          detailsComponent={Details}
           sectionIcon="credential.svg"
           toolBarIcons={ToolBarIcons}
           title={_('Credential')}

--- a/gsa/src/web/pages/credentials/detailspage.js
+++ b/gsa/src/web/pages/credentials/detailspage.js
@@ -218,6 +218,7 @@ Details.propTypes = {
 };
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -254,6 +255,7 @@ const Page = ({
       }) => (
         <EntityPage
           {...props}
+          entity={entity}
           sectionIcon="credential.svg"
           toolBarIcons={ToolBarIcons}
           title={_('Credential')}
@@ -273,8 +275,6 @@ const Page = ({
             permissionsComponent,
             permissionsTitle,
             onActivateTab,
-            entity,
-            ...other
           }) => {
             return (
               <Layout grow="1" flex="column">
@@ -333,6 +333,7 @@ const Page = ({
 };
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/cves/detailspage.js
+++ b/gsa/src/web/pages/cves/detailspage.js
@@ -26,8 +26,6 @@ import React from 'react';
 import _ from 'gmp/locale';
 import {dateTimeWithTimeZone} from 'gmp/locale/date';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from '../../utils/proptypes.js';
 
 import DetailsBlock from '../../entity/block.js';
@@ -231,7 +229,6 @@ const CvePage = props => (
             title={_('CVE')}
             detailsComponent={Details}
             infoComponent={EntityInfo}
-            permissionsComponent={false}
             toolBarIcons={ToolBarIcons}
             onCveDownloadClick={download}
             onPermissionChanged={onChanged}
@@ -240,8 +237,6 @@ const CvePage = props => (
           >
             {({
               activeTab = 0,
-              permissionsComponent,
-              permissionsTitle,
               tagsComponent,
               tagsTitle,
               onActivateTab,
@@ -262,16 +257,9 @@ const CvePage = props => (
                       <Tab>
                         {_('Information')}
                       </Tab>
-                      {isDefined(tagsComponent) &&
-                        <Tab>
-                          {tagsTitle}
-                        </Tab>
-                      }
-                      {isDefined(permissionsComponent) &&
-                        <Tab>
-                          {permissionsTitle}
-                        </Tab>
-                      }
+                      <Tab>
+                        {tagsTitle}
+                      </Tab>
                     </TabList>
                   </TabLayout>
 
@@ -282,16 +270,9 @@ const CvePage = props => (
                           entity={entity}
                         />
                       </TabPanel>
-                      {isDefined(tagsComponent) &&
-                        <TabPanel>
-                          {tagsComponent}
-                        </TabPanel>
-                      }
-                      {isDefined(permissionsComponent) &&
-                        <TabPanel>
-                          {permissionsComponent}
-                        </TabPanel>
-                      }
+                      <TabPanel>
+                        {tagsComponent}
+                      </TabPanel>
                     </TabPanels>
                   </Tabs>
                 </Layout>

--- a/gsa/src/web/pages/cves/detailspage.js
+++ b/gsa/src/web/pages/cves/detailspage.js
@@ -213,6 +213,7 @@ const CvePage = props => (
     name="cve"
   >
     {({
+      entity,
       onChanged,
       onDownloaded,
       onError,
@@ -234,6 +235,7 @@ const CvePage = props => (
           <EntityPage
             {...props}
             {...cprops}
+            entity={entity}
             sectionIcon="cve.svg"
             title={_('CVE')}
             detailsComponent={Details}
@@ -247,8 +249,6 @@ const CvePage = props => (
             {({
               activeTab = 0,
               onActivateTab,
-              entity,
-              ...other
             }) => {
               return (
                 <Layout grow="1" flex="column">

--- a/gsa/src/web/pages/cves/detailspage.js
+++ b/gsa/src/web/pages/cves/detailspage.js
@@ -33,6 +33,7 @@ import EntityPage from '../../entity/page.js';
 import EntityComponent from '../../entity/component.js';
 import EntityContainer from '../../entity/container.js';
 import {InfoLayout} from '../../entity/info.js';
+import EntitiesTab from 'web/entity/tab.js';
 
 import ExportIcon from '../../components/icon/exporticon.js';
 import ManualIcon from '../../components/icon/manualicon.js';
@@ -238,7 +239,6 @@ const CvePage = props => (
             {({
               activeTab = 0,
               tagsComponent,
-              tagsTitle,
               onActivateTab,
               entity,
               ...other
@@ -257,9 +257,9 @@ const CvePage = props => (
                       <Tab>
                         {_('Information')}
                       </Tab>
-                      <Tab>
-                        {tagsTitle}
-                      </Tab>
+                      <EntitiesTab entities={entity.userTags}>
+                        {_('User Tags')}
+                      </EntitiesTab>
                     </TabList>
                   </TabLayout>
 

--- a/gsa/src/web/pages/cves/detailspage.js
+++ b/gsa/src/web/pages/cves/detailspage.js
@@ -26,41 +26,41 @@ import React from 'react';
 import _ from 'gmp/locale';
 import {dateTimeWithTimeZone} from 'gmp/locale/date';
 
-import PropTypes from '../../utils/proptypes.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
 
-import DetailsBlock from '../../entity/block.js';
-import EntityPage from '../../entity/page.js';
-import EntityComponent from '../../entity/component.js';
-import EntityContainer from '../../entity/container.js';
-import {InfoLayout} from '../../entity/info.js';
-import EntitiesTab from 'web/entity/tab.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import CertLink from 'web/components/link/certlink';
+import DetailsLink from 'web/components/link/detailslink';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
 
-import CertLink from '../../components/link/certlink.js';
-import DetailsLink from '../../components/link/detailslink.js';
+import Table from 'web/components/table/stripedtable';
+import TableHeader from 'web/components/table/header';
+import TableHead from 'web/components/table/head';
+import TableBody from 'web/components/table/body';
+import TableData from 'web/components/table/data';
+import TableRow from 'web/components/table/row';
 
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
+import DetailsBlock from 'web/entity/block';
+import EntityPage from 'web/entity/page';
+import EntityComponent from 'web/entity/component';
+import EntityContainer from 'web/entity/container';
+import {InfoLayout} from 'web/entity/info';
+import EntitiesTab from 'web/entity/tab';
 
-import Table from '../../components/table/stripedtable.js';
-import TableHeader from '../../components/table/header.js';
-import TableHead from '../../components/table/head.js';
-import TableBody from '../../components/table/body.js';
-import TableData from '../../components/table/data.js';
-import TableRow from '../../components/table/row.js';
+import PropTypes from 'web/utils/proptypes';
 
-import CveDetails from './details.js';
+import CveDetails from './details';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/cves/detailspage.js
+++ b/gsa/src/web/pages/cves/detailspage.js
@@ -57,6 +57,7 @@ import EntityComponent from 'web/entity/component';
 import EntityContainer from 'web/entity/container';
 import {InfoLayout} from 'web/entity/info';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -215,6 +216,13 @@ const CvePage = props => (
       onChanged,
       onDownloaded,
       onError,
+      onTagAddClick,
+      onTagCreateClick,
+      onTagDeleteClick,
+      onTagDisableClick,
+      onTagEditClick,
+      onTagEnableClick,
+      onTagRemoveClick,
       ...cprops
     }) => (
       <EntityComponent
@@ -238,7 +246,6 @@ const CvePage = props => (
           >
             {({
               activeTab = 0,
-              tagsComponent,
               onActivateTab,
               entity,
               ...other
@@ -271,7 +278,16 @@ const CvePage = props => (
                         />
                       </TabPanel>
                       <TabPanel>
-                        {tagsComponent}
+                        <EntityTags
+                          entity={entity}
+                          onTagAddClick={onTagAddClick}
+                          onTagDeleteClick={onTagDeleteClick}
+                          onTagDisableClick={onTagDisableClick}
+                          onTagEditClick={onTagEditClick}
+                          onTagEnableClick={onTagEnableClick}
+                          onTagCreateClick={onTagCreateClick}
+                          onTagRemoveClick={onTagRemoveClick}
+                        />
                       </TabPanel>
                     </TabPanels>
                   </Tabs>

--- a/gsa/src/web/pages/cves/detailspage.js
+++ b/gsa/src/web/pages/cves/detailspage.js
@@ -54,14 +54,19 @@ import TableRow from 'web/components/table/row';
 import DetailsBlock from 'web/entity/block';
 import EntityPage from 'web/entity/page';
 import EntityComponent from 'web/entity/component';
-import EntityContainer from 'web/entity/container';
 import {InfoLayout} from 'web/entity/info';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/cves';
+
 import PropTypes from 'web/utils/proptypes';
 
 import CveDetails from './details';
+import withEntityContainer from 'web/entity/withEntityContainer';
 
 const ToolBarIcons = ({
   entity,
@@ -96,7 +101,7 @@ const Details = ({
   entity,
   links = true,
 }) => {
-  const {certs, nvts} = entity;
+  const {certs = [], nvts = []} = entity;
   let {products} = entity;
   products = products.sort();
   return (
@@ -207,100 +212,108 @@ EntityInfo.propTypes = {
   entity: PropTypes.model.isRequired,
 };
 
-const CvePage = props => (
-  <EntityContainer
-    {...props}
+const CvePage = ({
+  entity,
+  onChanged,
+  onDownloaded,
+  onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
+  ...props
+}) => (
+  <EntityComponent
     name="cve"
+    onDownloaded={onDownloaded}
+    onDownloadError={onError}
   >
-    {({
-      entity,
-      onChanged,
-      onDownloaded,
-      onError,
-      onTagAddClick,
-      onTagCreateClick,
-      onTagDeleteClick,
-      onTagDisableClick,
-      onTagEditClick,
-      onTagEnableClick,
-      onTagRemoveClick,
-      ...cprops
-    }) => (
-      <EntityComponent
-        name="cve"
-        onDownloaded={onDownloaded}
-        onDownloadError={onError}
+    {({download}) => (
+      <EntityPage
+        {...props}
+        entity={entity}
+        sectionIcon="cve.svg"
+        title={_('CVE')}
+        infoComponent={EntityInfo}
+        toolBarIcons={ToolBarIcons}
+        onCveDownloadClick={download}
+        onPermissionChanged={onChanged}
+        onPermissionDownloaded={onDownloaded}
+        onPermissionDownloadError={onError}
       >
-        {({download}) => (
-          <EntityPage
-            {...props}
-            {...cprops}
-            entity={entity}
-            sectionIcon="cve.svg"
-            title={_('CVE')}
-            detailsComponent={Details}
-            infoComponent={EntityInfo}
-            toolBarIcons={ToolBarIcons}
-            onCveDownloadClick={download}
-            onPermissionChanged={onChanged}
-            onPermissionDownloaded={onDownloaded}
-            onPermissionDownloadError={onError}
-          >
-            {({
-              activeTab = 0,
-              onActivateTab,
-            }) => {
-              return (
-                <Layout grow="1" flex="column">
-                  <TabLayout
-                    grow="1"
-                    align={['start', 'end']}
-                  >
-                    <TabList
-                      active={activeTab}
-                      align={['start', 'stretch']}
-                      onActivateTab={onActivateTab}
-                    >
-                      <Tab>
-                        {_('Information')}
-                      </Tab>
-                      <EntitiesTab entities={entity.userTags}>
-                        {_('User Tags')}
-                      </EntitiesTab>
-                    </TabList>
-                  </TabLayout>
+        {({
+          activeTab = 0,
+          onActivateTab,
+        }) => {
+          return (
+            <Layout grow="1" flex="column">
+              <TabLayout
+                grow="1"
+                align={['start', 'end']}
+              >
+                <TabList
+                  active={activeTab}
+                  align={['start', 'stretch']}
+                  onActivateTab={onActivateTab}
+                >
+                  <Tab>
+                    {_('Information')}
+                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
+                </TabList>
+              </TabLayout>
 
-                  <Tabs active={activeTab}>
-                    <TabPanels>
-                      <TabPanel>
-                        <Details
-                          entity={entity}
-                        />
-                      </TabPanel>
-                      <TabPanel>
-                        <EntityTags
-                          entity={entity}
-                          onTagAddClick={onTagAddClick}
-                          onTagDeleteClick={onTagDeleteClick}
-                          onTagDisableClick={onTagDisableClick}
-                          onTagEditClick={onTagEditClick}
-                          onTagEnableClick={onTagEnableClick}
-                          onTagCreateClick={onTagCreateClick}
-                          onTagRemoveClick={onTagRemoveClick}
-                        />
-                      </TabPanel>
-                    </TabPanels>
-                  </Tabs>
-                </Layout>
-              );
-            }}
-          </EntityPage>
-        )}
-      </EntityComponent>
+              <Tabs active={activeTab}>
+                <TabPanels>
+                  <TabPanel>
+                    <Details
+                      entity={entity}
+                    />
+                  </TabPanel>
+                  <TabPanel>
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
+                  </TabPanel>
+                </TabPanels>
+              </Tabs>
+            </Layout>
+          );
+        }}
+      </EntityPage>
     )}
-  </EntityContainer>
+  </EntityComponent>
 );
 
-export default CvePage;
+CvePage.propTypes = {
+  entity: PropTypes.model,
+  onChanged: PropTypes.func.isRequired,
+  onDownloaded: PropTypes.func.isRequired,
+  onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
+};
+
+export default withEntityContainer('cve', {
+  load: loadEntity,
+  entitySelector: selector,
+})(CvePage);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/dfncert/detailspage.js
+++ b/gsa/src/web/pages/dfncert/detailspage.js
@@ -48,9 +48,14 @@ import ExternalLink from 'web/components/link/externallink';
 import DetailsBlock from 'web/entity/block';
 import EntityPage from 'web/entity/page';
 import EntityComponent from 'web/entity/component';
-import EntityContainer from 'web/entity/container';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer from 'web/entity/withEntityContainer';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/dfncerts';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -155,96 +160,104 @@ Details.propTypes = {
   links: PropTypes.bool,
 };
 
-const DfnCertAdvPage = props => (
-  <EntityContainer
-    {...props}
+const DfnCertAdvPage = ({
+  entity,
+  onChanged,
+  onDownloaded,
+  onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
+  ...props
+}) => (
+  <EntityComponent
     name="dfncert"
-    resourceType="dfn_cert_adv"
+    onDownloaded={onDownloaded}
+    onDownloadError={onError}
   >
-    {({
-      entity,
-      onChanged,
-      onDownloaded,
-      onError,
-      onTagAddClick,
-      onTagCreateClick,
-      onTagDeleteClick,
-      onTagDisableClick,
-      onTagEditClick,
-      onTagEnableClick,
-      onTagRemoveClick,
-      ...cprops
-    }) => (
-      <EntityComponent
-        name="dfncert"
-        onDownloaded={onDownloaded}
-        onDownloadError={onError}
+    {({download}) => (
+      <EntityPage
+        {...props}
+        entity={entity}
+        sectionIcon="dfn_cert_adv.svg"
+        title={_('DFN-CERT Advisory')}
+        toolBarIcons={ToolBarIcons}
+        onDfnCertAdvDownloadClick={download}
       >
-        {({download}) => (
-          <EntityPage
-            {...props}
-            {...cprops}
-            entity={entity}
-            sectionIcon="dfn_cert_adv.svg"
-            title={_('DFN-CERT Advisory')}
-            toolBarIcons={ToolBarIcons}
-            onDfnCertAdvDownloadClick={download}
-          >
-            {({
-              activeTab = 0,
-              onActivateTab,
-            }) => {
-              return (
-                <Layout grow="1" flex="column">
-                  <TabLayout
-                    grow="1"
-                    align={['start', 'end']}
-                  >
-                    <TabList
-                      active={activeTab}
-                      align={['start', 'stretch']}
-                      onActivateTab={onActivateTab}
-                    >
-                      <Tab>
-                        {_('Information')}
-                      </Tab>
-                      <EntitiesTab entities={entity.userTags}>
-                        {_('User Tags')}
-                      </EntitiesTab>
-                    </TabList>
-                  </TabLayout>
+        {({
+          activeTab = 0,
+          onActivateTab,
+        }) => {
+          return (
+            <Layout grow="1" flex="column">
+              <TabLayout
+                grow="1"
+                align={['start', 'end']}
+              >
+                <TabList
+                  active={activeTab}
+                  align={['start', 'stretch']}
+                  onActivateTab={onActivateTab}
+                >
+                  <Tab>
+                    {_('Information')}
+                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
+                </TabList>
+              </TabLayout>
 
-                  <Tabs active={activeTab}>
-                    <TabPanels>
-                      <TabPanel>
-                        <Details
-                          entity={entity}
-                        />
-                      </TabPanel>
-                      <TabPanel>
-                        <EntityTags
-                          entity={entity}
-                          onTagAddClick={onTagAddClick}
-                          onTagDeleteClick={onTagDeleteClick}
-                          onTagDisableClick={onTagDisableClick}
-                          onTagEditClick={onTagEditClick}
-                          onTagEnableClick={onTagEnableClick}
-                          onTagCreateClick={onTagCreateClick}
-                          onTagRemoveClick={onTagRemoveClick}
-                        />
-                      </TabPanel>
-                    </TabPanels>
-                  </Tabs>
-                </Layout>
-              );
-            }}
-          </EntityPage>
-        )}
-      </EntityComponent>
+              <Tabs active={activeTab}>
+                <TabPanels>
+                  <TabPanel>
+                    <Details
+                      entity={entity}
+                    />
+                  </TabPanel>
+                  <TabPanel>
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
+                  </TabPanel>
+                </TabPanels>
+              </Tabs>
+            </Layout>
+          );
+        }}
+      </EntityPage>
     )}
-  </EntityContainer>
+  </EntityComponent>
 );
 
-export default DfnCertAdvPage;
+DfnCertAdvPage.propTypes = {
+  entity: PropTypes.model,
+  onChanged: PropTypes.func.isRequired,
+  onDownloaded: PropTypes.func.isRequired,
+  onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
+};
+
+export default withEntityContainer('dfncert', {
+  load: loadEntity,
+  entitySelector: selector,
+})(DfnCertAdvPage);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/dfncert/detailspage.js
+++ b/gsa/src/web/pages/dfncert/detailspage.js
@@ -53,6 +53,7 @@ import DetailsLink from '../../components/link/detailslink.js';
 import ExternalLink from '../../components/link/externallink.js';
 
 import DfnCertAdvDetails from './details.js';
+import EntitiesTab from 'web/entity/tab.js';
 
 const ToolBarIcons = ({
   entity,
@@ -183,7 +184,6 @@ const DfnCertAdvPage = props => (
             {({
               activeTab = 0,
               tagsComponent,
-              tagsTitle,
               onActivateTab,
               entity,
               ...other
@@ -202,9 +202,9 @@ const DfnCertAdvPage = props => (
                       <Tab>
                         {_('Information')}
                       </Tab>
-                      <Tab>
-                        {tagsTitle}
-                      </Tab>
+                      <EntitiesTab entities={entity.userTags}>
+                        {_('User Tags')}
+                      </EntitiesTab>
                     </TabList>
                   </TabLayout>
 

--- a/gsa/src/web/pages/dfncert/detailspage.js
+++ b/gsa/src/web/pages/dfncert/detailspage.js
@@ -50,6 +50,7 @@ import EntityPage from 'web/entity/page';
 import EntityComponent from 'web/entity/component';
 import EntityContainer from 'web/entity/container';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -164,6 +165,13 @@ const DfnCertAdvPage = props => (
       onChanged,
       onDownloaded,
       onError,
+      onTagAddClick,
+      onTagCreateClick,
+      onTagDeleteClick,
+      onTagDisableClick,
+      onTagEditClick,
+      onTagEnableClick,
+      onTagRemoveClick,
       ...cprops
     }) => (
       <EntityComponent
@@ -183,7 +191,6 @@ const DfnCertAdvPage = props => (
           >
             {({
               activeTab = 0,
-              tagsComponent,
               onActivateTab,
               entity,
               ...other
@@ -216,7 +223,16 @@ const DfnCertAdvPage = props => (
                         />
                       </TabPanel>
                       <TabPanel>
-                        {tagsComponent}
+                        <EntityTags
+                          entity={entity}
+                          onTagAddClick={onTagAddClick}
+                          onTagDeleteClick={onTagDeleteClick}
+                          onTagDisableClick={onTagDisableClick}
+                          onTagEditClick={onTagEditClick}
+                          onTagEnableClick={onTagEnableClick}
+                          onTagCreateClick={onTagCreateClick}
+                          onTagRemoveClick={onTagRemoveClick}
+                        />
                       </TabPanel>
                     </TabPanels>
                   </Tabs>

--- a/gsa/src/web/pages/dfncert/detailspage.js
+++ b/gsa/src/web/pages/dfncert/detailspage.js
@@ -27,33 +27,33 @@ import _ from 'gmp/locale';
 
 import {isDefined} from 'gmp/utils/identity';
 
-import PropTypes from '../../utils/proptypes.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
 
-import DetailsBlock from '../../entity/block.js';
-import EntityPage from '../../entity/page.js';
-import EntityComponent from '../../entity/component.js';
-import EntityContainer from '../../entity/container.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
+import DetailsLink from 'web/components/link/detailslink';
+import ExternalLink from 'web/components/link/externallink';
 
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
+import DetailsBlock from 'web/entity/block';
+import EntityPage from 'web/entity/page';
+import EntityComponent from 'web/entity/component';
+import EntityContainer from 'web/entity/container';
+import EntitiesTab from 'web/entity/tab';
 
-import DetailsLink from '../../components/link/detailslink.js';
-import ExternalLink from '../../components/link/externallink.js';
+import PropTypes from 'web/utils/proptypes';
 
-import DfnCertAdvDetails from './details.js';
-import EntitiesTab from 'web/entity/tab.js';
+import DfnCertAdvDetails from './details';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/dfncert/detailspage.js
+++ b/gsa/src/web/pages/dfncert/detailspage.js
@@ -177,14 +177,11 @@ const DfnCertAdvPage = props => (
             sectionIcon="dfn_cert_adv.svg"
             title={_('DFN-CERT Advisory')}
             detailsComponent={Details}
-            permissionsComponent={false}
             toolBarIcons={ToolBarIcons}
             onDfnCertAdvDownloadClick={download}
           >
             {({
               activeTab = 0,
-              permissionsComponent,
-              permissionsTitle,
               tagsComponent,
               tagsTitle,
               onActivateTab,
@@ -205,16 +202,9 @@ const DfnCertAdvPage = props => (
                       <Tab>
                         {_('Information')}
                       </Tab>
-                      {isDefined(tagsComponent) &&
-                        <Tab>
-                          {tagsTitle}
-                        </Tab>
-                      }
-                      {isDefined(permissionsComponent) &&
-                        <Tab>
-                          {permissionsTitle}
-                        </Tab>
-                      }
+                      <Tab>
+                        {tagsTitle}
+                      </Tab>
                     </TabList>
                   </TabLayout>
 
@@ -225,16 +215,9 @@ const DfnCertAdvPage = props => (
                           entity={entity}
                         />
                       </TabPanel>
-                      {isDefined(tagsComponent) &&
-                        <TabPanel>
-                          {tagsComponent}
-                        </TabPanel>
-                      }
-                      {isDefined(permissionsComponent) &&
-                        <TabPanel>
-                          {permissionsComponent}
-                        </TabPanel>
-                      }
+                      <TabPanel>
+                        {tagsComponent}
+                      </TabPanel>
                     </TabPanels>
                   </Tabs>
                 </Layout>

--- a/gsa/src/web/pages/dfncert/detailspage.js
+++ b/gsa/src/web/pages/dfncert/detailspage.js
@@ -185,7 +185,6 @@ const DfnCertAdvPage = props => (
             {...cprops}
             sectionIcon="dfn_cert_adv.svg"
             title={_('DFN-CERT Advisory')}
-            detailsComponent={Details}
             toolBarIcons={ToolBarIcons}
             onDfnCertAdvDownloadClick={download}
           >

--- a/gsa/src/web/pages/dfncert/detailspage.js
+++ b/gsa/src/web/pages/dfncert/detailspage.js
@@ -162,6 +162,7 @@ const DfnCertAdvPage = props => (
     resourceType="dfn_cert_adv"
   >
     {({
+      entity,
       onChanged,
       onDownloaded,
       onError,
@@ -183,6 +184,7 @@ const DfnCertAdvPage = props => (
           <EntityPage
             {...props}
             {...cprops}
+            entity={entity}
             sectionIcon="dfn_cert_adv.svg"
             title={_('DFN-CERT Advisory')}
             toolBarIcons={ToolBarIcons}
@@ -191,8 +193,6 @@ const DfnCertAdvPage = props => (
             {({
               activeTab = 0,
               onActivateTab,
-              entity,
-              ...other
             }) => {
               return (
                 <Layout grow="1" flex="column">

--- a/gsa/src/web/pages/filters/detailspage.js
+++ b/gsa/src/web/pages/filters/detailspage.js
@@ -147,7 +147,6 @@ const Page = ({
       }) => (
         <EntityPage
           {...props}
-          detailsComponent={FilterDetails}
           sectionIcon="filter.svg"
           toolBarIcons={ToolBarIcons}
           title={_('Filter')}

--- a/gsa/src/web/pages/filters/detailspage.js
+++ b/gsa/src/web/pages/filters/detailspage.js
@@ -41,18 +41,28 @@ import TabPanels from 'web/components/tab/tabpanels';
 import Tabs from 'web/components/tab/tabs';
 
 import EntityPage from 'web/entity/page';
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsResourceFilter,
+} from 'web/entity/withEntityContainer';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/filters';
+
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -242,18 +252,26 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-const FilterPage = props => (
-  <EntityContainer
-    {...props}
-    name="filter"
-    loaders={[
-      permissions_resource_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const load = gmp => {
+  const loadEntityFunc = loadEntity(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  return id => dispatch => {
+    dispatch(loadEntityFunc(id));
+    dispatch(loadPermissionsFunc(permissionsResourceFilter(id)));
+  };
+};
 
-export default FilterPage;
+const mapStateToProps = (rootState, {id}) => {
+  const permissionsSel = permissionsSelector(rootState);
+  return {
+    permissions: permissionsSel.getEntities(permissionsResourceFilter(id)),
+  };
+};
+
+export default withEntityContainer('filter', {
+  entitySelector: selector,
+  load,
+  mapStateToProps,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/filters/detailspage.js
+++ b/gsa/src/web/pages/filters/detailspage.js
@@ -25,8 +25,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from 'web/utils/proptypes';
 
 import EntityPage from 'web/entity/page';
@@ -178,16 +176,12 @@ const Page = ({
                     <Tab>
                       {_('Information')}
                     </Tab>
-                    {isDefined(tagsComponent) &&
-                      <Tab>
-                        {tagsTitle}
-                      </Tab>
-                    }
-                    {isDefined(permissionsComponent) &&
-                      <Tab>
-                        {permissionsTitle}
-                      </Tab>
-                    }
+                    <Tab>
+                      {tagsTitle}
+                    </Tab>
+                    <Tab>
+                      {permissionsTitle}
+                    </Tab>
                   </TabList>
                 </TabLayout>
 
@@ -198,16 +192,12 @@ const Page = ({
                         entity={entity}
                       />
                     </TabPanel>
-                    {isDefined(tagsComponent) &&
-                      <TabPanel>
-                        {tagsComponent}
-                      </TabPanel>
-                    }
-                    {isDefined(permissionsComponent) &&
-                      <TabPanel>
-                        {permissionsComponent}
-                      </TabPanel>
-                    }
+                    <TabPanel>
+                      {tagsComponent}
+                    </TabPanel>
+                    <TabPanel>
+                      {permissionsComponent}
+                    </TabPanel>
                   </TabPanels>
                 </Tabs>
               </Layout>

--- a/gsa/src/web/pages/filters/detailspage.js
+++ b/gsa/src/web/pages/filters/detailspage.js
@@ -46,6 +46,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -116,6 +117,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => {
   return (
@@ -157,7 +165,6 @@ const Page = ({
             activeTab = 0,
             permissionsComponent,
             permissionsTitle,
-            tagsComponent,
             onActivateTab,
             entity,
             ...other
@@ -193,7 +200,16 @@ const Page = ({
                       />
                     </TabPanel>
                     <TabPanel>
-                      {tagsComponent}
+                      <EntityTags
+                        entity={entity}
+                        onTagAddClick={onTagAddClick}
+                        onTagDeleteClick={onTagDeleteClick}
+                        onTagDisableClick={onTagDisableClick}
+                        onTagEditClick={onTagEditClick}
+                        onTagEnableClick={onTagEnableClick}
+                        onTagCreateClick={onTagCreateClick}
+                        onTagRemoveClick={onTagRemoveClick}
+                      />
                     </TabPanel>
                     <TabPanel>
                       {permissionsComponent}
@@ -213,6 +229,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const FilterPage = props => (

--- a/gsa/src/web/pages/filters/detailspage.js
+++ b/gsa/src/web/pages/filters/detailspage.js
@@ -45,6 +45,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -115,6 +116,7 @@ ToolBarIcons.propTypes = {
 
 const Page = ({
   entity,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -158,14 +160,9 @@ const Page = ({
           onFilterDownloadClick={download}
           onFilterEditClick={edit}
           onFilterSaveClick={save}
-          onPermissionChanged={onChanged}
-          onPermissionDownloaded={onDownloaded}
-          onPermissionDownloadError={onError}
         >
           {({
             activeTab = 0,
-            permissionsComponent,
-            permissionsTitle,
             onActivateTab,
           }) => {
             return (
@@ -185,9 +182,9 @@ const Page = ({
                     <EntitiesTab entities={entity.userTags}>
                       {_('User Tags')}
                     </EntitiesTab>
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
+                    <EntitiesTab entities={permissions}>
+                      {_('Permissions')}
+                    </EntitiesTab>
                   </TabList>
                 </TabLayout>
 
@@ -211,7 +208,13 @@ const Page = ({
                       />
                     </TabPanel>
                     <TabPanel>
-                      {permissionsComponent}
+                      <EntityPermissions
+                        entity={entity}
+                        permissions={permissions}
+                        onChanged={onChanged}
+                        onDownloaded={onDownloaded}
+                        onError={onError}
+                      />
                     </TabPanel>
                   </TabPanels>
                 </Tabs>
@@ -226,6 +229,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/filters/detailspage.js
+++ b/gsa/src/web/pages/filters/detailspage.js
@@ -114,6 +114,7 @@ ToolBarIcons.propTypes = {
 };
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -147,6 +148,7 @@ const Page = ({
       }) => (
         <EntityPage
           {...props}
+          entity={entity}
           sectionIcon="filter.svg"
           toolBarIcons={ToolBarIcons}
           title={_('Filter')}
@@ -165,8 +167,6 @@ const Page = ({
             permissionsComponent,
             permissionsTitle,
             onActivateTab,
-            entity,
-            ...other
           }) => {
             return (
               <Layout grow="1" flex="column">
@@ -225,6 +225,7 @@ const Page = ({
 };
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/filters/detailspage.js
+++ b/gsa/src/web/pages/filters/detailspage.js
@@ -32,6 +32,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntitiesTab from 'web/entity/tab';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -157,7 +158,6 @@ const Page = ({
             permissionsComponent,
             permissionsTitle,
             tagsComponent,
-            tagsTitle,
             onActivateTab,
             entity,
             ...other
@@ -176,9 +176,9 @@ const Page = ({
                     <Tab>
                       {_('Information')}
                     </Tab>
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
+                    <EntitiesTab entities={entity.userTags}>
+                      {_('User Tags')}
+                    </EntitiesTab>
                     <Tab>
                       {permissionsTitle}
                     </Tab>

--- a/gsa/src/web/pages/filters/detailspage.js
+++ b/gsa/src/web/pages/filters/detailspage.js
@@ -25,20 +25,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from 'web/utils/proptypes';
-
-import EntityPage from 'web/entity/page';
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
-import {goto_details, goto_list} from 'web/entity/component';
-import EntitiesTab from 'web/entity/tab';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import CreateIcon from 'web/entity/icon/createicon';
-import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
-
 import Divider from 'web/components/layout/divider';
 import IconDivider from 'web/components/layout/icondivider';
 import Layout from 'web/components/layout/layout.js';
@@ -53,6 +39,20 @@ import TabList from 'web/components/tab/tablist';
 import TabPanel from 'web/components/tab/tabpanel';
 import TabPanels from 'web/components/tab/tabpanels';
 import Tabs from 'web/components/tab/tabs';
+
+import EntityPage from 'web/entity/page';
+import EntityContainer, {
+  permissions_resource_loader,
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
+import EntitiesTab from 'web/entity/tab';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
 
 import FilterDetails from './details';
 import FilterComponent from './component';

--- a/gsa/src/web/pages/groups/detailspage.js
+++ b/gsa/src/web/pages/groups/detailspage.js
@@ -25,37 +25,37 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from '../../utils/proptypes.js';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
 
-import EntityPage from '../../entity/page.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
+
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
+
+import EntityPage from 'web/entity/page';
 import EntityContainer, {
   permissions_subject_loader,
-} from '../../entity/container.js';
-import {goto_details, goto_list} from '../../entity/component.js';
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import CloneIcon from '../../entity/icon/cloneicon.js';
-import CreateIcon from '../../entity/icon/createicon.js';
-import EditIcon from '../../entity/icon/editicon.js';
-import TrashIcon from '../../entity/icon/trashicon.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
 
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import PropTypes from 'web/utils/proptypes';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
-
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
-
-import GroupComponent from './component.js';
-import GroupDetails from './details.js';
+import GroupComponent from './component';
+import GroupDetails from './details';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/groups/detailspage.js
+++ b/gsa/src/web/pages/groups/detailspage.js
@@ -32,6 +32,7 @@ import EntityContainer, {
   permissions_subject_loader,
 } from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
+import EntitiesTab from 'web/entity/tab';
 
 import ExportIcon from '../../components/icon/exporticon.js';
 import CloneIcon from '../../entity/icon/cloneicon.js';
@@ -156,7 +157,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           tagsComponent,
-          tagsTitle,
           onActivateTab,
           entity,
           ...other
@@ -175,9 +175,9 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <Tab>
-                    {tagsTitle}
-                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
                   <Tab>
                     {permissionsTitle}
                   </Tab>

--- a/gsa/src/web/pages/groups/detailspage.js
+++ b/gsa/src/web/pages/groups/detailspage.js
@@ -148,7 +148,6 @@ const Page = ({
         {...props}
         sectionIcon="group.svg"
         title={_('Group')}
-        detailsComponent={GroupDetails}
         toolBarIcons={ToolBarIcons}
         onGroupCloneClick={clone}
         onGroupCreateClick={create}

--- a/gsa/src/web/pages/groups/detailspage.js
+++ b/gsa/src/web/pages/groups/detailspage.js
@@ -40,19 +40,29 @@ import TabPanels from 'web/components/tab/tabpanels';
 import Tabs from 'web/components/tab/tabs';
 
 import EntityPage from 'web/entity/page';
-import EntityContainer, {
-  permissions_subject_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsSubjectFilter,
+} from 'web/entity/withEntityContainer';
 
 import ExportIcon from 'web/components/icon/exporticon';
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/groups';
+
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -240,18 +250,26 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-const GroupPage = props => (
-  <EntityContainer
-    {...props}
-    name="group"
-    loaders={[
-      permissions_subject_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const load = gmp => {
+  const loadEntityFunc = loadEntity(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  return id => dispatch => {
+    dispatch(loadEntityFunc(id));
+    dispatch(loadPermissionsFunc(permissionsSubjectFilter(id)));
+  };
+};
 
-export default GroupPage;
+const mapStateToProps = (rootState, {id}) => {
+  const permissionsSel = permissionsSelector(rootState);
+  return {
+    permissions: permissionsSel.getEntities(permissionsSubjectFilter(id)),
+  };
+};
+
+export default withEntityContainer('group', {
+  entitySelector: selector,
+  load,
+  mapStateToProps,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/groups/detailspage.js
+++ b/gsa/src/web/pages/groups/detailspage.js
@@ -25,8 +25,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from '../../utils/proptypes.js';
 
 import EntityPage from '../../entity/page.js';
@@ -177,16 +175,12 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  {isDefined(tagsComponent) &&
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
-                  }
+                  <Tab>
+                    {tagsTitle}
+                  </Tab>
+                  <Tab>
+                    {permissionsTitle}
+                  </Tab>
                 </TabList>
               </TabLayout>
 
@@ -197,16 +191,12 @@ const Page = ({
                       entity={entity}
                     />
                   </TabPanel>
-                  {isDefined(tagsComponent) &&
-                    <TabPanel>
-                      {tagsComponent}
-                    </TabPanel>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <TabPanel>
-                      {permissionsComponent}
-                    </TabPanel>
-                  }
+                  <TabPanel>
+                    {tagsComponent}
+                  </TabPanel>
+                  <TabPanel>
+                    {permissionsComponent}
+                  </TabPanel>
                 </TabPanels>
               </Tabs>
             </Layout>

--- a/gsa/src/web/pages/groups/detailspage.js
+++ b/gsa/src/web/pages/groups/detailspage.js
@@ -44,6 +44,7 @@ import EntityContainer, {
   permissions_subject_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -115,6 +116,7 @@ ToolBarIcons.propTypes = {
 
 const Page = ({
   entity,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -157,14 +159,9 @@ const Page = ({
         onGroupDownloadClick={download}
         onGroupEditClick={edit}
         onGroupSaveClick={save}
-        onPermissionChanged={onChanged}
-        onPermissionDownloaded={onDownloaded}
-        onPermissionDownloadError={onError}
       >
         {({
           activeTab = 0,
-          permissionsComponent,
-          permissionsTitle,
           onActivateTab,
         }) => {
           return (
@@ -184,9 +181,9 @@ const Page = ({
                   <EntitiesTab entities={entity.userTags}>
                     {_('User Tags')}
                   </EntitiesTab>
-                  <Tab>
-                    {permissionsTitle}
-                  </Tab>
+                  <EntitiesTab entities={permissions}>
+                    {_('Permissions')}
+                  </EntitiesTab>
                 </TabList>
               </TabLayout>
 
@@ -210,7 +207,13 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {permissionsComponent}
+                    <EntityPermissions
+                      entity={entity}
+                      permissions={permissions}
+                      onChanged={onChanged}
+                      onDownloaded={onDownloaded}
+                      onError={onError}
+                    />
                   </TabPanel>
                 </TabPanels>
               </Tabs>
@@ -224,6 +227,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/groups/detailspage.js
+++ b/gsa/src/web/pages/groups/detailspage.js
@@ -45,6 +45,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import ExportIcon from 'web/components/icon/exporticon';
 import CloneIcon from 'web/entity/icon/cloneicon';
@@ -116,6 +117,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => (
   <GroupComponent
@@ -156,7 +164,6 @@ const Page = ({
           activeTab = 0,
           permissionsComponent,
           permissionsTitle,
-          tagsComponent,
           onActivateTab,
           entity,
           ...other
@@ -192,7 +199,16 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {tagsComponent}
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
                   </TabPanel>
                   <TabPanel>
                     {permissionsComponent}
@@ -211,6 +227,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const GroupPage = props => (

--- a/gsa/src/web/pages/groups/detailspage.js
+++ b/gsa/src/web/pages/groups/detailspage.js
@@ -114,6 +114,7 @@ ToolBarIcons.propTypes = {
 };
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -146,6 +147,7 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
+        entity={entity}
         sectionIcon="group.svg"
         title={_('Group')}
         toolBarIcons={ToolBarIcons}
@@ -164,8 +166,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           onActivateTab,
-          entity,
-          ...other
         }) => {
           return (
             <Layout grow="1" flex="column">
@@ -223,6 +223,7 @@ const Page = ({
 );
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/hosts/detailspage.js
+++ b/gsa/src/web/pages/hosts/detailspage.js
@@ -62,6 +62,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -279,6 +280,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => {
   const goto_host = goto_details('host', props);
@@ -327,7 +335,6 @@ const Page = ({
             activeTab = 0,
             permissionsComponent,
             permissionsTitle,
-            tagsComponent,
             onActivateTab,
             entity,
             ...other
@@ -363,7 +370,16 @@ const Page = ({
                       />
                     </TabPanel>
                     <TabPanel>
-                      {tagsComponent}
+                      <EntityTags
+                        entity={entity}
+                        onTagAddClick={onTagAddClick}
+                        onTagDeleteClick={onTagDeleteClick}
+                        onTagDisableClick={onTagDisableClick}
+                        onTagEditClick={onTagEditClick}
+                        onTagEnableClick={onTagEnableClick}
+                        onTagCreateClick={onTagCreateClick}
+                        onTagRemoveClick={onTagRemoveClick}
+                      />
                     </TabPanel>
                     <TabPanel>
                       {permissionsComponent}
@@ -383,6 +399,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const HostPage = props => (

--- a/gsa/src/web/pages/hosts/detailspage.js
+++ b/gsa/src/web/pages/hosts/detailspage.js
@@ -29,8 +29,6 @@ import _ from 'gmp/locale';
 
 import {isDefined} from 'gmp/utils/identity';
 
-import PropTypes from 'web/utils/proptypes';
-
 import SeverityBar from 'web/components/bar/severitybar';
 
 import ExportIcon from 'web/components/icon/exporticon';
@@ -69,6 +67,8 @@ import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
 
 import HostDetails from './details';
 import HostComponent from './component';

--- a/gsa/src/web/pages/hosts/detailspage.js
+++ b/gsa/src/web/pages/hosts/detailspage.js
@@ -63,6 +63,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntitiesTab from 'web/entity/tab';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -327,7 +328,6 @@ const Page = ({
             permissionsComponent,
             permissionsTitle,
             tagsComponent,
-            tagsTitle,
             onActivateTab,
             entity,
             ...other
@@ -346,9 +346,9 @@ const Page = ({
                     <Tab>
                       {_('Information')}
                     </Tab>
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
+                    <EntitiesTab entities={entity.userTags}>
+                      {_('User Tags')}
+                    </EntitiesTab>
                     <Tab>
                       {permissionsTitle}
                     </Tab>

--- a/gsa/src/web/pages/hosts/detailspage.js
+++ b/gsa/src/web/pages/hosts/detailspage.js
@@ -277,6 +277,7 @@ Details.propTypes = {
 
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -314,6 +315,7 @@ const Page = ({
       }) => (
         <EntityPage
           {...props}
+          entity={entity}
           sectionIcon="host.svg"
           toolBarIcons={ToolBarIcons}
           title={_('Host')}
@@ -335,8 +337,6 @@ const Page = ({
             permissionsComponent,
             permissionsTitle,
             onActivateTab,
-            entity,
-            ...other
           }) => {
             return (
               <Layout grow="1" flex="column">
@@ -395,6 +395,7 @@ const Page = ({
 };
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/hosts/detailspage.js
+++ b/gsa/src/web/pages/hosts/detailspage.js
@@ -61,6 +61,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -278,6 +279,7 @@ Details.propTypes = {
 
 const Page = ({
   entity,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -328,14 +330,9 @@ const Page = ({
           onHostDownloadClick={download}
           onHostEditClick={edit}
           onHostIdentifierDeleteClick={deleteidentifier}
-          onPermissionChanged={onChanged}
-          onPermissionDownloaded={onDownloaded}
-          onPermissionDownloadError={onError}
         >
           {({
             activeTab = 0,
-            permissionsComponent,
-            permissionsTitle,
             onActivateTab,
           }) => {
             return (
@@ -355,9 +352,9 @@ const Page = ({
                     <EntitiesTab entities={entity.userTags}>
                       {_('User Tags')}
                     </EntitiesTab>
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
+                    <EntitiesTab entities={permissions}>
+                      {_('Permissions')}
+                    </EntitiesTab>
                   </TabList>
                 </TabLayout>
 
@@ -381,7 +378,13 @@ const Page = ({
                       />
                     </TabPanel>
                     <TabPanel>
-                      {permissionsComponent}
+                      <EntityPermissions
+                        entity={entity}
+                        permissions={permissions}
+                        onChanged={onChanged}
+                        onDownloaded={onDownloaded}
+                        onError={onError}
+                      />
                     </TabPanel>
                   </TabPanels>
                 </Tabs>
@@ -396,6 +399,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/hosts/detailspage.js
+++ b/gsa/src/web/pages/hosts/detailspage.js
@@ -346,16 +346,12 @@ const Page = ({
                     <Tab>
                       {_('Information')}
                     </Tab>
-                    {isDefined(tagsComponent) &&
-                      <Tab>
-                        {tagsTitle}
-                      </Tab>
-                    }
-                    {isDefined(permissionsComponent) &&
-                      <Tab>
-                        {permissionsTitle}
-                      </Tab>
-                    }
+                    <Tab>
+                      {tagsTitle}
+                    </Tab>
+                    <Tab>
+                      {permissionsTitle}
+                    </Tab>
                   </TabList>
                 </TabLayout>
 
@@ -366,16 +362,12 @@ const Page = ({
                         entity={entity}
                       />
                     </TabPanel>
-                    {isDefined(tagsComponent) &&
-                      <TabPanel>
-                        {tagsComponent}
-                      </TabPanel>
-                    }
-                    {isDefined(permissionsComponent) &&
-                      <TabPanel>
-                        {permissionsComponent}
-                      </TabPanel>
-                    }
+                    <TabPanel>
+                      {tagsComponent}
+                    </TabPanel>
+                    <TabPanel>
+                      {permissionsComponent}
+                    </TabPanel>
                   </TabPanels>
                 </Tabs>
               </Layout>

--- a/gsa/src/web/pages/hosts/detailspage.js
+++ b/gsa/src/web/pages/hosts/detailspage.js
@@ -314,7 +314,6 @@ const Page = ({
       }) => (
         <EntityPage
           {...props}
-          detailsComponent={Details}
           sectionIcon="host.svg"
           toolBarIcons={ToolBarIcons}
           title={_('Host')}

--- a/gsa/src/web/pages/notes/detailspage.js
+++ b/gsa/src/web/pages/notes/detailspage.js
@@ -59,6 +59,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
+import EntitiesTab from 'web/entity/tab.js';
 
 import CloneIcon from '../../entity/icon/cloneicon.js';
 import CreateIcon from '../../entity/icon/createicon.js';
@@ -233,7 +234,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           tagsComponent,
-          tagsTitle,
           onActivateTab,
           entity,
           ...other
@@ -252,9 +252,9 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <Tab>
-                    {tagsTitle}
-                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
                   <Tab>
                     {permissionsTitle}
                   </Tab>

--- a/gsa/src/web/pages/notes/detailspage.js
+++ b/gsa/src/web/pages/notes/detailspage.js
@@ -252,16 +252,12 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  {isDefined(tagsComponent) &&
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
-                  }
+                  <Tab>
+                    {tagsTitle}
+                  </Tab>
+                  <Tab>
+                    {permissionsTitle}
+                  </Tab>
                 </TabList>
               </TabLayout>
 
@@ -272,16 +268,12 @@ const Page = ({
                       entity={entity}
                     />
                   </TabPanel>
-                  {isDefined(tagsComponent) &&
-                    <TabPanel>
-                      {tagsComponent}
-                    </TabPanel>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <TabPanel>
-                      {permissionsComponent}
-                    </TabPanel>
-                  }
+                  <TabPanel>
+                    {tagsComponent}
+                  </TabPanel>
+                  <TabPanel>
+                    {permissionsComponent}
+                  </TabPanel>
                 </TabPanels>
               </Tabs>
             </Layout>

--- a/gsa/src/web/pages/notes/detailspage.js
+++ b/gsa/src/web/pages/notes/detailspage.js
@@ -52,18 +52,28 @@ import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
 import EntityPage from 'web/entity/page';
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsResourceFilter,
+} from 'web/entity/withEntityContainer';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+
+import {
+  selector as notesSelector,
+  loadEntity,
+} from 'web/store/entities/notes';
+
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
 
 import {renderYesNo} from 'web/utils/render';
 import PropTypes from 'web/utils/proptypes';
@@ -317,18 +327,26 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-const NotePage = props => (
-  <EntityContainer
-    {...props}
-    name="note"
-    loaders={[
-      permissions_resource_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const load = gmp => {
+  const loadEntityFunc = loadEntity(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  return id => dispatch => {
+    dispatch(loadEntityFunc(id));
+    dispatch(loadPermissionsFunc(permissionsResourceFilter(id)));
+  };
+};
 
-export default NotePage;
+const mapStateToProps = (rootState, {id}) => {
+  const permissionsSel = permissionsSelector(rootState);
+  return {
+    permissions: permissionsSel.getEntities(permissionsResourceFilter(id)),
+  };
+};
+
+export default withEntityContainer('note', {
+  entitySelector: notesSelector,
+  load,
+  mapStateToProps,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/notes/detailspage.js
+++ b/gsa/src/web/pages/notes/detailspage.js
@@ -188,6 +188,7 @@ Details.propTypes = {
 };
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -220,6 +221,7 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
+        entity={entity}
         sectionIcon="note.svg"
         title={_('Note')}
         toolBarIcons={ToolBarIcons}
@@ -241,8 +243,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           onActivateTab,
-          entity,
-          ...other
         }) => {
           return (
             <Layout grow="1" flex="column">
@@ -300,6 +300,7 @@ const Page = ({
 );
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/notes/detailspage.js
+++ b/gsa/src/web/pages/notes/detailspage.js
@@ -222,7 +222,6 @@ const Page = ({
         {...props}
         sectionIcon="note.svg"
         title={_('Note')}
-        detailsComponent={Details}
         toolBarIcons={ToolBarIcons}
         onChanged={onChanged}
         onDownloaded={onDownloaded}

--- a/gsa/src/web/pages/notes/detailspage.js
+++ b/gsa/src/web/pages/notes/detailspage.js
@@ -57,6 +57,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -190,6 +191,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => (
   <NoteComponent
@@ -233,7 +241,6 @@ const Page = ({
           activeTab = 0,
           permissionsComponent,
           permissionsTitle,
-          tagsComponent,
           onActivateTab,
           entity,
           ...other
@@ -269,7 +276,16 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {tagsComponent}
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
                   </TabPanel>
                   <TabPanel>
                     {permissionsComponent}
@@ -288,6 +304,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const NotePage = props => (

--- a/gsa/src/web/pages/notes/detailspage.js
+++ b/gsa/src/web/pages/notes/detailspage.js
@@ -56,6 +56,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -188,6 +189,7 @@ Details.propTypes = {
 };
 
 const Page = ({
+  permissions = [],
   entity,
   onChanged,
   onDownloaded,
@@ -234,14 +236,9 @@ const Page = ({
         onNoteDownloadClick={download}
         onNoteEditClick={edit}
         onNoteSaveClick={save}
-        onPermissionChanged={onChanged}
-        onPermissionDownloaded={onDownloaded}
-        onPermissionDownloadError={onError}
       >
         {({
           activeTab = 0,
-          permissionsComponent,
-          permissionsTitle,
           onActivateTab,
         }) => {
           return (
@@ -261,9 +258,9 @@ const Page = ({
                   <EntitiesTab entities={entity.userTags}>
                     {_('User Tags')}
                   </EntitiesTab>
-                  <Tab>
-                    {permissionsTitle}
-                  </Tab>
+                  <EntitiesTab entities={permissions}>
+                    {_('Permissions')}
+                  </EntitiesTab>
                 </TabList>
               </TabLayout>
 
@@ -287,7 +284,13 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {permissionsComponent}
+                    <EntityPermissions
+                      entity={entity}
+                      permissions={permissions}
+                      onChanged={onChanged}
+                      onDownloaded={onDownloaded}
+                      onError={onError}
+                    />
                   </TabPanel>
                 </TabPanels>
               </Tabs>
@@ -301,6 +304,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/notes/detailspage.js
+++ b/gsa/src/web/pages/notes/detailspage.js
@@ -29,45 +29,45 @@ import {longDate} from 'gmp/locale/date';
 
 import {isDefined} from 'gmp/utils/identity';
 
-import {renderYesNo} from '../../utils/render.js';
-import PropTypes from '../../utils/proptypes.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
+import DetailsLink from 'web/components/link/detailslink';
 
-import DetailsLink from '../../components/link/detailslink.js';
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
 
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
+import InfoTable from 'web/components/table/infotable';
+import TableBody from 'web/components/table/body';
+import TableData from 'web/components/table/data';
+import TableRow from 'web/components/table/row';
 
-import InfoTable from '../../components/table/infotable.js';
-import TableBody from '../../components/table/body.js';
-import TableData from '../../components/table/data.js';
-import TableRow from '../../components/table/row.js';
-
-import EntityPage from '../../entity/page.js';
+import EntityPage from 'web/entity/page';
 import EntityContainer, {
   permissions_resource_loader,
-} from '../../entity/container.js';
-import {goto_details, goto_list} from '../../entity/component.js';
-import EntitiesTab from 'web/entity/tab.js';
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
+import EntitiesTab from 'web/entity/tab';
 
-import CloneIcon from '../../entity/icon/cloneicon.js';
-import CreateIcon from '../../entity/icon/createicon.js';
-import EditIcon from '../../entity/icon/editicon.js';
-import TrashIcon from '../../entity/icon/trashicon.js';
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
 
-import NoteDetails from './details.js';
-import NoteComponent from './component.js';
+import {renderYesNo} from 'web/utils/render';
+import PropTypes from 'web/utils/proptypes';
+
+import NoteDetails from './details';
+import NoteComponent from './component';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/nvts/detailspage.js
+++ b/gsa/src/web/pages/nvts/detailspage.js
@@ -51,6 +51,7 @@ import Override from 'web/entity/override';
 import EntityPage from 'web/entity/page';
 import EntityContainer, {loader} from 'web/entity/container';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import PropTypes from 'web/utils/proptypes';
 import withCapabilities from 'web/utils/withCapabilities';
@@ -232,6 +233,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => (
   <NvtComponent
@@ -263,7 +271,6 @@ const Page = ({
           activeTab = 0,
           permissionsComponent,
           permissionsTitle,
-          tagsComponent,
           onActivateTab,
           entity,
           ...other
@@ -296,7 +303,16 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {tagsComponent}
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
                   </TabPanel>
                 </TabPanels>
               </Tabs>
@@ -312,6 +328,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const nvt_id_filter = id => 'nvt_id=' + id;

--- a/gsa/src/web/pages/nvts/detailspage.js
+++ b/gsa/src/web/pages/nvts/detailspage.js
@@ -282,16 +282,9 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  {isDefined(tagsComponent) &&
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
-                  }
+                  <Tab>
+                    {tagsTitle}
+                  </Tab>
                 </TabList>
               </TabLayout>
 
@@ -302,16 +295,9 @@ const Page = ({
                       entity={entity}
                     />
                   </TabPanel>
-                  {isDefined(tagsComponent) &&
-                    <TabPanel>
-                      {tagsComponent}
-                    </TabPanel>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <TabPanel>
-                      {permissionsComponent}
-                    </TabPanel>
-                  }
+                  <TabPanel>
+                    {tagsComponent}
+                  </TabPanel>
                 </TabPanels>
               </Tabs>
             </Layout>

--- a/gsa/src/web/pages/nvts/detailspage.js
+++ b/gsa/src/web/pages/nvts/detailspage.js
@@ -254,7 +254,6 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
-        detailsComponent={Details}
         permissionsComponent={false}
         toolBarIcons={ToolBarIcons}
         title={_('NVT')}

--- a/gsa/src/web/pages/nvts/detailspage.js
+++ b/gsa/src/web/pages/nvts/detailspage.js
@@ -230,6 +230,7 @@ const open_dialog = (nvt, func) => {
 };
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -254,6 +255,7 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
+        entity={entity}
         permissionsComponent={false}
         toolBarIcons={ToolBarIcons}
         title={_('NVT')}
@@ -268,11 +270,7 @@ const Page = ({
       >
         {({
           activeTab = 0,
-          permissionsComponent,
-          permissionsTitle,
           onActivateTab,
-          entity,
-          ...other
         }) => {
           return (
             <Layout grow="1" flex="column">
@@ -324,6 +322,7 @@ const Page = ({
 );
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/nvts/detailspage.js
+++ b/gsa/src/web/pages/nvts/detailspage.js
@@ -27,37 +27,37 @@ import _ from 'gmp/locale';
 
 import {isDefined} from 'gmp/utils/identity';
 
-import PropTypes from '../../utils/proptypes.js';
-import withCapabilities from '../../utils/withCapabilities.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import Icon from 'web/components/icon/icon';
+import ListIcon from 'web/components/icon/listicon';
 
-import DetailsBlock from '../../entity/block.js';
-import Note from '../../entity/note.js';
-import Override from '../../entity/override.js';
-import EntityPage from '../../entity/page.js';
-import EntityContainer, {loader} from '../../entity/container.js';
-import EntitiesTab from 'web/entity/tab.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import Icon from '../../components/icon/icon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import Link from 'web/components/link/link';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
 
-import Link from '../../components/link/link.js';
+import DetailsBlock from 'web/entity/block';
+import Note from 'web/entity/note';
+import Override from 'web/entity/override';
+import EntityPage from 'web/entity/page';
+import EntityContainer, {loader} from 'web/entity/container';
+import EntitiesTab from 'web/entity/tab';
 
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
+import PropTypes from 'web/utils/proptypes';
+import withCapabilities from 'web/utils/withCapabilities';
 
-import NvtComponent from './component.js';
-import NvtDetails from './details.js';
-import Preferences from './preferences.js';
+import NvtComponent from './component';
+import NvtDetails from './details';
+import Preferences from './preferences';
 
 let ToolBarIcons = ({
   capabilities,

--- a/gsa/src/web/pages/nvts/detailspage.js
+++ b/gsa/src/web/pages/nvts/detailspage.js
@@ -35,6 +35,7 @@ import Note from '../../entity/note.js';
 import Override from '../../entity/override.js';
 import EntityPage from '../../entity/page.js';
 import EntityContainer, {loader} from '../../entity/container.js';
+import EntitiesTab from 'web/entity/tab.js';
 
 import ExportIcon from '../../components/icon/exporticon.js';
 import ManualIcon from '../../components/icon/manualicon.js';
@@ -263,7 +264,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           tagsComponent,
-          tagsTitle,
           onActivateTab,
           entity,
           ...other
@@ -282,9 +282,9 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <Tab>
-                    {tagsTitle}
-                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
                 </TabList>
               </TabLayout>
 

--- a/gsa/src/web/pages/nvts/detailspage.js
+++ b/gsa/src/web/pages/nvts/detailspage.js
@@ -256,7 +256,6 @@ const Page = ({
       <EntityPage
         {...props}
         entity={entity}
-        permissionsComponent={false}
         toolBarIcons={ToolBarIcons}
         title={_('NVT')}
         sectionIcon="nvt.svg"
@@ -264,9 +263,6 @@ const Page = ({
         onNoteCreateClick={nvt => open_dialog(nvt, notecreate)}
         onNvtDownloadClick={download}
         onOverrideCreateClick={nvt => open_dialog(nvt, overridecreate)}
-        onPermissionChanged={onChanged}
-        onPermissionDownloaded={onDownloaded}
-        onPermissionDownloadError={onError}
       >
         {({
           activeTab = 0,

--- a/gsa/src/web/pages/operatingsystems/detailspage.js
+++ b/gsa/src/web/pages/operatingsystems/detailspage.js
@@ -60,6 +60,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import PropTypes from 'web/utils/proptypes';
 import withCapabilities from 'web/utils/withCapabilities';
@@ -202,6 +203,13 @@ Details.propTypes = {
 const Page = ({
   onDownloaded,
   onChanged,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   onError,
   ...props
 }) => (
@@ -231,7 +239,6 @@ const Page = ({
           activeTab = 0,
           permissionsComponent,
           permissionsTitle,
-          tagsComponent,
           onActivateTab,
           entity,
           ...other
@@ -267,7 +274,16 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {tagsComponent}
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
                   </TabPanel>
                   <TabPanel>
                     {permissionsComponent}
@@ -286,6 +302,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const HostPage = props => (

--- a/gsa/src/web/pages/operatingsystems/detailspage.js
+++ b/gsa/src/web/pages/operatingsystems/detailspage.js
@@ -25,8 +25,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from 'web/utils/proptypes';
 import withCapabilities from 'web/utils/withCapabilities';
 
@@ -252,16 +250,12 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  {isDefined(tagsComponent) &&
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
-                  }
+                  <Tab>
+                    {tagsTitle}
+                  </Tab>
+                  <Tab>
+                    {permissionsTitle}
+                  </Tab>
                 </TabList>
               </TabLayout>
 
@@ -272,16 +266,12 @@ const Page = ({
                       entity={entity}
                     />
                   </TabPanel>
-                  {isDefined(tagsComponent) &&
-                    <TabPanel>
-                      {tagsComponent}
-                    </TabPanel>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <TabPanel>
-                      {permissionsComponent}
-                    </TabPanel>
-                  }
+                  <TabPanel>
+                    {tagsComponent}
+                  </TabPanel>
+                  <TabPanel>
+                    {permissionsComponent}
+                  </TabPanel>
                 </TabPanels>
               </Tabs>
             </Layout>

--- a/gsa/src/web/pages/operatingsystems/detailspage.js
+++ b/gsa/src/web/pages/operatingsystems/detailspage.js
@@ -201,6 +201,7 @@ Details.propTypes = {
 };
 
 const Page = ({
+  entity,
   onDownloaded,
   onChanged,
   onTagAddClick,
@@ -225,6 +226,7 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
+        entity={entity}
         sectionIcon="os.svg"
         title={_('Operating System')}
         toolBarIcons={ToolBarIcons}
@@ -239,8 +241,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           onActivateTab,
-          entity,
-          ...other
         }) => {
           return (
             <Layout grow="1" flex="column">
@@ -298,6 +298,7 @@ const Page = ({
 );
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/operatingsystems/detailspage.js
+++ b/gsa/src/web/pages/operatingsystems/detailspage.js
@@ -33,6 +33,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_list} from 'web/entity/component';
+import EntitiesTab from 'web/entity/tab';
 
 import Badge from 'web/components/badge/badge';
 
@@ -231,7 +232,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           tagsComponent,
-          tagsTitle,
           onActivateTab,
           entity,
           ...other
@@ -250,9 +250,9 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <Tab>
-                    {tagsTitle}
-                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
                   <Tab>
                     {permissionsTitle}
                   </Tab>

--- a/gsa/src/web/pages/operatingsystems/detailspage.js
+++ b/gsa/src/web/pages/operatingsystems/detailspage.js
@@ -25,16 +25,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from 'web/utils/proptypes';
-import withCapabilities from 'web/utils/withCapabilities';
-
-import EntityPage, {Col} from 'web/entity/page';
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
-import {goto_list} from 'web/entity/component';
-import EntitiesTab from 'web/entity/tab';
-
 import Badge from 'web/components/badge/badge';
 
 import SeverityBar from 'web/components/bar/severitybar';
@@ -63,6 +53,16 @@ import InfoTable from 'web/components/table/infotable';
 import TableBody from 'web/components/table/body';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
+
+import EntityPage, {Col} from 'web/entity/page';
+import EntityContainer, {
+  permissions_resource_loader,
+} from 'web/entity/container';
+import {goto_list} from 'web/entity/component';
+import EntitiesTab from 'web/entity/tab';
+
+import PropTypes from 'web/utils/proptypes';
+import withCapabilities from 'web/utils/withCapabilities';
 
 import OsComponent from './component';
 

--- a/gsa/src/web/pages/operatingsystems/detailspage.js
+++ b/gsa/src/web/pages/operatingsystems/detailspage.js
@@ -59,6 +59,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_list} from 'web/entity/component';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -202,6 +203,7 @@ Details.propTypes = {
 
 const Page = ({
   entity,
+  permissions = [],
   onDownloaded,
   onChanged,
   onTagAddClick,
@@ -238,8 +240,6 @@ const Page = ({
       >
         {({
           activeTab = 0,
-          permissionsComponent,
-          permissionsTitle,
           onActivateTab,
         }) => {
           return (
@@ -259,9 +259,9 @@ const Page = ({
                   <EntitiesTab entities={entity.userTags}>
                     {_('User Tags')}
                   </EntitiesTab>
-                  <Tab>
-                    {permissionsTitle}
-                  </Tab>
+                  <EntitiesTab entities={permissions}>
+                    {_('Permissions')}
+                  </EntitiesTab>
                 </TabList>
               </TabLayout>
 
@@ -285,7 +285,13 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {permissionsComponent}
+                    <EntityPermissions
+                      entity={entity}
+                      permissions={permissions}
+                      onChanged={onChanged}
+                      onDownloaded={onDownloaded}
+                      onError={onError}
+                    />
                   </TabPanel>
                 </TabPanels>
               </Tabs>
@@ -299,6 +305,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/operatingsystems/detailspage.js
+++ b/gsa/src/web/pages/operatingsystems/detailspage.js
@@ -225,7 +225,6 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
-        detailsComponent={Details}
         sectionIcon="os.svg"
         title={_('Operating System')}
         toolBarIcons={ToolBarIcons}

--- a/gsa/src/web/pages/ovaldefs/detailspage.js
+++ b/gsa/src/web/pages/ovaldefs/detailspage.js
@@ -347,6 +347,7 @@ const OvaldefPage = props => (
     name="ovaldef"
   >
     {({
+      entity,
       onChanged,
       onDownloaded,
       onError,
@@ -368,6 +369,7 @@ const OvaldefPage = props => (
           <EntityPage
             {...props}
             {...cprops}
+            entity={entity}
             sectionIcon="ovaldef.svg"
             title={_('OVAL Definition')}
             toolBarIcons={ToolBarIcons}
@@ -379,8 +381,6 @@ const OvaldefPage = props => (
             {({
               activeTab = 0,
               onActivateTab,
-              entity,
-              ...other
             }) => {
               return (
                 <Layout grow="1" flex="column">

--- a/gsa/src/web/pages/ovaldefs/detailspage.js
+++ b/gsa/src/web/pages/ovaldefs/detailspage.js
@@ -58,9 +58,14 @@ import TableRow from 'web/components/table/row';
 
 import EntityPage from 'web/entity/page';
 import EntityComponent from 'web/entity/component';
-import EntityContainer from 'web/entity/container';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer from 'web/entity/withEntityContainer';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/ovaldefs';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -341,95 +346,104 @@ Details.propTypes = {
   entity: PropTypes.model.isRequired,
 };
 
-const OvaldefPage = props => (
-  <EntityContainer
-    {...props}
+const OvaldefPage = ({
+  entity,
+  onChanged,
+  onDownloaded,
+  onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
+  ...props
+}) => (
+  <EntityComponent
     name="ovaldef"
+    onDownloaded={onDownloaded}
+    onDownloadError={onError}
   >
-    {({
-      entity,
-      onChanged,
-      onDownloaded,
-      onError,
-      onTagAddClick,
-      onTagCreateClick,
-      onTagDeleteClick,
-      onTagDisableClick,
-      onTagEditClick,
-      onTagEnableClick,
-      onTagRemoveClick,
-      ...cprops
-    }) => (
-      <EntityComponent
-        name="ovaldef"
-        onDownloaded={onDownloaded}
-        onDownloadError={onError}
+    {({download}) => (
+      <EntityPage
+        {...props}
+        entity={entity}
+        sectionIcon="ovaldef.svg"
+        title={_('OVAL Definition')}
+        toolBarIcons={ToolBarIcons}
+        onOvaldefDownloadClick={download}
       >
-        {({download}) => (
-          <EntityPage
-            {...props}
-            {...cprops}
-            entity={entity}
-            sectionIcon="ovaldef.svg"
-            title={_('OVAL Definition')}
-            toolBarIcons={ToolBarIcons}
-            onOvaldefDownloadClick={download}
-          >
-            {({
-              activeTab = 0,
-              onActivateTab,
-            }) => {
-              return (
-                <Layout grow="1" flex="column">
-                  <TabLayout
-                    grow="1"
-                    align={['start', 'end']}
-                  >
-                    <TabList
-                      active={activeTab}
-                      align={['start', 'stretch']}
-                      onActivateTab={onActivateTab}
-                    >
-                      <Tab>
-                        {_('Information')}
-                      </Tab>
-                      <EntitiesTab entities={entity.userTags}>
-                        {_('User Tags')}
-                      </EntitiesTab>
-                    </TabList>
-                  </TabLayout>
+        {({
+          activeTab = 0,
+          onActivateTab,
+        }) => {
+          return (
+            <Layout grow="1" flex="column">
+              <TabLayout
+                grow="1"
+                align={['start', 'end']}
+              >
+                <TabList
+                  active={activeTab}
+                  align={['start', 'stretch']}
+                  onActivateTab={onActivateTab}
+                >
+                  <Tab>
+                    {_('Information')}
+                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
+                </TabList>
+              </TabLayout>
 
-                  <Tabs active={activeTab}>
-                    <TabPanels>
-                      <TabPanel>
-                        <Details
-                          entity={entity}
-                        />
-                      </TabPanel>
-                      <TabPanel>
-                        <EntityTags
-                          entity={entity}
-                          onTagAddClick={onTagAddClick}
-                          onTagDeleteClick={onTagDeleteClick}
-                          onTagDisableClick={onTagDisableClick}
-                          onTagEditClick={onTagEditClick}
-                          onTagEnableClick={onTagEnableClick}
-                          onTagCreateClick={onTagCreateClick}
-                          onTagRemoveClick={onTagRemoveClick}
-                        />
-                      </TabPanel>
-                    </TabPanels>
-                  </Tabs>
-                </Layout>
-              );
-            }}
-          </EntityPage>
-        )}
-      </EntityComponent>
+              <Tabs active={activeTab}>
+                <TabPanels>
+                  <TabPanel>
+                    <Details
+                      entity={entity}
+                    />
+                  </TabPanel>
+                  <TabPanel>
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
+                  </TabPanel>
+                </TabPanels>
+              </Tabs>
+            </Layout>
+          );
+        }}
+      </EntityPage>
     )}
-  </EntityContainer>
+  </EntityComponent>
 );
 
-export default OvaldefPage;
+OvaldefPage.propTypes = {
+  entity: PropTypes.model,
+  onChanged: PropTypes.func.isRequired,
+  onDownloaded: PropTypes.func.isRequired,
+  onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
+};
+
+export default withEntityContainer('ovaldef', {
+  load: loadEntity,
+  entitySelector: selector,
+})(OvaldefPage);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/ovaldefs/detailspage.js
+++ b/gsa/src/web/pages/ovaldefs/detailspage.js
@@ -370,7 +370,6 @@ const OvaldefPage = props => (
             {...cprops}
             sectionIcon="ovaldef.svg"
             title={_('OVAL Definition')}
-            detailsComponent={Details}
             toolBarIcons={ToolBarIcons}
             onOvaldefDownloadClick={download}
             onPermissionChanged={onChanged}

--- a/gsa/src/web/pages/ovaldefs/detailspage.js
+++ b/gsa/src/web/pages/ovaldefs/detailspage.js
@@ -60,6 +60,7 @@ import EntityPage from 'web/entity/page';
 import EntityComponent from 'web/entity/component';
 import EntityContainer from 'web/entity/container';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -349,6 +350,13 @@ const OvaldefPage = props => (
       onChanged,
       onDownloaded,
       onError,
+      onTagAddClick,
+      onTagCreateClick,
+      onTagDeleteClick,
+      onTagDisableClick,
+      onTagEditClick,
+      onTagEnableClick,
+      onTagRemoveClick,
       ...cprops
     }) => (
       <EntityComponent
@@ -371,7 +379,6 @@ const OvaldefPage = props => (
           >
             {({
               activeTab = 0,
-              tagsComponent,
               onActivateTab,
               entity,
               ...other
@@ -404,7 +411,16 @@ const OvaldefPage = props => (
                         />
                       </TabPanel>
                       <TabPanel>
-                        {tagsComponent}
+                        <EntityTags
+                          entity={entity}
+                          onTagAddClick={onTagAddClick}
+                          onTagDeleteClick={onTagDeleteClick}
+                          onTagDisableClick={onTagDisableClick}
+                          onTagEditClick={onTagEditClick}
+                          onTagEnableClick={onTagEnableClick}
+                          onTagCreateClick={onTagCreateClick}
+                          onTagRemoveClick={onTagRemoveClick}
+                        />
                       </TabPanel>
                     </TabPanels>
                   </Tabs>

--- a/gsa/src/web/pages/ovaldefs/detailspage.js
+++ b/gsa/src/web/pages/ovaldefs/detailspage.js
@@ -31,39 +31,39 @@ import {longDate} from 'gmp/locale/date';
 
 import {isDefined} from 'gmp/utils/identity';
 
-import PropTypes from '../../utils/proptypes.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
 
-import EntityPage from '../../entity/page.js';
-import EntityComponent from '../../entity/component.js';
-import EntityContainer from '../../entity/container.js';
-import EntitiesTab from 'web/entity/tab.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import DetailsLink from 'web/components/link/detailslink';
+import ExternalLink from 'web/components/link/externallink';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
 
-import DetailsLink from '../../components/link/detailslink.js';
-import ExternalLink from '../../components/link/externallink.js';
+import Table from 'web/components/table/stripedtable';
+import TableBody from 'web/components/table/body';
+import TableData from 'web/components/table/data';
+import TableHeader from 'web/components/table/header';
+import TableHead from 'web/components/table/head';
+import TableRow from 'web/components/table/row';
 
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
+import EntityPage from 'web/entity/page';
+import EntityComponent from 'web/entity/component';
+import EntityContainer from 'web/entity/container';
+import EntitiesTab from 'web/entity/tab';
 
-import Table from '../../components/table/stripedtable.js';
-import TableBody from '../../components/table/body.js';
-import TableData from '../../components/table/data.js';
-import TableHeader from '../../components/table/header.js';
-import TableHead from '../../components/table/head.js';
-import TableRow from '../../components/table/row.js';
+import PropTypes from 'web/utils/proptypes';
 
-import OvaldefDetails from './details.js';
+import OvaldefDetails from './details';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/ovaldefs/detailspage.js
+++ b/gsa/src/web/pages/ovaldefs/detailspage.js
@@ -36,6 +36,7 @@ import PropTypes from '../../utils/proptypes.js';
 import EntityPage from '../../entity/page.js';
 import EntityComponent from '../../entity/component.js';
 import EntityContainer from '../../entity/container.js';
+import EntitiesTab from 'web/entity/tab.js';
 
 import ExportIcon from '../../components/icon/exporticon.js';
 import ManualIcon from '../../components/icon/manualicon.js';
@@ -371,7 +372,6 @@ const OvaldefPage = props => (
             {({
               activeTab = 0,
               tagsComponent,
-              tagsTitle,
               onActivateTab,
               entity,
               ...other
@@ -390,9 +390,9 @@ const OvaldefPage = props => (
                       <Tab>
                         {_('Information')}
                       </Tab>
-                      <Tab>
-                        {tagsTitle}
-                      </Tab>
+                      <EntitiesTab entities={entity.userTags}>
+                        {_('User Tags')}
+                      </EntitiesTab>
                     </TabList>
                   </TabLayout>
 

--- a/gsa/src/web/pages/ovaldefs/detailspage.js
+++ b/gsa/src/web/pages/ovaldefs/detailspage.js
@@ -362,7 +362,6 @@ const OvaldefPage = props => (
             sectionIcon="ovaldef.svg"
             title={_('OVAL Definition')}
             detailsComponent={Details}
-            permissionsComponent={false}
             toolBarIcons={ToolBarIcons}
             onOvaldefDownloadClick={download}
             onPermissionChanged={onChanged}
@@ -371,8 +370,6 @@ const OvaldefPage = props => (
           >
             {({
               activeTab = 0,
-              permissionsComponent,
-              permissionsTitle,
               tagsComponent,
               tagsTitle,
               onActivateTab,
@@ -393,16 +390,9 @@ const OvaldefPage = props => (
                       <Tab>
                         {_('Information')}
                       </Tab>
-                      {isDefined(tagsComponent) &&
-                        <Tab>
-                          {tagsTitle}
-                        </Tab>
-                      }
-                      {isDefined(permissionsComponent) &&
-                        <Tab>
-                          {permissionsTitle}
-                        </Tab>
-                      }
+                      <Tab>
+                        {tagsTitle}
+                      </Tab>
                     </TabList>
                   </TabLayout>
 
@@ -413,16 +403,9 @@ const OvaldefPage = props => (
                           entity={entity}
                         />
                       </TabPanel>
-                      {isDefined(tagsComponent) &&
-                        <TabPanel>
-                          {tagsComponent}
-                        </TabPanel>
-                      }
-                      {isDefined(permissionsComponent) &&
-                        <TabPanel>
-                          {permissionsComponent}
-                        </TabPanel>
-                      }
+                      <TabPanel>
+                        {tagsComponent}
+                      </TabPanel>
                     </TabPanels>
                   </Tabs>
                 </Layout>

--- a/gsa/src/web/pages/ovaldefs/detailspage.js
+++ b/gsa/src/web/pages/ovaldefs/detailspage.js
@@ -374,9 +374,6 @@ const OvaldefPage = props => (
             title={_('OVAL Definition')}
             toolBarIcons={ToolBarIcons}
             onOvaldefDownloadClick={download}
-            onPermissionChanged={onChanged}
-            onPermissionDownloaded={onDownloaded}
-            onPermissionDownloadError={onError}
           >
             {({
               activeTab = 0,

--- a/gsa/src/web/pages/overrides/detailspage.js
+++ b/gsa/src/web/pages/overrides/detailspage.js
@@ -29,45 +29,45 @@ import {longDate} from 'gmp/locale/date';
 
 import {isDefined} from 'gmp/utils/identity';
 
-import {renderYesNo} from '../../utils/render.js';
-import PropTypes from '../../utils/proptypes.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
+import DetailsLink from 'web/components/link/detailslink';
 
-import DetailsLink from '../../components/link/detailslink.js';
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
 
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
+import InfoTable from 'web/components/table/infotable';
+import TableBody from 'web/components/table/body';
+import TableData from 'web/components/table/data';
+import TableRow from 'web/components/table/row';
 
-import InfoTable from '../../components/table/infotable.js';
-import TableBody from '../../components/table/body.js';
-import TableData from '../../components/table/data.js';
-import TableRow from '../../components/table/row.js';
-
-import EntityPage from '../../entity/page.js';
+import EntityPage from 'web/entity/page';
 import EntityContainer, {
   permissions_resource_loader,
-} from '../../entity/container.js';
-import {goto_details, goto_list} from '../../entity/component.js';
-import EntitiesTab from 'web/entity/tab.js';
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
+import EntitiesTab from 'web/entity/tab';
 
-import CloneIcon from '../../entity/icon/cloneicon.js';
-import CreateIcon from '../../entity/icon/createicon.js';
-import EditIcon from '../../entity/icon/editicon.js';
-import TrashIcon from '../../entity/icon/trashicon.js';
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
 
-import OverrideDetails from './details.js';
-import OverrideComponent from './component.js';
+import PropTypes from 'web/utils/proptypes';
+import {renderYesNo} from 'web/utils/render';
+
+import OverrideDetails from './details';
+import OverrideComponent from './component';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/overrides/detailspage.js
+++ b/gsa/src/web/pages/overrides/detailspage.js
@@ -52,18 +52,28 @@ import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
 import EntityPage from 'web/entity/page';
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsResourceFilter,
+} from 'web/entity/withEntityContainer';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+
+import {
+  selector as overridesSelector,
+  loadEntity,
+} from 'web/store/entities/overrides';
+
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 import {renderYesNo} from 'web/utils/render';
@@ -317,18 +327,26 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-const OverridePage = props => (
-  <EntityContainer
-    {...props}
-    name="override"
-    loaders={[
-      permissions_resource_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const load = gmp => {
+  const loadOverride = loadEntity(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  return id => dispatch => {
+    dispatch(loadOverride(id));
+    dispatch(loadPermissionsFunc(permissionsResourceFilter(id)));
+  };
+};
 
-export default OverridePage;
+const mapStateToProps = (rootState, {id}) => {
+  const permissionsSel = permissionsSelector(rootState);
+  return {
+    permissions: permissionsSel.getEntities(permissionsResourceFilter(id)),
+  };
+};
+
+export default withEntityContainer('override', {
+  entitySelector: overridesSelector,
+  load,
+  mapStateToProps,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/overrides/detailspage.js
+++ b/gsa/src/web/pages/overrides/detailspage.js
@@ -59,6 +59,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
+import EntitiesTab from 'web/entity/tab.js';
 
 import CloneIcon from '../../entity/icon/cloneicon.js';
 import CreateIcon from '../../entity/icon/createicon.js';
@@ -233,7 +234,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           tagsComponent,
-          tagsTitle,
           onActivateTab,
           entity,
           ...other
@@ -252,9 +252,9 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <Tab>
-                    {tagsTitle}
-                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
                   <Tab>
                     {permissionsTitle}
                   </Tab>

--- a/gsa/src/web/pages/overrides/detailspage.js
+++ b/gsa/src/web/pages/overrides/detailspage.js
@@ -252,16 +252,12 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  {isDefined(tagsComponent) &&
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
-                  }
+                  <Tab>
+                    {tagsTitle}
+                  </Tab>
+                  <Tab>
+                    {permissionsTitle}
+                  </Tab>
                 </TabList>
               </TabLayout>
 
@@ -272,16 +268,12 @@ const Page = ({
                       entity={entity}
                     />
                   </TabPanel>
-                  {isDefined(tagsComponent) &&
-                    <TabPanel>
-                      {tagsComponent}
-                    </TabPanel>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <TabPanel>
-                      {permissionsComponent}
-                    </TabPanel>
-                  }
+                  <TabPanel>
+                    {tagsComponent}
+                  </TabPanel>
+                  <TabPanel>
+                    {permissionsComponent}
+                  </TabPanel>
                 </TabPanels>
               </Tabs>
             </Layout>

--- a/gsa/src/web/pages/overrides/detailspage.js
+++ b/gsa/src/web/pages/overrides/detailspage.js
@@ -188,6 +188,7 @@ Details.propTypes = {
 };
 
 const Page = ({
+  entity,
   onError,
   onChanged,
   onDownloaded,
@@ -220,6 +221,7 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
+        entity={entity}
         sectionIcon="override.svg"
         title={_('Override')}
         toolBarIcons={ToolBarIcons}
@@ -241,8 +243,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           onActivateTab,
-          entity,
-          ...other
         }) => {
           return (
             <Layout grow="1" flex="column">
@@ -300,6 +300,7 @@ const Page = ({
 );
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/overrides/detailspage.js
+++ b/gsa/src/web/pages/overrides/detailspage.js
@@ -222,7 +222,6 @@ const Page = ({
         {...props}
         sectionIcon="override.svg"
         title={_('Override')}
-        detailsComponent={Details}
         toolBarIcons={ToolBarIcons}
         onChanged={onChanged}
         onDownloaded={onDownloaded}

--- a/gsa/src/web/pages/overrides/detailspage.js
+++ b/gsa/src/web/pages/overrides/detailspage.js
@@ -56,6 +56,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -189,6 +190,7 @@ Details.propTypes = {
 
 const Page = ({
   entity,
+  permissions = [],
   onError,
   onChanged,
   onDownloaded,
@@ -234,14 +236,9 @@ const Page = ({
         onOverrideDownloadClick={download}
         onOverrideEditClick={edit}
         onOverrideSaveClick={save}
-        onPermissionChanged={onChanged}
-        onPermissionDownloaded={onDownloaded}
-        onPermissionDownloadError={onError}
       >
         {({
           activeTab = 0,
-          permissionsComponent,
-          permissionsTitle,
           onActivateTab,
         }) => {
           return (
@@ -261,9 +258,9 @@ const Page = ({
                   <EntitiesTab entities={entity.userTags}>
                     {_('User Tags')}
                   </EntitiesTab>
-                  <Tab>
-                    {permissionsTitle}
-                  </Tab>
+                  <EntitiesTab entities={permissions}>
+                    {_('Permissions')}
+                  </EntitiesTab>
                 </TabList>
               </TabLayout>
 
@@ -287,7 +284,13 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {permissionsComponent}
+                    <EntityPermissions
+                      entity={entity}
+                      permissions={permissions}
+                      onChanged={onChanged}
+                      onDownloaded={onDownloaded}
+                      onError={onError}
+                    />
                   </TabPanel>
                 </TabPanels>
               </Tabs>
@@ -301,6 +304,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/overrides/detailspage.js
+++ b/gsa/src/web/pages/overrides/detailspage.js
@@ -57,6 +57,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -190,6 +191,13 @@ const Page = ({
   onError,
   onChanged,
   onDownloaded,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => (
   <OverrideComponent
@@ -233,7 +241,6 @@ const Page = ({
           activeTab = 0,
           permissionsComponent,
           permissionsTitle,
-          tagsComponent,
           onActivateTab,
           entity,
           ...other
@@ -269,7 +276,16 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {tagsComponent}
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
                   </TabPanel>
                   <TabPanel>
                     {permissionsComponent}
@@ -288,6 +304,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const OverridePage = props => (

--- a/gsa/src/web/pages/permissions/detailspage.js
+++ b/gsa/src/web/pages/permissions/detailspage.js
@@ -25,8 +25,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from '../../utils/proptypes.js';
 
 import EntityPage from '../../entity/page.js';
@@ -139,7 +137,6 @@ const Page = ({
         <EntityPage
           {...props}
           detailsComponent={PermissionDetails}
-          permissionsComponent={false}
           sectionIcon="permission.svg"
           toolBarIcons={ToolBarIcons}
           title={_('Permission')}
@@ -152,8 +149,6 @@ const Page = ({
         >
           {({
             activeTab = 0,
-            permissionsComponent,
-            permissionsTitle,
             tagsComponent,
             tagsTitle,
             onActivateTab,
@@ -174,16 +169,9 @@ const Page = ({
                     <Tab>
                       {_('Information')}
                     </Tab>
-                    {isDefined(tagsComponent) &&
-                      <Tab>
-                        {tagsTitle}
-                      </Tab>
-                    }
-                    {isDefined(permissionsComponent) &&
-                      <Tab>
-                        {permissionsTitle}
-                      </Tab>
-                    }
+                    <Tab>
+                      {tagsTitle}
+                    </Tab>
                   </TabList>
                 </TabLayout>
 
@@ -194,16 +182,9 @@ const Page = ({
                         entity={entity}
                       />
                     </TabPanel>
-                    {isDefined(tagsComponent) &&
-                      <TabPanel>
-                        {tagsComponent}
-                      </TabPanel>
-                    }
-                    {isDefined(permissionsComponent) &&
-                      <TabPanel>
-                        {permissionsComponent}
-                      </TabPanel>
-                    }
+                    <TabPanel>
+                      {tagsComponent}
+                    </TabPanel>
                   </TabPanels>
                 </Tabs>
               </Layout>

--- a/gsa/src/web/pages/permissions/detailspage.js
+++ b/gsa/src/web/pages/permissions/detailspage.js
@@ -112,6 +112,7 @@ ToolBarIcons.propTypes = {
 };
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -145,6 +146,7 @@ const Page = ({
       }) => (
         <EntityPage
           {...props}
+          entity={entity}
           sectionIcon="permission.svg"
           toolBarIcons={ToolBarIcons}
           title={_('Permission')}
@@ -158,8 +160,6 @@ const Page = ({
           {({
             activeTab = 0,
             onActivateTab,
-            entity,
-            ...other
           }) => {
             return (
               <Layout grow="1" flex="column">
@@ -212,6 +212,7 @@ const Page = ({
 };
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/permissions/detailspage.js
+++ b/gsa/src/web/pages/permissions/detailspage.js
@@ -25,35 +25,35 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from '../../utils/proptypes.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
 
-import EntityPage from '../../entity/page.js';
-import EntityContainer from '../../entity/container.js';
-import {goto_details, goto_list} from '../../entity/component.js';
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
+
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
+
+import EntityPage from 'web/entity/page';
+import EntityContainer from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
 
-import CloneIcon from '../../entity/icon/cloneicon.js';
-import CreateIcon from '../../entity/icon/createicon.js';
-import EditIcon from '../../entity/icon/editicon.js';
-import TrashIcon from '../../entity/icon/trashicon.js';
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
+import PropTypes from 'web/utils/proptypes';
 
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
-
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
-
-import PermissionDetails from './details.js';
-import PermissionComponent from './component.js';
+import PermissionDetails from './details';
+import PermissionComponent from './component';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/permissions/detailspage.js
+++ b/gsa/src/web/pages/permissions/detailspage.js
@@ -41,15 +41,20 @@ import ManualIcon from 'web/components/icon/manualicon';
 import ListIcon from 'web/components/icon/listicon';
 
 import EntityPage from 'web/entity/page';
-import EntityContainer from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer from 'web/entity/withEntityContainer';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -225,15 +230,9 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-const PermissionPage = props => (
-  <EntityContainer
-    {...props}
-    name="permission"
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
-
-export default PermissionPage;
+export default withEntityContainer('permission', {
+  load: loadEntity,
+  entitySelector: selector,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/permissions/detailspage.js
+++ b/gsa/src/web/pages/permissions/detailspage.js
@@ -145,7 +145,6 @@ const Page = ({
       }) => (
         <EntityPage
           {...props}
-          detailsComponent={PermissionDetails}
           sectionIcon="permission.svg"
           toolBarIcons={ToolBarIcons}
           title={_('Permission')}

--- a/gsa/src/web/pages/permissions/detailspage.js
+++ b/gsa/src/web/pages/permissions/detailspage.js
@@ -44,6 +44,7 @@ import EntityPage from 'web/entity/page';
 import EntityContainer from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -114,6 +115,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => {
   return (
@@ -150,7 +158,6 @@ const Page = ({
         >
           {({
             activeTab = 0,
-            tagsComponent,
             onActivateTab,
             entity,
             ...other
@@ -183,7 +190,16 @@ const Page = ({
                       />
                     </TabPanel>
                     <TabPanel>
-                      {tagsComponent}
+                      <EntityTags
+                        entity={entity}
+                        onTagAddClick={onTagAddClick}
+                        onTagDeleteClick={onTagDeleteClick}
+                        onTagDisableClick={onTagDisableClick}
+                        onTagEditClick={onTagEditClick}
+                        onTagEnableClick={onTagEnableClick}
+                        onTagCreateClick={onTagCreateClick}
+                        onTagRemoveClick={onTagRemoveClick}
+                      />
                     </TabPanel>
                   </TabPanels>
                 </Tabs>
@@ -200,6 +216,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const PermissionPage = props => (

--- a/gsa/src/web/pages/permissions/detailspage.js
+++ b/gsa/src/web/pages/permissions/detailspage.js
@@ -30,6 +30,7 @@ import PropTypes from '../../utils/proptypes.js';
 import EntityPage from '../../entity/page.js';
 import EntityContainer from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
+import EntitiesTab from 'web/entity/tab';
 
 import CloneIcon from '../../entity/icon/cloneicon.js';
 import CreateIcon from '../../entity/icon/createicon.js';
@@ -150,7 +151,6 @@ const Page = ({
           {({
             activeTab = 0,
             tagsComponent,
-            tagsTitle,
             onActivateTab,
             entity,
             ...other
@@ -169,9 +169,9 @@ const Page = ({
                     <Tab>
                       {_('Information')}
                     </Tab>
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
+                    <EntitiesTab entities={entity.userTags}>
+                      {_('User Tags')}
+                    </EntitiesTab>
                   </TabList>
                 </TabLayout>
 

--- a/gsa/src/web/pages/portlists/detailspage.js
+++ b/gsa/src/web/pages/portlists/detailspage.js
@@ -41,18 +41,28 @@ import TabPanels from 'web/components/tab/tabpanels';
 import Tabs from 'web/components/tab/tabs';
 
 import EntityPage from 'web/entity/page';
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsResourceFilter,
+} from 'web/entity/withEntityContainer';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/portlists';
+
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -298,16 +308,26 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-const PortListPage = props => (
-  <EntityContainer
-    {...props}
-    name="portlist"
-    loaders={[
-      permissions_resource_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const load = gmp => {
+  const loadEntityFunc = loadEntity(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  return id => dispatch => {
+    dispatch(loadEntityFunc(id));
+    dispatch(loadPermissionsFunc(permissionsResourceFilter(id)));
+  };
+};
 
-export default PortListPage;
+const mapStateToProps = (rootState, {id}) => {
+  const permissionsSel = permissionsSelector(rootState);
+  return {
+    permissions: permissionsSel.getEntities(permissionsResourceFilter(id)),
+  };
+};
+
+export default withEntityContainer('portlist', {
+  entitySelector: selector,
+  load,
+  mapStateToProps,
+})(Page);
+
+// vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/portlists/detailspage.js
+++ b/gsa/src/web/pages/portlists/detailspage.js
@@ -46,6 +46,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -162,6 +163,13 @@ const Page = ({
   onError,
   onChanged,
   onDownloaded,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => (
   <PortListComponent
@@ -206,7 +214,6 @@ const Page = ({
           links = true,
           permissionsComponent,
           permissionsTitle,
-          tagsComponent,
           onActivateTab,
           entity,
           ...other
@@ -249,7 +256,16 @@ const Page = ({
                     <PortRanges entity={entity}/>
                   </TabPanel>
                   <TabPanel>
-                    {tagsComponent}
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
                   </TabPanel>
                   <TabPanel>
                     {permissionsComponent}
@@ -268,6 +284,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const PortListPage = props => (

--- a/gsa/src/web/pages/portlists/detailspage.js
+++ b/gsa/src/web/pages/portlists/detailspage.js
@@ -160,6 +160,7 @@ PortRanges.propTypes = {
 };
 
 const Page = ({
+  entity,
   onError,
   onChanged,
   onDownloaded,
@@ -192,6 +193,7 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
+        entity={entity}
         sectionIcon="port_list.svg"
         title={_('Port List')}
         toolBarIcons={ToolBarIcons}
@@ -214,8 +216,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           onActivateTab,
-          entity,
-          ...other
         }) => {
           return (
             <Layout grow="1" flex="column">
@@ -280,6 +280,7 @@ const Page = ({
 );
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/portlists/detailspage.js
+++ b/gsa/src/web/pages/portlists/detailspage.js
@@ -25,38 +25,38 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from '../../utils/proptypes.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
 
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
-
-import EntityPage from '../../entity/page.js';
+import EntityPage from 'web/entity/page';
 import EntityContainer, {
   permissions_resource_loader,
-} from '../../entity/container.js';
-import {goto_details, goto_list} from '../../entity/component.js';
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
 
-import CloneIcon from '../../entity/icon/cloneicon.js';
-import CreateIcon from '../../entity/icon/createicon.js';
-import EditIcon from '../../entity/icon/editicon.js';
-import TrashIcon from '../../entity/icon/trashicon.js';
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
 
-import PortListComponent from './component.js';
-import PortListDetails from './details.js';
-import PortRangesTable from './portrangestable.js';
+import PropTypes from 'web/utils/proptypes';
+
+import PortListComponent from './component';
+import PortListDetails from './details';
+import PortRangesTable from './portrangestable';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/portlists/detailspage.js
+++ b/gsa/src/web/pages/portlists/detailspage.js
@@ -23,8 +23,6 @@
  */
 import React from 'react';
 
-import glamorous from 'glamorous';
-
 import _ from 'gmp/locale';
 
 import PropTypes from '../../utils/proptypes.js';
@@ -49,6 +47,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
+import EntitiesTab from 'web/entity/tab';
 
 import CloneIcon from '../../entity/icon/cloneicon.js';
 import CreateIcon from '../../entity/icon/createicon.js';
@@ -58,22 +57,6 @@ import TrashIcon from '../../entity/icon/trashicon.js';
 import PortListComponent from './component.js';
 import PortListDetails from './details.js';
 import PortRangesTable from './portrangestable.js';
-
-const TabTitleCount = glamorous.span({
-  fontSize: '0.7em',
-});
-
-const TabTitle = ({title, count}) => (
-  <Layout flex="column" align={['center', 'center']}>
-    <span>{title}</span>
-    <TabTitleCount>(<i>{(count)}</i>)</TabTitleCount>
-  </Layout>
-);
-
-TabTitle.propTypes = {
-  count: PropTypes.number.isRequired,
-  title: PropTypes.string.isRequired,
-};
 
 const ToolBarIcons = ({
   entity,
@@ -224,16 +207,10 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           tagsComponent,
-          tagsTitle,
           onActivateTab,
           entity,
           ...other
         }) => {
-          const {
-            port_ranges = [],
-          } = entity;
-          const portRangesCount = port_ranges.length;
-
           return (
             <Layout grow="1" flex="column">
               <TabLayout
@@ -248,15 +225,12 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <Tab>
-                    <TabTitle
-                      title={_('Port Ranges')}
-                      count={portRangesCount}
-                    />
-                  </Tab>
-                  <Tab>
-                    {tagsTitle}
-                  </Tab>
+                  <EntitiesTab entities={entity.port_ranges}>
+                    {_('Port Ranges')}
+                  </EntitiesTab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
                   <Tab>
                     {permissionsTitle}
                   </Tab>

--- a/gsa/src/web/pages/portlists/detailspage.js
+++ b/gsa/src/web/pages/portlists/detailspage.js
@@ -194,7 +194,6 @@ const Page = ({
         {...props}
         sectionIcon="port_list.svg"
         title={_('Port List')}
-        detailsComponent={Details}
         toolBarIcons={ToolBarIcons}
         onChanged={onChanged}
         onDownloaded={onDownloaded}

--- a/gsa/src/web/pages/portlists/detailspage.js
+++ b/gsa/src/web/pages/portlists/detailspage.js
@@ -45,6 +45,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -161,6 +162,8 @@ PortRanges.propTypes = {
 
 const Page = ({
   entity,
+  links = true,
+  permissions = [],
   onError,
   onChanged,
   onDownloaded,
@@ -206,15 +209,9 @@ const Page = ({
         onPortListDownloadClick={download}
         onPortListEditClick={edit}
         onPortListSaveClick={save}
-        onPermissionChanged={onChanged}
-        onPermissionDownloaded={onDownloaded}
-        onPermissionDownloadError={onError}
       >
         {({
           activeTab = 0,
-          links = true,
-          permissionsComponent,
-          permissionsTitle,
           onActivateTab,
         }) => {
           return (
@@ -237,9 +234,9 @@ const Page = ({
                   <EntitiesTab entities={entity.userTags}>
                     {_('User Tags')}
                   </EntitiesTab>
-                  <Tab>
-                    {permissionsTitle}
-                  </Tab>
+                  <EntitiesTab entities={permissions}>
+                    {_('Permissions')}
+                  </EntitiesTab>
                 </TabList>
               </TabLayout>
 
@@ -267,7 +264,13 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {permissionsComponent}
+                    <EntityPermissions
+                      entity={entity}
+                      permissions={permissions}
+                      onChanged={onChanged}
+                      onDownloaded={onDownloaded}
+                      onError={onError}
+                    />
                   </TabPanel>
                 </TabPanels>
               </Tabs>
@@ -281,6 +284,8 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  links: PropTypes.bool,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/portlists/detailspage.js
+++ b/gsa/src/web/pages/portlists/detailspage.js
@@ -27,8 +27,6 @@ import glamorous from 'glamorous';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from '../../utils/proptypes.js';
 
 import ExportIcon from '../../components/icon/exporticon.js';
@@ -256,16 +254,12 @@ const Page = ({
                       count={portRangesCount}
                     />
                   </Tab>
-                  {isDefined(tagsComponent) &&
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
-                  }
+                  <Tab>
+                    {tagsTitle}
+                  </Tab>
+                  <Tab>
+                    {permissionsTitle}
+                  </Tab>
                 </TabList>
               </TabLayout>
 
@@ -280,16 +274,12 @@ const Page = ({
                   <TabPanel>
                     <PortRanges entity={entity}/>
                   </TabPanel>
-                  {isDefined(tagsComponent) &&
-                    <TabPanel>
-                      {tagsComponent}
-                    </TabPanel>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <TabPanel>
-                      {permissionsComponent}
-                    </TabPanel>
-                  }
+                  <TabPanel>
+                    {tagsComponent}
+                  </TabPanel>
+                  <TabPanel>
+                    {permissionsComponent}
+                  </TabPanel>
                 </TabPanels>
               </Tabs>
             </Layout>

--- a/gsa/src/web/pages/reportformats/detailspage.js
+++ b/gsa/src/web/pages/reportformats/detailspage.js
@@ -48,19 +48,29 @@ import TableHead from 'web/components/table/head';
 import TableRow from 'web/components/table/row';
 
 import EntityPage from 'web/entity/page';
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsResourceFilter,
+} from 'web/entity/withEntityContainer';
 
 import ExportIcon from 'web/components/icon/exporticon';
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import DeleteIcon from 'web/entity/icon/deleteicon';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/reportformats';
+
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 import withCapabilities from 'web/utils/withCapabilities';
@@ -345,18 +355,26 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-const ReportFormatPage = props => (
-  <EntityContainer
-    {...props}
-    name="reportformat"
-    loaders={[
-      permissions_resource_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const load = gmp => {
+  const loadEntityFunc = loadEntity(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  return id => dispatch => {
+    dispatch(loadEntityFunc(id));
+    dispatch(loadPermissionsFunc(permissionsResourceFilter(id)));
+  };
+};
 
-export default ReportFormatPage;
+const mapStateToProps = (rootState, {id}) => {
+  const permissionsSel = permissionsSelector(rootState);
+  return {
+    permissions: permissionsSel.getEntities(permissionsResourceFilter(id)),
+  };
+};
+
+export default withEntityContainer('reportformat', {
+  entitySelector: selector,
+  load,
+  mapStateToProps,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/reportformats/detailspage.js
+++ b/gsa/src/web/pages/reportformats/detailspage.js
@@ -52,6 +52,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -208,6 +209,7 @@ Parameters.propTypes = {
 const Page = ({
   entity,
   links = true,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -254,14 +256,9 @@ const Page = ({
         onReportFormatEditClick={edit}
         onReportFormatSaveClick={save}
         onReportFormatVerifyClick={verify}
-        onPermissionChanged={onChanged}
-        onPermissionDownloaded={onDownloaded}
-        onPermissionDownloadError={onError}
       >
         {({
           activeTab = 0,
-          permissionsComponent,
-          permissionsTitle,
           onActivateTab,
         }) => {
           return (
@@ -284,9 +281,9 @@ const Page = ({
                   <EntitiesTab entities={entity.userTags}>
                     {_('User Tags')}
                   </EntitiesTab>
-                  <Tab>
-                    {permissionsTitle}
-                  </Tab>
+                  <EntitiesTab entities={permissions}>
+                    {_('Permissions')}
+                  </EntitiesTab>
                 </TabList>
               </TabLayout>
 
@@ -314,7 +311,13 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {permissionsComponent}
+                    <EntityPermissions
+                      entity={entity}
+                      permissions={permissions}
+                      onChanged={onChanged}
+                      onDownloaded={onDownloaded}
+                      onError={onError}
+                    />
                   </TabPanel>
                 </TabPanels>
               </Tabs>
@@ -329,6 +332,7 @@ const Page = ({
 Page.propTypes = {
   entity: PropTypes.model,
   links: PropTypes.bool,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/reportformats/detailspage.js
+++ b/gsa/src/web/pages/reportformats/detailspage.js
@@ -25,46 +25,46 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from '../../utils/proptypes.js';
-import withCapabilities from '../../utils/withCapabilities.js';
+import ManualIcon from 'web/components/icon/manualicon';
+import Icon from 'web/components/icon/icon';
+import ListIcon from 'web/components/icon/listicon';
 
-import EntityPage from '../../entity/page.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
+
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
+
+import Table from 'web/components/table/stripedtable';
+import TableBody from 'web/components/table/body';
+import TableData from 'web/components/table/data';
+import TableHeader from 'web/components/table/header';
+import TableHead from 'web/components/table/head';
+import TableRow from 'web/components/table/row';
+
+import EntityPage from 'web/entity/page';
 import EntityContainer, {
   permissions_resource_loader,
-} from '../../entity/container.js';
-import {goto_details, goto_list} from '../../entity/component.js';
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import CloneIcon from '../../entity/icon/cloneicon.js';
-import CreateIcon from '../../entity/icon/createicon.js';
-import EditIcon from '../../entity/icon/editicon.js';
-import DeleteIcon from '../../entity/icon/deleteicon.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import DeleteIcon from 'web/entity/icon/deleteicon';
 
-import ManualIcon from '../../components/icon/manualicon.js';
-import Icon from '../../components/icon/icon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import PropTypes from 'web/utils/proptypes';
+import withCapabilities from 'web/utils/withCapabilities';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
-
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
-
-import Table from '../../components/table/stripedtable.js';
-import TableBody from '../../components/table/body.js';
-import TableData from '../../components/table/data.js';
-import TableHeader from '../../components/table/header.js';
-import TableHead from '../../components/table/head.js';
-import TableRow from '../../components/table/row.js';
-
-import ReportFormatComponent from './component.js';
-import ReportFormatDetails from './details.js';
+import ReportFormatComponent from './component';
+import ReportFormatDetails from './details';
 
 const ToolBarIcons = withCapabilities(({
   capabilities,

--- a/gsa/src/web/pages/reportformats/detailspage.js
+++ b/gsa/src/web/pages/reportformats/detailspage.js
@@ -206,6 +206,8 @@ Parameters.propTypes = {
 };
 
 const Page = ({
+  entity,
+  links = true,
   onChanged,
   onDownloaded,
   onError,
@@ -241,6 +243,7 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
+        entity={entity}
         sectionIcon="report_format.svg"
         title={_('Report Format')}
         toolBarIcons={ToolBarIcons}
@@ -257,12 +260,9 @@ const Page = ({
       >
         {({
           activeTab = 0,
-          links = true,
           permissionsComponent,
           permissionsTitle,
           onActivateTab,
-          entity,
-          ...other
         }) => {
           return (
             <Layout grow="1" flex="column">
@@ -327,6 +327,8 @@ const Page = ({
 );
 
 Page.propTypes = {
+  entity: PropTypes.model,
+  links: PropTypes.bool,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/reportformats/detailspage.js
+++ b/gsa/src/web/pages/reportformats/detailspage.js
@@ -243,7 +243,6 @@ const Page = ({
         {...props}
         sectionIcon="report_format.svg"
         title={_('Report Format')}
-        detailsComponent={Details}
         toolBarIcons={ToolBarIcons}
         onReportFormatCloneClick={clone}
         onReportFormatImportClick={import_func}

--- a/gsa/src/web/pages/reportformats/detailspage.js
+++ b/gsa/src/web/pages/reportformats/detailspage.js
@@ -23,8 +23,6 @@
  */
 import React from 'react';
 
-import glamorous from 'glamorous';
-
 import _ from 'gmp/locale';
 
 import PropTypes from '../../utils/proptypes.js';
@@ -35,6 +33,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
+import EntitiesTab from 'web/entity/tab';
 
 import ExportIcon from '../../components/icon/exporticon.js';
 import CloneIcon from '../../entity/icon/cloneicon.js';
@@ -66,22 +65,6 @@ import TableRow from '../../components/table/row.js';
 
 import ReportFormatComponent from './component.js';
 import ReportFormatDetails from './details.js';
-
-const TabTitleCount = glamorous.span({
-  fontSize: '0.7em',
-});
-
-const TabTitle = ({title, count}) => (
-  <Layout flex="column" align={['center', 'center']}>
-    <span>{title}</span>
-    <TabTitleCount>(<i>{(count)}</i>)</TabTitleCount>
-  </Layout>
-);
-
-TabTitle.propTypes = {
-  count: PropTypes.number.isRequired,
-  title: PropTypes.string.isRequired,
-};
 
 const ToolBarIcons = withCapabilities(({
   capabilities,
@@ -271,16 +254,10 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           tagsComponent,
-          tagsTitle,
           onActivateTab,
           entity,
           ...other
         }) => {
-          const {
-            params = [],
-          } = entity;
-          const paramsCount = params.length;
-
           return (
             <Layout grow="1" flex="column">
               <TabLayout
@@ -295,15 +272,12 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <Tab>
-                    <TabTitle
-                      title={_('Parameters')}
-                      count={paramsCount}
-                    />
-                  </Tab>
-                  <Tab>
-                    {tagsTitle}
-                  </Tab>
+                  <EntitiesTab entities={entity.params}>
+                    {_('Parameters')}
+                  </EntitiesTab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
                   <Tab>
                     {permissionsTitle}
                   </Tab>

--- a/gsa/src/web/pages/reportformats/detailspage.js
+++ b/gsa/src/web/pages/reportformats/detailspage.js
@@ -53,6 +53,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import ExportIcon from 'web/components/icon/exporticon';
 import CloneIcon from 'web/entity/icon/cloneicon';
@@ -208,6 +209,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => (
   <ReportFormatComponent
@@ -253,7 +261,6 @@ const Page = ({
           links = true,
           permissionsComponent,
           permissionsTitle,
-          tagsComponent,
           onActivateTab,
           entity,
           ...other
@@ -296,7 +303,16 @@ const Page = ({
                     <Parameters entity={entity}/>
                   </TabPanel>
                   <TabPanel>
-                    {tagsComponent}
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
                   </TabPanel>
                   <TabPanel>
                     {permissionsComponent}
@@ -315,6 +331,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const ReportFormatPage = props => (

--- a/gsa/src/web/pages/reportformats/detailspage.js
+++ b/gsa/src/web/pages/reportformats/detailspage.js
@@ -27,8 +27,6 @@ import glamorous from 'glamorous';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from '../../utils/proptypes.js';
 import withCapabilities from '../../utils/withCapabilities.js';
 
@@ -303,16 +301,12 @@ const Page = ({
                       count={paramsCount}
                     />
                   </Tab>
-                  {isDefined(tagsComponent) &&
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
-                  }
+                  <Tab>
+                    {tagsTitle}
+                  </Tab>
+                  <Tab>
+                    {permissionsTitle}
+                  </Tab>
                 </TabList>
               </TabLayout>
 
@@ -327,16 +321,12 @@ const Page = ({
                   <TabPanel>
                     <Parameters entity={entity}/>
                   </TabPanel>
-                  {isDefined(tagsComponent) &&
-                    <TabPanel>
-                      {tagsComponent}
-                    </TabPanel>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <TabPanel>
-                      {permissionsComponent}
-                    </TabPanel>
-                  }
+                  <TabPanel>
+                    {tagsComponent}
+                  </TabPanel>
+                  <TabPanel>
+                    {permissionsComponent}
+                  </TabPanel>
                 </TabPanels>
               </Tabs>
             </Layout>

--- a/gsa/src/web/pages/results/detailspage.js
+++ b/gsa/src/web/pages/results/detailspage.js
@@ -345,8 +345,6 @@ class Page extends React.Component {
     const {
       entity,
       onChanged,
-      onDownloaded,
-      onError,
       onTagAddClick,
       onTagCreateClick,
       onTagDeleteClick,
@@ -375,9 +373,6 @@ class Page extends React.Component {
                 onOverrideCreateClick={
                   result => this.openDialog(result, createoverride)}
                 onResultDownloadClick={this.handleDownload}
-                onPermissionChanged={onChanged}
-                onPermissionDownloaded={onDownloaded}
-                onPermissionDownloadError={onError}
               >
                 {({
                   activeTab = 0,

--- a/gsa/src/web/pages/results/detailspage.js
+++ b/gsa/src/web/pages/results/detailspage.js
@@ -57,13 +57,17 @@ import DetailsBlock from 'web/entity/block';
 import EntityPage from 'web/entity/page';
 import Note from 'web/entity/note';
 import Override from 'web/entity/override';
-import EntityContainer from 'web/entity/container';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer from 'web/entity/withEntityContainer';
+
+import {
+  loadEntity,
+  selector,
+} from 'web/store/entities/results';
 
 import PropTypes from 'web/utils/proptypes';
 import withCapabilities from 'web/utils/withCapabilities';
-import withGmp from 'web/utils/withGmp';
 
 import NoteComponent from '../notes/component';
 
@@ -446,17 +450,9 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-Page = withGmp(Page);
-
-const ResultPage = props => (
-  <EntityContainer
-    {...props}
-    name="result"
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
-
-export default ResultPage;
+export default withEntityContainer('result', {
+  entitySelector: selector,
+  load: loadEntity,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/results/detailspage.js
+++ b/gsa/src/web/pages/results/detailspage.js
@@ -59,6 +59,7 @@ import Note from 'web/entity/note';
 import Override from 'web/entity/override';
 import EntityContainer from 'web/entity/container';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import PropTypes from 'web/utils/proptypes';
 import withCapabilities from 'web/utils/withCapabilities';
@@ -341,7 +342,18 @@ class Page extends React.Component {
   }
 
   render() {
-    const {onChanged} = this.props;
+    const {
+      onChanged,
+      onDownloaded,
+      onError,
+      onTagAddClick,
+      onTagCreateClick,
+      onTagDeleteClick,
+      onTagDisableClick,
+      onTagEditClick,
+      onTagEnableClick,
+      onTagRemoveClick,
+    } = this.props;
     return (
       <NoteComponent
         onCreated={onChanged}
@@ -362,6 +374,9 @@ class Page extends React.Component {
                 onOverrideCreateClick={
                   result => this.openDialog(result, createoverride)}
                 onResultDownloadClick={this.handleDownload}
+                onPermissionChanged={onChanged}
+                onPermissionDownloaded={onDownloaded}
+                onPermissionDownloadError={onError}
               >
                 {({
                   activeTab = 0,
@@ -398,7 +413,16 @@ class Page extends React.Component {
                             />
                           </TabPanel>
                           <TabPanel>
-                            {tagsComponent}
+                            <EntityTags
+                              entity={entity}
+                              onTagAddClick={onTagAddClick}
+                              onTagDeleteClick={onTagDeleteClick}
+                              onTagDisableClick={onTagDisableClick}
+                              onTagEditClick={onTagEditClick}
+                              onTagEnableClick={onTagEnableClick}
+                              onTagCreateClick={onTagCreateClick}
+                              onTagRemoveClick={onTagRemoveClick}
+                            />
                           </TabPanel>
                         </TabPanels>
                       </Tabs>
@@ -415,13 +439,17 @@ class Page extends React.Component {
 }
 
 Page.propTypes = {
+  gmp: PropTypes.gmp.isRequired,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
-};
-
-Page.propTypes = {
-  gmp: PropTypes.gmp.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 Page = withGmp(Page);
@@ -431,7 +459,7 @@ const ResultPage = props => (
     {...props}
     name="result"
   >
-    {cprops => <Page {...cprops} />}
+    {cprops => <Page {...props} {...cprops} />}
   </EntityContainer>
 );
 

--- a/gsa/src/web/pages/results/detailspage.js
+++ b/gsa/src/web/pages/results/detailspage.js
@@ -25,8 +25,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import {MANUAL, TASK_SELECTED, RESULT_UUID} from 'gmp/models/override';
 
 import PropTypes from 'web/utils/proptypes';
@@ -358,7 +356,6 @@ class Page extends React.Component {
                 title={_('Result')}
                 toolBarIcons={ToolBarIcons}
                 detailsComponent={Details}
-                permissionsComponent={false}
                 onNoteCreateClick={
                   result => this.openDialog(result, createnote)}
                 onOverrideCreateClick={
@@ -367,8 +364,6 @@ class Page extends React.Component {
               >
                 {({
                   activeTab = 0,
-                  permissionsComponent,
-                  permissionsTitle,
                   tagsComponent,
                   tagsTitle,
                   onActivateTab,
@@ -389,16 +384,9 @@ class Page extends React.Component {
                           <Tab>
                             {_('Information')}
                           </Tab>
-                          {isDefined(tagsComponent) &&
-                            <Tab>
-                              {tagsTitle}
-                            </Tab>
-                          }
-                          {isDefined(permissionsComponent) &&
-                            <Tab>
-                              {permissionsTitle}
-                            </Tab>
-                          }
+                          <Tab>
+                            {tagsTitle}
+                          </Tab>
                         </TabList>
                       </TabLayout>
 
@@ -409,16 +397,9 @@ class Page extends React.Component {
                               entity={entity}
                             />
                           </TabPanel>
-                          {isDefined(tagsComponent) &&
-                            <TabPanel>
-                              {tagsComponent}
-                            </TabPanel>
-                          }
-                          {isDefined(permissionsComponent) &&
-                            <TabPanel>
-                              {permissionsComponent}
-                            </TabPanel>
-                          }
+                          <TabPanel>
+                            {tagsComponent}
+                          </TabPanel>
                         </TabPanels>
                       </Tabs>
                     </Layout>

--- a/gsa/src/web/pages/results/detailspage.js
+++ b/gsa/src/web/pages/results/detailspage.js
@@ -343,6 +343,7 @@ class Page extends React.Component {
 
   render() {
     const {
+      entity,
       onChanged,
       onDownloaded,
       onError,
@@ -365,6 +366,7 @@ class Page extends React.Component {
             {({create: createoverride}) => (
               <EntityPage
                 {...this.props}
+                entity={entity}
                 sectionIcon="result.svg"
                 title={_('Result')}
                 toolBarIcons={ToolBarIcons}
@@ -379,10 +381,7 @@ class Page extends React.Component {
               >
                 {({
                   activeTab = 0,
-                  tagsComponent,
                   onActivateTab,
-                  entity,
-                  ...other
                 }) => {
                   return (
                     <Layout grow="1" flex="column">
@@ -438,6 +437,7 @@ class Page extends React.Component {
 }
 
 Page.propTypes = {
+  entity: PropTypes.model,
   gmp: PropTypes.gmp.isRequired,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/results/detailspage.js
+++ b/gsa/src/web/pages/results/detailspage.js
@@ -368,7 +368,6 @@ class Page extends React.Component {
                 sectionIcon="result.svg"
                 title={_('Result')}
                 toolBarIcons={ToolBarIcons}
-                detailsComponent={Details}
                 onNoteCreateClick={
                   result => this.openDialog(result, createnote)}
                 onOverrideCreateClick={

--- a/gsa/src/web/pages/results/detailspage.js
+++ b/gsa/src/web/pages/results/detailspage.js
@@ -27,16 +27,6 @@ import _ from 'gmp/locale';
 
 import {MANUAL, TASK_SELECTED, RESULT_UUID} from 'gmp/models/override';
 
-import PropTypes from 'web/utils/proptypes';
-import withCapabilities from 'web/utils/withCapabilities';
-import withGmp from 'web/utils/withGmp';
-
-import DetailsBlock from 'web/entity/block';
-import EntityPage from 'web/entity/page';
-import Note from 'web/entity/note';
-import Override from 'web/entity/override';
-import EntityContainer from 'web/entity/container';
-
 import SeverityBar from 'web/components/bar/severitybar';
 
 import ExportIcon from 'web/components/icon/exporticon';
@@ -63,12 +53,22 @@ import TableBody from 'web/components/table/body';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
+import DetailsBlock from 'web/entity/block';
+import EntityPage from 'web/entity/page';
+import Note from 'web/entity/note';
+import Override from 'web/entity/override';
+import EntityContainer from 'web/entity/container';
+import EntitiesTab from 'web/entity/tab';
+
+import PropTypes from 'web/utils/proptypes';
+import withCapabilities from 'web/utils/withCapabilities';
+import withGmp from 'web/utils/withGmp';
+
 import NoteComponent from '../notes/component';
 
 import OverrideComponent from '../overrides/component';
 
 import ResultDetails from './details';
-import EntitiesTab from 'web/entity/tab';
 
 let ToolBarIcons = ({
   capabilities,

--- a/gsa/src/web/pages/results/detailspage.js
+++ b/gsa/src/web/pages/results/detailspage.js
@@ -68,6 +68,7 @@ import NoteComponent from '../notes/component';
 import OverrideComponent from '../overrides/component';
 
 import ResultDetails from './details';
+import EntitiesTab from 'web/entity/tab';
 
 let ToolBarIcons = ({
   capabilities,
@@ -365,7 +366,6 @@ class Page extends React.Component {
                 {({
                   activeTab = 0,
                   tagsComponent,
-                  tagsTitle,
                   onActivateTab,
                   entity,
                   ...other
@@ -384,9 +384,9 @@ class Page extends React.Component {
                           <Tab>
                             {_('Information')}
                           </Tab>
-                          <Tab>
-                            {tagsTitle}
-                          </Tab>
+                          <EntitiesTab entities={entity.userTags}>
+                            {_('User Tags')}
+                          </EntitiesTab>
                         </TabList>
                       </TabLayout>
 

--- a/gsa/src/web/pages/roles/detailspage.js
+++ b/gsa/src/web/pages/roles/detailspage.js
@@ -27,8 +27,6 @@ import glamorous from 'glamorous';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from '../../utils/proptypes.js';
 import {permissionDescription} from '../../utils/render.js';
 
@@ -285,16 +283,12 @@ const Page = ({
                       count={genPermsCount}
                     />
                   </Tab>
-                  {isDefined(tagsComponent) &&
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
-                  }
+                  <Tab>
+                    {tagsTitle}
+                  </Tab>
+                  <Tab>
+                    {permissionsTitle}
+                  </Tab>
                 </TabList>
               </TabLayout>
 
@@ -312,16 +306,12 @@ const Page = ({
                         general_permissions.entities : []}
                     />
                   </TabPanel>
-                  {isDefined(tagsComponent) &&
-                    <TabPanel>
-                      {tagsComponent}
-                    </TabPanel>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <TabPanel>
-                      {permissionsComponent}
-                    </TabPanel>
-                  }
+                  <TabPanel>
+                    {tagsComponent}
+                  </TabPanel>
+                  <TabPanel>
+                    {permissionsComponent}
+                  </TabPanel>
                 </TabPanels>
               </Tabs>
             </Layout>

--- a/gsa/src/web/pages/roles/detailspage.js
+++ b/gsa/src/web/pages/roles/detailspage.js
@@ -56,6 +56,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -195,6 +196,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   general_permissions = {entities: []},
   ...props
 }) => (
@@ -237,7 +245,6 @@ const Page = ({
           links = true,
           permissionsComponent,
           permissionsTitle,
-          tagsComponent,
           onActivateTab,
           entity,
           ...other
@@ -282,7 +289,16 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {tagsComponent}
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
                   </TabPanel>
                   <TabPanel>
                     {permissionsComponent}
@@ -302,6 +318,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const general_permissions_loader = loader('permissions',

--- a/gsa/src/web/pages/roles/detailspage.js
+++ b/gsa/src/web/pages/roles/detailspage.js
@@ -193,6 +193,8 @@ GeneralPermissions.propTypes = {
 };
 
 const Page = ({
+  entity,
+  links = true,
   onChanged,
   onDownloaded,
   onError,
@@ -226,6 +228,7 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
+        entity={entity}
         sectionIcon="role.svg"
         title={_('Role')}
         toolBarIcons={ToolBarIcons}
@@ -241,12 +244,9 @@ const Page = ({
       >
         {({
           activeTab = 0,
-          links = true,
           permissionsComponent,
           permissionsTitle,
           onActivateTab,
-          entity,
-          ...other
         }) => {
           return (
             <Layout grow="1" flex="column">
@@ -313,7 +313,9 @@ const Page = ({
 );
 
 Page.propTypes = {
+  entity: PropTypes.model,
   general_permissions: PropTypes.object,
+  links: PropTypes.bool,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/roles/detailspage.js
+++ b/gsa/src/web/pages/roles/detailspage.js
@@ -228,7 +228,6 @@ const Page = ({
         {...props}
         sectionIcon="role.svg"
         title={_('Role')}
-        detailsComponent={Details}
         toolBarIcons={ToolBarIcons}
         onRoleCloneClick={clone}
         onRoleCreateClick={create}

--- a/gsa/src/web/pages/roles/detailspage.js
+++ b/gsa/src/web/pages/roles/detailspage.js
@@ -25,48 +25,48 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from '../../utils/proptypes.js';
-import {permissionDescription} from '../../utils/render.js';
+import EntityNameTableData from 'web/entities/entitynametabledata';
 
-import EntityPage from '../../entity/page.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
+
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
+
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
+
+import Table from 'web/components/table/stripedtable';
+import TableBody from 'web/components/table/body';
+import TableData from 'web/components/table/data';
+import TableHeader from 'web/components/table/header';
+import TableHead from 'web/components/table/head';
+import TableRow from 'web/components/table/row';
+
+import EntityPage from 'web/entity/page';
 import EntityContainer, {
   loader,
   permissions_subject_loader,
-} from '../../entity/container.js';
-import {goto_details, goto_list} from '../../entity/component.js';
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
+import EntitiesTab from 'web/entity/tab';
 
-import CloneIcon from '../../entity/icon/cloneicon.js';
-import CreateIcon from '../../entity/icon/createicon.js';
-import EditIcon from '../../entity/icon/editicon.js';
-import TrashIcon from '../../entity/icon/trashicon.js';
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
 
-import EntityNameTableData from '../../entities/entitynametabledata.js';
+import PropTypes from 'web/utils/proptypes';
+import {permissionDescription} from 'web/utils/render';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
-
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
-
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
-
-import Table from '../../components/table/stripedtable.js';
-import TableBody from '../../components/table/body.js';
-import TableData from '../../components/table/data.js';
-import TableHeader from '../../components/table/header.js';
-import TableHead from '../../components/table/head.js';
-import TableRow from '../../components/table/row.js';
-
-import RoleComponent from './component.js';
-import RoleDetails from './details.js';
-import EntitiesTab from 'web/entity/tab.js';
+import RoleComponent from './component';
+import RoleDetails from './details';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/roles/detailspage.js
+++ b/gsa/src/web/pages/roles/detailspage.js
@@ -68,6 +68,7 @@ import {permissionDescription} from 'web/utils/render';
 
 import RoleComponent from './component';
 import RoleDetails from './details';
+import EntityPermissions from 'web/entity/permissions';
 
 const ToolBarIcons = ({
   entity,
@@ -195,6 +196,7 @@ GeneralPermissions.propTypes = {
 const Page = ({
   entity,
   links = true,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -238,14 +240,9 @@ const Page = ({
         onRoleDownloadClick={download}
         onRoleEditClick={edit}
         onRoleSaveClick={save}
-        onPermissionChanged={onChanged}
-        onPermissionDownloaded={onDownloaded}
-        onPermissionDownloadError={onError}
       >
         {({
           activeTab = 0,
-          permissionsComponent,
-          permissionsTitle,
           onActivateTab,
         }) => {
           return (
@@ -262,15 +259,15 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <EntitiesTab entities={general_permissions.entities}>
+                  <EntitiesTab entities={general_permissions}>
                     {_('General Command Permissions')}
                   </EntitiesTab>
                   <EntitiesTab entities={entity.userTags}>
                     {_('User Tags')}
                   </EntitiesTab>
-                  <Tab>
-                    {permissionsTitle}
-                  </Tab>
+                  <EntitiesTab entities={permissions}>
+                    {_('Permissions')}
+                  </EntitiesTab>
                 </TabList>
               </TabLayout>
 
@@ -284,7 +281,7 @@ const Page = ({
                   </TabPanel>
                   <TabPanel>
                     <GeneralPermissions
-                      permissions={general_permissions.entities}
+                      permissions={general_permissions}
                     />
                   </TabPanel>
                   <TabPanel>
@@ -300,7 +297,13 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {permissionsComponent}
+                    <EntityPermissions
+                      entity={entity}
+                      permissions={permissions}
+                      onChanged={onChanged}
+                      onDownloaded={onDownloaded}
+                      onError={onError}
+                    />
                   </TabPanel>
                 </TabPanels>
               </Tabs>
@@ -314,8 +317,9 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
-  general_permissions: PropTypes.object,
+  general_permissions: PropTypes.array,
   links: PropTypes.bool,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/roles/detailspage.js
+++ b/gsa/src/web/pages/roles/detailspage.js
@@ -23,8 +23,6 @@
  */
 import React from 'react';
 
-import glamorous from 'glamorous';
-
 import _ from 'gmp/locale';
 
 import PropTypes from '../../utils/proptypes.js';
@@ -68,22 +66,7 @@ import TableRow from '../../components/table/row.js';
 
 import RoleComponent from './component.js';
 import RoleDetails from './details.js';
-
-const TabTitleCount = glamorous.span({
-  fontSize: '0.7em',
-});
-
-const TabTitle = ({title, count}) => (
-  <Layout flex="column" align={['center', 'center']}>
-    <span>{title}</span>
-    <TabTitleCount>(<i>{(count)}</i>)</TabTitleCount>
-  </Layout>
-);
-
-TabTitle.propTypes = {
-  count: PropTypes.number.isRequired,
-  title: PropTypes.string.isRequired,
-};
+import EntitiesTab from 'web/entity/tab.js';
 
 const ToolBarIcons = ({
   entity,
@@ -212,7 +195,7 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
-  general_permissions,
+  general_permissions = {entities: []},
   ...props
 }) => (
   <RoleComponent
@@ -255,14 +238,10 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           tagsComponent,
-          tagsTitle,
           onActivateTab,
           entity,
           ...other
         }) => {
-          const genPermsCount = isDefined(general_permissions) ?
-            general_permissions.entities.length : 0;
-
           return (
             <Layout grow="1" flex="column">
               <TabLayout
@@ -277,15 +256,12 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <Tab>
-                    <TabTitle
-                      title={_('General Command Permissions')}
-                      count={genPermsCount}
-                    />
-                  </Tab>
-                  <Tab>
-                    {tagsTitle}
-                  </Tab>
+                  <EntitiesTab entities={general_permissions.entities}>
+                    {_('General Command Permissions')}
+                  </EntitiesTab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
                   <Tab>
                     {permissionsTitle}
                   </Tab>
@@ -302,8 +278,7 @@ const Page = ({
                   </TabPanel>
                   <TabPanel>
                     <GeneralPermissions
-                      permissions={isDefined(general_permissions) ?
-                        general_permissions.entities : []}
+                      permissions={general_permissions.entities}
                     />
                   </TabPanel>
                   <TabPanel>

--- a/gsa/src/web/pages/scanconfigs/detailspage.js
+++ b/gsa/src/web/pages/scanconfigs/detailspage.js
@@ -23,8 +23,6 @@
  */
 import React from 'react';
 
-import glamorous from 'glamorous';
-
 import _ from 'gmp/locale';
 
 import PropTypes from 'web/utils/proptypes';
@@ -60,6 +58,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntitiesTab from 'web/entity/tab';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -69,22 +68,6 @@ import TrashIcon from 'web/entity/icon/trashicon';
 import ScanConfigDetails from './details';
 import ScanConfigComponent from './component';
 import Trend from './trend';
-
-const TabTitleCount = glamorous.span({
-  fontSize: '0.7em',
-});
-
-const TabTitle = ({title, count}) => (
-  <Layout flex="column" align={['center', 'center']}>
-    <span>{title}</span>
-    <TabTitleCount>(<i>{(count)}</i>)</TabTitleCount>
-  </Layout>
-);
-
-TabTitle.propTypes = {
-  count: PropTypes.number.isRequired,
-  title: PropTypes.string.isRequired,
-};
 
 const ToolBarIcons = withCapabilities(({
   capabilities,
@@ -394,19 +377,13 @@ const Page = ({
             permissionsComponent,
             permissionsTitle,
             tagsComponent,
-            tagsTitle,
             onActivateTab,
             entity,
             ...other
           }) => {
             const {
-              family_list = [],
               preferences,
             } = entity;
-            const nvtFamiliesCount = family_list.length;
-            const nvtPrefsCount = preferences.nvt.length;
-            const scannerPrefsCount = preferences.scanner.length;
-
             return (
               <Layout grow="1" flex="column">
                 <TabLayout
@@ -421,27 +398,18 @@ const Page = ({
                     <Tab>
                       {_('Information')}
                     </Tab>
-                    <Tab>
-                      <TabTitle
-                        title={_('Scanner Preferences')}
-                        count={scannerPrefsCount}
-                      />
-                    </Tab>
-                    <Tab>
-                      <TabTitle
-                        title={_('NVT Families')}
-                        count={nvtFamiliesCount}
-                      />
-                    </Tab>
-                    <Tab>
-                      <TabTitle
-                        title={_('NVT Preferences')}
-                        count={nvtPrefsCount}
-                      />
-                    </Tab>
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
+                    <EntitiesTab entities={preferences.scanner}>
+                      {_('Scanner Preferences')}
+                    </EntitiesTab>
+                    <EntitiesTab entities={entity.family_list}>
+                      {_('NVT Families')}
+                    </EntitiesTab>
+                    <EntitiesTab entities={preferences.nvt}>
+                      {_('NVT Preferences')}
+                    </EntitiesTab>
+                    <EntitiesTab entities={entity.userTags}>
+                      {_('User Tags')}
+                    </EntitiesTab>
                     <Tab>
                       {permissionsTitle}
                     </Tab>

--- a/gsa/src/web/pages/scanconfigs/detailspage.js
+++ b/gsa/src/web/pages/scanconfigs/detailspage.js
@@ -56,6 +56,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -331,6 +332,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => {
 
@@ -376,7 +384,6 @@ const Page = ({
             activeTab = 0,
             permissionsComponent,
             permissionsTitle,
-            tagsComponent,
             onActivateTab,
             entity,
             ...other
@@ -433,7 +440,16 @@ const Page = ({
                       <NvtPreferences entity={entity}/>
                     </TabPanel>
                     <TabPanel>
-                      {tagsComponent}
+                      <EntityTags
+                        entity={entity}
+                        onTagAddClick={onTagAddClick}
+                        onTagDeleteClick={onTagDeleteClick}
+                        onTagDisableClick={onTagDisableClick}
+                        onTagEditClick={onTagEditClick}
+                        onTagEnableClick={onTagEnableClick}
+                        onTagCreateClick={onTagCreateClick}
+                        onTagRemoveClick={onTagRemoveClick}
+                      />
                     </TabPanel>
                     <TabPanel>
                       {permissionsComponent}
@@ -453,6 +469,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const ScanConfigPage = props => (

--- a/gsa/src/web/pages/scanconfigs/detailspage.js
+++ b/gsa/src/web/pages/scanconfigs/detailspage.js
@@ -329,6 +329,7 @@ Details.propTypes = {
 };
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -365,6 +366,7 @@ const Page = ({
       }) => (
         <EntityPage
           {...props}
+          entity={entity}
           sectionIcon="config.svg"
           toolBarIcons={ToolBarIcons}
           title={_('Scan Config')}
@@ -384,8 +386,6 @@ const Page = ({
             permissionsComponent,
             permissionsTitle,
             onActivateTab,
-            entity,
-            ...other
           }) => {
             const {
               preferences,
@@ -465,6 +465,7 @@ const Page = ({
 };
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/scanconfigs/detailspage.js
+++ b/gsa/src/web/pages/scanconfigs/detailspage.js
@@ -27,8 +27,6 @@ import glamorous from 'glamorous';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from 'web/utils/proptypes';
 import withCapabilities from 'web/utils/withCapabilities';
 
@@ -441,16 +439,12 @@ const Page = ({
                         count={nvtPrefsCount}
                       />
                     </Tab>
-                    {isDefined(tagsComponent) &&
-                      <Tab>
-                        {tagsTitle}
-                      </Tab>
-                    }
-                    {isDefined(permissionsComponent) &&
-                      <Tab>
-                        {permissionsTitle}
-                      </Tab>
-                    }
+                    <Tab>
+                      {tagsTitle}
+                    </Tab>
+                    <Tab>
+                      {permissionsTitle}
+                    </Tab>
                   </TabList>
                 </TabLayout>
 
@@ -470,16 +464,12 @@ const Page = ({
                     <TabPanel>
                       <NvtPreferences entity={entity}/>
                     </TabPanel>
-                    {isDefined(tagsComponent) &&
-                      <TabPanel>
-                        {tagsComponent}
-                      </TabPanel>
-                    }
-                    {isDefined(permissionsComponent) &&
-                      <TabPanel>
-                        {permissionsComponent}
-                      </TabPanel>
-                    }
+                    <TabPanel>
+                      {tagsComponent}
+                    </TabPanel>
+                    <TabPanel>
+                      {permissionsComponent}
+                    </TabPanel>
                   </TabPanels>
                 </Tabs>
               </Layout>

--- a/gsa/src/web/pages/scanconfigs/detailspage.js
+++ b/gsa/src/web/pages/scanconfigs/detailspage.js
@@ -51,18 +51,28 @@ import TabPanels from 'web/components/tab/tabpanels';
 import Tabs from 'web/components/tab/tabs';
 
 import EntityPage from 'web/entity/page';
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsResourceFilter,
+} from 'web/entity/withEntityContainer';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/scanconfigs';
+
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 import withCapabilities from 'web/utils/withCapabilities';
@@ -482,19 +492,26 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-const ScanConfigPage = props => (
-  <EntityContainer
-    {...props}
-    name="scanconfig"
-    resourceType="config"
-    loaders={[
-      permissions_resource_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const load = gmp => {
+  const loadEntityFunc = loadEntity(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  return id => dispatch => {
+    dispatch(loadEntityFunc(id));
+    dispatch(loadPermissionsFunc(permissionsResourceFilter(id)));
+  };
+};
 
-export default ScanConfigPage;
+const mapStateToProps = (rootState, {id}) => {
+  const permissionsSel = permissionsSelector(rootState);
+  return {
+    permissions: permissionsSel.getEntities(permissionsResourceFilter(id)),
+  };
+};
+
+export default withEntityContainer('scanconfig', {
+  entitySelector: selector,
+  load,
+  mapStateToProps,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/scanconfigs/detailspage.js
+++ b/gsa/src/web/pages/scanconfigs/detailspage.js
@@ -55,6 +55,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -330,6 +331,7 @@ Details.propTypes = {
 
 const Page = ({
   entity,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -377,14 +379,9 @@ const Page = ({
           onScanConfigEditClick={edit}
           onScanConfigSaveClick={save}
           onScanConfigImportClick={import_func}
-          onPermissionChanged={onChanged}
-          onPermissionDownloaded={onDownloaded}
-          onPermissionDownloadError={onError}
         >
           {({
             activeTab = 0,
-            permissionsComponent,
-            permissionsTitle,
             onActivateTab,
           }) => {
             const {
@@ -416,9 +413,9 @@ const Page = ({
                     <EntitiesTab entities={entity.userTags}>
                       {_('User Tags')}
                     </EntitiesTab>
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
+                    <EntitiesTab entities={permissions}>
+                      {_('Permissions')}
+                    </EntitiesTab>
                   </TabList>
                 </TabLayout>
 
@@ -451,7 +448,13 @@ const Page = ({
                       />
                     </TabPanel>
                     <TabPanel>
-                      {permissionsComponent}
+                      <EntityPermissions
+                        entity={entity}
+                        permissions={permissions}
+                        onChanged={onChanged}
+                        onDownloaded={onDownloaded}
+                        onError={onError}
+                      />
                     </TabPanel>
                   </TabPanels>
                 </Tabs>
@@ -466,6 +469,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/scanconfigs/detailspage.js
+++ b/gsa/src/web/pages/scanconfigs/detailspage.js
@@ -25,9 +25,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from 'web/utils/proptypes';
-import withCapabilities from 'web/utils/withCapabilities';
-
 import DetailsLink from 'web/components/link/detailslink';
 
 import Divider from 'web/components/layout/divider';
@@ -64,6 +61,9 @@ import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
+import withCapabilities from 'web/utils/withCapabilities';
 
 import ScanConfigDetails from './details';
 import ScanConfigComponent from './component';

--- a/gsa/src/web/pages/scanconfigs/detailspage.js
+++ b/gsa/src/web/pages/scanconfigs/detailspage.js
@@ -365,7 +365,6 @@ const Page = ({
       }) => (
         <EntityPage
           {...props}
-          detailsComponent={Details}
           sectionIcon="config.svg"
           toolBarIcons={ToolBarIcons}
           title={_('Scan Config')}

--- a/gsa/src/web/pages/scanners/detailspage.js
+++ b/gsa/src/web/pages/scanners/detailspage.js
@@ -46,18 +46,28 @@ import Icon from 'web/components/icon/icon';
 import ListIcon from 'web/components/icon/listicon';
 
 import EntityPage from 'web/entity/page';
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsResourceFilter,
+} from 'web/entity/withEntityContainer';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/scanners';
+
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -290,18 +300,26 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-const ScannerPage = props => (
-  <EntityContainer
-    {...props}
-    name="scanner"
-    loaders={[
-      permissions_resource_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const load = gmp => {
+  const loadEntityFunc = loadEntity(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  return id => dispatch => {
+    dispatch(loadEntityFunc(id));
+    dispatch(loadPermissionsFunc(permissionsResourceFilter(id)));
+  };
+};
 
-export default ScannerPage;
+const mapStateToProps = (rootState, {id}) => {
+  const permissionsSel = permissionsSelector(rootState);
+  return {
+    permissions: permissionsSel.getEntities(permissionsResourceFilter(id)),
+  };
+};
+
+export default withEntityContainer('scanner', {
+  entitySelector: selector,
+  load,
+  mapStateToProps,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/scanners/detailspage.js
+++ b/gsa/src/web/pages/scanners/detailspage.js
@@ -36,6 +36,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
+import EntitiesTab from 'web/entity/tab';
 
 import CloneIcon from '../../entity/icon/cloneicon.js';
 import CreateIcon from '../../entity/icon/createicon.js';
@@ -206,7 +207,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           tagsComponent,
-          tagsTitle,
           onActivateTab,
           entity,
           ...other
@@ -225,9 +225,9 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <Tab>
-                    {tabsTitle}
-                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
                   <Tab>
                     {permissionsTitle}
                   </Tab>

--- a/gsa/src/web/pages/scanners/detailspage.js
+++ b/gsa/src/web/pages/scanners/detailspage.js
@@ -152,6 +152,7 @@ ToolBarIcons.propTypes = {
 };
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -193,6 +194,7 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
+        entity={entity}
         sectionIcon="scanner.svg"
         toolBarIcons={ToolBarIcons}
         title={_('Scanner')}
@@ -214,8 +216,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           onActivateTab,
-          entity,
-          ...other
         }) => {
           return (
             <Layout grow="1" flex="column">
@@ -273,6 +273,7 @@ const Page = ({
 );
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/scanners/detailspage.js
+++ b/gsa/src/web/pages/scanners/detailspage.js
@@ -225,16 +225,12 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  {isDefined(tagsComponent) &&
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
-                  }
+                  <Tab>
+                    {tabsTitle}
+                  </Tab>
+                  <Tab>
+                    {permissionsTitle}
+                  </Tab>
                 </TabList>
               </TabLayout>
 
@@ -245,16 +241,12 @@ const Page = ({
                       entity={entity}
                     />
                   </TabPanel>
-                  {isDefined(tagsComponent) &&
-                    <TabPanel>
-                      {tagsComponent}
-                    </TabPanel>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <TabPanel>
-                      {permissionsComponent}
-                    </TabPanel>
-                  }
+                  <TabPanel>
+                    {tagsComponent}
+                  </TabPanel>
+                  <TabPanel>
+                    {permissionsComponent}
+                  </TabPanel>
                 </TabPanels>
               </Tabs>
             </Layout>

--- a/gsa/src/web/pages/scanners/detailspage.js
+++ b/gsa/src/web/pages/scanners/detailspage.js
@@ -51,6 +51,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -154,6 +155,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => (
   <ScannerComponent
@@ -206,7 +214,6 @@ const Page = ({
           activeTab = 0,
           permissionsComponent,
           permissionsTitle,
-          tagsComponent,
           onActivateTab,
           entity,
           ...other
@@ -242,7 +249,16 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {tagsComponent}
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
                   </TabPanel>
                   <TabPanel>
                     {permissionsComponent}
@@ -261,7 +277,15 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
+
 const ScannerPage = props => (
   <EntityContainer
     {...props}

--- a/gsa/src/web/pages/scanners/detailspage.js
+++ b/gsa/src/web/pages/scanners/detailspage.js
@@ -29,38 +29,38 @@ import {isDefined} from 'gmp/utils/identity';
 
 import {CVE_SCANNER_TYPE} from 'gmp/models/scanner';
 
-import PropTypes from '../../utils/proptypes.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
 
-import EntityPage from '../../entity/page.js';
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
+
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import Icon from 'web/components/icon/icon';
+import ListIcon from 'web/components/icon/listicon';
+
+import EntityPage from 'web/entity/page';
 import EntityContainer, {
   permissions_resource_loader,
-} from '../../entity/container.js';
-import {goto_details, goto_list} from '../../entity/component.js';
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
 
-import CloneIcon from '../../entity/icon/cloneicon.js';
-import CreateIcon from '../../entity/icon/createicon.js';
-import EditIcon from '../../entity/icon/editicon.js';
-import TrashIcon from '../../entity/icon/trashicon.js';
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
+import PropTypes from 'web/utils/proptypes';
 
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
-
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import Icon from '../../components/icon/icon.js';
-import ListIcon from '../../components/icon/listicon.js';
-
-import ScannerComponent from './component.js';
-import ScannerDetails from './details.js';
+import ScannerComponent from './component';
+import ScannerDetails from './details';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/scanners/detailspage.js
+++ b/gsa/src/web/pages/scanners/detailspage.js
@@ -193,7 +193,6 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
-        detailsComponent={ScannerDetails}
         sectionIcon="scanner.svg"
         toolBarIcons={ToolBarIcons}
         title={_('Scanner')}

--- a/gsa/src/web/pages/scanners/detailspage.js
+++ b/gsa/src/web/pages/scanners/detailspage.js
@@ -50,6 +50,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -153,6 +154,7 @@ ToolBarIcons.propTypes = {
 
 const Page = ({
   entity,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -207,14 +209,9 @@ const Page = ({
         onScannerEditClick={edit}
         onScannerSaveClick={save}
         onScannerVerifyClick={verify}
-        onPermissionChanged={onChanged}
-        onPermissionDownloaded={onDownloaded}
-        onPermissionDownloadError={onError}
       >
         {({
           activeTab = 0,
-          permissionsComponent,
-          permissionsTitle,
           onActivateTab,
         }) => {
           return (
@@ -234,9 +231,9 @@ const Page = ({
                   <EntitiesTab entities={entity.userTags}>
                     {_('User Tags')}
                   </EntitiesTab>
-                  <Tab>
-                    {permissionsTitle}
-                  </Tab>
+                  <EntitiesTab entities={permissions}>
+                    {_('Permissions')}
+                  </EntitiesTab>
                 </TabList>
               </TabLayout>
 
@@ -260,7 +257,13 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {permissionsComponent}
+                    <EntityPermissions
+                      entity={entity}
+                      permissions={permissions}
+                      onChanged={onChanged}
+                      onDownloaded={onDownloaded}
+                      onError={onError}
+                    />
                   </TabPanel>
                 </TabPanels>
               </Tabs>
@@ -274,6 +277,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/schedules/detailspage.js
+++ b/gsa/src/web/pages/schedules/detailspage.js
@@ -25,8 +25,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from '../../utils/proptypes.js';
 
 import EntityPage from '../../entity/page.js';
@@ -177,16 +175,12 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  {isDefined(tagsComponent) &&
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
-                  }
+                  <Tab>
+                    {tabsTitle}
+                  </Tab>
+                  <Tab>
+                    {permissionsTitle}
+                  </Tab>
                 </TabList>
               </TabLayout>
 
@@ -197,16 +191,12 @@ const Page = ({
                       entity={entity}
                     />
                   </TabPanel>
-                  {isDefined(tagsComponent) &&
-                    <TabPanel>
-                      {tagsComponent}
-                    </TabPanel>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <TabPanel>
-                      {permissionsComponent}
-                    </TabPanel>
-                  }
+                  <TabPanel>
+                    {tagsComponent}
+                  </TabPanel>
+                  <TabPanel>
+                    {permissionsComponent}
+                  </TabPanel>
                 </TabPanels>
               </Tabs>
             </Layout>

--- a/gsa/src/web/pages/schedules/detailspage.js
+++ b/gsa/src/web/pages/schedules/detailspage.js
@@ -46,13 +46,23 @@ import TabPanels from 'web/components/tab/tabpanels';
 import Tabs from 'web/components/tab/tabs';
 
 import EntityPage from 'web/entity/page';
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsResourceFilter,
+} from 'web/entity/withEntityContainer';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/schedules';
+
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -240,18 +250,26 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-const SchedulePage = props => (
-  <EntityContainer
-    {...props}
-    name="schedule"
-    loaders={[
-      permissions_resource_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const load = gmp => {
+  const loadEntityFunc = loadEntity(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  return id => dispatch => {
+    dispatch(loadEntityFunc(id));
+    dispatch(loadPermissionsFunc(permissionsResourceFilter(id)));
+  };
+};
 
-export default SchedulePage;
+const mapStateToProps = (rootState, {id}) => {
+  const permissionsSel = permissionsSelector(rootState);
+  return {
+    permissions: permissionsSel.getEntities(permissionsResourceFilter(id)),
+  };
+};
+
+export default withEntityContainer('schedule', {
+  entitySelector: selector,
+  load,
+  mapStateToProps,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/schedules/detailspage.js
+++ b/gsa/src/web/pages/schedules/detailspage.js
@@ -32,6 +32,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
+import EntitiesTab from 'web/entity/tab';
 
 import ExportIcon from '../../components/icon/exporticon.js';
 import CloneIcon from '../../entity/icon/cloneicon.js';
@@ -156,7 +157,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           tagsComponent,
-          tagsTitle,
           onActivateTab,
           entity,
           ...other
@@ -175,9 +175,9 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <Tab>
-                    {tabsTitle}
-                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
                   <Tab>
                     {permissionsTitle}
                   </Tab>

--- a/gsa/src/web/pages/schedules/detailspage.js
+++ b/gsa/src/web/pages/schedules/detailspage.js
@@ -114,6 +114,7 @@ ToolBarIcons.propTypes = {
 };
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -146,6 +147,7 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
+        entity={entity}
         sectionIcon="schedule.svg"
         title={_('Schedule')}
         toolBarIcons={ToolBarIcons}
@@ -164,8 +166,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           onActivateTab,
-          entity,
-          ...other
         }) => {
           return (
             <Layout grow="1" flex="column">
@@ -223,6 +223,7 @@ const Page = ({
 );
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/schedules/detailspage.js
+++ b/gsa/src/web/pages/schedules/detailspage.js
@@ -50,6 +50,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -115,6 +116,7 @@ ToolBarIcons.propTypes = {
 
 const Page = ({
   entity,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -157,14 +159,9 @@ const Page = ({
         onScheduleDownloadClick={download}
         onScheduleEditClick={edit}
         onScheduleSaveClick={save}
-        onPermissionChanged={onChanged}
-        onPermissionDownloaded={onDownloaded}
-        onPermissionDownloadError={onError}
       >
         {({
           activeTab = 0,
-          permissionsComponent,
-          permissionsTitle,
           onActivateTab,
         }) => {
           return (
@@ -184,9 +181,9 @@ const Page = ({
                   <EntitiesTab entities={entity.userTags}>
                     {_('User Tags')}
                   </EntitiesTab>
-                  <Tab>
-                    {permissionsTitle}
-                  </Tab>
+                  <EntitiesTab entities={permissions}>
+                    {_('Permissions')}
+                  </EntitiesTab>
                 </TabList>
               </TabLayout>
 
@@ -210,7 +207,13 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {permissionsComponent}
+                    <EntityPermissions
+                      entity={entity}
+                      permissions={permissions}
+                      onChanged={onChanged}
+                      onDownloaded={onDownloaded}
+                      onError={onError}
+                    />
                   </TabPanel>
                 </TabPanels>
               </Tabs>
@@ -224,6 +227,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/schedules/detailspage.js
+++ b/gsa/src/web/pages/schedules/detailspage.js
@@ -51,6 +51,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -116,6 +117,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => (
   <ScheduleComponent
@@ -156,7 +164,6 @@ const Page = ({
           activeTab = 0,
           permissionsComponent,
           permissionsTitle,
-          tagsComponent,
           onActivateTab,
           entity,
           ...other
@@ -192,7 +199,16 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {tagsComponent}
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
                   </TabPanel>
                   <TabPanel>
                     {permissionsComponent}
@@ -211,6 +227,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const SchedulePage = props => (

--- a/gsa/src/web/pages/schedules/detailspage.js
+++ b/gsa/src/web/pages/schedules/detailspage.js
@@ -25,37 +25,37 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from '../../utils/proptypes.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import DeleteIcon from 'web/entity/icon/deleteicon';
 
-import EntityPage from '../../entity/page.js';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
+
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
+
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
+
+import EntityPage from 'web/entity/page';
 import EntityContainer, {
   permissions_resource_loader,
-} from '../../entity/container.js';
-import {goto_details, goto_list} from '../../entity/component.js';
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import CloneIcon from '../../entity/icon/cloneicon.js';
-import CreateIcon from '../../entity/icon/createicon.js';
-import EditIcon from '../../entity/icon/editicon.js';
-import DeleteIcon from '../../entity/icon/deleteicon.js';
+import PropTypes from 'web/utils/proptypes';
 
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
-
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
-
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
-
-import ScheduleComponent from './component.js';
-import ScheduleDetails from './details.js';
+import ScheduleComponent from './component';
+import ScheduleDetails from './details';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/schedules/detailspage.js
+++ b/gsa/src/web/pages/schedules/detailspage.js
@@ -148,7 +148,6 @@ const Page = ({
         {...props}
         sectionIcon="schedule.svg"
         title={_('Schedule')}
-        detailsComponent={ScheduleDetails}
         toolBarIcons={ToolBarIcons}
         onScheduleCloneClick={clone}
         onScheduleCreateClick={create}

--- a/gsa/src/web/pages/tags/detailspage.js
+++ b/gsa/src/web/pages/tags/detailspage.js
@@ -25,15 +25,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from 'web/utils/proptypes';
-import withCapabilties from 'web/utils/withCapabilities';
-
-import EntityPage from 'web/entity/page';
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
-import {goto_details, goto_list} from 'web/entity/component';
-
 import Divider from 'web/components/layout/divider';
 import IconDivider from 'web/components/layout/icondivider';
 
@@ -41,11 +32,6 @@ import ExportIcon from 'web/components/icon/exporticon';
 import ManualIcon from 'web/components/icon/manualicon';
 import Icon from 'web/components/icon/icon';
 import ListIcon from 'web/components/icon/listicon';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import CreateIcon from 'web/entity/icon/createicon';
-import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
 
 import Layout from 'web/components/layout/layout';
 
@@ -56,10 +42,24 @@ import TabPanel from 'web/components/tab/tabpanel';
 import TabPanels from 'web/components/tab/tabpanels';
 import Tabs from 'web/components/tab/tabs';
 
-import ResourceList from 'web/pages/tags/resourcelist';
-import TagComponent from 'web/pages/tags/component';
-import TagDetails from 'web/pages/tags/details';
+import EntityPage from 'web/entity/page';
+import EntityContainer, {
+  permissions_resource_loader,
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
+import withCapabilties from 'web/utils/withCapabilities';
+
+import ResourceList from './resourcelist';
+import TagComponent from './component';
+import TagDetails from './details';
 
 const ToolBarIcons = withCapabilties(({
   capabilities,

--- a/gsa/src/web/pages/tags/detailspage.js
+++ b/gsa/src/web/pages/tags/detailspage.js
@@ -25,8 +25,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import glamorous from 'glamorous';
-
 import PropTypes from 'web/utils/proptypes';
 import withCapabilties from 'web/utils/withCapabilities';
 
@@ -61,22 +59,7 @@ import Tabs from 'web/components/tab/tabs';
 import ResourceList from 'web/pages/tags/resourcelist';
 import TagComponent from 'web/pages/tags/component';
 import TagDetails from 'web/pages/tags/details';
-
-const TabTitleCount = glamorous.span({
-  fontSize: '0.7em',
-});
-
-const TabTitle = ({title, count}) => (
-  <Layout flex="column" align={['center', 'center']}>
-    <span>{title}</span>
-    <TabTitleCount>(<i>{(count)}</i>)</TabTitleCount>
-  </Layout>
-);
-
-TabTitle.propTypes = {
-  count: PropTypes.numberOrNumberString.isRequired,
-  title: PropTypes.string.isRequired,
-};
+import EntitiesTab from 'web/entity/tab';
 
 const ToolBarIcons = withCapabilties(({
   capabilities,
@@ -222,13 +205,10 @@ const Page = ({
             permissionsComponent,
             permissionsTitle,
             resourcesComponent,
-            tagsTitle,
             onActivateTab,
             entity,
             ...other
           }) => {
-            const {resourceCount} = entity;
-
             return (
               <Layout grow="1" flex="column">
                 <TabLayout
@@ -243,12 +223,9 @@ const Page = ({
                     <Tab>
                       {_('Information')}
                     </Tab>
-                    <Tab>
-                      <TabTitle
-                        title={_('Assigned Items')}
-                        count={resourceCount}
-                      />
-                    </Tab>
+                    <EntitiesTab entities={entity.resouceCount}>
+                      {_('Assigned Items')}
+                    </EntitiesTab>
                     <Tab>
                       {permissionsTitle}
                     </Tab>

--- a/gsa/src/web/pages/tags/detailspage.js
+++ b/gsa/src/web/pages/tags/detailspage.js
@@ -60,6 +60,7 @@ import withCapabilties from 'web/utils/withCapabilities';
 import ResourceList from './resourcelist';
 import TagComponent from './component';
 import TagDetails from './details';
+import EntityPermissions from 'web/entity/permissions';
 
 const ToolBarIcons = withCapabilties(({
   capabilities,
@@ -149,6 +150,8 @@ ToolBarIcons.propTypes = {
 };
 
 const Page = ({
+  entity,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -182,10 +185,9 @@ const Page = ({
       }) => (
         <EntityPage
           {...props}
-          detailsComponent={TagDetails}
+          entity={entity}
           sectionIcon="tag.svg"
           toolBarIcons={ToolBarIcons}
-          tagsComponent={false}
           title={_('Tag')}
           onTagCloneClick={clone}
           onTagCreateClick={create}
@@ -196,18 +198,10 @@ const Page = ({
           onTagEnableClick={enable}
           onTagDisableClick={disable}
           onTagRemoveClick={remove}
-          onPermissionChanged={onChanged}
-          onPermissionDownloaded={onDownloaded}
-          onPermissionDownloadError={onError}
         >
           {({
             activeTab = 0,
-            permissionsComponent,
-            permissionsTitle,
-            resourcesComponent,
             onActivateTab,
-            entity,
-            ...other
           }) => {
             return (
               <Layout grow="1" flex="column">
@@ -223,12 +217,12 @@ const Page = ({
                     <Tab>
                       {_('Information')}
                     </Tab>
-                    <EntitiesTab entities={entity.resouceCount}>
+                    <EntitiesTab count={entity.resourceCount}>
                       {_('Assigned Items')}
                     </EntitiesTab>
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
+                    <EntitiesTab entities={permissions}>
+                      {_('Permissions')}
+                    </EntitiesTab>
                   </TabList>
                 </TabLayout>
 
@@ -243,7 +237,13 @@ const Page = ({
                       <ResourceList entity={entity}/>
                     </TabPanel>
                     <TabPanel>
-                      {permissionsComponent}
+                      <EntityPermissions
+                        entity={entity}
+                        permissions={permissions}
+                        onChanged={onChanged}
+                        onDownloaded={onDownloaded}
+                        onError={onError}
+                      />
                     </TabPanel>
                   </TabPanels>
                 </Tabs>

--- a/gsa/src/web/pages/tags/detailspage.js
+++ b/gsa/src/web/pages/tags/detailspage.js
@@ -27,8 +27,6 @@ import _ from 'gmp/locale';
 
 import glamorous from 'glamorous';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from 'web/utils/proptypes';
 import withCapabilties from 'web/utils/withCapabilities';
 
@@ -251,11 +249,9 @@ const Page = ({
                         count={resourceCount}
                       />
                     </Tab>
-                    {isDefined(permissionsComponent) &&
-                      <Tab>
-                        {permissionsTitle}
-                      </Tab>
-                    }
+                    <Tab>
+                      {permissionsTitle}
+                    </Tab>
                   </TabList>
                 </TabLayout>
 
@@ -269,11 +265,9 @@ const Page = ({
                     <TabPanel>
                       <ResourceList entity={entity}/>
                     </TabPanel>
-                    {isDefined(permissionsComponent) &&
-                      <TabPanel>
-                        {permissionsComponent}
-                      </TabPanel>
-                    }
+                    <TabPanel>
+                      {permissionsComponent}
+                    </TabPanel>
                   </TabPanels>
                 </Tabs>
               </Layout>

--- a/gsa/src/web/pages/targets/detailspage.js
+++ b/gsa/src/web/pages/targets/detailspage.js
@@ -166,6 +166,7 @@ Details.propTypes = {
 
 const Page = ({
   entity,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -200,7 +201,6 @@ const Page = ({
         <EntityPage
           {...props}
           entity={entity}
-          permissionsComponent={TargetPermissions}
           sectionIcon="target.svg"
           toolBarIcons={ToolBarIcons}
           title={_('Target')}
@@ -210,14 +210,9 @@ const Page = ({
           onTargetDownloadClick={download}
           onTargetEditClick={edit}
           onTargetSaveClick={save}
-          onPermissionChanged={onChanged}
-          onPermissionDownloaded={onDownloaded}
-          onPermissionDownloadError={onError}
         >
           {({
             activeTab = 0,
-            permissionsComponent,
-            permissionsTitle,
             onActivateTab,
           }) => {
             return (
@@ -237,9 +232,9 @@ const Page = ({
                     <EntitiesTab entities={entity.userTags}>
                       {_('User Tags')}
                     </EntitiesTab>
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
+                    <EntitiesTab entities={permissions}>
+                      {_('Permissions')}
+                    </EntitiesTab>
                   </TabList>
                 </TabLayout>
 
@@ -263,7 +258,13 @@ const Page = ({
                       />
                     </TabPanel>
                     <TabPanel>
-                      {permissionsComponent}
+                      <TargetPermissions
+                        entity={entity}
+                        permissions={permissions}
+                        onChanged={onChanged}
+                        onDownloaded={onDownloaded}
+                        onError={onError}
+                      />
                     </TabPanel>
                   </TabPanels>
                 </Tabs>
@@ -278,6 +279,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/targets/detailspage.js
+++ b/gsa/src/web/pages/targets/detailspage.js
@@ -29,44 +29,44 @@ import {isDefined} from 'gmp/utils/identity';
 
 import {TARGET_CREDENTIAL_NAMES} from 'gmp/models/target';
 
-import PropTypes from '../../utils/proptypes.js';
-import withComponentDefaults from '../../utils/withComponentDefaults.js';
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
 
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
 
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
+import InfoTable from 'web/components/table/infotable';
+import TableBody from 'web/components/table/body';
+import TableData from 'web/components/table/data';
+import TableRow from 'web/components/table/row';
 
-import InfoTable from '../../components/table/infotable.js';
-import TableBody from '../../components/table/body.js';
-import TableData from '../../components/table/data.js';
-import TableRow from '../../components/table/row.js';
-
-import EntityPage from '../../entity/page.js';
-import EntityPermissions from '../../entity/permissions.js';
+import EntityPage from 'web/entity/page';
+import EntityPermissions from 'web/entity/permissions';
 import EntityContainer, {
   permissions_resource_loader,
-} from '../../entity/container.js';
-import {goto_details, goto_list} from '../../entity/component.js';
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
 
-import CloneIcon from '../../entity/icon/cloneicon.js';
-import CreateIcon from '../../entity/icon/createicon.js';
-import EditIcon from '../../entity/icon/editicon.js';
-import TrashIcon from '../../entity/icon/trashicon.js';
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
 
-import TargetDetails from './details.js';
-import TargetComponent from './component.js';
+import PropTypes from 'web/utils/proptypes';
+import withComponentDefaults from 'web/utils/withComponentDefaults';
+
+import TargetDetails from './details';
+import TargetComponent from './component';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/targets/detailspage.js
+++ b/gsa/src/web/pages/targets/detailspage.js
@@ -198,7 +198,6 @@ const Page = ({
       }) => (
         <EntityPage
           {...props}
-          detailsComponent={Details}
           permissionsComponent={TargetPermissions}
           sectionIcon="target.svg"
           toolBarIcons={ToolBarIcons}

--- a/gsa/src/web/pages/targets/detailspage.js
+++ b/gsa/src/web/pages/targets/detailspage.js
@@ -56,6 +56,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -167,6 +168,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => {
   return (
@@ -209,7 +217,6 @@ const Page = ({
             activeTab = 0,
             permissionsComponent,
             permissionsTitle,
-            tagsComponent,
             onActivateTab,
             entity,
             ...other
@@ -245,7 +252,16 @@ const Page = ({
                       />
                     </TabPanel>
                     <TabPanel>
-                      {tagsComponent}
+                      <EntityTags
+                        entity={entity}
+                        onTagAddClick={onTagAddClick}
+                        onTagDeleteClick={onTagDeleteClick}
+                        onTagDisableClick={onTagDisableClick}
+                        onTagEditClick={onTagEditClick}
+                        onTagEnableClick={onTagEnableClick}
+                        onTagCreateClick={onTagCreateClick}
+                        onTagRemoveClick={onTagRemoveClick}
+                      />
                     </TabPanel>
                     <TabPanel>
                       {permissionsComponent}
@@ -265,6 +281,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const TargetPermissions = withComponentDefaults({

--- a/gsa/src/web/pages/targets/detailspage.js
+++ b/gsa/src/web/pages/targets/detailspage.js
@@ -165,6 +165,7 @@ Details.propTypes = {
 };
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -198,6 +199,7 @@ const Page = ({
       }) => (
         <EntityPage
           {...props}
+          entity={entity}
           permissionsComponent={TargetPermissions}
           sectionIcon="target.svg"
           toolBarIcons={ToolBarIcons}
@@ -217,8 +219,6 @@ const Page = ({
             permissionsComponent,
             permissionsTitle,
             onActivateTab,
-            entity,
-            ...other
           }) => {
             return (
               <Layout grow="1" flex="column">
@@ -277,6 +277,7 @@ const Page = ({
 };
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/targets/detailspage.js
+++ b/gsa/src/web/pages/targets/detailspage.js
@@ -51,17 +51,27 @@ import TableRow from 'web/components/table/row';
 
 import EntityPage from 'web/entity/page';
 import EntityPermissions from 'web/entity/permissions';
-import EntityContainer, {
-  permissions_resource_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsResourceFilter,
+} from 'web/entity/withEntityContainer';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/targets';
+
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 import withComponentDefaults from 'web/utils/withComponentDefaults';
@@ -307,18 +317,26 @@ const TargetPermissions = withComponentDefaults({
   ],
 })(EntityPermissions);
 
-const TargetPage = props => (
-  <EntityContainer
-    {...props}
-    name="target"
-    loaders={[
-      permissions_resource_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const load = gmp => {
+  const loadEntityFunc = loadEntity(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  return id => dispatch => {
+    dispatch(loadEntityFunc(id));
+    dispatch(loadPermissionsFunc(permissionsResourceFilter(id)));
+  };
+};
 
-export default TargetPage;
+const mapStateToProps = (rootState, {id}) => {
+  const permissionsSel = permissionsSelector(rootState);
+  return {
+    permissions: permissionsSel.getEntities(permissionsResourceFilter(id)),
+  };
+};
+
+export default withEntityContainer('target', {
+  entitySelector: selector,
+  load,
+  mapStateToProps,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/targets/detailspage.js
+++ b/gsa/src/web/pages/targets/detailspage.js
@@ -58,6 +58,7 @@ import EntityContainer, {
   permissions_resource_loader,
 } from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
+import EntitiesTab from 'web/entity/tab';
 
 import CloneIcon from '../../entity/icon/cloneicon.js';
 import CreateIcon from '../../entity/icon/createicon.js';
@@ -209,7 +210,6 @@ const Page = ({
             permissionsComponent,
             permissionsTitle,
             tagsComponent,
-            tagsTitle,
             onActivateTab,
             entity,
             ...other
@@ -228,9 +228,9 @@ const Page = ({
                     <Tab>
                       {_('Information')}
                     </Tab>
-                    <Tab>
-                      {tabsTitle}
-                    </Tab>
+                    <EntitiesTab entities={entity.userTags}>
+                      {_('User Tags')}
+                    </EntitiesTab>
                     <Tab>
                       {permissionsTitle}
                     </Tab>

--- a/gsa/src/web/pages/targets/detailspage.js
+++ b/gsa/src/web/pages/targets/detailspage.js
@@ -228,16 +228,12 @@ const Page = ({
                     <Tab>
                       {_('Information')}
                     </Tab>
-                    {isDefined(tagsComponent) &&
-                      <Tab>
-                        {tagsTitle}
-                      </Tab>
-                    }
-                    {isDefined(permissionsComponent) &&
-                      <Tab>
-                        {permissionsTitle}
-                      </Tab>
-                    }
+                    <Tab>
+                      {tabsTitle}
+                    </Tab>
+                    <Tab>
+                      {permissionsTitle}
+                    </Tab>
                   </TabList>
                 </TabLayout>
 
@@ -248,16 +244,12 @@ const Page = ({
                         entity={entity}
                       />
                     </TabPanel>
-                    {isDefined(tagsComponent) &&
-                      <TabPanel>
-                        {tagsComponent}
-                      </TabPanel>
-                    }
-                    {isDefined(permissionsComponent) &&
-                      <TabPanel>
-                        {permissionsComponent}
-                      </TabPanel>
-                    }
+                    <TabPanel>
+                      {tagsComponent}
+                    </TabPanel>
+                    <TabPanel>
+                      {permissionsComponent}
+                    </TabPanel>
                   </TabPanels>
                 </Tabs>
               </Layout>

--- a/gsa/src/web/pages/tasks/detailspage.js
+++ b/gsa/src/web/pages/tasks/detailspage.js
@@ -443,16 +443,12 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  {isDefined(tagsComponent) &&
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
-                  }
+                  <Tab>
+                    {tabsTitle}
+                  </Tab>
+                  <Tab>
+                    {permissionsTitle}
+                  </Tab>
                 </TabList>
               </TabLayout>
 
@@ -463,16 +459,12 @@ const Page = ({
                       entity={entity}
                     />
                   </TabPanel>
-                  {isDefined(tagsComponent) &&
-                    <TabPanel>
-                      {tagsComponent}
-                    </TabPanel>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <TabPanel>
-                      {permissionsComponent}
-                    </TabPanel>
-                  }
+                  <TabPanel>
+                    {tagsComponent}
+                  </TabPanel>
+                  <TabPanel>
+                    {permissionsComponent}
+                  </TabPanel>
                 </TabPanels>
               </Tabs>
             </Layout>

--- a/gsa/src/web/pages/tasks/detailspage.js
+++ b/gsa/src/web/pages/tasks/detailspage.js
@@ -83,6 +83,7 @@ import StopIcon from 'web/pages/tasks/icons/stopicon';
 import TaskDetails from 'web/pages/tasks/details';
 import TaskStatus from 'web/pages/tasks/status';
 import TaskComponent from 'web/pages/tasks/component';
+import EntitiesTab from 'web/entity/tab';
 
 const ToolBarIcons = ({
   entity,
@@ -424,7 +425,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           tagsComponent,
-          tagsTitle,
           onActivateTab,
           entity,
           ...other
@@ -443,9 +443,9 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <Tab>
-                    {tabsTitle}
-                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
                   <Tab>
                     {permissionsTitle}
                   </Tab>

--- a/gsa/src/web/pages/tasks/detailspage.js
+++ b/gsa/src/web/pages/tasks/detailspage.js
@@ -410,7 +410,6 @@ const Page = ({
         sectionIcon="task.svg"
         title={_('Task')}
         toolBarIcons={ToolBarIcons}
-        detailsComponent={Details}
         permissionsComponent={TaskPermissions}
         onChanged={onChanged}
         onError={onError}

--- a/gsa/src/web/pages/tasks/detailspage.js
+++ b/gsa/src/web/pages/tasks/detailspage.js
@@ -362,6 +362,7 @@ Details.propTypes = {
 };
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -407,6 +408,7 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
+        entity={entity}
         sectionIcon="task.svg"
         title={_('Task')}
         toolBarIcons={ToolBarIcons}
@@ -432,8 +434,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           onActivateTab,
-          entity,
-          ...other
         }) => {
           return (
             <Layout grow="1" flex="column">
@@ -491,6 +491,7 @@ const Page = ({
 );
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/tasks/detailspage.js
+++ b/gsa/src/web/pages/tasks/detailspage.js
@@ -65,6 +65,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import EditIcon from 'web/entity/icon/editicon';
@@ -364,6 +365,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => (
   <TaskComponent
@@ -424,7 +432,6 @@ const Page = ({
           activeTab = 0,
           permissionsComponent,
           permissionsTitle,
-          tagsComponent,
           onActivateTab,
           entity,
           ...other
@@ -460,7 +467,16 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {tagsComponent}
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
                   </TabPanel>
                   <TabPanel>
                     {permissionsComponent}
@@ -479,6 +495,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const TaskPermissions = withComponentDefaults({

--- a/gsa/src/web/pages/tasks/detailspage.js
+++ b/gsa/src/web/pages/tasks/detailspage.js
@@ -363,6 +363,7 @@ Details.propTypes = {
 
 const Page = ({
   entity,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -412,7 +413,6 @@ const Page = ({
         sectionIcon="task.svg"
         title={_('Task')}
         toolBarIcons={ToolBarIcons}
-        permissionsComponent={TaskPermissions}
         onChanged={onChanged}
         onError={onError}
         onContainerTaskCreateClick={createcontainer}
@@ -431,8 +431,6 @@ const Page = ({
       >
         {({
           activeTab = 0,
-          permissionsComponent,
-          permissionsTitle,
           onActivateTab,
         }) => {
           return (
@@ -452,9 +450,9 @@ const Page = ({
                   <EntitiesTab entities={entity.userTags}>
                     {_('User Tags')}
                   </EntitiesTab>
-                  <Tab>
-                    {permissionsTitle}
-                  </Tab>
+                  <EntitiesTab entities={permissions}>
+                    {_('Permissions')}
+                  </EntitiesTab>
                 </TabList>
               </TabLayout>
 
@@ -478,7 +476,13 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {permissionsComponent}
+                    <TaskPermissions
+                      entity={entity}
+                      permissions={permissions}
+                      onChanged={onChanged}
+                      onDownloaded={onDownloaded}
+                      onError={onError}
+                    />
                   </TabPanel>
                 </TabPanels>
               </Tabs>
@@ -492,6 +496,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/tasks/detailspage.js
+++ b/gsa/src/web/pages/tasks/detailspage.js
@@ -27,6 +27,8 @@ import React from 'react';
 import _ from 'gmp/locale';
 import {shortDate} from 'gmp/locale/date';
 
+import Filter from 'gmp/models/filter';
+
 import {isDefined} from 'gmp/utils/identity';
 
 import {TARGET_CREDENTIAL_NAMES} from 'gmp/models/target';
@@ -59,17 +61,33 @@ import TableRow from 'web/components/table/row';
 
 import EntityPage from 'web/entity/page';
 import EntityPermissions from 'web/entity/permissions';
-import EntityContainer, {
-  loader,
-  permissions_resource_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsResourceFilter,
+} from 'web/entity/withEntityContainer';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+
+import {
+  selector as notesSelector,
+  loadEntities as loadNotes,
+} from 'web/store/entities/notes';
+import {
+  selector as overridesSelector,
+  loadEntities as loadOverrides,
+} from 'web/store/entities/overrides';
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
+import {
+  selector as taskSelector,
+  loadEntity as loadTask,
+} from 'web/store/entities/tasks';
 
 import PropTypes from 'web/utils/proptypes';
 import {renderYesNo} from 'web/utils/render';
@@ -89,8 +107,8 @@ import TaskComponent from './component';
 const ToolBarIcons = ({
   entity,
   links,
-  notes,
-  overrides,
+  notes = [],
+  overrides = [],
   onTaskDeleteClick,
   onTaskCloneClick,
   onTaskDownloadClick,
@@ -102,11 +120,6 @@ const ToolBarIcons = ({
   onTaskStopClick,
   onTaskResumeClick,
 }) => {
-
-  const notes_count = isDefined(notes) ? notes.counts.length : undefined;
-  const override_count = isDefined(overrides) ? overrides.counts.length :
-    undefined;
-
   return (
     <Divider margin="10px">
       <IconDivider align={['start', 'start']}>
@@ -251,7 +264,7 @@ const ToolBarIcons = ({
 
         <IconDivider>
           <Badge
-            content={notes_count}
+            content={notes.length}
           >
             <Link
               to="notes"
@@ -265,7 +278,7 @@ const ToolBarIcons = ({
           </Badge>
 
           <Badge
-            content={override_count}
+            content={overrides.length}
           >
             <Link
               to="overrides"
@@ -287,8 +300,8 @@ const ToolBarIcons = ({
 ToolBarIcons.propTypes = {
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
-  notes: PropTypes.object,
-  overrides: PropTypes.object,
+  notes: PropTypes.array,
+  overrides: PropTypes.array,
   onContainerTaskCreateClick: PropTypes.func.isRequired,
   onReportImportClick: PropTypes.func.isRequired,
   onTaskCloneClick: PropTypes.func.isRequired,
@@ -544,22 +557,36 @@ const TaskPermissions = withComponentDefaults({
   ],
 })(EntityPermissions);
 
-const task_id_filter = id => 'task_id=' + id;
+const taskIdFilter = id => Filter.fromString('task_id=' + id).all();
 
-const TaskPage = props => (
-  <EntityContainer
-    {...props}
-    name="task"
-    loaders={[
-      loader('notes', task_id_filter),
-      loader('overrides', task_id_filter),
-      permissions_resource_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const mapStateToProps = (rootState, {id}) => {
+  const permSel = permissionsSelector(rootState);
+  const notesSel = notesSelector(rootState);
+  const overridesSel = overridesSelector(rootState);
+  return {
+    notes: notesSel.getEntities(taskIdFilter(id)),
+    overrides: overridesSel.getEntities(taskIdFilter(id)),
+    permissions: permSel.getEntities(permissionsResourceFilter(id)),
+  };
+};
 
-export default TaskPage;
+const load = gmp => {
+  const loadTaskFunc = loadTask(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  const loadNotesFunc = loadNotes(gmp);
+  const loadOverridesFunc = loadOverrides(gmp);
+  return id => dispatch => {
+    dispatch(loadTaskFunc(id));
+    dispatch(loadPermissionsFunc(permissionsResourceFilter(id)));
+    dispatch(loadNotesFunc(taskIdFilter(id)));
+    dispatch(loadOverridesFunc(taskIdFilter(id)));
+  };
+};
+
+export default withEntityContainer('task', {
+  load,
+  entitySelector: taskSelector,
+  mapStateToProps,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/tasks/detailspage.js
+++ b/gsa/src/web/pages/tasks/detailspage.js
@@ -31,22 +31,6 @@ import {isDefined} from 'gmp/utils/identity';
 
 import {TARGET_CREDENTIAL_NAMES} from 'gmp/models/target';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderYesNo} from 'web/utils/render';
-import withComponentDefaults from 'web/utils/withComponentDefaults';
-
-import EntityPage from 'web/entity/page';
-import EntityPermissions from 'web/entity/permissions';
-import EntityContainer, {
-  loader,
-  permissions_resource_loader,
-} from 'web/entity/container';
-import {goto_details, goto_list} from 'web/entity/component';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
-
 import Badge from 'web/components/badge/badge';
 
 import Divider from 'web/components/layout/divider';
@@ -73,17 +57,33 @@ import TableBody from 'web/components/table/body';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
-import ImportReportIcon from 'web/pages/tasks/icons/importreporticon';
-import NewIconMenu from 'web/pages/tasks/icons/newiconmenu';
-import ResumeIcon from 'web/pages/tasks/icons/resumeicon';
-import ScheduleIcon from 'web/pages/tasks/icons/scheduleicon';
-import StartIcon from 'web/pages/tasks/icons/starticon';
-import StopIcon from 'web/pages/tasks/icons/stopicon';
-
-import TaskDetails from 'web/pages/tasks/details';
-import TaskStatus from 'web/pages/tasks/status';
-import TaskComponent from 'web/pages/tasks/component';
+import EntityPage from 'web/entity/page';
+import EntityPermissions from 'web/entity/permissions';
+import EntityContainer, {
+  loader,
+  permissions_resource_loader,
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
+import {renderYesNo} from 'web/utils/render';
+import withComponentDefaults from 'web/utils/withComponentDefaults';
+
+import ImportReportIcon from './icons/importreporticon';
+import NewIconMenu from './icons/newiconmenu';
+import ResumeIcon from './icons/resumeicon';
+import ScheduleIcon from './icons/scheduleicon';
+import StartIcon from './icons/starticon';
+import StopIcon from './icons/stopicon';
+
+import TaskDetails from './details';
+import TaskStatus from './status';
+import TaskComponent from './component';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/users/detailspage.js
+++ b/gsa/src/web/pages/users/detailspage.js
@@ -25,8 +25,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
-
 import PropTypes from '../../utils/proptypes.js';
 
 import EntityPage from '../../entity/page.js';
@@ -177,16 +175,12 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  {isDefined(tagsComponent) &&
-                    <Tab>
-                      {tagsTitle}
-                    </Tab>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <Tab>
-                      {permissionsTitle}
-                    </Tab>
-                  }
+                  <Tab>
+                    {tabsTitle}
+                  </Tab>
+                  <Tab>
+                    {permissionsTitle}
+                  </Tab>
                 </TabList>
               </TabLayout>
 
@@ -197,16 +191,12 @@ const Page = ({
                       entity={entity}
                     />
                   </TabPanel>
-                  {isDefined(tagsComponent) &&
-                    <TabPanel>
-                      {tagsComponent}
-                    </TabPanel>
-                  }
-                  {isDefined(permissionsComponent) &&
-                    <TabPanel>
-                      {permissionsComponent}
-                    </TabPanel>
-                  }
+                  <TabPanel>
+                    {tagsComponent}
+                  </TabPanel>
+                  <TabPanel>
+                    {permissionsComponent}
+                  </TabPanel>
                 </TabPanels>
               </Tabs>
             </Layout>

--- a/gsa/src/web/pages/users/detailspage.js
+++ b/gsa/src/web/pages/users/detailspage.js
@@ -148,7 +148,6 @@ const Page = ({
         {...props}
         sectionIcon="user.svg"
         title={_('User')}
-        detailsComponent={UserDetails}
         toolBarIcons={ToolBarIcons}
         onUserCloneClick={clone}
         onUserCreateClick={create}

--- a/gsa/src/web/pages/users/detailspage.js
+++ b/gsa/src/web/pages/users/detailspage.js
@@ -32,6 +32,7 @@ import EntityContainer, {
   permissions_subject_loader,
 } from '../../entity/container.js';
 import {goto_details, goto_list} from '../../entity/component.js';
+import EntitiesTab from 'web/entity/tab';
 
 import ExportIcon from '../../components/icon/exporticon.js';
 import CloneIcon from '../../entity/icon/cloneicon.js';
@@ -156,7 +157,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           tagsComponent,
-          tagsTitle,
           onActivateTab,
           entity,
           ...other
@@ -175,9 +175,9 @@ const Page = ({
                   <Tab>
                     {_('Information')}
                   </Tab>
-                  <Tab>
-                    {tabsTitle}
-                  </Tab>
+                  <EntitiesTab entities={entity.userTags}>
+                    {_('User Tags')}
+                  </EntitiesTab>
                   <Tab>
                     {permissionsTitle}
                   </Tab>

--- a/gsa/src/web/pages/users/detailspage.js
+++ b/gsa/src/web/pages/users/detailspage.js
@@ -51,6 +51,7 @@ import EntityContainer, {
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
+import EntityTags from 'web/entity/tags';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -116,6 +117,13 @@ const Page = ({
   onChanged,
   onDownloaded,
   onError,
+  onTagAddClick,
+  onTagCreateClick,
+  onTagDeleteClick,
+  onTagDisableClick,
+  onTagEditClick,
+  onTagEnableClick,
+  onTagRemoveClick,
   ...props
 }) => (
   <UserComponent
@@ -156,7 +164,6 @@ const Page = ({
           activeTab = 0,
           permissionsComponent,
           permissionsTitle,
-          tagsComponent,
           onActivateTab,
           entity,
           ...other
@@ -192,7 +199,16 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {tagsComponent}
+                    <EntityTags
+                      entity={entity}
+                      onTagAddClick={onTagAddClick}
+                      onTagDeleteClick={onTagDeleteClick}
+                      onTagDisableClick={onTagDisableClick}
+                      onTagEditClick={onTagEditClick}
+                      onTagEnableClick={onTagEnableClick}
+                      onTagCreateClick={onTagCreateClick}
+                      onTagRemoveClick={onTagRemoveClick}
+                    />
                   </TabPanel>
                   <TabPanel>
                     {permissionsComponent}
@@ -211,6 +227,13 @@ Page.propTypes = {
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
+  onTagAddClick: PropTypes.func.isRequired,
+  onTagCreateClick: PropTypes.func.isRequired,
+  onTagDeleteClick: PropTypes.func.isRequired,
+  onTagDisableClick: PropTypes.func.isRequired,
+  onTagEditClick: PropTypes.func.isRequired,
+  onTagEnableClick: PropTypes.func.isRequired,
+  onTagRemoveClick: PropTypes.func.isRequired,
 };
 
 const UserPage = props => (

--- a/gsa/src/web/pages/users/detailspage.js
+++ b/gsa/src/web/pages/users/detailspage.js
@@ -114,6 +114,7 @@ ToolBarIcons.propTypes = {
 };
 
 const Page = ({
+  entity,
   onChanged,
   onDownloaded,
   onError,
@@ -146,6 +147,7 @@ const Page = ({
     }) => (
       <EntityPage
         {...props}
+        entity={entity}
         sectionIcon="user.svg"
         title={_('User')}
         toolBarIcons={ToolBarIcons}
@@ -164,8 +166,6 @@ const Page = ({
           permissionsComponent,
           permissionsTitle,
           onActivateTab,
-          entity,
-          ...other
         }) => {
           return (
             <Layout grow="1" flex="column">
@@ -223,6 +223,7 @@ const Page = ({
 );
 
 Page.propTypes = {
+  entity: PropTypes.model,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/users/detailspage.js
+++ b/gsa/src/web/pages/users/detailspage.js
@@ -25,37 +25,37 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from '../../utils/proptypes.js';
+import ExportIcon from 'web/components/icon/exporticon';
+import CloneIcon from 'web/entity/icon/cloneicon';
+import CreateIcon from 'web/entity/icon/createicon';
+import EditIcon from 'web/entity/icon/editicon';
+import DeleteIcon from 'web/entity/icon/deleteicon';
 
-import EntityPage from '../../entity/page.js';
+import ManualIcon from 'web/components/icon/manualicon';
+import ListIcon from 'web/components/icon/listicon';
+
+import Divider from 'web/components/layout/divider';
+import IconDivider from 'web/components/layout/icondivider';
+import Layout from 'web/components/layout/layout';
+
+import Tab from 'web/components/tab/tab';
+import TabLayout from 'web/components/tab/tablayout';
+import TabList from 'web/components/tab/tablist';
+import TabPanel from 'web/components/tab/tabpanel';
+import TabPanels from 'web/components/tab/tabpanels';
+import Tabs from 'web/components/tab/tabs';
+
+import EntityPage from 'web/entity/page';
 import EntityContainer, {
   permissions_subject_loader,
-} from '../../entity/container.js';
-import {goto_details, goto_list} from '../../entity/component.js';
+} from 'web/entity/container';
+import {goto_details, goto_list} from 'web/entity/component';
 import EntitiesTab from 'web/entity/tab';
 
-import ExportIcon from '../../components/icon/exporticon.js';
-import CloneIcon from '../../entity/icon/cloneicon.js';
-import CreateIcon from '../../entity/icon/createicon.js';
-import EditIcon from '../../entity/icon/editicon.js';
-import DeleteIcon from '../../entity/icon/deleteicon.js';
+import PropTypes from 'web/utils/proptypes';
 
-import ManualIcon from '../../components/icon/manualicon.js';
-import ListIcon from '../../components/icon/listicon.js';
-
-import Divider from '../../components/layout/divider.js';
-import IconDivider from '../../components/layout/icondivider.js';
-import Layout from '../../components/layout/layout.js';
-
-import Tab from '../../components/tab/tab.js';
-import TabLayout from '../../components/tab/tablayout.js';
-import TabList from '../../components/tab/tablist.js';
-import TabPanel from '../../components/tab/tabpanel.js';
-import TabPanels from '../../components/tab/tabpanels.js';
-import Tabs from '../../components/tab/tabs.js';
-
-import UserComponent from './component.js';
-import UserDetails from './details.js';
+import UserComponent from './component';
+import UserDetails from './details';
 
 const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/users/detailspage.js
+++ b/gsa/src/web/pages/users/detailspage.js
@@ -50,6 +50,7 @@ import EntityContainer, {
   permissions_subject_loader,
 } from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
+import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 
@@ -115,6 +116,7 @@ ToolBarIcons.propTypes = {
 
 const Page = ({
   entity,
+  permissions = [],
   onChanged,
   onDownloaded,
   onError,
@@ -157,14 +159,9 @@ const Page = ({
         onUserDownloadClick={download}
         onUserEditClick={edit}
         onUserSaveClick={save}
-        onPermissionChanged={onChanged}
-        onPermissionDownloaded={onDownloaded}
-        onPermissionDownloadError={onError}
       >
         {({
           activeTab = 0,
-          permissionsComponent,
-          permissionsTitle,
           onActivateTab,
         }) => {
           return (
@@ -184,9 +181,9 @@ const Page = ({
                   <EntitiesTab entities={entity.userTags}>
                     {_('User Tags')}
                   </EntitiesTab>
-                  <Tab>
-                    {permissionsTitle}
-                  </Tab>
+                  <EntitiesTab entities={permissions}>
+                    {_('Permissions')}
+                  </EntitiesTab>
                 </TabList>
               </TabLayout>
 
@@ -210,7 +207,13 @@ const Page = ({
                     />
                   </TabPanel>
                   <TabPanel>
-                    {permissionsComponent}
+                    <EntityPermissions
+                      entity={entity}
+                      permissions={permissions}
+                      onChanged={onChanged}
+                      onDownloaded={onDownloaded}
+                      onError={onError}
+                    />
                   </TabPanel>
                 </TabPanels>
               </Tabs>
@@ -224,6 +227,7 @@ const Page = ({
 
 Page.propTypes = {
   entity: PropTypes.model,
+  permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/users/detailspage.js
+++ b/gsa/src/web/pages/users/detailspage.js
@@ -46,13 +46,23 @@ import TabPanels from 'web/components/tab/tabpanels';
 import Tabs from 'web/components/tab/tabs';
 
 import EntityPage from 'web/entity/page';
-import EntityContainer, {
-  permissions_subject_loader,
-} from 'web/entity/container';
 import {goto_details, goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
+import withEntityContainer, {
+  permissionsSubjectFilter,
+} from 'web/entity/withEntityContainer';
+
+import {
+  selector,
+  loadEntity,
+} from 'web/store/entities/users';
+
+import {
+  selector as permissionsSelector,
+  loadEntities as loadPermissions,
+} from 'web/store/entities/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -240,18 +250,26 @@ Page.propTypes = {
   onTagRemoveClick: PropTypes.func.isRequired,
 };
 
-const UserPage = props => (
-  <EntityContainer
-    {...props}
-    name="user"
-    loaders={[
-      permissions_subject_loader,
-    ]}
-  >
-    {cprops => <Page {...props} {...cprops} />}
-  </EntityContainer>
-);
+const load = gmp => {
+  const loadEntityFunc = loadEntity(gmp);
+  const loadPermissionsFunc = loadPermissions(gmp);
+  return id => dispatch => {
+    dispatch(loadEntityFunc(id));
+    dispatch(loadPermissionsFunc(permissionsSubjectFilter(id)));
+  };
+};
 
-export default UserPage;
+const mapStateToProps = (rootState, {id}) => {
+  const permissionsSel = permissionsSelector(rootState);
+  return {
+    permissions: permissionsSel.getEntities(permissionsSubjectFilter(id)),
+  };
+};
+
+export default withEntityContainer('user', {
+  entitySelector: selector,
+  load,
+  mapStateToProps,
+})(Page);
 
 // vim: set ts=2 sw=2 tw=80:


### PR DESCRIPTION
Refactor all entity detail pages. Simplify EntityContainer and EntityPage components and do a lot more rendering at the detail pages directly. This should also improve the readability and to find the original of a prop.