### PR TITLE
Make DateTime component resilient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cleanup get_report function in gsad [#1263](https://github.com/greenbone/gsa/pull/1263)
 
 ### Fixed
+- Fix rendering DateTime without dates being passed [#1343](https://github.com/greenbone/gsa/pull/1343)
 - Fix restarting reload timers [#1341](https://github.com/greenbone/gsa/pull/1341)
 - Fix list of excluded hosts formatting [#1340](https://github.com/greenbone/gsa/pull/1340)
 - Fix installation of locale files [#1330](https://github.com/greenbone/gsa/pull/1330)

--- a/gsa/src/web/components/date/datetime.js
+++ b/gsa/src/web/components/date/datetime.js
@@ -20,15 +20,17 @@ import {connect} from 'react-redux';
 
 import {dateTimeWithTimeZone} from 'gmp/locale/date';
 
+import {isDefined} from 'gmp/utils/identity';
+
 import {getTimezone} from 'web/store/usersettings/selectors';
 
 import PropTypes from 'web/utils/proptypes';
 
 const DateTime = ({formatter = dateTimeWithTimeZone, timezone, date}) =>
-  formatter(date, timezone);
+  isDefined(date) ? formatter(date, timezone) : null;
 
 DateTime.propTypes = {
-  date: PropTypes.date.isRequired,
+  date: PropTypes.date,
   formatter: PropTypes.func,
   timezone: PropTypes.string,
 };


### PR DESCRIPTION
Don't crash DateTime component if no date is passed. Instead render
nothing by returning null if date prop is undefined.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
