### PR TITLE
Change order of options in TargetDialog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ $ cd gsa && git log
 
 ## gsa 8.0 unreleased
 
+ * Change order of options in target dialog #1233
  * Convert first filter keyword values less then one to one #1228
  * Always use equal relation for first and rows filter keywords #1228
  * Add confirmation dialog when creating a user without a role #1224

--- a/gsa/src/web/pages/targets/dialog.js
+++ b/gsa/src/web/pages/targets/dialog.js
@@ -296,24 +296,6 @@ const TargetDialog = ({
               </Divider>
             </FormGroup>
 
-            <FormGroup title={_('Reverse Lookup Only')}>
-              <YesNoRadio
-                name="reverse_lookup_only"
-                disabled={state.in_use}
-                value={state.reverse_lookup_only}
-                onChange={onValueChange}
-              />
-            </FormGroup>
-
-            <FormGroup title={_('Reverse Lookup Unify')}>
-              <YesNoRadio
-                name="reverse_lookup_unify"
-                disabled={state.in_use}
-                value={state.reverse_lookup_unify}
-                onChange={onValueChange}
-              />
-            </FormGroup>
-
             {capabilities.mayOp('get_port_lists') && (
               <FormGroup title={_('Port List')}>
                 <Divider>
@@ -449,6 +431,24 @@ const TargetDialog = ({
                 </Divider>
               </FormGroup>
             )}
+
+            <FormGroup title={_('Reverse Lookup Only')}>
+              <YesNoRadio
+                name="reverse_lookup_only"
+                disabled={state.in_use}
+                value={state.reverse_lookup_only}
+                onChange={onValueChange}
+              />
+            </FormGroup>
+
+            <FormGroup title={_('Reverse Lookup Unify')}>
+              <YesNoRadio
+                name="reverse_lookup_unify"
+                disabled={state.in_use}
+                value={state.reverse_lookup_unify}
+                onChange={onValueChange}
+              />
+            </FormGroup>
           </Layout>
         );
       }}


### PR DESCRIPTION
This change lets the user see all possible credential dropdowns and 
instead "hides" the Reverse Lookup Only and Reverse Lookup Unify options. 
The only indication that they are there is the scrollbar on the right, 
but I don't regard this as problem as it seems to be consensus that those 
settings are "advanced mode" anyway.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ N/A ] Tests
- [ X ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
