### PR TITLE
Add usage_type to get_tasks and get_configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added TLS certificates to the asset management.
   [#1455](https://github.com/greenbone/gsa/pull/1455),
   [#1461](https://github.com/greenbone/gsa/pull/1461)
+- Add policies and audits to separate compliance testing from regular
+  vulnerability scanning.
+  [#1460](https://github.com/greenbone/gsa/pull/1460)
+  [#1466](https://github.com/greenbone/gsa/pull/1466)
 
 ### Changed
 - Modified the BarChart's y-domain to avoid range [0,0]. [#1447](https://github.com/greenbone/gsa/pull/1447)

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -3028,11 +3028,14 @@ char *
 get_tasks_gmp (gvm_connection_t *connection, credentials_t *credentials,
                params_t *params, cmd_response_data_t *response_data)
 {
-  const char *schedules_only, *ignore_pagination;
+  const char *schedules_only, *ignore_pagination, *usage_type;
   gmp_arguments_t *arguments;
 
   schedules_only = params_value (params, "schedules_only");
   ignore_pagination = params_value (params, "ignore_pagination");
+  usage_type = params_value (params, "usage_type");
+  if (params_given (params, "usage_type"))
+    CHECK_VARIABLE_INVALID (usage_type, "Get Tasks");
 
   arguments = gmp_arguments_new ();
 
@@ -3044,6 +3047,11 @@ get_tasks_gmp (gvm_connection_t *connection, credentials_t *credentials,
   if (ignore_pagination)
     {
       gmp_arguments_add (arguments, "ignore_pargination", ignore_pagination);
+    }
+
+  if (usage_type)
+    {
+      gmp_arguments_add (arguments, "usage_type", usage_type);
     }
 
   return get_many (connection, "tasks", credentials, params, arguments,
@@ -7204,7 +7212,20 @@ char *
 get_configs_gmp (gvm_connection_t *connection, credentials_t *credentials,
                  params_t *params, cmd_response_data_t *response_data)
 {
-  return get_many (connection, "configs", credentials, params, NULL,
+  const char *usage_type;
+  gmp_arguments_t *arguments = NULL;
+
+  usage_type = params_value (params, "usage_type");
+  if (params_given (params, "usage_type"))
+    CHECK_VARIABLE_INVALID (usage_type, "Get Configs")
+
+  if (usage_type)
+    {
+      arguments = gmp_arguments_new ();
+      gmp_arguments_add (arguments, "usage_type", usage_type);
+    }
+
+  return get_many (connection, "configs", credentials, params, arguments,
                    response_data);
 }
 


### PR DESCRIPTION
This allows viewing only tasks and configs of a certain usage_type.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
