### PR TITLE
Don't allow access to referrer and window.opener object

### DIFF
--- a/gsa/src/web/components/link/blanklink.js
+++ b/gsa/src/web/components/link/blanklink.js
@@ -33,6 +33,7 @@ const BlankLink = ({
     {...props}
     href={to}
     target="_blank"
+    rel="noopener noreferrer" // https://mathiasbynens.github.io/rel-noopener
   >
     {children}
   </a>


### PR DESCRIPTION
Don't allow external links to access the window.opener object and the
http referrer.