### PR TITLE
Omp url redirect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ $ cd gsa && git log
 
 ## gsa 8.0 unreleased
 
+ * Support old secinfo URLs and redirect to replacement pages #1247
  * Add guest user login support #1246
  * Allow to set default host and operating system filters #1243
  * Don't crash if start or end date for performance page are invalid #1237

--- a/gsa/src/web/pages/omp.js
+++ b/gsa/src/web/pages/omp.js
@@ -1,0 +1,80 @@
+/* Copyright (C) 2019 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import 'core-js/fn/array/includes';
+
+import React from 'react';
+
+import {withRouter} from 'react-router-dom';
+
+import PropTypes from 'web/utils/proptypes';
+
+/**
+ * Component to redirect old secinfo urls like
+ *
+ * /omp?cmd=get_info&info_type=ovaldef&info_id=oval:org.mitre.oval:def:29419_6
+ *
+ * to the current replacement pages
+ */
+class LegacyOmpPage extends React.Component {
+  componentDidMount() {
+    const {location, history} = this.props;
+    const {cmd, info_type, info_id = ''} = location.query;
+
+    if (cmd !== 'get_info') {
+      history.replace('/notfound');
+      return;
+    }
+
+    const id = encodeURIComponent(info_id);
+
+    switch (info_type) {
+      case 'nvt':
+        history.replace('/nvt/' + id);
+        break;
+      case 'cve':
+        history.replace('/cve/' + id);
+        break;
+      case 'cpe':
+        history.replace('/cpe/' + id);
+        break;
+      case 'ovaldef':
+        history.replace('/ovaldef/' + id);
+        break;
+      case 'cert_bund_adv':
+        history.replace('/certbund/' + id);
+        break;
+      case 'dfn_cert_adv':
+        history.replace('/dfncert/' + id);
+        break;
+      default:
+        history.replace('/notfound');
+        break;
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+LegacyOmpPage.propTypes = {
+  history: PropTypes.object.isRequired,
+};
+
+export default withRouter(LegacyOmpPage);

--- a/gsa/src/web/routes.js
+++ b/gsa/src/web/routes.js
@@ -241,6 +241,7 @@ class Routes extends React.Component {
                     path="/scanconfig/:id"
                     component={ScanConfigDetailsPage}
                   />
+                  <Route path="/notfound" component={PageNotFound} />
                   <Route component={PageNotFound} />
                 </Switch>
               </Page>

--- a/gsa/src/web/routes.js
+++ b/gsa/src/web/routes.js
@@ -27,6 +27,7 @@ import qhistory from 'qhistory';
 import LocationObserver from 'web/components/observer/locationobserver';
 import SessionObserver from 'web/components/observer/sessionobserver';
 
+import LegacyOmpPage from './pages/omp';
 import Page from './pages/page';
 import PageNotFound from './pages/notfoundpage';
 import StartPage from './pages/start/page';
@@ -139,6 +140,7 @@ class Routes extends React.Component {
       <Router history={HISTORY}>
         <Switch>
           <Route path="/login" component={LoginPage} />
+          <Route path="/omp" component={LegacyOmpPage} />
           <Authorized>
             <SessionObserver />
             <LocationObserver>


### PR DESCRIPTION
Redirect from old secinfo urls like

https://secinfo.greenbone.net/omp?cmd=get_info&info_type=nvt&token=...

to the new version of that page.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [x] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
