### PR TITLE
Add C source format CircleCI check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run:
           name: Check Source Format
-          command: clang-format -i -style=file gsa/src/*.{c,h} && git diff --exit-code
+          command: clang-format -i -style=file gsad/src/*.{c,h} && git diff --exit-code
   js_test:
     working_directory: ~/gsa
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,13 @@
 version: 2
 jobs:
+  c_check_format:
+    docker:
+      - image: greenbone/build-env-gvm-libs-master-debian-buster-clang-core
+    steps:
+      - checkout
+      - run:
+          name: Check Source Format
+          command: clang-format -i -style=file gsa/src/*.{c,h} && git diff --exit-code
   js_test:
     working_directory: ~/gsa
     docker:
@@ -95,6 +103,7 @@ workflows:
   version: 2
   build_and_test:
     jobs:
+      - c_check_format
       - build_gsad
       - build_gsa
       - js_lint

--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,7 @@
+# clang-format configuration for Greenbone C code
+#
+# Minimum required clang-format version: 6.0
+
 ---
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: 'false'

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -172,9 +172,9 @@
  */
 #define DEFAULT_GSAD_PER_IP_CONNECTION_LIMIT 30
 
-#define COPYRIGHT \
-  "Copyright (C) 2010 - 2019 Greenbone Networks GmbH\n" \
-  "License GPLv2+: GNU GPL version 2 or later\n" \
+#define COPYRIGHT                                                        \
+  "Copyright (C) 2010 - 2019 Greenbone Networks GmbH\n"                  \
+  "License GPLv2+: GNU GPL version 2 or later\n"                         \
   "This is free software: you are free to change and redistribute it.\n" \
   "There is NO WARRANTY, to the extent permitted by law.\n\n"
 
@@ -508,8 +508,7 @@ init_validator ()
   gvm_validator_add (validator, "create_credentials_type", "^(gen|pass|key)$");
   gvm_validator_add (validator, "credential_type",
                      "^(cc|up|usk|smime|pgp|snmp|pw)$");
-  gvm_validator_add (validator, "credential_login",
-                     "^[-_[:alnum:]\\.@\\\\]*$");
+  gvm_validator_add (validator, "credential_login", "^[-_[:alnum:]\\.@\\\\]*$");
   gvm_validator_add (validator, "condition_data:name", "^.*$");
   gvm_validator_add (validator, "condition_data:value", "(?s)^.*$");
   gvm_validator_add (validator, "cvss_av", "^(L|A|N)$");
@@ -548,8 +547,7 @@ init_validator ()
                      "^.*[[0-9abcdefABCDEF\\-]*]:.*$");
   gvm_validator_add (validator, "exclude_file:value", "^yes$");
   gvm_validator_add (validator, "file", "(?s)^.*$");
-  gvm_validator_add (validator, "file:name",
-                     "^.*[[0-9abcdefABCDEF\\-]*]:.*$");
+  gvm_validator_add (validator, "file:name", "^.*[[0-9abcdefABCDEF\\-]*]:.*$");
   gvm_validator_add (validator, "file:value", "^yes$");
   gvm_validator_add (validator, "settings_changed:name", "^.*$");
   gvm_validator_add (validator, "settings_changed:value", "^[a-z0-9\\-]+$");
@@ -624,13 +622,11 @@ init_validator ()
   gvm_validator_add (validator, "password", "^.*$");
   gvm_validator_add (validator, "password:value", "(?s)^.*$");
   gvm_validator_add (validator, "port", "^.*$");
-  gvm_validator_add (validator, "port_range",
-                     "^((default)|([-0-9, TU:]+))$");
+  gvm_validator_add (validator, "port_range", "^((default)|([-0-9, TU:]+))$");
   gvm_validator_add (validator, "port_type", "^(tcp|udp)$");
   /** @todo Better regex. */
   gvm_validator_add (validator, "preference_name", "^.*$");
-  gvm_validator_add (validator, "preference:name",
-                     "^([^:]*:[^:]*:.*){0,400}$");
+  gvm_validator_add (validator, "preference:name", "^([^:]*:[^:]*:.*){0,400}$");
   gvm_validator_add (validator, "preference:value", "(?s)^.*$");
   gvm_validator_add (validator, "prev_action", "(?s)^.*$");
   gvm_validator_add (validator, "privacy_algorithm", "^(aes|des|)$");

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -139,7 +139,6 @@ gchar *manager_address = NULL;
  */
 int manager_port = 9390;
 
-
 #define XML_REPORT_FORMAT_ID "a994b278-1f62-11e1-96ac-406186ea4fc5"
 #define ANONXML_REPORT_FORMAT_ID "5057e5cc-b825-11e4-9d0e-28d24461215b"
 
@@ -446,18 +445,11 @@ envelope_gmp (gvm_connection_t *connection, credentials_t *credentials,
     "<i18n>%s</i18n>"
     "<client_address>%s</client_address>"
     "<backend_operation>%.2f</backend_operation>",
-    GSAD_VERSION,
-    vendor_version_get (),
-    user_get_token (user),
-    ctime_now,
-    timezone ? timezone : "",
-    user_get_username (user),
-    user_get_session_timeout (user),
-    user_get_role (user),
-    user_get_severity (user),
-    credentials_get_language (credentials),
-    user_get_client_address (user),
-    credentials_get_cmd_duration (credentials));
+    GSAD_VERSION, vendor_version_get (), user_get_token (user), ctime_now,
+    timezone ? timezone : "", user_get_username (user),
+    user_get_session_timeout (user), user_get_role (user),
+    user_get_severity (user), credentials_get_language (credentials),
+    user_get_client_address (user), credentials_get_cmd_duration (credentials));
 
   g_string_append (string, res);
   g_free (res);
@@ -9590,13 +9582,8 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
     " report_id=\"%s\""
     " delta_report_id=\"%s\""
     " format_id=\"%s\"/>",
-    ignore_pagination,
-    filter,
-    filter_id ? filter_id : FILT_ID_NONE,
-    report_id,
-    delta_report_id ? delta_report_id : "0",
-    format_id ? format_id : ""
-  );
+    ignore_pagination, filter, filter_id ? filter_id : FILT_ID_NONE, report_id,
+    delta_report_id ? delta_report_id : "0", format_id ? format_id : "");
 
   if (ret == -1)
     {
@@ -9853,9 +9840,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
         g_string_append (xml, extra_xml);
 
       if (delta_report_id)
-        g_string_append_printf (xml,
-                                "<delta>%s</delta>",
-                                delta_report_id);
+        g_string_append_printf (xml, "<delta>%s</delta>", delta_report_id);
 
       entity = NULL;
       if (read_entity_and_string_c (connection, &entity, &xml))
@@ -9870,20 +9855,20 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
             response_data);
         }
 
-    if (gmp_success (entity) != 1)
-      {
-        gchar *message;
+      if (gmp_success (entity) != 1)
+        {
+          gchar *message;
 
-        set_http_status_from_entity (entity, response_data);
+          set_http_status_from_entity (entity, response_data);
 
-        message =
-          gsad_message (credentials, "Error", __FUNCTION__, __LINE__,
-                        entity_attribute (entity, "status_text"), response_data);
+          message = gsad_message (credentials, "Error", __FUNCTION__, __LINE__,
+                                  entity_attribute (entity, "status_text"),
+                                  response_data);
 
-        g_string_free (xml, TRUE);
-        free_entity (entity);
-        return message;
-      }
+          g_string_free (xml, TRUE);
+          free_entity (entity);
+          return message;
+        }
 
       report_entity = entity_child (entity, "report");
       if (report_entity)
@@ -11886,13 +11871,13 @@ get_system_report_gmp (gvm_connection_t *connection, credentials_t *credentials,
           CHECK_VARIABLE_INVALID (start_time, "Get System Report")
           CHECK_VARIABLE_INVALID (end_time, "Get System Report")
 
-          gmp_command = g_markup_printf_escaped (
-            "<get_system_reports"
-            " name=\"%s\""
-            " start_time=\"%s\""
-            " end_time=\"%s\""
-            " slave_id=\"%s\"/>",
-            name, start_time, end_time, slave_id ? slave_id : "0");
+          gmp_command = g_markup_printf_escaped ("<get_system_reports"
+                                                 " name=\"%s\""
+                                                 " start_time=\"%s\""
+                                                 " end_time=\"%s\""
+                                                 " slave_id=\"%s\"/>",
+                                                 name, start_time, end_time,
+                                                 slave_id ? slave_id : "0");
         }
 
       if (gvm_connection_sendf (connection, "%s", gmp_command) == -1)
@@ -13999,7 +13984,7 @@ create_permission_gmp (gvm_connection_t *connection, credentials_t *credentials,
       break;
     case 1:
       cmd_response_data_set_status_code (response_data,
-                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
+                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
         credentials, "Internal error", __FUNCTION__, __LINE__,
         "An internal error occurred while creating a permission. "
@@ -14008,7 +13993,7 @@ create_permission_gmp (gvm_connection_t *connection, credentials_t *credentials,
         response_data);
     case 2:
       cmd_response_data_set_status_code (response_data,
-                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
+                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
         credentials, "Internal error", __FUNCTION__, __LINE__,
         "An internal error occurred while creating a permission. "
@@ -14017,7 +14002,7 @@ create_permission_gmp (gvm_connection_t *connection, credentials_t *credentials,
         response_data);
     default:
       cmd_response_data_set_status_code (response_data,
-                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
+                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
         credentials, "Internal error", __FUNCTION__, __LINE__,
         "An internal error occurred while creating a permission. "
@@ -14030,7 +14015,7 @@ create_permission_gmp (gvm_connection_t *connection, credentials_t *credentials,
     params_add (params, "permission_id", entity_attribute (entity, "id"));
 
   html = response_from_entity (connection, credentials, params, entity,
-                                "Create Permission", response_data);
+                               "Create Permission", response_data);
 
   free_entity (entity);
   g_free (response);

--- a/gsad/src/gsad_http.c
+++ b/gsad/src/gsad_http.c
@@ -412,8 +412,7 @@ create_not_found_response (const gchar *url, cmd_response_data_t *response_data)
     "</p>"
     "</body>"
     "</html>",
-    url
-  );
+    url);
 
   cmd_response_data_set_content_type (response_data,
                                       GSAD_CONTENT_TYPE_TEXT_HTML);
@@ -1030,18 +1029,17 @@ gsad_message (credentials_t *credentials, const char *title,
     }
   else
     {
-      xml =
-        g_strdup_printf ("<envelope>"
-                         "<version>%s</version>"
-                         "<vendor_version>%s</vendor_version>"
-                         "<gsad_response>"
-                         "%s"
-                         "<message>%s</message>"
-                         "<token></token>"
-                         "</gsad_response>"
-                         "</envelope>",
-                         GSAD_VERSION, vendor_version_get (),
-                         xmltitle, msg ? msg : "");
+      xml = g_strdup_printf ("<envelope>"
+                             "<version>%s</version>"
+                             "<vendor_version>%s</vendor_version>"
+                             "<gsad_response>"
+                             "%s"
+                             "<message>%s</message>"
+                             "<token></token>"
+                             "</gsad_response>"
+                             "</envelope>",
+                             GSAD_VERSION, vendor_version_get (), xmltitle,
+                             msg ? msg : "");
     }
 
   g_free (xmltitle);

--- a/gsad/src/gsad_user.c
+++ b/gsad/src/gsad_user.c
@@ -359,9 +359,8 @@ user_add (const gchar *username, const gchar *password, const gchar *timezone,
       user_free (user);
     }
 
-  user =
-    user_new_with_data (username, password, timezone, severity, role,
-                        capabilities, language, pw_warning, address);
+  user = user_new_with_data (username, password, timezone, severity, role,
+                             capabilities, language, pw_warning, address);
 
   session_add_user (user->token, user);
 


### PR DESCRIPTION
This adds clang-format checks to CircleCI for the C code, similar to the other modules.

**Checklist**:
 
- [] Tests N/A
- [] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry N/A
