### PR TITLE
 Fix z-Index of Select

### DIFF
--- a/gsa/src/web/components/form/__tests__/__snapshots__/selectelement.js.snap
+++ b/gsa/src/web/components/form/__tests__/__snapshots__/selectelement.js.snap
@@ -198,7 +198,7 @@ exports[`Menu tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   position: absolute;
-  z-index: 100;
+  z-index: 600;
   margin-top: -1px;
   box-sizing: border-box;
   top: 0px;
@@ -232,7 +232,7 @@ exports[`Menu tests should render with position adjust 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   position: absolute;
-  z-index: 100;
+  z-index: 600;
   margin-top: -1px;
   box-sizing: border-box;
   top: 0px;
@@ -266,7 +266,7 @@ exports[`Menu tests should render with position right 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   position: absolute;
-  z-index: 100;
+  z-index: 600;
   margin-top: -1px;
   box-sizing: border-box;
   top: 0px;

--- a/gsa/src/web/components/form/selectelements.js
+++ b/gsa/src/web/components/form/selectelements.js
@@ -90,7 +90,7 @@ const MenuContainer = styled.div`
   display: flex;
   flex-direction: column;
   position: absolute;
-  z-index: ${Theme.Layers.onTop};
+  z-index: ${Theme.Layers.menu};
   margin-top: -1px; /* collapse top border */
   box-sizing: border-box;
   top: ${props => props.y}px;


### PR DESCRIPTION
Fixes opening Select menus in dialogs, where they moved into the background with #1273.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ X ] Tests
- [ N/A ] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
