### PR TITLE
Allow percent signs in tag values and add CHANGES entry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,10 @@ $ cd gsa && git log
  * Sort alerts at task details alphanumerically #1094
  * Add solution type to report details powerfilter #1091
  * Add feature: Scan Report Content Composer #1073 #1084 #1086 #1090
+ * Tags can now contain backslashes and percent signs in the value and
+   hyphens in the name to allow using the special "smb-alert:file_path"
+   task tag #1107 #1142 #1145
+
 
 ## gsa 8.0+beta2 (2018-12-04)
 

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -677,7 +677,7 @@ init_validator ()
   gvm_validator_add (validator, "summary",    "^.{0,400}$");
   gvm_validator_add (validator, "tag_id",  "^[a-z0-9\\-]+$");
   gvm_validator_add (validator, "tag_name",  "^[\\:\\-_[:alnum:], \\./]{1,80}$");
-  gvm_validator_add (validator, "tag_value", "^[\\-_@[:alnum:], \\.\\\\]{0,200}$");
+  gvm_validator_add (validator, "tag_value", "^[\\-_@%[:alnum:], \\.\\\\]{0,200}$");
   gvm_validator_add (validator, "target_id",  "^[a-z0-9\\-]+$");
   gvm_validator_add (validator, "task_id",    "^[a-z0-9\\-]+$");
   gvm_validator_add (validator, "term",       "^.{0,1000}");


### PR DESCRIPTION
With this, the smb-alert:file_path tag can use placeholders.
Also, a CHANGES entry is added for the tag validator changes.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
