### PR TITLE
Send filt_id in get_report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix link to protocol documentation at about page [#1264](https://github.com/greenbone/gsa/pull/1264)
 - Fix testing alerts [#1260](https://github.com/greenbone/gsa/pull/1260)
 - Fix release build [#1259](https://github.com/greenbone/gsa/pull/1259), [#1265](https://github.com/greenbone/gsa/pull/1265)
+- Fix filtering on get_report page [#1307](https://github.com/greenbone/gsa/pull/1307)
 
 ### Removed
 - Remove sort by credential from Target view [1300](https://github.com/greenbone/gsa/pull/1300)

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -9697,7 +9697,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
   entity_t report_entity;
   const char *report_id, *delta_report_id;
   const char *format_id;
-  const char *filter;
+  const char *filter, *filt_id;
   int ret;
   int ignore_pagination;
   gchar *fname_format;
@@ -9713,20 +9713,26 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
   format_id = params_value (params, "report_format_id");
 
   filter = params_value (params, "filter");
+  filt_id = params_value (params, "filt_id");
 
   if (filter == NULL)
     filter = "";
+
+  if (filt_id == NULL)
+    filt_id = FILT_ID_USER_SETTING;
 
   ret = gvm_connection_sendf_xml (
     connection,
     "<get_reports"
     " ignore_pagination=\"%d\""
     " filter=\"%s\""
+    " filt_id=\"%s\""
     " report_id=\"%s\""
     " delta_report_id=\"%s\""
     " format_id=\"%s\"/>",
     ignore_pagination,
     filter,
+    filt_id,
     report_id,
     delta_report_id ? delta_report_id : "0",
     format_id ? format_id : ""


### PR DESCRIPTION
This will add the filt_id to the GMP command sent to gvmd, falling back
to FILT_ID_USER_SETTING (-2) if it's missing.

**Checklist**:
- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
