### PR TITLE
Simplify entities table row rendering

### DIFF
--- a/gsa/CMakeLists.txt
+++ b/gsa/CMakeLists.txt
@@ -389,6 +389,7 @@ set (GSA_JS_SRC_FILES
      ${GSA_SRC_DIR}/src/web/entities/selection.js
      ${GSA_SRC_DIR}/src/web/entities/table.js
      ${GSA_SRC_DIR}/src/web/entities/tagsdialog.js
+     ${GSA_SRC_DIR}/src/web/entities/withEntitiesActions.js
      ${GSA_SRC_DIR}/src/web/entities/withEntitiesContainer.js
      ${GSA_SRC_DIR}/src/web/entities/withRowDetails.js
      ${GSA_SRC_DIR}/src/web/entity/block.js

--- a/gsa/src/web/entities/actions.js
+++ b/gsa/src/web/entities/actions.js
@@ -24,67 +24,47 @@ import React from 'react';
 
 import {isDefined} from 'gmp/utils/identity';
 
-import Layout from '../components/layout/layout.js';
+import TableData from 'web/components/table/data';
 
-import PropTypes from '../utils/proptypes.js';
-import {renderComponent} from '../utils/render.js';
+import PropTypes from 'web/utils/proptypes';
+import SelectionType from 'web/utils/selectiontype';
 
-import SelectionType from '../utils/selectiontype.js';
+import EntitySelection from './selection';
 
-import EntitySelection from './selection.js';
-
-const EntityActions = ({
-  actionsComponent,
+const EntitiesActions = ({
+  children,
   entity,
   selectionType,
   onEntityDeselected,
   onEntitySelected,
-  ...other
+  ...props
 }) => {
-  if (!isDefined(actionsComponent) &&
+  if (!isDefined(children) &&
     selectionType !== SelectionType.SELECTION_USER) {
     return null;
   }
-
-  return (
-    <td className="table-actions">
-      {selectionType === SelectionType.SELECTION_USER ?
-        <Layout align={['center', 'center']}>
-          <EntitySelection
-            entity={entity}
-            onSelected={onEntitySelected}
-            onDeselected={onEntityDeselected}
-          />
-        </Layout> :
-        <Layout flex="column" grow>
-          {renderComponent(actionsComponent, {...other, entity})}
-        </Layout>
-      }
-    </td>
-  );
+  return selectionType === SelectionType.SELECTION_USER ?
+    <TableData align={['center', 'center']}>
+      <EntitySelection
+        entity={entity}
+        onSelected={onEntitySelected}
+        onDeselected={onEntityDeselected}
+      />
+    </TableData> :
+    <TableData grow>
+      {children({entity, ...props})}
+    </TableData>;
 };
 
-EntityActions.propTypes = {
+EntitiesActions.propTypes = {
   actionsComponent: PropTypes.component,
+  children: PropTypes.func,
   entity: PropTypes.model,
   selectionType: PropTypes.string,
   onEntityDeselected: PropTypes.func,
   onEntitySelected: PropTypes.func,
 };
 
-export const withEntityActions = component => {
-  // filter actions from parent. actions may contain this component
-  const EnityActionsWrapper = ({actions, ...props}) => { // eslint-disable-line no-unused
-    return <EntityActions actionsComponent={component} {...props}/>;
-  };
-
-  EnityActionsWrapper.propTypes = {
-    actions: PropTypes.any, // don't care
-  };
-
-  return EnityActionsWrapper;
-};
-
-export default EntityActions;
+export default EntitiesActions;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/entities/row.js
+++ b/gsa/src/web/entities/row.js
@@ -20,30 +20,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-
-import React from 'react';
-
 import styled from 'styled-components';
 
-import Theme from 'web/utils/theme';
 import withClickHandler from 'web/components/form/withClickHandler';
 
-import EntityActions from './actions';
-
-export const withEntityRow = (actions = EntityActions, options = {}) =>
-  Component => {
-
-  const EntityRowWrapper = props => {
-    return (
-      <Component
-        {...options}
-        actions={actions}
-        {...props}
-      />
-    );
-  };
-  return EntityRowWrapper;
-};
+import Theme from 'web/utils/theme';
 
 export const RowDetailsToggle = withClickHandler()(styled.span`
   {

--- a/gsa/src/web/entities/withEntitiesActions.js
+++ b/gsa/src/web/entities/withEntitiesActions.js
@@ -1,0 +1,37 @@
+/* Copyright (C) 2019 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import React from 'react';
+
+import EntitiesActions from './actions';
+
+const withEntitiesActions = Component => {
+  const EnitiesActionsWrapper = props => (
+    <EntitiesActions
+      {...props}
+    >
+      {actionprops => <Component {...actionprops}/>}
+    </EntitiesActions>
+  );
+
+  return EnitiesActionsWrapper;
+};
+
+export default withEntitiesActions;
+
+// vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/agents/row.js
+++ b/gsa/src/web/pages/agents/row.js
@@ -26,17 +26,6 @@ import React from 'react';
 import _ from 'gmp/locale';
 import {shortDate} from 'gmp/locale/date';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import EntityNameTableData from 'web/entities/entitynametabledata';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
-
 import ExportIcon from 'web/components/icon/exporticon';
 import Icon from 'web/components/icon/icon';
 
@@ -45,7 +34,17 @@ import IconDivider from 'web/components/layout/icondivider';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
-const Actions = ({
+import EntityNameTableData from 'web/entities/entitynametabledata';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
+
+
+const Actions = withEntitiesActions(({
   entity,
   onAgentDeleteClick,
   onAgentDownloadClick,
@@ -96,7 +95,7 @@ const Actions = ({
       onClick={onAgentVerifyClick}
     />
   </IconDivider>
-);
+));
 
 Actions.propTypes = {
   entity: PropTypes.model.isRequired,
@@ -109,7 +108,6 @@ Actions.propTypes = {
 };
 
 const Row = ({
-  actions,
   entity,
   links = true,
   onToggleDetailsClick,
@@ -126,17 +124,19 @@ const Row = ({
     <TableData>
       {entity.trust.status} ({shortDate(entity.trust.time)})
     </TableData>
-    {renderComponent(actions, {...props, entity})}
+    <Actions
+      {...props}
+      entity={entity}
+    />
   </TableRow>
 );
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(Actions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/alerts/row.js
+++ b/gsa/src/web/pages/alerts/row.js
@@ -26,19 +26,6 @@ import _ from 'gmp/locale';
 
 import {isDefined} from 'gmp/utils/identity';
 
-import compose from 'web/utils/compose';
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent, renderYesNo} from 'web/utils/render';
-import withCapabilities from 'web/utils/withCapabilities';
-
-import EntityNameTableData from 'web/entities/entitynametabledata';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
-
 import ExportIcon from 'web/components/icon/exporticon';
 import Icon from 'web/components/icon/icon';
 
@@ -49,11 +36,22 @@ import DetailsLink from 'web/components/link/detailslink';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
+import EntityNameTableData from 'web/entities/entitynametabledata';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
+import {renderYesNo} from 'web/utils/render';
+import withCapabilities from 'web/utils/withCapabilities';
+
 import Condition from './condition';
 import Event from './event';
 import Method from './method';
 
-const Actions = ({
+const Actions = withEntitiesActions(({
   entity,
   onAlertDeleteClick,
   onAlertDownloadClick,
@@ -97,7 +95,7 @@ const Actions = ({
       onClick={onAlertTestClick}
     />
   </IconDivider>
-);
+));
 
 Actions.propTypes = {
   entity: PropTypes.model,
@@ -125,56 +123,52 @@ const render_filter = (filter, caps, links = true) => {
 };
 
 const Row = ({
-  actions,
   capabilities,
   entity,
   links = true,
   onToggleDetailsClick,
   ...props
-}) => {
-  return (
-    <TableRow>
-      <EntityNameTableData
-        entity={entity}
-        link={links}
-        type="alert"
-        displayName={_('Alert')}
-        onToggleDetailsClick={onToggleDetailsClick}
+}) => (
+  <TableRow>
+    <EntityNameTableData
+      entity={entity}
+      link={links}
+      type="alert"
+      displayName={_('Alert')}
+      onToggleDetailsClick={onToggleDetailsClick}
+    />
+    <TableData>
+      <Event event={entity.event}/>
+    </TableData>
+    <TableData>
+      <Condition
+        condition={entity.condition}
+        event={entity.event}
       />
-      <TableData>
-        <Event event={entity.event}/>
-      </TableData>
-      <TableData>
-        <Condition
-          condition={entity.condition}
-          event={entity.event}
-        />
-      </TableData>
-      <TableData>
-        <Method method={entity.method}/>
-      </TableData>
-      <TableData>
-        {render_filter(entity.filter, capabilities)}
-      </TableData>
-      <TableData>
-        {renderYesNo(entity.active)}
-      </TableData>
-      {renderComponent(actions, {...props, entity})}
-    </TableRow>
-  );
-};
+    </TableData>
+    <TableData>
+      <Method method={entity.method}/>
+    </TableData>
+    <TableData>
+      {render_filter(entity.filter, capabilities)}
+    </TableData>
+    <TableData>
+      {renderYesNo(entity.active)}
+    </TableData>
+    <Actions
+      {...props}
+      entity={entity}
+    />
+  </TableRow>
+);
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   capabilities: PropTypes.capabilities.isRequired,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default compose(
-  withEntityRow(withEntityActions(Actions)),
-  withCapabilities,
-)(Row);
+export default withCapabilities(Row);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/certbund/row.js
+++ b/gsa/src/web/pages/certbund/row.js
@@ -25,11 +25,6 @@ import React from 'react';
 
 import {longDate} from 'gmp/locale/date';
 
-import PropTypes from 'web/utils/proptypes';
-import {na, renderComponent} from 'web/utils/render';
-
-import {withEntityRow, RowDetailsToggle} from 'web/entities/row';
-
 import SeverityBar from 'web/components/bar/severitybar';
 
 import Comment from 'web/components/comment/comment';
@@ -37,48 +32,53 @@ import Comment from 'web/components/comment/comment';
 import TableRow from 'web/components/table/row';
 import TableData from 'web/components/table/data';
 
+import EntitiesActions from 'web/entities/actions';
+import {RowDetailsToggle} from 'web/entities/row';
+
+import PropTypes from 'web/utils/proptypes';
+import {na} from 'web/utils/render';
+
 const Row = ({
   entity,
   links = true,
-  actions,
   onToggleDetailsClick,
-  ...other
-}) => {
-  return (
-    <TableRow>
-      <TableData>
-        <RowDetailsToggle
-          name={entity.id}
-          onClick={onToggleDetailsClick}
-        >
-          {entity.name}
-        </RowDetailsToggle>
-        <Comment text={entity.comment}/>
-      </TableData>
-      <TableData>
-        {na(entity.title)}
-      </TableData>
-      <TableData>
-        {longDate(entity.creationTime)}
-      </TableData>
-      <TableData>
-        {entity.cve_refs}
-      </TableData>
-      <TableData>
-        <SeverityBar severity={entity.severity}/>
-      </TableData>
-      {renderComponent(actions, {...other, entity})}
-    </TableRow>
-  );
-};
+  ...props
+}) => (
+  <TableRow>
+    <TableData>
+      <RowDetailsToggle
+        name={entity.id}
+        onClick={onToggleDetailsClick}
+      >
+        {entity.name}
+      </RowDetailsToggle>
+      <Comment text={entity.comment}/>
+    </TableData>
+    <TableData>
+      {na(entity.title)}
+    </TableData>
+    <TableData>
+      {longDate(entity.creationTime)}
+    </TableData>
+    <TableData>
+      {entity.cve_refs}
+    </TableData>
+    <TableData>
+      <SeverityBar severity={entity.severity}/>
+    </TableData>
+    <EntitiesActions
+      {...props}
+      entity={entity}
+    />
+  </TableRow>
+);
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow()(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/cpes/row.js
+++ b/gsa/src/web/pages/cpes/row.js
@@ -25,11 +25,6 @@ import React from 'react';
 
 import {longDate} from 'gmp/locale/date';
 
-import PropTypes from 'web/utils/proptypes';
-import {na, renderComponent} from 'web/utils/render';
-
-import {withEntityRow, RowDetailsToggle} from 'web/entities/row';
-
 import SeverityBar from 'web/components/bar/severitybar';
 
 import Comment from 'web/components/comment/comment';
@@ -37,48 +32,53 @@ import Comment from 'web/components/comment/comment';
 import TableRow from 'web/components/table/row';
 import TableData from 'web/components/table/data';
 
+import EntitiesActions from 'web/entities/actions';
+import {RowDetailsToggle} from 'web/entities/row';
+
+import PropTypes from 'web/utils/proptypes';
+import {na} from 'web/utils/render';
+
 const Row = ({
   entity,
   links = true,
-  actions,
   onToggleDetailsClick,
-  ...other
-}) => {
-  return (
-    <TableRow>
-      <TableData>
-        <RowDetailsToggle
-          name={entity.id}
-          onClick={onToggleDetailsClick}
-        >
-          {entity.name}
-        </RowDetailsToggle>
-        <Comment text={entity.comment}/>
-      </TableData>
-      <TableData>
-        {na(entity.title)}
-      </TableData>
-      <TableData>
-        {longDate(entity.modificationTime)}
-      </TableData>
-      <TableData>
-        {entity.cve_refs}
-      </TableData>
-      <TableData>
-        <SeverityBar severity={entity.severity}/>
-      </TableData>
-      {renderComponent(actions, {...other, entity})}
-    </TableRow>
-  );
-};
+  ...props
+}) => (
+  <TableRow>
+    <TableData>
+      <RowDetailsToggle
+        name={entity.id}
+        onClick={onToggleDetailsClick}
+      >
+        {entity.name}
+      </RowDetailsToggle>
+      <Comment text={entity.comment}/>
+    </TableData>
+    <TableData>
+      {na(entity.title)}
+    </TableData>
+    <TableData>
+      {longDate(entity.modificationTime)}
+    </TableData>
+    <TableData>
+      {entity.cve_refs}
+    </TableData>
+    <TableData>
+      <SeverityBar severity={entity.severity}/>
+    </TableData>
+    <EntitiesActions
+      {...props}
+      entity={entity}
+    />
+  </TableRow>
+);
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow()(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/credentials/row.js
+++ b/gsa/src/web/pages/credentials/row.js
@@ -26,17 +26,6 @@ import _ from 'gmp/locale';
 
 import {getCredentialTypeName} from 'gmp/models/credential';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import EntityNameTableData from 'web/entities/entitynametabledata';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
-
 import FootNote from 'web/components/footnote/footnote';
 
 import ExportIcon from 'web/components/icon/exporticon';
@@ -47,53 +36,60 @@ import IconDivider from 'web/components/layout/icondivider';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
+import EntityNameTableData from 'web/entities/entitynametabledata';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
+
 import CredentialDownloadIcon from './downloadicon';
 
-const Actions = ({
+const Actions = withEntitiesActions(({
   entity,
   onCredentialDeleteClick,
   onCredentialDownloadClick,
   onCredentialCloneClick,
   onCredentialEditClick,
   onCredentialInstallerDownloadClick,
-}) => {
-  return (
-    <IconDivider
-      align={['start', 'center']}
-      grow
-    >
-      <TrashIcon
-        displayName={_('Credential')}
-        name="credential"
-        entity={entity}
-        onClick={onCredentialDeleteClick}
-      />
-      <EditIcon
-        displayName={_('Credential')}
-        name="credential"
-        entity={entity}
-        onClick={onCredentialEditClick}
-      />
-      <CloneIcon
-        displayName={_('Credential')}
-        name="credential"
-        entity={entity}
-        title={_('Clone Credential')}
-        value={entity}
-        onClick={onCredentialCloneClick}
-      />
-      <ExportIcon
-        value={entity}
-        title={_('Export Credential')}
-        onClick={onCredentialDownloadClick}
-      />
-      <CredentialDownloadIcon
-        credential={entity}
-        onDownload={onCredentialInstallerDownloadClick}
-      />
-    </IconDivider>
-  );
-};
+}) => (
+  <IconDivider
+    align={['start', 'center']}
+    grow
+  >
+    <TrashIcon
+      displayName={_('Credential')}
+      name="credential"
+      entity={entity}
+      onClick={onCredentialDeleteClick}
+    />
+    <EditIcon
+      displayName={_('Credential')}
+      name="credential"
+      entity={entity}
+      onClick={onCredentialEditClick}
+    />
+    <CloneIcon
+      displayName={_('Credential')}
+      name="credential"
+      entity={entity}
+      title={_('Clone Credential')}
+      value={entity}
+      onClick={onCredentialCloneClick}
+    />
+    <ExportIcon
+      value={entity}
+      title={_('Export Credential')}
+      onClick={onCredentialDownloadClick}
+    />
+    <CredentialDownloadIcon
+      credential={entity}
+      onDownload={onCredentialInstallerDownloadClick}
+    />
+  </IconDivider>
+));
 
 Actions.propTypes = {
   entity: PropTypes.model.isRequired,
@@ -105,7 +101,6 @@ Actions.propTypes = {
 };
 
 const Row = ({
-  actions,
   entity,
   links = true,
   onToggleDetailsClick,
@@ -135,17 +130,19 @@ const Row = ({
     <TableData>
       {entity.login}
     </TableData>
-    {renderComponent(actions, {...props, entity})}
+    <Actions
+      {...props}
+      entity={entity}
+    />
   </TableRow>
 );
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(Actions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/cves/row.js
+++ b/gsa/src/web/pages/cves/row.js
@@ -27,11 +27,6 @@ import {longDate} from 'gmp/locale/date';
 
 import {shorten} from 'gmp/utils/string';
 
-import PropTypes from 'web/utils/proptypes';
-import {na, renderComponent} from 'web/utils/render';
-
-import {withEntityRow, RowDetailsToggle} from 'web/entities/row';
-
 import SeverityBar from 'web/components/bar/severitybar';
 
 import Comment from 'web/components/comment/comment';
@@ -40,69 +35,74 @@ import TableBody from 'web/components/table/body';
 import TableRow from 'web/components/table/row';
 import TableData from 'web/components/table/data';
 
+import EntitiesActions from 'web/entities/actions';
+import {RowDetailsToggle} from 'web/entities/row';
+
+import PropTypes from 'web/utils/proptypes';
+import {na} from 'web/utils/render';
+
 const Row = ({
   entity,
   links = true,
-  actions,
   onToggleDetailsClick,
-  ...other
-}) => {
-  return (
-    <TableBody>
-      <TableRow>
-        <TableData
-          rowSpan="2"
+  ...props
+}) => (
+  <TableBody>
+    <TableRow>
+      <TableData
+        rowSpan="2"
+      >
+        <RowDetailsToggle
+          name={entity.id}
+          onClick={onToggleDetailsClick}
         >
-          <RowDetailsToggle
-            name={entity.id}
-            onClick={onToggleDetailsClick}
-          >
-            {entity.name}
-          </RowDetailsToggle>
-          <Comment text={entity.comment}/>
-        </TableData>
-        <TableData>
-          {na(entity.cvssAccessVector)}
-        </TableData>
-        <TableData>
-          {na(entity.cvssAccessComplexity)}
-        </TableData>
-        <TableData>
-          {na(entity.cvssAuthentication)}
-        </TableData>
-        <TableData>
-          {na(entity.cvssConfidentialityImpact)}
-        </TableData>
-        <TableData>
-          {na(entity.cvssIntegrityImpact)}
-        </TableData>
-        <TableData>
-          {na(entity.cvssAvailabilityImpact)}
-        </TableData>
-        <TableData>
-          {longDate(entity.creationTime)}
-        </TableData>
-        <TableData>
-          <SeverityBar severity={entity.severity}/>
-        </TableData>
-        {renderComponent(actions, {...other, entity})}
-      </TableRow>
-      <TableRow>
-        <TableData colSpan="8">
-          {shorten(entity.description, 250)}
-        </TableData>
-      </TableRow>
-    </TableBody>
-  );
-};
+          {entity.name}
+        </RowDetailsToggle>
+        <Comment text={entity.comment}/>
+      </TableData>
+      <TableData>
+        {na(entity.cvssAccessVector)}
+      </TableData>
+      <TableData>
+        {na(entity.cvssAccessComplexity)}
+      </TableData>
+      <TableData>
+        {na(entity.cvssAuthentication)}
+      </TableData>
+      <TableData>
+        {na(entity.cvssConfidentialityImpact)}
+      </TableData>
+      <TableData>
+        {na(entity.cvssIntegrityImpact)}
+      </TableData>
+      <TableData>
+        {na(entity.cvssAvailabilityImpact)}
+      </TableData>
+      <TableData>
+        {longDate(entity.creationTime)}
+      </TableData>
+      <TableData>
+        <SeverityBar severity={entity.severity}/>
+      </TableData>
+      <EntitiesActions
+        {...props}
+        entity={entity}
+      />
+    </TableRow>
+    <TableRow>
+      <TableData colSpan="9">
+        {shorten(entity.description, 250)}
+      </TableData>
+    </TableRow>
+  </TableBody>
+);
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow()(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/dfncert/row.js
+++ b/gsa/src/web/pages/dfncert/row.js
@@ -25,11 +25,6 @@ import React from 'react';
 
 import {longDate} from 'gmp/locale/date';
 
-import PropTypes from 'web/utils/proptypes';
-import {na, renderComponent} from 'web/utils/render';
-
-import {withEntityRow, RowDetailsToggle} from 'web/entities/row';
-
 import SeverityBar from 'web/components/bar/severitybar';
 
 import Comment from 'web/components/comment/comment';
@@ -37,48 +32,53 @@ import Comment from 'web/components/comment/comment';
 import TableRow from 'web/components/table/row';
 import TableData from 'web/components/table/data';
 
+import EntitiesActions from 'web/entities/actions';
+import {RowDetailsToggle} from 'web/entities/row';
+
+import PropTypes from 'web/utils/proptypes';
+import {na} from 'web/utils/render';
+
 const Row = ({
   entity,
   links = true,
-  actions,
   onToggleDetailsClick,
-  ...other
-}) => {
-  return (
-    <TableRow>
-      <TableData>
-        <RowDetailsToggle
-          name={entity.id}
-          onClick={onToggleDetailsClick}
-        >
-          {entity.name}
-        </RowDetailsToggle>
-        <Comment text={entity.comment}/>
-      </TableData>
-      <TableData>
-        {na(entity.title)}
-      </TableData>
-      <TableData>
-        {longDate(entity.creationTime)}
-      </TableData>
-      <TableData>
-        {entity.cve_refs}
-      </TableData>
-      <TableData>
-        <SeverityBar severity={entity.severity}/>
-      </TableData>
-      {renderComponent(actions, {...other, entity})}
-    </TableRow>
-  );
-};
+  ...props
+}) => (
+  <TableRow>
+    <TableData>
+      <RowDetailsToggle
+        name={entity.id}
+        onClick={onToggleDetailsClick}
+      >
+        {entity.name}
+      </RowDetailsToggle>
+      <Comment text={entity.comment}/>
+    </TableData>
+    <TableData>
+      {na(entity.title)}
+    </TableData>
+    <TableData>
+      {longDate(entity.creationTime)}
+    </TableData>
+    <TableData>
+      {entity.cve_refs}
+    </TableData>
+    <TableData>
+      <SeverityBar severity={entity.severity}/>
+    </TableData>
+    <EntitiesActions
+      {...props}
+      entity={entity}
+    />
+  </TableRow>
+);
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow()(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/filters/row.js
+++ b/gsa/src/web/pages/filters/row.js
@@ -29,23 +29,21 @@ import {typeName} from 'gmp/utils/entitytype';
 
 import IconDivider from 'web/components/layout/icondivider';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import EntityNameTableData from 'web/entities/entitynametabledata';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
-
 import ExportIcon from 'web/components/icon/exporticon';
 
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
-const Actions = ({
+import EntityNameTableData from 'web/entities/entitynametabledata';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
+
+const Actions = withEntitiesActions(({
   entity,
   onFilterDeleteClick,
   onFilterDownloadClick,
@@ -82,7 +80,7 @@ const Actions = ({
       onClick={onFilterDownloadClick}
     />
   </IconDivider>
-);
+));
 
 Actions.propTypes = {
   entity: PropTypes.model.isRequired,
@@ -93,7 +91,6 @@ Actions.propTypes = {
 };
 
 const Row = ({
-  actions,
   entity,
   links = true,
   onToggleDetailsClick,
@@ -113,17 +110,19 @@ const Row = ({
     <TableData>
       {typeName(entity.filter_type)}
     </TableData>
-    {renderComponent(actions, {...props, entity})}
+    <Actions
+      {...props}
+      entity={entity}
+    />
   </TableRow>
 );
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(Actions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/groups/row.js
+++ b/gsa/src/web/pages/groups/row.js
@@ -24,65 +24,61 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import EntityNameTableData from 'web/entities/entitynametabledata';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import TrashIcon from 'web/entity/icon/trashicon';
-import EditIcon from 'web/entity/icon/editicon';
-
 import IconDivider from 'web/components/layout/icondivider';
 
 import ExportIcon from 'web/components/icon/exporticon';
 
 import TableRow from 'web/components/table/row';
 
-const IconActions = ({
-    entity,
-    onGroupEditClick,
-    onGroupCloneClick,
-    onGroupDeleteClick,
-    onGroupDownloadClick,
-  }) => {
-  return (
-    <IconDivider
-      align={['center', 'center']}
-      grow
-    >
-      <TrashIcon
-        displayName={_('Group')}
-        name="group"
-        entity={entity}
-        onClick={onGroupDeleteClick}
-      />
-      <EditIcon
-        displayName={_('Group')}
-        name="group"
-        entity={entity}
-        onClick={onGroupEditClick}
-      />
-      <CloneIcon
-        displayName={_('Group')}
-        name="user"
-        entity={entity}
-        title={_('Clone Group')}
-        value={entity}
-        onClick={onGroupCloneClick}
-      />
-      <ExportIcon
-        value={entity}
-        title={_('Export Group')}
-        onClick={onGroupDownloadClick}
-      />
-    </IconDivider>
-  );
-};
+import EntityNameTableData from 'web/entities/entitynametabledata';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
 
-IconActions.propTypes = {
+import CloneIcon from 'web/entity/icon/cloneicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+import EditIcon from 'web/entity/icon/editicon';
+
+import PropTypes from 'web/utils/proptypes';
+
+const Actions = withEntitiesActions(({
+  entity,
+  onGroupEditClick,
+  onGroupCloneClick,
+  onGroupDeleteClick,
+  onGroupDownloadClick,
+}) => (
+  <IconDivider
+    align={['center', 'center']}
+    grow
+  >
+    <TrashIcon
+      displayName={_('Group')}
+      name="group"
+      entity={entity}
+      onClick={onGroupDeleteClick}
+    />
+    <EditIcon
+      displayName={_('Group')}
+      name="group"
+      entity={entity}
+      onClick={onGroupEditClick}
+    />
+    <CloneIcon
+      displayName={_('Group')}
+      name="user"
+      entity={entity}
+      title={_('Clone Group')}
+      value={entity}
+      onClick={onGroupCloneClick}
+    />
+    <ExportIcon
+      value={entity}
+      title={_('Export Group')}
+      onClick={onGroupDownloadClick}
+    />
+  </IconDivider>
+));
+
+Actions.propTypes = {
   entity: PropTypes.model.isRequired,
   onGroupCloneClick: PropTypes.func.isRequired,
   onGroupDeleteClick: PropTypes.func.isRequired,
@@ -91,33 +87,32 @@ IconActions.propTypes = {
 };
 
 const Row = ({
-  actions,
   entity,
   links = true,
   onToggleDetailsClick,
   ...props
-}) => {
-  return (
-    <TableRow>
-      <EntityNameTableData
-        entity={entity}
-        link={links}
-        type="group"
-        displayName={_('Group')}
-        onToggleDetailsClick={onToggleDetailsClick}
-      />
-      {renderComponent(actions, {...props, entity})}
-    </TableRow>
-  );
-};
+}) => (
+  <TableRow>
+    <EntityNameTableData
+      entity={entity}
+      link={links}
+      type="group"
+      displayName={_('Group')}
+      onToggleDetailsClick={onToggleDetailsClick}
+    />
+    <Actions
+      {...props}
+      entity={entity}
+    />
+  </TableRow>
+);
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(IconActions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/hosts/row.js
+++ b/gsa/src/web/pages/hosts/row.js
@@ -28,16 +28,6 @@ import {longDate} from 'gmp/locale/date';
 
 import {isDefined} from 'gmp/utils/identity';
 
-import compose from 'web/utils/compose';
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-import withCapabilities from 'web/utils/withCapabilities';
-
-import EditIcon from 'web/entity/icon/editicon';
-import DeleteIcon from 'web/entity/icon/deleteicon';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow, RowDetailsToggle} from 'web/entities/row';
-
 import SeverityBar from 'web/components/bar/severitybar';
 
 import Comment from 'web/components/comment/comment';
@@ -51,15 +41,27 @@ import IconDivider from 'web/components/layout/icondivider';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
-const Actions = ({
-    capabilities,
-    entity,
-    onTargetCreateFromHostClick,
-    onHostEditClick,
-    onHostDeleteClick,
-    onHostDownloadClick,
-  }) => {
+import DeleteIcon from 'web/entity/icon/deleteicon';
+import EditIcon from 'web/entity/icon/editicon';
 
+import {RowDetailsToggle} from 'web/entities/row';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+import compose from 'web/utils/compose';
+import PropTypes from 'web/utils/proptypes';
+import withCapabilities from 'web/utils/withCapabilities';
+
+const Actions = compose(
+  withCapabilities,
+  withEntitiesActions,
+)(({
+  capabilities,
+  entity,
+  onTargetCreateFromHostClick,
+  onHostEditClick,
+  onHostDeleteClick,
+  onHostDownloadClick,
+}) => {
   let new_title;
   const can_create_target = capabilities.mayCreate('target');
   if (can_create_target) {
@@ -98,10 +100,9 @@ const Actions = ({
       />
     </IconDivider>
   );
-};
+});
 
 Actions.propTypes = {
-  capabilities: PropTypes.capabilities.isRequired,
   entity: PropTypes.model,
   onHostDeleteClick: PropTypes.func,
   onHostDownloadClick: PropTypes.func,
@@ -112,7 +113,6 @@ Actions.propTypes = {
 const Row = ({
   entity,
   links = true,
-  actions,
   onToggleDetailsClick,
   ...props
 }) => {
@@ -152,21 +152,20 @@ const Row = ({
           longDate(entity.modificationTime)
         }
       </TableData>
-      {renderComponent(actions, {...props, entity})}
+      <Actions
+        {...props}
+        entity={entity}
+      />
     </TableRow>
   );
 };
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default compose(
-  withEntityRow(withEntityActions(Actions)),
-  withCapabilities,
-)(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/notes/row.js
+++ b/gsa/src/web/pages/notes/row.js
@@ -27,16 +27,6 @@ import _ from 'gmp/locale';
 
 import {shorten} from 'gmp/utils/string';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow, RowDetailsToggle} from 'web/entities/row';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
-
 import ExportIcon from 'web/components/icon/exporticon';
 
 import IconDivider from 'web/components/layout/icondivider';
@@ -44,42 +34,48 @@ import IconDivider from 'web/components/layout/icondivider';
 import TableRow from 'web/components/table/row';
 import TableData from 'web/components/table/data';
 
+import {RowDetailsToggle} from 'web/entities/row';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
 
-const Actions = ({
-    entity,
-    onNoteDeleteClick,
-    onNoteDownloadClick,
-    onNoteCloneClick,
-    onNoteEditClick,
-  }) => {
-  return (
-    <IconDivider
-      align={['center', 'center']}
-      grow
-    >
-      <TrashIcon
-        entity={entity}
-        name="note"
-        onClick={onNoteDeleteClick}
-      />
-      <EditIcon
-        entity={entity}
-        name="note"
-        onClick={onNoteEditClick}
-      />
-      <CloneIcon
-        entity={entity}
-        name="note"
-        onClick={onNoteCloneClick}
-      />
-      <ExportIcon
-        value={entity}
-        title={_('Export Note')}
-        onClick={onNoteDownloadClick}
-      />
-    </IconDivider>
-  );
-};
+import CloneIcon from 'web/entity/icon/cloneicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
+
+const Actions = withEntitiesActions(({
+  entity,
+  onNoteDeleteClick,
+  onNoteDownloadClick,
+  onNoteCloneClick,
+  onNoteEditClick,
+}) => (
+  <IconDivider
+    align={['center', 'center']}
+    grow
+  >
+    <TrashIcon
+      entity={entity}
+      name="note"
+      onClick={onNoteDeleteClick}
+    />
+    <EditIcon
+      entity={entity}
+      name="note"
+      onClick={onNoteEditClick}
+    />
+    <CloneIcon
+      entity={entity}
+      name="note"
+      onClick={onNoteCloneClick}
+    />
+    <ExportIcon
+      value={entity}
+      title={_('Export Note')}
+      onClick={onNoteDownloadClick}
+    />
+  </IconDivider>
+));
 
 Actions.propTypes = {
   entity: PropTypes.model,
@@ -92,7 +88,6 @@ Actions.propTypes = {
 const Row = ({
   entity,
   links = true,
-  actions,
   onToggleDetailsClick,
   ...props
 }) => {
@@ -126,18 +121,20 @@ const Row = ({
       <TableData>
         {entity.isActive() ? _('yes') : _('no')}
       </TableData>
-      {renderComponent(actions, {...props, entity})}
+      <Actions
+        {...props}
+        entity={entity}
+      />
     </TableRow>
   );
 };
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(Actions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/nvts/row.js
+++ b/gsa/src/web/pages/nvts/row.js
@@ -25,11 +25,6 @@ import React from 'react';
 
 import {longDate} from 'gmp/locale/date';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import {withEntityRow, RowDetailsToggle} from 'web/entities/row';
-
 import SeverityBar from 'web/components/bar/severitybar';
 
 import SolutionTypeIcon from 'web/components/icon/solutiontypeicon';
@@ -42,72 +37,76 @@ import Link from 'web/components/link/link';
 import TableRow from 'web/components/table/row';
 import TableData from 'web/components/table/data';
 
+import EntitiesActions from 'web/entities/actions';
+import {RowDetailsToggle} from 'web/entities/row';
+
+import PropTypes from 'web/utils/proptypes';
+
 const Row = ({
   entity,
   links = true,
-  actions,
   onToggleDetailsClick,
-  ...other
-}) => {
-  return (
-    <TableRow>
-      <TableData>
-        <RowDetailsToggle
-          name={entity.id}
-          onClick={onToggleDetailsClick}
-        >
-          {entity.name}
-        </RowDetailsToggle>
-      </TableData>
-      <TableData>
-        <Link
-          to="nvts"
-          filter={'family="' + entity.family + '"'}
-          textOnly={!links}
-        >
-          {entity.family}
-        </Link>
-      </TableData>
-      <TableData>
-        {longDate(entity.creationTime)}
-      </TableData>
-      <TableData>
-        {longDate(entity.modificationTime)}
-      </TableData>
-      <TableData>
-        <Divider wrap>
-          {entity.cves.map(id => (
-            <CveLink
-              key={id}
-              id={id}
-              textOnly={!links}
-            />
-          ))}
-        </Divider>
-      </TableData>
-      <TableData align="center">
-        {entity && entity.tags &&
-          <SolutionTypeIcon type={entity.tags.solution_type}/>
-        }
-      </TableData>
-      <TableData>
-        <SeverityBar severity={entity.severity}/>
-      </TableData>
-      <TableData align="end">
-        {entity.qod && entity.qod.value} %
-      </TableData>
-      {renderComponent(actions, {...other, entity})}
-    </TableRow>
-  );
-};
+  ...props
+}) => (
+  <TableRow>
+    <TableData>
+      <RowDetailsToggle
+        name={entity.id}
+        onClick={onToggleDetailsClick}
+      >
+        {entity.name}
+      </RowDetailsToggle>
+    </TableData>
+    <TableData>
+      <Link
+        to="nvts"
+        filter={'family="' + entity.family + '"'}
+        textOnly={!links}
+      >
+        {entity.family}
+      </Link>
+    </TableData>
+    <TableData>
+      {longDate(entity.creationTime)}
+    </TableData>
+    <TableData>
+      {longDate(entity.modificationTime)}
+    </TableData>
+    <TableData>
+      <Divider wrap>
+        {entity.cves.map(id => (
+          <CveLink
+            key={id}
+            id={id}
+            textOnly={!links}
+          />
+        ))}
+      </Divider>
+    </TableData>
+    <TableData align="center">
+      {entity && entity.tags &&
+        <SolutionTypeIcon type={entity.tags.solution_type}/>
+      }
+    </TableData>
+    <TableData>
+      <SeverityBar severity={entity.severity}/>
+    </TableData>
+    <TableData align="end">
+      {entity.qod && entity.qod.value} %
+    </TableData>
+    <EntitiesActions
+      {...props}
+      entity={entity}
+    />
+  </TableRow>
+);
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow()(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/operatingsystems/row.js
+++ b/gsa/src/web/pages/operatingsystems/row.js
@@ -26,12 +26,6 @@ import React from 'react';
 import _ from 'gmp/locale';
 import {longDate} from 'gmp/locale/date';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-
 import SeverityBar from 'web/components/bar/severitybar';
 
 import CpeIcon from 'web/components/icon/cpeicon';
@@ -46,7 +40,11 @@ import Link from 'web/components/link/link';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
-const IconActions = ({
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+import PropTypes from 'web/utils/proptypes';
+
+const Actions = withEntitiesActions(({
   entity,
   onOsDeleteClick,
   onOsDownloadClick,
@@ -72,66 +70,68 @@ const IconActions = ({
       title={_('Export Operating System')}
     />
   </IconDivider>
-);
+));
 
-IconActions.propTypes = {
+Actions.propTypes = {
   entity: PropTypes.model.isRequired,
   onOsDeleteClick: PropTypes.func.isRequired,
   onOsDownloadClick: PropTypes.func.isRequired,
 };
 
-const Actions = withEntityActions(IconActions);
-
-const Row = ({entity, links = true, actions, ...props}) => {
-  return (
-    <TableRow>
-      <TableData>
-        <IconDivider align={['start', 'center']}>
-          <CpeIcon name={entity.name}/>
-          <DetailsLink
-            type={entity.entityType}
-            id={entity.id}
-            textOnly={!links}
-          >
-            {entity.name}
-          </DetailsLink>
-        </IconDivider>
-      </TableData>
-      <TableData>
-        {entity.title}
-      </TableData>
-      <TableData>
-        <SeverityBar severity={entity.latest_severity}/>
-      </TableData>
-      <TableData>
-        <SeverityBar severity={entity.highest_severity}/>
-      </TableData>
-      <TableData>
-        <SeverityBar severity={entity.average_severity}/>
-      </TableData>
-      <TableData>
-        <Link
-          to={'hosts'}
-          filter={'os~"' + entity.name + '"'}
+const Row = ({
+  entity,
+  links = true,
+  ...props
+}) => (
+  <TableRow>
+    <TableData>
+      <IconDivider align={['start', 'center']}>
+        <CpeIcon name={entity.name}/>
+        <DetailsLink
+          type={entity.entityType}
+          id={entity.id}
           textOnly={!links}
         >
-          {entity.hosts.length}
-        </Link>
-      </TableData>
-      <TableData>
-        {longDate(entity.modificationTime)}
-      </TableData>
-      {renderComponent(actions, {...props, entity})}
-    </TableRow>
-  );
-};
+          {entity.name}
+        </DetailsLink>
+      </IconDivider>
+    </TableData>
+    <TableData>
+      {entity.title}
+    </TableData>
+    <TableData>
+      <SeverityBar severity={entity.latest_severity}/>
+    </TableData>
+    <TableData>
+      <SeverityBar severity={entity.highest_severity}/>
+    </TableData>
+    <TableData>
+      <SeverityBar severity={entity.average_severity}/>
+    </TableData>
+    <TableData>
+      <Link
+        to={'hosts'}
+        filter={'os~"' + entity.name + '"'}
+        textOnly={!links}
+      >
+        {entity.hosts.length}
+      </Link>
+    </TableData>
+    <TableData>
+      {longDate(entity.modificationTime)}
+    </TableData>
+    <Actions
+      {...props}
+      entity={entity}
+    />
+  </TableRow>
+);
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
 };
 
-export default withEntityRow(Actions)(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/ovaldefs/row.js
+++ b/gsa/src/web/pages/ovaldefs/row.js
@@ -27,11 +27,6 @@ import {longDate} from 'gmp/locale/date';
 
 import {shorten} from 'gmp/utils/string';
 
-import PropTypes from 'web/utils/proptypes';
-import {na, renderComponent} from 'web/utils/render';
-
-import {withEntityRow, RowDetailsToggle} from 'web/entities/row';
-
 import SeverityBar from 'web/components/bar/severitybar';
 
 import Comment from 'web/components/comment/comment';
@@ -40,67 +35,72 @@ import TableBody from 'web/components/table/body';
 import TableRow from 'web/components/table/row';
 import TableData from 'web/components/table/data';
 
+import EntitiesActions from 'web/entities/actions';
+import {RowDetailsToggle} from 'web/entities/row';
+
+import PropTypes from 'web/utils/proptypes';
+import {na} from 'web/utils/render';
+
 const Row = ({
   entity,
   links = true,
-  actions,
   onToggleDetailsClick,
-  ...other
-}) => {
-  return (
-    <TableBody>
-      <TableRow>
-        <TableData
-          rowSpan="2"
+  ...props
+}) => (
+  <TableBody>
+    <TableRow>
+      <TableData
+        rowSpan="2"
+      >
+        <RowDetailsToggle
+          name={entity.id}
+          onClick={onToggleDetailsClick}
         >
-          <RowDetailsToggle
-            name={entity.id}
-            onClick={onToggleDetailsClick}
-          >
-            {entity.name}
-          </RowDetailsToggle>
-          <div>{shorten(entity.file, 45)}</div>
-          <Comment text={entity.comment}/>
-        </TableData>
-        <TableData>
-          {na(entity.version)}
-        </TableData>
-        <TableData>
-          {na(entity.status)}
-        </TableData>
-        <TableData>
-          {na(entity.class)}
-        </TableData>
-        <TableData>
-          {longDate(entity.creationTime)}
-        </TableData>
-        <TableData>
-          {longDate(entity.modificationTime)}
-        </TableData>
-        <TableData>
-          {entity.cve_refs}
-        </TableData>
-        <TableData>
-          <SeverityBar severity={entity.severity}/>
-        </TableData>
-        {renderComponent(actions, {...other, entity})}
-      </TableRow>
-      <TableRow>
-        <TableData colSpan="8">
-          {shorten(entity.title, 250)}
-        </TableData>
-      </TableRow>
-    </TableBody>
-  );
-};
+          {entity.name}
+        </RowDetailsToggle>
+        <div>{shorten(entity.file, 45)}</div>
+        <Comment text={entity.comment}/>
+      </TableData>
+      <TableData>
+        {na(entity.version)}
+      </TableData>
+      <TableData>
+        {na(entity.status)}
+      </TableData>
+      <TableData>
+        {na(entity.class)}
+      </TableData>
+      <TableData>
+        {longDate(entity.creationTime)}
+      </TableData>
+      <TableData>
+        {longDate(entity.modificationTime)}
+      </TableData>
+      <TableData>
+        {entity.cve_refs}
+      </TableData>
+      <TableData>
+        <SeverityBar severity={entity.severity}/>
+      </TableData>
+      <EntitiesActions
+        {...props}
+        entity={entity}
+      />
+    </TableRow>
+    <TableRow>
+      <TableData colSpan="8">
+        {shorten(entity.title, 250)}
+      </TableData>
+    </TableRow>
+  </TableBody>
+);
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow()(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/overrides/row.js
+++ b/gsa/src/web/pages/overrides/row.js
@@ -29,17 +29,6 @@ import {isDefined} from 'gmp/utils/identity';
 import {shorten} from 'gmp/utils/string';
 import {severityValue} from 'gmp/utils/number';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-import {
-  extraRiskFactor,
-  translateRiskFactor,
-  LOG_VALUE,
-} from 'web/utils/severity';
-
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow, RowDetailsToggle} from 'web/entities/row';
-
 import CloneIcon from 'web/entity/icon/cloneicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
@@ -53,6 +42,16 @@ import IconDivider from 'web/components/layout/icondivider';
 import TableRow from 'web/components/table/row';
 import TableData from 'web/components/table/data';
 
+import {RowDetailsToggle} from 'web/entities/row';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+import PropTypes from 'web/utils/proptypes';
+import {
+  extraRiskFactor,
+  translateRiskFactor,
+  LOG_VALUE,
+} from 'web/utils/severity';
+
 
 const render_severity = severity => {
   if (isDefined(severity)) {
@@ -64,41 +63,39 @@ const render_severity = severity => {
   return _('Any');
 };
 
-const Actions = ({
-    entity,
-    onOverrideDeleteClick,
-    onOverrideDownloadClick,
-    onOverrideCloneClick,
-    onOverrideEditClick,
-  }) => {
-  return (
-    <IconDivider
-      align={['center', 'center']}
-      grow
-    >
-      <TrashIcon
-        entity={entity}
-        name="override"
-        onClick={onOverrideDeleteClick}
-      />
-      <EditIcon
-        entity={entity}
-        name="override"
-        onClick={onOverrideEditClick}
-      />
-      <CloneIcon
-        entity={entity}
-        name="override"
-        onClick={onOverrideCloneClick}
-      />
-      <ExportIcon
-        value={entity}
-        title={_('Export Override')}
-        onClick={onOverrideDownloadClick}
-      />
-    </IconDivider>
-  );
-};
+const Actions = withEntitiesActions(({
+  entity,
+  onOverrideDeleteClick,
+  onOverrideDownloadClick,
+  onOverrideCloneClick,
+  onOverrideEditClick,
+}) => (
+  <IconDivider
+    align={['center', 'center']}
+    grow
+  >
+    <TrashIcon
+      entity={entity}
+      name="override"
+      onClick={onOverrideDeleteClick}
+    />
+    <EditIcon
+      entity={entity}
+      name="override"
+      onClick={onOverrideEditClick}
+    />
+    <CloneIcon
+      entity={entity}
+      name="override"
+      onClick={onOverrideCloneClick}
+    />
+    <ExportIcon
+      value={entity}
+      title={_('Export Override')}
+      onClick={onOverrideDownloadClick}
+    />
+  </IconDivider>
+));
 
 Actions.propTypes = {
   entity: PropTypes.model.isRequired,
@@ -111,50 +108,49 @@ Actions.propTypes = {
 const Row = ({
   entity,
   links = true,
-  actions,
   onToggleDetailsClick,
   ...props
-}) => {
-  return (
-    <TableRow>
-      <TableData>
-        <RowDetailsToggle
-          name={entity.id}
-          onClick={onToggleDetailsClick}
-        >
-          {shorten(entity.text)}
-        </RowDetailsToggle>
-      </TableData>
-      <TableData>
-        {entity.nvt ? entity.nvt.name : ''}
-      </TableData>
-      <TableData title={entity.hosts}>
-        {shorten(entity.hosts.join(', '))}
-      </TableData>
-      <TableData title={entity.port}>
-        {shorten(entity.port)}
-      </TableData>
-      <TableData>
-        {render_severity(entity.severity)}
-      </TableData>
-      <TableData>
-        <SeverityBar severity={entity.new_severity}/>
-      </TableData>
-      <TableData>
-        {entity.isActive() ? _('yes') : _('no')}
-      </TableData>
-      {renderComponent(actions, {...props, entity})}
-    </TableRow>
-  );
-};
+}) => (
+  <TableRow>
+    <TableData>
+      <RowDetailsToggle
+        name={entity.id}
+        onClick={onToggleDetailsClick}
+      >
+        {shorten(entity.text)}
+      </RowDetailsToggle>
+    </TableData>
+    <TableData>
+      {entity.nvt ? entity.nvt.name : ''}
+    </TableData>
+    <TableData title={entity.hosts}>
+      {shorten(entity.hosts.join(', '))}
+    </TableData>
+    <TableData title={entity.port}>
+      {shorten(entity.port)}
+    </TableData>
+    <TableData>
+      {render_severity(entity.severity)}
+    </TableData>
+    <TableData>
+      <SeverityBar severity={entity.new_severity}/>
+    </TableData>
+    <TableData>
+      {entity.isActive() ? _('yes') : _('no')}
+    </TableData>
+    <Actions
+      {...props}
+      entity={entity}
+    />
+  </TableRow>
+);
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(Actions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/permissions/row.js
+++ b/gsa/src/web/pages/permissions/row.js
@@ -28,21 +28,6 @@ import _ from 'gmp/locale';
 import {isDefined} from 'gmp/utils/identity';
 import {typeName, getEntityType} from 'gmp/utils/entitytype';
 
-import PropTypes from 'web/utils/proptypes';
-import {
-  renderComponent,
-  permissionDescription,
-} from 'web/utils/render';
-
-import EntityNameTableData from 'web/entities/entitynametabledata';
-import EntityLink from 'web/entity/link';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
-
 import ExportIcon from 'web/components/icon/exporticon';
 
 import IconDivider from 'web/components/layout/icondivider';
@@ -50,7 +35,19 @@ import IconDivider from 'web/components/layout/icondivider';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
-const Actions = ({
+import EntityNameTableData from 'web/entities/entitynametabledata';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+import EntityLink from 'web/entity/link';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
+import {permissionDescription} from 'web/utils/render';
+
+const Actions = withEntitiesActions(({
   entity,
   onPermissionDeleteClick,
   onPermissionDownloadClick,
@@ -88,7 +85,7 @@ const Actions = ({
       onClick={onPermissionDownloadClick}
     />
   </IconDivider>
-);
+));
 
 Actions.propTypes = {
   entity: PropTypes.model.isRequired,
@@ -99,7 +96,6 @@ Actions.propTypes = {
 };
 
 const Row = ({
-  actions,
   entity,
   links = true,
   onToggleDetailsClick,
@@ -132,17 +128,19 @@ const Row = ({
         <EntityLink entity={entity.subject}/>
       }
     </TableData>
-    {renderComponent(actions, {...props, entity})}
+    <Actions
+      {...props}
+      entity={entity}
+    />
   </TableRow>
 );
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(Actions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/portlists/row.js
+++ b/gsa/src/web/pages/portlists/row.js
@@ -25,11 +25,9 @@ import React from 'react';
 import _ from 'gmp/locale';
 
 import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
 
 import EntityNameTableData from 'web/entities/entitynametabledata';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import EditIcon from 'web/entity/icon/editicon';
@@ -87,10 +85,11 @@ IconActions.propTypes = {
   onPortListEditClick: PropTypes.func.isRequired,
 };
 
+const Actions = withEntitiesActions(IconActions);
+
 const Row = ({
   entity,
   links = true,
-  actions,
   onToggleDetailsClick,
   ...props
 }) => (
@@ -111,17 +110,19 @@ const Row = ({
     <TableData align="start">
       {entity.port_count.udp}
     </TableData>
-    {renderComponent(actions, {...props, entity})}
+    <Actions
+      {...props}
+      entity={entity}
+    />
   </TableRow>
 );
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(IconActions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/reportformats/row.js
+++ b/gsa/src/web/pages/reportformats/row.js
@@ -26,13 +26,7 @@ import React from 'react';
 import _ from 'gmp/locale';
 import {shortDate} from 'gmp/locale/date';
 
-import PropTypes from 'web/utils/proptypes';
-import withCapabilities from 'web/utils/withCapabilities';
-import {renderComponent, renderYesNo} from 'web/utils/render';
-
 import EntityNameTableData from 'web/entities/entitynametabledata';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
 
 import Comment from 'web/components/comment/comment';
 
@@ -48,7 +42,16 @@ import IconDivider from 'web/components/layout/icondivider';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
-const Actions = withCapabilities(({
+import compose from 'web/utils/compose';
+import PropTypes from 'web/utils/proptypes';
+import {renderYesNo} from 'web/utils/render';
+import withCapabilities from 'web/utils/withCapabilities';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+const Actions = compose(
+  withCapabilities,
+  withEntitiesActions,
+)(({
   capabilities,
   entity,
   onReportFormatCloneClick,
@@ -111,7 +114,6 @@ Actions.propTypes = {
 };
 
 const Row = ({
-  actions,
   entity,
   links = true,
   onToggleDetailsClick,
@@ -146,7 +148,10 @@ const Row = ({
     <TableData>
       {renderYesNo(entity.isActive())}
     </TableData>
-    {renderComponent(actions, {...props, entity})}
+    <Actions
+      {...props}
+      entity={entity}
+    />
   </TableRow>
 );
 
@@ -157,6 +162,6 @@ Row.propTypes = {
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(Actions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/reports/row.js
+++ b/gsa/src/web/pages/reports/row.js
@@ -26,12 +26,6 @@ import {isDefined} from 'gmp/utils/identity';
 
 import {TASK_STATUS, isActive} from 'gmp/models/task';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-
 import SeverityBar from 'web/components/bar/severitybar';
 import StatusBar from 'web/components/bar/statusbar';
 
@@ -46,7 +40,11 @@ import DetailsLink from 'web/components/link/detailslink';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
-const IconActions = ({
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+import PropTypes from 'web/utils/proptypes';
+
+const Actions = withEntitiesActions(({
   entity,
   selectedDeltaReport,
   onReportDeleteClick,
@@ -87,16 +85,20 @@ const IconActions = ({
       />
     </IconDivider>
   );
-};
+});
 
-IconActions.propTypes = {
+Actions.propTypes = {
   entity: PropTypes.model.isRequired,
   selectedDeltaReport: PropTypes.model,
   onReportDeleteClick: PropTypes.func.isRequired,
   onReportDeltaSelect: PropTypes.func.isRequired,
 };
 
-const Row = ({entity, links = true, actions, ...other}) => {
+const Row = ({
+  entity,
+  links = true,
+  ...props
+}) => {
   const {report} = entity;
   const {scan_run_status, task} = report;
 
@@ -156,18 +158,20 @@ const Row = ({entity, links = true, actions, ...other}) => {
       <TableData align="end">
         {report.result_count.false_positive.filtered}
       </TableData>
-      {renderComponent(actions, {...other, entity})}
+      <Actions
+        {...props}
+        entity={entity}
+      />
     </TableRow>
   );
 };
 
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
 };
 
-export default withEntityRow(withEntityActions(IconActions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/results/row.js
+++ b/gsa/src/web/pages/results/row.js
@@ -32,11 +32,6 @@ import {isDefined} from 'gmp/utils/identity';
 
 import {shorten} from 'gmp/utils/string';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import {withEntityRow, RowDetailsToggle} from 'web/entities/row';
-
 import SeverityBar from 'web/components/bar/severitybar';
 
 import Icon from 'web/components/icon/icon';
@@ -50,15 +45,19 @@ import DetailsLink from 'web/components/link/detailslink';
 import TableRow from 'web/components/table/row';
 import TableData from 'web/components/table/data';
 
+import {RowDetailsToggle} from 'web/entities/row';
+import EntitiesActions from 'web/entities/actions';
+
+import PropTypes from 'web/utils/proptypes';
+
 import ResultDelta from './delta';
 
 const Row = ({
-  actions,
   delta = false,
   entity,
   links = true,
   onToggleDetailsClick,
-  ...other
+  ...props
 }) => {
   const {host} = entity;
   const shown_name = isDefined(entity.name) ? entity.name : entity.nvt.oid;
@@ -137,19 +136,21 @@ const Row = ({
       <TableData>
         {longDate(entity.modificationTime)}
       </TableData>
-      {renderComponent(actions, {...other, entity})}
+      <EntitiesActions
+        {...props}
+        entity={entity}
+      />
     </TableRow>
   );
 };
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   delta: PropTypes.bool,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func,
 };
 
-export default withEntityRow()(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/roles/row.js
+++ b/gsa/src/web/pages/roles/row.js
@@ -24,24 +24,22 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import EntityNameTableData from 'web/entities/entitynametabledata';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import TrashIcon from 'web/entity/icon/trashicon';
-import EditIcon from 'web/entity/icon/editicon';
-
 import ExportIcon from 'web/components/icon/exporticon';
 
 import IconDivider from 'web/components/layout/icondivider';
 
 import TableRow from 'web/components/table/row';
 
-const IconActions = ({
+import EntityNameTableData from 'web/entities/entitynametabledata';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+import EditIcon from 'web/entity/icon/editicon';
+
+import PropTypes from 'web/utils/proptypes';
+
+const Actions = withEntitiesActions(({
   entity,
   onRoleCloneClick,
   onRoleDeleteClick,
@@ -78,9 +76,9 @@ const IconActions = ({
       onClick={onRoleDownloadClick}
     />
   </IconDivider>
-);
+));
 
-IconActions.propTypes = {
+Actions.propTypes = {
   entity: PropTypes.model,
   onRoleCloneClick: PropTypes.func,
   onRoleDeleteClick: PropTypes.func,
@@ -89,33 +87,32 @@ IconActions.propTypes = {
 };
 
 const Row = ({
-  actions,
   entity,
   links = true,
   onToggleDetailsClick,
   ...props
-}) => {
-  return (
-    <TableRow>
-      <EntityNameTableData
-        entity={entity}
-        link={links}
-        type="role"
-        displayName={_('Role')}
-        onToggleDetailsClick={onToggleDetailsClick}
-      />
-      {renderComponent(actions, {...props, entity})}
-    </TableRow>
-  );
-};
+}) => (
+  <TableRow>
+    <EntityNameTableData
+      entity={entity}
+      link={links}
+      type="role"
+      displayName={_('Role')}
+      onToggleDetailsClick={onToggleDetailsClick}
+    />
+    <Actions
+      {...props}
+      entity={entity}
+    />
+  </TableRow>
+);
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(IconActions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/scanconfigs/row.js
+++ b/gsa/src/web/pages/scanconfigs/row.js
@@ -26,25 +26,25 @@ import _ from 'gmp/locale';
 
 import IconDivider from 'web/components/layout/icondivider';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent, na} from 'web/utils/render';
-
-import EntityNameTableData from 'web/entities/entitynametabledata';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
-
 import ExportIcon from 'web/components/icon/exporticon';
 
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
+import EntityNameTableData from 'web/entities/entitynametabledata';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
+import {na} from 'web/utils/render';
+
+
 import Trend from './trend';
 
-const Actions = ({
+const Actions = withEntitiesActions(({
   entity,
   onScanConfigDeleteClick,
   onScanConfigDownloadClick,
@@ -78,7 +78,7 @@ const Actions = ({
       onClick={onScanConfigDownloadClick}
     />
   </IconDivider>
-);
+));
 
 Actions.propTypes = {
   entity: PropTypes.model.isRequired,
@@ -89,58 +89,57 @@ Actions.propTypes = {
 };
 
 const Row = ({
-    actions,
-    entity,
-    links = true,
-    onToggleDetailsClick,
-    ...props
-  }) => {
-  return (
-    <TableRow>
-      <EntityNameTableData
-        entity={entity}
-        link={links}
-        type="scanconfig"
-        displayName={_('Scan Config')}
-        onToggleDetailsClick={onToggleDetailsClick}
+  entity,
+  links = true,
+  onToggleDetailsClick,
+  ...props
+}) => (
+  <TableRow>
+    <EntityNameTableData
+      entity={entity}
+      link={links}
+      type="scanconfig"
+      displayName={_('Scan Config')}
+      onToggleDetailsClick={onToggleDetailsClick}
+    />
+    <TableData>
+      {na(entity.families.count)}
+    </TableData>
+    <TableData>
+      <Trend
+        trend={entity.families.trend}
+        titleDynamic={_('The family selection is DYNAMIC. New families ' +
+          'will automatically be added and considered.')}
+        titleStatic={_('The family selection is STATIC. New families ' +
+          'will NOT automatically be added and considered.')}
       />
-      <TableData>
-        {na(entity.families.count)}
-      </TableData>
-      <TableData>
-        <Trend
-          trend={entity.families.trend}
-          titleDynamic={_('The family selection is DYNAMIC. New families ' +
-            'will automatically be added and considered.')}
-          titleStatic={_('The family selection is STATIC. New families ' +
-            'will NOT automatically be added and considered.')}
-        />
-      </TableData>
-      <TableData>
-        {na(entity.nvts.count)}
-      </TableData>
-      <TableData>
-        <Trend
-          trend={entity.nvts.trend}
-          titleDynamic={_('The NVT selection is DYNAMIC. New NVTs of ' +
-            'selected families will automatically be added and considered.')}
-          titleStatic={_('The NVT selection is DYNAMIC. New NVTS of ' +
-            'selected families will NOT automatically be added and ' +
-            'considered.')}
-        />
-      </TableData>
-      {renderComponent(actions, {...props, entity})}
-    </TableRow>
-  );
-};
+    </TableData>
+    <TableData>
+      {na(entity.nvts.count)}
+    </TableData>
+    <TableData>
+      <Trend
+        trend={entity.nvts.trend}
+        titleDynamic={_('The NVT selection is DYNAMIC. New NVTs of ' +
+          'selected families will automatically be added and considered.')}
+        titleStatic={_('The NVT selection is DYNAMIC. New NVTS of ' +
+          'selected families will NOT automatically be added and ' +
+          'considered.')}
+      />
+    </TableData>
+    <Actions
+      {...props}
+      entity={entity}
+    />
+  </TableRow>
+);
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(Actions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/scanners/row.js
+++ b/gsa/src/web/pages/scanners/row.js
@@ -24,21 +24,11 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
+import {scannerTypeName, CVE_SCANNER_TYPE} from 'gmp/models/scanner';
+
 import {isDefined} from 'gmp/utils/identity';
 
 import IconDivider from 'web/components/layout/icondivider';
-
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import EntityNameTableData from 'web/entities/entitynametabledata';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-import EntityLink from 'web/entity/link';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
 
 import ExportIcon from 'web/components/icon/exporticon';
 import Icon from 'web/components/icon/icon';
@@ -46,10 +36,19 @@ import Icon from 'web/components/icon/icon';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
-import {scannerTypeName, CVE_SCANNER_TYPE} from 'gmp/models/scanner';
+import EntityNameTableData from 'web/entities/entitynametabledata';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+import EntityLink from 'web/entity/link';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
 
 
-const Actions = ({
+const Actions = withEntitiesActions(({
   entity,
   onScannerCertificateDownloadClick,
   onScannerCloneClick,
@@ -111,7 +110,7 @@ const Actions = ({
       />
     }
   </IconDivider>
-);
+));
 
 Actions.propTypes = {
   entity: PropTypes.model.isRequired,
@@ -155,17 +154,19 @@ const Row = ({
         <EntityLink entity={entity.credential}/>
       }
     </TableData>
-    {renderComponent(actions, {...props, entity})}
+    <Actions
+      {...props}
+      entity={entity}
+    />
   </TableRow>
 );
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(Actions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/schedules/row.js
+++ b/gsa/src/web/pages/schedules/row.js
@@ -28,29 +28,28 @@ import {dateTimeWithTimeZone} from 'gmp/locale/date';
 
 import {isDefined} from 'gmp/utils/identity';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import EntityNameTableData from 'web/entities/entitynametabledata';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
-
 import ExportIcon from 'web/components/icon/exporticon';
 
 import IconDivider from 'web/components/layout/icondivider';
 
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
+
+import EntityNameTableData from 'web/entities/entitynametabledata';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
+
 import {
   renderDuration,
   renderRecurrence,
 } from './render';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
 
-const Actions = ({
+const Actions = withEntitiesActions(({
   entity,
   onScheduleDeleteClick,
   onScheduleDownloadClick,
@@ -87,7 +86,7 @@ const Actions = ({
       onClick={onScheduleDownloadClick}
     />
   </IconDivider>
-);
+));
 
 Actions.propTypes = {
   entity: PropTypes.model.isRequired,
@@ -98,7 +97,6 @@ Actions.propTypes = {
 };
 
 const Row = ({
-  actions,
   entity,
   links = true,
   onToggleDetailsClick,
@@ -127,18 +125,20 @@ const Row = ({
       <TableData>
         {renderDuration(duration)}
       </TableData>
-      {renderComponent(actions, {...props, entity})}
+      <Actions
+        {...props}
+        entity={entity}
+      />
     </TableRow>
   );
 };
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(Actions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/secinfo/row.js
+++ b/gsa/src/web/pages/secinfo/row.js
@@ -25,12 +25,9 @@ import React from 'react';
 
 import {longDate} from 'gmp/locale/date';
 
+import {secInfoTypeName, secInfoType} from 'gmp/models/secinfo';
+
 import {shorten} from 'gmp/utils/string';
-
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import {withEntityRow, RowDetailsToggle} from 'web/entities/row';
 
 import SeverityBar from 'web/components/bar/severitybar';
 
@@ -40,61 +37,63 @@ import TableBody from 'web/components/table/body';
 import TableRow from 'web/components/table/row';
 import TableData from 'web/components/table/data';
 
-import {secInfoTypeName, secInfoType} from 'gmp/models/secinfo';
+import EntitiesActions from 'web/entities/actions';
+import {RowDetailsToggle} from 'web/entities/row';
+
+import PropTypes from 'web/utils/proptypes';
 
 const Row = ({
   entity,
   links = true,
-  actions,
   onToggleDetailsClick,
-  ...other
-}) => {
-  return (
-    <TableBody>
-      <TableRow>
-        <TableData
-          rowSpan="2"
+  ...props
+}) => (
+  <TableBody>
+    <TableRow>
+      <TableData
+        rowSpan="2"
+      >
+        <RowDetailsToggle
+          name={entity.id}
+          onClick={onToggleDetailsClick}
         >
-          <RowDetailsToggle
-            name={entity.id}
-            onClick={onToggleDetailsClick}
-          >
-            {entity.name}
-          </RowDetailsToggle>
-          <Comment text={entity.comment}/>
-        </TableData>
-        <TableData>
-          {secInfoTypeName(secInfoType(entity))}
-        </TableData>
-        <TableData>
-          {longDate(entity.creationTime)}
-        </TableData>
-        <TableData>
-          {longDate(entity.modificationTime)}
-        </TableData>
-        <TableData>
-          <SeverityBar severity={entity.severity}/>
-        </TableData>
-        {renderComponent(actions, {...other, entity})}
-      </TableRow>
-      <TableRow>
-        <TableData colSpan="5">
-          <span title={entity.extra}>
-            {shorten(entity.extra, 150)}
-          </span>
-        </TableData>
-      </TableRow>
-    </TableBody>
-  );
-};
+          {entity.name}
+        </RowDetailsToggle>
+        <Comment text={entity.comment}/>
+      </TableData>
+      <TableData>
+        {secInfoTypeName(secInfoType(entity))}
+      </TableData>
+      <TableData>
+        {longDate(entity.creationTime)}
+      </TableData>
+      <TableData>
+        {longDate(entity.modificationTime)}
+      </TableData>
+      <TableData>
+        <SeverityBar severity={entity.severity}/>
+      </TableData>
+      <EntitiesActions
+        {...props}
+        entity={entity}
+      />
+    </TableRow>
+    <TableRow>
+      <TableData colSpan="5">
+        <span title={entity.extra}>
+          {shorten(entity.extra, 150)}
+        </span>
+      </TableData>
+    </TableRow>
+  </TableBody>
+);
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.object.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow()(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/tags/row.js
+++ b/gsa/src/web/pages/tags/row.js
@@ -29,21 +29,6 @@ import {shortDate} from 'gmp/locale/date';
 
 import {typeName} from 'gmp/utils/entitytype';
 
-import PropTypes from 'web/utils/proptypes';
-import {
-  renderComponent,
-  renderYesNo,
-} from 'web/utils/render';
-import withCapabilities from 'web/utils/withCapabilities';
-
-import EntityNameTableData from 'web/entities/entitynametabledata';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
-
 import ExportIcon from 'web/components/icon/exporticon';
 import Icon from 'web/components/icon/icon';
 
@@ -52,7 +37,22 @@ import IconDivider from 'web/components/layout/icondivider';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
-const Actions = withCapabilities(({
+import EntityNameTableData from 'web/entities/entitynametabledata';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+
+import compose from 'web/utils/compose';
+import PropTypes from 'web/utils/proptypes';
+import {renderYesNo} from 'web/utils/render';
+import withCapabilities from 'web/utils/withCapabilities';
+
+const Actions = compose(
+  withCapabilities,
+  withEntitiesActions,
+)(({
   capabilities,
   entity,
   onTagCloneClick,
@@ -132,14 +132,11 @@ Actions.propTypes = {
 };
 
 const Row = ({
-    actions,
-    entity,
-    links = true,
-    onToggleDetailsClick,
-    ...props
-  }, {
-    capabilities,
-  }) => {
+  entity,
+  links = true,
+  onToggleDetailsClick,
+  ...props
+}) => {
   const {resourceCount, resourceType} = entity;
   return (
     <TableRow>
@@ -165,22 +162,20 @@ const Row = ({
       <TableData>
         {shortDate(entity.modificationTime)}
       </TableData>
-      {renderComponent(actions, {...props, entity})}
+      <Actions
+        {...props}
+        entity={entity}
+      />
     </TableRow>
   );
 };
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-Row.contextTypes = {
-  capabilities: PropTypes.capabilities.isRequired,
-};
-
-export default withEntityRow(withEntityActions(Actions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/targets/row.js
+++ b/gsa/src/web/pages/targets/row.js
@@ -29,18 +29,6 @@ import _ from 'gmp/locale';
 import {isDefined} from 'gmp/utils/identity';
 import {shorten} from 'gmp/utils/string';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-
-import EntityNameTableData from 'web/entities/entitynametabledata';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
-
 import ExportIcon from 'web/components/icon/exporticon';
 
 import IconDivider from 'web/components/layout/icondivider';
@@ -51,7 +39,16 @@ import DetailsLink from 'web/components/link/detailslink';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
-const IconActions = ({
+import EntityNameTableData from 'web/entities/entitynametabledata';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import EditIcon from 'web/entity/icon/editicon';
+import TrashIcon from 'web/entity/icon/trashicon';
+
+import PropTypes from 'web/utils/proptypes';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+const Actions = withEntitiesActions(({
   entity,
   onTargetEditClick,
   onTargetCloneClick,
@@ -88,9 +85,9 @@ const IconActions = ({
       onClick={onTargetDownloadClick}
     />
   </IconDivider>
-);
+));
 
-IconActions.propTypes = {
+Actions.propTypes = {
   entity: PropTypes.model,
   onTargetCloneClick: PropTypes.func.isRequired,
   onTargetDeleteClick: PropTypes.func.isRequired,
@@ -128,64 +125,63 @@ Cred.propTypes = {
   title: PropTypes.string,
 };
 
-
 const Row = ({
-  actions,
   entity,
   links = true,
   onToggleDetailsClick,
   ...props
-}) => {
-  return (
-    <TableRow>
-      <EntityNameTableData
-        entity={entity}
-        link={links}
-        type="target"
-        displayName={_('Target')}
-        onToggleDetailsClick={onToggleDetailsClick}
+}) => (
+  <TableRow>
+    <EntityNameTableData
+      entity={entity}
+      link={links}
+      type="target"
+      displayName={_('Target')}
+      onToggleDetailsClick={onToggleDetailsClick}
+    />
+    <TableData>
+      {shorten(entity.hosts.join(', '), 500)}
+    </TableData>
+    <TableData>
+      {entity.max_hosts}
+    </TableData>
+    <TableData>
+      <DetailsLink
+        type="portlist"
+        id={entity.port_list.id}
+        textOnly={!links}
+      >
+        {entity.port_list.name}
+      </DetailsLink>
+    </TableData>
+    <TableData flex="column" align="center">
+      <Cred
+        cred={entity.ssh_credential}
+        title={'SSH'}
+        links={links}
       />
-      <TableData>
-        {shorten(entity.hosts.join(', '), 500)}
-      </TableData>
-      <TableData>
-        {entity.max_hosts}
-      </TableData>
-      <TableData>
-        <DetailsLink
-          type="portlist"
-          id={entity.port_list.id}
-          textOnly={!links}
-        >
-          {entity.port_list.name}
-        </DetailsLink>
-      </TableData>
-      <TableData flex="column" align="center">
-        <Cred
-          cred={entity.ssh_credential}
-          title={'SSH'}
-          links={links}
-        />
-        <Cred
-          cred={entity.smb_credential}
-          title={'SMB'}
-          links={links}
-        />
-        <Cred
-          cred={entity.esxi_credential}
-          title={'ESXi'}
-          links={links}
-        />
-        <Cred
-          cred={entity.snmp_credential}
-          title={'SNMP'}
-          links={links}
-        />
-      </TableData>
-      {renderComponent(actions, {...props, entity})}
-    </TableRow>
-  );
-};
+      <Cred
+        cred={entity.smb_credential}
+        title={'SMB'}
+        links={links}
+      />
+      <Cred
+        cred={entity.esxi_credential}
+        title={'ESXi'}
+        links={links}
+      />
+      <Cred
+        cred={entity.snmp_credential}
+        title={'SNMP'}
+        links={links}
+      />
+    </TableData>
+    <Actions
+      {...props}
+      entity={entity}
+    />
+  </TableRow>
+);
 
 Row.propTypes = {
   actions: PropTypes.componentOrFalse,
@@ -194,6 +190,6 @@ Row.propTypes = {
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(IconActions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/tasks/actions.js
+++ b/gsa/src/web/pages/tasks/actions.js
@@ -26,17 +26,15 @@ import _ from 'gmp/locale';
 
 import {isDefined} from 'gmp/utils/identity';
 
-import PropTypes from 'web/utils/proptypes';
-
 import IconDivider from 'web/components/layout/icondivider';
 
-import {withEntityActions} from 'web/entities/actions';
+import ExportIcon from 'web/components/icon/exporticon';
+
+import withEntitiesActions from 'web/entities/withEntitiesActions';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
-
-import ExportIcon from 'web/components/icon/exporticon';
 
 import ImportReportIcon from 'web/pages/tasks/icons/importreporticon';
 import ResumeIcon from 'web/pages/tasks/icons/resumeicon';
@@ -44,60 +42,60 @@ import ScheduleIcon from 'web/pages/tasks/icons/scheduleicon';
 import StartIcon from 'web/pages/tasks/icons/starticon';
 import StopIcon from 'web/pages/tasks/icons/stopicon';
 
+import PropTypes from 'web/utils/proptypes';
+
 const Actions = ({
-    entity,
-    links,
-    onReportImportClick,
-    onTaskCloneClick,
-    onTaskDeleteClick,
-    onTaskDownloadClick,
-    onTaskEditClick,
-    onTaskResumeClick,
-    onTaskStartClick,
-    onTaskStopClick,
-  }) => {
-  return (
-    <IconDivider
-      align={['center', 'center']}
-      grow
-    >
-      {isDefined(entity.schedule) ?
-        <ScheduleIcon
-          schedule={entity.schedule}
-          links={links}
-        /> :
-        <StartIcon task={entity} onClick={onTaskStartClick}/>
-      }
+  entity,
+  links,
+  onReportImportClick,
+  onTaskCloneClick,
+  onTaskDeleteClick,
+  onTaskDownloadClick,
+  onTaskEditClick,
+  onTaskResumeClick,
+  onTaskStartClick,
+  onTaskStopClick,
+}) => (
+  <IconDivider
+    align={['center', 'center']}
+    grow
+  >
+    {isDefined(entity.schedule) ?
+      <ScheduleIcon
+        schedule={entity.schedule}
+        links={links}
+      /> :
+      <StartIcon task={entity} onClick={onTaskStartClick}/>
+    }
 
-      <ImportReportIcon task={entity} onClick={onReportImportClick}/>
+    <ImportReportIcon task={entity} onClick={onReportImportClick}/>
 
-      <StopIcon task={entity} onClick={onTaskStopClick}/>
+    <StopIcon task={entity} onClick={onTaskStopClick}/>
 
-      <ResumeIcon task={entity} onClick={onTaskResumeClick}/>
+    <ResumeIcon task={entity} onClick={onTaskResumeClick}/>
 
-      <TrashIcon
-        entity={entity}
-        name="task"
-        onClick={onTaskDeleteClick}
-      />
-      <EditIcon
-        entity={entity}
-        name="task"
-        onClick={onTaskEditClick}
-      />
-      <CloneIcon
-        entity={entity}
-        name="task"
-        onClick={onTaskCloneClick}
-      />
-      <ExportIcon
-        value={entity}
-        title={_('Export Task')}
-        onClick={onTaskDownloadClick}
-      />
-    </IconDivider>
-  );
-};
+    <TrashIcon
+      entity={entity}
+      name="task"
+      onClick={onTaskDeleteClick}
+    />
+    <EditIcon
+      entity={entity}
+      name="task"
+      onClick={onTaskEditClick}
+    />
+    <CloneIcon
+      entity={entity}
+      name="task"
+      onClick={onTaskCloneClick}
+    />
+    <ExportIcon
+      value={entity}
+      title={_('Export Task')}
+      onClick={onTaskDownloadClick}
+    />
+  </IconDivider>
+);
 
 Actions.propTypes = {
   entity: PropTypes.model.isRequired,
@@ -112,6 +110,6 @@ Actions.propTypes = {
   onTaskStopClick: PropTypes.func.isRequired,
 };
 
-export default withEntityActions(Actions);
+export default withEntitiesActions(Actions);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/tasks/row.js
+++ b/gsa/src/web/pages/tasks/row.js
@@ -29,10 +29,9 @@ import {longDate} from 'gmp/locale/date';
 import {isDefined, isString} from 'gmp/utils/identity';
 
 import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
 import withUserName from 'web/utils/withUserName';
 
-import {withEntityRow, RowDetailsToggle} from 'web/entities/row';
+import {RowDetailsToggle} from 'web/entities/row';
 
 import ObserverIcon from 'web/entity/icon/observericon';
 
@@ -180,11 +179,11 @@ const Row = ({
           <Trend name={entity.trend} />
         }
       </TableData>
-      {renderComponent(actions, {
-        links,
-        ...props,
-        entity,
-      })}
+      <Actions
+        {...props}
+        links={links}
+        entity={entity}
+      />
     </TableRow>
   );
 };
@@ -197,6 +196,6 @@ Row.propTypes = {
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(Actions)(withUserName(Row));
+export default withUserName(Row);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/users/row.js
+++ b/gsa/src/web/pages/users/row.js
@@ -27,17 +27,6 @@ import _ from 'gmp/locale';
 
 import {map} from 'gmp/utils/array';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import EntityNameTableData from 'web/entities/entitynametabledata';
-import {withEntityActions} from 'web/entities/actions';
-import {withEntityRow} from 'web/entities/row';
-
-import CloneIcon from 'web/entity/icon/cloneicon';
-import DeleteIcon from 'web/entity/icon/deleteicon';
-import EditIcon from 'web/entity/icon/editicon';
-
 import ExportIcon from 'web/components/icon/exporticon';
 
 import Divider from 'web/components/layout/divider';
@@ -48,9 +37,18 @@ import DetailsLink from 'web/components/link/detailslink';
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
 
+import EntityNameTableData from 'web/entities/entitynametabledata';
+import withEntitiesActions from 'web/entities/withEntitiesActions';
+
+import CloneIcon from 'web/entity/icon/cloneicon';
+import DeleteIcon from 'web/entity/icon/deleteicon';
+import EditIcon from 'web/entity/icon/editicon';
+
+import PropTypes from 'web/utils/proptypes';
+
 import {convert_auth_method, convert_allow} from './details';
 
-const IconActions = ({
+const Actions = withEntitiesActions(({
   entity,
   onUserCloneClick,
   onUserEditClick,
@@ -87,9 +85,9 @@ const IconActions = ({
       onClick={onUserDownloadClick}
     />
   </IconDivider>
-);
+));
 
-IconActions.propTypes = {
+Actions.propTypes = {
   entity: PropTypes.model.isRequired,
   onUserCloneClick: PropTypes.func.isRequired,
   onUserDeleteClick: PropTypes.func.isRequired,
@@ -98,7 +96,6 @@ IconActions.propTypes = {
 };
 
 const Row = ({
-  actions,
   entity,
   links = true,
   onToggleDetailsClick,
@@ -153,18 +150,20 @@ const Row = ({
       <TableData>
         {auth_method}
       </TableData>
-      {renderComponent(actions, {...props, entity})}
+      <Actions
+        {...props}
+        entity={entity}
+      />
     </TableRow>
   );
 };
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
   onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
-export default withEntityRow(withEntityActions(IconActions))(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/vulns/row.js
+++ b/gsa/src/web/pages/vulns/row.js
@@ -25,11 +25,6 @@ import React from 'react';
 
 import {longDate} from 'gmp/locale/date';
 
-import PropTypes from 'web/utils/proptypes';
-import {renderComponent} from 'web/utils/render';
-
-import {withEntityRow} from 'web/entities/row';
-
 import DetailsLink from 'web/components/link/detailslink';
 import Link from 'web/components/link/link';
 
@@ -38,11 +33,14 @@ import SeverityBar from 'web/components/bar/severitybar';
 import TableRow from 'web/components/table/row';
 import TableData from 'web/components/table/data';
 
+import EntitiesActions from 'web/entities/actions';
+
+import PropTypes from 'web/utils/proptypes';
+
 const Row = ({
   entity,
   links = true,
-  actions,
-  ...other
+  ...props
 }) => {
   const {results = {}, hosts = {}} = entity;
   return (
@@ -80,17 +78,19 @@ const Row = ({
       <TableData>
         {hosts.count}
       </TableData>
-      {renderComponent(actions, {...other, entity})}
+      <EntitiesActions
+        {...props}
+        entity={entity}
+      />
     </TableRow>
   );
 };
 
 Row.propTypes = {
-  actions: PropTypes.componentOrFalse,
   entity: PropTypes.object.isRequired,
   links: PropTypes.bool,
 };
 
-export default withEntityRow()(Row);
+export default Row;
 
 // vim: set ts=2 sw=2 tw=80:


### PR DESCRIPTION
While implementing a new entity type for the remediation module it became obvious that the current table rendering is to complicated and the usage of the different HOCs is confusing.

This PR makes rendering the rows and it's columns (especially the actions column) more obvious by simplifying the HOC usage.

Also the coding style of the touched js modules is updated and the imports got sorted alphabetically (mostly).