### PR TITLE
Fix QoD value for qodColorScale

### DIFF
--- a/gsa/src/web/components/dashboard/display/utils.js
+++ b/gsa/src/web/components/dashboard/display/utils.js
@@ -122,7 +122,7 @@ export const QOD_TYPES = {
 };
 
 export const qodColorScale = scaleOrdinal()
-  .domain([1, 30, 50, 70, 76, 80, 95, 97, 98, 99, 100])
+  .domain([1, 30, 50, 70, 75, 80, 95, 97, 98, 99, 100])
   .range([
     '#011f4b',
     '#023061',


### PR DESCRIPTION
We (GSF-dev and GVM-dev) should stick to the 11 QoD-values defined in the manual (https://docs.greenbone.net/GSM-Manual/gos-4/en/glossary.html#quality-of-detection-qod ).

This PR fixes the 76% to 75% value and GSF-dev will update the VTs that introduced 76% and 60% values.