### PR TITLE
Remove gsad trash case for tls_certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Add storybook [#1272](https://github.com/greenbone/gsa/pull/1286)
-- Added TLS certificates to the asset management. [#1455](https://github.com/greenbone/gsa/pull/1455)
+- Added TLS certificates to the asset management.
+  [#1455](https://github.com/greenbone/gsa/pull/1455),
+  [#1461](https://github.com/greenbone/gsa/pull/1461)
 
 ### Changed
 - Modified the BarChart's y-domain to avoid range [0,0]. [#1447](https://github.com/greenbone/gsa/pull/1447)

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -11600,9 +11600,6 @@ get_trash (gvm_connection_t *connection, credentials_t *credentials,
 
   GET_TRASH_RESOURCE ("GET_TICKETS", "get_tickets", "tickets");
 
-  GET_TRASH_RESOURCE ("GET_TLS_CERTIFICATES", "get_tls_certificates",
-                      "tls_certificates");
-
   /* Cleanup, and return transformed XML. */
 
   g_string_append (xml, "</get_trash>");


### PR DESCRIPTION
For consistency with other asset types, TLS certificates will no longer
use the trashcan in upcoming gvmd changes.

**Checklist**:
- N/A Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
