### PR TITLE
Alert content composer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ $ cd gsa && git checkout gsa-8.0 && git log
 
 ## gsa 8.0.1 (unreleased)
 
+ * Fix opening alert report composer #1280 #1276
  * Remove fifth from schedule #1279
  * Fix showing authentication methods in user dialog #1278
  * Fix Result details page #1275

--- a/gsa/src/web/pages/alerts/component.js
+++ b/gsa/src/web/pages/alerts/component.js
@@ -265,14 +265,13 @@ class AlertComponent extends React.Component {
     includeNotes,
     includeOverrides,
     filterId,
-    filterString,
     storeAsDefault,
   }) {
     if (storeAsDefault) {
       const {reportComposerDefaults} = this.props;
       const defaults = {
         ...reportComposerDefaults,
-        reportResultFilterId: filterId,
+        reportResultFilterId: filterId === UNSET_VALUE ? undefined : filterId,
         includeNotes,
         includeOverrides,
       };
@@ -443,10 +442,10 @@ class AlertComponent extends React.Component {
             name: alert.name,
             comment: alert.comment,
             filters,
-            filter_id: isDefined(alert.filter) ? alert.filter.id : NO_VALUE,
+            filter_id: isDefined(alert.filter) ? alert.filter.id : undefined,
             composerFilterId: isDefined(alert.filter)
               ? alert.filter.id
-              : NO_VALUE,
+              : undefined,
             composerIncludeNotes: getValue(method.data.composer_include_notes),
             composerIncludeOverrides: getValue(
               method.data.composer_include_overrides,
@@ -679,7 +678,7 @@ class AlertComponent extends React.Component {
             reportComposerDefaults.reportResultFilterId,
           )
             ? reportComposerDefaults.reportResultFilterId
-            : UNSET_VALUE;
+            : undefined;
 
           this.setState({
             active: undefined,
@@ -890,7 +889,7 @@ class AlertComponent extends React.Component {
 
   handleFilterIdChange(value) {
     this.setState({
-      composerFilterId: value,
+      composerFilterId: value === UNSET_VALUE ? undefined : value,
     });
 
     this.handleInteraction();

--- a/gsa/src/web/pages/alerts/component.js
+++ b/gsa/src/web/pages/alerts/component.js
@@ -140,7 +140,6 @@ class AlertComponent extends React.Component {
     this.handleOpenContentComposerDialog = this.handleOpenContentComposerDialog.bind(
       this,
     );
-    this.openContentComposerDialog = this.openContentComposerDialog.bind(this);
     this.closeContentComposerDialog = this.closeContentComposerDialog.bind(
       this,
     );

--- a/gsa/src/web/pages/alerts/component.js
+++ b/gsa/src/web/pages/alerts/component.js
@@ -241,18 +241,8 @@ class AlertComponent extends React.Component {
   }
 
   handleOpenContentComposerDialog() {
-    const {gmp} = this.props;
-    const {composerFilterId = NO_VALUE} = this.state;
-
-    gmp.filter.get({id: composerFilterId}).then(response => {
-      this.setState({
-        composerFilterString: isDefined(response.data)
-          ? response.data.toFilterCriteriaString()
-          : undefined,
-      });
-    });
-
     this.openContentComposerDialog();
+
     this.handleInteraction();
   }
 
@@ -261,13 +251,11 @@ class AlertComponent extends React.Component {
       method_data_composer_include_notes,
       method_data_composer_include_overrides,
       filter_id,
-      filter_string,
     } = this.state;
     this.setState({
       composerIncludeNotes: method_data_composer_include_notes,
       composerIncludeOverrides: method_data_composer_include_overrides,
       composerFilterId: filter_id,
-      composerFilterString: filter_string,
       composerStoreAsDefault: NO_VALUE,
       contentComposerDialogVisible: false,
     });
@@ -292,7 +280,6 @@ class AlertComponent extends React.Component {
     }
     this.setState({
       filter_id: filterId,
-      filter_string: filterString,
       method_data_composer_include_notes: includeNotes,
       method_data_composer_include_overrides: includeOverrides,
       composerStoreAsDefault: NO_VALUE,
@@ -902,16 +889,10 @@ class AlertComponent extends React.Component {
   }
 
   handleFilterIdChange(value) {
-    const {gmp} = this.props;
-    gmp.filter.get({id: value}).then(response => {
-      const composerFilterString = isDefined(response.data)
-        ? response.data.toFilterCriteriaString()
-        : undefined;
-      this.setState({
-        composerFilterId: value,
-        composerFilterString,
-      });
+    this.setState({
+      composerFilterId: value,
     });
+
     this.handleInteraction();
   }
 
@@ -947,7 +928,6 @@ class AlertComponent extends React.Component {
       filters,
       filter_id,
       composerFilterId,
-      composerFilterString,
       composerIncludeNotes,
       composerIncludeOverrides,
       credentials,
@@ -1206,7 +1186,6 @@ class AlertComponent extends React.Component {
                 includeOverrides={parseYesNo(composerIncludeOverrides)}
                 filterId={composerFilterId}
                 filters={result_filters}
-                filterString={composerFilterString}
                 storeAsDefault={parseYesNo(composerStoreAsDefault)}
                 title={_('Compose Content for Scan Report')}
                 onChange={this.handleValueChange}

--- a/gsa/src/web/pages/alerts/component.js
+++ b/gsa/src/web/pages/alerts/component.js
@@ -243,15 +243,17 @@ class AlertComponent extends React.Component {
   handleOpenContentComposerDialog() {
     const {gmp} = this.props;
     const {composerFilterId = NO_VALUE} = this.state;
+
     gmp.filter.get({id: composerFilterId}).then(response => {
       this.setState({
         composerFilterString: isDefined(response.data)
           ? response.data.toFilterCriteriaString()
           : undefined,
       });
-      this.openContentComposerDialog();
-      this.handleInteraction();
     });
+
+    this.openContentComposerDialog();
+    this.handleInteraction();
   }
 
   closeContentComposerDialog() {

--- a/gsa/src/web/pages/alerts/contentcomposerdialog.js
+++ b/gsa/src/web/pages/alerts/contentcomposerdialog.js
@@ -46,9 +46,8 @@ const StyledDiv = styled.div`
 `;
 
 const ContentComposerDialog = ({
-  filterId,
-  filters,
-  filterString = '',
+  filterId = UNSET_VALUE,
+  filters = [],
   includeNotes = COMPOSER_CONTENT_DEFAULTS.includeNotes,
   includeOverrides = COMPOSER_CONTENT_DEFAULTS.includeOverrides,
   storeAsDefault,
@@ -57,12 +56,11 @@ const ContentComposerDialog = ({
   onSave,
   onChange,
 }) => {
-  filterId =
-    filterId === NO_VALUE || !isDefined(filterId) ? UNSET_VALUE : filterId;
+  const filter =
+    filterId === UNSET_VALUE ? undefined : filters.find(f => f.id === filterId);
 
   const controlledValues = {
     filterId,
-    filterString,
     includeNotes,
     includeOverrides,
     storeAsDefault,
@@ -81,7 +79,7 @@ const ContentComposerDialog = ({
           <FormGroup title={_('Report Result Filter')} titleSize="3">
             <Select
               name="filterId"
-              value={values.filterId}
+              value={filterId}
               items={renderSelectItems(filters, UNSET_VALUE)}
               onChange={onFilterIdChange}
             />
@@ -91,7 +89,7 @@ const ContentComposerDialog = ({
               'To change the filter, please select a filter' +
                 ' from the dropdown menu.',
             )}
-            filterString={values.filterString}
+            filterString={isDefined(filter) ? filter.toFilterString() : ''}
             includeNotes={values.includeNotes}
             includeOverrides={values.includeOverrides}
             onValueChange={onChange}

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -5718,7 +5718,6 @@ create_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
   CHECK_VARIABLE_INVALID (condition, "Create Alert");
   CHECK_VARIABLE_INVALID (event, "Create Alert");
   CHECK_VARIABLE_INVALID (method, "Create Alert");
-  CHECK_VARIABLE_INVALID (filter_id, "Create Alert");
 
   /* Create the alert. */
 
@@ -5752,7 +5751,8 @@ create_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
                      "<active>%s</active>"
                      "<comment>%s</comment>"
                      "<event>%s",
-                     name, filter_id, active, comment ? comment : "", event);
+                     name, filter_id ? filter_id : "", active,
+                     comment ? comment : "", event);
 
   append_alert_event_data (xml, event_data, event);
 


### PR DESCRIPTION
Fix opening the content composer from the alert dialog.

- Always open dialog independent of loading errors
- Remove unnecessary loading of set filter
- Use undefined in state for not set filter id value

Fixes #1276 

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [x] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
