### PR TITLE
Don't start reload timer if a timer is already running

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ $ cd gsa && git checkout gsa-8.0 && git log
 
 ## gsa 8.0.1 (unreleased)
 
+ * Don't run more then one reload timer for a page #1289
  * Update dialog for Task Wizard, Advanced Task Wizard and Modify Task Wizard #1287
  * Add errordialog to fix missing error messages in trashcan #1286
  * Display current result, comparable result and diff between results for delta

--- a/gsa/src/web/entities/container.js
+++ b/gsa/src/web/entities/container.js
@@ -189,7 +189,7 @@ class EntitiesContainer extends React.Component {
   }
 
   startTimer() {
-    if (!this.isRunning) {
+    if (!this.isRunning || isDefined(this.timer)) {
       return;
     }
 

--- a/gsa/src/web/entity/container.js
+++ b/gsa/src/web/entity/container.js
@@ -86,7 +86,7 @@ class EntityContainer extends React.Component {
   }
 
   startTimer() {
-    if (!this.isRunning) {
+    if (!this.isRunning || isDefined(this.timer)) {
       return;
     }
 

--- a/gsa/src/web/pages/reports/detailspage.js
+++ b/gsa/src/web/pages/reports/detailspage.js
@@ -269,7 +269,7 @@ class ReportDetails extends React.Component {
   }
 
   startTimer() {
-    if (!this.isRunning) {
+    if (!this.isRunning || isDefined(this.timer)) {
       return;
     }
 


### PR DESCRIPTION
Avoid running multiple timers for the same page. This could happen
before when changing the filter while a timer was running.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [x] [CHANGES](https://github.com/greenbone/gsa/blob/master/CHANGES.md) Entry
