### PR TITLE
Allow to disable reload timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- Allow to disable reload timers [#1619](https://github.com/greenbone/gsa/pull/1619)
 - Added missing withRouter to withEntitiesContainer [#1614](https://github.com/greenbone/gsa/pull/1614)
 - Added parseTrend() function to ScanConfig model [#1583](https://github.com/greenbone/gsa/pull/1583)
 - Added DetailsPage and more functionalities to TLS Certificate assets [#1578](https://github.com/greenbone/gsa/pull/1578)

--- a/gsa/src/web/entities/container.js
+++ b/gsa/src/web/entities/container.js
@@ -55,6 +55,8 @@ import SelectionType from 'web/utils/selectiontype';
 
 import SortBy from 'web/components/sortby/sortby';
 
+import {handleDefaultReloadIntervalFunc} from 'web/entity/container';
+
 import TagDialog from 'web/pages/tags/dialog';
 
 import TagsDialog from './tagsdialog';
@@ -212,7 +214,7 @@ class EntitiesContainer extends React.Component {
     const {defaultReloadInterval, reloadInterval} = this.props;
 
     return isDefined(reloadInterval)
-      ? reloadInterval(this.props)
+      ? handleDefaultReloadIntervalFunc(reloadInterval)(this.props)
       : defaultReloadInterval;
   }
 
@@ -230,23 +232,26 @@ class EntitiesContainer extends React.Component {
     log.debug('Loading time was', loadTime, 'milliseconds');
 
     let interval = this.getReloadInterval();
+    if (interval <= 0) {
+      log.debug('No reload timer will be started.');
+      return;
+    }
 
     if (loadTime > interval) {
       // ensure timer is longer then the loading procedure
       interval = loadTime * LOAD_TIME_FACTOR;
     }
 
-    if (interval > 0) {
-      this.timer = global.setTimeout(this.handleTimer, interval);
-      log.debug(
-        'Started reload timer with id',
-        this.timer,
-        'and interval of',
-        interval,
-        'milliseconds for',
-        this.props.gmpname,
-      );
-    }
+    this.timer = global.setTimeout(this.handleTimer, interval);
+
+    log.debug(
+      'Started reload timer with id',
+      this.timer,
+      'and interval of',
+      interval,
+      'milliseconds for',
+      this.props.gmpname,
+    );
   }
 
   resetTimer() {

--- a/gsa/src/web/entity/container.js
+++ b/gsa/src/web/entity/container.js
@@ -26,6 +26,14 @@ import PropTypes from 'web/utils/proptypes';
 
 const log = logger.getLogger('web.entity.container');
 
+export const handleDefaultReloadIntervalFunc = func => ({
+  defaultReloadInterval,
+  ...args
+}) =>
+  defaultReloadInterval <= 0
+    ? defaultReloadInterval
+    : func({...args, defaultReloadInterval});
+
 const defaultReloadIntervalFunc = ({defaultReloadInterval, entity}) =>
   isDefined(entity) ? defaultReloadInterval : 0;
 
@@ -82,7 +90,7 @@ class EntityContainer extends React.Component {
   getReloadInterval() {
     const {reloadInterval = defaultReloadIntervalFunc} = this.props;
 
-    return reloadInterval(this.props);
+    return handleDefaultReloadIntervalFunc(reloadInterval)(this.props);
   }
 
   startTimer() {
@@ -96,16 +104,19 @@ class EntityContainer extends React.Component {
 
     const interval = this.getReloadInterval();
 
-    if (interval > 0) {
-      this.timer = global.setTimeout(this.handleTimer, interval);
-      log.debug(
-        'Started reload timer with id',
-        this.timer,
-        'and interval of',
-        interval,
-        'milliseconds',
-      );
+    if (interval <= 0) {
+      log.debug('No reload timer will be started.');
+      return;
     }
+
+    this.timer = global.setTimeout(this.handleTimer, interval);
+    log.debug(
+      'Started reload timer with id',
+      this.timer,
+      'and interval of',
+      interval,
+      'milliseconds',
+    );
   }
 
   resetTimer() {

--- a/gsa/src/web/pages/reports/detailspage.js
+++ b/gsa/src/web/pages/reports/detailspage.js
@@ -37,6 +37,8 @@ import withDownload from 'web/components/form/withDownload';
 
 import withDialogNotification from 'web/components/notification/withDialogNotifiaction'; // eslint-disable-line max-len
 
+import {handleDefaultReloadIntervalFunc} from 'web/entity/container';
+
 import withDefaultFilter from 'web/entities/withDefaultFilter';
 
 import DownloadReportDialog from 'web/pages/reports/downloadreportdialog';
@@ -105,6 +107,11 @@ const getFilter = (entity = {}) => {
   const {report = {}} = entity;
   return report.filter;
 };
+
+const reloadReportFunc = ({entity}) =>
+  isDefined(entity) && isActive(entity.report.scan_run_status)
+    ? DEFAULT_RELOAD_INTERVAL_ACTIVE
+    : 0; // report doesn't change anymore. no need to reload
 
 class ReportDetails extends React.Component {
   constructor(...args) {
@@ -280,10 +287,7 @@ class ReportDetails extends React.Component {
   }
 
   getReloadInterval() {
-    const {entity} = this.props;
-    return isDefined(entity) && isActive(entity.report.scan_run_status)
-      ? DEFAULT_RELOAD_INTERVAL_ACTIVE
-      : 0; // report doesn't change anymore. no need to reload
+    return handleDefaultReloadIntervalFunc(reloadReportFunc)(this.props);
   }
 
   startTimer() {
@@ -301,21 +305,24 @@ class ReportDetails extends React.Component {
 
     let interval = this.getReloadInterval();
 
-    if (loadTime > interval && interval !== 0) {
+    if (interval <= 0) {
+      log.debug('No reload timer will be started.');
+      return;
+    }
+
+    if (loadTime > interval) {
       // ensure timer is longer then the loading procedure
       interval = loadTime * LOAD_TIME_FACTOR;
     }
 
-    if (interval > 0) {
-      this.timer = global.setTimeout(this.handleTimer, interval);
-      log.debug(
-        'Started reload timer with id',
-        this.timer,
-        'and interval of',
-        interval,
-        'milliseconds',
-      );
-    }
+    this.timer = global.setTimeout(this.handleTimer, interval);
+    log.debug(
+      'Started reload timer with id',
+      this.timer,
+      'and interval of',
+      interval,
+      'milliseconds',
+    );
   }
 
   resetTimer() {
@@ -672,6 +679,7 @@ class ReportDetails extends React.Component {
 }
 
 ReportDetails.propTypes = {
+  defaultReloadInterval: PropTypes.number,
   deltaReportId: PropTypes.id,
   entity: PropTypes.model,
   entityError: PropTypes.object,
@@ -723,7 +731,7 @@ const mapDispatchToProps = (dispatch, {gmp}) => {
   };
 };
 
-const mapStateToProps = (rootState, {match}) => {
+const mapStateToProps = (rootState, {gmp, match}) => {
   const {id, deltaid} = match.params;
   const filterSel = filterSelector(rootState);
   const reportSel = reportSelector(rootState);
@@ -745,6 +753,7 @@ const mapStateToProps = (rootState, {match}) => {
 
   return {
     deltaReportId: deltaid,
+    defaultReloadInterval: gmp.reloadInterval,
     entity,
     entityError,
     filters: filterSel.getAllEntities(RESULTS_FILTER_FILTER),


### PR DESCRIPTION
Add a function that handles setting the default reload interval to less
or equal to 0 to disable the reloading of entities. Update load and
getReloadInterval methods to stop loading if the calculated reload
interval is less or equal to 0.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
