### PR TITLE
Don't require sessionTimeout for UserLink

### DIFF
--- a/gsa/src/web/components/link/userlink.js
+++ b/gsa/src/web/components/link/userlink.js
@@ -56,7 +56,7 @@ const UserLink = ({sessionTimeout, username}) => (
 );
 
 UserLink.propTypes = {
-  sessionTimeout: PropTypes.date.isRequired,
+  sessionTimeout: PropTypes.date,
   username: PropTypes.string.isRequired,
 };
 


### PR DESCRIPTION
The UserLink is render after a successfull login. Set sessionTimeout is
put into the redux store after the login. Therefore the sessionTimeout
may be undefined for a short amount of time.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [n/a] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
