### PR TITLE
Fix segfault due to NULL save_config_nvt_omp response

### DIFF
--- a/src/gsad.c
+++ b/src/gsad.c
@@ -4024,10 +4024,20 @@ send_response (struct MHD_Connection *connection, const char *content,
                size_t content_length)
 {
   struct MHD_Response *response;
-  size_t size = (content_length ? content_length : strlen (content));
+  size_t size;
   int ret;
 
-  response = MHD_create_response_from_buffer (size, (void *) content,
+  if (content)
+    size = (content_length ? content_length : strlen (content));
+  else
+    {
+      g_warning ("%s: content is NULL", __FUNCTION__);
+      status_code = MHD_HTTP_INTERNAL_SERVER_ERROR;
+      size = 0;
+    }
+
+  response = MHD_create_response_from_buffer (size,
+                                              (void *)(content ? content : ""),
                                               MHD_RESPMEM_MUST_COPY);
   gsad_add_content_type_header (response, &content_type);
 

--- a/src/gsad_omp.c
+++ b/src/gsad_omp.c
@@ -12677,6 +12677,7 @@ save_config_nvt_omp (openvas_connection_t *connection,
   const char *config_id;
   int success;
   char *modify_config_ret;
+  gchar *next_url;
 
   modify_config_ret = NULL;
   config_id = params_value (params, "config_id");
@@ -12876,6 +12877,23 @@ save_config_nvt_omp (openvas_connection_t *connection,
             }
         }
     }
+
+  /* Create a generic success message in case modify_config_ret is NULL,
+   *  which could happen if the last preference is a password and skipped.
+   * This assumes that messages are returned earlier in case of errors. */
+  next_url = next_page_url (credentials, params,
+                            NULL, "get_config_nvt",
+                            "Create Permissions",
+                            G_STRINGIFY (MHD_HTTP_OK),
+                            "All NVT preferences modified successfully");
+  modify_config_ret
+    = action_result_page (connection, credentials, params, response_data,
+                          "Modify Config",
+                          G_STRINGIFY (MHD_HTTP_OK),
+                          "All NVT preferences modified successfully",
+                          NULL,
+                          next_url);
+  g_free (next_url);
 
   return modify_config_ret;
 }


### PR DESCRIPTION
This addresses a segfault that could occur if the last preference on an NVT preferences edit dialog is skipped, e.g. when it's a password that's not overwritten, or possibly if no preferences are sent at all.

The first commit is about preventing the segfault in case a NULL response is passed to send_response, while the second one prevents save_config_nvt_omp from returning a NULL response under the conditions above.