### PR TITLE
dialog confirmation for verifying scanners

### DIFF
--- a/gsa/src/web/pages/scanners/component.js
+++ b/gsa/src/web/pages/scanners/component.js
@@ -162,23 +162,28 @@ class ScannerComponent extends React.Component {
     this.handleInteraction();
   }
 
+  handleVerifyFailure(response) {
+    const {onVerifyError} = this.props;
+    const message =
+      isDefined(response.root) &&
+      isDefined(response.root.action_result) &&
+      isDefined(response.root.action_result.message)
+        ? response.root.action_result.message
+        : _('Unknown Error');
+
+    if (isDefined(onVerifyError)) {
+      onVerifyError(new Error(message));
+    }
+  }
+
   handleVerifyScanner(scanner) {
-    const {gmp, onVerified, onVerifyError} = this.props;
+    const {gmp, onVerified} = this.props;
 
     this.handleInteraction();
 
-    return gmp.scanner.verify(scanner).then(onVerified, response => {
-      const message =
-        isDefined(response.root) &&
-        isDefined(response.root.get_scanner) &&
-        isDefined(response.root.get_scanner.verify_scanner_response)
-          ? response.root.get_scanner.verify_scanner_response._status_text
-          : _('Unkown Error');
-
-      if (isDefined(onVerifyError)) {
-        onVerifyError(new Error(message));
-      }
-    });
+    return gmp.scanner
+      .verify(scanner)
+      .then(onVerified, response => this.handleVerifyFailure(response));
   }
 
   handleCreateCredential(data) {

--- a/gsa/src/web/pages/scanners/listpage.js
+++ b/gsa/src/web/pages/scanners/listpage.js
@@ -72,6 +72,7 @@ const ScannersPage = ({
   onDownloaded,
   onError,
   onInteraction,
+  showSuccess,
   ...props
 }) => (
   <ScannerComponent
@@ -88,7 +89,10 @@ const ScannersPage = ({
     onDownloaded={onDownloaded}
     onDownloadError={onError}
     onInteraction={onInteraction}
-    onVerified={onChanged}
+    onVerified={() => {
+      onChanged();
+      showSuccess(_('Scanner Verified'));
+    }}
     onVerifyError={onError}
   >
     {({
@@ -129,6 +133,7 @@ const ScannersPage = ({
 );
 
 ScannersPage.propTypes = {
+  showSuccess: PropTypes.func.isRequired,
   onChanged: PropTypes.func.isRequired,
   onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,


### PR DESCRIPTION

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
Show a dialog in case of success of scanner verification. Also, in case of failure, show the correct error message (when there is one) instead of "Unknown Error". I moved handleVerifyFailure out of handleVerifyScanner because I was planning some sort of handleVerifySuccess before. If that is not necessary I can put it back in.
**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
