### PR TITLE
Remove validation of jsdoc comments

### DIFF
--- a/gsa/.eslintrc.js
+++ b/gsa/.eslintrc.js
@@ -156,7 +156,6 @@ module.exports = {
     'prefer-rest-params': 'error', // require using the rest parameters instead of arguments
     'prefer-spread': 'warn', // prefer spread operator Xyz.func(...args) instead of Xyz.func.apply(Xyz, args)
     'prefer-template': 'off',
-    'require-jsdoc': 'off',
     'sort-imports': 'off',
     'sort-keys': 'off',
     'spaced-comment': [
@@ -165,15 +164,6 @@ module.exports = {
       'always',
     ],
     'symbol-description': 'error', // require symbol description: Symbol('some description')
-    'valid-jsdoc': [
-      'warn',
-      {
-        requireReturnType: false,
-        requireReturn: false,
-        requireParamDescription: false,
-        requireReturnDescription: false,
-      },
-    ],
     yoda: [
       // disallow yoda conditions: if (1 === b)
       'error',


### PR DESCRIPTION
Support for these eslint rules is end-of-life
https://eslint.org/blog/2018/11/jsdoc-end-of-life

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [n/a] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
