### PR TITLE
Adjust icon size

### DIFF
--- a/gsa/src/web/pages/ldap/ldappage.js
+++ b/gsa/src/web/pages/ldap/ldappage.js
@@ -195,7 +195,7 @@ class LdapAuthentication extends React.Component {
           <ManualIcon
             page="gui_administration"
             anchor="ldap"
-            size="medium"
+            size="small"
             title={_('Help: LDAP per-User Authentication')}
           />
           <Section

--- a/gsa/src/web/pages/performance/performancepage.js
+++ b/gsa/src/web/pages/performance/performancepage.js
@@ -81,12 +81,12 @@ const ToolBar = ({
       <ManualIcon
         page="performance"
         anchor="appliance-performance"
-        size="medium"
+        size="small"
         title={_('Help: Performance')}
       />
       <IconMenu
         img="wizard.svg"
-        size="medium"
+        size="small"
       >
         <MenuEntry
           title={_('Report for Last Hour')}

--- a/gsa/src/web/pages/radius/radiuspage.js
+++ b/gsa/src/web/pages/radius/radiuspage.js
@@ -142,7 +142,7 @@ class RadiusAuthentication extends React.Component {
           <ManualIcon
             page="gui_administration"
             anchor="radius"
-            size="medium"
+            size="small"
             title={_('Help: RADIUS Authentication')}
           />
           <Section

--- a/gsa/src/web/pages/usersettings/usersettingspage.js
+++ b/gsa/src/web/pages/usersettings/usersettingspage.js
@@ -184,13 +184,13 @@ const ToolBarIcons = ({onEditSettingsClick}) => (
   <Layout>
     <IconDivider>
       <ManualIcon
-        size="medium"
+        size="small"
         page="gui_introduction"
         anchor="my-settings"
         title={_('Help: My Settings')}
       />
       <EditIcon
-        size="medium"
+        size="small"
         title={_('Edit My Settings')}
         onClick={onEditSettingsClick}
       />


### PR DESCRIPTION
Toolbar icons are set to "small" for pages: ldap, radius, performance, 
and usersettings.