### PR TITLE
Don't pass obsolete box props to layouts

### DIFF
--- a/gsa/src/web/pages/alerts/emailmethodpart.js
+++ b/gsa/src/web/pages/alerts/emailmethodpart.js
@@ -141,7 +141,7 @@ const EmailMethodPart = ({
             />
 
             {capabilities.mayOp('get_report_formats') && (
-              <Layout flex="column" box>
+              <Layout flex="column">
                 <Divider>
                   <Radio
                     name={prefix + 'notice'}

--- a/gsa/src/web/pages/alerts/sendmethodpart.js
+++ b/gsa/src/web/pages/alerts/sendmethodpart.js
@@ -40,7 +40,7 @@ const SendMethodPart = ({
   onChange,
 }) => {
   return (
-    <Layout flex="column" box grow="1">
+    <Layout flex="column" grow="1">
       <FormGroup title={_('Send to host')}>
         <Divider>
           <TextField

--- a/gsa/src/web/pages/alerts/smbmethodpart.js
+++ b/gsa/src/web/pages/alerts/smbmethodpart.js
@@ -53,7 +53,7 @@ const SmbMethodPart = ({
 }) => {
   credentials = credentials.filter(smb_credential_filter);
   return (
-    <Layout flex="column" box grow="1">
+    <Layout flex="column" grow="1">
       <FormGroup title=" ">
         <span>
           {_(

--- a/gsa/src/web/pages/alerts/snmpmethodpart.js
+++ b/gsa/src/web/pages/alerts/snmpmethodpart.js
@@ -36,7 +36,7 @@ const SnmpMethodPart = ({
   onChange,
 }) => {
   return (
-    <Layout flex="column" grow="1" box>
+    <Layout flex="column" grow="1">
       <FormGroup title={_('Community')}>
         <TextField
           size="30"

--- a/gsa/src/web/pages/targets/dialog.js
+++ b/gsa/src/web/pages/targets/dialog.js
@@ -333,7 +333,6 @@ const TargetDialog = ({
               <FormGroup title={_('SSH')}>
                 <Divider>
                   <Select
-                    box
                     name="ssh_credential_id"
                     disabled={state.in_use}
                     items={renderSelectItems(ssh_credentials, UNSET_VALUE)}

--- a/gsa/src/web/pages/targets/row.js
+++ b/gsa/src/web/pages/targets/row.js
@@ -96,7 +96,7 @@ const Cred = ({cred, title, links = true}) => {
   return (
     <Layout>
       <span>{title}: </span>
-      <Layout box>
+      <Layout>
         <DetailsLink type="credential" id={cred.id} textOnly={!links}>
           {cred.name}
         </DetailsLink>


### PR DESCRIPTION
Avoid raising PropType warnings by removing the obsolete box prop from
several Layout elements.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [n/a] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
