### PR TITLE
Adjust for changes in NVT preferences format.

### DIFF
--- a/gsa/src/gmp/commands/scanconfigs.js
+++ b/gsa/src/gmp/commands/scanconfigs.js
@@ -61,7 +61,7 @@ const convert_preferences = (values, nvt_name) => {
     const data = values[prop];
     const {type, value} = data;
     if (isDefined(value)) {
-      const typestring = nvt_name + '[' + type + ']:' + prop;
+      const typestring = nvt_name + ':' + type + ':' + prop;
       if (type === 'password') {
         ret['password:' + typestring] = 'yes';
       } else if (type === 'file') {
@@ -102,7 +102,7 @@ class ScanConfigCommand extends EntityCommand {
   save({id, name, comment = '', trend, select, scanner_preference_values}) {
     const data = {
       ...convert(trend, 'trend:'),
-      ...convert(scanner_preference_values, 'preference:scanner[scanner]:'),
+      ...convert(scanner_preference_values, 'preference:scanner:scanner:'),
       ...convert_select(select, 'select:'),
 
       cmd: 'save_config',
@@ -210,7 +210,7 @@ class ScanConfigCommand extends EntityCommand {
       timeout,
     };
 
-    data['preference:scanner[scanner]:timeout.' + oid] = manual_timeout;
+    data['preference:scanner:scanner:timeout.' + oid] = manual_timeout;
 
     log.debug('Saving scanconfignvt', data);
     return this.httpPost(data);

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -642,7 +642,7 @@ init_validator ()
   /** @todo Better regex. */
   gvm_validator_add (validator, "preference_name", "^(.*){0,400}$");
   gvm_validator_add (validator, "preference:name",
-                     "^([^[]*\\[[^]]*\\]:.*){0,400}$");
+                     "^([^:]*:[^:]*:.*){0,400}$");
   gvm_validator_add (validator, "preference:value", "(?s)^.*$");
   gvm_validator_add (validator, "prev_action", "(?s)^.*$");
   gvm_validator_add (validator, "privacy_algorithm", "^(aes|des|)$");

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -9974,8 +9974,8 @@ save_config_nvt_gmp (gvm_connection_t *connection, credentials_t *credentials,
            * must be reset.  This works around the need for the Manager to
            * send the actual password or show the actual file. */
 
-          /* LDAPsearch[entry]:Timeout value */
-          count = sscanf (preference_name, "%*[^[][%n%*[^]]%n]:", &type_start,
+          /* OID:PrefType:PrefName value */
+          count = sscanf (preference_name, "%*[^:]:%n%*[^:]%n:", &type_start,
                           &type_end);
           if (count == 0 && type_start > 0 && type_end > 0)
             {
@@ -13749,9 +13749,9 @@ save_report_format_gmp (gvm_connection_t *connection,
       while (params_iterator_next (&iter, &param_name, &param))
         {
           int type_start, type_end, count;
-          /* LDAPsearch[entry]:Timeout value */
+          /* OID:PrefType:PrefName value */
           count =
-            sscanf (param_name, "%*[^[][%n%*[^]]%n]:", &type_start, &type_end);
+            sscanf (param_name, "%*[^:]:%n%*[^:]%n:", &type_start, &type_end);
           if (count == 0 && type_start > 0 && type_end > 0)
             {
               gchar *value;


### PR DESCRIPTION
Now NVT preferences are stored in OID:PrefType:PrefName format.

Depends on PRs in scanner https://github.com/greenbone/openvas-scanner/pull/275 and gvmd https://github.com/greenbone/gvmd/pull/394

**Checklist**:

- [ ] Tests N/A
- [ ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry N/A
