### PR TITLE
Remove NODE_PATH variable from package.json

### DIFF
--- a/gsa/package.json
+++ b/gsa/package.json
@@ -66,12 +66,12 @@
     "x2js": "^3.2.6"
   },
   "scripts": {
-    "test": "NODE_PATH=src react-scripts test",
-    "test:coverage": "NODE_PATH=src react-scripts test --coverage --maxWorkers 2",
-    "lint": "NODE_PATH=src eslint --max-warnings 0 src",
-    "start": "NODE_PATH=src react-scripts start",
-    "build": "NODE_PATH=src react-scripts build",
-    "eject": "NODE_PATH=src react-scripts eject"
+    "test": "react-scripts test",
+    "test:coverage": "react-scripts test --coverage --maxWorkers 2",
+    "lint": "eslint --max-warnings 0 src",
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "eject": "react-scripts eject"
   },
   "devDependencies": {
     "eslint-config-prettier": "^4.0.0",


### PR DESCRIPTION
The variable was used by create-react-app to determine the source
directory for absolute imports. This mechanism is depreacted with
create-react-app 3 and replaced by jsconfig.json settings now.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [n/a] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
