### PR TITLE
Fix redirect from http to https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix using filename templates from usersettings [#1512](https://github.com/greenbone/gsa/pull/1512)
 - Allow to use additional options for starting gsad via systemd
   [#1514](https://github.com/greenbone/gsa/pull/1514)
+- Redirect to root URL by default [#1517](https://github.com/greenbone/gsa/pull/1517)
 
 [8.0.2]: https://github.com/greenbone/gsa/compare/v8.0.1...gsa-8.0
 

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -3057,8 +3057,7 @@ main (int argc, char **argv)
                        " %s\n",
                        __FUNCTION__, strerror (errno));
 #endif
-          redirect_location =
-            g_strdup_printf ("https://%%s:%i/login/login.html", gsad_port);
+          redirect_location = g_strdup_printf ("https://%%s:%i/", gsad_port);
           break;
         case -1:
           /* Parent when error. */


### PR DESCRIPTION
The login/login.html url doesn't exists anymore. It still works because
/login<*> will show the login js page but actually the old page doesn't
exist anymore.

Always redirect to the root location now. The js code is responsible for
showing the login page now.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
