### PR TITLE
Consider subtype in bulk delete of assets

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -55,6 +55,7 @@ Main changes compared to 7.0.3:
 * A credential can be selected for the PKCS12 file of Sourcefire Alerts.
 * The OID of the VT sending the SNMP Host Detail for Authentication failure /
   success was updated.
+* The bulk delete not working for assets was fixed.
 
 
 gsa 7.0.3 (2018-03-28)


### PR DESCRIPTION
This fixes bulk deleting assets selected by a filter by giving the
previously missing subtype like "host" to the GMP command used to
get the list of UUIDs to delete.

**Checklist**:

- N/A Tests
- [x] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
