### PR TITLE
Prevent linebreak in QoD values at listpage table rows

### DIFF
--- a/gsa/CMakeLists.txt
+++ b/gsa/CMakeLists.txt
@@ -523,6 +523,7 @@ set (GSA_JS_SRC_FILES
      ${GSA_SRC_DIR}/src/web/components/provider/gmpprovider.js
      ${GSA_SRC_DIR}/src/web/components/provider/iconsizeprovider.js
      ${GSA_SRC_DIR}/src/web/components/provider/subscriptionprovider.js
+     ${GSA_SRC_DIR}/src/web/components/qod/qod.js
      ${GSA_SRC_DIR}/src/web/components/section/header.js
      ${GSA_SRC_DIR}/src/web/components/section/section.js
      ${GSA_SRC_DIR}/src/web/components/sortby/sortby.js

--- a/gsa/src/web/components/qod/__tests__/__snapshots__/qod.js.snap
+++ b/gsa/src/web/components/qod/__tests__/__snapshots__/qod.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Qod tests should render Qod value 1`] = `
+.c0 {
+  white-space: nowrap;
+}
+
+<span
+  class="c0"
+>
+  42
+   %
+</span>
+`;
+
+exports[`Qod tests should render Qod value 2`] = `
+.c0 {
+  white-space: nowrap;
+}
+
+<span
+  class="c0"
+>
+  42
+   %
+</span>
+`;

--- a/gsa/src/web/components/qod/__tests__/qod.js
+++ b/gsa/src/web/components/qod/__tests__/qod.js
@@ -1,0 +1,43 @@
+/* Copyright (C) 2019 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import React from 'react';
+
+import Qod from 'web/components/qod/qod';
+
+import {render} from 'web/utils/testing';
+
+describe('Qod tests', () => {
+
+  test('should render Qod value', () => {
+    const {element} = render(<Qod value="42"/>);
+    const {element: element2} = render(<Qod value={42}/>);
+
+    expect(element).toMatchSnapshot();
+    expect(element2).toMatchSnapshot();
+  });
+
+  test('should prevent linebreaks', () => {
+    const {element} = render(<Qod value="42"/>);
+
+    expect(element).toHaveStyleRule('white-space', 'nowrap');
+  });
+});
+
+// vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/components/qod/qod.js
+++ b/gsa/src/web/components/qod/qod.js
@@ -1,0 +1,42 @@
+/* Copyright (C) 2019 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import React from 'react';
+
+import styled from 'styled-components';
+
+import PropTypes from 'web/utils/proptypes';
+
+const Span = styled.span`
+  white-space: nowrap;
+`;
+
+const Qod = ({value}) => (
+  <Span>
+    {value} %
+  </Span>
+);
+
+Qod.propTypes = {
+  value: PropTypes.numberOrNumberString.isRequired,
+};
+
+export default Qod;
+
+// vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/nvts/row.js
+++ b/gsa/src/web/pages/nvts/row.js
@@ -33,6 +33,8 @@ import Link from 'web/components/link/link';
 import TableRow from 'web/components/table/row';
 import TableData from 'web/components/table/data';
 
+import Qod from 'web/components/qod/qod';
+
 import EntitiesActions from 'web/entities/actions';
 import {RowDetailsToggle} from 'web/entities/row';
 
@@ -89,7 +91,9 @@ const Row = ({
       <SeverityBar severity={entity.severity}/>
     </TableData>
     <TableData align="end">
-      {entity.qod && entity.qod.value} %
+      {entity.qod &&
+        <Qod value={entity.qod.value}/>
+      }
     </TableData>
     <ActionsComponent
       {...props}

--- a/gsa/src/web/pages/results/row.js
+++ b/gsa/src/web/pages/results/row.js
@@ -42,6 +42,8 @@ import DetailsLink from 'web/components/link/detailslink';
 import TableRow from 'web/components/table/row';
 import TableData from 'web/components/table/data';
 
+import Qod from 'web/components/qod/qod';
+
 import {RowDetailsToggle} from 'web/entities/row';
 import EntitiesActions from 'web/entities/actions';
 
@@ -114,7 +116,7 @@ const Row = ({
         <SeverityBar severity={entity.severity}/>
       </TableData>
       <TableData align="end">
-        {entity.qod.value} %
+        <Qod value={entity.qod.value}/>
       </TableData>
       <TableData>
         <DetailsLink

--- a/gsa/src/web/pages/vulns/row.js
+++ b/gsa/src/web/pages/vulns/row.js
@@ -29,6 +29,8 @@ import SeverityBar from 'web/components/bar/severitybar';
 import TableRow from 'web/components/table/row';
 import TableData from 'web/components/table/data';
 
+import Qod from 'web/components/qod/qod';
+
 import EntitiesActions from 'web/entities/actions';
 
 import PropTypes from 'web/utils/proptypes';
@@ -61,7 +63,7 @@ const Row = ({
         <SeverityBar severity={entity.severity}/>
       </TableData>
       <TableData align="center">
-        {entity.qod} %
+        <Qod value={entity.qod}/>
       </TableData>
       <TableData>
         <Link


### PR DESCRIPTION
A new Qod component is added that takes care of formatting (no linebreak) and adding a '%' to the value supplied.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ X ] Tests
- [ N/A ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
