### PR TITLE
Fix various typos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@ Main changes compared to 8.0+beta1
   * Removed Scan, Asset, SecInfo Dashboards and added Dashboard "templates" to
     the main dashboard #974
   * Removed Dashboard Display menus with an icon overlay #971, #972
-  * Don't set an unkown locale #966
+  * Don't set an unknown locale #966
   * Require NodeJS >= 8 #964
   * Replaced glamorous with styled-components for settings styles
     #913, #919, #922, #924, #925, #929, #934, #938, #948, #949, #950
@@ -648,7 +648,7 @@ Main changes since 4.0.x:
 * Added support for setting the priorities for cipher suites when using HTTPS.
 * Add --drop option to drop privileges once the chroot is established.
   Attention: This action was previously part of the --chroot parameter, if
-  required, this now needs to be explicitely set.
+  required, this now needs to be explicitly set.
 * Add --face to support switching between different layouts.
 * Code cleanup.
 
@@ -858,7 +858,7 @@ Matthew Mundell, Timo Pollmeier and Hani Benhabiles.
 Main changes since 5.0+beta3:
 * Add --drop option to drop privileges once the chroot is established.
   Attention: This action was previously part of the --chroot parameter, if
-  required, this now needs to be explicitely set.
+  required, this now needs to be explicitly set.
 * The interface has been simplified, improved and made more consistent in a
   number of places.
 * Code cleanup.
@@ -1079,7 +1079,7 @@ Main changes since 2.0.x:
 * New: References info box in results view.
 * New: Product detection info box in results view.
 * New: Allow target list upload from file.
-* New: Support for note/overrrides lifetimes.
+* New: Support for note/overrides lifetimes.
 * New: Support for empty passwords has been added.
 * New: Support for changing user passwords.
 * New: Asset Management.
@@ -1146,7 +1146,7 @@ Main changes since 3.0+beta8:
 
 ## gsa 3.0+beta8 (2011-12-02)
 
-This is the eigth beta version of the upcoming 3.0 release of the Greenbone
+This is the eight beta version of the upcoming 3.0 release of the Greenbone
 Security Assistant (GSA). It is the web client that makes the full feature set
 of OpenVAS Manager available in a web browser.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It consists of
 
 and
 
-* [GSAD](https://github.com/greenbone/gsa/tree/master/gsad) - The http server talking to the [GVM deamon](https://github.com/greenbone/gvm)
+* [GSAD](https://github.com/greenbone/gsa/tree/master/gsad) - The http server talking to the [GVM daemon](https://github.com/greenbone/gvm)
 
 ## Installation
 

--- a/gsa/src/gmp/__tests__/log.js
+++ b/gsa/src/gmp/__tests__/log.js
@@ -97,7 +97,7 @@ describe('log tests', () => {
     expect(newLogger.defaultLogValue).toEqual(LogLevels.debug);
   });
 
-  test('should ignore unkown levels in RootLoogger setDefaultLogLevel', () => {
+  test('should ignore unknown levels in RootLoogger setDefaultLogLevel', () => {
     const logger = getRootLogger();
     expect(logger.init({loglevel: 'error'})).toEqual(true);
     expect(logger.level).toEqual('error');
@@ -109,7 +109,7 @@ describe('log tests', () => {
     expect(newLogger.defaultLogValue).toEqual(LogLevels.error);
   });
 
-  test('should ignore unkown levels in logger setDefaultLogLevel', () => {
+  test('should ignore unknown levels in logger setDefaultLogLevel', () => {
     const logger = getRootLogger();
     expect(logger.init({loglevel: 'error'})).toEqual(true);
     expect(logger.level).toEqual('error');

--- a/gsa/src/gmp/__tests__/parser.js
+++ b/gsa/src/gmp/__tests__/parser.js
@@ -292,7 +292,7 @@ describe('parseEnvelopeMeta tests', () => {
     });
   });
 
-  test('should drop unkown envelope information', () => {
+  test('should drop unknown envelope information', () => {
     expect(parseEnvelopeMeta({
       version: '1.0',
       backend_operation: '0.01',

--- a/gsa/src/gmp/locale/__tests__/lang.js
+++ b/gsa/src/gmp/locale/__tests__/lang.js
@@ -44,7 +44,7 @@ describe('setLocale tests', () => {
     expect(getLocale()).toEqual('de-CH');
   });
 
-  test('should fallback to en for unkown locales', () => {
+  test('should fallback to en for unknown locales', () => {
     setLocale('en');
     expect(getLocale()).toEqual('en');
 

--- a/gsa/src/gmp/models/__tests__/filter.js
+++ b/gsa/src/gmp/models/__tests__/filter.js
@@ -735,7 +735,7 @@ describe('Filter setSortOrder', () => {
     expect(filter.get('sort-reverse')).toEqual('foo');
   });
 
-  test('should set sort for unkown orders', () => {
+  test('should set sort for unknown orders', () => {
     const filter = Filter.fromString('sort-reverse=foo');
     filter.setSortOrder('foo');
 

--- a/gsa/src/gmp/models/__tests__/secinfo.js
+++ b/gsa/src/gmp/models/__tests__/secinfo.js
@@ -61,7 +61,7 @@ describe('SecInfo model tests', () => {
 
 });
 
-describe('SecInfo model funtion tests', () => {
+describe('SecInfo model function tests', () => {
 
   test('secInfoType should return infoType', () => {
     const secInfo1 = new SecInfo({allinfo: {type: 'nvt'}});

--- a/gsa/src/gmp/models/event.js
+++ b/gsa/src/gmp/models/event.js
@@ -365,7 +365,7 @@ class Event {
           // See https://github.com/mozilla-comm/ical.js/blob/master/lib/ical/recur_iterator.js#L373
           // But this may be valid e.g. when last day of month and the 31 of a
           // month are set in the rrule. Therefore ignore error and retry to get
-          // a new date. Fail after 5 unsuccessful attemps
+          // a new date. Fail after 5 unsuccessful attempts
           retries++;
           log.warn('Error raised while calculating next date', err);
         }

--- a/gsa/src/gmp/models/filter/filterterm.js
+++ b/gsa/src/gmp/models/filter/filterterm.js
@@ -83,7 +83,7 @@ class FilterTerm {
   /**
    * Return the filter term represented as a string
    *
-   * The fromat is {keyword}{relation}{value}
+   * The format is {keyword}{relation}{value}
    *
    * @return {String} filter term as a String
    */

--- a/gsa/src/gmp/utils/__tests__/entitytype.js
+++ b/gsa/src/gmp/utils/__tests__/entitytype.js
@@ -102,7 +102,7 @@ describe('normalizeType function tests', () => {
     expect(normalizeType('scanconfig')).toEqual('scanconfig');
   });
 
-  test('should pass through unkown types', () => {
+  test('should pass through unknown types', () => {
     expect(normalizeType('foo')).toEqual('foo');
   });
 
@@ -128,7 +128,7 @@ describe('apiType function tests', () => {
     expect(apiType('config')).toEqual('config');
   });
 
-  test('should pass through unkown types', () => {
+  test('should pass through unknown types', () => {
     expect(apiType('foo')).toEqual('foo');
   });
 
@@ -136,7 +136,7 @@ describe('apiType function tests', () => {
 
 describe('typeName function tests', () => {
 
-  test('should pass through unkown types', () => {
+  test('should pass through unknown types', () => {
     expect(typeName('foo')).toEqual('foo');
   });
 

--- a/gsa/src/gmp/utils/entitytype.js
+++ b/gsa/src/gmp/utils/entitytype.js
@@ -105,7 +105,7 @@ const ENTITY_TYPES = {
 /**
  * Get the translateable name for an entity type
  *
- * @param {String} type A entity type. Either an extrenal or GSA entity type.
+ * @param {String} type A entity type. Either an external or GSA entity type.
  *
  * @returns {String} A translated entity type name
  */

--- a/gsa/src/web/components/chart/donut.js
+++ b/gsa/src/web/components/chart/donut.js
@@ -252,7 +252,7 @@ class DonutChart extends React.Component {
     let donutHeight = height;
 
     if (show3d && width / height > MIN_RATIO) {
-      // dont allow 3d donut to be stretch horizontally anymore
+      // don't allow 3d donut to be stretch horizontally anymore
       donutWidth = height * MIN_RATIO;
     }
     else if (!show3d && width > height) {

--- a/gsa/src/web/components/chart/utils/__tests__/update.js
+++ b/gsa/src/web/components/chart/utils/__tests__/update.js
@@ -57,7 +57,7 @@ describe('shouldUpdate tests', () => {
     expect(shouldUpdate({showLegend: true}, {showLegend: true})).toEqual(false);
   });
 
-  test('should not update if unkown prop has changed', () => {
+  test('should not update if unknown prop has changed', () => {
     expect(shouldUpdate({foo: false}, {foo: true})).toEqual(false);
   });
 

--- a/gsa/src/web/components/link/__tests__/certlink.js
+++ b/gsa/src/web/components/link/__tests__/certlink.js
@@ -94,7 +94,7 @@ describe('CertLink tests', () => {
     expect(history.location.pathname).toEqual('/dfncert/foo');
   });
 
-  test('should not route to unkown type', () => {
+  test('should not route to unknown type', () => {
     const {render, history} = rendererWith({capabilities: true, router: true});
     const {element} = render(
       <CertLink

--- a/gsa/src/web/pages/operatingsystems/dashboard/vulnscoredisplay.js
+++ b/gsa/src/web/pages/operatingsystems/dashboard/vulnscoredisplay.js
@@ -165,7 +165,7 @@ export const OsVulnScoreTableDisplay = createDisplay({
   loaderComponent: OsVulnScoreLoader,
   displayComponent: DataTableDisplay,
   dataTitles: [
-    _l('Operating Sytem Name'),
+    _l('Operating System Name'),
     _l('Max. Average Severity Score'),
   ],
   dataRow: row => [row.x, row.y],

--- a/gsa/src/web/pages/tasks/component.js
+++ b/gsa/src/web/pages/tasks/component.js
@@ -228,8 +228,8 @@ class TaskComponent extends React.Component {
     const {data} = resp;
     const {gmp} = this.props;
 
-    gmp.targets.getAll().then(reponse => {
-      const {data: alltargets} = reponse;
+    gmp.targets.getAll().then(response => {
+      const {data: alltargets} = response;
 
       log.debug('adding target to task dialog', alltargets, data.id);
 

--- a/gsa/src/web/store/dashboard/data/__tests__/loader.js
+++ b/gsa/src/web/store/dashboard/data/__tests__/loader.js
@@ -98,7 +98,7 @@ describe('loadFunc tests', () => {
     });
   });
 
-  test('should faild loading dashboard data', () => {
+  test('should fail loading dashboard data', () => {
     const id = 'a1';
     const filter = Filter.fromString('foo=bar');
     const dispatch = jest.fn();

--- a/gsa/src/web/store/dashboard/settings/__tests__/actions.js
+++ b/gsa/src/web/store/dashboard/settings/__tests__/actions.js
@@ -169,7 +169,7 @@ describe('setDashboardSettingDefaults', () => {
 
 describe('resetDashboardSettingsRequest tests', () => {
 
-  test('should create a reset dashboard setings request action', () => {
+  test('should create a reset dashboard settings request action', () => {
     const id = 'a1';
     const settings = {
       foo: 'bar',

--- a/gsa/src/web/store/entities/__tests__/reports.js
+++ b/gsa/src/web/store/entities/__tests__/reports.js
@@ -429,7 +429,7 @@ describe('deltaSelector isLoading tests', () => {
     expect(selector.isLoading(id, deltaId)).toEqual(false);
   });
 
-  test('should be false for unkown id', () => {
+  test('should be false for unknown id', () => {
     const id = 'a1';
     const deltaId = 'a2';
     const rootState = createState('deltaReport', {
@@ -490,7 +490,7 @@ describe('deltaSelector getEntity tests', () => {
     expect(selector.getEntity('bar')).toBeUndefined();
   });
 
-  test('should return undefined for unkown id', () => {
+  test('should return undefined for unknown id', () => {
     const rootState = createState('deltaReport', {
       byId: {
         foo: {
@@ -547,7 +547,7 @@ describe('deltaSelector getError tests', () => {
     expect(selector.getError(id, deltaId)).toBeUndefined();
   });
 
-  test('should return undefined for unkown id', () => {
+  test('should return undefined for unknown id', () => {
     const id = 'a1';
     const deltaId = 'a2';
     const rootState = createState('deltaReport', {

--- a/gsa/src/web/store/entities/utils/__tests__/selectors.js
+++ b/gsa/src/web/store/entities/utils/__tests__/selectors.js
@@ -91,7 +91,7 @@ describe('EntitiesSelector isLoadingEntities tests', () => {
     expect(fooSelector.isLoadingEntities(filter)).toEqual(true);
   });
 
-  test('should be false for unkown filter', () => {
+  test('should be false for unknown filter', () => {
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       isLoading: {
@@ -139,7 +139,7 @@ describe('EntitiesSelector isLoadingEntity tests', () => {
     expect(fooSelector.isLoadingEntity(id)).toEqual(false);
   });
 
-  test('should be false for unkown id', () => {
+  test('should be false for unknown id', () => {
     const id = 'a1';
     const selector = createSelector('foo');
     const rootState = createState('foo', {
@@ -296,7 +296,7 @@ describe('EntitiesSelector getEntities tests', () => {
     expect(fooSelector.getEntities()).toBeUndefined();
   });
 
-  test('getEntities should return empty array for unkown filter', () => {
+  test('getEntities should return empty array for unknown filter', () => {
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       default: ['foo', 'bar'],
@@ -385,7 +385,7 @@ describe('EntitiesSelector getEntitiesError tests', () => {
     expect(fooSelector.getEntitiesError()).toBeUndefined();
   });
 
-  test('should return undefined for unkown filter', () => {
+  test('should return undefined for unknown filter', () => {
     const otherFilter = Filter.fromString('name=foo');
     const selector = createSelector('foo');
     const rootState = createState('foo', {
@@ -557,7 +557,7 @@ describe('EntitiesSelector getEntity tests', () => {
     expect(fooSelector.getEntity('bar')).toBeUndefined();
   });
 
-  test('should return undefined for unkown id', () => {
+  test('should return undefined for unknown id', () => {
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       byId: {
@@ -635,7 +635,7 @@ describe('EntitiesSelector getEntityError tests', () => {
     expect(fooSelector.getEntityError(id)).toEqual('An error');
   });
 
-  test('should return undefined for unkown id', () => {
+  test('should return undefined for unknown id', () => {
     const id = 'a1';
     const selector = createSelector('foo');
     const rootState = createState('foo', {

--- a/gsa/src/web/utils/__tests__/sort.js
+++ b/gsa/src/web/utils/__tests__/sort.js
@@ -72,7 +72,7 @@ describe('getProperty tests', () => {
     expect(getProperty({foo: 'bar'}, obj => obj.foo)).toEqual('bar');
   });
 
-  test('should return undefined for unkown properties', () => {
+  test('should return undefined for unknown properties', () => {
     expect(getProperty({value: 1}, 'foo')).toBeUndefined();
     expect(getProperty({value: 1}, obj => obj.foo)).toBeUndefined();
     expect(getProperty(undefined, obj => obj.foo)).toBeUndefined();

--- a/gsad/doc/Doxyfile.in
+++ b/gsad/doc/Doxyfile.in
@@ -1637,8 +1637,8 @@ EXTRA_PACKAGES         =
 # Note: Only use a user-defined header if you know what you are doing! The
 # following commands have a special meaning inside the header: $title,
 # $datetime, $date, $doxygenversion, $projectname, $projectnumber,
-# $projectbrief, $projectlogo. Doxygen will replace $title with the empy string,
-# for the replacement values of the other commands the user is refered to
+# $projectbrief, $projectlogo. Doxygen will replace $title with the empty string,
+# for the replacement values of the other commands the user is referred to
 # HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 

--- a/gsad/doc/Doxyfile_full.in
+++ b/gsad/doc/Doxyfile_full.in
@@ -1637,8 +1637,8 @@ EXTRA_PACKAGES         =
 # Note: Only use a user-defined header if you know what you are doing! The
 # following commands have a special meaning inside the header: $title,
 # $datetime, $date, $doxygenversion, $projectname, $projectnumber,
-# $projectbrief, $projectlogo. Doxygen will replace $title with the empy string,
-# for the replacement values of the other commands the user is refered to
+# $projectbrief, $projectlogo. Doxygen will replace $title with the empty string,
+# for the replacement values of the other commands the user is referred to
 # HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 

--- a/gsad/doc/Doxyfile_xml.in
+++ b/gsad/doc/Doxyfile_xml.in
@@ -1637,8 +1637,8 @@ EXTRA_PACKAGES         =
 # Note: Only use a user-defined header if you know what you are doing! The
 # following commands have a special meaning inside the header: $title,
 # $datetime, $date, $doxygenversion, $projectname, $projectnumber,
-# $projectbrief, $projectlogo. Doxygen will replace $title with the empy string,
-# for the replacement values of the other commands the user is refered to
+# $projectbrief, $projectlogo. Doxygen will replace $title with the empty string,
+# for the replacement values of the other commands the user is referred to
 # HTML_HEADER.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -2513,7 +2513,7 @@ gsad_init ()
 #endif
 
   /* Version check should be the very first call because it makes sure that
-   * important subsystems are intialized.
+   * important subsystems are initialized.
    * We pass NULL to gcry_check_version to disable the internal version mismatch
    * test. */
   if (!gcry_check_version (NULL))
@@ -2528,7 +2528,7 @@ gsad_init ()
 
   /* ... If required, other initialization goes here.  Note that the process
    * might still be running with increased privileges and that the secure
-   * memory has not been intialized. */
+   * memory has not been initialized. */
 
   /* Allocate a pool of 16k secure memory.  This make the secure memory
    * available and also drops privileges where needed. */
@@ -2755,7 +2755,7 @@ gsad_address_set_port (struct sockaddr_storage *address, int port)
 }
 
 /**
- * @brief Initalizes the address to listen on.
+ * @brief Initializes the address to listen on.
  *
  * @param[in]  address_str      Address to listen on.
  * @param[in]  port             Port to listen on.

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -23711,7 +23711,7 @@ authenticate_gmp (const gchar * username, const gchar * password,
  * @brief Login and create a session
  *
  * @param[in]   con             HTTP Connection
- * @param[in]   params          Request paramters
+ * @param[in]   params          Request parameters
  * @param[out]  response_data   Extra data return for the HTTP response
  * @param[in]   client_address  Client address
  *

--- a/gsad/src/gsad_http.c
+++ b/gsad/src/gsad_http.c
@@ -240,7 +240,7 @@ send_redirect_to_urn (http_connection_t *connection, const char *urn,
  *
  * @param[in]  connection  The connection handle.
  * @param[in]  uri         The full URI to redirect to.
- * @param[in]  sid         Session ID ot add, or NULL.
+ * @param[in]  sid         Session ID to add, or NULL.
  *
  * @return MHD_NO in case of a problem. Else MHD_YES.
  */


### PR DESCRIPTION
Fix various typos found by [codespell](https://github.com/codespell-project/codespell) 1.14

```
codespell . -S node_modules,build,*.png,.git,*.svg,*.gif,*.lock,*.po
```

There are a few left like e.g. in .po or .json files or https://github.com/greenbone/gsa/blob/f2d9c7b94791f0230a46f4bdb388cb51fcb35d14/gsa/src/web/pages/usersettings/usersettingspage.js#L265-L266 where i'm not sure how to handle them so i havn't touched them yet.