### PR TITLE
Search for "yarnpkg" in FindYarn.cmake

### DIFF
--- a/cmake/FindYarn.cmake
+++ b/cmake/FindYarn.cmake
@@ -18,7 +18,7 @@
 
 # CMake find module for yarn package manager
 
-find_program (YARN_EXECUTABLE NAMES yarn
+find_program (YARN_EXECUTABLE NAMES yarn yarnpkg
   HINTS
   $ENV{NODE_DIR}
   PATH_SUFFIXES bin


### PR DESCRIPTION
On Debian >= Buster yarn is now shipped but the binary is called "yarnpkg" instead of "yarn":

https://packages.debian.org/buster/all/yarnpkg/filelist

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
