### PR TITLE
Don't expect anchor having a href property

### DIFF
--- a/gsa/src/web/components/form/download.js
+++ b/gsa/src/web/components/form/download.js
@@ -21,6 +21,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+/* eslint-disable jsx-a11y/anchor-is-valid */
+
 import React from 'react';
 
 import PropTypes from '../../utils/proptypes.js';


### PR DESCRIPTION
Deactivate eslint warning with next version of create-react-app (2.0).