### PR TITLE
Change authentification to authentication.

### DIFF
--- a/gsa/src/web/pages/reports/hoststable.js
+++ b/gsa/src/web/pages/reports/hoststable.js
@@ -192,28 +192,28 @@ const renderAuthIcons = authSuccess => {
   return (
     <IconDivider>
       {showSmbSuccess && (
-        <VerifyIcon title={_('SMB authentification was successful')} />
+        <VerifyIcon title={_('SMB authentication was successful')} />
       )}
       {showSmbFailure && (
-        <VerifyNoIcon title={_('SMB authentification was unsuccessful')} />
+        <VerifyNoIcon title={_('SMB authentication was unsuccessful')} />
       )}
       {showSnmpSuccess && (
-        <VerifyIcon title={_('SNMP authentification was successful')} />
+        <VerifyIcon title={_('SNMP authentication was successful')} />
       )}
       {showSnmpFailure && (
-        <VerifyNoIcon title={_('SNMP authentification was unsuccessful')} />
+        <VerifyNoIcon title={_('SNMP authentication was unsuccessful')} />
       )}
       {showEsxiSuccess && (
-        <VerifyIcon title={_('ESXi authentification was successful')} />
+        <VerifyIcon title={_('ESXi authentication was successful')} />
       )}
       {showEsxiFailure && (
-        <VerifyNoIcon title={_('ESXi authentification was unsuccessful')} />
+        <VerifyNoIcon title={_('ESXi authentication was unsuccessful')} />
       )}
       {showSshSuccess && (
-        <VerifyIcon title={_('SSH authentification was successful')} />
+        <VerifyIcon title={_('SSH authentication was successful')} />
       )}
       {showSshFailure && (
-        <VerifyNoIcon title={_('SSH authentification was unsuccessful')} />
+        <VerifyNoIcon title={_('SSH authentication was unsuccessful')} />
       )}
     </IconDivider>
   );


### PR DESCRIPTION
While ``authentification`` is correct according to e.g. https://english.stackexchange.com/questions/7844/is-authentification-a-real-word or https://en.wiktionary.org/wiki/authentification rename the word to ``authentication`` to keep / use the same wording like in the documentation:

https://docs.greenbone.net/GSM-Manual/gos-4/en/search.html?q=authentication

Note that even some spellcheckers like the build-in of Firefox is also directly reporting a spelling error for ``authentification``.

Replacement for #1520

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
