### PR TITLE
modified edit schedule dialog to avoid start date in the past

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#1466](https://github.com/greenbone/gsa/pull/1466) [#1467](https://github.com/greenbone/gsa/pull/1467)
 
 ### Changed
+- Changed schedule dialog (added Now button) to help users jump to current time ASAP [#1519](https://github.com/greenbone/gsa/pull/1519)
 - Changed the filter dialogues for tasks and overrides [#1511](https://github.com/greenbone/gsa/pull/1511)
 - modified filterdialogs for reports and vulnerabilities [#1503](https://github.com/greenbone/gsa/pull/1503)
 - Changed filterdialog for tickets page [#1489](https://github.com/greenbone/gsa/pull/1489)

--- a/gsa/src/web/pages/schedules/dialog.js
+++ b/gsa/src/web/pages/schedules/dialog.js
@@ -215,8 +215,8 @@ class ScheduleDialog extends React.Component {
 
   handleNowButtonClick() {
     const {timezone} = this.state;
-    const Now = date().tz(timezone);
-    this.setState({startDate: Now});
+    const now = date().tz(timezone);
+    this.setState({startDate: now});
   }
 
   handleEndHoursChange(value) {

--- a/gsa/src/web/pages/schedules/dialog.js
+++ b/gsa/src/web/pages/schedules/dialog.js
@@ -46,6 +46,7 @@ import WeekDaySelect, {WeekDaysPropType} from './weekdayselect';
 import {renderDuration} from './render';
 import DaySelect from './dayselect';
 import MonthDaysSelect from './monthdaysselect';
+import Button from 'web/components/form/button';
 
 const RECURRENCE_ONCE = 'once';
 const RECURRENCE_HOURLY = ReccurenceFrequency.HOURLY;
@@ -134,6 +135,7 @@ class ScheduleDialog extends React.Component {
     this.handleEndHoursChange = this.handleEndHoursChange.bind(this);
     this.handleEndMinutesChange = this.handleEndMinutesChange.bind(this);
     this.handleTimezoneChange = this.handleTimezoneChange.bind(this);
+    this.handleNowButtonClick = this.handleNowButtonClick.bind(this);
   }
 
   initialState(props) {
@@ -209,6 +211,12 @@ class ScheduleDialog extends React.Component {
     this.setState(state => ({
       startDate: state.startDate.minutes(value),
     }));
+  }
+
+  handleNowButtonClick() {
+    const {timezone} = this.state;
+    const Now = date().tz(timezone);
+    this.setState({startDate: Now});
   }
 
   handleEndHoursChange(value) {
@@ -423,11 +431,12 @@ class ScheduleDialog extends React.Component {
               />
             </FormGroup>
 
-            <FormGroup title={_('Start')}>
+            <FormGroup title={_('First Run')}>
               <DatePicker
                 name="startDate"
                 value={startDate}
                 onChange={this.handleValueChange}
+                showYearDropdown
               />
               <Divider>
                 <Spinner
@@ -450,10 +459,11 @@ class ScheduleDialog extends React.Component {
                   onChange={this.handleStartMinutesChange}
                 />
                 <span>m</span>
+                <Button title="Now" onClick={this.handleNowButtonClick} />
               </Divider>
             </FormGroup>
 
-            <FormGroup title={_('End')}>
+            <FormGroup title={_('Run Until')}>
               <DatePicker
                 disabled={state.endOpen}
                 name="endDate"


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
- Added a "now" button to help users jump to current date
- Added year dropdown in case users deal with timeframes far from now, to avoid excessive clicking.
- Changed some titles to hopefully make explicit to the user values they're changing

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
