### PR TITLE
Consolidate create_report 

### DIFF
--- a/gsa/src/gmp/commands/reports.js
+++ b/gsa/src/gmp/commands/reports.js
@@ -35,7 +35,6 @@ import EntityCommand from './entity';
 const log = logger.getLogger('gmp.commands.reports');
 
 class ReportsCommand extends EntitiesCommand {
-
   constructor(http) {
     super(http, 'report', Report);
   }
@@ -56,26 +55,22 @@ class ReportsCommand extends EntitiesCommand {
     return this.getAggregates({
       aggregate_type: 'report',
       group_column: 'date',
-      dataColumns: [
-        'high',
-        'high_per_host',
-      ],
+      dataColumns: ['high', 'high_per_host'],
       filter,
     });
   }
 }
 
 class ReportCommand extends EntityCommand {
-
   constructor(http) {
     super(http, 'report', Report);
   }
 
   import(args) {
     const {task_id, in_assets = 1, xml_file} = args;
-    log.debug('Importing report', args);
+    log.debug('Creating report', args);
     return this.httpPost({
-      cmd: 'import_report',
+      cmd: 'create_report',
       task_id,
       in_assets,
       xml_file,
@@ -83,13 +78,16 @@ class ReportCommand extends EntityCommand {
   }
 
   download({id}, {reportFormatId, deltaReportId, filter}) {
-    return this.httpGet({
-      cmd: 'get_report',
-      delta_report_id: deltaReportId,
-      report_id: id,
-      report_format_id: reportFormatId,
-      filter: isDefined(filter) ? filter.all() : ALL_FILTER,
-    }, {transform: DefaultTransform, responseType: 'arraybuffer'});
+    return this.httpGet(
+      {
+        cmd: 'get_report',
+        delta_report_id: deltaReportId,
+        report_id: id,
+        report_format_id: reportFormatId,
+        filter: isDefined(filter) ? filter.all() : ALL_FILTER,
+      },
+      {transform: DefaultTransform, responseType: 'arraybuffer'},
+    );
   }
 
   addAssets({id}, {filter = ''}) {
@@ -121,12 +119,15 @@ class ReportCommand extends EntityCommand {
   }
 
   getDelta({id}, {id: delta_report_id}, {filter, ...options} = {}) {
-    return this.httpGet({
-      id,
-      delta_report_id,
-      filter,
-      ignore_pagination: 1,
-    }, {...options, transform: FastXmlTransform}).then(this.transformResponse);
+    return this.httpGet(
+      {
+        id,
+        delta_report_id,
+        filter,
+        ignore_pagination: 1,
+      },
+      {...options, transform: FastXmlTransform},
+    ).then(this.transformResponse);
   }
 
   get({id}, {filter, ...options} = {}) {

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009-2018 Greenbone Networks GmbH
+/* Copyright (C) 2009-2019 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -422,7 +422,6 @@ init_validator ()
                      "|(get_vulns)"
                      "|(import_config)"
                      "|(import_port_list)"
-                     "|(import_report)"
                      "|(import_report_format)"
                      "|(login)"
                      "|(move_task)"
@@ -1508,7 +1507,6 @@ exec_gmp_post (http_connection_t *con,
   ELSE (empty_trashcan)
   ELSE (import_config)
   ELSE (import_port_list)
-  ELSE (import_report)
   ELSE (import_report_format)
   ELSE (move_task)
   ELSE (renew_session)

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -2775,9 +2775,6 @@ create_report_gmp (gvm_connection_t *connection,
   CHECK_VARIABLE_INVALID (task_id, "Create Report");
   CHECK_VARIABLE_INVALID (xml_file, "Create Report");
 
-  if (params_given (params, "in_assets"))
-    CHECK_VARIABLE_INVALID (xml_file, "Create Report");
-
   if (strlen (xml_file) == 0)
     {
       return message_invalid (connection, credentials, params, response_data,

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -2750,20 +2750,7 @@ new_task_gmp (gvm_connection_t *connection, credentials_t * credentials,
 }
 
 /**
- * @brief Returns page to create a new container task.
- *
- * @param[in]  connection     Connection to manager.
- * @param[in]  credentials  Credentials of user issuing the action.
- * @param[in]  params       Request parameters.
- * @param[in]  message      If not NULL, display message.
- * @param[in]  extra_xml    Extra XML to insert inside page element.
- * @param[out] response_data  Extra data return for the HTTP response.
- *
- * @return Enveloped XML object.
- */
-
-/**
- * @brief Create a report, get all tasks, envelope the result.
+ * @brief Create a report, get all reports, envelope the result.
  *
  * @param[in]  connection     Connection to manager.
  * @param[in]  credentials    Username and password for authentication.

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -2780,20 +2780,20 @@ create_report_gmp (gvm_connection_t *connection,
   entity_t entity;
   int ret;
   gchar *command, *html, *response;
-  const char *task_id, *name, *comment, *xml_file;
+  const char *task_id, *xml_file;
   const char *in_assets;
 
   task_id = params_value (params, "task_id");
   xml_file = params_value (params, "xml_file");
-  name = params_value (params, "name");
-  comment = params_value (params, "comment");
   in_assets = params_value (params, "in_assets");
 
   if (task_id == NULL)
     {
-      CHECK_VARIABLE_INVALID (name, "Create Report");
-      CHECK_VARIABLE_INVALID (comment, "Create Report");
+      return message_invalid (connection, credentials, params, response_data,
+                              "Task ID required",
+                              "Create Report");
     }
+
   CHECK_VARIABLE_INVALID (xml_file, "Create Report");
 
   if (params_given (params, "in_assets"))
@@ -2801,20 +2801,9 @@ create_report_gmp (gvm_connection_t *connection,
 
   if (strlen (xml_file) == 0)
     {
-      if (task_id)
-        return message_invalid (connection, credentials, params, response_data,
-                                "Report required",
-                                "Create Report");
-
-      /* Create only the container task. */
-
-      command = g_markup_printf_escaped ("<create_task>"
-                                         "<target id=\"0\"/>"
-                                         "<name>%s</name>"
-                                         "<comment>%s</comment>"
-                                         "</create_task>",
-                                         name,
-                                         comment);
+      return message_invalid (connection, credentials, params, response_data,
+                              "Report required",
+                              "Create Report");
     }
   else
     {
@@ -2827,37 +2816,14 @@ create_report_gmp (gvm_connection_t *connection,
         xml_file_escaped = g_strdup (xml_file);
       g_strfreev (xml_file_array);
 
-      if (task_id)
-        command = g_strdup_printf ("<create_report>"
-                                   "<in_assets>%s</in_assets>"
-                                   "<task id=\"%s\"/>"
-                                   "%s"
-                                   "</create_report>",
-                                   in_assets ? in_assets : "0",
-                                   task_id ? task_id : "0",
-                                   xml_file_escaped ? xml_file_escaped : "");
-      else
-        {
-          gchar *name_escaped, *comment_escaped;
-          name_escaped = name ? g_markup_escape_text (name, -1)
-                              : NULL;
-          comment_escaped = comment ? g_markup_escape_text (comment, -1)
-                                    : NULL;
-          command = g_strdup_printf ("<create_report>"
-                                     "<in_assets>%s</in_assets>"
-                                     "<task>"
-                                     "<name>%s</name>"
-                                     "<comment>%s</comment>"
-                                     "</task>"
-                                     "%s"
-                                     "</create_report>",
-                                     in_assets ? in_assets : "",
-                                     name_escaped,
-                                     comment_escaped,
-                                     xml_file_escaped);
-          g_free (name_escaped);
-          g_free (comment_escaped);
-        }
+      command = g_strdup_printf ("<create_report>"
+                                 "<in_assets>%s</in_assets>"
+                                 "<task id=\"%s\"/>"
+                                 "%s"
+                                 "</create_report>",
+                                 in_assets ? in_assets : "0",
+                                 task_id,
+                                 xml_file_escaped ? xml_file_escaped : "");
       g_free (xml_file_escaped);
     }
 

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -2865,23 +2865,6 @@ create_report_gmp (gvm_connection_t *connection,
   return html;
 }
 
-/**
- * @brief Import report, get all reports, envelope the result.
- *
- * @param[in]  connection     Connection to manager.
- * @param[in]  credentials    Username and password for authentication.
- * @param[in]  params         Request parameters.
- * @param[out] response_data  Extra data return for the HTTP response.
- *
- * @return Enveloped XML object.
- */
-char *
-import_report_gmp (gvm_connection_t *connection,
-                   credentials_t * credentials, params_t *params,
-                   cmd_response_data_t* response_data)
-{
-  return create_report_gmp (connection, credentials, params, response_data);
-}
 
 /**
  * @brief Create a container task, serve next page.

--- a/gsad/src/gsad_gmp.h
+++ b/gsad/src/gsad_gmp.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009-2018 Greenbone Networks GmbH
+/* Copyright (C) 2009-2019 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -43,8 +43,6 @@ char * clone_gmp (gvm_connection_t *, credentials_t *, params_t *,
                   cmd_response_data_t*);
 
 char * create_report_gmp (gvm_connection_t *, credentials_t *,
-                          params_t *, cmd_response_data_t*);
-char * import_report_gmp (gvm_connection_t *, credentials_t *,
                           params_t *, cmd_response_data_t*);
 char * create_container_task_gmp (gvm_connection_t *,
                                   credentials_t *, params_t *,


### PR DESCRIPTION
Resolve the gsad command "import_report" and use the actual
GMP command create_report instead.

Drop the (already unused) option to create a task while creating a
report. This makes it mandatory to to apply a task_id for create_report.

Cleanup and simplify the code for create_report_gmp.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
