### PR TITLE
Fix getting a tag

### DIFF
--- a/gsa/src/gmp/commands/__tests__/tag.js
+++ b/gsa/src/gmp/commands/__tests__/tag.js
@@ -1,0 +1,163 @@
+/* Copyright (C) 2019 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import {TagCommand} from '../tags';
+
+import {
+  createActionResultResponse,
+  createEntityResponse,
+  createHttp,
+} from '../testing';
+
+describe('TagCommand tests', () => {
+  test('should create new tag with resources', () => {
+    const response = createActionResultResponse();
+    const fakeHttp = createHttp(response);
+
+    expect.hasAssertions();
+
+    const cmd = new TagCommand(fakeHttp);
+    return cmd
+      .create({
+        name: 'name',
+        comment: 'comment',
+        active: '1',
+        resource_ids: ['id1', 'id2'],
+        resource_type: 'type',
+        resources_action: 'action',
+      })
+      .then(resp => {
+        expect(fakeHttp.request).toHaveBeenCalledWith('post', {
+          data: {
+            cmd: 'create_tag',
+            tag_name: 'name',
+            comment: 'comment',
+            active: '1',
+            'resource_ids:': ['id1', 'id2'],
+            resource_type: 'type',
+            resources_action: 'action',
+            tag_value: '',
+          },
+        });
+
+        const {data} = resp;
+        expect(data.id).toEqual('foo');
+      });
+  });
+
+  test('should return single tag', () => {
+    const response = createEntityResponse('tag', {_id: 'foo'});
+    const fakeHttp = createHttp(response);
+
+    expect.hasAssertions();
+
+    const cmd = new TagCommand(fakeHttp);
+    return cmd.get({id: 'foo'}).then(resp => {
+      expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+        args: {
+          cmd: 'get_tag',
+          tag_id: 'foo',
+        },
+      });
+
+      const {data} = resp;
+      expect(data.id).toEqual('foo');
+    });
+  });
+
+  test('should save a tag', () => {
+    const response = createActionResultResponse();
+    const fakeHttp = createHttp(response);
+
+    expect.hasAssertions();
+
+    const cmd = new TagCommand(fakeHttp);
+    return cmd
+      .save({
+        id: 'foo',
+        name: 'bar',
+        comment: 'ipsum',
+        active: '1',
+        filter: 'fil',
+        resource_ids: ['id1'],
+        resource_type: 'type',
+        resources_action: 'action',
+        value: 'lorem',
+      })
+      .then(() => {
+        expect(fakeHttp.request).toHaveBeenCalledWith('post', {
+          data: {
+            cmd: 'save_tag',
+            tag_id: 'foo',
+            tag_name: 'bar',
+            comment: 'ipsum',
+            active: '1',
+            filter: 'fil',
+            'resource_ids:': ['id1'],
+            resource_type: 'type',
+            resources_action: 'action',
+            tag_value: 'lorem',
+          },
+        });
+      });
+  });
+
+  test('should enable a tag', () => {
+    const response = createActionResultResponse();
+    const fakeHttp = createHttp(response);
+
+    expect.hasAssertions();
+
+    const cmd = new TagCommand(fakeHttp);
+    return cmd
+      .enable({
+        id: 'foo',
+      })
+      .then(() => {
+        expect(fakeHttp.request).toHaveBeenCalledWith('post', {
+          data: {
+            cmd: 'toggle_tag',
+            tag_id: 'foo',
+            enable: '1',
+          },
+        });
+      });
+  });
+
+  test('should disable a tag', () => {
+    const response = createActionResultResponse();
+    const fakeHttp = createHttp(response);
+
+    expect.hasAssertions();
+
+    const cmd = new TagCommand(fakeHttp);
+    return cmd
+      .disable({
+        id: 'foo',
+      })
+      .then(() => {
+        expect(fakeHttp.request).toHaveBeenCalledWith('post', {
+          data: {
+            cmd: 'toggle_tag',
+            tag_id: 'foo',
+            enable: '0',
+          },
+        });
+      });
+  });
+});

--- a/gsa/src/gmp/commands/tags.js
+++ b/gsa/src/gmp/commands/tags.js
@@ -29,7 +29,7 @@ import EntityCommand from './entity';
 
 const log = logger.getLogger('gmp.commands.tags');
 
-class TagCommand extends EntityCommand {
+export class TagCommand extends EntityCommand {
   constructor(http) {
     super(http, 'tag', Tag);
   }
@@ -111,7 +111,7 @@ class TagCommand extends EntityCommand {
   }
 }
 
-class TagsCommand extends EntitiesCommand {
+export class TagsCommand extends EntitiesCommand {
   constructor(http) {
     super(http, 'tag', Tag);
   }

--- a/gsa/src/gmp/commands/tags.js
+++ b/gsa/src/gmp/commands/tags.js
@@ -35,8 +35,7 @@ class TagCommand extends EntityCommand {
   }
 
   getElementFromRoot(root) {
-    // response does contain two get_tags_response elements
-    return root.get_tag.get_tags_response[0].tag;
+    return root.get_tag.get_tags_response.tag;
   }
 
   create({


### PR DESCRIPTION
TagCommand.getElementFromRoot() accessed an array of two 
get_tags_response elements. As we currently only have one 
of those elements there was no array to access, therefore yielding 
an 'undefined' when calling get_tags_response[0].tag

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ X ] Tests
- [ N/A ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
