### PR TITLE
Dashboard improvements

### DIFF
--- a/gsa/src/web/components/dashboard/controls.js
+++ b/gsa/src/web/components/dashboard/controls.js
@@ -198,8 +198,9 @@ const mapStateToProps = (rootState, {dashboardId}) => {
 };
 
 const mapDispatchToProps = (dispatch, {gmp}) => ({
-  onResetClick: (...args) => dispatch(resetSettings(gmp)(...args)),
-  onNewDisplay: (...args) => dispatch(addDisplay(gmp)(...args)),
+  onResetClick: dashboardId => dispatch(resetSettings(gmp)(dashboardId)),
+  onNewDisplay: (dashboardId, displayId) =>
+    dispatch(addDisplay(gmp)(dashboardId, displayId)),
 });
 
 export default compose(

--- a/gsa/src/web/components/dashboard/dashboard.js
+++ b/gsa/src/web/components/dashboard/dashboard.js
@@ -36,7 +36,6 @@ import Logger from 'gmp/log';
 import {DEFAULT_ROW_HEIGHT} from 'gmp/commands/dashboards';
 
 import {isDefined} from 'gmp/utils/identity';
-import {debounce} from 'gmp/utils/event';
 import {excludeObjectProps} from 'gmp/utils/object';
 
 import {
@@ -136,17 +135,6 @@ export class Dashboard extends React.Component {
     this.handleRowResize = this.handleRowResize.bind(this);
     this.handleUpdateDisplay = this.handleUpdateDisplay.bind(this);
     this.handleRemoveDisplay = this.handleRemoveDisplay.bind(this);
-
-    this.save = debounce(this.save, 500);
-  }
-
-  static getDerivedStateFromProps(nextProps, prevState) {
-    // try to synchronize external and internal state
-    // update state items only if prop items have changed
-    return prevState.propItems === nextProps.items ? null : {
-        items: nextProps.items,
-        propItems: nextProps.items,
-      };
   }
 
   componentDidMount() {
@@ -170,7 +158,7 @@ export class Dashboard extends React.Component {
   }
 
   handleItemsChange(gridItems = []) {
-    const {items} = this.state;
+    const {items} = this.props;
 
     const displaysById = getDisplaysById(items);
 
@@ -183,7 +171,7 @@ export class Dashboard extends React.Component {
   }
 
   handleUpdateDisplay(id, props) {
-    const {items} = this.state;
+    const {items} = this.props;
 
     const rowIndex = items.findIndex(
       row => row.items.some(item => item.id === id));
@@ -208,13 +196,13 @@ export class Dashboard extends React.Component {
   }
 
   handleRemoveDisplay(id) {
-    const {items} = this.state;
+    const {items} = this.props;
 
     this.update({items: removeItem(items, id)});
   }
 
   handleRowResize(rowId, height) {
-    const {items = []} = this.state;
+    const {items = []} = this.props;
 
     const rowIndex = items.findIndex(row => row.id === rowId);
     const row = items[rowIndex];
@@ -252,7 +240,7 @@ export class Dashboard extends React.Component {
   render() {
     let {
       items,
-    } = this.state;
+    } = this.props;
     const {
       maxItemsPerRow = DEFAULT_MAX_ITEMS_PER_ROW,
       maxRows = DEFAULT_MAX_ROWS,

--- a/gsa/src/web/components/dashboard/dashboard.js
+++ b/gsa/src/web/components/dashboard/dashboard.js
@@ -146,14 +146,15 @@ export class Dashboard extends React.Component {
       maxRows = DEFAULT_MAX_ROWS,
     } = this.props;
 
+    const defaultDashboardSettings = convertDefaultDisplays(defaultDisplays);
     const defaults = {
-      ...convertDefaultDisplays(defaultDisplays),
+      ...defaultDashboardSettings,
       permittedDisplays,
       maxItemsPerRow,
       maxRows,
     };
 
-    this.props.setDefaultSettings(id, defaults);
+    this.props.setDefaultSettings(id, defaultDashboardSettings);
     this.props.loadSettings(id, defaults);
   }
 

--- a/gsa/src/web/store/dashboard/settings/__tests__/actions.js
+++ b/gsa/src/web/store/dashboard/settings/__tests__/actions.js
@@ -33,6 +33,9 @@ import {
   DASHBOARD_SETTINGS_SAVING_SUCCESS,
   DASHBOARD_SETTINGS_SAVING_ERROR,
   DASHBOARD_SETTINGS_SET_DEFAULTS,
+  DASHBOARD_SETTINGS_RESET_REQUEST,
+  DASHBOARD_SETTINGS_RESET_SUCCESS,
+  DASHBOARD_SETTINGS_RESET_ERROR,
   receivedDashboardSettings,
   requestDashboardSettings,
   receivedDashboardSettingsLoadingError,
@@ -44,6 +47,9 @@ import {
   resetSettings,
   addDisplay,
   setDashboardSettingDefaults,
+  resetDashboardSettingsRequest,
+  resetDashboardSettingsSuccess,
+  resetDashboardSettingsError,
 } from '../actions';
 
 const createRootState = (state = {byId: {}}) => ({
@@ -155,6 +161,47 @@ describe('setDashboardSettingDefaults', () => {
 
 });
 
+describe('resetDashboardSettingsRequest tests', () => {
+
+  test('should create a reset dashboard setings request action', () => {
+    const id = 'a1';
+    const settings = {
+      foo: 'bar',
+    };
+    expect(resetDashboardSettingsRequest(id, settings)).toEqual({
+      type: DASHBOARD_SETTINGS_RESET_REQUEST,
+      id,
+      settings,
+    });
+  });
+
+});
+
+describe('resetDashboardSettingsSuccess tests', () => {
+
+  test('should create a reset dashboard settings success action', () => {
+    const id = 'a1';
+    expect(resetDashboardSettingsSuccess(id)).toEqual({
+      type: DASHBOARD_SETTINGS_RESET_SUCCESS,
+      id,
+    });
+  });
+
+});
+
+describe('resetDashboardSettingsError tests', () => {
+
+  test('should create a reset dashboard settings error action', () => {
+    const id = 'a1';
+    const error = 'an error';
+    expect(resetDashboardSettingsError(id)).toEqual({
+      type: DASHBOARD_SETTINGS_RESET_ERROR,
+      id,
+      error,
+    });
+  });
+
+});
 
 describe('loadSettings tests', () => {
 

--- a/gsa/src/web/store/dashboard/settings/__tests__/actions.js
+++ b/gsa/src/web/store/dashboard/settings/__tests__/actions.js
@@ -36,9 +36,9 @@ import {
   DASHBOARD_SETTINGS_RESET_REQUEST,
   DASHBOARD_SETTINGS_RESET_SUCCESS,
   DASHBOARD_SETTINGS_RESET_ERROR,
-  receivedDashboardSettings,
-  requestDashboardSettings,
-  receivedDashboardSettingsLoadingError,
+  loadDashboardSettingsSuccess,
+  loadDashboardSettingsRequest,
+  loadDashboardSettingsError,
   saveDashboardSettingsRequest,
   saveDashboardSettingsSuccess,
   saveDashboardSettingsError,
@@ -58,12 +58,12 @@ const createRootState = (state = {byId: {}}) => ({
   },
 });
 
-describe('requestDashboardSettings tests', () => {
+describe('loadDashboardSettingsRequest tests', () => {
 
-  test('should create an action to request dashboard settings', () => {
+  test('should create a load dashboard settings request action', () => {
     const id = 'a1';
 
-    expect(requestDashboardSettings(id)).toEqual({
+    expect(loadDashboardSettingsRequest(id)).toEqual({
       id,
       type: DASHBOARD_SETTINGS_LOADING_REQUEST,
     });
@@ -71,7 +71,7 @@ describe('requestDashboardSettings tests', () => {
 
 });
 
-describe('receivedDashboardSettings tests', () => {
+describe('loadDashboardSettingsSuccess tests', () => {
 
   test('should create an action after receiving dashboard settings', () => {
     const id = 'a1';
@@ -83,7 +83,7 @@ describe('receivedDashboardSettings tests', () => {
       foo: 'bar',
     };
 
-    expect(receivedDashboardSettings(id, settings, defaultSettings)).toEqual({
+    expect(loadDashboardSettingsSuccess(id, settings, defaultSettings)).toEqual({
       settings,
       id,
       type: DASHBOARD_SETTINGS_LOADING_SUCCESS,
@@ -93,13 +93,12 @@ describe('receivedDashboardSettings tests', () => {
 
 });
 
-describe('receivedDashboardSettingsLoadingError tests', () => {
+describe('loadDashboardSettingsError tests', () => {
 
   test('should create an action to receive an error during loading', () => {
-    const error = 'An error occured';
     const id = 'a1';
-
-    expect(receivedDashboardSettingsLoadingError(id, error)).toEqual({
+    const error = 'An error occured';
+    expect(loadDashboardSettingsError(id, error)).toEqual({
       error,
       id,
       type: DASHBOARD_SETTINGS_LOADING_ERROR,

--- a/gsa/src/web/store/dashboard/settings/__tests__/actions.js
+++ b/gsa/src/web/store/dashboard/settings/__tests__/actions.js
@@ -194,7 +194,7 @@ describe('resetDashboardSettingsError tests', () => {
   test('should create a reset dashboard settings error action', () => {
     const id = 'a1';
     const error = 'an error';
-    expect(resetDashboardSettingsError(id)).toEqual({
+    expect(resetDashboardSettingsError(id, error)).toEqual({
       type: DASHBOARD_SETTINGS_RESET_ERROR,
       id,
       error,
@@ -409,7 +409,7 @@ describe('saveSettings tests', () => {
 
 });
 
-describe('resetSttings tests', () => {
+describe('resetSettings tests', () => {
 
   test('should reset settings successfully', () => {
     const id = 'a1';
@@ -440,14 +440,15 @@ describe('resetSttings tests', () => {
     expect(isFunction(resetSettings)).toEqual(true);
     return resetSettings(gmp)(id)(dispatch, getState).then(() => {
       expect(dispatch).toHaveBeenCalledTimes(2);
-      expect(dispatch.mock.calls[0]).toEqual([{
+      expect(dispatch).toHaveBeenNthCalledWith(1, {
         id,
         settings,
-        type: DASHBOARD_SETTINGS_SAVING_REQUEST,
-      }]);
-      expect(dispatch.mock.calls[1]).toEqual([{
-        type: DASHBOARD_SETTINGS_SAVING_SUCCESS,
-      }]);
+        type: DASHBOARD_SETTINGS_RESET_REQUEST,
+      });
+      expect(dispatch).toHaveBeenNthCalledWith(2, {
+        type: DASHBOARD_SETTINGS_RESET_SUCCESS,
+        id,
+      });
       expect(getState).toHaveBeenCalled();
       expect(saveSettingsPromise).toHaveBeenCalledWith(id, settings);
     });
@@ -483,15 +484,16 @@ describe('resetSttings tests', () => {
     expect(isFunction(resetSettings)).toEqual(true);
     return resetSettings(gmp)(id)(dispatch, getState).then(() => {
       expect(dispatch).toHaveBeenCalledTimes(2);
-      expect(dispatch.mock.calls[0]).toEqual([{
+      expect(dispatch).toHaveBeenNthCalledWith(1, {
         id,
         settings,
-        type: DASHBOARD_SETTINGS_SAVING_REQUEST,
-      }]);
-      expect(dispatch.mock.calls[1]).toEqual([{
-        type: DASHBOARD_SETTINGS_SAVING_ERROR,
+        type: DASHBOARD_SETTINGS_RESET_REQUEST,
+      });
+      expect(dispatch).toHaveBeenNthCalledWith(2, {
+        type: DASHBOARD_SETTINGS_RESET_ERROR,
+        id,
         error,
-      }]);
+      });
       expect(getState).toHaveBeenCalled();
       expect(saveSettingsPromise).toHaveBeenCalledWith(id, settings);
     });

--- a/gsa/src/web/store/dashboard/settings/__tests__/actions.js
+++ b/gsa/src/web/store/dashboard/settings/__tests__/actions.js
@@ -110,7 +110,7 @@ describe('receivedDashboardSettingsLoadingError tests', () => {
 
 describe('saveDashboardSettings tests', () => {
 
-  test('should create an action to save dashboard settings', () => {
+  test('should create a save dashboard settings request action', () => {
     const id = 'a1';
     const items = ['a', 'b'];
     const settings = {
@@ -124,9 +124,15 @@ describe('saveDashboardSettings tests', () => {
     });
   });
 
-  test('should create an action after dashboard settings have been saved', () => {
-    expect(savedDashboardSettings()).toEqual({
+});
+
+describe('savedDashboardSettings tests', () => {
+
+  test('should create a save dashboard settings success action', () => {
+    const id = 'a1';
+    expect(savedDashboardSettings(id)).toEqual({
       type: DASHBOARD_SETTINGS_SAVING_SUCCESS,
+      id,
     });
   });
 
@@ -134,12 +140,14 @@ describe('saveDashboardSettings tests', () => {
 
 describe('saveDashboardSettingsError tests', () => {
 
-  test('should create an action if an error has occurred during saving', () => {
+  test('should create a save dashboard setting error action', () => {
+    const id = 'a1';
     const error = 'An error';
 
-    expect(saveDashboardSettingsError(error)).toEqual({
+    expect(saveDashboardSettingsError(id, error)).toEqual({
       type: DASHBOARD_SETTINGS_SAVING_ERROR,
       error,
+      id,
     });
   });
 
@@ -354,14 +362,15 @@ describe('saveSettings tests', () => {
     expect(isFunction(saveSettings)).toEqual(true);
     return saveSettings(gmp)(id, settings)(dispatch, getState).then(() => {
       expect(dispatch).toHaveBeenCalledTimes(2);
-      expect(dispatch.mock.calls[0]).toEqual([{
+      expect(dispatch).toHaveBeenNthCalledWith(1, {
         id,
         settings,
         type: DASHBOARD_SETTINGS_SAVING_REQUEST,
-      }]);
-      expect(dispatch.mock.calls[1]).toEqual([{
+      });
+      expect(dispatch).toHaveBeenNthCalledWith(2, {
         type: DASHBOARD_SETTINGS_SAVING_SUCCESS,
-      }]);
+        id,
+      });
       expect(getState).not.toHaveBeenCalled();
       expect(saveSettingsPromise).toHaveBeenCalledWith(id, settings);
     });
@@ -393,15 +402,16 @@ describe('saveSettings tests', () => {
     expect(isFunction(saveSettings)).toEqual(true);
     return saveSettings(gmp)(id, settings)(dispatch, getState).then(() => {
       expect(dispatch).toHaveBeenCalledTimes(2);
-      expect(dispatch.mock.calls[0]).toEqual([{
+      expect(dispatch).toHaveBeenNthCalledWith(1, {
         id,
         settings,
         type: DASHBOARD_SETTINGS_SAVING_REQUEST,
-      }]);
-      expect(dispatch.mock.calls[1]).toEqual([{
+      });
+      expect(dispatch).toHaveBeenNthCalledWith(2, {
         type: DASHBOARD_SETTINGS_SAVING_ERROR,
         error,
-      }]);
+        id,
+      });
       expect(getState).not.toHaveBeenCalled();
       expect(saveSettingsPromise).toHaveBeenCalledWith(id, settings);
     });
@@ -539,14 +549,15 @@ describe('addDisplay tests', () => {
       getState).then(() => {
 
       expect(dispatch).toHaveBeenCalledTimes(2);
-      expect(dispatch.mock.calls[0]).toEqual([{
+      expect(dispatch).toHaveBeenNthCalledWith(1, {
         id: dashboardId,
         settings: expectedSettings,
         type: DASHBOARD_SETTINGS_SAVING_REQUEST,
-      }]);
-      expect(dispatch.mock.calls[1]).toEqual([{
+      });
+      expect(dispatch).toHaveBeenNthCalledWith(2, {
         type: DASHBOARD_SETTINGS_SAVING_SUCCESS,
-      }]);
+        id: dashboardId,
+      });
       expect(getState).toHaveBeenCalled();
       expect(saveSettingsPromise).toHaveBeenCalledWith(dashboardId, expectedSettings);
     });
@@ -700,15 +711,16 @@ describe('addDisplay tests', () => {
       getState).then(() => {
 
       expect(dispatch).toHaveBeenCalledTimes(2);
-      expect(dispatch.mock.calls[0]).toEqual([{
+      expect(dispatch).toHaveBeenNthCalledWith(1, {
         id: dashboardId,
         settings: expectedSettings,
         type: DASHBOARD_SETTINGS_SAVING_REQUEST,
-      }]);
-      expect(dispatch.mock.calls[1]).toEqual([{
+      });
+      expect(dispatch).toHaveBeenNthCalledWith(2, {
         type: DASHBOARD_SETTINGS_SAVING_ERROR,
         error,
-      }]);
+        id: dashboardId,
+      });
       expect(getState).toHaveBeenCalled();
       expect(saveSettingsPromise).toHaveBeenCalledWith(dashboardId, expectedSettings);
     });

--- a/gsa/src/web/store/dashboard/settings/__tests__/actions.js
+++ b/gsa/src/web/store/dashboard/settings/__tests__/actions.js
@@ -39,8 +39,8 @@ import {
   receivedDashboardSettings,
   requestDashboardSettings,
   receivedDashboardSettingsLoadingError,
-  saveDashboardSettings,
-  savedDashboardSettings,
+  saveDashboardSettingsRequest,
+  saveDashboardSettingsSuccess,
   saveDashboardSettingsError,
   loadSettings,
   saveSettings,
@@ -108,7 +108,7 @@ describe('receivedDashboardSettingsLoadingError tests', () => {
 
 });
 
-describe('saveDashboardSettings tests', () => {
+describe('saveDashboardSettingsRequest tests', () => {
 
   test('should create a save dashboard settings request action', () => {
     const id = 'a1';
@@ -117,7 +117,7 @@ describe('saveDashboardSettings tests', () => {
       items,
     };
 
-    expect(saveDashboardSettings(id, settings)).toEqual({
+    expect(saveDashboardSettingsRequest(id, settings)).toEqual({
       type: DASHBOARD_SETTINGS_SAVING_REQUEST,
       id,
       settings,
@@ -126,11 +126,11 @@ describe('saveDashboardSettings tests', () => {
 
 });
 
-describe('savedDashboardSettings tests', () => {
+describe('saveDashboardSettingsSuccess tests', () => {
 
   test('should create a save dashboard settings success action', () => {
     const id = 'a1';
-    expect(savedDashboardSettings(id)).toEqual({
+    expect(saveDashboardSettingsSuccess(id)).toEqual({
       type: DASHBOARD_SETTINGS_SAVING_SUCCESS,
       id,
     });

--- a/gsa/src/web/store/dashboard/settings/__tests__/reducers.js
+++ b/gsa/src/web/store/dashboard/settings/__tests__/reducers.js
@@ -29,7 +29,7 @@ import {
   receivedDashboardSettings,
   requestDashboardSettings,
   receivedDashboardSettingsLoadingError,
-  saveDashboardSettings,
+  saveDashboardSettingsRequest,
   setDashboardSettingDefaults,
 } from '../actions';
 
@@ -378,7 +378,7 @@ describe('dashboard settings reducers test for saving', () => {
       items: ['foo', 'bar'],
     };
 
-    expect(dashboardSettings(undefined, saveDashboardSettings(id, settings))).toEqual({
+    expect(dashboardSettings(undefined, saveDashboardSettingsRequest(id, settings))).toEqual({
       byId: {
         a1: {
           height: 100,
@@ -406,7 +406,7 @@ describe('dashboard settings reducers test for saving', () => {
       rows: ['foo', 'bar'],
     };
 
-    expect(dashboardSettings(state, saveDashboardSettings(id, settings))).toEqual({
+    expect(dashboardSettings(state, saveDashboardSettingsRequest(id, settings))).toEqual({
       byId: {
         a1: {
           height: 100,
@@ -437,7 +437,7 @@ describe('dashboard settings reducers test for saving', () => {
       items: ['foo', 'bar'],
     };
 
-    expect(dashboardSettings(state, saveDashboardSettings(id, settings))).toEqual({
+    expect(dashboardSettings(state, saveDashboardSettingsRequest(id, settings))).toEqual({
       byId: {
         a1: {
           height: 100,
@@ -466,7 +466,7 @@ describe('dashboard settings reducers test for saving', () => {
       thisIsWeird: true,
     };
 
-    expect(dashboardSettings(state, saveDashboardSettings(id, settings))).toEqual({
+    expect(dashboardSettings(state, saveDashboardSettingsRequest(id, settings))).toEqual({
       byId: {
         a1: {
           items: ['abc', 'def'],

--- a/gsa/src/web/store/dashboard/settings/__tests__/reducers.js
+++ b/gsa/src/web/store/dashboard/settings/__tests__/reducers.js
@@ -31,6 +31,7 @@ import {
   loadDashboardSettingsError,
   saveDashboardSettingsRequest,
   setDashboardSettingDefaults,
+  resetDashboardSettingsRequest,
 } from '../actions';
 
 describe('dashboard settings reducers tests for initial state', () => {
@@ -521,6 +522,127 @@ describe('dashboard settings reducers test for setting defaults', () => {
       },
       errors: {},
       isLoading: {},
+    });
+  });
+
+});
+
+describe('dashboard settings reducers test for resetting', () => {
+
+  test('should init state during reset request', () => {
+    const id = 'a1';
+    const settings = {
+      height: 100,
+      items: ['foo', 'bar'],
+    };
+
+    const action = resetDashboardSettingsRequest(id, settings);
+
+    expect(dashboardSettings(undefined, action)).toEqual({
+      byId: {
+        a1: {
+          height: 100,
+          items: ['foo', 'bar'],
+        },
+      },
+      defaults: {},
+      errors: {},
+      isLoading: {},
+    });
+  });
+
+  test('should update state during resetting settings', () => {
+    const state = {
+      byId: {
+        a2: {
+          rows: ['abc', 'def'],
+        },
+      },
+    };
+
+    const id = 'a1';
+    const settings = {
+      height: 100,
+      rows: ['foo', 'bar'],
+    };
+
+    const action = resetDashboardSettingsRequest(id, settings);
+
+    expect(dashboardSettings(state, action)).toEqual({
+      byId: {
+        a1: {
+          height: 100,
+          rows: ['foo', 'bar'],
+        },
+        a2: {
+          rows: ['abc', 'def'],
+        },
+      },
+      defaults: {},
+      errors: {},
+      isLoading: {},
+    });
+  });
+
+  test('should override state during resetting settings', () => {
+    const state = {
+      byId: {
+        a1: {
+          items: ['abc', 'def'],
+        },
+      },
+    };
+
+    const id = 'a1';
+    const settings = {
+      height: 100,
+      items: ['foo', 'bar'],
+    };
+
+    const action = resetDashboardSettingsRequest(id, settings);
+
+    expect(dashboardSettings(state, action)).toEqual({
+      byId: {
+        a1: {
+          height: 100,
+          items: ['foo', 'bar'],
+        },
+      },
+      defaults: {},
+      errors: {},
+      isLoading: {},
+    });
+  });
+
+  test('should merge settings into current state for resetting', () => {
+    const state = {
+      byId: {
+        a1: {
+          items: ['abc', 'def'],
+          foo: 'bar',
+        },
+      },
+    };
+
+    const id = 'a1';
+    const settings = {
+      foo: 'ipsum',
+      thisIsWeird: true,
+    };
+
+    const action = resetDashboardSettingsRequest(id, settings);
+
+    expect(dashboardSettings(state, action)).toEqual({
+      byId: {
+        a1: {
+          items: ['abc', 'def'],
+          foo: 'ipsum',
+          thisIsWeird: true,
+        },
+      },
+      defaults: {},
+      isLoading: {},
+      errors: {},
     });
   });
 

--- a/gsa/src/web/store/dashboard/settings/__tests__/reducers.js
+++ b/gsa/src/web/store/dashboard/settings/__tests__/reducers.js
@@ -26,9 +26,9 @@
 import dashboardSettings from '../reducers';
 
 import {
-  receivedDashboardSettings,
-  requestDashboardSettings,
-  receivedDashboardSettingsLoadingError,
+  loadDashboardSettingsSuccess,
+  loadDashboardSettingsRequest,
+  loadDashboardSettingsError,
   saveDashboardSettingsRequest,
   setDashboardSettingDefaults,
 } from '../actions';
@@ -51,7 +51,7 @@ describe('dashboard settings reducers tests for loading requests', () => {
 
   test('should handle request dashboard settings with id', () => {
     const id = 'a1';
-    const action = requestDashboardSettings(id);
+    const action = loadDashboardSettingsRequest(id);
 
     expect(dashboardSettings({}, action)).toEqual({
       byId: {},
@@ -67,7 +67,7 @@ describe('dashboard settings reducers tests for loading requests', () => {
 
   test('should handle request dashboard settings with id and defaults', () => {
     const id = 'a1';
-    const action = requestDashboardSettings(id);
+    const action = loadDashboardSettingsRequest(id);
 
     expect(dashboardSettings({}, action)).toEqual({
       byId: {},
@@ -81,7 +81,7 @@ describe('dashboard settings reducers tests for loading requests', () => {
 
   test('should reset isLoading and error in request dashboard settings', () => {
     const id = 'a1';
-    const action = requestDashboardSettings(id);
+    const action = loadDashboardSettingsRequest(id);
     const state = {
       isLoading: false,
       errors: {
@@ -110,7 +110,7 @@ describe('dashboard settings reducers tests for loading success', () => {
       rows: ['foo', 'bar'],
     };
 
-    const action = receivedDashboardSettings(id, settings);
+    const action = loadDashboardSettingsSuccess(id, settings);
 
     expect(dashboardSettings({}, action)).toEqual({
       byId: {
@@ -141,7 +141,7 @@ describe('dashboard settings reducers tests for loading success', () => {
         [id]: 'an previous error',
       },
     };
-    const action = receivedDashboardSettings(id, settings);
+    const action = loadDashboardSettingsSuccess(id, settings);
 
     expect(dashboardSettings(state, action)).toEqual({
       byId: {
@@ -174,7 +174,7 @@ describe('dashboard settings reducers tests for loading success', () => {
       rows: ['foo', 'bar'],
     };
 
-    const action = receivedDashboardSettings(id, settings);
+    const action = loadDashboardSettingsSuccess(id, settings);
 
     expect(dashboardSettings(state, action)).toEqual({
       byId: {
@@ -211,7 +211,7 @@ describe('dashboard settings reducers tests for loading success', () => {
       rows: ['foo', 'bar'],
     };
 
-    const action = receivedDashboardSettings(id, settings);
+    const action = loadDashboardSettingsSuccess(id, settings);
 
     expect(dashboardSettings(state, action)).toEqual({
       byId: {
@@ -251,7 +251,7 @@ describe('dashboard settings reducers tests for loading success', () => {
       rows: ['foo', 'bar'],
     };
 
-    const action = receivedDashboardSettings(id, settings, defaults);
+    const action = loadDashboardSettingsSuccess(id, settings, defaults);
 
     expect(dashboardSettings(state, action)).toEqual({
       byId: {
@@ -274,7 +274,7 @@ describe('dashboard settings reducers tests for loading success', () => {
   test('should handle receive dashboard error', () => {
     const id = 'a1';
     const error = 'An error occured';
-    const action = receivedDashboardSettingsLoadingError(id, error);
+    const action = loadDashboardSettingsError(id, error);
 
     expect(dashboardSettings({}, action)).toEqual({
       byId: {},
@@ -291,7 +291,7 @@ describe('dashboard settings reducers tests for loading success', () => {
   test('should reset isLoading in receive dashboard error', () => {
     const id = 'a1';
     const error = 'An error occured';
-    const action = receivedDashboardSettingsLoadingError(id, error);
+    const action = loadDashboardSettingsError(id, error);
     const state = {
       isLoading: {
         [id]: true,
@@ -313,7 +313,7 @@ describe('dashboard settings reducers tests for loading success', () => {
   test('should reset old error in receive dashboard error', () => {
     const id = 'a1';
     const error = 'An error occured';
-    const action = receivedDashboardSettingsLoadingError(id, error);
+    const action = loadDashboardSettingsError(id, error);
     const state = {
       errors: {
         [id]: 'An old error',
@@ -335,7 +335,7 @@ describe('dashboard settings reducers tests for loading success', () => {
   test('should keep state in receive dashboard error', () => {
     const id = 'a1';
     const error = 'An error occured';
-    const action = receivedDashboardSettingsLoadingError(id, error);
+    const action = loadDashboardSettingsError(id, error);
 
     const state = {
       byId: {

--- a/gsa/src/web/store/dashboard/settings/actions.js
+++ b/gsa/src/web/store/dashboard/settings/actions.js
@@ -149,11 +149,11 @@ export const resetSettings = gmp => id => (dispatch, getState) => {
   const settingsSelector = getDashboardSettings(rootState);
   const defaults = settingsSelector.getDefaultsById(id);
 
-  dispatch(saveDashboardSettings(id, defaults));
+  dispatch(resetDashboardSettingsRequest(id, defaults));
 
   return gmp.dashboard.saveSetting(id, defaults).then(
-    () => dispatch(savedDashboardSettings()),
-    error => dispatch(saveDashboardSettingsError(error)),
+    () => dispatch(resetDashboardSettingsSuccess(id)),
+    error => dispatch(resetDashboardSettingsError(id, error)),
   );
 };
 

--- a/gsa/src/web/store/dashboard/settings/actions.js
+++ b/gsa/src/web/store/dashboard/settings/actions.js
@@ -94,9 +94,7 @@ export const setDashboardSettingDefaults = (id, defaults) => ({
   defaults,
 });
 
-export const loadSettings = gmp => (id, defaults) =>
-  (dispatch, getState) => {
-
+export const loadSettings = gmp => (id, defaults) => (dispatch, getState) => {
   const rootState = getState();
   const settingsSelector = getDashboardSettings(rootState);
 
@@ -107,44 +105,37 @@ export const loadSettings = gmp => (id, defaults) =>
 
   dispatch(requestDashboardSettings(id));
 
-  const promise = gmp.dashboard.getSetting(id);
-  return promise.then(
-    response => dispatch(receivedDashboardSettings(id, response.data,
-       defaults)),
+  return gmp.dashboard.getSetting(id).then(
+    ({data}) => dispatch(receivedDashboardSettings(id, data, defaults)),
     error => dispatch(receivedDashboardSettingsLoadingError(id, error)),
   );
 };
 
-export const saveSettings = gmp => (id, settings) =>
-  (dispatch, getState) => {
-
+export const saveSettings = gmp => (id, settings) => dispatch => {
   dispatch(saveDashboardSettings(id, settings));
 
-  return gmp.dashboard.saveSetting(id, settings)
-    .then(
-      response => dispatch(savedDashboardSettings()),
-      error => dispatch(saveDashboardSettingsError(error)),
-    );
+  return gmp.dashboard.saveSetting(id, settings).then(
+    () => dispatch(savedDashboardSettings()),
+    error => dispatch(saveDashboardSettingsError(error)),
+  );
 };
 
-export const resetSettings = gmp => id =>
-  (dispatch, getState) => {
-
+export const resetSettings = gmp => id => (dispatch, getState) => {
   const rootState = getState();
   const settingsSelector = getDashboardSettings(rootState);
   const defaults = settingsSelector.getDefaultsById(id);
 
   dispatch(saveDashboardSettings(id, defaults));
 
-  return gmp.dashboard.saveSetting(id, defaults)
-    .then(
-      response => dispatch(savedDashboardSettings()),
-      error => dispatch(saveDashboardSettingsError(error)),
-    );
+  return gmp.dashboard.saveSetting(id, defaults).then(
+    () => dispatch(savedDashboardSettings()),
+    error => dispatch(saveDashboardSettingsError(error)),
+  );
 };
 
 export const addDisplay = gmp => (dashboardId, displayId, uuidFunc) =>
   (dispatch, getState) => {
+
   if (!isDefined(displayId) || !isDefined(dashboardId)) {
     return Promise.resolve();
   }
@@ -161,11 +152,10 @@ export const addDisplay = gmp => (dashboardId, displayId, uuidFunc) =>
 
   dispatch(saveDashboardSettings(dashboardId, newSettings));
 
-  return gmp.dashboard.saveSetting(dashboardId, newSettings)
-    .then(
-      response => dispatch(savedDashboardSettings()),
-      error => dispatch(saveDashboardSettingsError(error)),
-    );
+  return gmp.dashboard.saveSetting(dashboardId, newSettings).then(
+    response => dispatch(savedDashboardSettings()),
+    error => dispatch(saveDashboardSettingsError(error)),
+  );
 };
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/store/dashboard/settings/actions.js
+++ b/gsa/src/web/store/dashboard/settings/actions.js
@@ -45,6 +45,13 @@ export const DASHBOARD_SETTINGS_SAVING_REQUEST =
 export const DASHBOARD_SETTINGS_SET_DEFAULTS =
   'DASHBOARD_SETTINGS_SET_DEFAULTS';
 
+export const DASHBOARD_SETTINGS_RESET_REQUEST =
+  'DASHBOARD_SETTINGS_RESET_REQUEST';
+export const DASHBOARD_SETTINGS_RESET_SUCCESS =
+  'DASHBOARD_SETTINGS_RESET_SUCCESS';
+export const DASHBOARD_SETTINGS_RESET_ERROR =
+  'DASHBOARD_SETTINGS_RESET_ERROR';
+
 /**
  * Create an action to receive dashboard settings
  *
@@ -92,6 +99,23 @@ export const setDashboardSettingDefaults = (id, defaults) => ({
   type: DASHBOARD_SETTINGS_SET_DEFAULTS,
   id,
   defaults,
+});
+
+export const resetDashboardSettingsRequest = (id, settings) => ({
+  type: DASHBOARD_SETTINGS_RESET_REQUEST,
+  id,
+  settings,
+});
+
+export const resetDashboardSettingsSuccess = id => ({
+  type: DASHBOARD_SETTINGS_RESET_SUCCESS,
+  id,
+});
+
+export const resetDashboardSettingsError = (id, error) => ({
+  type: DASHBOARD_SETTINGS_RESET_ERROR,
+  id,
+  error,
 });
 
 export const loadSettings = gmp => (id, defaults) => (dispatch, getState) => {

--- a/gsa/src/web/store/dashboard/settings/actions.js
+++ b/gsa/src/web/store/dashboard/settings/actions.js
@@ -80,7 +80,7 @@ export const requestDashboardSettings = id => ({
   id,
 });
 
-export const savedDashboardSettings = id => ({
+export const saveDashboardSettingsSuccess = id => ({
   type: DASHBOARD_SETTINGS_SAVING_SUCCESS,
   id,
 });
@@ -91,7 +91,7 @@ export const saveDashboardSettingsError = (id, error) => ({
   error,
 });
 
-export const saveDashboardSettings = (id, settings) => ({
+export const saveDashboardSettingsRequest = (id, settings) => ({
   type: DASHBOARD_SETTINGS_SAVING_REQUEST,
   settings,
   id,
@@ -138,10 +138,10 @@ export const loadSettings = gmp => (id, defaults) => (dispatch, getState) => {
 };
 
 export const saveSettings = gmp => (id, settings) => dispatch => {
-  dispatch(saveDashboardSettings(id, settings));
+  dispatch(saveDashboardSettingsRequest(id, settings));
 
   return gmp.dashboard.saveSetting(id, settings).then(
-    () => dispatch(savedDashboardSettings(id)),
+    () => dispatch(saveDashboardSettingsSuccess(id)),
     error => dispatch(saveDashboardSettingsError(id, error)),
   );
 };
@@ -176,10 +176,10 @@ export const addDisplay = gmp => (dashboardId, displayId, uuidFunc) =>
 
   const newSettings = addDisplayToSettings(settings, displayId, uuidFunc);
 
-  dispatch(saveDashboardSettings(dashboardId, newSettings));
+  dispatch(saveDashboardSettingsRequest(dashboardId, newSettings));
 
   return gmp.dashboard.saveSetting(dashboardId, newSettings).then(
-    () => dispatch(savedDashboardSettings(dashboardId)),
+    () => dispatch(saveDashboardSettingsSuccess(dashboardId)),
     error => dispatch(saveDashboardSettingsError(dashboardId, error)),
   );
 };

--- a/gsa/src/web/store/dashboard/settings/actions.js
+++ b/gsa/src/web/store/dashboard/settings/actions.js
@@ -80,12 +80,14 @@ export const requestDashboardSettings = id => ({
   id,
 });
 
-export const savedDashboardSettings = () => ({
+export const savedDashboardSettings = id => ({
   type: DASHBOARD_SETTINGS_SAVING_SUCCESS,
+  id,
 });
 
-export const saveDashboardSettingsError = error => ({
+export const saveDashboardSettingsError = (id, error) => ({
   type: DASHBOARD_SETTINGS_SAVING_ERROR,
+  id,
   error,
 });
 
@@ -139,8 +141,8 @@ export const saveSettings = gmp => (id, settings) => dispatch => {
   dispatch(saveDashboardSettings(id, settings));
 
   return gmp.dashboard.saveSetting(id, settings).then(
-    () => dispatch(savedDashboardSettings()),
-    error => dispatch(saveDashboardSettingsError(error)),
+    () => dispatch(savedDashboardSettings(id)),
+    error => dispatch(saveDashboardSettingsError(id, error)),
   );
 };
 
@@ -177,8 +179,8 @@ export const addDisplay = gmp => (dashboardId, displayId, uuidFunc) =>
   dispatch(saveDashboardSettings(dashboardId, newSettings));
 
   return gmp.dashboard.saveSetting(dashboardId, newSettings).then(
-    response => dispatch(savedDashboardSettings()),
-    error => dispatch(saveDashboardSettingsError(error)),
+    () => dispatch(savedDashboardSettings(dashboardId)),
+    error => dispatch(saveDashboardSettingsError(dashboardId, error)),
   );
 };
 

--- a/gsa/src/web/store/dashboard/settings/actions.js
+++ b/gsa/src/web/store/dashboard/settings/actions.js
@@ -53,7 +53,7 @@ export const DASHBOARD_SETTINGS_RESET_ERROR =
   'DASHBOARD_SETTINGS_RESET_ERROR';
 
 /**
- * Create an action to receive dashboard settings
+ * Create a load dashboard settings success action
  *
  * @param {String} id              ID of the dashboard
  * @param {Object} settings        Settings loaded for all dashboards
@@ -62,20 +62,21 @@ export const DASHBOARD_SETTINGS_RESET_ERROR =
  *
  * @returns {Object} The action object
  */
-export const receivedDashboardSettings = (id, settings, defaultSettings) => ({
+export const loadDashboardSettingsSuccess = (id, settings, defaultSettings) =>
+({
   type: DASHBOARD_SETTINGS_LOADING_SUCCESS,
   id,
   settings,
   defaultSettings,
 });
 
-export const receivedDashboardSettingsLoadingError = (id, error) => ({
+export const loadDashboardSettingsError = (id, error) => ({
   type: DASHBOARD_SETTINGS_LOADING_ERROR,
   id,
   error,
 });
 
-export const requestDashboardSettings = id => ({
+export const loadDashboardSettingsRequest = id => ({
   type: DASHBOARD_SETTINGS_LOADING_REQUEST,
   id,
 });
@@ -129,11 +130,11 @@ export const loadSettings = gmp => (id, defaults) => (dispatch, getState) => {
     return Promise.resolve();
   }
 
-  dispatch(requestDashboardSettings(id));
+  dispatch(loadDashboardSettingsRequest(id));
 
   return gmp.dashboard.getSetting(id).then(
-    ({data}) => dispatch(receivedDashboardSettings(id, data, defaults)),
-    error => dispatch(receivedDashboardSettingsLoadingError(id, error)),
+    ({data}) => dispatch(loadDashboardSettingsSuccess(id, data, defaults)),
+    error => dispatch(loadDashboardSettingsError(id, error)),
   );
 };
 

--- a/gsa/src/web/store/dashboard/settings/reducers.js
+++ b/gsa/src/web/store/dashboard/settings/reducers.js
@@ -28,6 +28,7 @@ import {
   DASHBOARD_SETTINGS_LOADING_SUCCESS,
   DASHBOARD_SETTINGS_SAVING_REQUEST,
   DASHBOARD_SETTINGS_SET_DEFAULTS,
+  DASHBOARD_SETTINGS_RESET_REQUEST,
 } from './actions';
 
 import {combineReducers} from 'web/store/utils';
@@ -60,6 +61,7 @@ const byId = (state = {}, action) => {
           ...settings,
         },
       };
+    case DASHBOARD_SETTINGS_RESET_REQUEST:
     case DASHBOARD_SETTINGS_SAVING_REQUEST:
       return {
         ...state,


### PR DESCRIPTION
* Remove state sync in Dashboards
* Make reset more explicit
* Cleanup dashboard settings actions
* Don't store constant settings like maxRows into the backend