### PR TITLE
Replace german "ist" with englisch "is" in a comment.

### DIFF
--- a/gsa/src/web/pages/alerts/method.js
+++ b/gsa/src/web/pages/alerts/method.js
@@ -366,7 +366,7 @@ const Method = ({method, details = false}) => {
   }
 
   if (method.type === METHOD_TYPE_START_TASK) {
-    // FIXME task name ist missing
+    // FIXME task name is missing
     // in xslt the tasks have been added to the response
     // we should improve the backend to return the name for the task id here too
     return _('Start Task');


### PR DESCRIPTION
While this is a FIXME which will probably disappear in the future we should still keep the language in English.