### PR TITLE
Renamed omp_status to gmp_status in translation files.

### DIFF
--- a/gsa/po/gsa-ar.po
+++ b/gsa/po/gsa-ar.po
@@ -359,11 +359,11 @@ msgid "Invalid request command: \"{{command}}"
 msgstr ""
 
 #: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2927
-msgid "Error {{omp_status}}: {{omp_status_text}}"
+msgid "Error {{gmp_status}}: {{gmp_status_text}}"
 msgstr ""
 
 #: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2929
-msgid "GMP Error {{omp_status}}: {{omp_status_text}}"
+msgid "GMP Error {{gmp_status}}: {{gmp_status_text}}"
 msgstr ""
 
 #: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:3216

--- a/gsa/po/gsa-de.po
+++ b/gsa/po/gsa-de.po
@@ -1038,11 +1038,11 @@ msgid "Invalid request command: \"{{command}}"
 msgstr "Ungültiger Befehl für Anfrage: \"{{command}}\""
 
 #: ng/src/web/components/dashboard/legacy/datasource.js:309
-msgid "Error {{omp_status}}: {{omp_status_text}}"
-msgstr "Fehler {{omp_status}}: {{omp_status_text}}"
+msgid "Error {{gmp_status}}: {{gmp_status_text}}"
+msgstr "Fehler {{gmp_status}}: {{gmp_status_text}}"
 
 #: ng/src/web/components/dashboard/legacy/datasource.js:313
-msgid "GMP Error {{omp_status}}: {{omp_status_text}}"
+msgid "GMP Error {{gmp_status}}: {{gmp_status_text}}"
 msgstr ""
 
 #: ng/src/web/components/dashboard/commoncharts.js:50

--- a/gsa/po/gsa-fr.po
+++ b/gsa/po/gsa-fr.po
@@ -352,11 +352,11 @@ msgid "Invalid request command: \"{{command}}"
 msgstr ""
 
 #: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2927
-msgid "Error {{omp_status}}: {{omp_status_text}}"
+msgid "Error {{gmp_status}}: {{gmp_status_text}}"
 msgstr ""
 
 #: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2929
-msgid "GMP Error {{omp_status}}: {{omp_status_text}}"
+msgid "GMP Error {{gmp_status}}: {{gmp_status_text}}"
 msgstr ""
 
 #: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:3216

--- a/gsa/po/gsa-pt_BR.po
+++ b/gsa/po/gsa-pt_BR.po
@@ -372,13 +372,13 @@ msgstr "Comando solicitado inválido: \"{{command}}"
 
 #: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2927
 #, fuzzy
-msgid "Error {{omp_status}}: {{omp_status_text}}"
-msgstr "Erro {{omp_status}}: {{omp_status_text}}"
+msgid "Error {{gmp_status}}: {{gmp_status_text}}"
+msgstr "Erro {{gmp_status}}: {{gmp_status_text}}"
 
 #: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2929
 #, fuzzy
-msgid "GMP Error {{omp_status}}: {{omp_status_text}}"
-msgstr "GMP Erro {{omp_status}}: {{omp_status_text}}"
+msgid "GMP Error {{gmp_status}}: {{gmp_status_text}}"
+msgstr "GMP Erro {{gmp_status}}: {{gmp_status_text}}"
 
 #: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:3216
 #, fuzzy

--- a/gsa/po/gsa-ru.po
+++ b/gsa/po/gsa-ru.po
@@ -133,12 +133,12 @@ msgstr ""
 
 #: /home/bricks/source/gsad/src/html/classic/js/gsa_graphics_base.js:2204
 #: /home/bricks/source/gsad/src/html/classic/js/gsa_graphics_base.js:2246
-msgid "Error {{omp_status}}: {{omp_status_text}}"
+msgid "Error {{gmp_status}}: {{gmp_status_text}}"
 msgstr ""
 
 #: /home/bricks/source/gsad/src/html/classic/js/gsa_graphics_base.js:2207
 #: /home/bricks/source/gsad/src/html/classic/js/gsa_graphics_base.js:2249
-msgid "GMP Error {{omp_status}}: {{omp_status_text}}"
+msgid "GMP Error {{gmp_status}}: {{gmp_status_text}}"
 msgstr ""
 
 #: /home/bricks/source/gsad/src/html/classic/js/gsa_graphics_base.js:2275

--- a/gsa/po/gsa-tr.po
+++ b/gsa/po/gsa-tr.po
@@ -352,11 +352,11 @@ msgid "Invalid request command: \"{{command}}"
 msgstr ""
 
 #: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2927
-msgid "Error {{omp_status}}: {{omp_status_text}}"
+msgid "Error {{gmp_status}}: {{gmp_status_text}}"
 msgstr ""
 
 #: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:2929
-msgid "GMP Error {{omp_status}}: {{omp_status_text}}"
+msgid "GMP Error {{gmp_status}}: {{gmp_status_text}}"
 msgstr ""
 
 #: /home/timo/openvas/src/proj1-trunk/gsa/src/html/classic/js/gsa_dashboard.js:3216

--- a/gsa/po/gsa-zh_CN.po
+++ b/gsa/po/gsa-zh_CN.po
@@ -131,12 +131,12 @@ msgstr ""
 
 #: /home/bricks/source/gsad/src/html/classic/js/gsa_graphics_base.js:2204
 #: /home/bricks/source/gsad/src/html/classic/js/gsa_graphics_base.js:2246
-msgid "Error {{omp_status}}: {{omp_status_text}}"
+msgid "Error {{gmp_status}}: {{gmp_status_text}}"
 msgstr ""
 
 #: /home/bricks/source/gsad/src/html/classic/js/gsa_graphics_base.js:2207
 #: /home/bricks/source/gsad/src/html/classic/js/gsa_graphics_base.js:2249
-msgid "GMP Error {{omp_status}}: {{omp_status_text}}"
+msgid "GMP Error {{gmp_status}}: {{gmp_status_text}}"
 msgstr ""
 
 #: /home/bricks/source/gsad/src/html/classic/js/gsa_graphics_base.js:2275


### PR DESCRIPTION
Actually, this change has no effect. But with this patch
my QA system does not complain anymore about the use of "omp"
in these files.