### PR TITLE
Fix displaying ical events without timezone info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Cleanup get_report function in gsad [#1263](https://github.com/greenbone/gsa/pull/1263)
 
 ### Fixed
+- Fix displaying schedules created during migration [#1478](https://github.com/greenbone/gsa/pull/1478)
 - Fix showing Loading indicator at entities pages [#1469](https://github.com/greenbone/gsa/pull/1469)
 - Show notes and overrides for results and their icon indicator in results rows [#1446](https://github.com/greenbone/gsa/pull/1446)
 - Display text if gvm-libs is build without LDAP and/or Radius support [#1437](https://github.com/greenbone/gsa/pull/1437)

--- a/gsa/src/gmp/models/__tests__/event.js
+++ b/gsa/src/gmp/models/__tests__/event.js
@@ -1,0 +1,74 @@
+/* Copyright (C) 2019 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import Event from '../event';
+
+describe('Event model tests', () => {
+  test('should parse event start from icalendar without timzeone', () => {
+    const icalendar = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Greenbone.net//NONSGML Greenbone Security Manager 8.0.0//EN
+BEGIN:VEVENT
+UID:c35f82f1-7798-4b84-b2c4-761a33068956
+DTSTAMP:20190715T124352Z
+DTSTART:20190716T040000
+END:VEVENT
+END:VCALENDAR
+`;
+
+    const event = Event.fromIcal(icalendar, 'Europe/Berlin');
+
+    expect(event.event).toBeDefined();
+
+    const {startDate: eventStartDate} = event.event;
+
+    expect(eventStartDate).toBeDefined();
+    expect(eventStartDate.utcOffset()).toEqual(0);
+
+    // no timezone in ical should be considered as datetime in passed timezone (Europe/Berlin)
+    const {startDate} = event;
+    expect(startDate.hour()).toEqual(4);
+    expect(startDate.tz('UTC').hour()).toEqual(2);
+  });
+
+  test('should parse event start from icalendar using utc', () => {
+    const icalendar = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Greenbone.net//NONSGML Greenbone Security Manager 8.0.0//EN
+BEGIN:VEVENT
+UID:c35f82f1-7798-4b84-b2c4-761a33068956
+DTSTAMP:20190715T124352Z
+DTSTART:20190716T040000Z
+END:VEVENT
+END:VCALENDAR
+`;
+
+    const event = Event.fromIcal(icalendar, 'Europe/Berlin');
+
+    expect(event.event).toBeDefined();
+
+    const {startDate: eventStartDate} = event.event;
+
+    expect(eventStartDate).toBeDefined();
+    expect(eventStartDate.utcOffset()).toEqual(0);
+
+    const {startDate} = event;
+    expect(startDate.hour()).toEqual(6);
+    expect(startDate.tz('UTC').hour()).toEqual(4);
+  });
+});

--- a/gsa/src/gmp/models/event.js
+++ b/gsa/src/gmp/models/event.js
@@ -32,10 +32,16 @@ import date, {duration as createDuration} from './date';
 
 const log = Logger.getLogger('gmp.models.event');
 
-const convertIcalDate = (idate, timezone) =>
-  isDefined(timezone)
-    ? date.unix(idate.toUnixTime()).tz(timezone)
-    : date.unix(idate.toUnixTime());
+const convertIcalDate = (idate, timezone) => {
+  if (isDefined(timezone)) {
+    if (idate.zone === ical.Timezone.localTimezone) {
+      // assume timezone hasn't been set and date wasn't supposed to use floating and therefore local timezone
+      return date.tz(idate.toString(), timezone);
+    }
+    return date.unix(idate.toUnixTime()).tz(timezone);
+  }
+  return date.unix(idate.toUnixTime());
+};
 
 const setEventDuration = (event, duration) => {
   // setting the duration of an event directly isn't possible in


### PR DESCRIPTION
Consider datetimes in ical data to be in the timezone passed in the
additional timezone field. Before the schedule datetimes onyl would have
been displayed in this timezone.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
