### PR TITLE
Only use exact circleci cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
       - restore_cache:
           keys:
             - v1-deps-{{ checksum "./gsa/yarn.lock"  }}
-            - v1-deps
       - run:
           working_directory: ~/gsa/gsa
           name: Update JavaScript dependencies
@@ -45,7 +44,6 @@ jobs:
       - restore_cache:
           keys:
             - v1-deps-{{ checksum "./gsa/yarn.lock"  }}
-            - v1-deps
       - run:
           working_directory: ~/gsa/gsa
           name: Update JavaScript dependencies
@@ -86,7 +84,6 @@ jobs:
       - restore_cache:
           keys:
             - v1-deps-{{ checksum "./gsa/yarn.lock"  }}
-            - v1-deps
       - run:
           name: Configure and compile
           command: mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release -DSKIP_GSAD=1 .. && make install


### PR DESCRIPTION
The old cache may not fit to the current build because of changes to the
configuration and paths.