### PR TITLE
Fix segfault due to NULL save_config_nvt_omp response (master)

### DIFF
--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -11412,6 +11412,15 @@ save_config_nvt_gmp (gvm_connection_t *connection, credentials_t *
 
     }
 
+  /* Create a generic success message in case modify_config_ret is NULL,
+   *  which could happen if the last preference is a password and skipped.
+   * This assumes that messages are returned earlier in case of errors. */
+  modify_config_ret
+    = action_result (connection, credentials, params, response_data,
+                     "Modify Config",
+                     "All NVT preferences modified successfully",
+                     NULL, NULL);
+
   return modify_config_ret;
 }
 

--- a/gsad/src/gsad_http.c
+++ b/gsad/src/gsad_http.c
@@ -314,10 +314,19 @@ send_response (http_connection_t *connection, const char *content,
                size_t content_length)
 {
   http_response_t *response;
-  size_t size = (content_length ? content_length : strlen (content));
+  size_t size;
   int ret;
 
-  response = MHD_create_response_from_buffer (size, (void *) content,
+  if (content)
+    size = (content_length ? content_length : strlen (content));
+  else
+    {
+      g_warning ("%s: content is NULL", __FUNCTION__);
+      status_code = MHD_HTTP_INTERNAL_SERVER_ERROR;
+      size = 0;
+    }
+  response = MHD_create_response_from_buffer (size,
+                                              (void *)(content ? content : ""),
                                               MHD_RESPMEM_MUST_COPY);
 
   gsad_add_content_type_header (response, &content_type);


### PR DESCRIPTION
This is the master branch version of #1044, which fixes a potential segfault when saving NVT preferences. 