### PR TITLE
Revert #1109

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,6 @@ $ cd gsa && git log
 
 ## gsa 8.0 unreleased
 
- * Add SMB file path type to alerts #1108
  * Add Alemba vFire alert to GUI #1100
  * Sort alerts at task details alphanumerically #1094
  * Add solution type to report details powerfilter #1091

--- a/gsa/src/gmp/commands/alerts.js
+++ b/gsa/src/gmp/commands/alerts.js
@@ -69,7 +69,6 @@ const method_data_fields = [
   'scp_report_format',
   'smb_credential',
   'smb_file_path',
-  'smb_file_path_type',
   'smb_report_format',
   'smb_share_path',
   'tp_sms_hostname',

--- a/gsa/src/web/pages/alerts/dialog.js
+++ b/gsa/src/web/pages/alerts/dialog.js
@@ -216,7 +216,6 @@ const DEFAULTS = {
   method_data_send_host: '',
   method_data_send_port: '',
   method_data_smb_file_path: 'report.xml',
-  method_data_smb_file_path_type: 'full',
   method_data_smb_share_path: '\\\\localhost\\gvm-reports',
   method_data_snmp_agent: 'localhost',
   method_data_snmp_community: 'public',
@@ -700,7 +699,6 @@ class AlertDialog extends React.Component {
                   reportFormats={report_formats}
                   smbCredential={values.method_data_smb_credential}
                   smbFilePath={values.method_data_smb_file_path}
-                  smbFilePathType={values.method_data_smb_file_path_type}
                   smbSharePath={values.method_data_smb_share_path}
                   smbReportFormat={values.method_data_smb_report_format}
                   onNewCredentialClick={onNewSmbCredentialClick}
@@ -846,7 +844,6 @@ AlertDialog.propTypes = {
   method_data_send_report_format: PropTypes.id,
   method_data_smb_credential: PropTypes.id,
   method_data_smb_file_path: PropTypes.string,
-  method_data_smb_file_path_type: PropTypes.string,
   method_data_smb_report_format: PropTypes.id,
   method_data_smb_share_path: PropTypes.string,
   method_data_snmp_agent: PropTypes.string,

--- a/gsa/src/web/pages/alerts/smbmethodpart.js
+++ b/gsa/src/web/pages/alerts/smbmethodpart.js
@@ -35,7 +35,6 @@ import withPrefix from 'web/utils/withPrefix';
 
 import Select from 'web/components/form/select';
 import FormGroup from 'web/components/form/formgroup';
-import Radio from 'web/components/form/radio';
 import TextField from 'web/components/form/textfield';
 
 import NewIcon from 'web/components/icon/newicon';
@@ -46,7 +45,6 @@ const SmbMethodPart = ({
   reportFormats,
   smbCredential,
   smbFilePath,
-  smbFilePathType,
   smbReportFormat,
   smbSharePath,
   onChange,
@@ -98,29 +96,13 @@ const SmbMethodPart = ({
       </FormGroup>
 
       <FormGroup title={_('File path')}>
-        <Divider grow="1">
-          <Radio
-            title="Directory"
-            checked={smbFilePathType === 'directory'}
-            name={prefix + 'smb_file_path_type'}
-            value={'directory'}
-            onChange={onChange}
-          />
-          <Radio
-            title="Full path"
-            checked={smbFilePathType === 'full'}
-            name={prefix + 'smb_file_path_type'}
-            value={'full'}
-            onChange={onChange}
-          />
-          <TextField
-            grow="1"
-            name={prefix + 'smb_file_path'}
-            maxLength="256"
-            value={smbFilePath}
-            onChange={onChange}
-          />
-        </Divider>
+        <TextField
+          grow="1"
+          name={prefix + 'smb_file_path'}
+          maxLength="256"
+          value={smbFilePath}
+          onChange={onChange}
+        />
       </FormGroup>
 
       <FormGroup title={_('Report Format')}>
@@ -141,7 +123,6 @@ SmbMethodPart.propTypes = {
   reportFormats: PropTypes.array,
   smbCredential: PropTypes.id,
   smbFilePath: PropTypes.string.isRequired,
-  smbFilePathType: PropTypes.string.isRequired,
   smbReportFormat: PropTypes.id,
   smbSharePath: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,


### PR DESCRIPTION
smb_file_path_type handling is removed from GSA.
**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ N/A ] Tests
- [ X ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
