### PR TITLE
Fix timer handling at report details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix rendering DateTime without dates being passed [#1343](https://github.com/greenbone/gsa/pull/1343)
-- Fix restarting reload timers [#1341](https://github.com/greenbone/gsa/pull/1341)
+- Fix restarting reload timers
+  [#1341](https://github.com/greenbone/gsa/pull/1341),
+  [#1351](https://github.com/greenbone/gsa/pull/1351)
 - Fix list of excluded hosts formatting [#1340](https://github.com/greenbone/gsa/pull/1340)
 - Fix installation of locale files [#1330](https://github.com/greenbone/gsa/pull/1330)
 - Fix list of options of possible Filter types [#1326](https://github.com/greenbone/gsa/pull/1326)

--- a/gsa/src/web/pages/reports/detailspage.js
+++ b/gsa/src/web/pages/reports/detailspage.js
@@ -237,6 +237,8 @@ class ReportDetails extends React.Component {
       filter,
     });
 
+    this.clearTimer();
+
     this.startDurationMeasurement();
 
     this.setState(({lastFilter}) => ({
@@ -266,6 +268,10 @@ class ReportDetails extends React.Component {
 
   startTimer() {
     if (!this.isRunning || isDefined(this.timer)) {
+      log.debug('Not starting timer', {
+        isRunning: this.isRunning,
+        timer: this.timer,
+      });
       return;
     }
 
@@ -292,9 +298,16 @@ class ReportDetails extends React.Component {
     }
   }
 
+  resetTimer() {
+    this.timer = undefined;
+  }
+
   clearTimer() {
     if (isDefined(this.timer)) {
       log.debug('Clearing reload timer with id', this.timer);
+
+      this.resetTimer();
+
       global.clearTimeout(this.timer);
     }
   }
@@ -302,7 +315,8 @@ class ReportDetails extends React.Component {
   handleTimer() {
     log.debug('Timer', this.timer, 'finished. Reloading data.');
 
-    this.timer = undefined;
+    this.resetTimer();
+
     this.reload();
   }
 


### PR DESCRIPTION
* Clear possible running timer if load is called (resets timer when
  user requests reload)
* Reset timer id to undefined when timer is cleared (allows to start a
  new timer)

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
