### PR TITLE
[gsa-7.0] make the build reproducible (pulled from downstream)

### DIFF
--- a/tools/generate-cpe-icon-dict.sh
+++ b/tools/generate-cpe-icon-dict.sh
@@ -152,4 +152,5 @@ else
 fi
 
 # Close root element
-echo "\n</cpe_icon_dict>"
+echo
+echo "</cpe_icon_dict>"

--- a/tools/generate-zone-dict.sh
+++ b/tools/generate-zone-dict.sh
@@ -98,7 +98,7 @@ else
 fi
 
 echo "  <!-- Generated. -->"
-sed '/^\#/d' /usr/share/zoneinfo/zone.tab | cut -s -f 3 | sort | sed -e "s;\(.*\);  <zone><name>\1</name></zone>;"
+sed '/^\#/d' /usr/share/zoneinfo/zone.tab | cut -s -f 3 | LC_ALL=C sort | sed -e "s;\(.*\);  <zone><name>\1</name></zone>;"
 
 # Append manual zones.
 if [ -r "$APPEND_FILE" ]


### PR DESCRIPTION
Pulled the patch from https://sources.debian.org/patches/greenbone-security-assistant/7.0.3+dfsg.1-1/0001-make-the-build-reproducible.patch/ to make the build reproducible.

Rationale:

> One shell script does not normalize the locale while sorting, and
another one relies on echo interpreting escape sequences by default.
> 
> https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=843110