### PR TITLE
Do not send pkcs_credential if it is empty

### DIFF
--- a/src/gsad_omp.c
+++ b/src/gsad_omp.c
@@ -8266,7 +8266,8 @@ append_alert_method_data (GString *xml, params_t *data, const char *method,
       {
         if (strcmp (name, "defense_center_ip") == 0
             || strcmp (name, "defense_center_port") == 0
-            || strcmp (name, "pkcs12_credential") == 0)
+            || (strcmp (name, "pkcs12_credential") == 0
+                && strcmp (param->value, "")))
           xml_string_append (xml,
                              "<data><name>%s</name>%s</data>",
                              name,


### PR DESCRIPTION
Sending an empty string would make manager reject the alert because
it cannot find the credential.

**Checklist**:
- Tests N/A
- [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry N/A
