### PR TITLE
Add "NVTs by solution type" to all dashboards

### DIFF
--- a/src/html/classic/graphics.xsl
+++ b/src/html/classic/graphics.xsl
@@ -549,6 +549,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       data-chart-title-count="count"
       data-chart-type="donut"/>
   </div>
+  <div class="dashboard-data-source"
+    data-source-name="nvt-by-solution-type-source"
+    data-aggregate-type="nvt"
+    data-group-column="solution_type"
+    data-filter="{$filter}"
+    data-filter-id="{$filt_id}">
+    <span class="dashboard-chart"
+      data-chart-name="nvt-by-solution-type"
+      data-chart-title="NVTs by solution type"
+      data-chart-title-count="count"
+      data-chart-type="donut"/>
+  </div>
 </xsl:template>
 
 <xsl:template name="ovaldef-charts">
@@ -887,19 +899,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <xsl:with-param name="filter" select="$filter"/>
         <xsl:with-param name="filt_id" select="$filt_id"/>
       </xsl:call-template>
-
-      <div class="dashboard-data-source"
-        data-source-name="nvt-by-solution-type-source"
-        data-aggregate-type="{$type}"
-        data-group-column="solution_type"
-        data-filter="{$filter}"
-        data-filter-id="{$filt_id}">
-        <span class="dashboard-chart"
-          data-chart-name="nvt-by-solution-type"
-          data-chart-title="NVTs by solution type"
-          data-chart-title-count="count"
-          data-chart-type="donut"/>
-      </div>
     </xsl:if>
 
     <xsl:if test="$type = 'ovaldef'">


### PR DESCRIPTION
The chart has been moved to the "nvt-charts" template so it is available
on both the main and SecInfo dashboards, not just the NVTs page.