### PR TITLE
Don't require credentials for TaskComponent

### DIFF
--- a/gsa/src/web/pages/tasks/component.js
+++ b/gsa/src/web/pages/tasks/component.js
@@ -917,7 +917,7 @@ TaskComponent.propTypes = {
   alerts: PropTypes.arrayOf(PropTypes.model),
   capabilities: PropTypes.capabilities.isRequired,
   children: PropTypes.func.isRequired,
-  credentials: PropTypes.arrayOf(PropTypes.model).isRequired,
+  credentials: PropTypes.arrayOf(PropTypes.model),
   defaultAlertId: PropTypes.id,
   defaultEsxiCredential: PropTypes.id,
   defaultPortListId: PropTypes.id,


### PR DESCRIPTION
The credentials are only loaded when opening the advanced task wizard.
Therefore they must not be required.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [n/a] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
