### PR TITLE
Logging configuration

### DIFF
--- a/gsa/public/config.js
+++ b/gsa/public/config.js
@@ -1,3 +1,2 @@
 config = {
-  loglevel: 'warn',
 };

--- a/gsa/src/gmp/__tests__/gmpsettings.js
+++ b/gsa/src/gmp/__tests__/gmpsettings.js
@@ -24,6 +24,7 @@ import GmpSettings, {
   DEFAULT_MANUAL_URL,
   DEFAULT_RELOAD_INTERVAL,
   DEFAULT_PROTOCOLDOC_URL,
+  DEFAULT_LOG_LEVEL,
 } from 'gmp/gmpsettings';
 
 const createStorage = state => {
@@ -40,6 +41,7 @@ describe('GmpSettings tests', () => {
   test('should init with defaults', () => {
     const storage = createStorage();
     const settings = new GmpSettings(storage);
+    expect(settings.loglevel).toEqual(DEFAULT_LOG_LEVEL);
     expect(settings.reloadinterval).toEqual(DEFAULT_RELOAD_INTERVAL);
     expect(settings.locale).toBeUndefined();
     expect(settings.manualurl).toEqual(DEFAULT_MANUAL_URL);
@@ -51,7 +53,8 @@ describe('GmpSettings tests', () => {
     expect(settings.timezone).toBeUndefined();
     expect(settings.username).toBeUndefined();
 
-    expect(storage.setItem).toHaveBeenCalledTimes(0);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).toHaveBeenCalledWith('loglevel', DEFAULT_LOG_LEVEL);
   });
 
   test('should init with passed options', () => {
@@ -59,6 +62,7 @@ describe('GmpSettings tests', () => {
     const settings = new GmpSettings(storage, {
       reloadinterval: 10,
       locale: 'en',
+      loglevel: 'error',
       manualurl: 'http://manual',
       protocol: 'http',
       protocoldocurl: 'http://protocol',
@@ -79,8 +83,10 @@ describe('GmpSettings tests', () => {
     expect(settings.timeout).toEqual(30000);
     expect(settings.timezone).toBeUndefined();
     expect(settings.username).toBeUndefined();
+    expect(settings.loglevel).toEqual('error');
 
-    expect(storage.setItem).toHaveBeenCalledTimes(0);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).toHaveBeenCalledWith('loglevel', 'error');
   });
 
   test('should init from store', () => {
@@ -89,6 +95,7 @@ describe('GmpSettings tests', () => {
       token: 'atoken',
       timezone: 'cet',
       username: 'foo',
+      loglevel: 'error',
     });
 
     const settings = new GmpSettings(storage, {
@@ -108,8 +115,10 @@ describe('GmpSettings tests', () => {
     expect(settings.timeout).toBeUndefined();
     expect(settings.timezone).toEqual('cet');
     expect(settings.username).toEqual('foo');
+    expect(settings.loglevel).toEqual('error');
 
-    expect(storage.setItem).toHaveBeenCalledTimes(0);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).toHaveBeenCalledWith('loglevel', 'error');
   });
 
   test('should ensure options override settings from storage', () => {
@@ -124,6 +133,7 @@ describe('GmpSettings tests', () => {
       timeout: 10000,
       timezone: 'cest',
       username: 'bar',
+      loglevel: 'error',
     });
 
     const settings = new GmpSettings(storage, {
@@ -137,6 +147,7 @@ describe('GmpSettings tests', () => {
       timeout: 30000,
       timezone: 'cet',
       username: 'foo',
+      loglevel: 'debug',
     });
 
     expect(settings.reloadinterval).toEqual(10);
@@ -149,8 +160,10 @@ describe('GmpSettings tests', () => {
     expect(settings.timeout).toEqual(30000);
     expect(settings.timezone).toEqual('cest');
     expect(settings.username).toEqual('bar');
+    expect(settings.loglevel).toEqual('debug');
 
-    expect(storage.setItem).toHaveBeenCalledTimes(0);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).toHaveBeenCalledWith('loglevel', 'debug');
   });
 
   test('should delete settings from storage', () => {
@@ -159,6 +172,7 @@ describe('GmpSettings tests', () => {
       token: 'atoken',
       timezone: 'cet',
       username: 'foo',
+      loglevel: 'error',
     });
 
     const settings = new GmpSettings(storage, {});
@@ -167,8 +181,10 @@ describe('GmpSettings tests', () => {
     expect(settings.token).toEqual('atoken');
     expect(settings.timezone).toEqual('cet');
     expect(settings.username).toEqual('foo');
+    expect(settings.loglevel).toEqual('error');
 
-    expect(storage.setItem).toHaveBeenCalledTimes(0);
+    expect(storage.setItem).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).toHaveBeenCalledWith('loglevel', 'error');
 
     settings.locale = undefined;
     expect(storage.removeItem).toBeCalledWith('locale');
@@ -181,6 +197,9 @@ describe('GmpSettings tests', () => {
 
     settings.username = undefined;
     expect(storage.removeItem).toBeCalledWith('username');
+
+    settings.loglevel = undefined;
+    expect(storage.removeItem).toBeCalledWith('loglevel');
   });
 
 });

--- a/gsa/src/gmp/__tests__/log.js
+++ b/gsa/src/gmp/__tests__/log.js
@@ -1,0 +1,307 @@
+/* Greenbone Security Assistant
+ *
+ * Authors:
+ * Björn Ricks <bjoern.ricks@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2018 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import {
+  RootLogger,
+  DEFAULT_LOG_LEVEL,
+  LogLevels,
+} from '../log.js';
+import {isFunction} from 'util';
+
+let origConsole;
+let testConsole;
+
+const getRootLogger = () => new RootLogger();
+
+describe('log tests', () => {
+
+  beforeEach(() => {
+    origConsole = global.console;
+    testConsole = {
+      error: jest.fn(),
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+      trace: jest.fn(),
+    };
+
+    global.console = testConsole;
+  });
+
+  afterEach(() => {
+    global.console = origConsole;
+  });
+
+  test('should init with defaults', () => {
+    const logger = getRootLogger();
+    expect(logger.level).toEqual(DEFAULT_LOG_LEVEL);
+  });
+
+  test('should init loglevel', () => {
+    const logger = getRootLogger();
+    expect(logger.init({loglevel: 'error'})).toEqual(true);
+    expect(logger.level).toEqual('error');
+  });
+
+  test('should ignore unknown loglevel in init', () => {
+    const logger = getRootLogger();
+    expect(logger.init({loglevel: 'foo'})).toEqual(false);
+    expect(logger.level).toEqual(DEFAULT_LOG_LEVEL);
+  });
+
+  test('should return new logger', () => {
+    const logger = getRootLogger();
+    const newLogger = logger.getLogger('foo.bar');
+
+    expect(newLogger).toBeDefined();
+
+    expect(isFunction(newLogger.error)).toEqual(true);
+    expect(isFunction(newLogger.warn)).toEqual(true);
+    expect(isFunction(newLogger.info)).toEqual(true);
+    expect(isFunction(newLogger.debug)).toEqual(true);
+    expect(isFunction(newLogger.trace)).toEqual(true);
+    expect(newLogger.silent).toBeUndefined();
+    expect(isFunction(newLogger.setLevel)).toEqual(true);
+    expect(isFunction(newLogger.setDefaultLevel)).toEqual(true);
+    expect(newLogger.defaultLogValue).toEqual(LogLevels.error);
+  });
+
+  test('should setDefaultLogLevel', () => {
+    const logger = getRootLogger();
+    expect(logger.init({loglevel: 'error'})).toEqual(true);
+    expect(logger.level).toEqual('error');
+
+    const newLogger = logger.getLogger('foo.bar');
+    expect(newLogger.defaultLogValue).toEqual(LogLevels.error);
+
+    expect(logger.setDefaultLevel('debug')).toEqual(true);
+    expect(newLogger.defaultLogValue).toEqual(LogLevels.debug);
+  });
+
+  test('should ignore unkown levels in setDefaultLogLevel', () => {
+    const logger = getRootLogger();
+    expect(logger.init({loglevel: 'error'})).toEqual(true);
+    expect(logger.level).toEqual('error');
+
+    const newLogger = logger.getLogger('foo.bar');
+    expect(newLogger.defaultLogValue).toEqual(LogLevels.error);
+
+    expect(logger.setDefaultLevel('foo')).toEqual(false);
+    expect(newLogger.defaultLogValue).toEqual(LogLevels.error);
+  });
+
+  test('should return same logger instance for the same name', () => {
+    const logger = getRootLogger();
+    const newLogger = logger.getLogger('foo.bar');
+    expect(newLogger).toBeDefined();
+
+    const anotherLogger = logger.getLogger('foo.bar');
+    expect(anotherLogger).toBeDefined();
+
+    expect(anotherLogger).toBe(newLogger);
+  });
+
+  test('should allow to set level on logger', () => {
+    const logger = getRootLogger();
+    expect(logger.init({loglevel: 'error'})).toEqual(true);
+
+    const newLogger = logger.getLogger('foo.bar');
+    expect(newLogger.defaultLogValue).toEqual(LogLevels.error);
+    expect(isFunction(newLogger.setLevel)).toEqual(true);
+
+    newLogger.setLevel('debug');
+    expect(newLogger.logValue).toEqual(LogLevels.debug);
+  });
+
+  test('should set loglevel to silent for unknown loglevels', () => {
+    const logger = getRootLogger();
+    expect(logger.init({loglevel: 'error'})).toEqual(true);
+
+    const newLogger = logger.getLogger('foo.bar');
+    expect(newLogger.defaultLogValue).toEqual(LogLevels.error);
+    expect(isFunction(newLogger.setLevel)).toEqual(true);
+
+    newLogger.setLevel('foo');
+    expect(testConsole.error).toHaveBeenCalled();
+    expect(newLogger.logValue).toEqual(LogLevels.silent);
+  });
+
+  test('should log debug when level changes', () => {
+    const logger = getRootLogger();
+    const newLogger = logger.getLogger('foo.bar');
+    newLogger.setLevel('error');
+    expect(newLogger.logValue).toEqual(LogLevels.error);
+
+    expect(testConsole.trace).not.toHaveBeenCalled();
+    newLogger.trace('foo');
+    expect(testConsole.trace).not.toHaveBeenCalled();
+
+    expect(testConsole.debug).not.toHaveBeenCalled();
+    newLogger.debug('foo');
+    expect(testConsole.debug).not.toHaveBeenCalled();
+
+    expect(testConsole.info).not.toHaveBeenCalled();
+    newLogger.info('foo');
+    expect(testConsole.info).not.toHaveBeenCalled();
+
+    expect(testConsole.warn).not.toHaveBeenCalled();
+    newLogger.warn('foo');
+    expect(testConsole.warn).not.toHaveBeenCalled();
+
+    expect(testConsole.error).not.toHaveBeenCalled();
+    newLogger.error('foo');
+    expect(testConsole.error).toHaveBeenCalled();
+
+    newLogger.setLevel('debug');
+
+    expect(testConsole.trace).not.toHaveBeenCalled();
+    newLogger.trace('foo');
+    expect(testConsole.trace).not.toHaveBeenCalled();
+
+    expect(testConsole.debug).not.toHaveBeenCalled();
+    newLogger.debug('foo');
+    expect(testConsole.debug).toHaveBeenCalled();
+
+    expect(testConsole.info).not.toHaveBeenCalled();
+    newLogger.info('foo');
+    expect(testConsole.info).toHaveBeenCalled();
+
+    expect(testConsole.warn).not.toHaveBeenCalled();
+    newLogger.warn('foo');
+    expect(testConsole.warn).toHaveBeenCalled();
+
+    expect(testConsole.error).toHaveBeenCalledTimes(1);
+    newLogger.error('foo');
+    expect(testConsole.error).toHaveBeenCalledTimes(2);
+  });
+
+  test('should log debug when default level changes', () => {
+    const logger = getRootLogger();
+    expect(logger.init({loglevel: 'error'})).toEqual(true);
+
+    const newLogger = logger.getLogger('foo.bar');
+    expect(newLogger.logValue).toBeUndefined();
+    expect(newLogger.defaultLogValue).toEqual(LogLevels.error);
+
+    expect(testConsole.trace).not.toHaveBeenCalled();
+    newLogger.trace('foo');
+    expect(testConsole.trace).not.toHaveBeenCalled();
+
+    expect(testConsole.debug).not.toHaveBeenCalled();
+    newLogger.debug('foo');
+    expect(testConsole.debug).not.toHaveBeenCalled();
+
+    expect(testConsole.info).not.toHaveBeenCalled();
+    newLogger.info('foo');
+    expect(testConsole.info).not.toHaveBeenCalled();
+
+    expect(testConsole.warn).not.toHaveBeenCalled();
+    newLogger.warn('foo');
+    expect(testConsole.warn).not.toHaveBeenCalled();
+
+    expect(testConsole.error).not.toHaveBeenCalled();
+    newLogger.error('foo');
+    expect(testConsole.error).toHaveBeenCalled();
+
+    logger.setDefaultLevel('debug');
+    expect(newLogger.logValue).toBeUndefined();
+    expect(newLogger.defaultLogValue).toEqual(LogLevels.debug);
+
+    expect(testConsole.trace).not.toHaveBeenCalled();
+    newLogger.trace('foo');
+    expect(testConsole.trace).not.toHaveBeenCalled();
+
+    expect(testConsole.debug).not.toHaveBeenCalled();
+    newLogger.debug('foo');
+    expect(testConsole.debug).toHaveBeenCalled();
+
+    expect(testConsole.info).not.toHaveBeenCalled();
+    newLogger.info('foo');
+    expect(testConsole.info).toHaveBeenCalled();
+
+    expect(testConsole.warn).not.toHaveBeenCalled();
+    newLogger.warn('foo');
+    expect(testConsole.warn).toHaveBeenCalled();
+
+    expect(testConsole.error).toHaveBeenCalledTimes(1);
+    newLogger.error('foo');
+    expect(testConsole.error).toHaveBeenCalledTimes(2);
+  });
+
+  test('should not override level if default level changes', () => {
+    const logger = getRootLogger();
+    expect(logger.init({loglevel: 'error'})).toEqual(true);
+
+    const newLogger = logger.getLogger('foo.bar');
+    newLogger.setLevel('error');
+
+    expect(newLogger.logValue).toEqual(LogLevels.error);
+    expect(newLogger.defaultLogValue).toEqual(LogLevels.error);
+
+    expect(testConsole.trace).not.toHaveBeenCalled();
+    newLogger.trace('foo');
+    expect(testConsole.trace).not.toHaveBeenCalled();
+
+    expect(testConsole.debug).not.toHaveBeenCalled();
+    newLogger.debug('foo');
+    expect(testConsole.debug).not.toHaveBeenCalled();
+
+    expect(testConsole.info).not.toHaveBeenCalled();
+    newLogger.info('foo');
+    expect(testConsole.info).not.toHaveBeenCalled();
+
+    expect(testConsole.warn).not.toHaveBeenCalled();
+    newLogger.warn('foo');
+    expect(testConsole.warn).not.toHaveBeenCalled();
+
+    expect(testConsole.error).not.toHaveBeenCalled();
+    newLogger.error('foo');
+    expect(testConsole.error).toHaveBeenCalled();
+
+    logger.setDefaultLevel('debug');
+    expect(newLogger.logValue).toEqual(LogLevels.error);
+    expect(newLogger.defaultLogValue).toEqual(LogLevels.debug);
+
+    expect(testConsole.trace).not.toHaveBeenCalled();
+    newLogger.trace('foo');
+    expect(testConsole.trace).not.toHaveBeenCalled();
+
+    expect(testConsole.debug).not.toHaveBeenCalled();
+    newLogger.debug('foo');
+    expect(testConsole.debug).not.toHaveBeenCalled();
+
+    expect(testConsole.info).not.toHaveBeenCalled();
+    newLogger.info('foo');
+    expect(testConsole.info).not.toHaveBeenCalled();
+
+    expect(testConsole.warn).not.toHaveBeenCalled();
+    newLogger.warn('foo');
+    expect(testConsole.warn).not.toHaveBeenCalled();
+
+    expect(testConsole.error).toHaveBeenCalledTimes(1);
+    newLogger.error('foo');
+    expect(testConsole.error).toHaveBeenCalledTimes(2);
+  });
+
+});
+
+// vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/gmp/gmp.js
+++ b/gsa/src/gmp/gmp.js
@@ -79,27 +79,28 @@ import GmpSettings from './gmpsettings';
 
 const log = logger.getLogger('gmp');
 
-
 class Gmp {
 
   constructor(options = {}) {
     const {
-      reloadinterval,
+      loglevel,
+      manualurl,
       protocol,
+      protocoldocurl,
+      reloadinterval,
       server,
       storage,
-      manualurl,
-      protocoldocurl,
       timeout,
     } = options;
 
     log.debug('Using gmp options', options);
 
     this.settings = new GmpSettings(storage, {
-      reloadinterval,
+      loglevel,
       manualurl,
       protocol,
       protocoldocurl,
+      reloadinterval,
       server,
       timeout,
     });

--- a/gsa/src/gmp/gmp.js
+++ b/gsa/src/gmp/gmp.js
@@ -93,8 +93,6 @@ class Gmp {
       timeout,
     } = options;
 
-    log.debug('Using gmp options', options);
-
     this.settings = new GmpSettings(storage, {
       loglevel,
       manualurl,
@@ -104,6 +102,10 @@ class Gmp {
       server,
       timeout,
     });
+
+    logger.init(this.settings);
+
+    log.debug('Using gmp options', options);
 
     this.http = new GmpHttp(this.settings);
 

--- a/gsa/src/gmp/gmp.js
+++ b/gsa/src/gmp/gmp.js
@@ -107,6 +107,8 @@ class Gmp {
 
     log.debug('Using gmp options', options);
 
+    this.log = logger;
+
     this.http = new GmpHttp(this.settings);
 
     this._login = new LoginCommand(this.http);

--- a/gsa/src/gmp/gmpsettings.js
+++ b/gsa/src/gmp/gmpsettings.js
@@ -26,6 +26,7 @@ export const DEFAULT_RELOAD_INTERVAL = 15 * 1000; // fifteen seconds
 export const DEFAULT_MANUAL_URL = 'http://docs.greenbone.net/GSM-Manual/gos-4/';
 export const DEFAULT_PROTOCOLDOC_URL =
   'http://docs.greenbone.net/API/OMP/omp-7.0.html';
+export const DEFAULT_LOG_LEVEL = 'warn';
 
 const set = (storage, name, value) => {
   if (isDefined(value)) {
@@ -39,19 +40,21 @@ const set = (storage, name, value) => {
 class GmpSettings {
   constructor(storage = global.localStorage, options = {}) {
     const {
-      reloadinterval = DEFAULT_RELOAD_INTERVAL,
+      loglevel = storage.loglevel,
       manualurl = DEFAULT_MANUAL_URL,
       protocol = global.location.protocol,
       protocoldocurl = DEFAULT_PROTOCOLDOC_URL,
+      reloadinterval = DEFAULT_RELOAD_INTERVAL,
       server = global.location.host,
       timeout,
     } = {...options};
     this.storage = storage;
 
-    this.reloadinterval = reloadinterval;
+    this.loglevel = isDefined(loglevel) ? loglevel : DEFAULT_LOG_LEVEL;
     this.manualurl = manualurl;
     this.protocol = protocol;
     this.protocoldocurl = protocoldocurl;
+    this.reloadinterval = reloadinterval;
     this.server = server;
     this.timeout = timeout;
   }
@@ -86,6 +89,14 @@ class GmpSettings {
 
   get locale() {
     return this.storage.locale;
+  }
+
+  get loglevel() {
+    return this.storage.loglevel;
+  }
+
+  set loglevel(value) {
+    set(this.storage, 'loglevel', value);
   }
 }
 


### PR DESCRIPTION
Allow runtime configuration of logging.

To change the default log level just put the following code into your browsers console:
```js
gmp.log.setDefaultLevel('debug')
```
to enable all debug output or
```js
gmp.log.setDefaultLevel('error')
```
to enable only error output.
