### PR TITLE
modified y-domain of bar.js to account for yMax = 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add storybook [#1272](https://github.com/greenbone/gsa/pull/1286)
 
 ### Changed
+- Modified the y-domain of bar graph to account for yMax = 0 [#1445](https://github.com/greenbone/gsa/pull/1445)
 - Changed FilterTerm to convert all filter keywords to lower case [#1444](https://github.com/greenbone/gsa/pull/1444)
 - Use Reacts new ref API (no innerRef anymore [#1441](https://github.com/greenbone/gsa/pull/1441))
 - Allow dynamic ref types in NVT model and adjust CertLink to it [#1434](https://github.com/greenbone/gsa/pull/1434)

--- a/gsa/src/web/components/chart/bar.js
+++ b/gsa/src/web/components/chart/bar.js
@@ -155,7 +155,7 @@ class BarChart extends React.Component {
 
     const yScale = scaleLinear()
       .range(horizontal ? [0, maxWidth] : [maxHeight, 0])
-      .domain([0, yMax])
+      .domain([0, Math.abs(yMax) > 0 ? yMax : 10])
 
       /*
         nice seems to round first and last value.


### PR DESCRIPTION
<!--

-->
  The default data had yMax = 0, resulting in the graph having y-domain [0:0]. This change supplies range [0:10] in such a case.
**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
