### PR TITLE
Support Sourcefire PKCS12 password

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ $ cd gsa && git log
 
 ## gsa 8.0 unreleased
 
+ * Add Sourcefire PKCS12 password support #1150
  * Add Alemba vFire alert to GUI #1100
  * Sort alerts at task details alphanumerically #1094
  * Add solution type to report details powerfilter #1091

--- a/gsa/src/gmp/commands/alerts.js
+++ b/gsa/src/gmp/commands/alerts.js
@@ -55,6 +55,7 @@ const method_data_fields = [
   'defense_center_ip',
   'defense_center_port',
   'pkcs12',
+  'pkcs12_credential',
   'verinice_server_url',
   'verinice_server_credential',
   'verinice_server_report_format',

--- a/gsa/src/gmp/models/credential.js
+++ b/gsa/src/gmp/models/credential.js
@@ -31,6 +31,7 @@ export const CLIENT_CERTIFICATE_CREDENTIAL_TYPE = 'cc';
 export const SNMP_CREDENTIAL_TYPE = 'snmp';
 export const SMIME_CREDENTIAL_TYPE = 'smime';
 export const PGP_CREDENTIAL_TYPE = 'pgp';
+export const PASSWORD_ONLY_CREDENTIAL_TYPE = 'pw';
 
 export const SSH_CREDENTIAL_TYPES = [
   USERNAME_PASSWORD_CREDENTIAL_TYPE,
@@ -65,6 +66,7 @@ export const ALL_CREDENTIAL_TYPES = [
   SNMP_CREDENTIAL_TYPE,
   SMIME_CREDENTIAL_TYPE,
   PGP_CREDENTIAL_TYPE,
+  PASSWORD_ONLY_CREDENTIAL_TYPE,
 ];
 
 export const ssh_credential_filter = credential =>
@@ -83,6 +85,9 @@ export const snmp_credential_filter = credential =>
 export const email_credential_filter = credential =>
   credential.credential_type === SMIME_CREDENTIAL_TYPE ||
   credential.credential_type === PGP_CREDENTIAL_TYPE;
+
+export const password_only_credential_filter = credential =>
+  credential.credential_type === PASSWORD_ONLY_CREDENTIAL_TYPE;
 
 export const vFire_credential_filter = credential =>
 credential.credential_type === USERNAME_PASSWORD_CREDENTIAL_TYPE;
@@ -103,6 +108,7 @@ const TYPE_NAMES = {
   cc: _l('Client Certificate'),
   snmp: _l('SNMP'),
   pgp: _l('PGP Key'),
+  pw: _l('Password only'),
   smime: _l('S/MIME Certificate'),
 };
 

--- a/gsa/src/web/pages/alerts/component.js
+++ b/gsa/src/web/pages/alerts/component.js
@@ -36,6 +36,7 @@ import {
 
 import {
   email_credential_filter,
+  password_only_credential_filter,
   smb_credential_filter,
   vFire_credential_filter,
 } from 'gmp/models/credential';
@@ -122,6 +123,8 @@ class AlertComponent extends React.Component {
       .bind(this);
     this.handleFilterIdChange = this.handleFilterIdChange.bind(this);
     this.handleTestAlert = this.handleTestAlert.bind(this);
+    this.handlePasswordOnlyCredentialChange =
+      this.handlePasswordOnlyCredentialChange.bind(this);
     this.handleScpCredentialChange = this.handleScpCredentialChange.bind(this);
     this.handleSaveComposerContent = this.handleSaveComposerContent.bind(this);
     this.handleSmbCredentialChange = this.handleSmbCredentialChange.bind(this);
@@ -141,6 +144,8 @@ class AlertComponent extends React.Component {
     this.openContentComposerDialog = this.openContentComposerDialog.bind(this);
     this.closeContentComposerDialog =
       this.closeContentComposerDialog.bind(this);
+    this.openPasswordOnlyCredentialDialog =
+      this.openPasswordOnlyCredentialDialog.bind(this);
     this.openScpCredentialDialog = this.openScpCredentialDialog.bind(this);
     this.openSmbCredentialDialog = this.openSmbCredentialDialog.bind(this);
     this.openVeriniceCredentialDialog = this.openVeriniceCredentialDialog.bind(
@@ -201,6 +206,12 @@ class AlertComponent extends React.Component {
         else if (this.credentialType === 'email') {
           this.setState({
             method_data_recipient_credential: credential_id,
+            credentials,
+          });
+        }
+        else if (this.credentialType === 'pw') {
+          this.setState({
+            method_data_pkcs12_credential: credential_id,
             credentials,
           });
         }
@@ -303,6 +314,10 @@ class AlertComponent extends React.Component {
     this.openCredentialDialog({type: 'verinice', types});
   }
 
+  openPasswordOnlyCredentialDialog(types) {
+    this.openCredentialDialog({type: 'pw', types});
+  }
+
   openVfireCredentialDialog(types) {
     this.openCredentialDialog({type: 'vfire', types});
   }
@@ -339,6 +354,8 @@ class AlertComponent extends React.Component {
 
         const emailCredentials = credentials.filter(email_credential_filter);
         const vFireCredentials = credentials.filter(vFire_credential_filter);
+        const passwordOnlyCredentials =
+          credentials.filter(password_only_credential_filter);
 
         const result_filters = filters.filter(filter_results_filter);
         const secinfo_filters = filters.filter(filter_secinfo_filter);
@@ -408,6 +425,9 @@ class AlertComponent extends React.Component {
         const recipient_credential_id = isDefined(
           method.data.recipient_credential) ?
           getValue(method.data.recipient_credential) : undefined;
+
+        const pkcs12_credential_id = isDefined(method.data.pkcs12_credential) ?
+          getValue(method.data.pkcs12_credential) : undefined;
 
         const vfire_credential_id = isDefined(method.data.vfire_credential) ?
           getValue(method.data.vfire_credential) : undefined;
@@ -528,6 +548,8 @@ class AlertComponent extends React.Component {
           method_data_verinice_server_credential: selectSaveId(credentials,
             verinice_credential_id),
 
+          method_data_pkcs12_credential: selectSaveId(passwordOnlyCredentials,
+            pkcs12_credential_id),
           method_data_vfire_credential: selectSaveId(vFireCredentials,
             vfire_credential_id),
           method_data_vfire_base_url: getValue(method.data.vfire_base_url),
@@ -648,6 +670,7 @@ class AlertComponent extends React.Component {
           method_data_smb_file_path_type: undefined,
           method_data_verinice_server_report_format: select_verinice_report_id(
             report_formats),
+          method_data_pkcs12_credential: undefined,
           method_data_vfire_credential: undefined,
           method_data_vfire_base_url: undefined,
           method_data_vfire_call_description: undefined,
@@ -725,6 +748,10 @@ class AlertComponent extends React.Component {
           alert));
       }
     });
+  }
+
+  handlePasswordOnlyCredentialChange(credential) {
+    this.setState({method_data_pkcs12_credential: credential});
   }
 
   handleScpCredentialChange(credential) {
@@ -870,6 +897,7 @@ class AlertComponent extends React.Component {
       method_data_verinice_server_report_format,
       method_data_verinice_server_url,
       method_data_verinice_server_credential,
+      method_data_pkcs12_credential,
       method_data_vfire_credential,
       method_data_vfire_base_url,
       method_data_vfire_call_description,
@@ -990,6 +1018,7 @@ class AlertComponent extends React.Component {
                   method_data_verinice_server_url}
                 method_data_verinice_server_credential=
                   {method_data_verinice_server_credential}
+                method_data_pkcs12_credential={method_data_pkcs12_credential}
                 method_data_vfire_credential={method_data_vfire_credential}
                 method_data_vfire_base_url={method_data_vfire_base_url}
                 method_data_vfire_call_description=
@@ -1015,6 +1044,8 @@ class AlertComponent extends React.Component {
                 onOpenContentComposerDialogClick=
                   {this.handleOpenContentComposerDialog}
                 onNewEmailCredentialClick={this.openEmailCredentialDialog}
+                onNewPasswordOnlyCredentialClick=
+                  {this.openPasswordOnlyCredentialDialog}
                 onNewScpCredentialClick={this.openScpCredentialDialog}
                 onNewSmbCredentialClick={this.openSmbCredentialDialog}
                 onNewVeriniceCredentialClick={this.openVeriniceCredentialDialog}
@@ -1027,6 +1058,8 @@ class AlertComponent extends React.Component {
                 }}
                 onReportFormatsChange={this.handleReportFormatsChange}
                 onEmailCredentialChange={this.handleEmailCredentialChange}
+                onPasswordOnlyCredentialChange=
+                  {this.handlePasswordOnlyCredentialChange}
                 onScpCredentialChange={this.handleScpCredentialChange}
                 onSmbCredentialChange={this.handleSmbCredentialChange}
                 onVerinceCredentialChange={this.handleVeriniceCredentialChange}

--- a/gsa/src/web/pages/alerts/component.js
+++ b/gsa/src/web/pages/alerts/component.js
@@ -670,7 +670,7 @@ class AlertComponent extends React.Component {
           method_data_smb_file_path_type: undefined,
           method_data_verinice_server_report_format: select_verinice_report_id(
             report_formats),
-          method_data_pkcs12_credential: undefined,
+          method_data_pkcs12_credential: UNSET_VALUE,
           method_data_vfire_credential: undefined,
           method_data_vfire_base_url: undefined,
           method_data_vfire_call_description: undefined,

--- a/gsa/src/web/pages/alerts/component.js
+++ b/gsa/src/web/pages/alerts/component.js
@@ -549,7 +549,7 @@ class AlertComponent extends React.Component {
             verinice_credential_id),
 
           method_data_pkcs12_credential: selectSaveId(passwordOnlyCredentials,
-            pkcs12_credential_id),
+            pkcs12_credential_id, '0'),
           method_data_vfire_credential: selectSaveId(vFireCredentials,
             vfire_credential_id),
           method_data_vfire_base_url: getValue(method.data.vfire_base_url),

--- a/gsa/src/web/pages/alerts/dialog.js
+++ b/gsa/src/web/pages/alerts/dialog.js
@@ -322,6 +322,7 @@ class AlertDialog extends React.Component {
       method_data_smb_credential,
       method_data_tp_sms_credential,
       method_data_verinice_server_credential,
+      method_data_pkcs12_credential,
       method_data_vfire_base_url,
       method_data_vfire_credential,
       method_data_vfire_session_type,
@@ -335,6 +336,7 @@ class AlertDialog extends React.Component {
       onClose,
       onEmailCredentialChange,
       onNewEmailCredentialClick,
+      onNewPasswordOnlyCredentialClick,
       onNewScpCredentialClick,
       onNewSmbCredentialClick,
       onNewVeriniceCredentialClick,
@@ -343,6 +345,7 @@ class AlertDialog extends React.Component {
       onOpenContentComposerDialogClick,
       onReportFormatsChange,
       onSave,
+      onPasswordOnlyCredentialChange,
       onScpCredentialChange,
       onSmbCredentialChange,
       onTippingPointCredentialChange,
@@ -429,6 +432,7 @@ class AlertDialog extends React.Component {
 
     const controlledValues = {
       filter_id,
+      method_data_pkcs12_credential,
       method_data_composer_include_notes,
       method_data_composer_include_overrides,
       method_data_recipient_credential,
@@ -719,11 +723,15 @@ class AlertDialog extends React.Component {
 
               {values.method === METHOD_TYPE_SOURCEFIRE &&
                 <SourcefireMethodPart
+                  credentials={credentials}
+                  pkcs12Credential={values.method_data_pkcs12_credential}
                   prefix="method_data"
                   defenseCenterIp={values.method_data_defense_center_ip}
                   defenseCenterPort={
                     parseInt(values.method_data_defense_center_port)}
                   onChange={onValueChange}
+                  onCredentialChange={onPasswordOnlyCredentialChange}
+                  onNewCredentialClick={onNewPasswordOnlyCredentialClick}
                 />
               }
 
@@ -833,6 +841,7 @@ AlertDialog.propTypes = {
   method_data_notice: PropTypes.string,
   method_data_notice_attach_format: PropTypes.id,
   method_data_notice_report_format: PropTypes.id,
+  method_data_pkcs12_credential: PropTypes.id,
   method_data_recipient_credential: PropTypes.id,
   method_data_scp_credential: PropTypes.id,
   method_data_scp_host: PropTypes.string,
@@ -878,12 +887,14 @@ AlertDialog.propTypes = {
   onClose: PropTypes.func.isRequired,
   onEmailCredentialChange: PropTypes.func.isRequired,
   onNewEmailCredentialClick: PropTypes.func.isRequired,
+  onNewPasswordOnlyCredentialClick: PropTypes.func.isRequired,
   onNewScpCredentialClick: PropTypes.func.isRequired,
   onNewSmbCredentialClick: PropTypes.func.isRequired,
   onNewTippingPointCredentialClick: PropTypes.func.isRequired,
   onNewVeriniceCredentialClick: PropTypes.func.isRequired,
   onNewVfireCredentialClick: PropTypes.func.isRequired,
   onOpenContentComposerDialogClick: PropTypes.func.isRequired,
+  onPasswordOnlyCredentialChange: PropTypes.func.isRequired,
   onReportFormatsChange: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
   onScpCredentialChange: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/alerts/sourcefiremethodpart.js
+++ b/gsa/src/web/pages/alerts/sourcefiremethodpart.js
@@ -20,22 +20,37 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import Layout from '../../components/layout/layout.js';
+import {
+  PASSWORD_ONLY_CREDENTIAL_TYPE,
+  password_only_credential_filter,
+} from 'gmp/models/credential';
 
-import PropTypes from '../../utils/proptypes.js';
-import withPrefix from '../../utils/withPrefix.js';
+import NewIcon from 'web/components/icon/newicon';
 
-import Spinner from '../../components/form/spinner.js';
-import FormGroup from '../../components/form/formgroup.js';
-import TextField from '../../components/form/textfield.js';
-import FileField from '../../components/form/filefield.js';
+import Divider from 'web/components/layout/divider';
+import Layout from 'web/components/layout/layout';
+
+import Select from 'web/components/form/select';
+import Spinner from 'web/components/form/spinner';
+import FormGroup from 'web/components/form/formgroup';
+import TextField from 'web/components/form/textfield';
+import FileField from 'web/components/form/filefield';
+
+import PropTypes from 'web/utils/proptypes';
+import {renderSelectItems} from 'web/utils/render';
+import withPrefix from 'web/utils/withPrefix';
 
 const SourcefireMethodPart = ({
+  credentials,
+  pkcs12Credential,
   prefix,
   defenseCenterIp,
   defenseCenterPort,
   onChange,
+  onCredentialChange,
+  onNewCredentialClick,
 }) => {
+  const credentialOptions = credentials.filter(password_only_credential_filter);
   return (
     <Layout
       flex="column"
@@ -62,7 +77,24 @@ const SourcefireMethodPart = ({
         />
       </FormGroup>
 
-      <FormGroup title={_('PKCS12 file')}>
+      <FormGroup title={_('PKCS12 Credential')}>
+        <Divider>
+          <Select
+            name={prefix + 'pkcs12_credential'}
+            items={renderSelectItems(credentialOptions)}
+            value={pkcs12Credential}
+            onChange={onCredentialChange}
+          />
+          <NewIcon
+            size="small"
+            value={[PASSWORD_ONLY_CREDENTIAL_TYPE]}
+            title={_('Create a credential')}
+            onClick={onNewCredentialClick}
+          />
+        </Divider>
+      </FormGroup>
+
+      <FormGroup title={_('PKCS12 File')}>
         <FileField
           name={prefix + 'pkcs12'}
           onChange={onChange}
@@ -73,10 +105,14 @@ const SourcefireMethodPart = ({
 };
 
 SourcefireMethodPart.propTypes = {
+  credentials: PropTypes.array.isRequired,
   defenseCenterIp: PropTypes.string.isRequired,
   defenseCenterPort: PropTypes.numberOrNumberString.isRequired,
+  pkcs12Credential: PropTypes.id,
   prefix: PropTypes.string,
   onChange: PropTypes.func.isRequired,
+  onCredentialChange: PropTypes.func.isRequired,
+  onNewCredentialClick: PropTypes.func.isRequired,
 };
 
 export default withPrefix(SourcefireMethodPart);

--- a/gsa/src/web/pages/alerts/sourcefiremethodpart.js
+++ b/gsa/src/web/pages/alerts/sourcefiremethodpart.js
@@ -37,7 +37,7 @@ import TextField from 'web/components/form/textfield';
 import FileField from 'web/components/form/filefield';
 
 import PropTypes from 'web/utils/proptypes';
-import {renderSelectItems} from 'web/utils/render';
+import {renderSelectItems, UNSET_VALUE} from 'web/utils/render';
 import withPrefix from 'web/utils/withPrefix';
 
 const SourcefireMethodPart = ({
@@ -81,7 +81,7 @@ const SourcefireMethodPart = ({
         <Divider>
           <Select
             name={prefix + 'pkcs12_credential'}
-            items={renderSelectItems(credentialOptions)}
+            items={renderSelectItems(credentialOptions, UNSET_VALUE)}
             value={pkcs12Credential}
             onChange={onCredentialChange}
           />

--- a/gsa/src/web/pages/credentials/dialog.js
+++ b/gsa/src/web/pages/credentials/dialog.js
@@ -38,6 +38,7 @@ import {
   SNMP_PRIVACY_ALOGRITHM_NONE,
   SNMP_PRIVACY_ALGORITHM_AES,
   SNMP_PRIVACY_ALGORITHM_DES,
+  PASSWORD_ONLY_CREDENTIAL_TYPE,
   PGP_CREDENTIAL_TYPE,
   SMIME_CREDENTIAL_TYPE,
   VFIRE_CREDENTIAL_TYPES,
@@ -308,7 +309,8 @@ class CredentialsDialog extends React.Component {
 
               {(state.credential_type === USERNAME_PASSWORD_CREDENTIAL_TYPE ||
                 state.credential_type === SNMP_CREDENTIAL_TYPE ||
-                state.credential_type === VFIRE_CREDENTIAL_TYPES) &&
+                state.credential_type === VFIRE_CREDENTIAL_TYPES ||
+                state.credential_type === PASSWORD_ONLY_CREDENTIAL_TYPE) &&
                 <FormGroup
                   title={_('Password')}
                 >

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -525,7 +525,7 @@ init_validator ()
   gvm_validator_add (validator, "condition",  "^[[:alnum:] ]{0,100}$");
   gvm_validator_add (validator, "credential_id", "^[a-z0-9\\-]+$");
   gvm_validator_add (validator, "create_credentials_type", "^(gen|pass|key)$");
-  gvm_validator_add (validator, "credential_type", "^(cc|up|usk|smime|pgp|snmp)$");
+  gvm_validator_add (validator, "credential_type", "^(cc|up|usk|smime|pgp|snmp|pw)$");
   gvm_validator_add (validator, "credential_login", "^[-_[:alnum:]\\.@\\\\]{0,40}$");
   gvm_validator_add (validator, "condition_data:name", "^(.*){0,400}$");
   gvm_validator_add (validator, "condition_data:value", "(?s)^.*$");

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -7393,7 +7393,8 @@ append_alert_method_data (GString *xml, params_t *data, const char *method,
       {
         if (strcmp (name, "defense_center_ip") == 0
             || strcmp (name, "defense_center_port") == 0
-            || strcmp (name, "pkcs12_credential") == 0)
+            || (strcmp (name, "pkcs12_credential") == 0
+                && !str_equal (param->value, "0")))
           xml_string_append (xml,
                              "<data><name>%s</name>%s</data>",
                              name,


### PR DESCRIPTION
Added support for the PKCS12 password used by sourcefire. This includes adding a new credential type (pw) to gsa and gsad.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ N/A ] Tests
- [ X ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
