### PR TITLE
Rework README to match template

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@ INSTALLATION INSTRUCTIONS FOR GREENBONE SECURITY ASSISTANT
 ==========================================================
 
 Please note: The reference system used by most of the developers is Debian
-GNU/Linux 'Stretch' 9. The build might fail on any other system. Also it is
+GNU/Linux 'Stretch' 9. The build might fail on any other system. Also, it is
 necessary to install dependent development packages.
 
 
@@ -25,7 +25,7 @@ Prerequisites:
 Prerequisites for using translations:
 * gettext
   (when building from source)
-* an installed English UTF-8 locale (e.g. "en_US.UTF8", "en_GB.UTF8")
+* an installed English UTF-8 locale (e.g. `en_US.UTF8`, `en_GB.UTF8`)
   (See "Setting up translations")
 
 Prerequisites for building documentation:
@@ -37,49 +37,53 @@ also to build the JavaScript translations:
 * python-polib
 
 Install prerequisites on Debian GNU/Linux:
-# apt-get install libmicrohttpd-dev libxml2-dev
+
+    apt-get install libmicrohttpd-dev libxml2-dev
 
 
 Compiling Greenbone Security Assistant
 --------------------------------------
 
 If you have installed required libraries to a non-standard location, remember to
-set the PKG_CONFIG_PATH environment variable to the location of you pkg-config
+set the `PKG_CONFIG_PATH` environment variable to the location of you pkg-config
 files before configuring:
 
-    $ export PKG_CONFIG_PATH=/your/location/lib/pkgconfig:$PKG_CONFIG_PATH
+    export PKG_CONFIG_PATH=/your/location/lib/pkgconfig:$PKG_CONFIG_PATH
 
-Create a build directory and change into it with
+Create a build directory and change into it with:
 
-    $ mkdir build
-    $ cd build
+    mkdir build
+    cd build
 
-Then configure the build with
+Then configure the build with:
 
-    $ cmake -DCMAKE_INSTALL_PREFIX=/path/to/your/installation ..
+    cmake -DCMAKE_INSTALL_PREFIX=/path/to/your/installation ..
 
-or (if you want to use the default installation path /usr/local)
+Or (if you want to use the default installation path /usr/local):
 
-    $ cmake ..
+    cmake ..
 
-This only needs to be done once.  Note: It is assumed that the other GVM
-components are installed to the same path.  If not, you need to set some paths
-separately, see below for details.
+This only needs to be done once.
 
-Thereafter, the following commands are useful.
+Thereafter, the following commands are useful:
 
-    $ make                # build the Greenbone Security Assistant
-    $ make doc            # build the documentation
-    $ make doc-full       # build more developer-oriented documentation
-    $ make install        # install the build
-    $ make rebuild_cache  # rebuild the cmake cache
+    make                # build the scanner
+    make doc            # build the documentation
+    make doc-full       # build more developer-oriented documentation
+    make install        # install the build
+    make rebuild_cache  # rebuild the cmake cache
 
+Please note that you may have to execute `make install` as root, especially if
+you have specified a prefix for which your user does not have full permissions.
+
+To clean up the build environment, simply remove the contents of the `build`
+directory you created above.
 
 In case you have installed the Greenbone Security Assistant into a path
 different from the other GVM modules, you might need to set some paths
-explicitly before running cmake. The certificate and key locations in
-GVM_SERVER_CERTIFICATE, GVM_SERVER_KEY and GVM_CA_CERTIFICATE in
-the top level CMakeLists.txt may need modifying.
+explicitly before running `cmake`. The certificate and key locations in
+`GVM_SERVER_CERTIFICATE`, `GVM_SERVER_KEY` and `GVM_CA_CERTIFICATE` in
+the top-level CMakeLists.txt may need modifying.
 
 
 Compiling Greenbone Security Assistant GUI
@@ -89,59 +93,59 @@ Prerequisites for using the GUI:
 * node.js >= 8.0
 * Either yarn >= 1.0 or npm. yarn is faster and more reliable, but younger.
 
-On Debian Stretch node.js is too old. Follow these steps for a
-sufficiently new version. Be aware that this will remove your
-current installation of node.js, npm and related packages.
-
+The `nodejs` on Debian Stretch is too old to build GSA. Follow the steps below
+to install a sufficiently new version. Be aware that this will remove your
+current installation of `node.js`, `npm` and related packages.
 
 ```sh
-$ sudo apt-get install apt-transport-https
+sudo apt-get install apt-transport-https
 ```
 
 ```sh
-$ curl --silent --show-error https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-$ echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+curl --silent --show-error https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 ```
 ```sh
-$ curl --silent --show-error https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
-$ echo "deb https://deb.nodesource.com/node_8.x stretch main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+curl --silent --show-error https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
+echo "deb https://deb.nodesource.com/node_8.x stretch main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 ```
 
 ```sh
-$ sudo apt-get update
+sudo apt-get update
 ```
 
 ```sh
-$ sudo apt-get install nodejs yarn
+sudo apt-get install nodejs yarn
 ```
+
 
 Developing Greenbone Security Assistant GUI
 -------------------------------------------
 
 Installing gsad requires to re-build the JavaScript bundle. This process is
-very time consuming and therefore may be avoided during development. It is
+very time-consuming and therefore may be avoided during development. It is
 possible to run GSA in a special web development server. The development
 server can be started with:
 
 ```sh
-$ cd /path/to/gsa-sources/ng && yarn run start
+cd /path/to/gsa-sources/ng && yarn run start
 ```
 
 Afterwards the development web server is set up and a new browser window is
-opened for the url http://127.0.0.1:8080 containing the GSA web application.
-If a JavaScript file of GSA in the src folder is changed the browser window
+opened at the URL `http://127.0.0.1:8080`, containing the GSA web application.
+When a JavaScript file of GSA in the src folder is changed, the browser window
 will reload automatically.
 
 Besides the development server gsad needs to be running with CORS enabled.
 
 ```sh
-$ gsad --http-cors="http://127.0.0.1:8080"
+gsad --http-cors="http://127.0.0.1:8080"
 ```
 
-To be able to communicate with gsad the web application needs to know the server
-url. This can be accomplished by editing the
-/path/to/gsa-sources/ng/public/config.js file.
-The following lines can be used for a local gsad running with https on port
+To be able to communicate with gsad, the web application needs to know the server
+URL. This can be accomplished by editing the
+`/path/to/gsa-sources/ng/public/config.js` file.
+The following lines can be used for a local gsad running with HTTPS on port
 9392:
 
 ```javascript
@@ -151,15 +155,16 @@ The following lines can be used for a local gsad running with https on port
   };
 ```
 
-For http only the protocol property must be 'http' accordingly.
+For HTTP only the protocol property must be `'http'` accordingly.
 
-After changing the config.js file the browser window should be reloaded
+After changing the `config.js` file, the browser window should be reloaded
 manually.
+
 
 Logging Configuration
 ---------------------
 
-By default GSA writes logs to the file
+By default, GSA writes logs to the file
 
     <install-prefix>/var/log/gvm/gsad.log
 
@@ -175,8 +180,8 @@ The configuration is divided into domains like this one
     file=/var/log/gvm/gsad.log
     level=128
 
-The "level" field controls the amount of logging that is written.
-The value of "level" can be
+The `level` field controls the amount of logging that is written.
+The value of `level` can be:
 
       4  Errors.
       8  Critical situation.
@@ -191,7 +196,7 @@ will include Warnings, Critical situations and Errors.
 To get absolutely all logging, set the level to 128 for all domains in the
 configuration file.
 
-Logging to "syslog" can be enabled in each domain like:
+Logging to `syslog` can be enabled in each domain like:
 
     [gsad main]
     prepend=%t %p
@@ -200,48 +205,42 @@ Logging to "syslog" can be enabled in each domain like:
     syslog_facility=daemon
     level=128
 
+
 Setting up translations
 -----------------------
 
-To build the translation .mo files, you need to have the gettext tools like
- msgfmt installed. Once the .mo files are built, the tools are no longer
- needed.
-(For more information on the creation of translation files, see i18n-howto.txt
- in the GSA source documentation.)
+To build the translation `.mo` files, you need to have the `gettext` tools like
+`msgfmt` installed. Once the `.mo` files are built, the tools are no longer
+needed.
+(For more information on the creation of translation files, see the
+[i18n-howto.txt](gsad/doc/i18n-howto.txt) file in the GSA source documentation.)
 
-To use the translations you need to have an English locale with UTF-8 encoding
- installed, for example "en_US.UTF8" or "en_GB.UTF8".
-The name of this locale then has to be assigned to an environment variable
- recognized by the libc function "setlocale" like LANG, LC_MESSAGES or LC_ALL.
-If these environment variables are all unset, set to "C" or an equivalent like
- "POSIX" or invalid, translations will be disabled.
+To use the translations, you need to have an English locale with UTF-8 encoding
+installed, for example `en_US.UTF8` or `en_GB.UTF8`.  The name of this locale
+then has to be assigned to an environment variable recognized by the libc
+function `setlocale` like `LANG`, `LC_MESSAGES` or `LC_ALL`.  If these
+environment variables are all unset, set to `C` or an equivalent like `POSIX`
+or invalid, translations will be disabled.
 
 
 Static code analysis with the Clang Static Analyzer
 ---------------------------------------------------
 
-If you want to use the Clang Static Analyzer (http://clang-analyzer.llvm.org/)
-to do a static code analysis, you can do so by adding the following parameter
-when configuring the build:
+If you want to use the Clang Static Analyzer (https://clang-analyzer.llvm.org/)
+to do a static code analysis, you can do so by prefixing the configuration and
+build commands with `scan-build`:
 
-  -DCMAKE_C_COMPILER=/usr/share/clang/scan-build/ccc-analyzer
-
-Note that the example above uses the default location of ccc-analyzer in Debian
-GNU/Linux and may be different in other environments.
-
-To have the analysis results aggregated into a set of HTML files, use the
-following command:
-
-    $ scan-build make
+    scan-build cmake ..
+    scan-build make
 
 The tool will provide a hint on how to launch a web browser with the results.
 
 It is recommended to do this analysis in a separate, empty build directory and
-to empty the build directory before "scan-build" call.
+to empty the build directory before `scan-build` call.
 
 
 Specifying Diffie-Hellman parameters file
 ---------------------------------------------------
 
-For --dh-params' value to take effect, LibmicroHTTPD version 0.9.35 or higher is
-required.
+For the value of `--dh-params` to take effect, LibmicroHTTPD version 0.9.35 or
+higher is required.

--- a/README.md
+++ b/README.md
@@ -1,54 +1,80 @@
-<img src="https://www.greenbone.net/wp-content/uploads/01_Logo-mit-Schriftzug_500px_on_white_horiz1.jpg" alt="Greenbone Logo" width="400px"/>
+![Greenbone Logo](https://www.greenbone.net/wp-content/uploads/gb_logo_resilience_horizontal.png)
 
 # Greenbone Security Assistant
 
-[![GitHub release](https://img.shields.io/github/release/greenbone/gsa.svg)](https://github.com/greenbone/gsa/releases)
-[![codecov](https://codecov.io/gh/greenbone/gsa/branch/master/graph/badge.svg)](https://codecov.io/gh/greenbone/gsa)
+[![GitHub releases](https://img.shields.io/github/release/greenbone/gsa.svg)](https://github.com/greenbone/gsa/releases)
+[![code test coverage](https://codecov.io/gh/greenbone/gsa/branch/master/graph/badge.svg)](https://codecov.io/gh/greenbone/gsa)
 [![CircleCI](https://circleci.com/gh/greenbone/gsa/tree/master.svg?style=svg)](https://circleci.com/gh/greenbone/gsa/tree/master)
 
-## About
+The Greenbone Security Assistant is the web interface developed for the
+[Greenbone Security Manager
+appliances](https://www.greenbone.net/en/product-comparison/).
 
-The Greenbone Security Assistant - is the web interface developed for the
-[Greenbone Security Manager appliances](https://www.greenbone.net/en/product-comparison/).
-It connects to the Greenbone Vulnerability Manager - **GVM** - to provide for a full-featured
-user interface for vulnerability management.
+It connects to the Greenbone Vulnerability Manager **GVM** to provide a
+full-featured user interface for vulnerability management.
 
-Greenbone Security Assistant is developed and maintained by [Greenbone Networks](https://www.greenbone.net/).
-
-It consists of
+Greenbone Security Assistant consists of
 
 * [GSA](https://github.com/greenbone/gsa/tree/master/gsa) - The webpage written in [React](https://reactjs.org/)
 
 and
 
-* [GSAD](https://github.com/greenbone/gsa/tree/master/gsad) - The http server talking to the [GVM daemon](https://github.com/greenbone/gvm)
+* [GSAD](https://github.com/greenbone/gsa/tree/master/gsad) - The HTTP server talking to the [GVM daemon](https://github.com/greenbone/gvmd)
 
 ## Installation
 
-See [INSTALL](./INSTALL.md) for details.
+This module can be configured, built and installed with following commands:
+
+    cmake .
+    make install
+
+For detailed installation requirements and instructions, please see the file
+[INSTALL.md](INSTALL.md).
+
+If you are not familiar or comfortable building from source code, we recommend
+that you use the Greenbone Community Edition, a prepared virtual machine with a
+readily available setup. Information regarding the virtual machine is available
+at <https://www.greenbone.net/en/community-edition/>.
 
 ## Usage
 
-Starting Greenbone Security Assistant:
-
-In case everything was installed using the defaults, then starting the http
+In case everything was installed using the defaults, then starting the HTTP
 daemon of the Greenbone Security Assistant can be done with this simple command:
 
     gsad
 
-The daemon will then listen on port 443, in other words the web interface
-is available in your network under "https://<your host>".
+The daemon will listen on port 443, making the web interface
+available in your network at `https://<your host>`.
 
 If port 443 was not available or the user has no root privileges,
-gsad tries to serve at port 9392 as a fallback ("https://<your host>:9392").
+gsad tries to serve at port 9392 as a fallback (`https://<your host>:9392`).
 
-To see all available command line options of gsad enter this command:
+To see all available command line options of gsad, enter this command:
 
     gsad --help
 
+## Support
+
+For any question on the usage of `gsa` please use the [Greenbone Community
+Portal](https://community.greenbone.net/c/gse). If you found a problem with the
+software, please [create an issue](https://github.com/greenbone/gsa/issues) on
+GitHub. If you are a Greenbone customer you may alternatively or additionally
+forward your issue to the Greenbone Support Portal.
+
+## Maintainer
+
+This project is maintained by [Greenbone Networks
+GmbH](https://www.greenbone.net/).
+
+## Contributing
+
+Your contributions are highly appreciated. Please [create a pull
+request](https://github.com/greenbone/gsa/pulls) on GitHub. Bigger changes need
+to be discussed with the development team via the [issues section at
+github](https://github.com/greenbone/gsa/issues) first.
+
 ## License
 
-Greenbone Security Assistant is licensed under GNU General Public License
-Version 2 or any later version. Please see file [LICENSE](./LICENSE) for details.
+Copyright (C) 2009-2018 [Greenbone Networks GmbH](https://www.greenbone.net/)
 
-Copyright (C) by Greenbone Networks GmbH (see https://www.greenbone.net).
+Licensed under the [GNU General Public License v2.0 or later](LICENSE).


### PR DESCRIPTION
The commits adjust layout and content of the `README` file to match the template provided by the `greenbone/templates` repository. Also, the layout and content of the `INSTALL.md` file have been updated as well.

This makes `gsa` consistent with the changes from greenbone/gvm-libs#147.