### PR TITLE
GSAd changes for SMB alert updates

### DIFF
--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -701,8 +701,8 @@ init_validator ()
   gvm_validator_add (validator, "subject_type",  "^(group|role|user)$");
   gvm_validator_add (validator, "summary",    "^.{0,400}$");
   gvm_validator_add (validator, "tag_id",  "^[a-z0-9\\-]+$");
-  gvm_validator_add (validator, "tag_name",       "^[\\:-_[:alnum:], \\./]{1,80}$");
-  gvm_validator_add (validator, "tag_value",       "^[\\-_@[:alnum:], \\./]{0,200}$");
+  gvm_validator_add (validator, "tag_name",  "^[\\:\\-_[:alnum:], \\./]{1,80}$");
+  gvm_validator_add (validator, "tag_value", "^[\\-_@[:alnum:], \\.\\\\]{0,200}$");
   gvm_validator_add (validator, "target_id",  "^[a-z0-9\\-]+$");
   gvm_validator_add (validator, "task_id",    "^[a-z0-9\\-]+$");
   gvm_validator_add (validator, "term",       "^.{0,1000}");

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -7262,6 +7262,7 @@ append_alert_method_data (GString *xml, params_t *data, const char *method,
             || (strcmp (method, "SMB") == 0
                 && (strcmp (name, "smb_credential") == 0
                     || strcmp (name, "smb_file_path") == 0
+                    || strcmp (name, "smb_file_path_type") == 0
                     || strcmp (name, "smb_report_format") == 0
                     || strcmp (name, "smb_share_path") == 0))
             || (strcmp (method, "SNMP") == 0


### PR DESCRIPTION
This lets gsad accept the smb_file_path_type alert method data and allows creating the tag
"smb-alert:file_path" with a Windows path as the value.