### PR TITLE
GUI miscellaneous #12

### DIFF
--- a/gsa/src/web/components/errorboundary/errorboundary.js
+++ b/gsa/src/web/components/errorboundary/errorboundary.js
@@ -21,7 +21,7 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import Icon from 'web/components/icon/icon';
+import StNonAvailableIcon from 'web/components/icon/stnonavailableicon';
 import Divider from 'web/components/layout/divider';
 
 import PropTypes from 'web/utils/proptypes';
@@ -52,7 +52,7 @@ class ErrorBoundary extends React.Component {
       return (
         <ErrorContainer>
           <Divider>
-            <Icon img={'st_nonavailable.svg'} size="medium" />
+            <StNonAvailableIcon size="medium" />
             <b>{message}</b>
             <span>{_('Please try again.')}</span>
           </Divider>

--- a/gsa/src/web/entities/__tests__/__snapshots__/tagsdialog.js.snap
+++ b/gsa/src/web/entities/__tests__/__snapshots__/tagsdialog.js.snap
@@ -5,7 +5,22 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   <div
     id="portals"
   >
-    .c4 {
+    .c24 {
+  cursor: pointer;
+}
+
+.c23 {
+  height: 16px;
+  width: 16px;
+  line-height: 16px;
+}
+
+.c23 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -509,21 +524,6 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   cursor: default;
 }
 
-.c24 {
-  cursor: pointer;
-}
-
-.c23 {
-  height: 16px;
-  width: 16px;
-  line-height: 16px;
-}
-
-.c23 * {
-  height: inherit;
-  width: inherit;
-}
-
 @media print {
   .c24 {
     display: none;
@@ -699,6 +699,21 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
 `;
 
 exports[`TagsDialog dialog component tests should render dialog 1`] = `
+.c24 {
+  cursor: pointer;
+}
+
+.c23 {
+  height: 16px;
+  width: 16px;
+  line-height: 16px;
+}
+
+.c23 * {
+  height: inherit;
+  width: inherit;
+}
+
 .c4 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1200,21 +1215,6 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
-}
-
-.c24 {
-  cursor: pointer;
-}
-
-.c23 {
-  height: 16px;
-  width: 16px;
-  line-height: 16px;
-}
-
-.c23 * {
-  height: inherit;
-  width: inherit;
 }
 
 @media print {

--- a/gsa/src/web/pages/ldap/ldappage.js
+++ b/gsa/src/web/pages/ldap/ldappage.js
@@ -157,7 +157,7 @@ class LdapAuthentication extends React.Component {
 
     const {
       authdn,
-      certificateInfo,
+      certificateInfo = {},
       dialogVisible,
       enable,
       ldaphost,


### PR DESCRIPTION
* Don't  crash LDAP page when CertificateInfo is undefined
* Use StNonAvialableIcon in ErrorBoundary
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ N/A ] Tests
- [ N/A ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
