### PR TITLE
Don't show external link dialog when clicking on greenbone.net link

### DIFF
--- a/gsa/src/web/pages/help/about.js
+++ b/gsa/src/web/pages/help/about.js
@@ -83,11 +83,13 @@ const About = () => (
           </DivP>
           <DivP>
             Copyright 2009-2018 by&nbsp;
-            <ExternalLink
-              to="https://www.greenbone.net"
+            <a
+              href="https://www.greenbone.net"
+              target="_blank"
+              rel="noopener noreferrer"
             >
               Greenbone Networks GmbH
-            </ExternalLink>
+            </a>
           </DivP>
           <DivP>
             License: GNU General Public License version 2 or any later version


### PR DESCRIPTION
Greenbone clearly does endorse the content of greenbone.net so it is 
unsuitable to show such a dialog.