### PR TITLE
Load all entities at report details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cleanup get_report function in gsad [#1263](https://github.com/greenbone/gsa/pull/1263)
 
 ### Fixed
+- Load all filters and report formats at the report details page [#1401](https://github.com/greenbone/gsa/pull/1401)
 - Don't link to hosts not being added to the assets [#1399](https://github.com/greenbone/gsa/pull/1399)
 - Fix adding and removing host assets at the report details [#1397](https://github.com/greenbone/gsa/pull/1397)
 - Fix displaying the observer group name at tasks list page [#1393](https://github.com/greenbone/gsa/pull/1393)

--- a/gsa/src/web/pages/reports/detailspage.js
+++ b/gsa/src/web/pages/reports/detailspage.js
@@ -42,12 +42,12 @@ import withDefaultFilter from 'web/entities/withDefaultFilter';
 import DownloadReportDialog from 'web/pages/reports/downloadreportdialog';
 
 import {
-  loadEntities as loadFilters,
+  loadAllEntities as loadFilters,
   selector as filterSelector,
 } from 'web/store/entities/filters';
 
 import {
-  loadEntities as loadReportFormats,
+  loadAllEntities as loadReportFormats,
   selector as reportFormatsSelector,
 } from 'web/store/entities/reportformats';
 
@@ -708,8 +708,8 @@ const mapStateToProps = (rootState, {match}) => {
     entityError,
     reportFilter: getFilter(entity),
     isLoading: !isDefined(entity),
-    filters: filterSel.getEntities(RESULTS_FILTER_FILTER),
-    reportFormats: reportFormatsSel.getEntities(REPORT_FORMATS_FILTER),
+    filters: filterSel.getAllEntities(RESULTS_FILTER_FILTER),
+    reportFormats: reportFormatsSel.getAllEntities(REPORT_FORMATS_FILTER),
     reportId: id,
     deltaReportId: deltaid,
     reportComposerDefaults: getReportComposerDefaults(rootState),


### PR DESCRIPTION
Ensure all filters and report formats are loaded at the report details
page not only the default row count.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
