### PR TITLE
Don't reject promise if no setting is available

### DIFF
--- a/gsa/src/gmp/commands/dashboards.js
+++ b/gsa/src/gmp/commands/dashboards.js
@@ -22,6 +22,8 @@
  */
 import uuid from 'uuid/v4';
 
+import {isDefined} from '../utils/identity';
+
 import logger from '../log';
 
 import GmpCommand from './gmp';
@@ -75,6 +77,11 @@ class DashboardCommand extends GmpCommand {
     }).then(response => {
       const {data} = response;
       const {setting} = data.get_settings.get_settings_response;
+
+      if (!isDefined(setting)) {
+        return response.setData({});
+      }
+
       const {value, name} = setting;
       let config;
       try {


### PR DESCRIPTION
When requesting the dashboard settings from the backend don't throw if
no setting is returned from the response which will lead to a promise
rejection. Instead return an empty object for the settings.

Should fix #1098