### PR TITLE
Enlarge questionmark in os_unknown.svg icon

### DIFF
--- a/gsa/public/img/os_unknown.svg
+++ b/gsa/public/img/os_unknown.svg
@@ -1,21 +1,98 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="52.509" height="52.52" version="1.0" viewBox="0 0 52.509 52.52" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
- <defs>
-  <linearGradient id="linearGradient13956" x1="46.592" x2="43.592" y1="89.585" y2="-74.733" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#483737" offset="0"/>
-   <stop stop-color="#fff" offset="1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient13966" x1="26.48" x2="26.48" y1="1.3939" y2="52.843" gradientUnits="userSpaceOnUse">
-   <stop stop-color="#fff" offset="0"/>
-   <stop stop-color="#fff" stop-opacity="0" offset="1"/>
-  </linearGradient>
- </defs>
- <g transform="translate(-3.8191 -6.1557)">
-  <g transform="translate(-840.83 182.27)" fill="#71c000" stroke="#71c000" stroke-linejoin="bevel" stroke-width="3.379"></g>
-  <g transform="translate(-1426.6 -26.29)" fill="#71c000" stroke="#71c000" stroke-linejoin="bevel" stroke-width="3.379"></g>
-  <rect x="4.9083" y="7.2196" width="50.731" height="50.549" ry="7.0914" color="black" fill="url(#linearGradient13956)" fill-rule="evenodd" stroke="#2b2b2b" stroke-width=".997"/>
-  <g transform="matrix(-.0039739 .6296 -.6296 -.0039739 295.58 -273.62)" fill="#fff"></g>
-  <path transform="translate(3.8191 6.1557)" d="m2.1818 45.429-0.18182-37.636s1.0909-5.6364 5.4545-5.8182c4.3636-0.18182 37.455 0 37.455 0s5.8182 0 6 7.2727c0.18182 7.2727-0.18182 36.727-0.18182 36.727" color="black" fill="none" stroke="url(#linearGradient13966)"/>
-  <text x="15.530712" y="49.888474" fill="#ffffff" font-family="'Bitstream Vera Serif'" font-weight="bold" style="line-height:0%" xml:space="preserve"><tspan x="15.530712" y="49.888474">?</tspan></text>
- </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   width="52.509"
+   height="52.52"
+   version="1.0"
+   viewBox="0 0 52.509 52.52"
+   id="svg30">
+  <defs
+     id="defs12">
+    <linearGradient
+       id="linearGradient13956"
+       x1="46.592"
+       x2="43.592"
+       y1="89.585"
+       y2="-74.733"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#483737"
+         offset="0"
+         id="stop2" />
+      <stop
+         stop-color="#fff"
+         offset="1"
+         id="stop4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient13966"
+       x1="26.48"
+       x2="26.48"
+       y1="1.3939"
+       y2="52.843"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#fff"
+         offset="0"
+         id="stop7" />
+      <stop
+         stop-color="#fff"
+         stop-opacity="0"
+         offset="1"
+         id="stop9" />
+    </linearGradient>
+  </defs>
+  <g
+     transform="translate(-3.8191 -6.1557)"
+     id="g28">
+    <g
+       transform="translate(-840.83 182.27)"
+       fill="#71c000"
+       stroke="#71c000"
+       stroke-linejoin="bevel"
+       stroke-width="3.379"
+       id="g14" />
+    <g
+       transform="translate(-1426.6 -26.29)"
+       fill="#71c000"
+       stroke="#71c000"
+       stroke-linejoin="bevel"
+       stroke-width="3.379"
+       id="g16" />
+    <rect
+       x="4.9083"
+       y="7.2196"
+       width="50.731"
+       height="50.549"
+       ry="7.0914"
+       color="black"
+       fill="url(#linearGradient13956)"
+       fill-rule="evenodd"
+       stroke="#2b2b2b"
+       stroke-width=".997"
+       id="rect18" />
+    <g
+       transform="matrix(-.0039739 .6296 -.6296 -.0039739 295.58 -273.62)"
+       fill="#fff"
+       id="g20" />
+    <path
+       transform="translate(3.8191 6.1557)"
+       d="m2.1818 45.429-0.18182-37.636s1.0909-5.6364 5.4545-5.8182c4.3636-0.18182 37.455 0 37.455 0s5.8182 0 6 7.2727c0.18182 7.2727-0.18182 36.727-0.18182 36.727"
+       color="black"
+       fill="none"
+       stroke="url(#linearGradient13966)"
+       id="path22" />
+    <text
+       x="17.09339"
+       y="49.846512"
+       font-weight="bold"
+       style="font-weight:bold;font-size:46.12754822px;line-height:0%;font-family:'Bitstream Vera Serif';fill:#ffffff;stroke-width:3.84396219"
+       xml:space="preserve"
+       id="text26"
+       transform="scale(0.9999248,1.0000752)"><tspan
+         x="17.09339"
+         y="49.846512"
+         id="tspan24"
+         style="stroke-width:3.84396219">?</tspan></text>
+  </g>
 </svg>


### PR DESCRIPTION
For unknown reasons the questionmark was reduced in scale and moved to 
the lower left. It's know recognizable and centered again.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ N/A ] Tests
- [ N/A ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
