### PR TITLE
Fix loading timezone and locale at login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cleanup get_report function in gsad [#1263](https://github.com/greenbone/gsa/pull/1263)
 
 ### Fixed
+- Fix loading data on login [#1426](https://github.com/greenbone/gsa/pull/1426)
 - Fix result undefined error on result details [#1423](https://github.com/greenbone/gsa/pull/1423)
 - Fix showing Scanner Preferences in EditScanConfigDialog [#1420](https://github.com/greenbone/gsa/pull/1420)
 - Don't crash if second result for delta is undefined [#1418](https://github.com/greenbone/gsa/pull/1418)

--- a/gsa/src/gmp/commands/login.js
+++ b/gsa/src/gmp/commands/login.js
@@ -34,7 +34,7 @@ class LoginCommand extends HttpCommand {
       login: username,
       password,
     }).then(
-      response => new Login(response.data),
+      response => new Login(response),
       rej => {
         if (rej.isError && rej.isError()) {
           switch (rej.status) {

--- a/gsa/src/gmp/models/__tests__/login.js
+++ b/gsa/src/gmp/models/__tests__/login.js
@@ -23,16 +23,20 @@ import Login from 'gmp/models/login';
 describe('Login model tests', () => {
   test('should set all properties correctly', () => {
     const elem = {
-      client_address: '1.2.3.4',
-      guest: '0',
-      i18n: 'en',
-      role: 'admin',
-      severity: '8.5',
-      timezone: 'UTC',
-      token: '123abc',
-      vendor_version: '42',
-      version: '1337',
-      session: '12345',
+      data: {
+        client_address: '1.2.3.4',
+        guest: '0',
+        role: 'admin',
+        severity: '8.5',
+        token: '123abc',
+        session: '12345',
+      },
+      meta: {
+        i18n: 'en',
+        timezone: 'UTC',
+        vendor_version: '42',
+        version: '1337',
+      },
     };
     const login = new Login(elem);
     const login2 = new Login({});

--- a/gsa/src/gmp/models/login.js
+++ b/gsa/src/gmp/models/login.js
@@ -24,17 +24,17 @@ import {isDefined} from 'gmp/utils/identity';
 
 class Login {
   constructor(elem) {
-    this.clientAddress = elem.client_address;
-    this.guest = elem.guest;
-    this.locale = elem.i18n;
-    this.role = elem.role;
-    this.severity = elem.severity;
-    this.timezone = elem.timezone;
-    this.token = elem.token;
-    this.vendorVersion = elem.vendor_version;
-    this.version = elem.version;
-
-    const unixSeconds = parseInt(elem.session);
+    const {data = {}, meta = {}} = elem;
+    this.clientAddress = data.client_address;
+    this.guest = data.guest;
+    this.locale = meta.i18n;
+    this.role = data.role;
+    this.severity = data.severity;
+    this.timezone = meta.timezone;
+    this.token = data.token;
+    this.vendorVersion = meta.vendor_version;
+    this.version = meta.version;
+    const unixSeconds = parseInt(data.session);
 
     this.sessionTimeout = isDefined(unixSeconds)
       ? moment.unix(unixSeconds)


### PR DESCRIPTION
timezone and i18n are not found in the response.data but response.meta, 
so login variables have to be stitched together from both those fields.

This solves several issues including non-workign user settings and the 
performance page.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ X ] Tests
- [ X ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
