### PR TITLE
Report details update indicators

### DIFF
--- a/gsa/src/web/entities/container.js
+++ b/gsa/src/web/entities/container.js
@@ -624,7 +624,6 @@ class EntitiesContainer extends React.Component {
           selectionType: selectionType,
           sortBy,
           sortDir,
-          updating: isUpdating, // TODO remove after list pages are converted to use isUpdating
           onChanged: this.handleChanged,
           onDeleteBulk: this.handleDeleteBulk,
           onDownloadBulk: this.handleDownloadBulk,

--- a/gsa/src/web/entities/table.js
+++ b/gsa/src/web/entities/table.js
@@ -53,7 +53,7 @@ const exclude_props = [
 ];
 
 const UpdatingStripedTable = styled(StripedTable)`
-  opacity: ${props => props.updating ? '0.2' : '1.0'};
+  opacity: ${props => props.isUpdating ? '0.2' : '1.0'};
 `;
 
 const DetailsIcon = styled(FoldIcon)`
@@ -140,7 +140,7 @@ class EntitiesTable extends React.Component {
       filter,
       footnote = true,
       toggleDetailsIcon = true,
-      updating,
+      isUpdating = false,
       sortBy: currentSortBy,
       sortDir: currentSortDir,
       links,
@@ -258,7 +258,7 @@ class EntitiesTable extends React.Component {
         <UpdatingStripedTable
           header={header}
           footer={footer}
-          updating={updating}
+          isUpdating={isUpdating}
         >
           {body}
         </UpdatingStripedTable>
@@ -286,6 +286,7 @@ EntitiesTable.propTypes = {
   footer: PropTypes.componentOrFalse,
   footnote: PropTypes.bool,
   header: PropTypes.componentOrFalse,
+  isUpdating: PropTypes.bool,
   links: PropTypes.bool,
   pagination: PropTypes.componentOrFalse,
   row: PropTypes.component.isRequired,
@@ -293,7 +294,6 @@ EntitiesTable.propTypes = {
   sortBy: PropTypes.string,
   sortDir: PropTypes.string,
   toggleDetailsIcon: PropTypes.bool,
-  updating: PropTypes.bool,
   onFirstClick: PropTypes.func,
   onLastClick: PropTypes.func,
   onNextClick: PropTypes.func,

--- a/gsa/src/web/pages/reports/detailscontent.js
+++ b/gsa/src/web/pages/reports/detailscontent.js
@@ -228,6 +228,7 @@ const PageContent = ({
   filter,
   filters,
   isLoading = true,
+  isUpdating = false,
   sorting,
   showError,
   showErrorMessage,
@@ -470,6 +471,7 @@ const PageContent = ({
                       delta={delta}
                       filter={filter}
                       hasTarget={!isContainer}
+                      isUpdating={isUpdating}
                       progress={task.progress}
                       results={isDefined(results) ? results.entities : {}}
                       sortField={sorting.results.sortField}
@@ -510,6 +512,7 @@ const PageContent = ({
                           entities={entities}
                           entitiesCounts={entitiesCounts}
                           filter={filter}
+                          isUpdating={isUpdating}
                           sortBy={sortBy}
                           sortDir={sortDir}
                           toggleDetailsIcon={false}
@@ -547,6 +550,7 @@ const PageContent = ({
                           entities={entities}
                           entitiesCounts={entitiesCounts}
                           filter={filter}
+                          isUpdating={isUpdating}
                           sortBy={sortBy}
                           sortDir={sortDir}
                           toggleDetailsIcon={false}
@@ -584,6 +588,7 @@ const PageContent = ({
                           entities={entities}
                           entitiesCounts={entitiesCounts}
                           filter={filter}
+                          isUpdating={isUpdating}
                           sortBy={sortBy}
                           sortDir={sortDir}
                           toggleDetailsIcon={false}
@@ -621,6 +626,7 @@ const PageContent = ({
                           entities={entities}
                           entitiesCounts={entitiesCounts}
                           filter={filter}
+                          isUpdating={isUpdating}
                           sortBy={sortBy}
                           sortDir={sortDir}
                           toggleDetailsIcon={false}
@@ -658,6 +664,7 @@ const PageContent = ({
                           entities={entities}
                           entitiesCounts={entitiesCounts}
                           filter={filter}
+                          isUpdating={isUpdating}
                           sortBy={sortBy}
                           sortDir={sortDir}
                           toggleDetailsIcon={false}
@@ -695,6 +702,7 @@ const PageContent = ({
                           entities={entities}
                           entitiesCounts={entitiesCounts}
                           filter={filter}
+                          isUpdating={isUpdating}
                           sortBy={sortBy}
                           sortDir={sortDir}
                           toggleDetailsIcon={false}
@@ -732,6 +740,7 @@ const PageContent = ({
                           entities={entities}
                           entitiesCounts={entitiesCounts}
                           filter={filter}
+                          isUpdating={isUpdating}
                           sortBy={sortBy}
                           sortDir={sortDir}
                           toggleDetailsIcon={false}
@@ -771,6 +780,7 @@ const PageContent = ({
                           entities={entities}
                           entitiesCounts={entitiesCounts}
                           filter={filter}
+                          isUpdating={isUpdating}
                           sortBy={sortBy}
                           sortDir={sortDir}
                           toggleDetailsIcon={false}
@@ -809,11 +819,11 @@ PageContent.propTypes = {
   filter: PropTypes.filter,
   filters: PropTypes.array,
   isLoading: PropTypes.bool,
+  isUpdating: PropTypes.bool,
   showError: PropTypes.func.isRequired,
   showErrorMessage: PropTypes.func.isRequired,
   showSuccessMessage: PropTypes.func.isRequired,
   sorting: PropTypes.object,
-  updating: PropTypes.bool,
   onActivateTab: PropTypes.func.isRequired,
   onAddToAssetsClick: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/reports/detailspage.js
+++ b/gsa/src/web/pages/reports/detailspage.js
@@ -236,10 +236,18 @@ class ReportDetails extends React.Component {
 
     this.startDurationMeasurement();
 
-    this.setState({reportId, deltaReportId});
+    this.setState(({lastFilter}) => ({
+      reportId,
+      deltaReportId,
+      isUpdating: isDefined(lastFilter) && !lastFilter.equals(filter), // show update indicator if filter has changed
+      lastFilter: filter,
+    }));
 
     this.props.loadReport(reportId, deltaReportId, filter)
-      .then(() => this.startTimer());
+      .then(() => {
+        this.startTimer();
+        this.setState({isUpdating: false});
+      });
   }
 
   reload() {
@@ -526,6 +534,7 @@ class ReportDetails extends React.Component {
     } = this.props;
     const {
       activeTab,
+      isUpdating = false,
       showFilterDialog,
       showDownloadReportDialog,
       sorting,
@@ -546,6 +555,7 @@ class ReportDetails extends React.Component {
               filter={filter}
               filters={filters}
               isLoading={isLoading}
+              isUpdating={isUpdating}
               sorting={sorting}
               onActivateTab={this.handleActivateTab}
               onAddToAssetsClick={this.handleAddToAssets}

--- a/gsa/src/web/pages/reports/resultstab.js
+++ b/gsa/src/web/pages/reports/resultstab.js
@@ -34,6 +34,7 @@ const ResultsTab = ({
   delta = false,
   filter,
   hasTarget,
+  isUpdating = false,
   progress,
   results,
   sortField,
@@ -99,6 +100,7 @@ const ResultsTab = ({
           entitiesCounts={entitiesCounts}
           filter={filter}
           footer={false}
+          isUpdating={isUpdating}
           sortBy={sortBy}
           sortDir={sortDir}
           toggleDetailsIcon={false}
@@ -118,6 +120,7 @@ ResultsTab.propTypes = {
   delta: PropTypes.bool,
   filter: PropTypes.filter.isRequired,
   hasTarget: PropTypes.bool,
+  isUpdating: PropTypes.bool,
   progress: PropTypes.number.isRequired,
   results: PropTypes.array.isRequired,
   sortField: PropTypes.string.isRequired,


### PR DESCRIPTION
Show transparent tables at the result details page tabs if a user has causes a new loading procedure by changing the current filter. Currently there is no indicator that we are actually updating the data in the background if the filter has changed and we have a lot of data. In that case the user might think that nothing has changed and updating the filter doesn't work.