### PR TITLE
Cleanup get_report function in gsad

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ $ cd gsa && git checkout gsa-8.0 && git log
 
 ## gsa 8.0.1 (unreleased)
 
+ * Cleanup get_report function in gsad #1263
  * Fix testing alerts #1260
  * Fix release build #1259
 

--- a/gsa/src/gmp/commands/reports.js
+++ b/gsa/src/gmp/commands/reports.js
@@ -94,7 +94,6 @@ class ReportCommand extends EntityCommand {
     return this.httpPost({
       cmd: 'create_asset',
       report_id: id,
-      no_redirect: '1',
       filter,
     });
   }
@@ -103,9 +102,7 @@ class ReportCommand extends EntityCommand {
     return this.httpPost({
       cmd: 'delete_asset',
       report_id: id,
-      no_redirect: '1',
       filter,
-      next: 'get_report', // seems not to work without next param
     });
   }
 


### PR DESCRIPTION
Remove unused code paths from get_report function in gsad. Most of this
original code has become obsolete with GSA 8. It was required to pass
arbitrary parameters to the XSLT transformation in GSA 7.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [x] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
