### PR TITLE
 ticketstatusgroup updated with new filter strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#1466](https://github.com/greenbone/gsa/pull/1466) [#1467](https://github.com/greenbone/gsa/pull/1467)
 
 ### Changed
+- TicketStatusGroup updated with new filter strings [#1594](https://github.com/greenbone/gsa/pull/1594)
 - Reuse NvtFamilies, NvtPreferences and ScannerPreferences from scanconfig detailspage for policy detailspage [#1593](https://github.com/greenbone/gsa/pull/1593)
 - Fix sensor icon not visible in audit row and reuse renderReport from tasks for audits [#1577](https://github.com/greenbone/gsa/pull/1577)
 - Reuse scanconfig edit dialogs for policies [#1573](https://github.com/greenbone/gsa/pull/1573)

--- a/gsa/src/web/components/powerfilter/__tests__/__snapshots__/ticketstatusgroup.js.snap
+++ b/gsa/src/web/components/powerfilter/__tests__/__snapshots__/ticketstatusgroup.js.snap
@@ -334,9 +334,9 @@ exports[`TicketStatusGroup tests should render 1`] = `
         <div
           class="c5"
           data-testid="select-selected-value"
-          title="0"
+          title="Closed"
         >
-          0
+          Closed
         </div>
         <div
           class="c6"

--- a/gsa/src/web/components/powerfilter/__tests__/__snapshots__/ticketstatusgroup.js.snap
+++ b/gsa/src/web/components/powerfilter/__tests__/__snapshots__/ticketstatusgroup.js.snap
@@ -334,9 +334,9 @@ exports[`TicketStatusGroup tests should render 1`] = `
         <div
           class="c5"
           data-testid="select-selected-value"
-          title="Open"
+          title="0"
         >
-          Open
+          0
         </div>
         <div
           class="c6"

--- a/gsa/src/web/components/powerfilter/__tests__/ticketstatusgroup.js
+++ b/gsa/src/web/components/powerfilter/__tests__/ticketstatusgroup.js
@@ -45,7 +45,7 @@ describe('TicketStatusGroup tests', () => {
   });
 
   test('should render value from filter and change it', () => {
-    const filter = Filter.fromString('status=0');
+    const filter = Filter.fromString('status=Open');
     const handleChange = jest.fn();
 
     // eslint-disable-next-line no-shadow
@@ -67,7 +67,7 @@ describe('TicketStatusGroup tests', () => {
     fireEvent.click(domItems[2]);
 
     expect(handleChange).toBeCalled();
-    expect(handleChange).toBeCalledWith('2', 'status');
+    expect(handleChange).toBeCalledWith('"Fix Verified"', 'status');
   });
   test('should process title', () => {
     const filter = Filter.fromString('status=0');

--- a/gsa/src/web/components/powerfilter/__tests__/ticketstatusgroup.js
+++ b/gsa/src/web/components/powerfilter/__tests__/ticketstatusgroup.js
@@ -31,7 +31,7 @@ import Filter from 'gmp/models/filter';
 
 describe('TicketStatusGroup tests', () => {
   test('should render', () => {
-    const filter = Filter.fromString('status=0');
+    const filter = Filter.fromString('status=Closed');
     const handleChange = jest.fn();
     const {element} = render(
       <TicketStatusGroup
@@ -45,7 +45,7 @@ describe('TicketStatusGroup tests', () => {
   });
 
   test('should render value from filter and change it', () => {
-    const filter = Filter.fromString('status=Open');
+    const filter = Filter.fromString('status=Closed');
     const handleChange = jest.fn();
 
     // eslint-disable-next-line no-shadow
@@ -58,7 +58,7 @@ describe('TicketStatusGroup tests', () => {
     );
 
     const displayedValue = getByTestId('select-selected-value');
-    expect(displayedValue).toHaveTextContent('Open');
+    expect(displayedValue).toHaveTextContent('Closed');
 
     openSelectElement(element);
 
@@ -70,7 +70,7 @@ describe('TicketStatusGroup tests', () => {
     expect(handleChange).toBeCalledWith('"Fix Verified"', 'status');
   });
   test('should process title', () => {
-    const filter = Filter.fromString('status=0');
+    const filter = Filter.fromString('status=Open');
     const handleChange = jest.fn();
     const {element} = render(
       <TicketStatusGroup

--- a/gsa/src/web/components/powerfilter/ticketstatusgroup.js
+++ b/gsa/src/web/components/powerfilter/ticketstatusgroup.js
@@ -47,10 +47,10 @@ const TicketStatusFilterGroup = ({
         value={status}
         onChange={onChange}
         items={[
-          {label: _('Open'), value: '0'},
-          {label: _('Fixed'), value: '1'},
-          {label: _('Fix Verified'), value: '2'},
-          {label: _('Closed'), value: '3'},
+          {label: _('Open'), value: 'Open'},
+          {label: _('Fixed'), value: 'Fixed'},
+          {label: _('Fix Verified'), value: '"Fix Verified"'}, // this is the way I found that has the filter returned as status="Fix Verified". All the single word terms are fine.
+          {label: _('Closed'), value: 'Closed'},
         ]}
       />
     </FormGroup>

--- a/gsa/src/web/components/powerfilter/ticketstatusgroup.js
+++ b/gsa/src/web/components/powerfilter/ticketstatusgroup.js
@@ -60,7 +60,7 @@ const TicketStatusFilterGroup = ({
 TicketStatusFilterGroup.propTypes = {
   filter: PropTypes.filter.isRequired,
   name: PropTypes.string,
-  status: PropTypes.number,
+  status: PropTypes.string,
   onChange: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
Changed select value from status integers to status strings. I'm not completely sure about the "Fix Verified". The other values are single words and can be used without double quotes, but "Fix Verified" absolutely needs it.
**Checklist**:
Changed 
<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
