### PR TITLE
Allow to load all permission filters at the permissions list page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cleanup get_report function in gsad [#1263](https://github.com/greenbone/gsa/pull/1263)
 
 ### Fixed
-
+- Fix loading filters at permission list page [#1306](https://github.com/greenbone/gsa/pull/1306)
 - Fix filter in Report Results view cannot be saved & Fix error for create filter with no available results [#1303](https://github.com/greenbone/gsa/pull/1303)
 - Fix creating permissions via the create multiple permissions dialog [#1302](https://github.com/greenbone/gsa/pull/1302)
 - Fix showing host in Scanner dialog [#1301](https://github.com/greenbone/gsa/pull/1301)

--- a/gsa/src/gmp/models/filter.js
+++ b/gsa/src/gmp/models/filter.js
@@ -730,6 +730,7 @@ export const OS_FILTER_FILTER = Filter.fromString('type=os');
 export const OVALDEFS_FILTER_FILTER = Filter.fromString('type=info');
 export const OVERRIDES_FILTER_FILTER = Filter.fromString('type=override');
 export const PORTLISTS_FILTER_FILTER = Filter.fromString('type=port_list');
+export const PERMISSIONS_FILTER_FILTER = Filter.fromString('type=permission');
 export const REPORT_FORMATS_FILTER_FILTER = Filter.fromString(
   'type=report_format',
 );

--- a/gsa/src/web/pages/permissions/listpage.js
+++ b/gsa/src/web/pages/permissions/listpage.js
@@ -20,6 +20,8 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
+import {PERMISSIONS_FILTER_FILTER} from 'gmp/models/filter';
+
 import PropTypes from 'web/utils/proptypes';
 import withCapabilities from 'web/utils/withCapabilities';
 
@@ -87,6 +89,7 @@ const Page = ({onChanged, onDownloaded, onError, onInteraction, ...props}) => (
         sectionIcon={<PermissionIcon size="large" />}
         table={Table}
         filterEditDialog={FilterDialog}
+        filtersFilter={PERMISSIONS_FILTER_FILTER}
         title={_('Permissions')}
         toolBarIcons={ToolBarIcons}
         onError={onError}


### PR DESCRIPTION
Add a permissions filter filter for permission list page

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
