### PR TITLE
Add include_certificate_data to gsad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add storybook [#1272](https://github.com/greenbone/gsa/pull/1286)
 - Added TLS certificates to the asset management.
   [#1455](https://github.com/greenbone/gsa/pull/1455),
-  [#1461](https://github.com/greenbone/gsa/pull/1461)
+  [#1461](https://github.com/greenbone/gsa/pull/1461),
+  [#1600](https://github.com/greenbone/gsa/pull/1600)
 - Add usage type to task and scanconfig commands [#1460](https://github.com/greenbone/gsa/pull/1460)
   [#1466](https://github.com/greenbone/gsa/pull/1466) [#1467](https://github.com/greenbone/gsa/pull/1467)
 

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -816,6 +816,7 @@ init_validator ()
   gvm_validator_alias (validator, "in_assets", "boolean");
   gvm_validator_alias (validator, "in_use", "boolean");
   gvm_validator_alias (validator, "include_related", "number");
+  gvm_validator_alias (validator, "include_certificate_data", "boolean");
   gvm_validator_alias (validator, "inheritor_id", "id");
   gvm_validator_alias (validator, "ignore_pagination", "boolean");
   gvm_validator_alias (validator, "event", "condition");

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -16935,8 +16935,22 @@ get_tls_certificates_gmp (gvm_connection_t *connection,
                           credentials_t *credentials, params_t *params,
                           cmd_response_data_t *response_data)
 {
-  return get_many (connection, "tls_certificates", credentials, params, NULL,
-                   response_data);
+  gmp_arguments_t *arguments = gmp_arguments_new ();
+  const char *include_certificate_data;
+
+  if (params_given (params, "include_certificate_data"))
+    {
+      include_certificate_data = params_value (params,
+                                               "include_certificate_data");
+      CHECK_VARIABLE_INVALID (include_certificate_data,
+                              "Get TLS Certificate");
+      gmp_arguments_add (arguments,
+                         "include_certificate_data",
+                         include_certificate_data);
+    }
+
+  return get_many (connection, "tls_certificates", credentials, params,
+                   arguments, response_data);
 }
 
 /**
@@ -16954,8 +16968,22 @@ get_tls_certificate_gmp (gvm_connection_t *connection,
                          credentials_t *credentials, params_t *params,
                          cmd_response_data_t *response_data)
 {
+  gmp_arguments_t *arguments = gmp_arguments_new ();
+  const char *include_certificate_data;
+
+  if (params_given (params, "include_certificate_data"))
+    {
+      include_certificate_data = params_value (params,
+                                               "include_certificate_data");
+      CHECK_VARIABLE_INVALID (include_certificate_data,
+                              "Get TLS Certificate");
+      gmp_arguments_add (arguments,
+                         "include_certificate_data",
+                         include_certificate_data);
+    }
+
   return get_one (connection, "tls_certificate", credentials, params, NULL,
-                  NULL, response_data);
+                  arguments, response_data);
 }
 
 /**

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -16940,12 +16940,10 @@ get_tls_certificates_gmp (gvm_connection_t *connection,
 
   if (params_given (params, "include_certificate_data"))
     {
-      include_certificate_data = params_value (params,
-                                               "include_certificate_data");
-      CHECK_VARIABLE_INVALID (include_certificate_data,
-                              "Get TLS Certificate");
-      gmp_arguments_add (arguments,
-                         "include_certificate_data",
+      include_certificate_data =
+        params_value (params, "include_certificate_data");
+      CHECK_VARIABLE_INVALID (include_certificate_data, "Get TLS Certificate");
+      gmp_arguments_add (arguments, "include_certificate_data",
                          include_certificate_data);
     }
 
@@ -16973,12 +16971,10 @@ get_tls_certificate_gmp (gvm_connection_t *connection,
 
   if (params_given (params, "include_certificate_data"))
     {
-      include_certificate_data = params_value (params,
-                                               "include_certificate_data");
-      CHECK_VARIABLE_INVALID (include_certificate_data,
-                              "Get TLS Certificate");
-      gmp_arguments_add (arguments,
-                         "include_certificate_data",
+      include_certificate_data =
+        params_value (params, "include_certificate_data");
+      CHECK_VARIABLE_INVALID (include_certificate_data, "Get TLS Certificate");
+      gmp_arguments_add (arguments, "include_certificate_data",
                          include_certificate_data);
     }
 


### PR DESCRIPTION
This allows getting the certificate file of TLS certificate assets
without requesting the full details including the sources.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
