### PR TITLE
Initialize filterName with an empty string

### DIFF
--- a/gsa/src/web/components/powerfilter/createnamedfiltergroup.js
+++ b/gsa/src/web/components/powerfilter/createnamedfiltergroup.js
@@ -35,7 +35,7 @@ const StyledLayout = styled(Layout)`
 `;
 
 const CreateNamedFilterGroup = ({
-  filterName,
+  filterName = '',
   saveNamedFilter = false,
   onValueChange,
 }) => (


### PR DESCRIPTION
Avoid proptype warning for changing from uncontrolled to controlled.