### PR TITLE
Don't allow tagging vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cleanup get_report function in gsad [#1263](https://github.com/greenbone/gsa/pull/1263)
 
 ### Fixed
+Don't allow bulk tagging vulnerabilities [#1429](https://github.com/greenbone/gsa/pull/1429)
 - Fix parsing CVSS authentication SINGLE_INSTANCE [#1427](https://github.com/greenbone/gsa/pull/1427)
 - Fix loading data on login [#1426](https://github.com/greenbone/gsa/pull/1426)
 - Fix result undefined error on result details [#1423](https://github.com/greenbone/gsa/pull/1423)

--- a/gsa/src/web/pages/vulns/listpage.js
+++ b/gsa/src/web/pages/vulns/listpage.js
@@ -74,6 +74,7 @@ const Page = ({filter, onFilterChanged, onInteraction, ...props}) => (
     filterEditDialog={VulnsFilterDialog}
     filtersFilter={VULNS_FILTER_FILTER}
     table={VulnsTable}
+    tags={false}
     title={_('Vulnerabilities')}
     sectionIcon={<VulnerabilityIcon size="large" />}
     toolBarIcons={ToolBarIcons}


### PR DESCRIPTION
There is no vulnerability resource type for tags, so don't offer bulk 
tagging at vulns listpage.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ N/A ] Tests
- [ X ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
