### PR TITLE
Add Alemba vFire alert method to gsad

### DIFF
--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -881,6 +881,8 @@ init_validator ()
   gvm_validator_alias (validator, "resource_ids:name",     "number");
   gvm_validator_alias (validator, "resource_ids:value",    "info_id");
   gvm_validator_alias (validator, "result_hosts_only", "boolean");
+  gvm_validator_alias (validator, "report_format_ids:name",  "number");
+  gvm_validator_alias (validator, "report_format_ids:value", "report_format_id");
   gvm_validator_alias (validator, "result_task_id", "optional_task_id");
   gvm_validator_alias (validator, "result_uuid", "optional_id");
   gvm_validator_alias (validator, "report_result_id",  "result_id");
@@ -1110,6 +1112,7 @@ params_append_mhd (params_t *params,
   if ((strcmp (name, "alert_ids:") == 0)
       || (strcmp(name, "role_ids:") == 0)
       || (strcmp(name, "group_ids:") == 0)
+      || (strcmp(name, "report_format_ids:") == 0)
       || (strcmp(name, "id_list:") == 0)
       || (strcmp(name, "resource_ids:") == 0))
     {
@@ -1719,6 +1722,7 @@ params_mhd_add (void *params, enum MHD_ValueKind kind, const char *name,
   if ((strcmp (name, "alert_ids:") == 0)
       || (strcmp(name, "role_ids:") == 0)
       || (strcmp(name, "group_ids:") == 0)
+      || (strcmp(name, "report_format_ids:") == 0)
       || (strcmp(name, "id_list:") == 0))
     {
       param_t *param;


### PR DESCRIPTION
This PR is a port of the gsad portions #1092 from GSA 7.0 to master
and adds alert data params for the Alemba vFire method including a
way to specify multiple report formats for methods that support it.

