### PR TITLE
Fix getting the result object from the response

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ $ cd gsa && git checkout gsa-8.0 && git log
 
 ## gsa 8.0.1 (unreleased)
 
+ * Fix Result details page #1275
  * Add tooltips to deactivated text fields in AlertDialog #1269
  * Fix displaying reserved filter keywords in content composer #1268
  * Disable inputs for improper option selection in EmailMethodPart of

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ $ cd gsa && git checkout gsa-8.0 && git log
 
 ## gsa 8.0.1 (unreleased)
 
- * Add tooltips to deactived textfields in AlertDialog #1269
+ * Add tooltips to deactivated text fields in AlertDialog #1269
  * Fix displaying reserved filter keywords in content composer #1268
  * Disable inputs for improper option selection in EmailMethodPart of
    AlertDialog #1266

--- a/gsa/src/gmp/commands/__tests__/result.js
+++ b/gsa/src/gmp/commands/__tests__/result.js
@@ -1,0 +1,43 @@
+/* Copyright (C) 2019 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import {ResultCommand} from '../results';
+
+import {createEntityResponse, createHttp} from '../testing';
+
+describe('ResultCommand tests', () => {
+  test('should return single result', () => {
+    const response = createEntityResponse('result', {_id: 'foo'});
+    const fakeHttp = createHttp(response);
+
+    expect.hasAssertions();
+
+    const cmd = new ResultCommand(fakeHttp);
+    return cmd.get({id: 'foo'}).then(resp => {
+      expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+        args: {
+          cmd: 'get_result',
+          result_id: 'foo',
+        },
+      });
+
+      const {data} = resp;
+      expect(data.id).toEqual('foo');
+    });
+  });
+});

--- a/gsa/src/gmp/commands/__tests__/results.js
+++ b/gsa/src/gmp/commands/__tests__/results.js
@@ -1,0 +1,139 @@
+/* Copyright (C) 2019 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import {ALL_FILTER} from 'gmp/models/filter';
+
+import {
+  createHttp,
+  createEntitiesResponse,
+  createAggregatesResponse,
+} from '../testing';
+import {ResultsCommand} from '../results';
+
+describe('ResultsCommand tests', () => {
+  test('should return all results', () => {
+    const response = createEntitiesResponse('result', [
+      {
+        _id: '1',
+      },
+      {
+        _id: '2',
+      },
+    ]);
+
+    const fakeHttp = createHttp(response);
+
+    expect.hasAssertions();
+
+    const cmd = new ResultsCommand(fakeHttp);
+    return cmd.getAll().then(resp => {
+      expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+        args: {
+          cmd: 'get_results',
+          filter: ALL_FILTER.toFilterString(),
+        },
+      });
+      const {data} = resp;
+      expect(data.length).toEqual(2);
+    });
+  });
+
+  test('should return results', () => {
+    const response = createEntitiesResponse('result', [
+      {
+        _id: '1',
+      },
+      {
+        _id: '2',
+      },
+    ]);
+
+    const fakeHttp = createHttp(response);
+
+    expect.hasAssertions();
+
+    const cmd = new ResultsCommand(fakeHttp);
+    return cmd.get().then(resp => {
+      expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+        args: {
+          cmd: 'get_results',
+        },
+      });
+      const {data} = resp;
+      expect(data.length).toEqual(2);
+    });
+  });
+
+  test('should aggregate Description Word Counts', () => {
+    const response = createAggregatesResponse();
+    const fakeHttp = createHttp(response);
+
+    expect.hasAssertions();
+
+    const cmd = new ResultsCommand(fakeHttp);
+    return cmd.getDescriptionWordCountsAggregates().then(resp => {
+      expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+        args: {
+          cmd: 'get_aggregate',
+          aggregate_type: 'result',
+          group_column: 'description',
+          aggregate_mode: 'word_counts',
+          max_groups: 250,
+        },
+      });
+    });
+  });
+
+  test('should aggregate word counts', () => {
+    const response = createAggregatesResponse();
+    const fakeHttp = createHttp(response);
+
+    expect.hasAssertions();
+
+    const cmd = new ResultsCommand(fakeHttp);
+    return cmd.getWordCountsAggregates().then(resp => {
+      expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+        args: {
+          cmd: 'get_aggregate',
+          aggregate_type: 'result',
+          group_column: 'vulnerability',
+          aggregate_mode: 'word_counts',
+          max_groups: 250,
+        },
+      });
+    });
+  });
+
+  test('should aggregate severities', () => {
+    const response = createAggregatesResponse();
+    const fakeHttp = createHttp(response);
+
+    expect.hasAssertions();
+
+    const cmd = new ResultsCommand(fakeHttp);
+    return cmd.getSeverityAggregates().then(resp => {
+      expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+        args: {
+          cmd: 'get_aggregate',
+          aggregate_type: 'result',
+          group_column: 'severity',
+        },
+      });
+    });
+  });
+});

--- a/gsa/src/gmp/commands/results.js
+++ b/gsa/src/gmp/commands/results.js
@@ -23,7 +23,7 @@ import Result from '../models/result';
 import EntitiesCommand from './entities';
 import EntityCommand from './entity';
 
-class ResultsCommand extends EntitiesCommand {
+export class ResultsCommand extends EntitiesCommand {
   constructor(http) {
     super(http, 'result', Result);
   }
@@ -61,7 +61,7 @@ class ResultsCommand extends EntitiesCommand {
   }
 }
 
-class ResultCommand extends EntityCommand {
+export class ResultCommand extends EntityCommand {
   constructor(http) {
     super(http, 'result', Result);
   }

--- a/gsa/src/gmp/commands/results.js
+++ b/gsa/src/gmp/commands/results.js
@@ -67,7 +67,7 @@ class ResultCommand extends EntityCommand {
   }
 
   getElementFromRoot(root) {
-    return root.get_result.commands_response.get_results_response.result;
+    return root.get_result.get_results_response.result;
   }
 }
 

--- a/gsa/src/gmp/commands/testing.js
+++ b/gsa/src/gmp/commands/testing.js
@@ -67,6 +67,18 @@ export const createActionResultResponse = () =>
     },
   );
 
+export const createAggregatesResponse = (data = {}) =>
+  new Response(
+    {},
+    {
+      get_aggregate: {
+        get_aggregates_response: {
+          aggregate: data,
+        },
+      },
+    },
+  );
+
 export const createHttp = response => ({
   request: jest.fn().mockReturnValue(Promise.resolve(response)),
 });


### PR DESCRIPTION
Update getting the result object from the response. The response got
changed with 892110429d9f9b1c6d83304e31e2516d17cec513 and dropped the
commands_response part by using the standard code for retrieving a
single entity in gsad.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
