### PR TITLE
Consider timezone when using durations for performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add tooltips to deactivated text fields in AlertDialog [#1269](https://github.com/greenbone/gsa/pull/1269)
 
 ### Changed
-- Render all dates in the current configured timezone of the user [#1327](https://github.com/greenbone/gsa/pull/1327)
+- Render all dates in the current configured timezone of the user
+  [#1327](https://github.com/greenbone/gsa/pull/1327), [#1329](https://github.com/greenbone/gsa/pull/1329)
 - Change default PortList for NewTargetDialog [#1321](https://github.com/greenbone/gsa/pull/1321)
 - Update dependencies of react, react-dom, react-redux and create-react-app [#1312](https://github.com/greenbone/gsa/pull/1312)
 - Adjust clickable area of Select [#1296](https://github.com/greenbone/gsa/pull/1296)

--- a/gsa/src/web/pages/performance/performancepage.js
+++ b/gsa/src/web/pages/performance/performancepage.js
@@ -232,7 +232,8 @@ class PerformancePage extends React.Component {
 
   handleDurationChange(duration) {
     if (isDefined(duration)) {
-      const end = date();
+      const {timezone} = this.props;
+      const end = date().tz(timezone);
       const start = end.clone().subtract(DURATIONS[duration], 'seconds');
 
       this.setState({


### PR DESCRIPTION
If the performance timeline is calculated from a duration also consider
the current user timezone.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
