### PR TITLE
modified y-domain to avoid range [0,0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add storybook [#1272](https://github.com/greenbone/gsa/pull/1286)
 
 ### Changed
+- Modified the BarChart's y-domain to avoid range [0,0]. [#1447](https://github.com/greenbone/gsa/pull/1447)
 - Changed FilterTerm to convert all filter keywords to lower case [#1444](https://github.com/greenbone/gsa/pull/1444)
 - Use Reacts new ref API (no innerRef anymore [#1441](https://github.com/greenbone/gsa/pull/1441))
 - Allow dynamic ref types in NVT model and adjust CertLink to it [#1434](https://github.com/greenbone/gsa/pull/1434)

--- a/gsa/src/web/components/chart/bar.js
+++ b/gsa/src/web/components/chart/bar.js
@@ -155,7 +155,7 @@ class BarChart extends React.Component {
 
     const yScale = scaleLinear()
       .range(horizontal ? [0, maxWidth] : [maxHeight, 0])
-      .domain([0, yMax])
+      .domain([0, Math.abs(yMax) > 0 ? yMax : 10])
 
       /*
         nice seems to round first and last value.


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
modified y-domain to avoid range [0,0]. The previous version had y-domain [0,0] with default data.
**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
