### PR TITLE
Don't add debug flag for libmicrohttpd in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cleanup get_report function in gsad [#1263](https://github.com/greenbone/gsa/pull/1263)
 
 ### Fixed
+- Only run libmicrohttp in debug mode if gsad build type is debug [#1295](https://github.com/greenbone/gsa/pull/1295)
 - Fix dialog can be moved outside browser frame [#1294](https://github.com/greenbone/gsa/pull/1294)
 - Fix permission description [#1292](https://github.com/greenbone/gsa/pull/1292)
 - Fix port ranges from file radio button [#1291](https://github.com/greenbone/gsa/pull/1291)

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -2585,6 +2585,7 @@ start_http_daemon (int port,
                    http_handler_t *http_handlers,
                    struct sockaddr_storage *address)
 {
+  unsigned int flags;
   int ipv6_flag;
 
   if (address->ss_family == AF_INET6)
@@ -2596,12 +2597,17 @@ start_http_daemon (int port,
 #endif
   else
     ipv6_flag = MHD_NO_FLAG;
+
+  flags =
+    MHD_USE_THREAD_PER_CONNECTION | MHD_USE_INTERNAL_POLLING_THREAD | ipv6_flag;
+#ifndef NDEBUG
+  flags = flags | MHD_USE_DEBUG;
+#endif
+
   return MHD_start_daemon (
-    MHD_USE_THREAD_PER_CONNECTION | MHD_USE_INTERNAL_POLLING_THREAD
-      | MHD_USE_DEBUG | ipv6_flag,
-    port, NULL, NULL, handler, http_handlers, MHD_OPTION_NOTIFY_COMPLETED,
-    free_resources, NULL, MHD_OPTION_SOCK_ADDR, address,
-    MHD_OPTION_PER_IP_CONNECTION_LIMIT, get_per_ip_connection_limit (),
+    flags, port, NULL, NULL, handler, http_handlers,
+    MHD_OPTION_NOTIFY_COMPLETED, free_resources, NULL, MHD_OPTION_SOCK_ADDR,
+    address, MHD_OPTION_PER_IP_CONNECTION_LIMIT, get_per_ip_connection_limit (),
     MHD_OPTION_EXTERNAL_LOGGER, mhd_logger, NULL, MHD_OPTION_END);
 }
 
@@ -2611,6 +2617,7 @@ start_https_daemon (int port, const char *key, const char *cert,
                     http_handler_t *http_handlers,
                     struct sockaddr_storage *address)
 {
+  unsigned int flags;
   int ipv6_flag;
 
   if (address->ss_family == AF_INET6)
@@ -2622,13 +2629,18 @@ start_https_daemon (int port, const char *key, const char *cert,
 #endif
   else
     ipv6_flag = MHD_NO_FLAG;
+
+  flags = MHD_USE_THREAD_PER_CONNECTION | MHD_USE_INTERNAL_POLLING_THREAD
+          | MHD_USE_SSL | ipv6_flag;
+#ifndef NDEBUG
+  flags = flags | MHD_USE_DEBUG;
+#endif
+
   return MHD_start_daemon (
-    MHD_USE_THREAD_PER_CONNECTION | MHD_USE_INTERNAL_POLLING_THREAD
-      | MHD_USE_DEBUG | MHD_USE_SSL | ipv6_flag,
-    port, NULL, NULL, &handle_request, http_handlers, MHD_OPTION_HTTPS_MEM_KEY,
-    key, MHD_OPTION_HTTPS_MEM_CERT, cert, MHD_OPTION_NOTIFY_COMPLETED,
-    free_resources, NULL, MHD_OPTION_SOCK_ADDR, address,
-    MHD_OPTION_PER_IP_CONNECTION_LIMIT, get_per_ip_connection_limit (),
+    flags, port, NULL, NULL, &handle_request, http_handlers,
+    MHD_OPTION_HTTPS_MEM_KEY, key, MHD_OPTION_HTTPS_MEM_CERT, cert,
+    MHD_OPTION_NOTIFY_COMPLETED, free_resources, NULL, MHD_OPTION_SOCK_ADDR,
+    address, MHD_OPTION_PER_IP_CONNECTION_LIMIT, get_per_ip_connection_limit (),
     MHD_OPTION_HTTPS_PRIORITIES, priorities, MHD_OPTION_EXTERNAL_LOGGER,
     mhd_logger, NULL,
 /* LibmicroHTTPD 0.9.35 and higher. */


### PR DESCRIPTION
Add the debug flag for libmicrohttpd only if NDEBUG is not set. This is
only the case for CMAKE_BUILD_TYPE Debug.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
