### PR TITLE
Add Buster yarn package executable

### DIFF
--- a/cmake/FindYarn.cmake
+++ b/cmake/FindYarn.cmake
@@ -18,7 +18,7 @@
 
 # CMake find module for yarn package manager
 
-find_program (YARN_EXECUTABLE NAMES yarn
+find_program (YARN_EXECUTABLE NAMES yarn yarnpkg
   HINTS
   $ENV{NODE_DIR}
   PATH_SUFFIXES bin


### PR DESCRIPTION
Debian Buster ships with a yarn package that's compatible with gsa but it's executable name is `yarnpkg`

**Checklist**:

- [] Tests - N/A
- [] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry - N/A
