### PR TITLE
Fix typo in OS table header

### DIFF
--- a/gsa/src/web/pages/operatingsystems/table.js
+++ b/gsa/src/web/pages/operatingsystems/table.js
@@ -121,7 +121,7 @@ const Header = ({
           sortBy={sort ? 'average_severity' : false}
           onSortChange={onSortChange}
         >
-          {_('Avarage')}
+          {_('Average')}
         </TableHead>
       </TableRow>
     </TableHeader>


### PR DESCRIPTION
This PR fixes a small typo in the Operating Systems table.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry N/A
