### PR TITLE
Avoid undefined behavior in filters with first and rows keywords

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,8 @@ $ cd gsa && git log
  * Don't create a container task from the task dialog accidentially #1220
  * Use "Do not automatically delete reports" as default again in task dialog
    #1220
+ * Convert first filter keyword values less then one to one #1228
+ * Always use equal relation for first and rows filter keywords #1228
 
 
 ## gsa 8.0+beta2 (2018-12-04)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ $ cd gsa && git log
 
 ## gsa 8.0 unreleased
 
+ * Convert first filter keyword values less then one to one #1228
+ * Always use equal relation for first and rows filter keywords #1228
  * Add confirmation dialog when creating a user without a role #1224
  * Use dialogs to edit LDAP and RADIUS authentification #1212 #1213
  * Renamed "PGP Key" credential to "PGP Encryption Key" #1208
@@ -36,11 +38,9 @@ $ cd gsa && git log
  * Fix race condition resulting in not displaying scan config details at task
    dialog when opening the dialog for the first time #1220
  * Fix saving run schedule once setting from Task dialog #1220
- * Don't create a container task from the task dialog accidentially #1220
+ * Don't create a container task from the task dialog accidentally #1220
  * Use "Do not automatically delete reports" as default again in task dialog
    #1220
- * Convert first filter keyword values less then one to one #1228
- * Always use equal relation for first and rows filter keywords #1228
 
 
 ## gsa 8.0+beta2 (2018-12-04)

--- a/gsa/src/gmp/models/__tests__/filter.js
+++ b/gsa/src/gmp/models/__tests__/filter.js
@@ -71,6 +71,17 @@ describe('Filter parse from string tests', () => {
       expect(Filter.fromString(fstring).toFilterString()).toEqual(fstring);
     });
   });
+
+  test('should convert first if less then 1', () => {
+    let filter = Filter.fromString('first=0');
+    expect(filter.toFilterString()).toEqual('first=1');
+
+    filter = Filter.fromString('first=-1');
+    expect(filter.toFilterString()).toEqual('first=1');
+
+    filter = Filter.fromString('first=-666');
+    expect(filter.toFilterString()).toEqual('first=1');
+  });
 });
 
 describe('Filter parse from keywords', () => {

--- a/gsa/src/gmp/models/__tests__/filter.js
+++ b/gsa/src/gmp/models/__tests__/filter.js
@@ -260,6 +260,15 @@ describe('Filter set', () => {
     expect(filter.has('sort')).toEqual(false);
     expect(filter.has('sort-reverse')).toEqual(true);
   });
+
+  test('should convert 0 or negative values for first to 1', () => {
+    const filter = new Filter();
+    filter.set('first', '0');
+    expect(filter.get('first')).toEqual(1);
+
+    filter.set('first', '-666');
+    expect(filter.get('first')).toEqual(1);
+  });
 });
 
 describe('Filter has', () => {

--- a/gsa/src/gmp/models/__tests__/filter.js
+++ b/gsa/src/gmp/models/__tests__/filter.js
@@ -82,6 +82,28 @@ describe('Filter parse from string tests', () => {
     filter = Filter.fromString('first=-666');
     expect(filter.toFilterString()).toEqual('first=1');
   });
+
+  test('should always use equal relation for first keyword', () => {
+    let filter = Filter.fromString('first>1');
+    expect(filter.toFilterString()).toEqual('first=1');
+
+    filter = Filter.fromString('first<1');
+    expect(filter.toFilterString()).toEqual('first=1');
+
+    filter = Filter.fromString('first>1');
+    expect(filter.toFilterString()).toEqual('first=1');
+  });
+
+  test('should always use equal relation for rows keyword', () => {
+    let filter = Filter.fromString('rows>1');
+    expect(filter.toFilterString()).toEqual('rows=1');
+
+    filter = Filter.fromString('rows<1');
+    expect(filter.toFilterString()).toEqual('rows=1');
+
+    filter = Filter.fromString('rows>1');
+    expect(filter.toFilterString()).toEqual('rows=1');
+  });
 });
 
 describe('Filter parse from keywords', () => {

--- a/gsa/src/gmp/models/filter.js
+++ b/gsa/src/gmp/models/filter.js
@@ -348,13 +348,8 @@ class Filter extends Model {
    * @return {Filter} This filter
    */
   set(keyword, value, relation = '=') {
-    this._setTerm(
-      new FilterTerm({
-        keyword,
-        value,
-        relation,
-      }),
-    );
+    const converted = convert(keyword, value, relation);
+    this._setTerm(new FilterTerm(converted));
     return this;
   }
 

--- a/gsa/src/gmp/models/filter/__tests__/convert.js
+++ b/gsa/src/gmp/models/filter/__tests__/convert.js
@@ -81,6 +81,16 @@ describe('convert tests', () => {
       relation: '=',
       value: 1,
     });
+    expect(convert('first', '1', '>')).toEqual({
+      keyword: 'first',
+      relation: '=',
+      value: 1,
+    });
+    expect(convert('first', '1', 'foo')).toEqual({
+      keyword: 'first',
+      relation: '=',
+      value: 1,
+    });
   });
 
   test('should convert min_qod keyword', () => {
@@ -116,6 +126,21 @@ describe('convert tests', () => {
       keyword: 'rows',
       relation: '=',
       value: 99,
+    });
+    expect(convert('rows', '-1', '=')).toEqual({
+      keyword: 'rows',
+      relation: '=',
+      value: -1,
+    });
+    expect(convert('rows', '1', '>')).toEqual({
+      keyword: 'rows',
+      relation: '=',
+      value: 1,
+    });
+    expect(convert('rows', '1', 'foo')).toEqual({
+      keyword: 'rows',
+      relation: '=',
+      value: 1,
     });
   });
 

--- a/gsa/src/gmp/models/filter/__tests__/convert.js
+++ b/gsa/src/gmp/models/filter/__tests__/convert.js
@@ -64,12 +64,22 @@ describe('convert tests', () => {
     expect(convert('first', '0', '=')).toEqual({
       keyword: 'first',
       relation: '=',
-      value: 0,
+      value: 1,
     });
     expect(convert('first', '666', '=')).toEqual({
       keyword: 'first',
       relation: '=',
       value: 666,
+    });
+    expect(convert('first', '-1', '=')).toEqual({
+      keyword: 'first',
+      relation: '=',
+      value: 1,
+    });
+    expect(convert('first', '-9999999', '=')).toEqual({
+      keyword: 'first',
+      relation: '=',
+      value: 1,
     });
   });
 

--- a/gsa/src/gmp/models/filter/convert.js
+++ b/gsa/src/gmp/models/filter/convert.js
@@ -39,9 +39,12 @@ const convertFirst = (keyword, value, relation) => {
   return {
     keyword,
     value: intValue > 0 ? intValue : 1,
-    relation,
+    relation: '=',
   };
 };
+
+const convertRows = (keyword, value, relation) =>
+  convertInt(keyword, value, '=');
 
 const convertNoRelation = (keyword, value, relation) => ({
   keyword,
@@ -58,7 +61,7 @@ const KEYWORD_CONVERTERS = {
   notes: convertBooleanInt,
   overrides: convertBooleanInt,
   result_hosts_only: convertBooleanInt,
-  rows: convertInt,
+  rows: convertRows,
 };
 
 const VALUE_CONVERTERS = {

--- a/gsa/src/gmp/models/filter/convert.js
+++ b/gsa/src/gmp/models/filter/convert.js
@@ -34,6 +34,15 @@ const convertInt = (keyword, value, relation) => ({
   relation,
 });
 
+const convertFirst = (keyword, value, relation) => {
+  const intValue = parseInt(value);
+  return {
+    keyword,
+    value: intValue > 0 ? intValue : 1,
+    relation,
+  };
+};
+
 const convertNoRelation = (keyword, value, relation) => ({
   keyword,
   value,
@@ -44,7 +53,7 @@ const convertNoRelationAndKeyword = (keyword, value, relation) => ({value});
 const KEYWORD_CONVERTERS = {
   apply_overrides: convertBooleanInt,
   autofp: convertInt,
-  first: convertInt,
+  first: convertFirst,
   min_qod: convertInt,
   notes: convertBooleanInt,
   overrides: convertBooleanInt,


### PR DESCRIPTION
Filter keywords first with a value less then 1 are not allowed. Therefore all values less then 1 are converted to 1 automatically.

Also for rows and first must always use the equal = relation. Other relations like >, < are not defined.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
