### PR TITLE
added loading indicator to edit config dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [8.0.2] - unreleased
 
 ### Added
+- Added loading indicator for edit config dialog [#1579](https://github.com/greenbone/gsa/pull/1579)
 - Added tooltip for settings in task edit dialog that can't be changed once the task has been run [#1568](https://github.com/greenbone/gsa/pull/1568)
 - Added success dialog to report formats listpage [#1566](https://github.com/greenbone/gsa/pull/1566)
 - Added an explicit get_capabilities command to gsad [#1538](https://github.com/greenbone/gsa/pull/1538)

--- a/gsa/src/web/pages/scanconfigs/editdialog.js
+++ b/gsa/src/web/pages/scanconfigs/editdialog.js
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 
 import styled from 'styled-components';
 
@@ -40,6 +40,7 @@ import Radio from 'web/components/form/radio';
 import TextField from 'web/components/form/textfield';
 import Select from 'web/components/form/select';
 import YesNoRadio from 'web/components/form/yesnoradio';
+import Loading from 'web/components/loading/loading';
 import {noop_convert} from 'web/components/form/withChangeHandler';
 
 import EditIcon from 'web/components/icon/editicon';
@@ -478,6 +479,18 @@ const EditDialog = ({
     trend,
   };
 
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsLoading(false);
+    }, 500);
+    // we want to show loading indicator while the content of the dialog is loading. 500ms is arbitrary, but the loading indicator will not disappear until rerender with the required content.
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
+
   return (
     <SaveDialog
       title={title}
@@ -487,6 +500,10 @@ const EditDialog = ({
       values={controlledData}
     >
       {({values: state, onValueChange}) => {
+        if (isLoading) {
+          return <Loading />;
+        }
+
         return (
           <Layout flex="column">
             <FormGroup title={_('Name')}>


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Adding loading indicator to spin for 500ms before dialog content is rendered.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
