### PR TITLE
XML escape asset_hosts filter for create_target

### DIFF
--- a/src/gsad_omp.c
+++ b/src/gsad_omp.c
@@ -9519,8 +9519,9 @@ create_target_omp (openvas_connection_t *connection,
                        target_snmp_credential);
 
   if (strcmp (target_source, "asset_hosts") == 0)
-    asset_hosts_element = g_strdup_printf ("<asset_hosts filter=\"%s\"/>",
-                                           hosts_filter);
+    asset_hosts_element = g_markup_printf_escaped ("<asset_hosts"
+                                                   " filter=\"%s\"/>",
+                                                   hosts_filter);
   else
     asset_hosts_element = g_strdup ("");
 


### PR DESCRIPTION
With this filters containing quote marks and other XML reserved
characters can be used to create a new host.