### PR TITLE
Fix CertBund model categories parsing

### DIFF
--- a/gsa/src/gmp/models/__tests__/certbund.js
+++ b/gsa/src/gmp/models/__tests__/certbund.js
@@ -66,7 +66,7 @@ describe('CertBundAdv model tests', () => {
     expect(certBundAdv.categories).toEqual(['foo', 'bar']);
   });
 
-  test('should return string if single CategoryTree is given', () => {
+  test('should return array also if single CategoryTree is given', () => {
     const elem = {
       raw_data: {
         Advisory: {
@@ -75,7 +75,7 @@ describe('CertBundAdv model tests', () => {
       },
     };
     const certBundAdv = new CertBundAdv(elem);
-    expect(certBundAdv.categories).toEqual('foo');
+    expect(certBundAdv.categories).toEqual(['foo']);
   });
 
   test('should return empty descriptions array if no advisory is given', () => {

--- a/gsa/src/gmp/models/__tests__/dfncert.js
+++ b/gsa/src/gmp/models/__tests__/dfncert.js
@@ -1,0 +1,104 @@
+/* Greenbone Security Assistant
+ *
+ * Authors:
+ * Steffen Waterkamp <steffen.waterkamp@greenbone.net>
+ *
+ * Copyright:
+ * Copyright (C) 2018 Greenbone Networks GmbH
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import DfnCertAdv from 'gmp/models/dfncert';
+import Info from 'gmp/models/info';
+import {testModel} from 'gmp/models/testing';
+
+testModel(DfnCertAdv, 'dfncert');
+
+describe('DfnCertAdv model tests', () => {
+
+  test('should be instance of Info', () => {
+    const dfnCertAdv = new DfnCertAdv({});
+
+    expect(dfnCertAdv).toBeInstanceOf(Info);
+  });
+
+  test('should parse severity correctly', () => {
+    const dfnCertAdv = new DfnCertAdv({max_cvss: '5.0'});
+    const dfnCertAdv2 = new DfnCertAdv({max_cvss: '10'});
+
+    expect(dfnCertAdv.max_cvss).toBeUndefined();
+    expect(dfnCertAdv.severity).toEqual(5.0);
+    expect(dfnCertAdv2.severity).toEqual(10);
+  });
+
+  test('should parse advisory links', () => {
+    const elem = {
+      raw_data: {
+        entry: {
+          link: [
+            {
+              _rel: 'alternate',
+              _href: 'prot://url',
+            },
+            {
+              _href: 'prot://url2',
+            },
+            {
+              _href: 'prot://url3',
+            },
+          ],
+        },
+      },
+    };
+    const dfnCertAdv = new DfnCertAdv(elem);
+
+    expect(dfnCertAdv.advisory_link).toEqual('prot://url');
+    expect(dfnCertAdv.additional_links).toEqual(['prot://url2', 'prot://url3']);
+  });
+
+  test('should parse summary', () => {
+    const elem = {
+      raw_data: {
+        entry: {
+          summary: {
+            __text: 'foo',
+          },
+        },
+      },
+    };
+    const dfnCertAdv = new DfnCertAdv(elem);
+
+    expect(dfnCertAdv.summary).toEqual('foo');
+  });
+
+  test('should parse CVEs', () => {
+    const elem = {
+      raw_data: {
+        entry: {
+          cve: [
+            {__text: 'lorem'},
+            {__text: 'ipsum'},
+            {__text: 'dolor'},
+          ],
+        },
+      },
+    };
+    const dfnCertAdv = new DfnCertAdv(elem);
+
+    expect(dfnCertAdv.cves).toEqual(['lorem', 'ipsum', 'dolor']);
+  });
+
+});

--- a/gsa/src/gmp/models/certbund.js
+++ b/gsa/src/gmp/models/certbund.js
@@ -54,7 +54,7 @@ class CertBundAdv extends Info {
       ret.risk = advisory.Risk;
       ret.reference_source = advisory.Reference_Source;
       ret.reference_url = advisory.Reference_URL;
-      ret.categories = advisory.CategoryTree;
+      ret.categories = map(advisory.CategoryTree, categoryTree => categoryTree);
 
       if (!isDefined(ret.version) && isDefined(advisory.Ref_Num)) {
         ret.version = advisory.Ref_Num._update;


### PR DESCRIPTION
Always return an array for categories.

Also, add tests for DFNCert model, because it was already in my commit pipeline...