### PR TITLE
Fix parsing vulnerability descriptions in reports

### DIFF
--- a/gsa/src/gmp/__tests__/parser.js
+++ b/gsa/src/gmp/__tests__/parser.js
@@ -29,11 +29,11 @@ import {
   parseEnvelopeMeta,
   parseFloat,
   parseInt,
-  parseName,
   parseProgressElement,
   parseProperties,
   parseQod,
   parseSeverity,
+  parseXmlEncodedString,
   parseText,
   parseTextElement,
   parseYesNo,
@@ -573,14 +573,14 @@ describe('parseCvssBaseVector tests', () => {
   });
 });
 
-describe('parseName tests', () => {
+describe('parseXmlEncodedString tests', () => {
   test('should unescape xml entities', () => {
-    expect(parseName('unesc &lt;')).toEqual('unesc <');
-    expect(parseName('unesc &gt;')).toEqual('unesc >');
-    expect(parseName('unesc &amp;')).toEqual('unesc &');
-    expect(parseName('unesc &apos;')).toEqual(`unesc '`);
-    expect(parseName('unesc &quot;')).toEqual('unesc "');
-    expect(parseName(`unesc <>&'" &quot;`)).toEqual(`unesc <>&'" "`);
+    expect(parseXmlEncodedString('unesc &lt;')).toEqual('unesc <');
+    expect(parseXmlEncodedString('unesc &gt;')).toEqual('unesc >');
+    expect(parseXmlEncodedString('unesc &amp;')).toEqual('unesc &');
+    expect(parseXmlEncodedString('unesc &apos;')).toEqual(`unesc '`);
+    expect(parseXmlEncodedString('unesc &quot;')).toEqual('unesc "');
+    expect(parseXmlEncodedString(`unes <>&'" &quot;`)).toEqual(`unes <>&'" "`);
   });
 });
 

--- a/gsa/src/gmp/models/nvt.js
+++ b/gsa/src/gmp/models/nvt.js
@@ -22,7 +22,7 @@ import {isDefined, isString} from '../utils/identity';
 import {isEmpty, split} from '../utils/string';
 import {map} from '../utils/array';
 
-import {parseFloat, parseSeverity} from '../parser';
+import {parseFloat, parseSeverity, parseXmlEncodedString} from '../parser';
 
 import Info from './info';
 
@@ -35,7 +35,7 @@ const parse_tags = tags => {
     const splited = tags.split('|');
     for (const t of splited) {
       const [key, value] = split(t, '=', 1);
-      newtags[key] = value;
+      newtags[key] = parseXmlEncodedString(value);
     }
   }
 

--- a/gsa/src/gmp/models/report/parser.js
+++ b/gsa/src/gmp/models/report/parser.js
@@ -25,7 +25,7 @@ import {isDefined} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
 import {filter as filter_func, forEach, map} from 'gmp/utils/array';
 
-import {parseName, parseSeverity, parseDate} from 'gmp/parser';
+import {parseSeverity, parseDate, parseXmlEncodedString} from 'gmp/parser';
 
 import {
   parseCollectionList,
@@ -556,7 +556,7 @@ export const parse_errors = (report, filter) => {
       },
       nvt: {
         id: nvt._oid,
-        name: parseName(nvt.name),
+        name: parseXmlEncodedString(nvt.name),
       },
       port,
     };

--- a/gsa/src/gmp/parser.js
+++ b/gsa/src/gmp/parser.js
@@ -131,13 +131,11 @@ const esc2xml = {
   '&gt;': `>`,
 };
 
-const decodeXml = string =>
+export const parseXmlEncodedString = string =>
   string.replace(
     /(&quot;|&lt;|&gt;|&amp;|&apos;)/g,
     (str, symbol) => esc2xml[symbol],
   );
-
-export const parseName = name => decodeXml(name);
 
 export const parseProperties = (element = {}, object = {}) => {
   const copy = {...object, ...element}; // create shallow copy
@@ -148,7 +146,7 @@ export const parseProperties = (element = {}, object = {}) => {
   }
 
   if (isString(element.name) && element.name.length > 0) {
-    copy.name = parseName(element.name);
+    copy.name = parseXmlEncodedString(element.name);
   }
 
   if (isDefined(element.creation_time)) {


### PR DESCRIPTION
This fixes unescaping of special characters in vulnerability 
descriptions such as "Insight" taken from the tags-string.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ X ] Tests
- [ N/A ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
