### PR TITLE
Scanner prefs

### DIFF
--- a/gsa/src/web/pages/scanconfigs/editdialog.js
+++ b/gsa/src/web/pages/scanconfigs/editdialog.js
@@ -167,7 +167,6 @@ class ScannerPreference extends React.Component {
       name === 'save_knowledge_base' ||
       name === 'silent_dependencies' ||
       name === 'slice_network_addresses' ||
-      name === 'use_mac_addr' ||
       name === 'drop_privileges' ||
       name === 'network_scan' ||
       name === 'report_host_details';

--- a/gsa/src/web/pages/scanconfigs/editdialog.js
+++ b/gsa/src/web/pages/scanconfigs/editdialog.js
@@ -149,7 +149,6 @@ class ScannerPreference extends React.Component {
       name === 'reverse_lookup' ||
       name === 'unscanned_closed' ||
       name === 'nasl_no_signature_check' ||
-      name === 'ping_hosts' ||
       name === 'reverse_lookup' ||
       name === 'unscanned_closed_udp' ||
       name === 'auto_enable_dependencies' ||


### PR DESCRIPTION
- use_mac_addr was removed from scanner https://github.com/greenbone/openvas-scanner/pull/181
- There are two 'ping_hosts' checks, remove one.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests N/A
- [] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry N/A
