### PR TITLE
Fix "once" option for schedules in TaskDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   logged in [#1508](https://github.com/greenbone/gsa/pull/1508)
 
 ### Fixed
+- Fix handling schedule_periods ("once" option) in TaskDialog [#1563](https://github.com/greenbone/gsa/pull/1563)
 - Fix showing inactive VerifyIcon at ReportFormats detailspage [#1554](https://github.com/greenbone/gsa/pull/1554)
 - Fix showing SensorIcon for tasks [#1548](https://github.com/greenbone/gsa/pull/1548)
 - Always show an identifier for results [#1543](https://github.com/greenbone/gsa/pull/1543)

--- a/gsa/src/web/pages/tasks/dialog.js
+++ b/gsa/src/web/pages/tasks/dialog.js
@@ -268,6 +268,7 @@ const TaskDialog = ({
     name,
     scanner_type,
     scanner_id,
+    schedule_periods,
     source_iface,
     tag_id,
     tags,


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [ X ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
