### PR TITLE
Use loaded filter from state in EntitiesContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cleanup get_report function in gsad [#1263](https://github.com/greenbone/gsa/pull/1263)
 
 ### Fixed
+- Use correct loaded filter in entities container [#1359](https://github.com/greenbone/gsa/pull/1359)
 - Fix parsing a filter id of '0' [#1358](https://github.com/greenbone/gsa/pull/1358)
 - Parse report timestamp as date object [#1357](https://github.com/greenbone/gsa/pull/1357)
 - Don't crash topology chart if host has no severity [#1356](https://github.com/greenbone/gsa/pull/1356)

--- a/gsa/src/web/entities/container.js
+++ b/gsa/src/web/entities/container.js
@@ -283,8 +283,8 @@ class EntitiesContainer extends React.Component {
 
   handleDownloadBulk(filename = 'export.xml') {
     const {entitiesCommand} = this;
-    const {selected, selectionType} = this.state;
-    const {loadedFilter, onDownload} = this.props;
+    const {loadedFilter, selected, selectionType} = this.state;
+    const {onDownload} = this.props;
 
     let promise;
 
@@ -306,8 +306,7 @@ class EntitiesContainer extends React.Component {
 
   handleDeleteBulk() {
     const {entitiesCommand} = this;
-    const {selected, selectionType} = this.state;
-    const {loadedFilter} = this.props;
+    const {loadedFilter, selected, selectionType} = this.state;
     let promise;
 
     if (selectionType === SelectionType.SELECTION_USER) {
@@ -347,7 +346,7 @@ class EntitiesContainer extends React.Component {
   }
 
   handleSortChange(field) {
-    const {loadedFilter} = this.props;
+    const {loadedFilter} = this.state;
 
     let sort = 'sort';
     const sortField = loadedFilter.getSortBy();
@@ -375,19 +374,19 @@ class EntitiesContainer extends React.Component {
   }
 
   handleFirst() {
-    const {loadedFilter: filter} = this.props;
+    const {loadedFilter: filter} = this.state;
 
     this.changeFilter(filter.first());
   }
 
   handleNext() {
-    const {loadedFilter: filter} = this.props;
+    const {loadedFilter: filter} = this.state;
 
     this.changeFilter(filter.next());
   }
 
   handlePrevious() {
-    const {loadedFilter: filter} = this.props;
+    const {loadedFilter: filter} = this.state;
 
     this.changeFilter(filter.previous());
   }
@@ -470,8 +469,8 @@ class EntitiesContainer extends React.Component {
   }
 
   handleAddMultiTag({comment, id, name, value = ''}) {
-    const {gmp, loadedFilter} = this.props;
-    const {selectionType, selected, entities = []} = this.state;
+    const {gmp} = this.props;
+    const {loadedFilter, selectionType, selected, entities = []} = this.state;
 
     const entitiesType = getEntityType(entities[0]);
 


### PR DESCRIPTION
Always use the actual displayed and used loaded filter. Avoid using a
new filter that hasn't data yet. Using a not displayed filter may result
in unexpected behavior.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
