### PR TITLE
Selecting save id improvements

### DIFF
--- a/gsa/src/gmp/utils/__tests__/array.js
+++ b/gsa/src/gmp/utils/__tests__/array.js
@@ -207,6 +207,12 @@ describe('filter function tests', () => {
 });
 
 describe('first function tests', () => {
+
+  test('should return non for undefined array', () => {
+    expect(first()).toEqual({});
+    expect(first(undefined, 'foo')).toEqual('foo');
+  });
+
   test('should return first value from array', () => {
     expect(first(['foo', 'bar'])).toEqual('foo');
     expect(first([undefined])).toBeUndefined();

--- a/gsa/src/gmp/utils/__tests__/id.js
+++ b/gsa/src/gmp/utils/__tests__/id.js
@@ -68,6 +68,21 @@ describe('selectSaveId function tests', () => {
     expect(selectSaveId(list, 4, 42)).toBe(42);
     expect(selectSaveId(list, '2', 42)).toBe(42);
   });
+
+  test('should select first entry id if id is undefined', () => {
+    const list = [{id: 1}, {id: 2}, {id: 3}];
+
+    expect(selectSaveId(list)).toEqual(1);
+  });
+
+  test('should return undefined for undefined list', () => {
+    expect(selectSaveId()).toBeUndefined();
+  });
+
+  test('should return empty_default for undefined list', () => {
+    expect(selectSaveId(undefined, undefined, 'foo')).toEqual('foo');
+  });
+
 });
 
 describe('hasId tests', () => {

--- a/gsa/src/gmp/utils/array.js
+++ b/gsa/src/gmp/utils/array.js
@@ -84,6 +84,10 @@ export function first(array, non = {}) {
     return array[0];
   }
 
+  if (!isDefined(array)) {
+    return non;
+  }
+
   // support array like objects which have an iterator
   if (!isDefined(array[Symbol.iterator])) { // not an array like object
     return non;


### PR DESCRIPTION
Adjust first function to not crash if a list is empty. This allows to use selectSaveId for getting the first model item id of a list and not to crash if the list hasn't been loaded yet.

- [ x] Tests
