### PR TITLE
Unescape names

### DIFF
--- a/gsa/src/gmp/__tests__/parser.js
+++ b/gsa/src/gmp/__tests__/parser.js
@@ -29,6 +29,7 @@ import {
   parseEnvelopeMeta,
   parseFloat,
   parseInt,
+  parseName,
   parseProgressElement,
   parseProperties,
   parseQod,
@@ -569,6 +570,17 @@ describe('parseCvssBaseVector tests', () => {
     expect(parseCvssBaseVector({availabilityImpact: 'COMPLETE'})).toEqual(
       'AV:ERROR/AC:ERROR/Au:ERROR/C:ERROR/I:ERROR/A:C',
     );
+  });
+});
+
+describe('parseName tests', () => {
+  test('should unescape xml entities', () => {
+    expect(parseName('unesc &lt;')).toEqual('unesc <');
+    expect(parseName('unesc &gt;')).toEqual('unesc >');
+    expect(parseName('unesc &amp;')).toEqual('unesc &');
+    expect(parseName('unesc &apos;')).toEqual(`unesc '`);
+    expect(parseName('unesc &quot;')).toEqual('unesc "');
+    expect(parseName(`unesc <>&'" &quot;`)).toEqual(`unesc <>&'" "`);
   });
 });
 

--- a/gsa/src/gmp/__tests__/parser.js
+++ b/gsa/src/gmp/__tests__/parser.js
@@ -22,23 +22,23 @@ import {isDate, isDuration} from 'gmp/models/date';
 
 import {
   parseCsv,
+  parseCvssBaseVector,
+  parseCvssBaseFromVector,
+  parseDate,
+  parseDuration,
   parseEnvelopeMeta,
   parseFloat,
   parseInt,
   parseProgressElement,
+  parseProperties,
   parseQod,
-  parseTextElement,
   parseSeverity,
+  parseText,
+  parseTextElement,
   parseYesNo,
   YES_VALUE,
   NO_VALUE,
-  parseDate,
-  parseDuration,
   setProperties,
-  parseProperties,
-  parseCvssBaseVector,
-  parseCvssBaseFromVector,
-  parseText,
 } from '../parser';
 
 describe('parseInt tests', () => {

--- a/gsa/src/gmp/models/report/parser.js
+++ b/gsa/src/gmp/models/report/parser.js
@@ -25,7 +25,7 @@ import {isDefined} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
 import {filter as filter_func, forEach, map} from 'gmp/utils/array';
 
-import {parseSeverity, parseDate} from 'gmp/parser';
+import {parseName, parseSeverity, parseDate} from 'gmp/parser';
 
 import {
   parseCollectionList,
@@ -556,7 +556,7 @@ export const parse_errors = (report, filter) => {
       },
       nvt: {
         id: nvt._oid,
-        name: nvt.name,
+        name: parseName(nvt.name),
       },
       port,
     };

--- a/gsa/src/gmp/models/report/parser.js
+++ b/gsa/src/gmp/models/report/parser.js
@@ -41,7 +41,7 @@ import Host from './host';
 import OperatingSystem from './os';
 import Port from './port';
 import TLSCertificate from './tlscertificate';
-import Vulerability from './vulnerability';
+import Vulnerability from './vulnerability';
 
 import Result from '../result';
 
@@ -237,7 +237,7 @@ export const parse_vulnerabilities = (report, filter) => {
       if (isDefined(vuln)) {
         vuln.addResult(results);
       } else {
-        vuln = new Vulerability(result);
+        vuln = new Vulnerability(result);
         temp_vulns[oid] = vuln;
       }
 

--- a/gsa/src/gmp/models/report/vulnerability.js
+++ b/gsa/src/gmp/models/report/vulnerability.js
@@ -23,7 +23,7 @@ import {parseQod} from 'gmp/parser';
 
 import Vulnerability from 'gmp/models/vulnerability';
 
-class RfpVulnerabilty extends Vulnerability {
+class RfpVulnerability extends Vulnerability {
   addHost(host) {
     if (!(host.ip in this.hosts.hosts_by_ip)) {
       this.hosts.hosts_by_ip[host.ip] = host;
@@ -67,6 +67,6 @@ class RfpVulnerabilty extends Vulnerability {
   }
 }
 
-export default RfpVulnerabilty;
+export default RfpVulnerability;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/gmp/parser.js
+++ b/gsa/src/gmp/parser.js
@@ -123,12 +123,32 @@ export const parseEnvelopeMeta = envelope => {
   return meta;
 };
 
+const esc2xml = {
+  '&quot;': `"`,
+  '&apos;': `'`,
+  '&amp;': `&`,
+  '&lt;': `<`,
+  '&gt;': `>`,
+};
+
+const decodeXml = string =>
+  string.replace(
+    /(&quot;|&lt;|&gt;|&amp;|&apos;)/g,
+    (str, symbol) => esc2xml[symbol],
+  );
+
+export const parseName = name => decodeXml(name);
+
 export const parseProperties = (element = {}, object = {}) => {
   const copy = {...object, ...element}; // create shallow copy
 
   if (isString(element._id) && element._id.length > 0) {
     // only set id if it id defined
     copy.id = element._id;
+  }
+
+  if (isString(element.name) && element.name.length > 0) {
+    copy.name = parseName(element.name);
   }
 
   if (isDefined(element.creation_time)) {


### PR DESCRIPTION
Entity names will now manually be unescaped as well as NVT names from within reports. The latter are parsed separately.

Changes for the other missing entities and corresponding tests will follow for master.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests (see text above)
- [ N/A ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
