### PR TITLE
Fix "Current User" inheritance on "Delete User"

### DIFF
--- a/gsa/src/web/pages/users/confirmdeletedialog.js
+++ b/gsa/src/web/pages/users/confirmdeletedialog.js
@@ -66,7 +66,7 @@ const ConfirmDeleteDialog = ({
       value: '--',
     }, {
       label: _('Current User'),
-      value: 'self,',
+      value: 'self',
     },
     ...renderSelectItems(inheritorUsers),
   ];

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -2334,6 +2334,10 @@ delete_resource (gvm_connection_t *connection, const char *type,
       inheritor_id = params_value (params, "inheritor_id");
       if (inheritor_id)
         extra_attribs = g_strdup_printf ("inheritor_id=\"%s\"", inheritor_id);
+      else if (params_given (params, "inheritor_id"))
+        return message_invalid (connection, credentials, params, response_data,
+                                "Invalid inheritor_id",
+                                "Delete User");
     }
 
   /* Delete the resource and get all resources. */


### PR DESCRIPTION
Due to a stray comma in the dialog selecting "Current User" resulted in
no user inheriting the resources of the deleted user.
The typo is fixed and a check has been added to see if the inheritor_id
is given but invalid.