### PR TITLE
Modify privacy password and algorithm separately (7.0)

### DIFF
--- a/src/gsad_omp.c
+++ b/src/gsad_omp.c
@@ -6782,22 +6782,17 @@ save_credential_omp (openvas_connection_t *connection,
     {
       xml_string_append (command,
                          "<privacy>");
-      if (privacy_algorithm && strcmp (privacy_algorithm, ""))
+      if (privacy_algorithm)
         {
           xml_string_append (command,
                              "<algorithm>%s</algorithm>",
                              privacy_algorithm);
-          if (change_privacy_password)
-            xml_string_append (command,
-                               "<password>%s</password>",
-                               privacy_password);
         }
-      else if (privacy_algorithm)
+      if (change_privacy_password && privacy_password)
         {
           xml_string_append (command,
-                             "<algorithm></algorithm>");
-          xml_string_append (command,
-                             "<password></password>");
+                             "<password>%s</password>",
+                             privacy_password);
         }
 
       xml_string_append (command,


### PR DESCRIPTION
When modifying SNMP credentials, the privacy algorithm can now be
updated without changing the privacy password.