### PR TITLE
Fix installation of locale files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cleanup get_report function in gsad [#1263](https://github.com/greenbone/gsa/pull/1263)
 
 ### Fixed
+- Fix installation of locale files [#1330](https://github.com/greenbone/gsa/pull/1330)
 - Fix list of options of possible Filter types [#1326](https://github.com/greenbone/gsa/pull/1326)
 - Fix timezone handling at performance page [#1325](https://github.com/greenbone/gsa/pull/1325)
 - Fix creating and editing alerts without a result filter [#1315](https://github.com/greenbone/gsa/pull/1315)

--- a/gsa/po/CMakeLists.txt
+++ b/gsa/po/CMakeLists.txt
@@ -101,7 +101,7 @@ if (GETTEXT_FOUND)
                         COMMENT "Creating translation template (.pot) file from JS")
 
     install (DIRECTORY
-             ${GSA_BUILD_DIR}/locales
+             ${GSA_LOCALE_DIR}
              DESTINATION ${GSA_DEST_DIR})
 
   else (PY_POLIB_FOUND)


### PR DESCRIPTION
Install the locales from the gsa/public/locales directory instead of
from the nodejs build dir. It seems that under some circumstances the
locale files haven't been put into the nodejs build dir.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
