### PR TITLE
Allow to sort scan config nvts in edit dialog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,8 @@ $ cd gsa && git log
    performance page.
  * Add link referencing the performance during scan time to the report details
    page.
+ * Allow to sort the nvts table at the edit scan config families dialog by
+   name, oid, severity, timeout and selected #1210
 
 
 ## gsa 8.0+beta2 (2018-12-04)


### PR DESCRIPTION
Allow to sort the nvts at the edit scan config families dialog by name,
oid, severity, timeout and selected. Sorting by selected is a bit
"hackish" because the selected information isn't contained in the nvts
array.

**Checklist**:

- [N/A] Tests
- [x] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
