### PR TITLE
 Adjust filter term for task specific Reports view

### DIFF
--- a/gsa/src/web/pages/tasks/row.js
+++ b/gsa/src/web/pages/tasks/row.js
@@ -74,7 +74,7 @@ const render_report_total = (entity, links) => {
     <Layout>
       <Link
         to={'reports'}
-        filter={'task_id=' + entity.id + ' sort-reverse=date&filt_id=-2'}
+        filter={'task_id=' + entity.id + ' sort-reverse=date'}
         title={_(
           'View list of all reports for Task {{name}},' +
             ' including unfinished ones',


### PR DESCRIPTION
When clicking on the number of reports of a task in the task 
view, the reports view is opened with a specific filter. This PR fixes 
the filter so that reports will be sorted by descending date.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ N/A ] Tests
- [ N/A ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
