### PR TITLE
Corrected OID of VT setting Auth-SNMP-Success/Auth-SNMP-Failure Host …

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,8 @@ Main changes compared to 7.0.3:
 * Tags can now contain backslashes and percent signs in the value and
   hyphens in the name to allow using the special "smb-alert:file_path"
   task tag.
+* The OID of the VT sending the SNMP Host Detail for Authentication failure /
+  success was updated.
 
 
 gsa 7.0.3 (2018-03-28)

--- a/src/html/classic/omp.xsl
+++ b/src/html/classic/omp.xsl
@@ -33118,13 +33118,13 @@ was created or assigned erroneously.
                 </a>
               </xsl:if>
               <xsl:if test="detail[name = 'Auth-SNMP-Success']">
-                <a href="/omp?cmd=get_results&amp;filter=report_id={$id} and host=&#34;{$current_host}&#34; and &#34;1.3.6.1.4.1.25623.1.0.105076&#34;&amp;token={/envelope/token}"
+                <a href="/omp?cmd=get_results&amp;filter=report_id={$id} and host=&#34;{$current_host}&#34; and &#34;1.3.6.1.4.1.25623.1.0.10265&#34;&amp;token={/envelope/token}"
                   class="icon icon-sm">
                   <img src="/img/indicator_operation_ok.svg" title="{detail[name = 'Auth-SNMP-Success']/value}"/>
                 </a>
               </xsl:if>
               <xsl:if test="detail[name = 'Auth-SNMP-Failure']">
-                <a href="/omp?cmd=get_results&amp;filter=report_id={$id} and host=&#34;{$current_host}&#34; and &#34;1.3.6.1.4.1.25623.1.0.105076&#34;&amp;token={/envelope/token}"
+                <a href="/omp?cmd=get_results&amp;filter=report_id={$id} and host=&#34;{$current_host}&#34; and &#34;1.3.6.1.4.1.25623.1.0.10265&#34;&amp;token={/envelope/token}"
                   class="icon icon-sm">
                   <img src="/img/indicator_operation_failed.svg" title="{detail[name = 'Auth-SNMP-Failure']/value}"/>
                 </a>


### PR DESCRIPTION
…Details

Follow-up commit of the initial SNMP handling in https://github.com/greenbone/gsa/commit/37de0c1eed7e1061e8811cdacae80657213e04f1

OID 1.3.6.1.4.1.25623.1.0.105076 (gb_snmp_authorization.nasl) had only set the SNMP community / credentials within the KB without sending the expected Host Details. The VT doing the login check (snmp_detect.nasl, OID: 1.3.6.1.4.1.25623.1.0.10265) was updated now to send such Host Details so the OID needs to be updated in this code path as well.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [x] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
