### PR TITLE
Remove code path for "prognostic" report type.

### DIFF
--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -703,7 +703,7 @@ init_validator ()
   gvm_validator_add (validator, "threat",     "^(High|Medium|Low|Alarm|Log|False Positive|)$");
   gvm_validator_add (validator, "trend",       "^(0|1)$");
   gvm_validator_add (validator, "trend:value", "^(0|1)$");
-  gvm_validator_add (validator, "type",       "^(assets|prognostic)$");
+  gvm_validator_add (validator, "type",       "^(assets)$");
   gvm_validator_add (validator, "search_phrase", "^[[:alnum:][:punct:] äöüÄÖÜß]{0,400}$");
   gvm_validator_add (validator, "sort_field", "^[_[:alnum:] ]{1,40}$");
   gvm_validator_add (validator, "sort_order", "^(ascending|descending)$");
@@ -807,11 +807,6 @@ init_validator ()
   gvm_validator_alias (validator, "group_ids:name",     "number");
   gvm_validator_alias (validator, "group_ids:value",    "id_optional");
   gvm_validator_alias (validator, "groups",             "optional_number");
-  gvm_validator_alias (validator, "host_search_phrase", "search_phrase");
-  gvm_validator_alias (validator, "host_first_result",  "first_result");
-  gvm_validator_alias (validator, "host_max_results",   "max_results");
-  gvm_validator_alias (validator, "host_levels",        "levels");
-  gvm_validator_alias (validator, "host_count",         "number");
   gvm_validator_alias (validator, "hosts_manual",       "hosts");
   gvm_validator_alias (validator, "hosts_filter",       "filter");
   gvm_validator_alias (validator, "exclude_hosts",      "hosts_opt");


### PR DESCRIPTION
The GMP command in older version supported "type='prognostic'"
for "get_reports" command. There were some remaining code paths
being removed now. The new web UI does niot use this anymore.

Subsequently some of the validators can be removed as well.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
