### PR TITLE
Allow to override id prop for Details pages

### DIFF
--- a/gsa/src/web/entity/withEntityContainer.js
+++ b/gsa/src/web/entity/withEntityContainer.js
@@ -80,9 +80,10 @@ const withEntityContainer = (
     load: id => dispatch(load(gmp)(id)),
   });
 
-  const mapStateToProps = (rootState, {gmp, match, ...props}) => {
-    let {id} = match.params;
-    id = decodeURIComponent(id); // needs to be done for CPE IDs
+  const mapStateToProps = (rootState, {gmp, id, match, ...props}) => {
+    if (!isDefined(id)) {
+      id = decodeURIComponent(match.params.id); // decodeURIComponent needs to be done for CPE IDs
+    }
     const entitySel = entitySelector(rootState);
     const otherProps = isDefined(componentMapStateToProps)
       ? componentMapStateToProps(rootState, {


### PR DESCRIPTION
In tests it is currently not possible to set the id of the entity to be
rendered. This commit extends withEntityComponent to allow overriding
the id of the entity to be loaded.