### PR TITLE
Require yarn 1.0

### DIFF
--- a/cmake/FindYarn.cmake
+++ b/cmake/FindYarn.cmake
@@ -31,9 +31,25 @@ find_program (YARN_EXECUTABLE NAMES yarn
 
 include (FindPackageHandleStandardArgs)
 
+if (YARN_EXECUTABLE)
+  execute_process(COMMAND ${YARN_EXECUTABLE} --version
+                  OUTPUT_VARIABLE _VERSION
+                  RESULT_VARIABLE
+                  _YARN_VERSION_RESULT)
+  if (NOT _YARN_VERSION_RESULT)
+    string (REPLACE "\n" "" YARN_VERSION_STRING "${_VERSION}")
+    string (REPLACE "v" "" YARN_VERSION_STRING "${YARN_VERSION_STRING}")
+    string (REPLACE "." ";" _VERSION_LIST "${YARN_VERSION_STRING}")
+    list (GET _VERSION_LIST 0 YARN_VERSION_MAJOR)
+    list (GET _VERSION_LIST 1 YARN_VERSION_MINOR)
+    list (GET _VERSION_LIST 2 YARN_VERSION_PATCH)
+  endif ()
+endif (YARN_EXECUTABLE)
+
 find_package_handle_standard_args (Yarn
   REQUIRED_VARS YARN_EXECUTABLE
-  FAIL_MESSAGE "Could not find yarn executable. Please install yarn (see https://yarnpkg.com/)."
+  VERSION_VAR YARN_VERSION_STRING
+  FAIL_MESSAGE "Could not find yarn executable. Please install yarn (see https://yarnpkg.com/)"
 )
 
 mark_as_advanced (YARN_EXECUTABLE)

--- a/gsa/CMakeLists.txt
+++ b/gsa/CMakeLists.txt
@@ -24,7 +24,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
 find_package (Node 8.0 REQUIRED)
-find_package (Yarn QUIET)
+find_package (Yarn 1.0)
 
 set (GSA_BUILD_DIR ${CMAKE_CURRENT_SOURCE_DIR}/build)
 set (GSA_DEST_DIR ${GSAD_DATA_DIR}/web)


### PR DESCRIPTION
Versions beyond 1.0 will fail because the command shortcut `yarn install` isn't supported. It would have been possible to support versions lower then 1.0 by adjusting the package install command but yarn 1.0 is the first stable version and already more then one year old. Therefore supporting older versions doesn't make sense to me.