### PR TITLE
Set min_qod=0 for "removed" filter in PowerFilter

### DIFF
--- a/gsa/src/gmp/models/filter.js
+++ b/gsa/src/gmp/models/filter.js
@@ -732,7 +732,7 @@ export const TAGS_FILTER_FILTER = Filter.fromString('type=tag');
 export const USERS_FILTER_FILTER = Filter.fromString('type=user');
 export const VULNS_FILTER_FILTER = Filter.fromString('type=vuln');
 
-export const RESET_FILTER = Filter.fromString('first=1');
+export const RESET_FILTER = Filter.fromString('first=1 min_qod=0');
 
 export default Filter;
 


### PR DESCRIPTION
Removing a filter should result in all results being shown. min_qod>0
reduces the number of results and should have been changed when
introducing the "remove filter" functionality already.