### PR TITLE
Fix showing counts in report detailscontent tab titles

### DIFF
--- a/gsa/src/web/pages/reports/detailscontent.js
+++ b/gsa/src/web/pages/reports/detailscontent.js
@@ -100,7 +100,7 @@ const TabTitle = ({title, counts}) => (
   <Layout flex="column" align={['center', 'center']}>
     <span>{title}</span>
     <TabTitleCounts>
-      (<i>{_('{{filtered}} of {{full}}', counts)}</i>)
+      (<i>{_('{{filtered}} of {{all}}', counts)}</i>)
     </TabTitleCounts>
   </Layout>
 );
@@ -322,7 +322,7 @@ const PageContent = ({
   );
 
   const {full, filtered} = result_count;
-  const resultCounts = {filtered, full};
+  const resultCounts = {filtered, all: full};
 
   return (
     <Layout


### PR DESCRIPTION
The last change to the counts was erroneous. The counts that were displayed were taken from some cache. When the cache is now empty the TabTitle showed only "x of " as count. This PR fixes this issue by basically reverting part of the change connected with showing the loading indicator for reports.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ N/A ] Tests
- [ N/A ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
