### PR TITLE
Remove height CSS from bulk selection check boxes.

### DIFF
--- a/src/html/classic/omp.xsl
+++ b/src/html/classic/omp.xsl
@@ -20825,7 +20825,7 @@ should not have received it.
       <xsl:when test="/envelope/params/bulk_select = 1">
         <td style="text-align:center">
           <label style="width:100%">
-            <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%; height:100%" title="{gsa:i18n ('Select for bulk action')}"/>
+            <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%;" title="{gsa:i18n ('Select for bulk action')}"/>
           </label>
         </td>
       </xsl:when>
@@ -20942,7 +20942,7 @@ should not have received it.
         <xsl:when test="/envelope/params/bulk_select = 1">
           <td style="text-align:center" rowspan="2">
             <label style="width:100%">
-              <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%; height:100%" title="{gsa:i18n ('Select for bulk action')}"/>
+              <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%;" title="{gsa:i18n ('Select for bulk action')}"/>
             </label>
           </td>
         </xsl:when>
@@ -21055,7 +21055,7 @@ should not have received it.
       <xsl:when test="/envelope/params/bulk_select = 1">
         <td style="text-align:center">
           <label style="width:100%">
-            <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%; height:100%" title="{gsa:i18n ('Select for bulk action')}"/>
+            <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%;" title="{gsa:i18n ('Select for bulk action')}"/>
           </label>
         </td>
       </xsl:when>
@@ -21167,7 +21167,7 @@ should not have received it.
         <xsl:when test="/envelope/params/bulk_select = 1">
           <td style="text-align:center" rowspan="2">
             <label style="width:100%">
-              <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%; height:100%" title="{gsa:i18n ('Select for bulk action')}"/>
+              <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%;" title="{gsa:i18n ('Select for bulk action')}"/>
             </label>
           </td>
         </xsl:when>
@@ -21236,7 +21236,7 @@ should not have received it.
       <xsl:when test="/envelope/params/bulk_select = 1">
         <td style="text-align:center">
           <label style="width:100%">
-            <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%; height:100%" title="{gsa:i18n ('Select for bulk action')}"/>
+            <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%;" title="{gsa:i18n ('Select for bulk action')}"/>
           </label>
         </td>
       </xsl:when>
@@ -21290,7 +21290,7 @@ should not have received it.
       <xsl:when test="/envelope/params/bulk_select = 1">
         <td style="text-align:center">
           <label style="width:100%">
-            <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%; height:100%" title="{gsa:i18n ('Select for bulk action')}"/>
+            <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%;" title="{gsa:i18n ('Select for bulk action')}"/>
           </label>
         </td>
       </xsl:when>
@@ -21366,7 +21366,7 @@ should not have received it.
         <xsl:when test="/envelope/params/bulk_select = 1">
           <td style="text-align:center" rowspan="2">
             <label style="width:100%">
-              <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%; height:100%" title="{gsa:i18n ('Select for bulk action')}"/>
+              <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%;" title="{gsa:i18n ('Select for bulk action')}"/>
             </label>
           </td>
         </xsl:when>
@@ -39595,7 +39595,7 @@ should not have received it.
       <xsl:when test="/envelope/params/bulk_select = 1">
         <td style="text-align:center">
           <label style="width:100%">
-            <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%; height:100%" title="{gsa:i18n ('Select for bulk action')}"/>
+            <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%;" title="{gsa:i18n ('Select for bulk action')}"/>
           </label>
         </td>
       </xsl:when>
@@ -39730,7 +39730,7 @@ should not have received it.
       <xsl:when test="/envelope/params/bulk_select = 1">
         <td style="text-align:center">
           <label style="width:100%">
-            <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%; height:100%" title="{gsa:i18n ('Select for bulk action')}"/>
+            <input name="bulk_selected:{../@id}" type="checkbox" style="width:100%;" title="{gsa:i18n ('Select for bulk action')}"/>
           </label>
         </td>
       </xsl:when>


### PR DESCRIPTION
The height CSS declaration has been removed from the inline style
because the check boxes would not appear correctly in some browsers
like Chrome.