### PR TITLE
Display PGP Encryption Key for crendential type pgp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ $ cd gsa && git log
    performance page.
  * Add link referencing the performance during scan time to the report details
    page.
+ * Renamed "PGP Key" credential to "PGP Encryption Key" #1208
 
 
 ## gsa 8.0+beta2 (2018-12-04)

--- a/gsa/src/gmp/models/__tests__/credential.js
+++ b/gsa/src/gmp/models/__tests__/credential.js
@@ -228,7 +228,9 @@ describe('getCredentialTypeName tests', () => {
     expect(getCredentialTypeName(SMIME_CREDENTIAL_TYPE)).toEqual(
       'S/MIME Certificate',
     );
-    expect(getCredentialTypeName(PGP_CREDENTIAL_TYPE)).toEqual('PGP Key');
+    expect(getCredentialTypeName(PGP_CREDENTIAL_TYPE)).toEqual(
+      'PGP Encryption Key',
+    );
   });
 });
 

--- a/gsa/src/gmp/models/credential.js
+++ b/gsa/src/gmp/models/credential.js
@@ -99,7 +99,7 @@ const TYPE_NAMES = {
   usk: _l('Username + SSH Key'),
   cc: _l('Client Certificate'),
   snmp: _l('SNMP'),
-  pgp: _l('PGP Key'),
+  pgp: _l('PGP Encryption Key'),
   pw: _l('Password only'),
   smime: _l('S/MIME Certificate'),
 };


### PR DESCRIPTION
We likely get a second pgp credential for signing in future.

**Checklist**:

- [x] Tests
- [x] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
