### PR TITLE
Add Yarn offline mode option.

### DIFF
--- a/gsa/CMakeLists.txt
+++ b/gsa/CMakeLists.txt
@@ -42,6 +42,10 @@ if (NOT YARN_FOUND)
 else (NOT YARN_FOUND)
   message (STATUS "Found Yarn: ${YARN_EXECUTABLE}")
   set (INSTALLER ${YARN_EXECUTABLE})
+  if (YARN_OFFLINE)
+    set (YARN_OFFLINE "--offline")
+    MESSAGE( STATUS "Using Yarn in offline mode")
+  endif (YARN_OFFLINE)
   list (APPEND GSA_PKG_FILES ${GSA_SRC_DIR}/yarn.lock)
 endif (NOT YARN_FOUND)
 
@@ -859,14 +863,14 @@ set (GSA_FILES
 
 add_custom_command (OUTPUT node-modules.stamp
                     DEPENDS ${GSA_PKG_FILES}
-                    COMMAND ${INSTALLER} "install"
+                    COMMAND ${INSTALLER} "${YARN_OFFLINE}" "install"
                     COMMAND cmake -E touch ${CMAKE_CURRENT_BINARY_DIR}/node-modules.stamp
                     WORKING_DIRECTORY ${GSA_SRC_DIR}
                     COMMENT "Install gsa-ng js dependencies")
 
 
 add_custom_command (OUTPUT bundle.stamp
-                    COMMAND ${INSTALLER} run build
+                    COMMAND ${INSTALLER} "${YARN_OFFLINE}" run build
                     COMMAND cmake -E touch ${CMAKE_CURRENT_BINARY_DIR}/bundle.stamp
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     DEPENDS  ${CMAKE_CURRENT_BINARY_DIR}/node-modules.stamp

--- a/gsa/CMakeLists.txt
+++ b/gsa/CMakeLists.txt
@@ -864,14 +864,14 @@ set (GSA_FILES
 add_custom_command (OUTPUT node-modules.stamp
                     DEPENDS ${GSA_PKG_FILES}
                     COMMAND ${INSTALLER} "${INSTALLER_ARGS}" "install"
-                    COMMAND cmake -E touch ${CMAKE_CURRENT_BINARY_DIR}/node-modules.stamp
+                    COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/node-modules.stamp
                     WORKING_DIRECTORY ${GSA_SRC_DIR}
                     COMMENT "Install gsa-ng js dependencies")
 
 
 add_custom_command (OUTPUT bundle.stamp
                     COMMAND ${INSTALLER} "${INSTALLER_ARGS}" run build
-                    COMMAND cmake -E touch ${CMAKE_CURRENT_BINARY_DIR}/bundle.stamp
+                    COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/bundle.stamp
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     DEPENDS  ${CMAKE_CURRENT_BINARY_DIR}/node-modules.stamp
                              ${GSA_PKG_FILES}

--- a/gsa/CMakeLists.txt
+++ b/gsa/CMakeLists.txt
@@ -43,7 +43,7 @@ else (NOT YARN_FOUND)
   message (STATUS "Found Yarn: ${YARN_EXECUTABLE}")
   set (INSTALLER ${YARN_EXECUTABLE})
   if (YARN_OFFLINE)
-    set (YARN_OFFLINE "--offline")
+    set (INSTALLER_ARGS "--offline")
     MESSAGE( STATUS "Using Yarn in offline mode")
   endif (YARN_OFFLINE)
   list (APPEND GSA_PKG_FILES ${GSA_SRC_DIR}/yarn.lock)
@@ -863,14 +863,14 @@ set (GSA_FILES
 
 add_custom_command (OUTPUT node-modules.stamp
                     DEPENDS ${GSA_PKG_FILES}
-                    COMMAND ${INSTALLER} "${YARN_OFFLINE}" "install"
+                    COMMAND ${INSTALLER} "${INSTALLER_ARGS}" "install"
                     COMMAND cmake -E touch ${CMAKE_CURRENT_BINARY_DIR}/node-modules.stamp
                     WORKING_DIRECTORY ${GSA_SRC_DIR}
                     COMMENT "Install gsa-ng js dependencies")
 
 
 add_custom_command (OUTPUT bundle.stamp
-                    COMMAND ${INSTALLER} "${YARN_OFFLINE}" run build
+                    COMMAND ${INSTALLER} "${INSTALLER_ARGS}" run build
                     COMMAND cmake -E touch ${CMAKE_CURRENT_BINARY_DIR}/bundle.stamp
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     DEPENDS  ${CMAKE_CURRENT_BINARY_DIR}/node-modules.stamp


### PR DESCRIPTION
This will be needed, to build it without internet connection.
In this case all needed npm packages can be preloaded into the yarn cache.