### PR TITLE
Find python modules correctly

### DIFF
--- a/cmake/FindPythonModule.cmake
+++ b/cmake/FindPythonModule.cmake
@@ -1,26 +1,67 @@
-# From: https://cmake.org/pipermail/cmake/2011-January/041666.html
+# - Macro to find a python module
 #
-# Use it like that: find_python_module(PyQt4 REQUIRED)
+# Usage:
+#  include (FindPythonModule)
+#  find_python_module (module [VERSION] [REQUIRED])
+#
+# The following variables are defined:
+#  MODULE_FOUND - true if found
+#  MODULE_LOCATION - directory of the module, or it's library file if binary module
+#  MODULE_VERSION_STRING - module version, if available through __version__
+#
 
+macro (find_python_module module)
 
-function(find_python_module module)
-    string(TOUPPER ${module} module_upper)
-    if(NOT PY_${module_upper})
-        if(ARGC GREATER 1 AND ARGV1 STREQUAL "REQUIRED")
-            set(${module}_FIND_REQUIRED TRUE)
-        endif()
-        # A module's location is usually a directory, but for binary modules
-        # it's a .so file.
-        execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
-            "import re, ${module}; print re.compile('/__init__.py.*').sub('',${module}.__file__)"
-            RESULT_VARIABLE _${module}_status
-            OUTPUT_VARIABLE _${module}_location
-            ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-        if(NOT _${module}_status)
-            set(PY_${module_upper} ${_${module}_location} CACHE STRING
-                "Location of Python module ${module}")
-        endif(NOT _${module}_status)
-    endif(NOT PY_${module_upper})
-    find_package_handle_standard_args(PY_${module} DEFAULT_MSG PY_${module_upper})
-    set(PY_${module_upper}_FOUND ${PY_${module_upper}_FOUND} PARENT_SCOPE)
-endfunction(find_python_module)
+  string (TOUPPER ${module} module_upper)
+  if (NOT ${module_upper}_FOUND)
+
+    # parse arguments
+    set (${module}_FIND_OPTIONAL TRUE)
+    if (${ARGC} EQUAL 2)
+      if (${ARGV1} MATCHES REQUIRED)
+        set (${module}_FIND_OPTIONAL FALSE)
+      else ()
+        set (${module}_FIND_VERSION ${ARGV1})
+      endif ()
+    elseif (${ARGC} EQUAL 3)
+      if (${ARGV2} MATCHES REQUIRED)
+        set (${module}_FIND_OPTIONAL FALSE)
+      endif ()
+      set (${module}_FIND_VERSION ${ARGV1})
+    endif ()
+
+    # A module's location is usually a directory, but for binary modules it's a .so file.
+    execute_process (COMMAND "${PYTHON_EXECUTABLE}" "-c" 
+                      "import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
+                      RESULT_VARIABLE _${module}_status
+                      OUTPUT_VARIABLE _${module}_location
+                      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (NOT _${module}_status)
+      set (${module_upper}_LOCATION ${_${module}_location}
+            CACHE STRING "Location of Python module ${module}")
+      # retrieve version
+      execute_process (COMMAND "${PYTHON_EXECUTABLE}" "-c" "import ${module}; print(${module}.__version__)"
+                        RESULT_VARIABLE _${module}_status
+                        OUTPUT_VARIABLE _${module}_version
+                        ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+      set (_${module_upper}_VERSION_MATCH TRUE)
+      if (NOT _${module}_status)
+        set (${module_upper}_VERSION_STRING ${_${module}_version})
+        if (${module}_FIND_VERSION)
+          if (${module}_FIND_VERSION VERSION_GREATER ${module_upper}_VERSION_STRING)
+            set (_${module_upper}_VERSION_MATCH FALSE)
+          endif ()
+        endif ()
+        mark_as_advanced (${module_upper}_VERSION_STRING)
+      endif ()
+    endif ()
+
+    find_package_handle_standard_args (${module} REQUIRED_VARS ${module_upper}_LOCATION
+                                        ${module}_FIND_OPTIONAL
+                                        _${module_upper}_VERSION_MATCH
+                                        VERSION_VAR ${module_upper}_VERSION_STRING
+                                     )
+    mark_as_advanced (${module_upper}_LOCATION)
+  endif (NOT ${module_upper}_FOUND)
+endmacro (find_python_module)

--- a/gsa/po/CMakeLists.txt
+++ b/gsa/po/CMakeLists.txt
@@ -43,7 +43,7 @@ macro (MAKE_TRANSLATION _LANG)
 endmacro ()
 
 if (GETTEXT_FOUND)
-  if (PY_POLIB_FOUND)
+  if (POLIB_FOUND)
 
     file (MAKE_DIRECTORY ${GSA_LOCALE_DIR})
 
@@ -107,9 +107,9 @@ if (GETTEXT_FOUND)
              ${GSA_LOCALE_DIR}
              DESTINATION ${GSA_DEST_DIR})
 
-  else (PY_POLIB_FOUND)
+  else (POLIB_FOUND)
     message (WARNING "Could not build translation files: Python interpreter or polib Python module not found.")
-  endif (PY_POLIB_FOUND)
+  endif (POLIB_FOUND)
 
 else (GETTEXT_FOUND)
   message (WARNING "Could not build translation files: gettext not found.")


### PR DESCRIPTION
**Fixes (missing: PY_POLIB) error on build time.**

Actual behavior:

```
-- Could NOT find PY_polib (missing: PY_POLIB) 
   CMake Warning at gsa/po/CMakeLists.txt:108 (message):
   Could not build translation files: Python interpreter or polib Python
   module not found.
```
Expected behavior:

`-- Found polib: /usr/lib64/python3.6/site-packages/polib.py (found version "1.1.0")`

After fix:

`-- Found polib: /usr/lib64/python3.6/site-packages/polib.py (found version "1.1.0")`

I tried to push gsa-8.0 branch but messed it up, sorry :)
Old PR https://github.com/greenbone/gsa/pull/1482