### PR TITLE
Use Node 8 for CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   js_test:
     working_directory: ~/gsa
     docker:
-      - image: circleci/node:6
+      - image: circleci/node:8
         environment:
           ENV: CI
     steps:
@@ -31,7 +31,7 @@ jobs:
   js_lint:
     working_directory: ~/gsa
     docker:
-      - image: circleci/node:6
+      - image: circleci/node:8
         environment:
           ENV: CI
     steps:


### PR DESCRIPTION
This commit modifies the CircleCI configuration to use the appropriate
Docker image for Node 8 for the `js_lint` and `js_test` jobs (instead of
Node 6).