### PR TITLE
Added a loading timer for empty trash button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [8.0.2] - unreleased
 
 ### Added
+- Added a loading timer for empty trash button [#1604](https://github.com/greenbone/gsa/pull/1604)
 - Added details to alert details page [#1591](https://github.com/greenbone/gsa/pull/1591)
 - Added loading indicator for edit config dialog [#1579](https://github.com/greenbone/gsa/pull/1579)
 - Added tooltip for settings in task edit dialog that can't be changed once the task has been run [#1568](https://github.com/greenbone/gsa/pull/1568)

--- a/gsa/src/web/pages/extras/trashcanpage.js
+++ b/gsa/src/web/pages/extras/trashcanpage.js
@@ -28,7 +28,7 @@ import {isDefined} from 'gmp/utils/identity';
 
 import ErrorDialog from 'web/components/dialog/errordialog';
 
-import Button from 'web/components/form/button';
+import LoadingButton from 'web/components/form/loadingbutton';
 
 import ManualIcon from 'web/components/icon/manualicon';
 import TrashcanIcon from 'web/components/icon/trashcanicon';
@@ -89,22 +89,27 @@ const ToolBarIcons = () => (
   />
 );
 
-const EmptyTrashButton = withCapabilities(({onClick, capabilities}) => {
-  if (!capabilities.mayOp('empty_trashcan')) {
-    return null;
-  }
-  return (
-    <Layout align="end">
-      <Button onClick={onClick}>{_('Empty Trash')}</Button>
-    </Layout>
-  );
-});
+const EmptyTrashButton = withCapabilities(
+  ({onClick, capabilities, loading}) => {
+    if (!capabilities.mayOp('empty_trashcan')) {
+      return null;
+    }
+    return (
+      <Layout align="end">
+        <LoadingButton onClick={onClick} loading={loading}>
+          {_('Empty Trash')}
+        </LoadingButton>
+      </Layout>
+    );
+  },
+);
 
 class Trashcan extends React.Component {
   constructor(...args) {
     super(...args);
     this.state = {
       trash: undefined,
+      loading: false,
     };
 
     this.createContentRow = this.createContentRow.bind(this);
@@ -173,15 +178,20 @@ class Trashcan extends React.Component {
 
   handleEmpty() {
     const {gmp} = this.props;
-
     this.handleInteraction();
+
+    this.setState({loading: true});
 
     gmp.trashcan
       .empty()
-      .then(this.getTrash)
+      .then(() => {
+        this.getTrash();
+        this.setState({loading: false});
+      })
       .catch(error => {
         this.setState({
           error: error,
+          loading: false,
         });
       });
   }
@@ -294,7 +304,7 @@ class Trashcan extends React.Component {
   }
 
   render() {
-    const {error, trash} = this.state;
+    const {error, trash, loading} = this.state;
 
     if (!isDefined(trash) && !isDefined(error)) {
       return <Loading />;
@@ -322,8 +332,7 @@ class Trashcan extends React.Component {
           />
         )}
         <Section img={<TrashcanIcon size="large" />} title={_('Trashcan')} />
-        <EmptyTrashButton onClick={this.handleEmpty} />
-
+        <EmptyTrashButton onClick={this.handleEmpty} loading={loading} />
         <LinkTarget id="Contents" />
         <h1>{_('Contents')}</h1>
         <Table>


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
Change the EmptyTrashButton to use LoadingButton instead, so users will have feedback when they empty the trashcan.
**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
