### PR TITLE
Don't crash performance page if passed dates are invalid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ $ cd gsa && git log
 
 ## gsa 8.0 unreleased
 
+ * Don't crash if start or end date for performance page are invalid #1237
  * Change order of options in target dialog #1233
  * Don't limit the input field lengths anymore #1232
  * Convert first filter keyword values less then one to one #1228

--- a/gsa/src/web/pages/performance/performancepage.js
+++ b/gsa/src/web/pages/performance/performancepage.js
@@ -221,8 +221,16 @@ class PerformancePage extends React.Component {
     this.props.loadScanners();
 
     if (isDefined(start) && isDefined(end)) {
-      const startDate = date(start);
-      const endDate = date(end);
+      let startDate = date(start);
+
+      if (!startDate.isValid()) {
+        startDate = date();
+      }
+
+      let endDate = date(end);
+      if (!endDate.isValid()) {
+        endDate = date();
+      }
 
       this.setState({
         duration: undefined,


### PR DESCRIPTION
Use current time if start or end date is invalid.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
