### PR TITLE
Always put gsad_message responses into an <envelope> element

### DIFF
--- a/gsad/src/gsad_http.c
+++ b/gsad/src/gsad_http.c
@@ -1090,11 +1090,17 @@ gsad_message (credentials_t *credentials, const char *title,
     }
   else
     {
-      xml = g_strdup_printf ("<gsad_response>"
+      xml = g_strdup_printf ("<envelope>"
+                             "<version>%s</version>"
+                             "<vendor_version>%s</vendor_version>"
+                             "<gsad_response>"
                              "%s"
                              "<message>%s</message>"
                              "<token></token>"
-                             "</gsad_response>",
+                             "</gsad_response>"
+                             "</envelope>",
+                             GSAD_VERSION,
+                             vendor_version_get (),
                              xmltitle,
                              msg);
     }


### PR DESCRIPTION
GSA requires an envelope root element. Therefore always put
gsad_response elements as a child of envelope.