### PR TITLE
Allow percent signs in tag values

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -48,8 +48,9 @@ Main changes compared to 7.0.3:
 * An issue with handling XRef URLs without scheme prefix has been addressed.
 * Various small usability improvements for the auth config page, empty list
   pages and the "Edit filter" icons.
-* Tags can now contain backslashes in the value and hyphens in the name
-  to allow using the special "smb-alert:file_path" task tag.
+* Tags can now contain backslashes and percent signs in the value and
+  hyphens in the name to allow using the special "smb-alert:file_path"
+  task tag.
 
 
 gsa 7.0.3 (2018-03-28)

--- a/src/gsad.c
+++ b/src/gsad.c
@@ -1465,7 +1465,7 @@ init_validator ()
   openvas_validator_add (validator, "summary",    "^.{0,400}$");
   openvas_validator_add (validator, "tag_id",  "^[a-z0-9\\-]+$");
   openvas_validator_add (validator, "tag_name",  "^[\\:\\-_[:alnum:], \\./]{1,80}$");
-  openvas_validator_add (validator, "tag_value", "^[\\-_@[:alnum:], \\.\\\\]{0,200}$");
+  openvas_validator_add (validator, "tag_value", "^[\\-_@%[:alnum:], \\.\\\\]{0,200}$");
   openvas_validator_add (validator, "target_id",  "^[a-z0-9\\-]+$");
   openvas_validator_add (validator, "task_id",    "^[a-z0-9\\-]+$");
   openvas_validator_add (validator, "term",       "^.{0,1000}");


### PR DESCRIPTION
By allowing percent signs in the tag values, the smb-alert:file_path tag can use placeholders.

**Checklist**:
- Tests N/A
- [x] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
