### PR TITLE
Ical date recurrence fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   logged in [#1508](https://github.com/greenbone/gsa/pull/1508)
 
 ### Fixed
+- Fix calculating the next date of schedules [#1539](https://github.com/greenbone/gsa/pull/1539)
 - Fix linking to best OS in host details [#1528](https://github.com/greenbone/gsa/pull/1528)
 - Fix showing details for tasks [#1515](https://github.com/greenbone/gsa/pull/1515)
 - Fix using filename templates from usersettings [#1512](https://github.com/greenbone/gsa/pull/1512)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   logged in [#1508](https://github.com/greenbone/gsa/pull/1508)
 
 ### Fixed
-- Fix calculating the next date of schedules [#1539](https://github.com/greenbone/gsa/pull/1539)
 - Don't crash Alerts listpage and trashcan when Alert data is missing [#1541](https://github.com/greenbone/gsa/pull/1541)
+- Fix calculating the next date of schedules [#1539](https://github.com/greenbone/gsa/pull/1539)
 - Fix linking to best OS in host details [#1528](https://github.com/greenbone/gsa/pull/1528)
 - Redirect to root URL by default [#1517](https://github.com/greenbone/gsa/pull/1517)
 - Fix showing details for tasks [#1515](https://github.com/greenbone/gsa/pull/1515)

--- a/gsa/src/gmp/models/__tests__/event.js
+++ b/gsa/src/gmp/models/__tests__/event.js
@@ -16,7 +16,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+import date from '../date';
+
 import Event from '../event';
+
+const ICAL_FORMAT = 'YYYYMMDD[T]HHmmss[Z]';
 
 describe('Event model tests', () => {
   test('should parse event start from icalendar without timzeone', () => {
@@ -70,5 +74,67 @@ END:VCALENDAR
     const {startDate} = event;
     expect(startDate.hour()).toEqual(6);
     expect(startDate.tz('UTC').hour()).toEqual(4);
+  });
+
+  test('should calculate start date as next date for daily recurrence', () => {
+    const now = date
+      .tz('utc')
+      .minutes(0)
+      .seconds(0)
+      .milliseconds(0);
+    const startDate = now.clone().add(1, 'hour');
+    const icalendar = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Greenbone.net//NONSGML Greenbone Security Manager 8.0.0//EN
+BEGIN:VEVENT
+UID:c35f82f1-7798-4b84-b2c4-761a33068956
+DTSTART:${startDate.format(ICAL_FORMAT)}
+DTSTAMP:${now.format(ICAL_FORMAT)}
+RRULE:FREQ=DAILY
+END:VEVENT
+END:VCALENDAR
+`;
+
+    const event = Event.fromIcal(icalendar, 'Europe/Berlin');
+
+    expect(event).toBeDefined();
+
+    const {nextDate} = event;
+
+    // next event should be start date
+    expect(nextDate.isSame(startDate)).toEqual(true);
+  });
+
+  test('should calculate next day as next day for daily recurrence', () => {
+    const now = date
+      .tz('utc')
+      .minutes(0)
+      .seconds(0)
+      .milliseconds(0);
+    const startDate = now.clone().subtract(1, 'hour');
+    const icalendar = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Greenbone.net//NONSGML Greenbone Security Manager 8.0.0//EN
+BEGIN:VEVENT
+UID:c35f82f1-7798-4b84-b2c4-761a33068956
+DTSTART:${startDate.format(ICAL_FORMAT)}
+DTSTAMP:${now.format(ICAL_FORMAT)}
+RRULE:FREQ=DAILY
+END:VEVENT
+END:VCALENDAR
+`;
+
+    const event = Event.fromIcal(icalendar, 'Europe/Berlin');
+
+    expect(event).toBeDefined();
+
+    const {nextDate} = event;
+
+    // next event should be next day
+    expect(nextDate.isSame(startDate)).toEqual(false);
+    expect(nextDate.isAfter(startDate)).toEqual(true);
+
+    const rDate = startDate.clone().add(1, 'day');
+    expect(nextDate.isSame(rDate)).toEqual(true);
   });
 });

--- a/gsa/src/gmp/models/event.js
+++ b/gsa/src/gmp/models/event.js
@@ -370,7 +370,13 @@ class Event {
           // month are set in the rrule. Therefore ignore error and retry to get
           // a new date. Fail after 5 unsuccessful attempts
           retries++;
-          log.warn('Error raised while calculating next date', err);
+          if (retries >= 5) {
+            log.error(
+              'Error raised while calculating next date.',
+              'ical event was:\n' + this.event + '\n',
+              err,
+            );
+          }
         }
       }
     }

--- a/gsa/src/gmp/models/event.js
+++ b/gsa/src/gmp/models/event.js
@@ -352,14 +352,14 @@ class Event {
 
   get nextDate() {
     if (this.isRecurring()) {
-      const now = ical.Time.now();
+      const now = date();
       const it = this.event.iterator();
 
       let retries = 0;
       while (true && retries <= 5) {
         try {
           const next = it.next();
-          if (next.compare(now) >= 0) {
+          if (next.toUnixTime() >= now.unix()) {
             return convertIcalDate(next, this.timezone);
           }
           retries = 0;


### PR DESCRIPTION
Fix calculating the next date of a schedule ical event. ical times are evil :imp: 

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
