### PR TITLE
Fix using a filter string for get_report

### DIFF
--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -9630,7 +9630,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
     " format_id=\"%s\"/>",
     ignore_pagination,
     filter,
-    filter_id ? filter_id : "",
+    filter_id ? filter_id : FILT_ID_NONE,
     report_id,
     delta_report_id ? delta_report_id : "0",
     format_id ? format_id : ""


### PR DESCRIPTION
filt_id must be 0 or not set to work correctly in gvmd. filt_id="" is an
invalid filter id...

This got introduced with #1314 

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [n/a] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
