### PR TITLE
Disable EditIcon while loading filters (also fix loading filters)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cleanup get_report function in gsad [#1263](https://github.com/greenbone/gsa/pull/1263)
 
 ### Fixed
+- Fix race condition in EditUserSettingsDialog and loading all default filters [#1383](https://github.com/greenbone/gsa/pull/1383)
 - Fix scheduled task tooltip time format [#1382](https://github.com/greenbone/gsa/pull/1382)
 - Fix updating Titlebar after session timeout [#1377](https://github.com/greenbone/gsa/pull/1377)
 - Use German manual for *DE* locale [#1372](https://github.com/greenbone/gsa/pull/1372)

--- a/gsa/src/gmp/commands/users.js
+++ b/gsa/src/gmp/commands/users.js
@@ -326,7 +326,7 @@ class UserCommand extends EntityCommand {
       [saveDefaultFilterSettingId('target')]: data.targetsFilter,
       [saveDefaultFilterSettingId('task')]: data.tasksFilter,
       [saveDefaultFilterSettingId('ticket')]: data.ticketsFilter,
-      [saveDefaultFilterSettingId('user')]: data.userssFilter,
+      [saveDefaultFilterSettingId('user')]: data.usersFilter,
       [saveDefaultFilterSettingId('vulnerability')]: data.vulnerabilitiesFilter,
       [saveDefaultFilterSettingId('cpe')]: data.cpeFilter,
       [saveDefaultFilterSettingId('cve')]: data.cveFilter,

--- a/gsa/src/web/pages/usersettings/dialog.js
+++ b/gsa/src/web/pages/usersettings/dialog.js
@@ -97,10 +97,14 @@ let UserSettingsDialog = ({
   reportFormatsFilter,
   resultsFilter,
   rolesFilter,
+  scannersFilter,
   schedulesFilter,
   tagsFilter,
   targetsFilter,
   tasksFilter,
+  ticketsFilter,
+  usersFilter,
+  vulnerabilitiesFilter,
   cpeFilter,
   cveFilter,
   nvtFilter,
@@ -155,10 +159,14 @@ let UserSettingsDialog = ({
     reportFormatsFilter,
     resultsFilter,
     rolesFilter,
+    scannersFilter,
     schedulesFilter,
     tagsFilter,
     targetsFilter,
     tasksFilter,
+    ticketsFilter,
+    usersFilter,
+    vulnerabilitiesFilter,
     cpeFilter,
     cveFilter,
     nvtFilter,
@@ -245,6 +253,7 @@ let UserSettingsDialog = ({
                     configsFilter={values.configsFilter}
                     credentialsFilter={values.credentialsFilter}
                     filtersFilter={values.filtersFilter}
+                    groupsFilter={values.groupsFilter}
                     hostsFilter={values.hostsFilter}
                     notesFilter={values.notesFilter}
                     operatingSystemsFilter={values.operatingSystemsFilter}
@@ -255,10 +264,14 @@ let UserSettingsDialog = ({
                     reportFormatsFilter={values.reportFormatsFilter}
                     resultsFilter={values.resultsFilter}
                     rolesFilter={values.rolesFilter}
+                    scannersFilter={values.scannersFilter}
                     schedulesFilter={values.schedulesFilter}
                     tagsFilter={values.tagsFilter}
                     targetsFilter={values.targetsFilter}
                     tasksFilter={values.tasksFilter}
+                    ticketsFilter={values.ticketsFilter}
+                    usersFilter={values.usersFilter}
+                    vulnerabilitiesFilter={values.vulnerabilitiesFilter}
                     cpeFilter={values.cpeFilter}
                     cveFilter={values.cveFilter}
                     nvtFilter={values.nvtFilter}
@@ -310,6 +323,7 @@ UserSettingsDialog.propTypes = {
   dynamicSeverity: PropTypes.string,
   filters: PropTypes.array,
   filtersFilter: PropTypes.string,
+  groupsFilter: PropTypes.string,
   hostsFilter: PropTypes.string,
   listExportFileName: PropTypes.string,
   maxRowsPerPage: PropTypes.string,
@@ -332,6 +346,7 @@ UserSettingsDialog.propTypes = {
   resultsFilter: PropTypes.string,
   rolesFilter: PropTypes.string,
   rowsPerPage: PropTypes.string,
+  scannersFilter: PropTypes.string,
   schedules: PropTypes.array,
   schedulesFilter: PropTypes.string,
   secInfoFilter: PropTypes.string,
@@ -340,8 +355,11 @@ UserSettingsDialog.propTypes = {
   targets: PropTypes.array,
   targetsFilter: PropTypes.string,
   tasksFilter: PropTypes.string,
+  ticketsFilter: PropTypes.string,
   timezone: PropTypes.string,
   userInterfaceLanguage: PropTypes.string,
+  usersFilter: PropTypes.string,
+  vulnerabilitiesFilter: PropTypes.string,
   onClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
 };

--- a/gsa/src/web/pages/usersettings/usersettingspage.js
+++ b/gsa/src/web/pages/usersettings/usersettingspage.js
@@ -162,7 +162,7 @@ SettingTableRow.propTypes = {
   type: PropTypes.string.isRequired,
 };
 
-const ToolBarIcons = ({onEditSettingsClick}) => (
+const ToolBarIcons = ({disableEditIcon, onEditSettingsClick}) => (
   <Layout>
     <IconDivider>
       <ManualIcon
@@ -172,6 +172,7 @@ const ToolBarIcons = ({onEditSettingsClick}) => (
         title={_('Help: My Settings')}
       />
       <EditIcon
+        disabled={disableEditIcon}
         size="small"
         title={_('Edit My Settings')}
         onClick={onEditSettingsClick}
@@ -181,6 +182,7 @@ const ToolBarIcons = ({onEditSettingsClick}) => (
 );
 
 ToolBarIcons.propTypes = {
+  disableEditIcon: PropTypes.bool.isRequired,
   onEditSettingsClick: PropTypes.func.isRequired,
 };
 
@@ -191,6 +193,7 @@ class UserSettings extends React.Component {
     this.state = {
       activeTab: 0,
       dialogVisible: false,
+      disableEditIcon: true,
     };
 
     this.openDialog = this.openDialog.bind(this);
@@ -224,7 +227,14 @@ class UserSettings extends React.Component {
   }
 
   loadSettings() {
-    this.props.loadFilterDefaults();
+    this.props
+      .loadFilterDefaults()
+      .then(() => {
+        this.setState({disableEditIcon: false});
+      })
+      .catch(() => {
+        this.setState({disableEditIcon: false});
+      });
     this.props.loadSettings();
   }
 
@@ -280,8 +290,7 @@ class UserSettings extends React.Component {
   }
 
   render() {
-    const {activeTab, dialogVisible} = this.state;
-
+    const {activeTab, dialogVisible, disableEditIcon} = this.state;
     const {
       capabilities,
       filters,
@@ -359,7 +368,10 @@ class UserSettings extends React.Component {
     return (
       <ErrorBoundary errElement={_('page')}>
         <Layout flex="column">
-          <ToolBarIcons onEditSettingsClick={this.openDialog} />
+          <ToolBarIcons
+            disableEditIcon={disableEditIcon}
+            onEditSettingsClick={this.openDialog}
+          />
           <Section
             img={<MySettingsIcon size="large" />}
             title={_('My Settings')}
@@ -1105,39 +1117,40 @@ const mapDispatchToProps = (dispatch, {gmp}) => ({
   loadAlerts: () => dispatch(loadAlerts(gmp)(ALL_FILTER)),
   loadCredentials: () => dispatch(loadCredentials(gmp)(ALL_FILTER)),
   loadFilters: () => dispatch(loadFilters(gmp)(ALL_FILTER)),
-  loadFilterDefaults: () => {
-    dispatch(loadUserSettingsDefaultFilter(gmp)('agent'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('alert'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('scanconfig'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('credential'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('filter'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('group'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('host'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('note'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('operatingsystem'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('override'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('permission'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('portlist'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('report'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('reportformat'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('result'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('role'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('scanner'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('schedule'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('tag'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('target'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('task'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('ticket'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('user'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('vulnerability'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('cpe'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('cve'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('certbund'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('dfncert'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('nvt'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('ovaldef'));
-    dispatch(loadUserSettingsDefaultFilter(gmp)('allinfo'));
-  },
+  loadFilterDefaults: () =>
+    Promise.all([
+      dispatch(loadUserSettingsDefaultFilter(gmp)('agent')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('alert')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('scanconfig')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('credential')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('filter')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('group')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('host')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('note')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('operatingsystem')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('override')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('permission')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('portlist')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('report')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('reportformat')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('result')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('role')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('scanner')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('schedule')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('tag')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('target')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('task')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('ticket')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('user')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('vulnerability')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('cpe')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('cve')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('certbund')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('dfncert')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('nvt')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('ovaldef')),
+      dispatch(loadUserSettingsDefaultFilter(gmp)('allinfo')),
+    ]),
   loadPortLists: () => dispatch(loadPortLists(gmp)(ALL_FILTER)),
   loadReportFormats: () => dispatch(loadReportFormats(gmp)(ALL_FILTER)),
   loadScanConfigs: () => dispatch(loadScanConfigs(gmp)(ALL_FILTER)),


### PR DESCRIPTION
This will prevent a race condition when opening the EditDialog. Before this change, it was possible that the dialog opened before all settings (filters in particular) where loaded.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ N/A ] Tests
- [ X ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
