### PR TITLE
Revert "Add smb_file_path_type alert method data to gsad" [master]

### DIFF
--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -7299,7 +7299,6 @@ append_alert_method_data (GString *xml, params_t *data, const char *method,
             || (strcmp (method, "SMB") == 0
                 && (strcmp (name, "smb_credential") == 0
                     || strcmp (name, "smb_file_path") == 0
-                    || strcmp (name, "smb_file_path_type") == 0
                     || strcmp (name, "smb_report_format") == 0
                     || strcmp (name, "smb_share_path") == 0))
             || (strcmp (method, "SNMP") == 0


### PR DESCRIPTION
This reverts commit d4d21824751f08e2933283c4ad5b626232fe935e.
The manager no longer uses smb_file_path_type to decide how to
interpret the path.

**Checklist**:

- Tests N/A
- [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) N/A
