### PR TITLE
Update model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#1507](https://github.com/greenbone/gsa/pull/1507)
 
 ### Changed
+- Update response data parsing in Model classes [#1633](https://github.com/greenbone/gsa/pull/1633)
 - Fix statusbar content can be more than 100% and add progressbar colors to theme [1621](https://github.com/greenbone/gsa/pull/1621)
 - Allow to overwrite details=1 for command results.get() [#1618](https://github.com/greenbone/gsa/pull/1618)
 - Ensure not to request the report details when loading a list of reports [#1617](https://github.com/greenbone/gsa/pull/1617)

--- a/gsa/src/gmp/__tests__/model.js
+++ b/gsa/src/gmp/__tests__/model.js
@@ -17,11 +17,35 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import Model from 'gmp/model';
+import Model, {parseModelFromElement} from 'gmp/model';
 import {testModel} from 'gmp/models/testing';
 
 describe('Model tests', () => {
   testModel(Model, 'unknown');
+});
+
+describe('parseModelFromElement tests', () => {
+  test('should parse model', () => {
+    const element = {
+      _id: '1',
+    };
+    const model = parseModelFromElement(element);
+
+    expect(model.id).toEqual('1');
+    expect(model).toBeInstanceOf(Model);
+    expect(model.entityType).toEqual('unknown');
+  });
+
+  test('should parse model and set entity type', () => {
+    const element = {
+      _id: '1',
+    };
+    const model = parseModelFromElement(element, 'foo');
+
+    expect(model.id).toEqual('1');
+    expect(model).toBeInstanceOf(Model);
+    expect(model.entityType).toEqual('foo');
+  });
 });
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/gmp/collection/parser.js
+++ b/gsa/src/gmp/collection/parser.js
@@ -33,7 +33,9 @@ export function parseInfoEntities(response, name, modelclass, filter_func) {
   if (!isArray(response.info)) {
     return [];
   }
-  return response.info.filter(filter_func).map(info => new modelclass(info));
+  return response.info
+    .filter(filter_func)
+    .map(info => modelclass.fromElement(info));
 }
 
 export function parseInfoCounts(response) {
@@ -84,7 +86,7 @@ export function parseInfoCounts(response) {
 }
 
 export function parseFilter(element) {
-  return new Filter(element.filters);
+  return Filter.fromElement(element.filters);
 }
 
 export function parseCounts(element, name, plural_name) {
@@ -114,7 +116,9 @@ export function parseCounts(element, name, plural_name) {
 const parseElements = (response, name) => response[name];
 
 const parseEntities = (response, name, modelclass = Model) =>
-  map(parseElements(response, name), element => new modelclass(element));
+  map(parseElements(response, name), element =>
+    modelclass.fromElement(element),
+  );
 
 export const parseReportResultEntities = (response, name, modelclass) =>
   parseEntities(response.results, name, modelclass);

--- a/gsa/src/gmp/commands/__tests__/entities.js
+++ b/gsa/src/gmp/commands/__tests__/entities.js
@@ -42,7 +42,7 @@ describe('EntitiesCommand tests', () => {
   });
 
   test('should add filter_id parameter', () => {
-    const filter = new Filter({_id: 'bar'});
+    const filter = Filter.fromElement({_id: 'bar'});
     const response = createEntitiesResponse('foo', []);
     const fakeHttp = createHttp(response);
 
@@ -60,7 +60,7 @@ describe('EntitiesCommand tests', () => {
   });
 
   test('should prefer filter_id over filter parameter', () => {
-    const filter = new Filter({
+    const filter = Filter.fromElement({
       _id: 'bar',
       keywords: {
         keyword: {relation: '=', value: 'bar', column: 'foo'},

--- a/gsa/src/gmp/commands/__tests__/entity.js
+++ b/gsa/src/gmp/commands/__tests__/entity.js
@@ -49,7 +49,7 @@ describe('EntityCommand tests', () => {
   });
 
   test('should add filter_id parameter', () => {
-    const filter = new Filter({_id: 'bar'});
+    const filter = Filter.fromElement({_id: 'bar'});
     const response = createEntityResponse('foo', {});
     const fakeHttp = createHttp(response);
 
@@ -68,7 +68,7 @@ describe('EntityCommand tests', () => {
   });
 
   test('should prefer filter_id over filter parameter', () => {
-    const filter = new Filter({
+    const filter = Filter.fromElement({
       _id: 'bar',
       keywords: {
         keyword: {relation: '=', value: 'bar', column: 'foo'},

--- a/gsa/src/gmp/commands/entity.js
+++ b/gsa/src/gmp/commands/entity.js
@@ -49,7 +49,7 @@ class EntityCommand extends GmpCommand {
   }
 
   getModelFromResponse(response) {
-    return new this.clazz(this.getElementFromRoot(response.data));
+    return this.clazz.fromElement(this.getElementFromRoot(response.data));
   }
 
   transformResponse(response) {

--- a/gsa/src/gmp/commands/filters.js
+++ b/gsa/src/gmp/commands/filters.js
@@ -71,12 +71,12 @@ class FilterCommand extends EntityCommand {
 
 // FIXME parsing counts is horrible
 
-const parse_filter = element => {
+const parseFilter = element => {
   const filter =
     isDefined(element) && isDefined(element.filters)
       ? element.filters[0]
       : undefined;
-  return new Filter(filter);
+  return Filter.fromElement(filter);
 };
 
 const parse_counts = element => {
@@ -115,7 +115,7 @@ class FiltersCommand extends EntitiesCommand {
     const response = this.getEntitiesResponse(root);
     return parseCollectionList(response, this.name, this.clazz, {
       meta,
-      filter_parse_func: parse_filter,
+      filter_parse_func: parseFilter,
       collection_count_parse_func: parse_collection_counts,
     });
   }

--- a/gsa/src/gmp/model.js
+++ b/gsa/src/gmp/model.js
@@ -39,12 +39,8 @@ class Model {
   static entityType = 'unknown';
 
   constructor(type) {
-    this.init();
-
     this.entityType = isDefined(type) ? type : this.constructor.entityType;
   }
-
-  init() {}
 
   setProperties(properties) {
     return setProperties(properties, this);

--- a/gsa/src/gmp/model.js
+++ b/gsa/src/gmp/model.js
@@ -68,7 +68,7 @@ class Model {
     return f;
   }
 
-  static parseElement(element) {
+  static parseElement(element = {}) {
     const copy = parseDefaultProperties(element);
 
     if (isDefined(element.end_time)) {

--- a/gsa/src/gmp/model.js
+++ b/gsa/src/gmp/model.js
@@ -63,6 +63,12 @@ class Model {
     return Model.parseElement(element);
   }
 
+  static fromElement(element = {}) {
+    const f = new this();
+    f.setProperties(this.parseElement(element));
+    return f;
+  }
+
   static parseElement(element) {
     const copy = parseDefaultProperties(element);
 

--- a/gsa/src/gmp/model.js
+++ b/gsa/src/gmp/model.js
@@ -32,8 +32,12 @@ import {
 
 import Capabilities from './capabilities/capabilities.js';
 
-export const parseModelFromElement = (element, entityType) =>
-  new Model(entityType).updateFromElement(element);
+export const parseModelFromElement = (element, entityType) => {
+  const m = new Model(entityType);
+  const props = Model.parseElement(element);
+  m.setProperties(props);
+  return m;
+};
 
 class Model {
   static entityType = 'unknown';
@@ -44,14 +48,6 @@ class Model {
 
   setProperties(properties) {
     return setProperties(properties, this);
-  }
-
-  updateFromElement(elem) {
-    if (isDefined(elem)) {
-      const properties = this.parseProperties(elem);
-      this.setProperties(properties);
-    }
-    return this;
   }
 
   parseProperties(element) {

--- a/gsa/src/gmp/model.js
+++ b/gsa/src/gmp/model.js
@@ -32,6 +32,9 @@ import {
 
 import Capabilities from './capabilities/capabilities.js';
 
+export const parseModelFromElement = (element, entityType) =>
+  new Model(undefined, entityType).updateFromElement(element);
+
 class Model {
   static entityType = 'unknown';
 

--- a/gsa/src/gmp/model.js
+++ b/gsa/src/gmp/model.js
@@ -93,7 +93,7 @@ class Model {
 
     if (isDefined(element.user_tags)) {
       copy.userTags = map(element.user_tags.tag, tag => {
-        return new Model(tag, 'tag');
+        return parseModelFromElement(tag, 'tag');
       });
       delete copy.user_tags;
     } else {

--- a/gsa/src/gmp/model.js
+++ b/gsa/src/gmp/model.js
@@ -21,7 +21,7 @@ import {isEmpty} from './utils/string';
 import {map} from './utils/array';
 
 import {
-  parseProperties,
+  parseProperties as parseDefaultProperties,
   parseYesNo,
   parseDate,
   parseBoolean,
@@ -59,27 +59,31 @@ class Model {
     return this;
   }
 
-  parseProperties(elem) {
-    const copy = parseProperties(elem);
+  parseProperties(element) {
+    return Model.parseElement(element);
+  }
 
-    if (isDefined(elem.end_time)) {
-      if (elem.end_time.length > 0) {
-        copy.endTime = parseDate(elem.end_time);
+  static parseElement(element) {
+    const copy = parseDefaultProperties(element);
+
+    if (isDefined(element.end_time)) {
+      if (element.end_time.length > 0) {
+        copy.endTime = parseDate(element.end_time);
       }
       delete copy.end_time;
     }
 
-    if (isDefined(elem.permissions)) {
+    if (isDefined(element.permissions)) {
       // these are the permissions the current user has on the entity
-      const caps = map(elem.permissions.permission, perm => perm.name);
+      const caps = map(element.permissions.permission, perm => perm.name);
       copy.userCapabilities = new Capabilities(caps);
       delete copy.permissions;
     } else {
       copy.userCapabilities = new Capabilities();
     }
 
-    if (isDefined(elem.user_tags)) {
-      copy.userTags = map(elem.user_tags.tag, tag => {
+    if (isDefined(element.user_tags)) {
+      copy.userTags = map(element.user_tags.tag, tag => {
         return new Model(tag, 'tag');
       });
       delete copy.user_tags;
@@ -90,22 +94,22 @@ class Model {
     const yes_no_props = ['writable', 'orphan', 'active', 'trash'];
 
     for (const name of yes_no_props) {
-      const prop = elem[name];
+      const prop = element[name];
       if (isDefined(prop)) {
         copy[name] = parseYesNo(prop);
       }
     }
 
-    if (isDefined(elem.in_use)) {
-      copy.inUse = parseBoolean(elem.in_use);
+    if (isDefined(element.in_use)) {
+      copy.inUse = parseBoolean(element.in_use);
       delete copy.in_use;
     }
 
-    if (isDefined(elem.owner) && isEmpty(elem.owner.name)) {
+    if (isDefined(element.owner) && isEmpty(element.owner.name)) {
       delete copy.owner;
     }
 
-    if (isEmpty(elem.comment)) {
+    if (isEmpty(element.comment)) {
       delete copy.comment;
     }
 

--- a/gsa/src/gmp/model.js
+++ b/gsa/src/gmp/model.js
@@ -50,6 +50,13 @@ class Model {
     return setProperties(properties, this);
   }
 
+  getProperties() {
+    return Object.entries(this).reduce((prev, [key, value]) => {
+      prev[key] = value;
+      return prev;
+    }, {});
+  }
+
   static fromElement(element = {}) {
     const f = new this();
     f.setProperties(this.parseElement(element));

--- a/gsa/src/gmp/model.js
+++ b/gsa/src/gmp/model.js
@@ -50,10 +50,6 @@ class Model {
     return setProperties(properties, this);
   }
 
-  parseProperties(element) {
-    return Model.parseElement(element);
-  }
-
   static fromElement(element = {}) {
     const f = new this();
     f.setProperties(this.parseElement(element));

--- a/gsa/src/gmp/model.js
+++ b/gsa/src/gmp/model.js
@@ -33,19 +33,15 @@ import {
 import Capabilities from './capabilities/capabilities.js';
 
 export const parseModelFromElement = (element, entityType) =>
-  new Model(undefined, entityType).updateFromElement(element);
+  new Model(entityType).updateFromElement(element);
 
 class Model {
   static entityType = 'unknown';
 
-  constructor(element, type) {
+  constructor(type) {
     this.init();
 
     this.entityType = isDefined(type) ? type : this.constructor.entityType;
-
-    if (element) {
-      this.updateFromElement(element);
-    }
   }
 
   init() {}

--- a/gsa/src/gmp/models/__tests__/agent.js
+++ b/gsa/src/gmp/models/__tests__/agent.js
@@ -35,7 +35,7 @@ describe('Agent Model tests', () => {
         },
       },
     };
-    const agent = new Agent(elem);
+    const agent = Agent.fromElement(elem);
 
     expect(agent.installer).toBeUndefined();
     expect(agent.trust.time).toEqual(parseDate('2018-10-10T11:41:23.022Z'));
@@ -43,7 +43,7 @@ describe('Agent Model tests', () => {
   });
 
   test('should return undefined for trust if installer or trust are undefined', () => {
-    const agent = new Agent({});
+    const agent = Agent.fromElement({});
 
     expect(agent.trust).toBeUndefined();
   });

--- a/gsa/src/gmp/models/__tests__/alert.js
+++ b/gsa/src/gmp/models/__tests__/alert.js
@@ -54,7 +54,7 @@ describe('Alert Model tests', () => {
         },
       },
     };
-    const alert = new Alert(elem);
+    const alert = Alert.fromElement(elem);
 
     expect(alert.condition).toEqual({
       data: {},
@@ -90,7 +90,7 @@ describe('Alert Model tests', () => {
       },
     };
 
-    const alert = new Alert(elem);
+    const alert = Alert.fromElement(elem);
     expect(alert.method).toEqual({
       data: {
         bar: {
@@ -108,7 +108,7 @@ describe('Alert Model tests', () => {
 
   test('should return given filter as instance of filter model', () => {
     const elem = {filter: 'rows=1337'};
-    const alert = new Alert(elem);
+    const alert = Alert.fromElement(elem);
 
     expect(alert.filter).toEqual(new Model('rows=1337', 'filter'));
   });
@@ -119,13 +119,13 @@ describe('Alert Model tests', () => {
         task: {},
       },
     };
-    const alert = new Alert(elem);
+    const alert = Alert.fromElement(elem);
 
     expect(alert.tasks).toEqual([new Model({}, 'task')]);
   });
 
   test('should return empty array if no tasks are given', () => {
-    const alert = new Alert({});
+    const alert = Alert.fromElement({});
 
     expect(alert.tasks).toEqual([]);
   });
@@ -139,20 +139,20 @@ describe('Alert Model tests', () => {
         },
       },
     };
-    const alert = new Alert(elem);
+    const alert = Alert.fromElement(elem);
 
     expect(alert.method.data.report_formats).toEqual(['123', '456', '789']);
   });
 
   test('should return empty array if no report format ids are given', () => {
-    const alert = new Alert({});
+    const alert = Alert.fromElement({});
 
     expect(alert.method.data.report_formats).toEqual([]);
   });
 
   test('isActive() should return correct true/false', () => {
-    const alert1 = new Alert({active: '0'});
-    const alert2 = new Alert({active: '1'});
+    const alert1 = Alert.fromElement({active: '0'});
+    const alert2 = Alert.fromElement({active: '1'});
 
     expect(alert1.isActive()).toBe(false);
     expect(alert2.isActive()).toBe(true);

--- a/gsa/src/gmp/models/__tests__/alert.js
+++ b/gsa/src/gmp/models/__tests__/alert.js
@@ -110,18 +110,24 @@ describe('Alert Model tests', () => {
     const elem = {filter: 'rows=1337'};
     const alert = Alert.fromElement(elem);
 
-    expect(alert.filter).toEqual(new Model('rows=1337', 'filter'));
+    expect(alert.filter).toBeInstanceOf(Model);
+    expect(alert.filter.entityType).toEqual('filter');
   });
 
   test('should return given tasks as array of instances of task model', () => {
     const elem = {
       tasks: {
-        task: {},
+        task: {_id: 't1'},
       },
     };
     const alert = Alert.fromElement(elem);
 
-    expect(alert.tasks).toEqual([new Model({}, 'task')]);
+    expect(alert.tasks.length).toEqual(1);
+
+    const [task] = alert.tasks;
+    expect(task).toBeInstanceOf(Model);
+    expect(task.entityType).toEqual('task');
+    expect(task.id).toEqual('t1');
   });
 
   test('should return empty array if no tasks are given', () => {

--- a/gsa/src/gmp/models/__tests__/certbund.js
+++ b/gsa/src/gmp/models/__tests__/certbund.js
@@ -29,7 +29,7 @@ testModel(CertBundAdv, 'certbund');
 
 describe('CertBundAdv model tests', () => {
   test('should be instance of Info', () => {
-    const certBundAdv = new CertBundAdv({});
+    const certBundAdv = CertBundAdv.fromElement({});
 
     expect(certBundAdv).toBeInstanceOf(Info);
   });
@@ -38,14 +38,14 @@ describe('CertBundAdv model tests', () => {
     const elem = {
       max_cvss: '8.5',
     };
-    const certBundAdv = new CertBundAdv(elem);
+    const certBundAdv = CertBundAdv.fromElement(elem);
 
     expect(certBundAdv.severity).toEqual(8.5);
     expect(certBundAdv.max_cvss).toBeUndefined();
   });
 
   test('should return empty categories array if no advisory is given', () => {
-    const certBundAdv = new CertBundAdv({});
+    const certBundAdv = CertBundAdv.fromElement({});
     expect(certBundAdv.categories).toEqual([]);
   });
 
@@ -57,7 +57,7 @@ describe('CertBundAdv model tests', () => {
         },
       },
     };
-    const certBundAdv = new CertBundAdv(elem);
+    const certBundAdv = CertBundAdv.fromElement(elem);
     expect(certBundAdv.categories).toEqual(['foo', 'bar']);
   });
 
@@ -69,12 +69,12 @@ describe('CertBundAdv model tests', () => {
         },
       },
     };
-    const certBundAdv = new CertBundAdv(elem);
+    const certBundAdv = CertBundAdv.fromElement(elem);
     expect(certBundAdv.categories).toEqual(['foo']);
   });
 
   test('should return empty descriptions array if no advisory is given', () => {
-    const certBundAdv = new CertBundAdv({});
+    const certBundAdv = CertBundAdv.fromElement({});
     expect(certBundAdv.description).toEqual([]);
   });
 
@@ -88,7 +88,7 @@ describe('CertBundAdv model tests', () => {
         },
       },
     };
-    const certBundAdv = new CertBundAdv(elem);
+    const certBundAdv = CertBundAdv.fromElement(elem);
     expect(certBundAdv.description).toEqual(['foo', 'bar']);
   });
 
@@ -104,12 +104,12 @@ describe('CertBundAdv model tests', () => {
         },
       },
     };
-    const certBundAdv = new CertBundAdv(elem);
+    const certBundAdv = CertBundAdv.fromElement(elem);
     expect(certBundAdv.description).toEqual(['foo']);
   });
 
   test('should return empty additional_information array if no advisory is given', () => {
-    const certBundAdv = new CertBundAdv({});
+    const certBundAdv = CertBundAdv.fromElement({});
     expect(certBundAdv.additional_information).toEqual([]);
   });
 
@@ -138,7 +138,7 @@ describe('CertBundAdv model tests', () => {
         },
       },
     };
-    const certBundAdv = new CertBundAdv(elem);
+    const certBundAdv = CertBundAdv.fromElement(elem);
     const res = [
       {
         issuer: 'foo',
@@ -171,7 +171,7 @@ describe('CertBundAdv model tests', () => {
         },
       },
     };
-    const certBundAdv = new CertBundAdv(elem);
+    const certBundAdv = CertBundAdv.fromElement(elem);
     const res = [
       {
         issuer: 'foo',
@@ -191,7 +191,7 @@ describe('CertBundAdv model tests', () => {
         },
       },
     };
-    const certBundAdv = new CertBundAdv(elem);
+    const certBundAdv = CertBundAdv.fromElement(elem);
     expect(certBundAdv.version).toEqual('5');
   });
 
@@ -216,7 +216,7 @@ describe('CertBundAdv model tests', () => {
         },
       },
     };
-    const certBundAdv = new CertBundAdv(elem);
+    const certBundAdv = CertBundAdv.fromElement(elem);
     const res = [
       {
         revision: '42',
@@ -233,7 +233,7 @@ describe('CertBundAdv model tests', () => {
   });
 
   test('should return empty cves array if no advisory is given', () => {
-    const certBundAdv = new CertBundAdv({});
+    const certBundAdv = CertBundAdv.fromElement({});
     expect(certBundAdv.cves).toEqual([]);
   });
 
@@ -247,7 +247,7 @@ describe('CertBundAdv model tests', () => {
         },
       },
     };
-    const certBundAdv = new CertBundAdv(elem);
+    const certBundAdv = CertBundAdv.fromElement(elem);
 
     expect(certBundAdv.cves).toEqual(['foo', 'bar']);
   });
@@ -262,7 +262,7 @@ describe('CertBundAdv model tests', () => {
         },
       },
     };
-    const certBundAdv = new CertBundAdv(elem);
+    const certBundAdv = CertBundAdv.fromElement(elem);
 
     expect(certBundAdv.cves).toEqual(['foo']);
   });

--- a/gsa/src/gmp/models/__tests__/cpe.js
+++ b/gsa/src/gmp/models/__tests__/cpe.js
@@ -25,8 +25,8 @@ testModel(Cpe, 'cpe');
 
 describe('CPE model tests', () => {
   test('should parse severity correctly', () => {
-    const cpe = new Cpe({max_cvss: '5.0'});
-    const cpe2 = new Cpe({max_cvss: '10'});
+    const cpe = Cpe.fromElement({max_cvss: '5.0'});
+    const cpe2 = Cpe.fromElement({max_cvss: '10'});
 
     expect(cpe.max_cvss).toBeUndefined();
     expect(cpe.severity).toEqual(5.0);
@@ -34,7 +34,7 @@ describe('CPE model tests', () => {
   });
 
   test('should parse "(null)" max_cvss as undefined severity', () => {
-    const cpe = new Cpe({max_cvss: '(null)'});
+    const cpe = Cpe.fromElement({max_cvss: '(null)'});
 
     expect(cpe.severity).toBeUndefined();
   });
@@ -68,7 +68,7 @@ describe('CPE model tests', () => {
         },
       },
     };
-    const cpe = new Cpe(elem);
+    const cpe = Cpe.fromElement(elem);
 
     expect(cpe.cves).toEqual([
       {
@@ -83,21 +83,21 @@ describe('CPE model tests', () => {
   });
 
   test('should return empty array if no cves are defined', () => {
-    const cpe = new Cpe({});
+    const cpe = Cpe.fromElement({});
 
     expect(cpe.cves).toEqual([]);
   });
 
   test('should return undefined if status is empty', () => {
-    const cpe = new Cpe({status: ''});
-    const cpe2 = new Cpe({status: 'foo'});
+    const cpe = Cpe.fromElement({status: ''});
+    const cpe2 = Cpe.fromElement({status: 'foo'});
 
     expect(cpe.status).toBeUndefined();
     expect(cpe2.status).toEqual('foo');
   });
 
   test('should parse update_time as date', () => {
-    const cpe = new Cpe({update_time: '2018-10-10T11:41:23.022Z'});
+    const cpe = Cpe.fromElement({update_time: '2018-10-10T11:41:23.022Z'});
 
     expect(cpe.updateTime).toBeDefined();
     expect(cpe.update_time).toBeUndefined();

--- a/gsa/src/gmp/models/__tests__/credential.js
+++ b/gsa/src/gmp/models/__tests__/credential.js
@@ -42,18 +42,18 @@ import {testModel} from 'gmp/models/testing';
 
 import {parseDate, NO_VALUE, YES_VALUE} from 'gmp/parser';
 
-const USERNAME_PASSWORD_CREDENTIAL = new Credential({
+const USERNAME_PASSWORD_CREDENTIAL = Credential.fromElement({
   type: USERNAME_PASSWORD_CREDENTIAL_TYPE,
 });
-const USERNAME_SSH_KEY_CREDENTIAL = new Credential({
+const USERNAME_SSH_KEY_CREDENTIAL = Credential.fromElement({
   type: USERNAME_SSH_KEY_CREDENTIAL_TYPE,
 });
-const CLIENT_CERTIFICATE_CREDENTIAL = new Credential({
+const CLIENT_CERTIFICATE_CREDENTIAL = Credential.fromElement({
   type: CLIENT_CERTIFICATE_CREDENTIAL_TYPE,
 });
-const SNMP_CREDENTIAL = new Credential({type: SNMP_CREDENTIAL_TYPE});
-const PGP_CREDENTIAL = new Credential({type: PGP_CREDENTIAL_TYPE});
-const SMIME_CREDENTIAL = new Credential({type: SMIME_CREDENTIAL_TYPE});
+const SNMP_CREDENTIAL = Credential.fromElement({type: SNMP_CREDENTIAL_TYPE});
+const PGP_CREDENTIAL = Credential.fromElement({type: PGP_CREDENTIAL_TYPE});
+const SMIME_CREDENTIAL = Credential.fromElement({type: SMIME_CREDENTIAL_TYPE});
 
 const createAllCredentials = () => [
   CLIENT_CERTIFICATE_CREDENTIAL,
@@ -74,7 +74,7 @@ describe('Credential Model tests', () => {
         expiration_time: '2019-10-10T11:41:23.022Z',
       },
     };
-    const credential = new Credential(elem);
+    const credential = Credential.fromElement(elem);
 
     expect(credential.certificate_info.activationTime).toEqual(
       parseDate('2018-10-10T11:41:23.022Z'),
@@ -87,7 +87,7 @@ describe('Credential Model tests', () => {
   });
 
   test('should parse type', () => {
-    const credential = new Credential({type: 'foo'});
+    const credential = Credential.fromElement({type: 'foo'});
 
     expect(credential.credential_type).toEqual('foo');
   });
@@ -95,8 +95,8 @@ describe('Credential Model tests', () => {
   test('should parse allow_insecure as Yes/No', () => {
     const elem1 = {allow_insecure: '1'};
     const elem2 = {allow_insecure: '0'};
-    const cred1 = new Credential(elem1);
-    const cred2 = new Credential(elem2);
+    const cred1 = Credential.fromElement(elem1);
+    const cred2 = Credential.fromElement(elem2);
 
     expect(cred1.allow_insecure).toEqual(YES_VALUE);
     expect(cred2.allow_insecure).toEqual(NO_VALUE);
@@ -108,13 +108,13 @@ describe('Credential Model tests', () => {
         target: {},
       },
     };
-    const credential = new Credential(elem);
+    const credential = Credential.fromElement(elem);
 
     expect(credential.targets).toEqual([new Model({}, 'target')]);
   });
 
   test('should return empty array if no targets are given', () => {
-    const credential = new Credential({});
+    const credential = Credential.fromElement({});
 
     expect(credential.targets).toEqual([]);
   });
@@ -125,14 +125,14 @@ describe('Credential Model tests', () => {
         scanner: {},
       },
     };
-    const credential = new Credential(elem);
+    const credential = Credential.fromElement(elem);
 
     expect(credential.scanners).toEqual([new Model({}, 'scanner')]);
   });
 
   test('isAllowInsecure() should return correct true/false', () => {
-    const cred1 = new Credential({allow_insecure: '0'});
-    const cred2 = new Credential({allow_insecure: '1'});
+    const cred1 = Credential.fromElement({allow_insecure: '0'});
+    const cred2 = Credential.fromElement({allow_insecure: '1'});
 
     expect(cred1.isAllowInsecure()).toBe(false);
     expect(cred2.isAllowInsecure()).toBe(true);

--- a/gsa/src/gmp/models/__tests__/credential.js
+++ b/gsa/src/gmp/models/__tests__/credential.js
@@ -105,29 +105,40 @@ describe('Credential Model tests', () => {
   test('should return given targets as array of instances of target model', () => {
     const elem = {
       targets: {
-        target: {},
+        target: {_id: 't1'},
       },
     };
     const credential = Credential.fromElement(elem);
 
-    expect(credential.targets).toEqual([new Model({}, 'target')]);
+    expect(credential.targets.length).toEqual(1);
+
+    const [target] = credential.targets;
+    expect(target).toBeInstanceOf(Model);
+    expect(target.id).toEqual('t1');
+    expect(target.entityType).toEqual('target');
   });
 
   test('should return empty array if no targets are given', () => {
     const credential = Credential.fromElement({});
 
+    expect(credential.targets.length).toEqual(0);
     expect(credential.targets).toEqual([]);
   });
 
   test('should return given scanners as array of instances of scanner model', () => {
     const elem = {
       scanners: {
-        scanner: {},
+        scanner: {_id: 's1'},
       },
     };
     const credential = Credential.fromElement(elem);
 
-    expect(credential.scanners).toEqual([new Model({}, 'scanner')]);
+    expect(credential.scanners.length).toEqual(1);
+
+    const [scanner] = credential.scanners;
+    expect(scanner).toBeInstanceOf(Model);
+    expect(scanner.id).toEqual('s1');
+    expect(scanner.entityType).toEqual('scanner');
   });
 
   test('isAllowInsecure() should return correct true/false', () => {

--- a/gsa/src/gmp/models/__tests__/cve.js
+++ b/gsa/src/gmp/models/__tests__/cve.js
@@ -31,7 +31,7 @@ testModel(Cve, 'cve');
 
 describe('CVE model tests', () => {
   test('should be instance of Info', () => {
-    const certBundAdv = new Cve({});
+    const certBundAdv = Cve.fromElement({});
 
     expect(certBundAdv).toBeInstanceOf(Info);
   });
@@ -40,7 +40,7 @@ describe('CVE model tests', () => {
     const elem = {
       update_time: '2018-10-10T23:00:00.000+0000',
     };
-    const cve = new Cve(elem);
+    const cve = Cve.fromElement(elem);
 
     expect(cve.update_time).toBeUndefined();
     expect(cve.updateTime).toEqual(parseDate('2018-10-10T23:00:00.000+0000'));
@@ -50,7 +50,7 @@ describe('CVE model tests', () => {
     const elem = {
       cvss: '8.5',
     };
-    const cve = new Cve(elem);
+    const cve = Cve.fromElement(elem);
 
     expect(cve.severity).toEqual(8.5);
     expect(cve.cvss).toBeUndefined();
@@ -85,7 +85,7 @@ describe('CVE model tests', () => {
         oid: '1337.42',
       },
     ];
-    const cve = new Cve(elem);
+    const cve = Cve.fromElement(elem);
 
     expect(cve.nvts).toEqual(res);
   });
@@ -121,13 +121,13 @@ describe('CVE model tests', () => {
         title: 'sit',
       },
     ];
-    const cve = new Cve(elem);
+    const cve = Cve.fromElement(elem);
 
     expect(cve.certs).toEqual(res);
   });
 
   test('should return empty array if no certs are given', () => {
-    const cve = new Cve({});
+    const cve = Cve.fromElement({});
 
     expect(cve.certs).toEqual([]);
   });
@@ -144,7 +144,7 @@ describe('CVE model tests', () => {
         availability_impact: 'COMPLETE',
       },
     };
-    const cve = new Cve(elem);
+    const cve = Cve.fromElement(elem);
 
     expect(cve.cvssBaseVector).toEqual('AV:N/AC:L/Au:N/C:C/I:C/A:C');
     expect(cve.cvssAccessComplexity).toEqual('LOW');
@@ -161,13 +161,13 @@ describe('CVE model tests', () => {
         products: 'foo:bar/dolor ipsum:lorem',
       },
     };
-    const cve = new Cve(elem);
+    const cve = Cve.fromElement(elem);
 
     expect(cve.products).toEqual(['foo:bar/dolor', 'ipsum:lorem']);
   });
 
   test('should return empty array if no vulnerable products are given', () => {
-    const cve = new Cve({});
+    const cve = Cve.fromElement({});
 
     expect(cve.products).toEqual([]);
   });
@@ -185,7 +185,7 @@ describe('CVE model tests', () => {
         },
       },
     };
-    const cve = new Cve(elem);
+    const cve = Cve.fromElement(elem);
 
     expect(cve.cwe_id).toEqual('123abc');
     expect(isDate(cve.publishedTime)).toBe(true);
@@ -211,7 +211,7 @@ describe('CVE model tests', () => {
         },
       },
     };
-    const cve = new Cve(elem);
+    const cve = Cve.fromElement(elem);
     const res = [
       {
         name: 'lorem',
@@ -239,7 +239,7 @@ describe('CVE model tests', () => {
         },
       },
     };
-    const cve = new Cve(elem);
+    const cve = Cve.fromElement(elem);
 
     expect(cve.source).toEqual('prot://url');
   });
@@ -256,7 +256,7 @@ describe('CVE model tests', () => {
         },
       },
     };
-    const cve = new Cve(elem);
+    const cve = Cve.fromElement(elem);
 
     expect(cve.description).toEqual('lorem ipsum');
   });
@@ -273,7 +273,7 @@ describe('CVE model tests', () => {
         },
       },
     };
-    const cve = new Cve(elem);
+    const cve = Cve.fromElement(elem);
 
     expect(cve.products).toEqual(['lorem', 'ipsum']);
   });
@@ -287,13 +287,13 @@ describe('CVE model tests', () => {
         },
       },
     };
-    const cve = new Cve(elem);
+    const cve = Cve.fromElement(elem);
 
     expect(cve.raw_data).toBeUndefined();
   });
 
   test('should return empty array for references if no raw data is given', () => {
-    const cve = new Cve({});
+    const cve = Cve.fromElement({});
 
     expect(cve.references).toEqual([]);
   });

--- a/gsa/src/gmp/models/__tests__/dfncert.js
+++ b/gsa/src/gmp/models/__tests__/dfncert.js
@@ -25,14 +25,14 @@ testModel(DfnCertAdv, 'dfncert');
 
 describe('DfnCertAdv model tests', () => {
   test('should be instance of Info', () => {
-    const dfnCertAdv = new DfnCertAdv({});
+    const dfnCertAdv = DfnCertAdv.fromElement({});
 
     expect(dfnCertAdv).toBeInstanceOf(Info);
   });
 
   test('should parse severity correctly', () => {
-    const dfnCertAdv = new DfnCertAdv({max_cvss: '5.0'});
-    const dfnCertAdv2 = new DfnCertAdv({max_cvss: '10'});
+    const dfnCertAdv = DfnCertAdv.fromElement({max_cvss: '5.0'});
+    const dfnCertAdv2 = DfnCertAdv.fromElement({max_cvss: '10'});
 
     expect(dfnCertAdv.max_cvss).toBeUndefined();
     expect(dfnCertAdv.severity).toEqual(5.0);
@@ -58,7 +58,7 @@ describe('DfnCertAdv model tests', () => {
         },
       },
     };
-    const dfnCertAdv = new DfnCertAdv(elem);
+    const dfnCertAdv = DfnCertAdv.fromElement(elem);
 
     expect(dfnCertAdv.advisory_link).toEqual('prot://url');
     expect(dfnCertAdv.additional_links).toEqual(['prot://url2', 'prot://url3']);
@@ -74,7 +74,7 @@ describe('DfnCertAdv model tests', () => {
         },
       },
     };
-    const dfnCertAdv = new DfnCertAdv(elem);
+    const dfnCertAdv = DfnCertAdv.fromElement(elem);
 
     expect(dfnCertAdv.summary).toEqual('foo');
   });
@@ -87,7 +87,7 @@ describe('DfnCertAdv model tests', () => {
         },
       },
     };
-    const dfnCertAdv = new DfnCertAdv(elem);
+    const dfnCertAdv = DfnCertAdv.fromElement(elem);
 
     expect(dfnCertAdv.cves).toEqual(['lorem', 'ipsum', 'dolor']);
   });

--- a/gsa/src/gmp/models/__tests__/filter.js
+++ b/gsa/src/gmp/models/__tests__/filter.js
@@ -119,7 +119,7 @@ describe('Filter parse from keywords', () => {
         ],
       },
     };
-    const filter = new Filter(elem);
+    const filter = Filter.fromElement(elem);
     expect(filter.toFilterString()).toEqual('~abc');
   });
 
@@ -150,7 +150,7 @@ describe('Filter parse from keywords', () => {
         ],
       },
     };
-    let filter = new Filter(elem);
+    let filter = Filter.fromElement(elem);
     expect(filter.toFilterString()).toEqual('~abc and not ~def');
 
     elem = {
@@ -194,7 +194,7 @@ describe('Filter parse from keywords', () => {
         ],
       },
     };
-    filter = new Filter(elem);
+    filter = Filter.fromElement(elem);
     expect(filter.toFilterString()).toEqual(
       '~abc and not ~def rows=10 first=1 sort=name',
     );
@@ -238,7 +238,7 @@ describe('Filter parse from keywords', () => {
       },
     };
 
-    const filter = new Filter(elem);
+    const filter = Filter.fromElement(elem);
     const filterstring =
       'severity>3.9 and severity<7 first=1 rows=10 sort=name';
     expect(filter.toFilterString()).toEqual(filterstring);
@@ -250,7 +250,7 @@ describe('Filter parse from keywords', () => {
 
 describe('Filter set', () => {
   test('should allow to set a filter term', () => {
-    const filter = new Filter();
+    const filter = Filter.fromElement();
     expect(filter.set('abc', '1', '=').toFilterString()).toEqual('abc=1');
   });
 
@@ -260,7 +260,7 @@ describe('Filter set', () => {
   });
 
   test('should remove sort-reverse when adding sort filter term', () => {
-    const filter = new Filter();
+    const filter = Filter.fromElement();
 
     filter.set('sort-reverse', 'foo', '=');
     expect(filter.has('sort-reverse')).toEqual(true);
@@ -272,7 +272,7 @@ describe('Filter set', () => {
   });
 
   test('should remove sort when adding sort-reverse filter term', () => {
-    const filter = new Filter();
+    const filter = Filter.fromElement();
 
     filter.set('sort', 'foo', '=');
     expect(filter.has('sort')).toEqual(true);
@@ -284,7 +284,7 @@ describe('Filter set', () => {
   });
 
   test('should convert 0 or negative values for first to 1', () => {
-    const filter = new Filter();
+    const filter = Filter.fromElement();
     filter.set('first', '0');
     expect(filter.get('first')).toEqual(1);
 
@@ -293,7 +293,7 @@ describe('Filter set', () => {
   });
 
   test('should reset filter id', () => {
-    const filter = new Filter({_id: 'foo'});
+    const filter = Filter.fromElement({_id: 'foo'});
 
     expect(filter.id).toEqual('foo');
 
@@ -361,7 +361,7 @@ describe('Filter equal', () => {
   test('empty filter should equal itself', () => {
     let filter = Filter.fromString('');
     expect(filter.equals(filter)).toEqual(true);
-    filter = new Filter();
+    filter = Filter.fromElement();
     expect(filter.equals(filter)).toEqual(true);
   });
 
@@ -573,7 +573,7 @@ describe('Filter getTerms', () => {
 
 describe('Filter parse elem', () => {
   test('Should parse public properties', () => {
-    const filter1 = new Filter({
+    const filter1 = Filter.fromElement({
       _id: '100',
       type: 'foo',
     });
@@ -583,7 +583,7 @@ describe('Filter parse elem', () => {
   });
 
   test('Should not parse term as public property', () => {
-    const filter1 = new Filter({
+    const filter1 = Filter.fromElement({
       term: 'abc=1',
     });
 
@@ -591,7 +591,7 @@ describe('Filter parse elem', () => {
   });
 
   test('should parse alerts', () => {
-    const filter1 = new Filter({
+    const filter1 = Filter.fromElement({
       term: 'abc=1',
       alerts: {
         alert: [
@@ -610,7 +610,7 @@ describe('Filter parse elem', () => {
   });
 
   test('should parse id of zero as undefined id', () => {
-    const filter = new Filter({_id: UNKNOWN_FILTER_ID});
+    const filter = Filter.fromElement({_id: UNKNOWN_FILTER_ID});
     expect(filter.id).toBeUndefined();
   });
 });
@@ -625,7 +625,7 @@ describe('Filter copy', () => {
   });
 
   test('should copy public properties', () => {
-    const filter1 = new Filter({
+    const filter1 = Filter.fromElement({
       term: 'abc=1',
       _id: '100',
       type: 'foo',
@@ -1033,7 +1033,7 @@ describe('filter hasTerm', () => {
 });
 
 describe('Filter fromTerm', () => {
-  test('should add FilterTerm to the new Filter', () => {
+  test('should add FilterTerm to the Filter.fromElement', () => {
     const term = new FilterTerm({
       keyword: 'abc',
       relation: '=',
@@ -1044,7 +1044,7 @@ describe('Filter fromTerm', () => {
     expect(filter.toFilterString()).toEqual('abc=1');
   });
 
-  test('should add several FilterTerms to the new Filter', () => {
+  test('should add several FilterTerms to the Filter.fromElement', () => {
     const term1 = new FilterTerm({
       keyword: 'abc',
       relation: '=',

--- a/gsa/src/gmp/models/__tests__/group.js
+++ b/gsa/src/gmp/models/__tests__/group.js
@@ -26,27 +26,27 @@ describe('Group model tests', () => {
   test('should parse multiple users', () => {
     const elem = {};
     elem.users = 'foo, bar';
-    const group = new Group(elem);
+    const group = Group.fromElement(elem);
 
     expect(group.users).toEqual(['foo', 'bar']);
   });
 
   test('should parse single user', () => {
     const elem = {users: 'foo'};
-    const group = new Group(elem);
+    const group = Group.fromElement(elem);
 
     expect(group.users).toEqual(['foo']);
   });
 
   test('should parse empty users string to empty array', () => {
     const elem = {users: ''};
-    const group = new Group(elem);
+    const group = Group.fromElement(elem);
 
     expect(group.users).toEqual([]);
   });
 
   test('should parse empty object to have empty users array', () => {
-    const group = new Group({});
+    const group = Group.fromElement({});
 
     expect(group.users).toEqual([]);
   });

--- a/gsa/src/gmp/models/__tests__/host.js
+++ b/gsa/src/gmp/models/__tests__/host.js
@@ -29,7 +29,7 @@ testModel(Host, 'host');
 
 describe('Host model tests', () => {
   test('should be instance of Asset', () => {
-    const host = new Host({});
+    const host = Host.fromElement({});
 
     expect(host).toBeInstanceOf(Asset);
   });
@@ -49,8 +49,8 @@ describe('Host model tests', () => {
         },
       },
     };
-    const host = new Host(elem);
-    const host2 = new Host(elem2);
+    const host = Host.fromElement(elem);
+    const host2 = Host.fromElement(elem2);
 
     expect(host.severity).toEqual(8.5);
     expect(host2.severity).toEqual(10);
@@ -79,8 +79,8 @@ describe('Host model tests', () => {
         ],
       },
     };
-    const host = new Host(elem);
-    const host2 = new Host({});
+    const host = Host.fromElement(elem);
+    const host2 = Host.fromElement({});
     const res = [
       {
         creationTime: parseDate('2018-10-10T13:31:00+01:00'),
@@ -132,9 +132,9 @@ describe('Host model tests', () => {
         ],
       },
     };
-    const host = new Host(elem);
-    const host2 = new Host(elem2);
-    const host3 = new Host(elem3);
+    const host = Host.fromElement(elem);
+    const host2 = Host.fromElement(elem2);
+    const host3 = Host.fromElement(elem3);
 
     expect(host.hostname).toEqual('foo');
     expect(host2.hostname).toEqual('bar');
@@ -152,7 +152,7 @@ describe('Host model tests', () => {
         ],
       },
     };
-    const host = new Host(elem);
+    const host = Host.fromElement(elem);
 
     expect(host.ip).toEqual('123.456.789.42');
   });
@@ -192,7 +192,7 @@ describe('Host model tests', () => {
         value: 'c:/.3',
       },
     };
-    const host = new Host(elem);
+    const host = Host.fromElement(elem);
 
     expect(host.details).toEqual(res);
   });
@@ -226,13 +226,13 @@ describe('Host model tests', () => {
         },
       ],
     ];
-    const host = new Host(elem);
+    const host = Host.fromElement(elem);
 
     expect(host.routes).toEqual(res);
   });
 
   test('should return empty array if no routes are given', () => {
-    const host = new Host({});
+    const host = Host.fromElement({});
 
     expect(host.routes).toEqual([]);
   });
@@ -241,7 +241,7 @@ describe('Host model tests', () => {
     const elem = {
       host: {},
     };
-    const host = new Host(elem);
+    const host = Host.fromElement(elem);
 
     expect(host.host).toBeUndefined();
   });

--- a/gsa/src/gmp/models/__tests__/login.js
+++ b/gsa/src/gmp/models/__tests__/login.js
@@ -38,8 +38,8 @@ describe('Login model tests', () => {
         version: '1337',
       },
     };
-    const login = new Login(elem);
-    const login2 = new Login({});
+    const login = Login.fromElement(elem);
+    const login2 = Login.fromElement({});
 
     expect(login.clientAddress).toEqual('1.2.3.4');
     expect(login.guest).toEqual('0');

--- a/gsa/src/gmp/models/__tests__/note.js
+++ b/gsa/src/gmp/models/__tests__/note.js
@@ -24,9 +24,9 @@ import {testModel} from 'gmp/models/testing';
 
 import {NO_VALUE, YES_VALUE} from 'gmp/parser';
 
-testModel(Note, 'note');
-
 describe('Note model tests', () => {
+  testModel(Note, 'note', {testIsActive: false});
+
   test('should parse severity', () => {
     const note = new Note({severity: '8.5'});
     const note2 = new Note({severity: '10'});

--- a/gsa/src/gmp/models/__tests__/note.js
+++ b/gsa/src/gmp/models/__tests__/note.js
@@ -28,9 +28,9 @@ describe('Note model tests', () => {
   testModel(Note, 'note', {testIsActive: false});
 
   test('should parse severity', () => {
-    const note = new Note({severity: '8.5'});
-    const note2 = new Note({severity: '10'});
-    const note3 = new Note({});
+    const note = Note.fromElement({severity: '8.5'});
+    const note2 = Note.fromElement({severity: '10'});
+    const note3 = Note.fromElement({});
 
     expect(note.severity).toEqual(8.5);
     expect(note2.severity).toEqual(10);
@@ -38,16 +38,16 @@ describe('Note model tests', () => {
   });
 
   test('should parse active as yes/no correctly', () => {
-    const note1 = new Note({active: '0'});
-    const note2 = new Note({active: '1'});
+    const note1 = Note.fromElement({active: '0'});
+    const note2 = Note.fromElement({active: '1'});
 
     expect(note1.active).toEqual(NO_VALUE);
     expect(note2.active).toEqual(YES_VALUE);
   });
 
   test('should parse text_excerpt as yes/no correctly', () => {
-    const note1 = new Note({text_excerpt: '0'});
-    const note2 = new Note({text_excerpt: '1'});
+    const note1 = Note.fromElement({text_excerpt: '0'});
+    const note2 = Note.fromElement({text_excerpt: '1'});
 
     expect(note1.text_excerpt).toEqual(NO_VALUE);
     expect(note2.text_excerpt).toEqual(YES_VALUE);
@@ -57,24 +57,24 @@ describe('Note model tests', () => {
     const elem = {
       hosts: '123.456.789.42, 987.654.321.1',
     };
-    const note1 = new Note(elem);
-    const note2 = new Note({hosts: ''});
+    const note1 = Note.fromElement(elem);
+    const note2 = Note.fromElement({hosts: ''});
 
     expect(note1.hosts).toEqual(['123.456.789.42', '987.654.321.1']);
     expect(note2.hosts).toEqual([]);
   });
 
   test('should delete port if it is empty, pass it on otherwise', () => {
-    const note1 = new Note({port: 'general/tcp'});
-    const note2 = new Note({port: ''});
+    const note1 = Note.fromElement({port: 'general/tcp'});
+    const note2 = Note.fromElement({port: ''});
 
     expect(note1.port).toEqual('general/tcp');
     expect(note2.port).toBeUndefined();
   });
 
   test('isExcerpt() should return correct true/false', () => {
-    const note1 = new Note({text_excerpt: '1'});
-    const note2 = new Note({text_excerpt: '0'});
+    const note1 = Note.fromElement({text_excerpt: '1'});
+    const note2 = Note.fromElement({text_excerpt: '0'});
 
     expect(note1.isExcerpt()).toEqual(true);
     expect(note2.isExcerpt()).toEqual(false);
@@ -91,9 +91,9 @@ describe('Note model tests', () => {
         _id: '',
       },
     };
-    const note1 = new Note(elem1);
-    const note2 = new Note(elem2);
-    const note3 = new Note({});
+    const note1 = Note.fromElement(elem1);
+    const note2 = Note.fromElement(elem2);
+    const note3 = Note.fromElement({});
 
     expect(note1.task).toBeInstanceOf(Model);
     expect(note2.task).toBeUndefined();
@@ -111,9 +111,9 @@ describe('Note model tests', () => {
         _id: '',
       },
     };
-    const note1 = new Note(elem1);
-    const note2 = new Note(elem2);
-    const note3 = new Note({});
+    const note1 = Note.fromElement(elem1);
+    const note2 = Note.fromElement(elem2);
+    const note3 = Note.fromElement({});
 
     expect(note1.result).toBeInstanceOf(Model);
     expect(note2.result).toBeUndefined();
@@ -127,7 +127,7 @@ describe('Note model tests', () => {
         name: 'foo',
       },
     };
-    const note = new Note(elem);
+    const note = Note.fromElement(elem);
 
     expect(note.nvt).toBeInstanceOf(Nvt);
     expect(note.name).toEqual('foo');

--- a/gsa/src/gmp/models/__tests__/note.js
+++ b/gsa/src/gmp/models/__tests__/note.js
@@ -96,6 +96,8 @@ describe('Note model tests', () => {
     const note3 = Note.fromElement({});
 
     expect(note1.task).toBeInstanceOf(Model);
+    expect(note1.task.id).toEqual('123abc');
+    expect(note1.task.entityType).toEqual('task');
     expect(note2.task).toBeUndefined();
     expect(note3.task).toBeUndefined();
   });
@@ -116,6 +118,8 @@ describe('Note model tests', () => {
     const note3 = Note.fromElement({});
 
     expect(note1.result).toBeInstanceOf(Model);
+    expect(note1.result.id).toEqual('123abc');
+    expect(note1.result.entityType).toEqual('result');
     expect(note2.result).toBeUndefined();
     expect(note3.result).toBeUndefined();
   });

--- a/gsa/src/gmp/models/__tests__/nvt.js
+++ b/gsa/src/gmp/models/__tests__/nvt.js
@@ -28,8 +28,8 @@ describe('nvt Model tests', () => {
   testModelMethods(Nvt);
 
   test('should parse NVT oid as id', () => {
-    const nvt1 = new Nvt({_oid: '42.1337'});
-    const nvt2 = new Nvt({});
+    const nvt1 = Nvt.fromElement({_oid: '42.1337'});
+    const nvt2 = Nvt.fromElement({});
 
     expect(nvt1.id).toEqual('42.1337');
     expect(nvt1.oid).toEqual('42.1337');
@@ -38,26 +38,28 @@ describe('nvt Model tests', () => {
   });
 
   test('should not allow to overwrite id', () => {
-    const nvt = new Nvt({_oid: 'foo'});
+    const nvt = Nvt.fromElement({_oid: 'foo'});
 
     expect(() => (nvt.id = 'bar')).toThrow();
   });
 
   test('should be instance of Info', () => {
     const nvt = new Nvt({});
+    const nvt2 = Nvt.fromElement({});
 
     expect(nvt).toBeInstanceOf(Info);
+    expect(nvt2).toBeInstanceOf(Info);
   });
 
   test('should parse nvt_type', () => {
-    const nvt = new Nvt({_type: 'foo'});
+    const nvt = Nvt.fromElement({_type: 'foo'});
 
     expect(nvt.nvt_type).toEqual('foo');
   });
 
   test('should parse tags', () => {
-    const nvt1 = new Nvt({tags: 'bv=/A:P|st=vf'});
-    const nvt2 = new Nvt({});
+    const nvt1 = Nvt.fromElement({tags: 'bv=/A:P|st=vf'});
+    const nvt2 = Nvt.fromElement({});
     const res = {
       bv: '/A:P',
       st: 'vf',
@@ -68,11 +70,11 @@ describe('nvt Model tests', () => {
   });
 
   test('should parse cve and cve_id', () => {
-    const nvt1 = new Nvt({cve: '42', cve_id: '21'});
-    const nvt2 = new Nvt({cve: '42, 21'});
-    const nvt3 = new Nvt({cve: ''});
-    const nvt4 = new Nvt({cve: 'NOCVE'});
-    const nvt5 = new Nvt({});
+    const nvt1 = Nvt.fromElement({cve: '42', cve_id: '21'});
+    const nvt2 = Nvt.fromElement({cve: '42, 21'});
+    const nvt3 = Nvt.fromElement({cve: ''});
+    const nvt4 = Nvt.fromElement({cve: 'NOCVE'});
+    const nvt5 = Nvt.fromElement({});
 
     expect(nvt1.cves).toEqual(['42', '21']);
     expect(nvt1.cve).toBeUndefined();
@@ -84,11 +86,11 @@ describe('nvt Model tests', () => {
   });
 
   test('should parse bid and bugtraq_id', () => {
-    const nvt1 = new Nvt({bid: '42', bugtraq_id: '21'});
-    const nvt2 = new Nvt({bid: '42, 21'});
-    const nvt3 = new Nvt({bid: ''});
-    const nvt4 = new Nvt({bid: 'NOBID'});
-    const nvt5 = new Nvt({});
+    const nvt1 = Nvt.fromElement({bid: '42', bugtraq_id: '21'});
+    const nvt2 = Nvt.fromElement({bid: '42, 21'});
+    const nvt3 = Nvt.fromElement({bid: ''});
+    const nvt4 = Nvt.fromElement({bid: 'NOBID'});
+    const nvt5 = Nvt.fromElement({});
 
     expect(nvt1.bids).toEqual(['42', '21']);
     expect(nvt1.bid).toBeUndefined();
@@ -100,8 +102,8 @@ describe('nvt Model tests', () => {
   });
 
   test('should parse severity', () => {
-    const nvt1 = new Nvt({cvss_base: '8.5'});
-    const nvt2 = new Nvt({cvss_base: ''});
+    const nvt1 = Nvt.fromElement({cvss_base: '8.5'});
+    const nvt2 = Nvt.fromElement({cvss_base: ''});
 
     expect(nvt1.severity).toEqual(8.5);
     expect(nvt1.cvss_base).toBeUndefined();
@@ -126,8 +128,8 @@ describe('nvt Model tests', () => {
         lorem: 'ipsum',
       },
     ];
-    const nvt1 = new Nvt({});
-    const nvt2 = new Nvt(elem);
+    const nvt1 = Nvt.fromElement({});
+    const nvt2 = Nvt.fromElement(elem);
 
     expect(nvt1.preferences).toEqual([]);
     expect(nvt2.preferences).toEqual(res);
@@ -203,10 +205,10 @@ describe('nvt Model tests', () => {
       },
     ];
 
-    const nvt1 = new Nvt({});
-    const nvt2 = new Nvt(elem2);
-    const nvt3 = new Nvt(elem3);
-    const nvt4 = new Nvt(elem4);
+    const nvt1 = Nvt.fromElement({});
+    const nvt2 = Nvt.fromElement(elem2);
+    const nvt3 = Nvt.fromElement(elem3);
+    const nvt4 = Nvt.fromElement(elem4);
 
     expect(nvt1.certs).toEqual([]);
     expect(nvt2.cert).toBeUndefined();
@@ -217,14 +219,14 @@ describe('nvt Model tests', () => {
   });
 
   test('should parse xrefs with correct protocol', () => {
-    const nvt1 = new Nvt({xrefs: '42'});
-    const nvt2 = new Nvt({xrefs: '42, 21'});
-    const nvt3 = new Nvt({xrefs: 'URL:42'});
-    const nvt4 = new Nvt({xrefs: 'URL:http://42'});
-    const nvt5 = new Nvt({xrefs: 'URL:https://42'});
-    const nvt6 = new Nvt({xrefs: 'URL:ftp://42'});
-    const nvt7 = new Nvt({xrefs: 'URL:ftps://42'});
-    const nvt8 = new Nvt({xrefs: 'ftps://42'});
+    const nvt1 = Nvt.fromElement({xrefs: '42'});
+    const nvt2 = Nvt.fromElement({xrefs: '42, 21'});
+    const nvt3 = Nvt.fromElement({xrefs: 'URL:42'});
+    const nvt4 = Nvt.fromElement({xrefs: 'URL:http://42'});
+    const nvt5 = Nvt.fromElement({xrefs: 'URL:https://42'});
+    const nvt6 = Nvt.fromElement({xrefs: 'URL:ftp://42'});
+    const nvt7 = Nvt.fromElement({xrefs: 'URL:ftps://42'});
+    const nvt8 = Nvt.fromElement({xrefs: 'ftps://42'});
 
     expect(nvt1.xrefs).toEqual([{ref: '42', type: 'other'}]);
     expect(nvt2.xrefs).toEqual([
@@ -241,12 +243,13 @@ describe('nvt Model tests', () => {
   });
 
   test('should parse qod', () => {
-    const nvt1 = new Nvt({});
-    const nvt2 = new Nvt({qod: {value: ''}});
-    const nvt3 = new Nvt({qod: {value: '75.5'}});
-    const nvt4 = new Nvt({qod: {type: ''}});
-    const nvt5 = new Nvt({qod: {type: 'foo'}});
-    const nvt6 = new Nvt({qod: {value: '75.5', type: 'foo'}});
+    const nvt1 = Nvt.fromElement({});
+    const nvt2 = Nvt.fromElement({qod: {value: ''}});
+    const nvt3 = Nvt.fromElement({qod: {value: '75.5'}});
+    const nvt4 = Nvt.fromElement({qod: {type: ''}});
+    const nvt5 = Nvt.fromElement({qod: {type: 'foo'}});
+    const nvt6 = Nvt.fromElement({qod: {value: '75.5', type: 'foo'}});
+
     expect(nvt1.qod).toBeUndefined();
     expect(nvt2.qod.value).toBeUndefined();
     expect(nvt3.qod.value).toEqual(75.5);
@@ -256,9 +259,9 @@ describe('nvt Model tests', () => {
   });
 
   test('should parse default_timeout', () => {
-    const nvt1 = new Nvt({});
-    const nvt2 = new Nvt({default_timeout: ''});
-    const nvt3 = new Nvt({default_timeout: '123'});
+    const nvt1 = Nvt.fromElement({});
+    const nvt2 = Nvt.fromElement({default_timeout: ''});
+    const nvt3 = Nvt.fromElement({default_timeout: '123'});
 
     expect(nvt1.default_timeout).toBeUndefined();
     expect(nvt2.default_timeout).toBeUndefined();
@@ -266,9 +269,9 @@ describe('nvt Model tests', () => {
   });
 
   test('should parse timeout', () => {
-    const nvt1 = new Nvt({});
-    const nvt2 = new Nvt({timeout: ''});
-    const nvt3 = new Nvt({timeout: '123'});
+    const nvt1 = Nvt.fromElement({});
+    const nvt2 = Nvt.fromElement({timeout: ''});
+    const nvt3 = Nvt.fromElement({timeout: '123'});
 
     expect(nvt1.timeout).toBeUndefined();
     expect(nvt2.timeout).toBeUndefined();

--- a/gsa/src/gmp/models/__tests__/nvt.js
+++ b/gsa/src/gmp/models/__tests__/nvt.js
@@ -25,7 +25,7 @@ import {testModelProperties, testModelMethods} from 'gmp/models/testing';
 
 describe('nvt Model tests', () => {
   testModelProperties(Nvt, 'nvt');
-  testModelMethods(Nvt, 'nvt');
+  testModelMethods(Nvt);
 
   test('should parse NVT oid as id', () => {
     const nvt1 = new Nvt({_oid: '42.1337'});

--- a/gsa/src/gmp/models/__tests__/nvt.js
+++ b/gsa/src/gmp/models/__tests__/nvt.js
@@ -21,10 +21,10 @@
 
 import Nvt from 'gmp/models/nvt';
 import Info from 'gmp/models/info';
-import {testModelProperties, testModelMethods} from 'gmp/models/testing';
+import {testModelFromElement, testModelMethods} from 'gmp/models/testing';
 
 describe('nvt Model tests', () => {
-  testModelProperties(Nvt, 'nvt');
+  testModelFromElement(Nvt, 'nvt');
   testModelMethods(Nvt);
 
   test('should parse NVT oid as id', () => {

--- a/gsa/src/gmp/models/__tests__/nvt.js
+++ b/gsa/src/gmp/models/__tests__/nvt.js
@@ -21,11 +21,28 @@
 
 import Nvt from 'gmp/models/nvt';
 import Info from 'gmp/models/info';
-import {testNvtModel} from 'gmp/models/testing';
+import {testModelProperties, testModelMethods} from 'gmp/models/testing';
 
-testNvtModel(Nvt, 'nvt');
+describe('nvt Model tests', () => {
+  testModelProperties(Nvt, 'nvt');
+  testModelMethods(Nvt, 'nvt');
 
-describe('NVT model tests', () => {
+  test('should parse NVT oid as id', () => {
+    const nvt1 = new Nvt({_oid: '42.1337'});
+    const nvt2 = new Nvt({});
+
+    expect(nvt1.id).toEqual('42.1337');
+    expect(nvt1.oid).toEqual('42.1337');
+    expect(nvt2.id).toBeUndefined();
+    expect(nvt2.oid).toBeUndefined();
+  });
+
+  test('should not allow to overwrite id', () => {
+    const nvt = new Nvt({_oid: 'foo'});
+
+    expect(() => (nvt.id = 'bar')).toThrow();
+  });
+
   test('should be instance of Info', () => {
     const nvt = new Nvt({});
 

--- a/gsa/src/gmp/models/__tests__/nvt.js
+++ b/gsa/src/gmp/models/__tests__/nvt.js
@@ -44,7 +44,7 @@ describe('nvt Model tests', () => {
   });
 
   test('should be instance of Info', () => {
-    const nvt = new Nvt({});
+    const nvt = new Nvt();
     const nvt2 = Nvt.fromElement({});
 
     expect(nvt).toBeInstanceOf(Info);

--- a/gsa/src/gmp/models/__tests__/os.js
+++ b/gsa/src/gmp/models/__tests__/os.js
@@ -26,7 +26,7 @@ testModel(OperatingSystem, 'operatingsystem');
 
 describe('OperatingSystem model tests', () => {
   test('should be an instance of Asset', () => {
-    const os = new OperatingSystem({});
+    const os = OperatingSystem.fromElement({});
 
     expect(os instanceof Asset).toBe(true);
   });
@@ -45,8 +45,8 @@ describe('OperatingSystem model tests', () => {
         },
       },
     };
-    const os1 = new OperatingSystem(elem);
-    const os2 = new OperatingSystem({});
+    const os1 = OperatingSystem.fromElement(elem);
+    const os2 = OperatingSystem.fromElement({});
 
     expect(os1.average_severity).toEqual(7);
     expect(os1.latest_severity).toEqual(8);
@@ -62,7 +62,7 @@ describe('OperatingSystem model tests', () => {
         title: 'foo',
       },
     };
-    const os = new OperatingSystem(elem);
+    const os = OperatingSystem.fromElement(elem);
 
     expect(os.title).toEqual('foo');
   });
@@ -73,7 +73,7 @@ describe('OperatingSystem model tests', () => {
         installs: '42',
       },
     };
-    const os = new OperatingSystem(elem);
+    const os = OperatingSystem.fromElement(elem);
 
     expect(os.hosts.length).toEqual('42');
   });
@@ -84,7 +84,7 @@ describe('OperatingSystem model tests', () => {
         installs: '42',
       },
     };
-    const os = new OperatingSystem(elem);
+    const os = OperatingSystem.fromElement(elem);
 
     expect(os.os).toBeUndefined();
   });

--- a/gsa/src/gmp/models/__tests__/ovaldef.js
+++ b/gsa/src/gmp/models/__tests__/ovaldef.js
@@ -30,23 +30,23 @@ testModel(Ovaldef, 'ovaldef');
 
 describe('Ovaldef model tests', () => {
   test('should parse severity', () => {
-    const ovaldef = new Ovaldef({max_cvss: '8.5'});
+    const ovaldef = Ovaldef.fromElement({max_cvss: '8.5'});
 
     expect(ovaldef.severity).toEqual(8.5);
     expect(ovaldef.max_cvss).toBeUndefined();
   });
 
   test('should parse deprecated', () => {
-    const ovaldef1 = new Ovaldef({deprecated: '0'});
-    const ovaldef2 = new Ovaldef({deprecated: '1'});
+    const ovaldef1 = Ovaldef.fromElement({deprecated: '0'});
+    const ovaldef2 = Ovaldef.fromElement({deprecated: '1'});
 
     expect(ovaldef1.deprecated).toEqual(NO_VALUE);
     expect(ovaldef2.deprecated).toEqual(YES_VALUE);
   });
 
   test('isDeprecated() should return correct true/false', () => {
-    const ovaldef1 = new Ovaldef({deprecated: '0'});
-    const ovaldef2 = new Ovaldef({deprecated: '1'});
+    const ovaldef1 = Ovaldef.fromElement({deprecated: '0'});
+    const ovaldef2 = Ovaldef.fromElement({deprecated: '1'});
 
     expect(ovaldef1.isDeprecated()).toEqual(false);
     expect(ovaldef2.isDeprecated()).toEqual(true);
@@ -63,9 +63,9 @@ describe('Ovaldef model tests', () => {
         },
       },
     };
-    const ovaldef = new Ovaldef(elem);
-    const ovaldef2 = new Ovaldef({});
-    const ovaldef3 = new Ovaldef({raw_data: {}});
+    const ovaldef = Ovaldef.fromElement(elem);
+    const ovaldef2 = Ovaldef.fromElement({});
+    const ovaldef3 = Ovaldef.fromElement({raw_data: {}});
 
     expect(ovaldef.short_id).toEqual('123abc');
     expect(ovaldef.version).toEqual('42');
@@ -115,7 +115,7 @@ describe('Ovaldef model tests', () => {
         },
       },
     };
-    const ovaldef = new Ovaldef(elem);
+    const ovaldef = Ovaldef.fromElement(elem);
 
     expect(ovaldef.affecteds[0].products).toEqual(['foo', 'bar']);
     expect(ovaldef.affecteds[0].platforms).toEqual(['lorem', 'ipsum']);
@@ -134,7 +134,7 @@ describe('Ovaldef model tests', () => {
   });
 
   test('should return empty arrays if no metadata is given', () => {
-    const ovaldef = new Ovaldef({});
+    const ovaldef = Ovaldef.fromElement({});
 
     expect(ovaldef.affecteds).toEqual([]);
     expect(ovaldef.references).toEqual([]);
@@ -167,7 +167,7 @@ describe('Ovaldef model tests', () => {
         },
       },
     };
-    const ovaldef = new Ovaldef(elem);
+    const ovaldef = Ovaldef.fromElement(elem);
 
     expect(ovaldef.criterias[0].criterions[0].applicability_check).toEqual(
       'foo',
@@ -206,7 +206,7 @@ describe('Ovaldef model tests', () => {
         },
       },
     };
-    const ovaldef = new Ovaldef(elem);
+    const ovaldef = Ovaldef.fromElement(elem);
 
     expect(
       ovaldef.criterias[0].extend_definitions[0].applicability_check,
@@ -228,7 +228,7 @@ describe('Ovaldef model tests', () => {
         },
       },
     };
-    const ovaldef = new Ovaldef(elem);
+    const ovaldef = Ovaldef.fromElement(elem);
 
     expect(ovaldef.criterias[0].comment).toEqual('lorem');
   });
@@ -243,7 +243,7 @@ describe('Ovaldef model tests', () => {
         },
       },
     };
-    const ovaldef = new Ovaldef(elem);
+    const ovaldef = Ovaldef.fromElement(elem);
 
     expect(ovaldef.criterias[0].operator).toEqual('and');
   });
@@ -267,15 +267,15 @@ describe('Ovaldef model tests', () => {
         },
       },
     };
-    const ovaldef = new Ovaldef(elem);
-    const ovaldef2 = new Ovaldef(elem2);
+    const ovaldef = Ovaldef.fromElement(elem);
+    const ovaldef2 = Ovaldef.fromElement(elem2);
 
     expect(ovaldef.criterias[0].negate).toEqual(true);
     expect(ovaldef2.criterias[0].negate).toEqual(false);
   });
 
   test('should return empty arrays if no definition is given', () => {
-    const ovaldef = new Ovaldef({});
+    const ovaldef = Ovaldef.fromElement({});
 
     expect(ovaldef.affecteds).toEqual([]);
     expect(ovaldef.references).toEqual([]);
@@ -283,22 +283,22 @@ describe('Ovaldef model tests', () => {
   });
 
   test('should delete raw_data', () => {
-    const ovaldef = new Ovaldef({});
+    const ovaldef = Ovaldef.fromElement({});
 
     expect(ovaldef.raw_data).toBeUndefined();
   });
 
   test('should return deprecated as yes/no', () => {
-    const ovaldef1 = new Ovaldef({deprecated: '0'});
-    const ovaldef2 = new Ovaldef({deprecated: '1'});
+    const ovaldef1 = Ovaldef.fromElement({deprecated: '0'});
+    const ovaldef2 = Ovaldef.fromElement({deprecated: '1'});
 
     expect(ovaldef1.deprecated).toEqual(NO_VALUE);
     expect(ovaldef2.deprecated).toEqual(YES_VALUE);
   });
 
   test('isDeprecated() should return correct true/false', () => {
-    const ovaldef1 = new Ovaldef({deprecated: '0'});
-    const ovaldef2 = new Ovaldef({deprecated: '1'});
+    const ovaldef1 = Ovaldef.fromElement({deprecated: '0'});
+    const ovaldef2 = Ovaldef.fromElement({deprecated: '1'});
 
     expect(ovaldef1.isDeprecated()).toEqual(false);
     expect(ovaldef2.isDeprecated()).toEqual(true);

--- a/gsa/src/gmp/models/__tests__/override.js
+++ b/gsa/src/gmp/models/__tests__/override.js
@@ -24,9 +24,9 @@ import {testModel} from 'gmp/models/testing';
 
 import {NO_VALUE, YES_VALUE} from 'gmp/parser';
 
-testModel(Override, 'override');
-
 describe('Note model tests', () => {
+  testModel(Override, 'override', {testIsActive: false});
+
   test('should parse severity', () => {
     const override1 = new Override({severity: '8.5'});
     const override2 = new Override({severity: '10'});

--- a/gsa/src/gmp/models/__tests__/override.js
+++ b/gsa/src/gmp/models/__tests__/override.js
@@ -28,9 +28,9 @@ describe('Note model tests', () => {
   testModel(Override, 'override', {testIsActive: false});
 
   test('should parse severity', () => {
-    const override1 = new Override({severity: '8.5'});
-    const override2 = new Override({severity: '10'});
-    const override3 = new Override({});
+    const override1 = Override.fromElement({severity: '8.5'});
+    const override2 = Override.fromElement({severity: '10'});
+    const override3 = Override.fromElement({});
 
     expect(override1.severity).toEqual(8.5);
     expect(override2.severity).toEqual(10);
@@ -38,9 +38,9 @@ describe('Note model tests', () => {
   });
 
   test('should parse new_severity', () => {
-    const override1 = new Override({new_severity: '8.5'});
-    const override2 = new Override({new_severity: '10'});
-    const override3 = new Override({});
+    const override1 = Override.fromElement({new_severity: '8.5'});
+    const override2 = Override.fromElement({new_severity: '10'});
+    const override3 = Override.fromElement({});
 
     expect(override1.new_severity).toEqual(8.5);
     expect(override2.new_severity).toEqual(10);
@@ -48,16 +48,16 @@ describe('Note model tests', () => {
   });
 
   test('should parse active as yes/no correctly', () => {
-    const override1 = new Override({active: '0'});
-    const override2 = new Override({active: '1'});
+    const override1 = Override.fromElement({active: '0'});
+    const override2 = Override.fromElement({active: '1'});
 
     expect(override1.active).toEqual(NO_VALUE);
     expect(override2.active).toEqual(YES_VALUE);
   });
 
   test('should parse text_excerpt as yes/no correctly', () => {
-    const override1 = new Override({text_excerpt: '0'});
-    const override2 = new Override({text_excerpt: '1'});
+    const override1 = Override.fromElement({text_excerpt: '0'});
+    const override2 = Override.fromElement({text_excerpt: '1'});
 
     expect(override1.text_excerpt).toEqual(NO_VALUE);
     expect(override2.text_excerpt).toEqual(YES_VALUE);
@@ -67,16 +67,16 @@ describe('Note model tests', () => {
     const elem = {
       hosts: '123.456.789.42, 987.654.321.1',
     };
-    const override1 = new Override(elem);
-    const override2 = new Override({hosts: ''});
+    const override1 = Override.fromElement(elem);
+    const override2 = Override.fromElement({hosts: ''});
 
     expect(override1.hosts).toEqual(['123.456.789.42', '987.654.321.1']);
     expect(override2.hosts).toEqual([]);
   });
 
   test('isExcerpt() should return correct true/false', () => {
-    const override1 = new Override({text_excerpt: '1'});
-    const override2 = new Override({text_excerpt: '0'});
+    const override1 = Override.fromElement({text_excerpt: '1'});
+    const override2 = Override.fromElement({text_excerpt: '0'});
 
     expect(override1.isExcerpt()).toEqual(true);
     expect(override2.isExcerpt()).toEqual(false);
@@ -93,9 +93,9 @@ describe('Note model tests', () => {
         _id: '',
       },
     };
-    const override1 = new Override(elem1);
-    const override2 = new Override(elem2);
-    const override3 = new Override({});
+    const override1 = Override.fromElement(elem1);
+    const override2 = Override.fromElement(elem2);
+    const override3 = Override.fromElement({});
 
     expect(override1.task).toBeInstanceOf(Model);
     expect(override2.task).toBeUndefined();
@@ -113,9 +113,9 @@ describe('Note model tests', () => {
         _id: '',
       },
     };
-    const override1 = new Override(elem1);
-    const override2 = new Override(elem2);
-    const override3 = new Override({});
+    const override1 = Override.fromElement(elem1);
+    const override2 = Override.fromElement(elem2);
+    const override3 = Override.fromElement({});
 
     expect(override1.result).toBeInstanceOf(Model);
     expect(override2.result).toBeUndefined();
@@ -129,7 +129,7 @@ describe('Note model tests', () => {
         name: 'foo',
       },
     };
-    const override = new Override(elem);
+    const override = Override.fromElement(elem);
 
     expect(override.nvt).toBeInstanceOf(Nvt);
     expect(override.name).toEqual('foo');

--- a/gsa/src/gmp/models/__tests__/override.js
+++ b/gsa/src/gmp/models/__tests__/override.js
@@ -98,6 +98,8 @@ describe('Note model tests', () => {
     const override3 = Override.fromElement({});
 
     expect(override1.task).toBeInstanceOf(Model);
+    expect(override1.task.id).toEqual('123abc');
+    expect(override1.task.entityType).toEqual('task');
     expect(override2.task).toBeUndefined();
     expect(override3.task).toBeUndefined();
   });
@@ -118,6 +120,8 @@ describe('Note model tests', () => {
     const override3 = Override.fromElement({});
 
     expect(override1.result).toBeInstanceOf(Model);
+    expect(override1.result.id).toEqual('123abc');
+    expect(override1.result.entityType).toEqual('result');
     expect(override2.result).toBeUndefined();
     expect(override3.result).toBeUndefined();
   });

--- a/gsa/src/gmp/models/__tests__/permission.js
+++ b/gsa/src/gmp/models/__tests__/permission.js
@@ -33,7 +33,7 @@ describe('Permission model tests', () => {
         type: 'alert',
       },
     };
-    const permission = new Permission(elem);
+    const permission = Permission.fromElement(elem);
 
     expect(permission.resource.entityType).toEqual('alert');
     expect(permission.resource.id).toEqual('123');
@@ -45,7 +45,7 @@ describe('Permission model tests', () => {
         type: 'alert',
       },
     };
-    const permission = new Permission(elem);
+    const permission = Permission.fromElement(elem);
 
     expect(permission.resource).toBeUndefined();
   });
@@ -57,7 +57,7 @@ describe('Permission model tests', () => {
         type: 'alert',
       },
     };
-    const permission = new Permission(elem);
+    const permission = Permission.fromElement(elem);
 
     expect(permission.subject).toEqual(
       new Model(elem.subject, elem.subject.type),
@@ -70,7 +70,7 @@ describe('Permission model tests', () => {
         type: 'alert',
       },
     };
-    const permission = new Permission(elem);
+    const permission = Permission.fromElement(elem);
 
     expect(permission.subject).toBeUndefined();
   });

--- a/gsa/src/gmp/models/__tests__/permission.js
+++ b/gsa/src/gmp/models/__tests__/permission.js
@@ -35,6 +35,7 @@ describe('Permission model tests', () => {
     };
     const permission = Permission.fromElement(elem);
 
+    expect(permission.resource).toBeInstanceOf(Model);
     expect(permission.resource.entityType).toEqual('alert');
     expect(permission.resource.id).toEqual('123');
   });
@@ -59,9 +60,9 @@ describe('Permission model tests', () => {
     };
     const permission = Permission.fromElement(elem);
 
-    expect(permission.subject).toEqual(
-      new Model(elem.subject, elem.subject.type),
-    );
+    expect(permission.subject).toBeInstanceOf(Model);
+    expect(permission.subject.id).toEqual('123');
+    expect(permission.subject.entityType).toEqual('alert');
   });
 
   test('should not parse subject if no id is given', () => {

--- a/gsa/src/gmp/models/__tests__/portlist.js
+++ b/gsa/src/gmp/models/__tests__/portlist.js
@@ -45,7 +45,7 @@ describe('PortList model tests', () => {
         ],
       },
     };
-    const portList = new PortList(elem);
+    const portList = PortList.fromElement(elem);
 
     expect(portList.port_ranges[0]).toBeInstanceOf(Model);
     expect(portList.port_ranges[0].entityType).toEqual('portrange');
@@ -73,7 +73,7 @@ describe('PortList model tests', () => {
         udp: '1',
       },
     };
-    const portList = new PortList(elem);
+    const portList = PortList.fromElement(elem);
 
     expect(portList.port_count.all).toEqual(42);
     expect(portList.port_count.tcp).toEqual(20);
@@ -81,7 +81,7 @@ describe('PortList model tests', () => {
   });
 
   test('should return counts of zero, if port_count is not defined', () => {
-    const portList = new PortList({});
+    const portList = PortList.fromElement({});
 
     expect(portList.port_count.all).toEqual(0);
     expect(portList.port_count.tcp).toEqual(0);
@@ -94,7 +94,7 @@ describe('PortList model tests', () => {
         target: [{id: '123'}, {id: '456'}],
       },
     };
-    const portList = new PortList(elem);
+    const portList = PortList.fromElement(elem);
 
     expect(portList.targets[0]).toBeInstanceOf(Model);
     expect(portList.targets[0].entityType).toEqual('target');
@@ -105,7 +105,7 @@ describe('PortList model tests', () => {
   });
 
   test('should return empty array if no targets are given', () => {
-    const portList = new PortList({});
+    const portList = PortList.fromElement({});
 
     expect(portList.targets).toEqual([]);
   });

--- a/gsa/src/gmp/models/__tests__/reportformat.js
+++ b/gsa/src/gmp/models/__tests__/reportformat.js
@@ -42,8 +42,8 @@ describe('ReportFormat model tests', () => {
         __text: 'bar',
       },
     };
-    const reportFormat = new ReportFormat(elem);
-    const reportFormat2 = new ReportFormat(elem2);
+    const reportFormat = ReportFormat.fromElement(elem);
+    const reportFormat2 = ReportFormat.fromElement(elem2);
 
     expect(reportFormat.trust.value).toEqual('foo');
     expect(isDate(reportFormat.trust.time)).toEqual(true);
@@ -52,22 +52,22 @@ describe('ReportFormat model tests', () => {
   });
 
   test('should return empty object if no trust is given', () => {
-    const reportFormat = new ReportFormat({});
+    const reportFormat = ReportFormat.fromElement({});
 
     expect(reportFormat.trust).toEqual({});
   });
 
   test('should parse active as yes/no correctly', () => {
-    const reportFormat = new ReportFormat({active: '0'});
-    const reportFormat2 = new ReportFormat({active: '1'});
+    const reportFormat = ReportFormat.fromElement({active: '0'});
+    const reportFormat2 = ReportFormat.fromElement({active: '1'});
 
     expect(reportFormat.active).toEqual(NO_VALUE);
     expect(reportFormat2.active).toEqual(YES_VALUE);
   });
 
   test('should parse predefined as yes/no correctly', () => {
-    const reportFormat = new ReportFormat({predefined: '0'});
-    const reportFormat2 = new ReportFormat({predefined: '1'});
+    const reportFormat = ReportFormat.fromElement({predefined: '0'});
+    const reportFormat2 = ReportFormat.fromElement({predefined: '1'});
 
     expect(reportFormat.predefined).toEqual(NO_VALUE);
     expect(reportFormat2.predefined).toEqual(YES_VALUE);
@@ -79,7 +79,7 @@ describe('ReportFormat model tests', () => {
         alert: [{id: '12'}],
       },
     };
-    const reportFormat = new ReportFormat(elem);
+    const reportFormat = ReportFormat.fromElement(elem);
 
     expect(reportFormat.alerts[0]).toBeInstanceOf(Model);
     expect(reportFormat.alerts[0].entityType).toEqual('alert');
@@ -87,7 +87,7 @@ describe('ReportFormat model tests', () => {
   });
 
   test('should return empty array if no alerts are given', () => {
-    const reportFormat = new ReportFormat({});
+    const reportFormat = ReportFormat.fromElement({});
 
     expect(reportFormat.alerts).toEqual([]);
   });
@@ -109,7 +109,7 @@ describe('ReportFormat model tests', () => {
           },
         ],
       };
-      const reportFormat = new ReportFormat(elem);
+      const reportFormat = ReportFormat.fromElement(elem);
 
       expect(reportFormat.param).toBeUndefined();
       expect(reportFormat.params[0].default).toEqual('ipsum');
@@ -132,7 +132,7 @@ describe('ReportFormat model tests', () => {
           },
         ],
       };
-      const reportFormat = new ReportFormat(elem);
+      const reportFormat = ReportFormat.fromElement(elem);
 
       expect(reportFormat.params[0].default).toEqual('ipsum');
       expect(reportFormat.params[0].name).toEqual('foo');
@@ -156,7 +156,7 @@ describe('ReportFormat model tests', () => {
         {value: 'opt1', name: 'opt1'},
         {value: 'opt2', name: 'opt2'},
       ];
-      const reportFormat = new ReportFormat(elem);
+      const reportFormat = ReportFormat.fromElement(elem);
 
       expect(reportFormat.params[0].options).toEqual(res);
     });
@@ -172,7 +172,7 @@ describe('ReportFormat model tests', () => {
           },
         ],
       };
-      const reportFormat = new ReportFormat(elem);
+      const reportFormat = ReportFormat.fromElement(elem);
 
       expect(reportFormat.params[0].options).toEqual([]);
     });
@@ -216,9 +216,9 @@ describe('ReportFormat model tests', () => {
           },
         ],
       };
-      const reportFormat = new ReportFormat(elem);
-      const reportFormat2 = new ReportFormat(elem2);
-      const reportFormat3 = new ReportFormat(elem3);
+      const reportFormat = ReportFormat.fromElement(elem);
+      const reportFormat2 = ReportFormat.fromElement(elem2);
+      const reportFormat3 = ReportFormat.fromElement(elem3);
 
       expect(reportFormat.params[0].value).toEqual('foo');
       expect(reportFormat2.params[0].value).toEqual('bar');
@@ -228,16 +228,16 @@ describe('ReportFormat model tests', () => {
 
   describe('ReportFormat model method tests', () => {
     test('isPredefined() returns correct true/false', () => {
-      const reportFormat = new ReportFormat({predefined: '0'});
-      const reportFormat2 = new ReportFormat({predefined: '1'});
+      const reportFormat = ReportFormat.fromElement({predefined: '0'});
+      const reportFormat2 = ReportFormat.fromElement({predefined: '1'});
 
       expect(reportFormat.isPredefined()).toBe(false);
       expect(reportFormat2.isPredefined()).toBe(true);
     });
 
     test('isActive() returns correct true/false', () => {
-      const reportFormat = new ReportFormat({active: '0'});
-      const reportFormat2 = new ReportFormat({active: '1'});
+      const reportFormat = ReportFormat.fromElement({active: '0'});
+      const reportFormat2 = ReportFormat.fromElement({active: '1'});
 
       expect(reportFormat.isActive()).toBe(false);
       expect(reportFormat2.isActive()).toBe(true);
@@ -254,8 +254,8 @@ describe('ReportFormat model tests', () => {
           __text: 'yes',
         },
       };
-      const reportFormat = new ReportFormat(elem);
-      const reportFormat2 = new ReportFormat(elem2);
+      const reportFormat = ReportFormat.fromElement(elem);
+      const reportFormat2 = ReportFormat.fromElement(elem2);
 
       expect(reportFormat.isTrusted()).toBe(false);
       expect(reportFormat2.isTrusted()).toBe(true);

--- a/gsa/src/gmp/models/__tests__/result.js
+++ b/gsa/src/gmp/models/__tests__/result.js
@@ -42,8 +42,8 @@ describe('Result model tests', () => {
         __text: 'foo',
       },
     };
-    const result = new Result(elem);
-    const result2 = new Result(elem2);
+    const result = Result.fromElement(elem);
+    const result2 = Result.fromElement(elem2);
     const res = {
       name: 'foo',
       id: '123',
@@ -58,7 +58,7 @@ describe('Result model tests', () => {
   });
 
   test('should parse host string', () => {
-    const result = new Result({host: 'foo'});
+    const result = Result.fromElement({host: 'foo'});
     const res = {
       name: 'foo',
       hostname: '',
@@ -73,7 +73,7 @@ describe('Result model tests', () => {
       __text: 'foo',
       hostname: 'bar',
     };
-    const result = new Result({host});
+    const result = Result.fromElement({host});
 
     expect(result.host).toEqual({
       name: 'foo',
@@ -87,14 +87,14 @@ describe('Result model tests', () => {
         _oid: 'bar',
       },
     };
-    const result = new Result(elem);
+    const result = Result.fromElement(elem);
 
     expect(result.nvt).toBeInstanceOf(Nvt);
   });
 
   test('should parse severity', () => {
-    const result = new Result({severity: '4.2'});
-    const result2 = new Result({});
+    const result = Result.fromElement({severity: '4.2'});
+    const result2 = Result.fromElement({});
 
     expect(result.severity).toEqual(4.2);
     expect(result2.severity).toBeUndefined();
@@ -106,22 +106,22 @@ describe('Result model tests', () => {
         _oid: '42',
       },
     };
-    const result = new Result({name: 'foo'});
-    const result2 = new Result(elem);
+    const result = Result.fromElement({name: 'foo'});
+    const result2 = Result.fromElement(elem);
 
     expect(result.vulnerability).toEqual('foo');
     expect(result2.vulnerability).toEqual('42');
   });
 
   test('should parse report', () => {
-    const result = new Result({report: 'foo'});
+    const result = Result.fromElement({report: 'foo'});
 
     expect(result.report).toBeInstanceOf(Model);
     expect(result.report.entityType).toEqual('report');
   });
 
   test('should parse task', () => {
-    const result = new Result({task: 'foo'});
+    const result = Result.fromElement({task: 'foo'});
 
     expect(result.task).toBeInstanceOf(Model);
     expect(result.task.entityType).toEqual('task');
@@ -156,13 +156,13 @@ describe('Result model tests', () => {
         },
       },
     };
-    const result = new Result(elem);
+    const result = Result.fromElement(elem);
 
     expect(result.detection).toEqual(res);
   });
 
   test('should parse delta string', () => {
-    const result = new Result({delta: 'foo'});
+    const result = Result.fromElement({delta: 'foo'});
 
     expect(result.delta).toBeInstanceOf(Delta);
     expect(result.delta).toEqual({delta_type: 'foo'});
@@ -174,7 +174,7 @@ describe('Result model tests', () => {
         __text: 'foo',
       },
     };
-    const result = new Result(elem);
+    const result = Result.fromElement(elem);
 
     expect(result.delta).toBeInstanceOf(Delta);
     expect(result.delta.delta_type).toEqual('foo');
@@ -191,7 +191,7 @@ describe('Result model tests', () => {
         },
       },
     };
-    const result = new Result(elem);
+    const result = Result.fromElement(elem);
 
     expect(result.delta).toBeInstanceOf(Delta);
     expect(result.delta.delta_type).toEqual(Delta.TYPE_CHANGED);
@@ -201,7 +201,7 @@ describe('Result model tests', () => {
   });
 
   test('should parse original severity', () => {
-    const result = new Result({original_severity: '4.2'});
+    const result = Result.fromElement({original_severity: '4.2'});
 
     expect(result.original_severity).toEqual(4.2);
   });
@@ -217,7 +217,7 @@ describe('Result model tests', () => {
       type: 'foo',
       value: 42.5,
     };
-    const result = new Result(elem);
+    const result = Result.fromElement(elem);
 
     expect(result.qod).toEqual(res);
   });
@@ -228,14 +228,14 @@ describe('Result model tests', () => {
         note: ['foo', 'bar'],
       },
     };
-    const result = new Result(elem);
+    const result = Result.fromElement(elem);
 
     expect(result.notes[0]).toBeInstanceOf(Note);
     expect(result.notes[1]).toBeInstanceOf(Note);
   });
 
   test('should return empty array if no notes are given', () => {
-    const result = new Result({});
+    const result = Result.fromElement({});
 
     expect(result.notes).toEqual([]);
   });
@@ -246,21 +246,21 @@ describe('Result model tests', () => {
         override: ['foo', 'bar'],
       },
     };
-    const result = new Result(elem);
+    const result = Result.fromElement(elem);
 
     expect(result.overrides[0]).toBeInstanceOf(Override);
     expect(result.overrides[1]).toBeInstanceOf(Override);
   });
 
   test('should return empty array if no overrides are given', () => {
-    const result = new Result({});
+    const result = Result.fromElement({});
 
     expect(result.overrides).toEqual([]);
   });
 
   test('hasDelta() should return correct true/false', () => {
-    const result = new Result({delta: 'defined'});
-    const result2 = new Result({});
+    const result = Result.fromElement({delta: 'defined'});
+    const result2 = Result.fromElement({});
 
     expect(result.hasDelta()).toEqual(true);
     expect(result2.hasDelta()).toEqual(false);

--- a/gsa/src/gmp/models/__tests__/result.js
+++ b/gsa/src/gmp/models/__tests__/result.js
@@ -90,6 +90,7 @@ describe('Result model tests', () => {
     const result = Result.fromElement(elem);
 
     expect(result.nvt).toBeInstanceOf(Nvt);
+    expect(result.nvt.oid).toEqual('bar');
   });
 
   test('should parse severity', () => {
@@ -231,7 +232,9 @@ describe('Result model tests', () => {
     const result = Result.fromElement(elem);
 
     expect(result.notes[0]).toBeInstanceOf(Note);
+    expect(result.notes[0].entityType).toEqual('note');
     expect(result.notes[1]).toBeInstanceOf(Note);
+    expect(result.notes[1].entityType).toEqual('note');
   });
 
   test('should return empty array if no notes are given', () => {
@@ -249,7 +252,9 @@ describe('Result model tests', () => {
     const result = Result.fromElement(elem);
 
     expect(result.overrides[0]).toBeInstanceOf(Override);
+    expect(result.overrides[0].entityType).toEqual('override');
     expect(result.overrides[1]).toBeInstanceOf(Override);
+    expect(result.overrides[1].entityType).toEqual('override');
   });
 
   test('should return empty array if no overrides are given', () => {

--- a/gsa/src/gmp/models/__tests__/role.js
+++ b/gsa/src/gmp/models/__tests__/role.js
@@ -25,27 +25,27 @@ testModel(Role, 'role');
 describe('Role model tests', () => {
   test('should parse multiple users', () => {
     const elem = {users: 'foo, bar'};
-    const role = new Role(elem);
+    const role = Role.fromElement(elem);
 
     expect(role.users).toEqual(['foo', 'bar']);
   });
 
   test('should parse single user', () => {
     const elem = {users: 'foo'};
-    const role = new Role(elem);
+    const role = Role.fromElement(elem);
 
     expect(role.users).toEqual(['foo']);
   });
 
   test('should parse empty users string to empty array', () => {
     const elem = {users: ''};
-    const role = new Role(elem);
+    const role = Role.fromElement(elem);
 
     expect(role.users).toEqual([]);
   });
 
   test('should parse empty object to have empty users array', () => {
-    const role = new Role({});
+    const role = Role.fromElement({});
 
     expect(role.users).toEqual([]);
   });

--- a/gsa/src/gmp/models/__tests__/scanconfig.js
+++ b/gsa/src/gmp/models/__tests__/scanconfig.js
@@ -242,6 +242,7 @@ describe('ScanConfig model tests', () => {
     const scanConfig = ScanConfig.fromElement(elem);
 
     expect(scanConfig.tasks[0]).toBeInstanceOf(Model);
+    expect(scanConfig.tasks[0].id).toEqual('123');
     expect(scanConfig.tasks[0].entityType).toEqual('task');
   });
 

--- a/gsa/src/gmp/models/__tests__/scanconfig.js
+++ b/gsa/src/gmp/models/__tests__/scanconfig.js
@@ -54,7 +54,7 @@ describe('ScanConfig model tests', () => {
         },
       },
     ];
-    const scanConfig = new ScanConfig(elem);
+    const scanConfig = ScanConfig.fromElement(elem);
 
     expect(scanConfig.family_list).toEqual(res);
   });
@@ -72,7 +72,7 @@ describe('ScanConfig model tests', () => {
         ],
       },
     };
-    const scanConfig = new ScanConfig(elem);
+    const scanConfig = ScanConfig.fromElement(elem);
 
     expect(scanConfig.family_list[0].nvts.count).toBeUndefined();
     expect(scanConfig.family_list[0].nvts.max).toBeUndefined();
@@ -99,13 +99,13 @@ describe('ScanConfig model tests', () => {
         max: 42,
       },
     };
-    const scanConfig = new ScanConfig(elem);
+    const scanConfig = ScanConfig.fromElement(elem);
 
     expect(scanConfig.families.foo).toEqual(res);
   });
 
   test('should return empty family_list array if no families are given', () => {
-    const scanConfig = new ScanConfig({});
+    const scanConfig = ScanConfig.fromElement({});
 
     expect(scanConfig.family_list).toEqual([]);
   });
@@ -117,7 +117,7 @@ describe('ScanConfig model tests', () => {
         growing: '1',
       },
     };
-    const scanConfig = new ScanConfig(elem);
+    const scanConfig = ScanConfig.fromElement(elem);
 
     expect(scanConfig.families.count).toEqual(42);
     expect(scanConfig.families.trend).toEqual(SCANCONFIG_TREND_DYNAMIC);
@@ -139,7 +139,7 @@ describe('ScanConfig model tests', () => {
       known: 21,
       max: 1337,
     };
-    const scanConfig = new ScanConfig(elem);
+    const scanConfig = ScanConfig.fromElement(elem);
 
     expect(scanConfig.nvts).toEqual(res);
     expect(scanConfig.nvt_count).toBeUndefined();
@@ -148,7 +148,7 @@ describe('ScanConfig model tests', () => {
   });
 
   test('should return empty object if no nvt_counts are given', () => {
-    const scanConfig = new ScanConfig({});
+    const scanConfig = ScanConfig.fromElement({});
 
     expect(scanConfig.nvts).toEqual({});
   });
@@ -193,21 +193,21 @@ describe('ScanConfig model tests', () => {
       },
     ];
 
-    const scanConfig = new ScanConfig(elem);
+    const scanConfig = ScanConfig.fromElement(elem);
 
     expect(scanConfig.preferences.scanner).toEqual(scannerPreferences);
     expect(scanConfig.preferences.nvt).toEqual(nvtPreferences);
   });
 
   test('should return empty arrays if no preferences are given', () => {
-    const scanConfig = new ScanConfig({});
+    const scanConfig = ScanConfig.fromElement({});
 
     expect(scanConfig.preferences.scanner).toEqual([]);
     expect(scanConfig.preferences.nvt).toEqual([]);
   });
 
   test('should parse type', () => {
-    const scanConfig = new ScanConfig({type: '21'});
+    const scanConfig = ScanConfig.fromElement({type: '21'});
 
     expect(scanConfig.scan_config_type).toEqual(21);
   });
@@ -219,8 +219,8 @@ describe('ScanConfig model tests', () => {
         id: '123abc',
       },
     };
-    const scanConfig = new ScanConfig(elem);
-    const scanConfig2 = new ScanConfig({});
+    const scanConfig = ScanConfig.fromElement(elem);
+    const scanConfig2 = ScanConfig.fromElement({});
 
     expect(scanConfig.scanner).toBeInstanceOf(Model);
     expect(scanConfig.scanner.entityType).toEqual('scanner');
@@ -239,14 +239,14 @@ describe('ScanConfig model tests', () => {
         ],
       },
     };
-    const scanConfig = new ScanConfig(elem);
+    const scanConfig = ScanConfig.fromElement(elem);
 
     expect(scanConfig.tasks[0]).toBeInstanceOf(Model);
     expect(scanConfig.tasks[0].entityType).toEqual('task');
   });
 
   test('should return empty array if no tasks are given', () => {
-    const scanConfig = new ScanConfig({});
+    const scanConfig = ScanConfig.fromElement({});
 
     expect(scanConfig.tasks).toEqual([]);
   });

--- a/gsa/src/gmp/models/__tests__/scanner.js
+++ b/gsa/src/gmp/models/__tests__/scanner.js
@@ -60,6 +60,7 @@ describe('Scanner model tests', () => {
 
     expect(scanner.credential).toBeInstanceOf(Credential);
     expect(scanner.credential.id).toEqual('123abc');
+    expect(scanner.credential.entityType).toEqual('credential');
     expect(scanner2.credential).toBeUndefined();
   });
 
@@ -101,6 +102,7 @@ describe('Scanner model tests', () => {
 
     expect(scanner.tasks[0]).toBeInstanceOf(Model);
     expect(scanner.tasks[0].entityType).toEqual('task');
+    expect(scanner.tasks[0].id).toEqual('123');
   });
 
   test('should return empty array if no tasks are given', () => {
@@ -119,6 +121,7 @@ describe('Scanner model tests', () => {
 
     expect(scanner.configs[0]).toBeInstanceOf(Model);
     expect(scanner.configs[0].entityType).toEqual('scanconfig');
+    expect(scanner.configs[0].id).toEqual('123');
   });
 
   test('should return empty array if no configs are given', () => {

--- a/gsa/src/gmp/models/__tests__/scanner.js
+++ b/gsa/src/gmp/models/__tests__/scanner.js
@@ -39,7 +39,7 @@ testModel(Scanner, 'scanner');
 
 describe('Scanner model tests', () => {
   test('should parse type', () => {
-    const scanner = new Scanner({type: '42'});
+    const scanner = Scanner.fromElement({type: '42'});
 
     expect(scanner.scannerType).toEqual(42);
   });
@@ -55,8 +55,8 @@ describe('Scanner model tests', () => {
         _id: '',
       },
     };
-    const scanner = new Scanner(elem);
-    const scanner2 = new Scanner(elem2);
+    const scanner = Scanner.fromElement(elem);
+    const scanner2 = Scanner.fromElement(elem2);
 
     expect(scanner.credential).toBeInstanceOf(Credential);
     expect(scanner.credential.id).toEqual('123abc');
@@ -67,8 +67,8 @@ describe('Scanner model tests', () => {
     const elem = {
       ca_pub: {},
     };
-    const scanner = new Scanner({});
-    const scanner2 = new Scanner(elem);
+    const scanner = Scanner.fromElement({});
+    const scanner2 = Scanner.fromElement(elem);
 
     expect(scanner.ca_pub).toBeUndefined();
     expect(scanner2.ca_pub).toEqual({certificate: {}});
@@ -82,7 +82,7 @@ describe('Scanner model tests', () => {
         expiration_time: '2018-10-10T23:59:00.000+0000',
       },
     };
-    const scanner = new Scanner(elem);
+    const scanner = Scanner.fromElement(elem);
 
     expect(isDate(scanner.ca_pub.info.activationTime)).toEqual(true);
     expect(isDate(scanner.ca_pub.info.expirationTime)).toEqual(true);
@@ -97,14 +97,14 @@ describe('Scanner model tests', () => {
         task: [{id: '123'}],
       },
     };
-    const scanner = new Scanner(elem);
+    const scanner = Scanner.fromElement(elem);
 
     expect(scanner.tasks[0]).toBeInstanceOf(Model);
     expect(scanner.tasks[0].entityType).toEqual('task');
   });
 
   test('should return empty array if no tasks are given', () => {
-    const scanner = new Scanner({});
+    const scanner = Scanner.fromElement({});
 
     expect(scanner.tasks).toEqual([]);
   });
@@ -115,14 +115,14 @@ describe('Scanner model tests', () => {
         config: [{id: '123'}],
       },
     };
-    const scanner = new Scanner(elem);
+    const scanner = Scanner.fromElement(elem);
 
     expect(scanner.configs[0]).toBeInstanceOf(Model);
     expect(scanner.configs[0].entityType).toEqual('scanconfig');
   });
 
   test('should return empty array if no configs are given', () => {
-    const scanner = new Scanner({});
+    const scanner = Scanner.fromElement({});
 
     expect(scanner.configs).toEqual([]);
   });
@@ -167,8 +167,8 @@ describe('Scanner model tests', () => {
       mandatory: YES_VALUE,
       default: 'amet',
     };
-    const scanner = new Scanner(elem);
-    const scanner2 = new Scanner(elem2);
+    const scanner = Scanner.fromElement(elem);
+    const scanner2 = Scanner.fromElement(elem2);
 
     expect(scanner.info.scanner.name).toEqual('foo');
     expect(scanner.info.scanner.version).toEqual('42');
@@ -187,10 +187,10 @@ describe('Scanner model tests', () => {
     const elem3 = {type: GMP_SCANNER_TYPE};
     const elem4 = {type: OSP_SCANNER_TYPE};
 
-    const scanner1 = new Scanner(elem1);
-    const scanner2 = new Scanner(elem2);
-    const scanner3 = new Scanner(elem3);
-    const scanner4 = new Scanner(elem4);
+    const scanner1 = Scanner.fromElement(elem1);
+    const scanner2 = Scanner.fromElement(elem2);
+    const scanner3 = Scanner.fromElement(elem3);
+    const scanner4 = Scanner.fromElement(elem4);
 
     expect(scanner1.isClonable()).toEqual(false);
     expect(scanner2.isClonable()).toEqual(false);
@@ -204,10 +204,10 @@ describe('Scanner model tests', () => {
     const elem3 = {type: GMP_SCANNER_TYPE};
     const elem4 = {type: OSP_SCANNER_TYPE};
 
-    const scanner1 = new Scanner(elem1);
-    const scanner2 = new Scanner(elem2);
-    const scanner3 = new Scanner(elem3);
-    const scanner4 = new Scanner(elem4);
+    const scanner1 = Scanner.fromElement(elem1);
+    const scanner2 = Scanner.fromElement(elem2);
+    const scanner3 = Scanner.fromElement(elem3);
+    const scanner4 = Scanner.fromElement(elem4);
 
     expect(scanner1.isClonable()).toEqual(false);
     expect(scanner2.isClonable()).toEqual(false);
@@ -216,9 +216,9 @@ describe('Scanner model tests', () => {
   });
 
   test('hasUnixSocket() should return correct true/false', () => {
-    const scanner1 = new Scanner({host: '/foo'});
-    const scanner2 = new Scanner({host: 'bar'});
-    const scanner3 = new Scanner({host: {}});
+    const scanner1 = Scanner.fromElement({host: '/foo'});
+    const scanner2 = Scanner.fromElement({host: 'bar'});
+    const scanner3 = Scanner.fromElement({host: {}});
 
     expect(scanner1.hasUnixSocket()).toEqual(true);
     expect(scanner2.hasUnixSocket()).toEqual(false);

--- a/gsa/src/gmp/models/__tests__/schedule.js
+++ b/gsa/src/gmp/models/__tests__/schedule.js
@@ -59,6 +59,7 @@ describe('Schedule model tests', () => {
 
     expect(schedule.tasks[0]).toBeInstanceOf(Model);
     expect(schedule.tasks[0].entityType).toEqual('task');
+    expect(schedule.tasks[0].id).toEqual('123');
   });
 });
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/gmp/models/__tests__/schedule.js
+++ b/gsa/src/gmp/models/__tests__/schedule.js
@@ -37,7 +37,7 @@ describe('Schedule model tests', () => {
       simple_duration: 'adipiscing',
       simple_period: 'elit',
     };
-    const schedule = new Schedule(elem);
+    const schedule = Schedule.fromElement(elem);
 
     expect(schedule.first_time).toBeUndefined();
     expect(schedule.next_time).toBeUndefined();
@@ -55,7 +55,7 @@ describe('Schedule model tests', () => {
         task: [{id: '123'}],
       },
     };
-    const schedule = new Schedule(elem);
+    const schedule = Schedule.fromElement(elem);
 
     expect(schedule.tasks[0]).toBeInstanceOf(Model);
     expect(schedule.tasks[0].entityType).toEqual('task');

--- a/gsa/src/gmp/models/__tests__/secinfo.js
+++ b/gsa/src/gmp/models/__tests__/secinfo.js
@@ -25,13 +25,13 @@ testModel(SecInfo, 'allinfo');
 
 describe('SecInfo model tests', () => {
   test('should be instance of Info', () => {
-    const secInfo = new SecInfo({});
+    const secInfo = SecInfo.fromElement({});
 
     expect(secInfo).toBeInstanceOf(Info);
   });
 
   test('should parse type', () => {
-    const secInfo = new SecInfo({_type: 'nvt'});
+    const secInfo = SecInfo.fromElement({_type: 'nvt'});
 
     expect(secInfo.infoType).toEqual('nvt');
   });
@@ -43,7 +43,7 @@ describe('SecInfo model tests', () => {
         other: {},
       },
     };
-    const secInfo = new SecInfo(elem);
+    const secInfo = SecInfo.fromElement(elem);
 
     expect(secInfo.allInfo).toBeUndefined();
     expect(secInfo._type).toBeUndefined();
@@ -54,8 +54,8 @@ describe('SecInfo model tests', () => {
 
 describe('SecInfo model function tests', () => {
   test('secInfoType should return infoType', () => {
-    const secInfo1 = new SecInfo({allinfo: {type: 'nvt'}});
-    const secInfo2 = new SecInfo({});
+    const secInfo1 = SecInfo.fromElement({allinfo: {type: 'nvt'}});
+    const secInfo2 = SecInfo.fromElement({});
 
     expect(secInfoType(secInfo1)).toEqual('nvt');
     expect(secInfoType(secInfo2)).toBeUndefined();

--- a/gsa/src/gmp/models/__tests__/setting.js
+++ b/gsa/src/gmp/models/__tests__/setting.js
@@ -20,7 +20,7 @@ import Setting from '../setting';
 
 describe('Setting tests', () => {
   test('should create setting from an element', () => {
-    const setting = new Setting({
+    const setting = Setting.fromElement({
       _id: 'foo',
       comment: 'a comment',
       name: 'bar',
@@ -36,7 +36,7 @@ describe('Setting tests', () => {
   });
 
   test('should not set empty value', () => {
-    const setting = new Setting({
+    const setting = Setting.fromElement({
       value: '',
     });
 
@@ -44,7 +44,7 @@ describe('Setting tests', () => {
   });
 
   test('should consider 0 as undefined value', () => {
-    const setting = new Setting({
+    const setting = Setting.fromElement({
       value: '0',
     });
 
@@ -52,7 +52,7 @@ describe('Setting tests', () => {
   });
 
   test('should ignore (null) in comment', () => {
-    const setting = new Setting({
+    const setting = Setting.fromElement({
       comment: '(null)',
     });
 

--- a/gsa/src/gmp/models/__tests__/tag.js
+++ b/gsa/src/gmp/models/__tests__/tag.js
@@ -33,27 +33,27 @@ describe('Tag model tests', () => {
         },
       },
     };
-    const tag = new Tag(elem);
+    const tag = Tag.fromElement(elem);
 
     expect(tag.resourceType).toEqual('foo');
     expect(tag.resourceCount).toEqual(42);
   });
 
   test('should return count of 0 and no type if no resources are given', () => {
-    const tag = new Tag({});
+    const tag = Tag.fromElement({});
 
     expect(tag.resourceType).toBeUndefined();
     expect(tag.resourceCount).toEqual(0);
   });
 
   test('should parse value to undefined, if no value is given', () => {
-    const tag = new Tag({});
+    const tag = Tag.fromElement({});
 
     expect(tag.value).toBeUndefined();
   });
 
   test('should parse value', () => {
-    const tag = new Tag({value: 'foo'});
+    const tag = Tag.fromElement({value: 'foo'});
 
     expect(tag.value).toEqual('foo');
   });

--- a/gsa/src/gmp/models/__tests__/target.js
+++ b/gsa/src/gmp/models/__tests__/target.js
@@ -42,6 +42,8 @@ describe('Target model tests', () => {
     const target3 = Target.fromElement({});
 
     expect(target1.port_list).toBeInstanceOf(PortList);
+    expect(target1.port_list.entityType).toEqual('portlist');
+    expect(target1.port_list.id).toEqual('123');
     expect(target2.port_list).toBeUndefined();
     expect(target3.port_list).toBeUndefined();
   });
@@ -53,6 +55,7 @@ describe('Target model tests', () => {
 
     expect(target1.smb_credential).toBeInstanceOf(Model);
     expect(target1.smb_credential.entityType).toEqual('credential');
+    expect(target1.smb_credential.id).toEqual('123');
     expect(target2.smb_credential).toBeUndefined();
     expect(target3.smb_credential).toBeUndefined();
   });
@@ -111,6 +114,7 @@ describe('Target model tests', () => {
 
     expect(target.tasks[0]).toBeInstanceOf(Model);
     expect(target.tasks[0].entityType).toEqual('task');
+    expect(target.tasks[0].id).toEqual('123');
   });
 });
 

--- a/gsa/src/gmp/models/__tests__/target.js
+++ b/gsa/src/gmp/models/__tests__/target.js
@@ -37,9 +37,9 @@ describe('Target model tests', () => {
         _id: '',
       },
     };
-    const target1 = new Target(elem1);
-    const target2 = new Target(elem2);
-    const target3 = new Target({});
+    const target1 = Target.fromElement(elem1);
+    const target2 = Target.fromElement(elem2);
+    const target3 = Target.fromElement({});
 
     expect(target1.port_list).toBeInstanceOf(PortList);
     expect(target2.port_list).toBeUndefined();
@@ -47,9 +47,9 @@ describe('Target model tests', () => {
   });
 
   test('should parse credentials', () => {
-    const target1 = new Target({smb_credential: {_id: '123'}});
-    const target2 = new Target({smb_credential: {_id: ''}});
-    const target3 = new Target({});
+    const target1 = Target.fromElement({smb_credential: {_id: '123'}});
+    const target2 = Target.fromElement({smb_credential: {_id: ''}});
+    const target3 = Target.fromElement({});
 
     expect(target1.smb_credential).toBeInstanceOf(Model);
     expect(target1.smb_credential.entityType).toEqual('credential');
@@ -61,8 +61,8 @@ describe('Target model tests', () => {
     const elem = {
       hosts: '123.456.789.42, 987.654.321.1',
     };
-    const target1 = new Target(elem);
-    const target2 = new Target({hosts: ''});
+    const target1 = Target.fromElement(elem);
+    const target2 = Target.fromElement({hosts: ''});
 
     expect(target1.hosts).toEqual(['123.456.789.42', '987.654.321.1']);
     expect(target2.hosts).toEqual([]);
@@ -72,27 +72,27 @@ describe('Target model tests', () => {
     const elem = {
       exclude_hosts: '123.456.789.42, 987.654.321.1',
     };
-    const target1 = new Target(elem);
-    const target2 = new Target({exclude_hosts: ''});
+    const target1 = Target.fromElement(elem);
+    const target2 = Target.fromElement({exclude_hosts: ''});
 
     expect(target1.exclude_hosts).toEqual(['123.456.789.42', '987.654.321.1']);
     expect(target2.exclude_hosts).toEqual([]);
   });
 
   test('should parse max_hosts', () => {
-    const target = new Target({max_hosts: '42'});
+    const target = Target.fromElement({max_hosts: '42'});
 
     expect(target.max_hosts).toEqual(42);
   });
 
   test('should parse reverse_lookup_only', () => {
-    const target = new Target({reverse_lookup_only: '0'});
+    const target = Target.fromElement({reverse_lookup_only: '0'});
 
     expect(target.reverse_lookup_only).toEqual(0);
   });
 
   test('should parse reverse_lookup_unify', () => {
-    const target = new Target({reverse_lookup_unify: '1'});
+    const target = Target.fromElement({reverse_lookup_unify: '1'});
 
     expect(target.reverse_lookup_unify).toEqual(1);
   });
@@ -107,7 +107,7 @@ describe('Target model tests', () => {
         ],
       },
     };
-    const target = new Target(elem);
+    const target = Target.fromElement(elem);
 
     expect(target.tasks[0]).toBeInstanceOf(Model);
     expect(target.tasks[0].entityType).toEqual('task');

--- a/gsa/src/gmp/models/__tests__/task.js
+++ b/gsa/src/gmp/models/__tests__/task.js
@@ -77,6 +77,7 @@ describe('Task Model parse tests', () => {
 
     expect(task.first_report).toBeInstanceOf(Report);
     expect(task.first_report.id).toEqual('r1');
+    expect(task.first_report.entityType).toEqual('report');
   });
 
   test('should parse last_report', () => {
@@ -95,6 +96,7 @@ describe('Task Model parse tests', () => {
 
     expect(task.last_report).toBeInstanceOf(Report);
     expect(task.last_report.id).toEqual('r1');
+    expect(task.last_report.entityType).toEqual('report');
   });
 
   test('should parse second_last_report', () => {
@@ -113,6 +115,7 @@ describe('Task Model parse tests', () => {
 
     expect(task.second_last_report).toBeInstanceOf(Report);
     expect(task.second_last_report.id).toEqual('r1');
+    expect(task.second_last_report.entityType).toEqual('report');
   });
 
   test('should parse current_report', () => {
@@ -131,6 +134,7 @@ describe('Task Model parse tests', () => {
 
     expect(task.current_report).toBeInstanceOf(Report);
     expect(task.current_report.id).toEqual('r1');
+    expect(task.current_report.entityType).toEqual('report');
   });
 
   test('should parse config', () => {
@@ -147,6 +151,7 @@ describe('Task Model parse tests', () => {
 
     expect(task.config).toBeInstanceOf(Model);
     expect(task.config.id).toEqual('c1');
+    expect(task.config.entityType).toEqual('scanconfig');
   });
 
   test('should parse slave', () => {
@@ -163,6 +168,7 @@ describe('Task Model parse tests', () => {
 
     expect(task.slave).toBeInstanceOf(Model);
     expect(task.slave.id).toEqual('s1');
+    expect(task.slave.entityType).toEqual('slave');
   });
 
   test('should parse target', () => {
@@ -179,6 +185,7 @@ describe('Task Model parse tests', () => {
 
     expect(task.target).toBeInstanceOf(Model);
     expect(task.target.id).toEqual('t1');
+    expect(task.target.entityType).toEqual('target');
   });
 });
 

--- a/gsa/src/gmp/models/__tests__/task.js
+++ b/gsa/src/gmp/models/__tests__/task.js
@@ -25,6 +25,9 @@ import Task, {
   HOSTS_ORDERING_SEQUENTIAL,
   TASK_STATUS,
 } from 'gmp/models/task';
+
+import Report from '../report';
+
 import {testModel} from '../testing';
 
 describe('Task Model parse tests', () => {
@@ -54,6 +57,78 @@ describe('Task Model parse tests', () => {
     obj = {hosts_ordering: HOSTS_ORDERING_SEQUENTIAL};
     task = Task.fromElement(obj);
     expect(task.hosts_ordering).toEqual(HOSTS_ORDERING_SEQUENTIAL);
+  });
+
+  test('should parse first_report', () => {
+    const element = {
+      _id: 't1',
+      first_report: {
+        report: {
+          _id: 'r1',
+        },
+      },
+    };
+
+    const task = Task.fromElement(element);
+
+    expect(task.id).toEqual('t1');
+
+    expect(task.first_report).toBeInstanceOf(Report);
+    expect(task.first_report.id).toEqual('r1');
+  });
+
+  test('should parse last_report', () => {
+    const element = {
+      _id: 't1',
+      last_report: {
+        report: {
+          _id: 'r1',
+        },
+      },
+    };
+
+    const task = Task.fromElement(element);
+
+    expect(task.id).toEqual('t1');
+
+    expect(task.last_report).toBeInstanceOf(Report);
+    expect(task.last_report.id).toEqual('r1');
+  });
+
+  test('should parse second_last_report', () => {
+    const element = {
+      _id: 't1',
+      second_last_report: {
+        report: {
+          _id: 'r1',
+        },
+      },
+    };
+
+    const task = Task.fromElement(element);
+
+    expect(task.id).toEqual('t1');
+
+    expect(task.second_last_report).toBeInstanceOf(Report);
+    expect(task.second_last_report.id).toEqual('r1');
+  });
+
+  test('should parse current_report', () => {
+    const element = {
+      _id: 't1',
+      current_report: {
+        report: {
+          _id: 'r1',
+        },
+      },
+    };
+
+    const task = Task.fromElement(element);
+
+    expect(task.id).toEqual('t1');
+
+    expect(task.current_report).toBeInstanceOf(Report);
+    expect(task.current_report.id).toEqual('r1');
   });
 });
 

--- a/gsa/src/gmp/models/__tests__/task.js
+++ b/gsa/src/gmp/models/__tests__/task.js
@@ -29,6 +29,8 @@ import Task, {
 } from 'gmp/models/task';
 
 import Report from '../report';
+import Scanner from '../scanner';
+import Schedule from '../schedule';
 
 import {testModel} from '../testing';
 
@@ -186,6 +188,65 @@ describe('Task Model parse tests', () => {
     expect(task.target).toBeInstanceOf(Model);
     expect(task.target.id).toEqual('t1');
     expect(task.target.entityType).toEqual('target');
+  });
+
+  test('should parse alerts', () => {
+    const element = {
+      _id: 't1',
+      alert: [
+        {
+          _id: 'a1',
+        },
+        {
+          _id: 'a2',
+        },
+      ],
+    };
+
+    const task = Task.fromElement(element);
+
+    expect(task.id).toEqual('t1');
+
+    expect(task.alerts[0]).toBeInstanceOf(Model);
+    expect(task.alerts[0].id).toEqual('a1');
+    expect(task.alerts[0].entityType).toEqual('alert');
+    expect(task.alerts[1]).toBeInstanceOf(Model);
+    expect(task.alerts[1].entityType).toEqual('alert');
+    expect(task.alerts[1].id).toEqual('a2');
+  });
+
+  test('should parse scanner', () => {
+    const element = {
+      _id: 't1',
+      scanner: {
+        _id: 's1',
+      },
+    };
+
+    const task = Task.fromElement(element);
+
+    expect(task.id).toEqual('t1');
+
+    expect(task.scanner).toBeInstanceOf(Scanner);
+    expect(task.scanner.id).toEqual('s1');
+    expect(task.scanner.entityType).toEqual('scanner');
+  });
+
+  test('should parse schedule', () => {
+    const element = {
+      _id: 't1',
+      schedule: {
+        _id: 's1',
+      },
+    };
+
+    const task = Task.fromElement(element);
+
+    expect(task.id).toEqual('t1');
+
+    expect(task.schedule).toBeInstanceOf(Schedule);
+    expect(task.schedule.id).toEqual('s1');
+    expect(task.schedule.entityType).toEqual('schedule');
   });
 });
 

--- a/gsa/src/gmp/models/__tests__/task.js
+++ b/gsa/src/gmp/models/__tests__/task.js
@@ -278,6 +278,47 @@ describe('Task Model parse tests', () => {
 
     expect(task.result_count).toEqual(666);
   });
+
+  test('should parse schedule periods', () => {
+    const element = {
+      _id: 't1',
+      schedule_periods: '666',
+    };
+
+    const task = Task.fromElement(element);
+
+    expect(task.id).toEqual('t1');
+
+    expect(task.schedule_periods).toEqual(666);
+  });
+
+  test('should parse progress', () => {
+    const task1 = Task.fromElement({
+      _id: 't1',
+    });
+
+    expect(task1.progress).toEqual(0);
+
+    const task2 = Task.fromElement({
+      _id: 't1',
+      progress: {},
+    });
+    expect(task2.progress).toEqual(0);
+
+    const task3 = Task.fromElement({
+      _id: 't1',
+      progress: {
+        __text: '66',
+      },
+    });
+    expect(task3.progress).toEqual(66);
+
+    const task4 = Task.fromElement({
+      _id: 't1',
+      progress: '66',
+    });
+    expect(task4.progress).toEqual(66);
+  });
 });
 
 describe(`Task Model methods tests`, () => {

--- a/gsa/src/gmp/models/__tests__/task.js
+++ b/gsa/src/gmp/models/__tests__/task.js
@@ -32,35 +32,35 @@ describe('Task Model parse tests', () => {
 
   test('should parse undefined hosts_ordering', () => {
     const obj = {hosts_ordering: undefined};
-    const task = new Task(obj);
+    const task = Task.fromElement(obj);
     expect(task.hosts_ordering).toBeUndefined();
   });
 
   test('should parse unknown hosts_ordering as undefined', () => {
     const obj = {hosts_ordering: 'foo'};
-    const task = new Task(obj);
+    const task = Task.fromElement(obj);
     expect(task.hosts_ordering).toBeUndefined();
   });
 
   test('should parse known hosts_ordering', () => {
     let obj = {hosts_ordering: HOSTS_ORDERING_RANDOM};
-    let task = new Task(obj);
+    let task = Task.fromElement(obj);
     expect(task.hosts_ordering).toEqual(HOSTS_ORDERING_RANDOM);
 
     obj = {hosts_ordering: HOSTS_ORDERING_REVERSE};
-    task = new Task(obj);
+    task = Task.fromElement(obj);
     expect(task.hosts_ordering).toEqual(HOSTS_ORDERING_REVERSE);
 
     obj = {hosts_ordering: HOSTS_ORDERING_SEQUENTIAL};
-    task = new Task(obj);
+    task = Task.fromElement(obj);
     expect(task.hosts_ordering).toEqual(HOSTS_ORDERING_SEQUENTIAL);
   });
 });
 
 describe(`Task Model methods tests`, () => {
   test('should be a container if target_id is not set', () => {
-    const task1 = new Task({});
-    const task2 = new Task({target: {_id: 'foo'}});
+    const task1 = Task.fromElement({});
+    const task2 = Task.fromElement({target: {_id: 'foo'}});
 
     expect(task1.isContainer()).toEqual(true);
     expect(task2.isContainer()).toEqual(false);
@@ -83,7 +83,7 @@ describe(`Task Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const task = new Task({status});
+      const task = Task.fromElement({status});
       expect(task.isActive()).toEqual(exp);
     }
   });
@@ -105,7 +105,7 @@ describe(`Task Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const task = new Task({status});
+      const task = Task.fromElement({status});
       expect(task.isRunning()).toEqual(exp);
     }
   });
@@ -127,7 +127,7 @@ describe(`Task Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const task = new Task({status});
+      const task = Task.fromElement({status});
       expect(task.isStopped()).toEqual(exp);
     }
   });
@@ -149,7 +149,7 @@ describe(`Task Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const task = new Task({status});
+      const task = Task.fromElement({status});
       expect(task.isInterrupted()).toEqual(exp);
     }
   });
@@ -171,16 +171,16 @@ describe(`Task Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const task = new Task({status});
+      const task = Task.fromElement({status});
       expect(task.isNew()).toEqual(exp);
     }
   });
 
   test('should be changeable if alterable or new', () => {
-    let task = new Task({status: TASK_STATUS.new, alterable: '0'});
+    let task = Task.fromElement({status: TASK_STATUS.new, alterable: '0'});
     expect(task.isChangeable()).toEqual(true);
 
-    task = new Task({status: TASK_STATUS.done, alterable: '1'});
+    task = Task.fromElement({status: TASK_STATUS.done, alterable: '1'});
     expect(task.isChangeable()).toEqual(true);
   });
 });

--- a/gsa/src/gmp/models/__tests__/task.js
+++ b/gsa/src/gmp/models/__tests__/task.js
@@ -248,6 +248,36 @@ describe('Task Model parse tests', () => {
     expect(task.schedule.id).toEqual('s1');
     expect(task.schedule.entityType).toEqual('schedule');
   });
+
+  test('should parse report counts', () => {
+    const element = {
+      _id: 't1',
+      report_count: {
+        __text: '13',
+        finished: '14',
+      },
+    };
+
+    const task = Task.fromElement(element);
+
+    expect(task.id).toEqual('t1');
+
+    expect(task.report_count.total).toEqual(13);
+    expect(task.report_count.finished).toEqual(14);
+  });
+
+  test('should parse result counts', () => {
+    const element = {
+      _id: 't1',
+      result_count: '666',
+    };
+
+    const task = Task.fromElement(element);
+
+    expect(task.id).toEqual('t1');
+
+    expect(task.result_count).toEqual(666);
+  });
 });
 
 describe(`Task Model methods tests`, () => {

--- a/gsa/src/gmp/models/__tests__/task.js
+++ b/gsa/src/gmp/models/__tests__/task.js
@@ -19,6 +19,8 @@
 
 import 'core-js/fn/object/entries';
 
+import Model from 'gmp/model';
+
 import Task, {
   HOSTS_ORDERING_RANDOM,
   HOSTS_ORDERING_REVERSE,
@@ -129,6 +131,54 @@ describe('Task Model parse tests', () => {
 
     expect(task.current_report).toBeInstanceOf(Report);
     expect(task.current_report.id).toEqual('r1');
+  });
+
+  test('should parse config', () => {
+    const element = {
+      _id: 't1',
+      config: {
+        _id: 'c1',
+      },
+    };
+
+    const task = Task.fromElement(element);
+
+    expect(task.id).toEqual('t1');
+
+    expect(task.config).toBeInstanceOf(Model);
+    expect(task.config.id).toEqual('c1');
+  });
+
+  test('should parse slave', () => {
+    const element = {
+      _id: 't1',
+      slave: {
+        _id: 's1',
+      },
+    };
+
+    const task = Task.fromElement(element);
+
+    expect(task.id).toEqual('t1');
+
+    expect(task.slave).toBeInstanceOf(Model);
+    expect(task.slave.id).toEqual('s1');
+  });
+
+  test('should parse target', () => {
+    const element = {
+      _id: 't1',
+      target: {
+        _id: 't1',
+      },
+    };
+
+    const task = Task.fromElement(element);
+
+    expect(task.id).toEqual('t1');
+
+    expect(task.target).toBeInstanceOf(Model);
+    expect(task.target.id).toEqual('t1');
   });
 });
 

--- a/gsa/src/gmp/models/__tests__/task.js
+++ b/gsa/src/gmp/models/__tests__/task.js
@@ -25,11 +25,11 @@ import Task, {
   HOSTS_ORDERING_SEQUENTIAL,
   TASK_STATUS,
 } from 'gmp/models/task';
-import {testModelProperties} from '../testing';
+import {testModel} from '../testing';
 
-testModelProperties(Task, 'task', {testIsActive: false});
+describe('Task Model parse tests', () => {
+  testModel(Task, 'task', {testIsActive: false});
 
-describe('Task model tests', () => {
   test('should parse undefined hosts_ordering', () => {
     const obj = {hosts_ordering: undefined};
     const task = new Task(obj);

--- a/gsa/src/gmp/models/__tests__/ticket.js
+++ b/gsa/src/gmp/models/__tests__/ticket.js
@@ -25,12 +25,12 @@ testModel(Ticket, 'ticket');
 
 describe('Additional Ticket Model tests', () => {
   test('should parse assignedTo', () => {
-    let ticket = new Ticket({assigned_to: {}});
+    let ticket = Ticket.fromElement({assigned_to: {}});
 
     expect(ticket.assigned_to).toBeUndefined();
     expect(ticket.assignedTo).toBeUndefined();
 
-    ticket = new Ticket({assigned_to: {user: {_id: 'foo'}}});
+    ticket = Ticket.fromElement({assigned_to: {user: {_id: 'foo'}}});
 
     expect(ticket.assigned_to).toBeUndefined();
     expect(ticket.assignedTo).toBeDefined();
@@ -39,60 +39,60 @@ describe('Additional Ticket Model tests', () => {
   });
 
   test('should parse result', () => {
-    let ticket = new Ticket({});
+    let ticket = Ticket.fromElement({});
     expect(ticket.result).toBeUndefined();
 
-    ticket = new Ticket({result: {_id: 'foo'}});
+    ticket = Ticket.fromElement({result: {_id: 'foo'}});
     expect(ticket.result).toBeDefined();
     expect(ticket.result.id).toEqual('foo');
   });
 
   test('should parse report', () => {
-    let ticket = new Ticket({});
+    let ticket = Ticket.fromElement({});
     expect(ticket.report).toBeUndefined();
 
-    ticket = new Ticket({report: {_id: 'foo'}});
+    ticket = Ticket.fromElement({report: {_id: 'foo'}});
     expect(ticket.report).toBeDefined();
     expect(ticket.report.id).toEqual('foo');
   });
 
   test('should parse task', () => {
-    let ticket = new Ticket({});
+    let ticket = Ticket.fromElement({});
     expect(ticket.task).toBeUndefined();
 
-    ticket = new Ticket({task: {_id: 'foo'}});
+    ticket = Ticket.fromElement({task: {_id: 'foo'}});
     expect(ticket.task).toBeDefined();
     expect(ticket.task.id).toEqual('foo');
   });
 
   test('should parse confirmedReport', () => {
-    let ticket = new Ticket({});
+    let ticket = Ticket.fromElement({});
     expect(ticket.fixVerifiedReport).toBeUndefined();
     expect(ticket.fix_verified_report).toBeUndefined();
 
-    ticket = new Ticket({fix_verified_report: {_id: 'foo'}});
+    ticket = Ticket.fromElement({fix_verified_report: {_id: 'foo'}});
     expect(ticket.fixVerifiedReport).toBeDefined();
     expect(ticket.fix_verified_report).toBeUndefined();
     expect(ticket.fixVerifiedReport.id).toEqual('foo');
   });
 
   test('should parse severity', () => {
-    const ticket = new Ticket({severity: '10.0'});
+    const ticket = Ticket.fromElement({severity: '10.0'});
 
     expect(ticket.severity).toBe(10);
   });
 
   test('should parse nvt', () => {
-    let ticket = new Ticket({});
+    let ticket = Ticket.fromElement({});
     expect(ticket.nvt).toBeUndefined();
 
-    ticket = new Ticket({nvt: {_oid: 'foo'}});
+    ticket = Ticket.fromElement({nvt: {_oid: 'foo'}});
     expect(ticket.nvt).toBeDefined();
     expect(ticket.nvt.oid).toEqual('foo');
   });
 
   test('should parse openTime', () => {
-    const ticket = new Ticket({open_time: '2019-01-01T12:00:00Z'});
+    const ticket = Ticket.fromElement({open_time: '2019-01-01T12:00:00Z'});
 
     expect(ticket.open_time).toBeUndefined();
     expect(ticket.openTime).toBeDefined();
@@ -100,7 +100,9 @@ describe('Additional Ticket Model tests', () => {
   });
 
   test('should parse fixVerifiedTime', () => {
-    const ticket = new Ticket({fix_verified_time: '2019-01-01T12:00:00Z'});
+    const ticket = Ticket.fromElement({
+      fix_verified_time: '2019-01-01T12:00:00Z',
+    });
 
     expect(ticket.fix_verified_time).toBeUndefined();
     expect(ticket.fixVerifiedTime).toBeDefined();
@@ -108,7 +110,7 @@ describe('Additional Ticket Model tests', () => {
   });
 
   test('should parse fixedTime', () => {
-    const ticket = new Ticket({fixed_time: '2019-01-01T12:00:00Z'});
+    const ticket = Ticket.fromElement({fixed_time: '2019-01-01T12:00:00Z'});
 
     expect(ticket.fixed_time).toBeUndefined();
     expect(ticket.fixedTime).toBeDefined();
@@ -116,7 +118,7 @@ describe('Additional Ticket Model tests', () => {
   });
 
   test('should parse closedTime', () => {
-    const ticket = new Ticket({closed_time: '2019-01-01T12:00:00Z'});
+    const ticket = Ticket.fromElement({closed_time: '2019-01-01T12:00:00Z'});
 
     expect(ticket.closed_time).toBeUndefined();
     expect(ticket.closedTime).toBeDefined();
@@ -124,7 +126,7 @@ describe('Additional Ticket Model tests', () => {
   });
 
   test('should parse solutionType', () => {
-    const ticket = new Ticket({solution_type: 'foo'});
+    const ticket = Ticket.fromElement({solution_type: 'foo'});
 
     expect(ticket.solution_type).toBeUndefined();
     expect(ticket.solutionType).toBeDefined();
@@ -132,33 +134,33 @@ describe('Additional Ticket Model tests', () => {
   });
 
   test('should parse openNote', () => {
-    let ticket = new Ticket({open_note: ''});
+    let ticket = Ticket.fromElement({open_note: ''});
     expect(ticket.open_note).toBeUndefined();
     expect(ticket.openNote).toBeUndefined();
 
-    ticket = new Ticket({open_note: 'foo'});
+    ticket = Ticket.fromElement({open_note: 'foo'});
     expect(ticket.open_note).toBeUndefined();
     expect(ticket.openNote).toBeDefined();
     expect(ticket.openNote).toEqual('foo');
   });
 
   test('should parse fixedNote', () => {
-    let ticket = new Ticket({fixed_note: ''});
+    let ticket = Ticket.fromElement({fixed_note: ''});
     expect(ticket.fixed_note).toBeUndefined();
     expect(ticket.fixedNote).toBeUndefined();
 
-    ticket = new Ticket({fixed_note: 'foo'});
+    ticket = Ticket.fromElement({fixed_note: 'foo'});
     expect(ticket.fixed_note).toBeUndefined();
     expect(ticket.fixedNote).toBeDefined();
     expect(ticket.fixedNote).toEqual('foo');
   });
 
   test('should parse closedNote', () => {
-    let ticket = new Ticket({closed_note: ''});
+    let ticket = Ticket.fromElement({closed_note: ''});
     expect(ticket.closed_note).toBeUndefined();
     expect(ticket.closedNote).toBeUndefined();
 
-    ticket = new Ticket({closed_note: 'foo'});
+    ticket = Ticket.fromElement({closed_note: 'foo'});
     expect(ticket.closed_note).toBeUndefined();
     expect(ticket.closedNote).toBeDefined();
     expect(ticket.closedNote).toEqual('foo');

--- a/gsa/src/gmp/models/__tests__/user.js
+++ b/gsa/src/gmp/models/__tests__/user.js
@@ -36,7 +36,7 @@ describe('User model tests', () => {
         },
       ],
     };
-    const user = new User(elem);
+    const user = User.fromElement(elem);
 
     expect(user.roles[0]).toBeInstanceOf(Model);
     expect(user.roles[0].entityType).toEqual('role');
@@ -53,8 +53,8 @@ describe('User model tests', () => {
         ],
       },
     };
-    const user = new User(elem);
-    const user2 = new User({});
+    const user = User.fromElement(elem);
+    const user2 = User.fromElement({});
 
     expect(user.groups[0]).toBeInstanceOf(Model);
     expect(user.groups[0].entityType).toEqual('group');
@@ -75,8 +75,8 @@ describe('User model tests', () => {
     const res2 = {
       addresses: [],
     };
-    const user = new User(elem);
-    const user2 = new User({});
+    const user = User.fromElement(elem);
+    const user2 = User.fromElement({});
 
     expect(user.hosts).toEqual(res);
     expect(user2.hosts).toEqual(res2);
@@ -96,8 +96,8 @@ describe('User model tests', () => {
     const res2 = {
       addresses: [],
     };
-    const user = new User(elem);
-    const user2 = new User({});
+    const user = User.fromElement(elem);
+    const user2 = User.fromElement({});
 
     expect(user.ifaces).toEqual(res);
     expect(user2.ifaces).toEqual(res2);
@@ -114,9 +114,9 @@ describe('User model tests', () => {
         source: 'radius_connect',
       },
     };
-    const user1 = new User(elem1);
-    const user2 = new User(elem2);
-    const user3 = new User({});
+    const user1 = User.fromElement(elem1);
+    const user2 = User.fromElement(elem2);
+    const user3 = User.fromElement({});
 
     expect(user1.auth_method).toEqual(AUTH_METHOD_LDAP);
     expect(user2.auth_method).toEqual(AUTH_METHOD_RADIUS);

--- a/gsa/src/gmp/models/agent.js
+++ b/gsa/src/gmp/models/agent.js
@@ -25,10 +25,6 @@ import {parseDate} from '../parser';
 class Agent extends Model {
   static entityType = 'agent';
 
-  parseProperties(element) {
-    return Agent.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/agent.js
+++ b/gsa/src/gmp/models/agent.js
@@ -25,13 +25,17 @@ import {parseDate} from '../parser';
 class Agent extends Model {
   static entityType = 'agent';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return Agent.parseElement(element);
+  }
 
-    if (isDefined(elem.installer) && isDefined(elem.installer.trust)) {
+  static parseElement(element) {
+    const ret = super.parseElement(element);
+
+    if (isDefined(element.installer) && isDefined(element.installer.trust)) {
       ret.trust = {
-        time: parseDate(elem.installer.trust.time),
-        status: elem.installer.trust.__text,
+        time: parseDate(element.installer.trust.time),
+        status: element.installer.trust.__text,
       };
 
       delete ret.installer;

--- a/gsa/src/gmp/models/alert.js
+++ b/gsa/src/gmp/models/alert.js
@@ -24,7 +24,7 @@ import {forEach, map} from '../utils/array';
 
 import {parseYesNo, YES_VALUE} from '../parser.js';
 
-import Model from '../model.js';
+import Model, {parseModelFromElement} from '../model.js';
 
 export const EVENT_TYPE_UPDATED_SECINFO = 'Updated SecInfo arrived';
 export const EVENT_TYPE_NEW_SECINFO = 'New SecInfo arrived';
@@ -123,11 +123,13 @@ class Alert extends Model {
     }
 
     if (isDefined(ret.filter)) {
-      ret.filter = new Model(ret.filter, 'filter');
+      ret.filter = parseModelFromElement(ret.filter, 'filter');
     }
 
     if (isDefined(element.tasks)) {
-      ret.tasks = map(element.tasks.task, task => new Model(task, 'task'));
+      ret.tasks = map(element.tasks.task, task =>
+        parseModelFromElement(task, 'task'),
+      );
     } else {
       ret.tasks = [];
     }

--- a/gsa/src/gmp/models/alert.js
+++ b/gsa/src/gmp/models/alert.js
@@ -93,8 +93,12 @@ const create_values = data => {
 class Alert extends Model {
   static entityType = 'alert';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return Alert.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const ret = super.parseElement(element);
 
     const types = ['condition', 'method', 'event'];
 
@@ -122,8 +126,8 @@ class Alert extends Model {
       ret.filter = new Model(ret.filter, 'filter');
     }
 
-    if (isDefined(elem.tasks)) {
-      ret.tasks = map(elem.tasks.task, task => new Model(task, 'task'));
+    if (isDefined(element.tasks)) {
+      ret.tasks = map(element.tasks.task, task => new Model(task, 'task'));
     } else {
       ret.tasks = [];
     }
@@ -137,7 +141,7 @@ class Alert extends Model {
       ret.method.data.report_formats = [];
     }
 
-    ret.active = parseYesNo(elem.active);
+    ret.active = parseYesNo(element.active);
 
     return ret;
   }

--- a/gsa/src/gmp/models/alert.js
+++ b/gsa/src/gmp/models/alert.js
@@ -93,10 +93,6 @@ const create_values = data => {
 class Alert extends Model {
   static entityType = 'alert';
 
-  parseProperties(element) {
-    return Alert.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/certbund.js
+++ b/gsa/src/gmp/models/certbund.js
@@ -26,8 +26,12 @@ import Info from './info';
 class CertBundAdv extends Info {
   static entityType = 'certbund';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem, 'cert_bund_adv');
+  parseProperties(element) {
+    return CertBundAdv.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const ret = super.parseElement(element, 'cert_bund_adv');
 
     ret.severity = parseSeverity(ret.max_cvss);
     delete ret.max_cvss;
@@ -59,12 +63,12 @@ class CertBundAdv extends Info {
         isDefined(advisory.Description) &&
         isDefined(advisory.Description.Element)
       ) {
-        forEach(advisory.Description.Element, element => {
-          if (isDefined(element.TextBlock)) {
-            ret.description.push(element.TextBlock);
-          } else if (isDefined(element.Infos)) {
+        forEach(advisory.Description.Element, desciptionElement => {
+          if (isDefined(desciptionElement.TextBlock)) {
+            ret.description.push(desciptionElement.TextBlock);
+          } else if (isDefined(desciptionElement.Infos)) {
             ret.additional_information = ret.additional_information.concat(
-              map(element.Infos.Info, info => ({
+              map(desciptionElement.Infos.Info, info => ({
                 issuer: info._Info_Issuer,
                 url: info._Info_URL,
               })),

--- a/gsa/src/gmp/models/certbund.js
+++ b/gsa/src/gmp/models/certbund.js
@@ -26,10 +26,6 @@ import Info from './info';
 class CertBundAdv extends Info {
   static entityType = 'certbund';
 
-  parseProperties(element) {
-    return CertBundAdv.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element, 'cert_bund_adv');
 

--- a/gsa/src/gmp/models/cpe.js
+++ b/gsa/src/gmp/models/cpe.js
@@ -28,8 +28,12 @@ import {parseSeverity, parseDate} from '../parser';
 class Cpe extends Info {
   static entityType = 'cpe';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem, 'cpe');
+  parseProperties(element) {
+    return Cpe.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const ret = super.parseElement(element, 'cpe');
 
     ret.severity = parseSeverity(ret.max_cvss);
     delete ret.max_cvss;

--- a/gsa/src/gmp/models/cpe.js
+++ b/gsa/src/gmp/models/cpe.js
@@ -28,10 +28,6 @@ import {parseSeverity, parseDate} from '../parser';
 class Cpe extends Info {
   static entityType = 'cpe';
 
-  parseProperties(element) {
-    return Cpe.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element, 'cpe');
 

--- a/gsa/src/gmp/models/credential.js
+++ b/gsa/src/gmp/models/credential.js
@@ -109,8 +109,12 @@ export const getCredentialTypeName = type => `${TYPE_NAMES[type]}`;
 class Credential extends Model {
   static entityType = 'credential';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return Credential.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const ret = super.parseElement(element);
 
     if (isDefined(ret.certificate_info)) {
       ret.certificate_info.activationTime = parseDate(
@@ -123,22 +127,22 @@ class Credential extends Model {
       delete ret.certificate_info.expiration_time;
     }
 
-    ret.credential_type = elem.type;
+    ret.credential_type = element.type;
 
-    ret.allow_insecure = parseYesNo(elem.allow_insecure);
+    ret.allow_insecure = parseYesNo(element.allow_insecure);
 
-    if (isDefined(elem.targets)) {
+    if (isDefined(element.targets)) {
       ret.targets = map(
-        elem.targets.target,
+        element.targets.target,
         target => new Model(target, 'target'),
       );
     } else {
       ret.targets = [];
     }
 
-    if (isDefined(elem.scanners)) {
+    if (isDefined(element.scanners)) {
       ret.scanners = map(
-        elem.scanners.scanner,
+        element.scanners.scanner,
         scanner => new Model(scanner, 'scanner'),
       );
     }

--- a/gsa/src/gmp/models/credential.js
+++ b/gsa/src/gmp/models/credential.js
@@ -109,10 +109,6 @@ export const getCredentialTypeName = type => `${TYPE_NAMES[type]}`;
 class Credential extends Model {
   static entityType = 'credential';
 
-  parseProperties(element) {
-    return Credential.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/credential.js
+++ b/gsa/src/gmp/models/credential.js
@@ -16,7 +16,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-import Model from '../model';
+import Model, {parseModelFromElement} from '../model';
 
 import {_l} from '../locale/lang';
 
@@ -132,18 +132,16 @@ class Credential extends Model {
     ret.allow_insecure = parseYesNo(element.allow_insecure);
 
     if (isDefined(element.targets)) {
-      ret.targets = map(
-        element.targets.target,
-        target => new Model(target, 'target'),
+      ret.targets = map(element.targets.target, target =>
+        parseModelFromElement(target, 'target'),
       );
     } else {
       ret.targets = [];
     }
 
     if (isDefined(element.scanners)) {
-      ret.scanners = map(
-        element.scanners.scanner,
-        scanner => new Model(scanner, 'scanner'),
+      ret.scanners = map(element.scanners.scanner, scanner =>
+        parseModelFromElement(scanner, 'scanner'),
       );
     }
 

--- a/gsa/src/gmp/models/cve.js
+++ b/gsa/src/gmp/models/cve.js
@@ -51,10 +51,6 @@ const rename_props = (obj, rename = {}) => {
 class Cve extends Info {
   static entityType = 'cve';
 
-  parseProperties(element) {
-    return Cve.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element, 'cve');
 

--- a/gsa/src/gmp/models/cve.js
+++ b/gsa/src/gmp/models/cve.js
@@ -51,8 +51,12 @@ const rename_props = (obj, rename = {}) => {
 class Cve extends Info {
   static entityType = 'cve';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem, 'cve');
+  parseProperties(element) {
+    return Cve.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const ret = super.parseElement(element, 'cve');
 
     if (isDefined(ret.update_time)) {
       ret.updateTime = parseDate(ret.update_time);

--- a/gsa/src/gmp/models/dfncert.js
+++ b/gsa/src/gmp/models/dfncert.js
@@ -26,8 +26,12 @@ import Info from './info';
 class DfnCertAdv extends Info {
   static entityType = 'dfncert';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem, 'dfn_cert_adv');
+  parseProperties(element) {
+    return DfnCertAdv.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const ret = super.parseElement(element, 'dfn_cert_adv');
 
     ret.severity = parseSeverity(ret.max_cvss);
     delete ret.max_cvss;

--- a/gsa/src/gmp/models/dfncert.js
+++ b/gsa/src/gmp/models/dfncert.js
@@ -26,10 +26,6 @@ import Info from './info';
 class DfnCertAdv extends Info {
   static entityType = 'dfncert';
 
-  parseProperties(element) {
-    return DfnCertAdv.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element, 'dfn_cert_adv');
 

--- a/gsa/src/gmp/models/filter.js
+++ b/gsa/src/gmp/models/filter.js
@@ -78,10 +78,6 @@ class Filter extends Model {
     this.id = id;
   }
 
-  parseProperties(element) {
-    return Filter.parseElement(element);
-  }
-
   /**
    * Parse properties from the passed element object
    *

--- a/gsa/src/gmp/models/filter.js
+++ b/gsa/src/gmp/models/filter.js
@@ -22,7 +22,7 @@ import 'core-js/fn/array/includes';
 import {isDefined, isString} from '../utils/identity';
 import {forEach, map} from '../utils/array';
 
-import Model from '../model.js';
+import Model, {parseModelFromElement} from '../model.js';
 
 import {setProperties} from '../parser';
 
@@ -121,7 +121,9 @@ class Filter extends Model {
     }
 
     if (isDefined(ret.alerts)) {
-      ret.alerts = map(ret.alerts.alert, alert => new Model(alert, 'alert'));
+      ret.alerts = map(ret.alerts.alert, alert =>
+        parseModelFromElement(alert, 'alert'),
+      );
     }
 
     return ret;

--- a/gsa/src/gmp/models/filter.js
+++ b/gsa/src/gmp/models/filter.js
@@ -35,19 +35,19 @@ export const UNKNOWN_FILTER_ID = '0';
 /**
  * Parses FilterTerms from filterstring
  *
- * @param {String} filterstring  Filter representation as a string
+ * @param {String} filterString  Filter representation as a string
  *
  * @return {Array} Array of parsed FilterTerms
  */
-const parseFilterTermsFromString = filterstring => {
+const parseFilterTermsFromString = filterString => {
   const terms = [];
-  if (isString(filterstring)) {
-    const fterms = filterstring.split(' ');
-    for (let fterm of fterms) {
+  if (isString(filterString)) {
+    const filterTerms = filterString.split(' ');
+    for (let filterTerm of filterTerms) {
       // strip whitespace
-      fterm = fterm.trim();
-      if (fterm.length > 0) {
-        terms.push(FilterTerm.fromString(fterm));
+      filterTerm = filterTerm.trim();
+      if (filterTerm.length > 0) {
+        terms.push(FilterTerm.fromString(filterTerm));
       }
     }
   }

--- a/gsa/src/gmp/models/filter.js
+++ b/gsa/src/gmp/models/filter.js
@@ -62,17 +62,14 @@ const parseFilterTermsFromString = filterstring => {
 class Filter extends Model {
   static entityType = 'filter';
 
-  get length() {
-    return this.terms.length;
+  constructor() {
+    super();
+
+    this.terms = [];
   }
 
-  /**
-   * Init the Filter
-   *
-   * Creates the internal data structure.
-   */
-  init() {
-    this.terms = [];
+  get length() {
+    return this.terms.length;
   }
 
   setProperties({id, ...properties}) {

--- a/gsa/src/gmp/models/filter.js
+++ b/gsa/src/gmp/models/filter.js
@@ -81,16 +81,19 @@ class Filter extends Model {
     this.id = id;
   }
 
+  parseProperties(element) {
+    return Filter.parseElement(element);
+  }
+
   /**
-   * Parse properties from the passed element object for being set in this
-   * Filter model.
+   * Parse properties from the passed element object
    *
-   * @param {Object} elem  Element object to parse properties from.
+   * @param {Object} element  Element object to parse properties from.
    *
    * @return {Object} An object with properties for the new Filter model
    */
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  static parseElement(element) {
+    const ret = super.parseElement(element);
 
     ret.filter_type = ret._type;
 

--- a/gsa/src/gmp/models/group.js
+++ b/gsa/src/gmp/models/group.js
@@ -23,10 +23,14 @@ import Model from '../model';
 class Group extends Model {
   static entityType = 'group';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return Group.parseElement(element);
+  }
 
-    ret.users = parseCsv(elem.users);
+  static parseElement(element) {
+    const ret = super.parseElement(element);
+
+    ret.users = parseCsv(element.users);
 
     return ret;
   }

--- a/gsa/src/gmp/models/group.js
+++ b/gsa/src/gmp/models/group.js
@@ -23,10 +23,6 @@ import Model from '../model';
 class Group extends Model {
   static entityType = 'group';
 
-  parseProperties(element) {
-    return Group.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/host.js
+++ b/gsa/src/gmp/models/host.js
@@ -58,10 +58,6 @@ class Identifier {
 class Host extends Asset {
   static entityType = 'host';
 
-  parseProperties(element) {
-    return Host.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/host.js
+++ b/gsa/src/gmp/models/host.js
@@ -58,8 +58,12 @@ class Identifier {
 class Host extends Asset {
   static entityType = 'host';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return Host.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const ret = super.parseElement(element);
 
     if (isDefined(ret.host) && isDefined(ret.host.severity)) {
       ret.severity = parseSeverity(ret.host.severity.value);

--- a/gsa/src/gmp/models/info.js
+++ b/gsa/src/gmp/models/info.js
@@ -25,6 +25,10 @@ class Info extends Model {
   static entityType = 'info';
 
   parseProperties(elem, infoType) {
+    return Info.parseElement(elem, infoType);
+  }
+
+  static parseElement(elem, infoType) {
     const info_elem = elem[infoType];
 
     if (isDefined(info_elem)) {
@@ -37,7 +41,7 @@ class Info extends Model {
       delete elem[infoType];
     }
 
-    return super.parseProperties(elem);
+    return super.parseElement(elem);
   }
 }
 

--- a/gsa/src/gmp/models/info.js
+++ b/gsa/src/gmp/models/info.js
@@ -24,10 +24,6 @@ import Model from '../model.js';
 class Info extends Model {
   static entityType = 'info';
 
-  parseProperties(elem, infoType) {
-    return Info.parseElement(elem, infoType);
-  }
-
   static parseElement(elem, infoType) {
     const info_elem = elem[infoType];
 

--- a/gsa/src/gmp/models/login.js
+++ b/gsa/src/gmp/models/login.js
@@ -40,6 +40,10 @@ class Login {
       ? moment.unix(unixSeconds)
       : undefined;
   }
+
+  static fromElement(element) {
+    return new Login(element);
+  }
 }
 
 export default Login;

--- a/gsa/src/gmp/models/note.js
+++ b/gsa/src/gmp/models/note.js
@@ -19,7 +19,7 @@
 import {isModelElement} from '../utils/identity';
 import {isEmpty} from '../utils/string';
 
-import Model from '../model';
+import Model, {parseModelFromElement} from '../model';
 import {
   parseCsv,
   parseSeverity,
@@ -44,7 +44,7 @@ class Note extends Model {
     let ret = super.parseElement(element);
 
     if (ret.nvt) {
-      ret.nvt = new Nvt(ret.nvt);
+      ret.nvt = Nvt.fromElement(ret.nvt);
       ret.name = ret.nvt.name;
     }
 
@@ -53,13 +53,13 @@ class Note extends Model {
     ret.severity = parseSeverity(ret.severity);
 
     if (isModelElement(ret.task)) {
-      ret.task = new Model(ret.task, 'task');
+      ret.task = parseModelFromElement(ret.task, 'task');
     } else {
       delete ret.task;
     }
 
     if (isModelElement(ret.result)) {
-      ret.result = new Model(ret.result, 'result');
+      ret.result = parseModelFromElement(ret.result, 'result');
     } else {
       delete ret.result;
     }

--- a/gsa/src/gmp/models/note.js
+++ b/gsa/src/gmp/models/note.js
@@ -36,8 +36,12 @@ export const NOTE_INACTIVE_VALUE = '-1';
 class Note extends Model {
   static entityType = 'note';
 
-  parseProperties(elem) {
-    let ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return Note.parseElement(element);
+  }
+
+  static parseElement(element) {
+    let ret = super.parseElement(element);
 
     if (ret.nvt) {
       ret.nvt = new Nvt(ret.nvt);
@@ -60,12 +64,12 @@ class Note extends Model {
       delete ret.result;
     }
 
-    ret.active = parseYesNo(elem.active);
-    ret.text_excerpt = parseYesNo(elem.text_excerpt);
+    ret.active = parseYesNo(element.active);
+    ret.text_excerpt = parseYesNo(element.text_excerpt);
 
-    ret.hosts = parseCsv(elem.hosts);
+    ret.hosts = parseCsv(element.hosts);
 
-    if (isEmpty(elem.port)) {
+    if (isEmpty(element.port)) {
       delete ret.port;
     }
 

--- a/gsa/src/gmp/models/note.js
+++ b/gsa/src/gmp/models/note.js
@@ -36,10 +36,6 @@ export const NOTE_INACTIVE_VALUE = '-1';
 class Note extends Model {
   static entityType = 'note';
 
-  parseProperties(element) {
-    return Note.parseElement(element);
-  }
-
   static parseElement(element) {
     let ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/nvt.js
+++ b/gsa/src/gmp/models/nvt.js
@@ -52,10 +52,14 @@ const parse_ids = (ids, no) => {
 class Nvt extends Info {
   static entityType = 'nvt';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem, 'nvt');
+  parseProperties(element) {
+    return Nvt.parseElement(element);
+  }
 
-    ret.nvt_type = elem._type;
+  static parseElement(element) {
+    const ret = super.parseElement(element, 'nvt');
+
+    ret.nvt_type = element._type;
 
     ret.oid = isEmpty(ret._oid) ? undefined : ret._oid;
     ret.id = ret.oid;
@@ -135,28 +139,28 @@ class Nvt extends Info {
 
     delete ret.xref;
 
-    if (isDefined(elem.qod)) {
-      if (isEmpty(elem.qod.value)) {
+    if (isDefined(element.qod)) {
+      if (isEmpty(element.qod.value)) {
         delete ret.qod.value;
       } else {
-        ret.qod.value = parseFloat(elem.qod.value);
+        ret.qod.value = parseFloat(element.qod.value);
       }
 
-      if (isEmpty(elem.qod.type)) {
+      if (isEmpty(element.qod.type)) {
         delete ret.qod.type;
       }
     }
 
-    if (isEmpty(elem.default_timeout)) {
+    if (isEmpty(element.default_timeout)) {
       delete ret.default_timeout;
     } else {
-      ret.default_timeout = parseFloat(elem.default_timeout);
+      ret.default_timeout = parseFloat(element.default_timeout);
     }
 
-    if (isEmpty(elem.timeout)) {
+    if (isEmpty(element.timeout)) {
       delete ret.timeout;
     } else {
-      ret.timeout = parseFloat(elem.timeout);
+      ret.timeout = parseFloat(element.timeout);
     }
 
     return ret;

--- a/gsa/src/gmp/models/nvt.js
+++ b/gsa/src/gmp/models/nvt.js
@@ -52,10 +52,6 @@ const parse_ids = (ids, no) => {
 class Nvt extends Info {
   static entityType = 'nvt';
 
-  parseProperties(element) {
-    return Nvt.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element, 'nvt');
 

--- a/gsa/src/gmp/models/os.js
+++ b/gsa/src/gmp/models/os.js
@@ -22,10 +22,6 @@ import {parseSeverity} from '../parser';
 class OperatingSystem extends Asset {
   static entityType = 'operatingsystem';
 
-  parseProperties(element) {
-    return OperatingSystem.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/os.js
+++ b/gsa/src/gmp/models/os.js
@@ -22,8 +22,12 @@ import {parseSeverity} from '../parser';
 class OperatingSystem extends Asset {
   static entityType = 'operatingsystem';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return OperatingSystem.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const ret = super.parseElement(element);
 
     if (ret.os) {
       ret.average_severity = ret.os.average_severity

--- a/gsa/src/gmp/models/ovaldef.js
+++ b/gsa/src/gmp/models/ovaldef.js
@@ -73,8 +73,12 @@ class Criteria {
 class Ovaldef extends Info {
   static entityType = 'ovaldef';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem, 'ovaldef');
+  parseProperties(element) {
+    return Ovaldef.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const ret = super.parseElement(element, 'ovaldef');
 
     ret.severity = parseSeverity(ret.max_cvss);
     delete ret.max_cvss;

--- a/gsa/src/gmp/models/ovaldef.js
+++ b/gsa/src/gmp/models/ovaldef.js
@@ -73,10 +73,6 @@ class Criteria {
 class Ovaldef extends Info {
   static entityType = 'ovaldef';
 
-  parseProperties(element) {
-    return Ovaldef.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element, 'ovaldef');
 

--- a/gsa/src/gmp/models/override.js
+++ b/gsa/src/gmp/models/override.js
@@ -19,7 +19,7 @@
 import {isModelElement} from '../utils/identity';
 import {isEmpty} from '../utils/string';
 
-import Model from '../model';
+import Model, {parseModelFromElement} from '../model';
 import {
   parseCsv,
   parseSeverity,
@@ -60,7 +60,7 @@ class Override extends Model {
     let ret = super.parseElement(element);
 
     if (ret.nvt) {
-      ret.nvt = new Nvt(ret.nvt);
+      ret.nvt = Nvt.fromElement(ret.nvt);
       ret.name = ret.nvt.name;
     }
 
@@ -71,13 +71,13 @@ class Override extends Model {
     ret = {...ret, ...parseTextElement(ret.text)};
 
     if (isModelElement(ret.task)) {
-      ret.task = new Model(ret.task, 'task');
+      ret.task = parseModelFromElement(ret.task, 'task');
     } else {
       delete ret.task;
     }
 
     if (isModelElement(ret.result)) {
-      ret.result = new Model(ret.result, 'result');
+      ret.result = parseModelFromElement(ret.result, 'result');
     } else {
       delete ret.result;
     }

--- a/gsa/src/gmp/models/override.js
+++ b/gsa/src/gmp/models/override.js
@@ -52,10 +52,6 @@ export const SEVERITY_FALSE_POSITIVE = -1;
 class Override extends Model {
   static entityType = 'override';
 
-  parseProperties(element) {
-    return Override.parseElement(element);
-  }
-
   static parseElement(element) {
     let ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/override.js
+++ b/gsa/src/gmp/models/override.js
@@ -52,8 +52,12 @@ export const SEVERITY_FALSE_POSITIVE = -1;
 class Override extends Model {
   static entityType = 'override';
 
-  parseProperties(elem) {
-    let ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return Override.parseElement(element);
+  }
+
+  static parseElement(element) {
+    let ret = super.parseElement(element);
 
     if (ret.nvt) {
       ret.nvt = new Nvt(ret.nvt);
@@ -78,12 +82,12 @@ class Override extends Model {
       delete ret.result;
     }
 
-    ret.active = parseYesNo(elem.active);
-    ret.text_excerpt = parseYesNo(elem.text_excerpt);
+    ret.active = parseYesNo(element.active);
+    ret.text_excerpt = parseYesNo(element.text_excerpt);
 
     ret.hosts = parseCsv(ret.hosts);
 
-    if (isEmpty(elem.port)) {
+    if (isEmpty(element.port)) {
       delete ret.port;
     }
 

--- a/gsa/src/gmp/models/permission.js
+++ b/gsa/src/gmp/models/permission.js
@@ -25,17 +25,21 @@ import Model from '../model';
 class Permission extends Model {
   static entityType = 'permission';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return Permission.parseElement(element);
+  }
 
-    if (isDefined(elem.resource) && !isEmpty(elem.resource._id)) {
-      ret.resource = new Model(elem.resource, elem.resource.type);
+  static parseElement(element) {
+    const ret = super.parseElement(element);
+
+    if (isDefined(element.resource) && !isEmpty(element.resource._id)) {
+      ret.resource = new Model(element.resource, element.resource.type);
     } else {
       delete ret.resource;
     }
 
-    if (isDefined(elem.subject) && !isEmpty(elem.subject._id)) {
-      ret.subject = new Model(elem.subject, elem.subject.type);
+    if (isDefined(element.subject) && !isEmpty(element.subject._id)) {
+      ret.subject = new Model(element.subject, element.subject.type);
     } else {
       delete ret.subject;
     }

--- a/gsa/src/gmp/models/permission.js
+++ b/gsa/src/gmp/models/permission.js
@@ -20,7 +20,7 @@
 import {isDefined} from '../utils/identity';
 import {isEmpty} from '../utils/string';
 
-import Model from '../model';
+import Model, {parseModelFromElement} from '../model';
 
 class Permission extends Model {
   static entityType = 'permission';
@@ -33,13 +33,19 @@ class Permission extends Model {
     const ret = super.parseElement(element);
 
     if (isDefined(element.resource) && !isEmpty(element.resource._id)) {
-      ret.resource = new Model(element.resource, element.resource.type);
+      ret.resource = parseModelFromElement(
+        element.resource,
+        element.resource.type,
+      );
     } else {
       delete ret.resource;
     }
 
     if (isDefined(element.subject) && !isEmpty(element.subject._id)) {
-      ret.subject = new Model(element.subject, element.subject.type);
+      ret.subject = parseModelFromElement(
+        element.subject,
+        element.subject.type,
+      );
     } else {
       delete ret.subject;
     }

--- a/gsa/src/gmp/models/permission.js
+++ b/gsa/src/gmp/models/permission.js
@@ -25,10 +25,6 @@ import Model, {parseModelFromElement} from '../model';
 class Permission extends Model {
   static entityType = 'permission';
 
-  parseProperties(element) {
-    return Permission.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/portlist.js
+++ b/gsa/src/gmp/models/portlist.js
@@ -40,10 +40,6 @@ class PortRange extends Model {
 class PortList extends Model {
   static entityType = 'portlist';
 
-  parseProperties(element) {
-    return PortList.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/portlist.js
+++ b/gsa/src/gmp/models/portlist.js
@@ -26,9 +26,13 @@ import {parseInt} from '../parser';
 class PortRange extends Model {
   static entityType = 'portrange';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
-    ret.protocol_type = elem.type;
+  parseProperties(element) {
+    return PortRange.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const ret = super.parseElement(element);
+    ret.protocol_type = element.type;
     return ret;
   }
 }
@@ -36,8 +40,12 @@ class PortRange extends Model {
 class PortList extends Model {
   static entityType = 'portlist';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return PortList.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const ret = super.parseElement(element);
 
     const ranges = isDefined(ret.port_ranges) ? ret.port_ranges.port_range : [];
 
@@ -46,7 +54,7 @@ class PortList extends Model {
       return new PortRange(range);
     });
 
-    const {port_count} = elem;
+    const {port_count} = element;
     if (isDefined(port_count)) {
       ret.port_count = {
         all: isDefined(port_count.all) ? parseInt(port_count.all) : 0,
@@ -61,9 +69,9 @@ class PortList extends Model {
       };
     }
 
-    if (isDefined(elem.targets) && isDefined(elem.targets.target)) {
+    if (isDefined(element.targets) && isDefined(element.targets.target)) {
       ret.targets = map(
-        elem.targets.target,
+        element.targets.target,
         target => new Model(target, 'target'),
       );
     } else {

--- a/gsa/src/gmp/models/portlist.js
+++ b/gsa/src/gmp/models/portlist.js
@@ -19,7 +19,7 @@
 import {isDefined} from '../utils/identity';
 import {map} from '../utils/array';
 
-import Model from '../model';
+import Model, {parseModelFromElement} from '../model';
 
 import {parseInt} from '../parser';
 
@@ -51,7 +51,7 @@ class PortList extends Model {
 
     ret.port_ranges = map(ranges, range => {
       range.port_list_id = ret.id;
-      return new PortRange(range);
+      return PortRange.fromElement(range);
     });
 
     const {port_count} = element;
@@ -70,9 +70,8 @@ class PortList extends Model {
     }
 
     if (isDefined(element.targets) && isDefined(element.targets.target)) {
-      ret.targets = map(
-        element.targets.target,
-        target => new Model(target, 'target'),
+      ret.targets = map(element.targets.target, target =>
+        parseModelFromElement(target, 'target'),
       );
     } else {
       ret.targets = [];

--- a/gsa/src/gmp/models/report.js
+++ b/gsa/src/gmp/models/report.js
@@ -29,8 +29,12 @@ import ReportReport from './report/report';
 class Report extends Model {
   static entityType = 'report';
 
-  parseProperties(elem) {
-    const copy = super.parseProperties(elem);
+  parseProperties(element) {
+    return Report.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const copy = super.parseElement(element);
 
     const {
       report,
@@ -42,7 +46,7 @@ class Report extends Model {
       scan_start,
       scan_end,
       timestamp,
-    } = elem;
+    } = element;
 
     if (isDefined(report)) {
       copy.report = new ReportReport(report);

--- a/gsa/src/gmp/models/report.js
+++ b/gsa/src/gmp/models/report.js
@@ -29,10 +29,6 @@ import ReportReport from './report/report';
 class Report extends Model {
   static entityType = 'report';
 
-  parseProperties(element) {
-    return Report.parseElement(element);
-  }
-
   static parseElement(element) {
     const copy = super.parseElement(element);
 

--- a/gsa/src/gmp/models/report.js
+++ b/gsa/src/gmp/models/report.js
@@ -20,7 +20,7 @@ import {isDefined} from '../utils/identity';
 
 import {parseSeverity, parseDate} from '../parser';
 
-import Model from '../model';
+import Model, {parseModelFromElement} from '../model';
 
 import ReportReport from './report/report';
 
@@ -49,11 +49,11 @@ class Report extends Model {
     } = element;
 
     if (isDefined(report)) {
-      copy.report = new ReportReport(report);
+      copy.report = ReportReport.fromElement(report);
     }
 
-    copy.report_format = new Model(report_format, 'reportformat');
-    copy.task = new Model(task, 'task');
+    copy.report_format = parseModelFromElement(report_format, 'reportformat');
+    copy.task = parseModelFromElement(task, 'task');
 
     if (isDefined(severity)) {
       copy.severity = parseSeverity(severity);

--- a/gsa/src/gmp/models/report/__tests__/cve.js
+++ b/gsa/src/gmp/models/report/__tests__/cve.js
@@ -1,0 +1,78 @@
+/* Copyright (C) 2019 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import ReportCve from '../cve';
+
+describe('ReportCve tests', () => {
+  test('should parse cves', () => {
+    const reportcve1 = ReportCve.fromElement({
+      cve: 'NOCVE',
+    });
+    const reportcve2 = ReportCve.fromElement({
+      cve: '1, 2',
+    });
+
+    expect(reportcve1.cves.length).toEqual(0);
+    expect(reportcve2.cves.length).toEqual(2);
+    expect(reportcve2.cves[0]).toEqual('1');
+    expect(reportcve2.cves[1]).toEqual('2');
+  });
+
+  test('should parse oid/id', () => {
+    const reportcve = ReportCve.fromElement({
+      _oid: 'c1',
+    });
+    expect(reportcve.id).toEqual('c1');
+  });
+
+  test('should add hosts', () => {
+    const reportcve = new ReportCve();
+
+    expect(reportcve.hosts).toBeDefined();
+    expect(reportcve.hosts.hosts_by_ip).toEqual({});
+    expect(reportcve.hosts.count).toEqual(0);
+
+    const host = {name: 'foo', ip: '1.2.3.4'};
+    reportcve.addHost(host);
+
+    expect(reportcve.hosts.hosts_by_ip['1.2.3.4']).toEqual(host);
+    expect(reportcve.hosts.count).toEqual(1);
+  });
+
+  test('should add result', () => {
+    const reportcve = new ReportCve();
+
+    expect(reportcve.occurrences).toEqual(0);
+    expect(reportcve.severity).toBeUndefined();
+
+    reportcve.addResult({severity: '1.0'});
+
+    expect(reportcve.occurrences).toEqual(1);
+    expect(reportcve.severity).toEqual(1.0);
+
+    reportcve.addResult({severity: '9.0'});
+
+    expect(reportcve.occurrences).toEqual(2);
+    expect(reportcve.severity).toEqual(9.0);
+
+    reportcve.addResult({severity: '5.0'});
+
+    expect(reportcve.occurrences).toEqual(3);
+    expect(reportcve.severity).toEqual(9.0);
+  });
+});

--- a/gsa/src/gmp/models/report/__tests__/parser.js
+++ b/gsa/src/gmp/models/report/__tests__/parser.js
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import {parse_hosts} from '../parser';
+import {parseHosts} from '../parser';
 
 describe('report parser tests', () => {
   test('parse_hosts tests', () => {
@@ -66,7 +66,7 @@ describe('report parser tests', () => {
       rows: 2,
       last: 2,
     };
-    const parsedHosts = parse_hosts(hosts, 'foo=bar');
+    const parsedHosts = parseHosts(hosts, 'foo=bar');
 
     expect(parsedHosts.entities.length).toEqual(2);
     expect(parsedHosts.entities[0].id).toEqual('1.1.1.1');

--- a/gsa/src/gmp/models/report/cve.js
+++ b/gsa/src/gmp/models/report/cve.js
@@ -23,10 +23,21 @@ import {setProperties, parseSeverity} from '../../parser';
 import Nvt from '../nvt';
 
 class ReportCve {
-  constructor(elem) {
-    this.parseProperties(elem);
-
+  constructor() {
     this.occurrences = 0;
+
+    this.hosts = {
+      hosts_by_ip: {},
+      count: 0,
+    };
+  }
+
+  static fromElement(element) {
+    const cve = new ReportCve();
+
+    setProperties(this.parseElement(element), cve);
+
+    return cve;
   }
 
   addHost(host) {
@@ -36,30 +47,23 @@ class ReportCve {
     }
   }
 
-  addResult(result) {
+  addResult({severity: resultSeverity}) {
     this.occurrences += 1;
 
-    const severity = parseSeverity(result.severity);
+    const severity = parseSeverity(resultSeverity);
 
     if (!isDefined(this.severity) || severity > this.severity) {
       this.severity = severity;
     }
   }
 
-  parseProperties(elem) {
+  static parseElement(element) {
     const copy = {};
 
-    const nvt = new Nvt(elem);
+    const nvt = Nvt.fromElement(element);
 
     copy.id = nvt.id;
     copy.cves = nvt.cves;
-
-    copy.hosts = {
-      hosts_by_ip: {},
-      count: 0,
-    };
-
-    setProperties(copy, this);
 
     return copy;
   }

--- a/gsa/src/gmp/models/report/parser.js
+++ b/gsa/src/gmp/models/report/parser.js
@@ -45,7 +45,7 @@ import ReportVulnerability from './vulnerability';
 
 import Result from '../result';
 
-const empty_collection_list = filter => {
+const emptyCollectionList = filter => {
   return {
     filter,
     counts: new CollectionCounts(),
@@ -53,7 +53,7 @@ const empty_collection_list = filter => {
   };
 };
 
-const get_cert = (certs, fingerprint) => {
+const getTlsCertificate = (certs, fingerprint) => {
   let cert = certs[fingerprint];
 
   if (!isDefined(cert)) {
@@ -63,11 +63,11 @@ const get_cert = (certs, fingerprint) => {
   return cert;
 };
 
-export const parse_tls_certificates = (report, filter) => {
+export const parseTlsCertificates = (report, filter) => {
   const {host: hosts, ssl_certs} = report;
 
   if (!isDefined(ssl_certs)) {
-    return empty_collection_list(filter);
+    return emptyCollectionList(filter);
   }
 
   const {count: full_count} = ssl_certs;
@@ -84,7 +84,7 @@ export const parse_tls_certificates = (report, filter) => {
       if (name.startsWith('SSLInfo')) {
         const [port, fingerprint] = value.split('::');
 
-        const cert = get_cert(host_certs, fingerprint);
+        const cert = getTlsCertificate(host_certs, fingerprint);
 
         cert.ip = host.ip;
 
@@ -92,7 +92,7 @@ export const parse_tls_certificates = (report, filter) => {
       } else if (name.startsWith('SSLDetails')) {
         const [, fingerprint] = name.split(':');
 
-        const cert = get_cert(host_certs, fingerprint);
+        const cert = getTlsCertificate(host_certs, fingerprint);
 
         value.split('|').reduce((c, v) => {
           let [key, val] = v.split(':');
@@ -107,7 +107,7 @@ export const parse_tls_certificates = (report, filter) => {
       } else if (name.startsWith('Cert')) {
         const [, fingerprint] = name.split(':');
 
-        const cert = get_cert(host_certs, fingerprint);
+        const cert = getTlsCertificate(host_certs, fingerprint);
 
         // currently cert data starts with x509:
         // not sure if there are other types of certs
@@ -168,12 +168,12 @@ export const parse_tls_certificates = (report, filter) => {
   };
 };
 
-export const parse_ports = (report, filter) => {
+export const parsePorts = (report, filter) => {
   const temp_ports = {};
   const {ports} = report;
 
   if (!isDefined(ports)) {
-    return empty_collection_list(filter);
+    return emptyCollectionList(filter);
   }
 
   const {count: full_count} = ports;
@@ -215,12 +215,12 @@ export const parse_ports = (report, filter) => {
   };
 };
 
-export const parse_vulnerabilities = (report, filter) => {
+export const parseVulnerabilities = (report, filter) => {
   const temp_vulns = {};
   const {vulns, results = {}} = report;
 
   if (!isDefined(vulns)) {
-    return empty_collection_list(filter);
+    return emptyCollectionList(filter);
   }
 
   const {count: full_count} = vulns;
@@ -264,13 +264,13 @@ export const parse_vulnerabilities = (report, filter) => {
   };
 };
 
-export const parse_apps = (report, filter) => {
+export const parseApps = (report, filter) => {
   const {host: hosts, apps, results = {}} = report;
   const apps_temp = {};
   const cpe_host_details = {};
 
   if (!isDefined(apps)) {
-    return empty_collection_list(filter);
+    return emptyCollectionList(filter);
   }
 
   const {count: full_count} = apps;
@@ -360,7 +360,7 @@ export const parse_apps = (report, filter) => {
   };
 };
 
-export const parse_host_severities = (results = {}) => {
+export const parseHostSeverities = (results = {}) => {
   const severities = {};
 
   // if the there are several results find the highest severity for the ip
@@ -385,16 +385,16 @@ export const parse_host_severities = (results = {}) => {
   return severities;
 };
 
-export const parse_operatingsystems = (report, filter) => {
+export const parseOperatingSystems = (report, filter) => {
   const {host: hosts, results, os: os_count} = report;
 
   if (!isDefined(os_count)) {
-    return empty_collection_list(filter);
+    return emptyCollectionList(filter);
   }
 
   const operating_systems = {};
 
-  const severities = parse_host_severities(results);
+  const severities = parseHostSeverities(results);
 
   forEach(hosts, host => {
     const {detail: details, ip} = host;
@@ -447,14 +447,14 @@ export const parse_operatingsystems = (report, filter) => {
   };
 };
 
-export const parse_hosts = (report, filter) => {
+export const parseHosts = (report, filter) => {
   const {host: hosts, results, hosts: hosts_count} = report;
 
   if (!isDefined(hosts_count)) {
-    return empty_collection_list(filter);
+    return emptyCollectionList(filter);
   }
 
-  const severities = parse_host_severities(results);
+  const severities = parseHostSeverities(results);
 
   const hosts_array = map(hosts, host => {
     const {port_count = {}} = host;
@@ -495,7 +495,7 @@ const parse_report_report_counts = elem => {
   return new CollectionCounts(counts);
 };
 
-export const parse_results = (report, filter) => {
+export const parseResults = (report, filter) => {
   const {results} = report;
 
   if (!isDefined(results)) {
@@ -516,7 +516,7 @@ export const parse_errors = (report, filter) => {
   const {host: hosts, errors} = report;
 
   if (!isDefined(errors)) {
-    return empty_collection_list(filter);
+    return emptyCollectionList(filter);
   }
 
   const {count: full_count} = errors;
@@ -580,11 +580,11 @@ export const parse_errors = (report, filter) => {
   };
 };
 
-export const parse_closed_cves = (report, filter) => {
+export const parseClosedCves = (report, filter) => {
   const {host: hosts, closed_cves} = report;
 
   if (!isDefined(closed_cves)) {
-    return empty_collection_list(filter);
+    return emptyCollectionList(filter);
   }
 
   // count doesn't fit to our counting of cves. we split the db rows with a csv
@@ -648,11 +648,11 @@ export const parse_closed_cves = (report, filter) => {
   };
 };
 
-export const parse_cves = (report, filter) => {
+export const parseCves = (report, filter) => {
   const {results} = report;
 
   if (!isDefined(results)) {
-    return empty_collection_list(filter);
+    return emptyCollectionList(filter);
   }
 
   const cves = {};

--- a/gsa/src/gmp/models/report/parser.js
+++ b/gsa/src/gmp/models/report/parser.js
@@ -670,7 +670,7 @@ export const parseCves = (report, filter) => {
       let cve = cves[id];
 
       if (!isDefined(cve)) {
-        cve = new ReportCve(nvt);
+        cve = ReportCve.fromElement(nvt);
         cves[id] = cve;
       }
 

--- a/gsa/src/gmp/models/report/parser.js
+++ b/gsa/src/gmp/models/report/parser.js
@@ -35,13 +35,13 @@ import {
 
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
-import App from './app';
-import Cve from './cve';
-import Host from './host';
-import OperatingSystem from './os';
-import Port from './port';
-import TLSCertificate from './tlscertificate';
-import Vulnerability from './vulnerability';
+import ReportApp from './app';
+import ReportCve from './cve';
+import ReportHost from './host';
+import ReportOperatingSystem from './os';
+import ReportPort from './port';
+import ReportTLSCertificate from './tlscertificate';
+import ReportVulnerability from './vulnerability';
 
 import Result from '../result';
 
@@ -57,7 +57,7 @@ const get_cert = (certs, fingerprint) => {
   let cert = certs[fingerprint];
 
   if (!isDefined(cert)) {
-    cert = new TLSCertificate(fingerprint);
+    cert = new ReportTLSCertificate(fingerprint);
     certs[fingerprint] = cert;
   }
   return cert;
@@ -189,7 +189,7 @@ export const parse_ports = (report, filter) => {
 
         tport.setSeverity(severity);
       } else {
-        tport = new Port(port);
+        tport = new ReportPort(port);
         temp_ports[id] = tport;
       }
 
@@ -237,7 +237,7 @@ export const parse_vulnerabilities = (report, filter) => {
       if (isDefined(vuln)) {
         vuln.addResult(results);
       } else {
-        vuln = new Vulnerability(result);
+        vuln = new ReportVulnerability(result);
         temp_vulns[oid] = vuln;
       }
 
@@ -318,7 +318,7 @@ export const parse_apps = (report, filter) => {
         let app = apps_temp[cpe];
 
         if (!isDefined(app)) {
-          app = new App({...detail, severity: severities[cpe]});
+          app = new ReportApp({...detail, severity: severities[cpe]});
           apps_temp[cpe] = app;
         }
 
@@ -417,7 +417,7 @@ export const parse_operatingsystems = (report, filter) => {
         const severity = severities[ip];
 
         if (!isDefined(os)) {
-          os = operating_systems[best_os_cpe] = new OperatingSystem({
+          os = operating_systems[best_os_cpe] = new ReportOperatingSystem({
             best_os_cpe,
             best_os_txt,
           });
@@ -459,7 +459,7 @@ export const parse_hosts = (report, filter) => {
   const hosts_array = map(hosts, host => {
     const {port_count = {}} = host;
     const severity = severities[host.ip];
-    return new Host({...host, severity, portsCount: port_count.page});
+    return new ReportHost({...host, severity, portsCount: port_count.page});
   });
 
   const {length: filtered_count} = hosts_array;
@@ -670,7 +670,7 @@ export const parse_cves = (report, filter) => {
       let cve = cves[id];
 
       if (!isDefined(cve)) {
-        cve = new Cve(nvt);
+        cve = new ReportCve(nvt);
         cves[id] = cve;
       }
 

--- a/gsa/src/gmp/models/report/report.js
+++ b/gsa/src/gmp/models/report/report.js
@@ -43,16 +43,28 @@ import {
 class ReportReport extends Model {
   static entityType = 'report';
 
-  parseProperties(elem) {
-    const copy = super.parseProperties(elem);
+  parseProperties(element) {
+    return ReportReport.parseElement(element);
+  }
 
-    const {delta, severity, scan_start, scan_end, task, scan, timestamp} = elem;
+  static parseElement(element) {
+    const copy = super.parseElement(element);
 
-    const filter = parseFilter(elem);
+    const {
+      delta,
+      severity,
+      scan_start,
+      scan_end,
+      task,
+      scan,
+      timestamp,
+    } = element;
+
+    const filter = parseFilter(element);
 
     copy.filter = filter;
 
-    copy.report_type = elem._type;
+    copy.report_type = element._type;
 
     delete copy.filters;
 
@@ -67,27 +79,27 @@ class ReportReport extends Model {
 
     copy.task = new ReportTask(task, 'task');
 
-    copy.results = parse_results(elem, filter);
+    copy.results = parse_results(element, filter);
 
-    copy.hosts = parse_hosts(elem, filter);
+    copy.hosts = parse_hosts(element, filter);
 
-    copy.tls_certificates = parse_tls_certificates(elem, filter);
+    copy.tls_certificates = parse_tls_certificates(element, filter);
 
     delete copy.host;
 
-    copy.applications = parse_apps(elem, filter);
+    copy.applications = parse_apps(element, filter);
 
-    copy.vulnerabilities = parse_vulnerabilities(elem, filter);
+    copy.vulnerabilities = parse_vulnerabilities(element, filter);
 
-    copy.operatingsystems = parse_operatingsystems(elem, filter);
+    copy.operatingsystems = parse_operatingsystems(element, filter);
 
-    copy.ports = parse_ports(elem, filter);
+    copy.ports = parse_ports(element, filter);
 
-    copy.cves = parse_cves(elem, filter);
+    copy.cves = parse_cves(element, filter);
 
-    copy.closed_cves = parse_closed_cves(elem, filter);
+    copy.closed_cves = parse_closed_cves(element, filter);
 
-    copy.errors = parse_errors(elem, filter);
+    copy.errors = parse_errors(element, filter);
 
     copy.scan_start = parseDate(scan_start);
 

--- a/gsa/src/gmp/models/report/report.js
+++ b/gsa/src/gmp/models/report/report.js
@@ -75,9 +75,9 @@ class ReportReport extends Model {
       };
     }
 
-    copy.severity_class = new Model(copy.severity_class);
+    copy.severity_class = Model.fromElement(copy.severity_class);
 
-    copy.task = new ReportTask(task, 'task');
+    copy.task = ReportTask.fromElement(task);
 
     copy.results = parse_results(element, filter);
 

--- a/gsa/src/gmp/models/report/report.js
+++ b/gsa/src/gmp/models/report/report.js
@@ -28,16 +28,16 @@ import Model from '../../model';
 import ReportTask from './task';
 
 import {
-  parse_apps,
-  parse_closed_cves,
-  parse_cves,
+  parseApps,
+  parseClosedCves,
+  parseCves,
   parse_errors,
-  parse_hosts,
-  parse_operatingsystems,
-  parse_ports,
-  parse_results,
-  parse_tls_certificates,
-  parse_vulnerabilities,
+  parseHosts,
+  parseOperatingSystems,
+  parsePorts,
+  parseResults,
+  parseTlsCertificates,
+  parseVulnerabilities,
 } from './parser';
 
 class ReportReport extends Model {
@@ -79,25 +79,25 @@ class ReportReport extends Model {
 
     copy.task = ReportTask.fromElement(task);
 
-    copy.results = parse_results(element, filter);
+    copy.results = parseResults(element, filter);
 
-    copy.hosts = parse_hosts(element, filter);
+    copy.hosts = parseHosts(element, filter);
 
-    copy.tls_certificates = parse_tls_certificates(element, filter);
+    copy.tls_certificates = parseTlsCertificates(element, filter);
 
     delete copy.host;
 
-    copy.applications = parse_apps(element, filter);
+    copy.applications = parseApps(element, filter);
 
-    copy.vulnerabilities = parse_vulnerabilities(element, filter);
+    copy.vulnerabilities = parseVulnerabilities(element, filter);
 
-    copy.operatingsystems = parse_operatingsystems(element, filter);
+    copy.operatingsystems = parseOperatingSystems(element, filter);
 
-    copy.ports = parse_ports(element, filter);
+    copy.ports = parsePorts(element, filter);
 
-    copy.cves = parse_cves(element, filter);
+    copy.cves = parseCves(element, filter);
 
-    copy.closed_cves = parse_closed_cves(element, filter);
+    copy.closed_cves = parseClosedCves(element, filter);
 
     copy.errors = parse_errors(element, filter);
 

--- a/gsa/src/gmp/models/report/task.js
+++ b/gsa/src/gmp/models/report/task.js
@@ -21,7 +21,7 @@ import {isEmpty} from '../../utils/string';
 
 import {parseProgressElement} from '../../parser';
 
-import Model from '../../model';
+import Model, {parseModelFromElement} from '../../model';
 
 /*
  * Use own task model for reports to avoid cyclic dependencies
@@ -39,7 +39,7 @@ class ReportTask extends Model {
 
     const {target} = element;
     if (isDefined(target) && !isEmpty(target._id)) {
-      copy.target = new Model(target, 'target');
+      copy.target = parseModelFromElement(target, 'target');
     } else {
       delete copy.target;
     }

--- a/gsa/src/gmp/models/report/task.js
+++ b/gsa/src/gmp/models/report/task.js
@@ -30,17 +30,21 @@ import Model from '../../model';
 class ReportTask extends Model {
   static entityType = 'task';
 
-  parseProperties(elem) {
-    const copy = super.parseProperties(elem);
+  parseProperties(element) {
+    return ReportTask.parseElement(element);
+  }
 
-    const {target} = elem;
+  static parseElement(element) {
+    const copy = super.parseElement(element);
+
+    const {target} = element;
     if (isDefined(target) && !isEmpty(target._id)) {
       copy.target = new Model(target, 'target');
     } else {
       delete copy.target;
     }
 
-    copy.progress = parseProgressElement(elem.progress);
+    copy.progress = parseProgressElement(element.progress);
 
     return copy;
   }

--- a/gsa/src/gmp/models/report/vulnerability.js
+++ b/gsa/src/gmp/models/report/vulnerability.js
@@ -44,10 +44,14 @@ class RfpVulnerability extends Vulnerability {
     }
   }
 
-  parseProperties(elem) {
+  parseProperties(element) {
+    return RfpVulnerability.parseElement(element);
+  }
+
+  static parseElement(element) {
     const copy = {};
 
-    const {nvt = {}, name, qod = {}} = elem;
+    const {nvt = {}, name, qod = {}} = element;
     const {_oid: oid} = nvt;
 
     copy.id = oid;

--- a/gsa/src/gmp/models/reportformat.js
+++ b/gsa/src/gmp/models/reportformat.js
@@ -58,8 +58,12 @@ class Param {
 class ReportFormat extends Model {
   static entityType = 'reportformat';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return ReportFormat.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const ret = super.parseElement(element);
 
     if (isDefined(ret.trust)) {
       ret.trust = {
@@ -82,9 +86,9 @@ class ReportFormat extends Model {
       ret.alerts = [];
     }
 
-    ret.active = parseYesNo(elem.active);
+    ret.active = parseYesNo(element.active);
 
-    ret.predefined = parseYesNo(elem.predefined);
+    ret.predefined = parseYesNo(element.predefined);
 
     return ret;
   }

--- a/gsa/src/gmp/models/reportformat.js
+++ b/gsa/src/gmp/models/reportformat.js
@@ -22,7 +22,7 @@ import {isEmpty} from '../utils/string';
 
 import {parseDate, parseYesNo, YES_VALUE} from '../parser';
 
-import Model from '../model';
+import Model, {parseModelFromElement} from '../model';
 
 const get_value = val => {
   return isObject(val) ? val.__text : val;
@@ -81,7 +81,9 @@ class ReportFormat extends Model {
     delete ret.param;
 
     if (isDefined(ret.alerts)) {
-      ret.alerts = map(ret.alerts.alert, alert => new Model(alert, 'alert'));
+      ret.alerts = map(ret.alerts.alert, alert =>
+        parseModelFromElement(alert, 'alert'),
+      );
     } else {
       ret.alerts = [];
     }

--- a/gsa/src/gmp/models/reportformat.js
+++ b/gsa/src/gmp/models/reportformat.js
@@ -58,10 +58,6 @@ class Param {
 class ReportFormat extends Model {
   static entityType = 'reportformat';
 
-  parseProperties(element) {
-    return ReportFormat.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/result.js
+++ b/gsa/src/gmp/models/result.js
@@ -50,10 +50,6 @@ export class Delta {
 class Result extends Model {
   static entityType = 'result';
 
-  parseProperties(element) {
-    return Result.parseElement(element);
-  }
-
   static parseElement(element) {
     const copy = super.parseElement(element);
 

--- a/gsa/src/gmp/models/result.js
+++ b/gsa/src/gmp/models/result.js
@@ -50,8 +50,12 @@ export class Delta {
 class Result extends Model {
   static entityType = 'result';
 
-  parseProperties(elem) {
-    const copy = super.parseProperties(elem);
+  parseProperties(element) {
+    return Result.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const copy = super.parseElement(element);
 
     const {
       description,
@@ -68,7 +72,7 @@ class Result extends Model {
       delta,
       qod = {},
       tickets,
-    } = elem;
+    } = element;
 
     if (isString(host)) {
       // openvas 8

--- a/gsa/src/gmp/models/result.js
+++ b/gsa/src/gmp/models/result.js
@@ -21,7 +21,7 @@ import {forEach, map} from 'gmp/utils/array';
 import {isDefined, isString} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
 
-import Model from '../model';
+import Model, {parseModelFromElement} from '../model';
 import {parseSeverity, parseQod} from '../parser';
 
 import Nvt from './nvt';
@@ -42,7 +42,7 @@ export class Delta {
     } else {
       this.delta_type = elem.__text;
       this.diff = elem.diff;
-      this.result = new Model(elem.result, 'result');
+      this.result = parseModelFromElement(elem.result, 'result');
     }
   }
 }
@@ -91,7 +91,7 @@ class Result extends Model {
       };
     }
 
-    copy.nvt = new Nvt(nvt);
+    copy.nvt = Nvt.fromElement(nvt);
 
     if (isDefined(description)) {
       copy.description = description;
@@ -104,11 +104,11 @@ class Result extends Model {
     copy.vulnerability = isDefined(name) ? name : nvt._oid;
 
     if (isDefined(report)) {
-      copy.report = new Model(report, 'report');
+      copy.report = parseModelFromElement(report, 'report');
     }
 
     if (isDefined(task)) {
-      copy.task = new Model(task, 'task');
+      copy.task = parseModelFromElement(task, 'task');
     }
 
     if (isDefined(detection) && isDefined(detection.result)) {
@@ -138,15 +138,15 @@ class Result extends Model {
 
     copy.qod = parseQod(qod);
     copy.notes = isDefined(notes)
-      ? map(notes.note, note => new Note(note))
+      ? map(notes.note, note => Note.fromElement(note))
       : [];
     copy.overrides = isDefined(overrides)
-      ? map(overrides.override, override => new Override(override))
+      ? map(overrides.override, override => Override.fromElement(override))
       : [];
 
     // parse tickets as models only. we don't have other data then the id here
     copy.tickets = isDefined(tickets)
-      ? map(tickets.ticket, ticket => new Model(ticket, 'ticket'))
+      ? map(tickets.ticket, ticket => parseModelFromElement(ticket, 'ticket'))
       : [];
 
     return copy;

--- a/gsa/src/gmp/models/role.js
+++ b/gsa/src/gmp/models/role.js
@@ -23,10 +23,14 @@ import Model from '../model';
 class Role extends Model {
   static entityType = 'role';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return Role.parseElement(element);
+  }
 
-    ret.users = parseCsv(elem.users);
+  static parseElement(element) {
+    const ret = super.parseElement(element);
+
+    ret.users = parseCsv(element.users);
 
     return ret;
   }

--- a/gsa/src/gmp/models/role.js
+++ b/gsa/src/gmp/models/role.js
@@ -23,10 +23,6 @@ import Model from '../model';
 class Role extends Model {
   static entityType = 'role';
 
-  parseProperties(element) {
-    return Role.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/scanconfig.js
+++ b/gsa/src/gmp/models/scanconfig.js
@@ -60,10 +60,6 @@ const parseTrend = parseInt;
 class ScanConfig extends Model {
   static entityType = 'scanconfig';
 
-  parseProperties(element) {
-    return ScanConfig.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/scanconfig.js
+++ b/gsa/src/gmp/models/scanconfig.js
@@ -23,7 +23,7 @@ import {isEmpty} from '../utils/string';
 
 import {parseInt} from '../parser';
 
-import Model from '../model';
+import Model, {parseModelFromElement} from '../model';
 
 import _ from '../locale';
 
@@ -154,11 +154,13 @@ class ScanConfig extends Model {
         ...element.scanner,
         name: element.scanner.__text,
       };
-      ret.scanner = new Model(scanner, 'scanner');
+      ret.scanner = parseModelFromElement(scanner, 'scanner');
     }
 
     if (isDefined(element.tasks)) {
-      ret.tasks = map(element.tasks.task, task => new Model(task, 'task'));
+      ret.tasks = map(element.tasks.task, task =>
+        parseModelFromElement(task, 'task'),
+      );
     } else {
       ret.tasks = [];
     }

--- a/gsa/src/gmp/models/scanconfig.js
+++ b/gsa/src/gmp/models/scanconfig.js
@@ -60,15 +60,19 @@ const parseTrend = parseInt;
 class ScanConfig extends Model {
   static entityType = 'scanconfig';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return ScanConfig.parseElement(element);
+  }
+
+  static parseElement(element) {
+    const ret = super.parseElement(element);
 
     // for displaying the selected nvts (1 of 33) an object for accessing the
     // family by name is required
     const families = {};
 
-    if (isDefined(elem.families)) {
-      ret.family_list = map(elem.families.family, family => {
+    if (isDefined(element.families)) {
+      ret.family_list = map(element.families.family, family => {
         const {name} = family;
         const new_family = {
           name,
@@ -120,8 +124,8 @@ class ScanConfig extends Model {
     const nvt_preferences = [];
     const scanner_preferences = [];
 
-    if (isDefined(elem.preferences)) {
-      forEach(elem.preferences.preference, preference => {
+    if (isDefined(element.preferences)) {
+      forEach(element.preferences.preference, preference => {
         const pref = {...preference};
         if (isEmpty(pref.nvt.name)) {
           delete pref.nvt;
@@ -143,18 +147,18 @@ class ScanConfig extends Model {
       nvt: nvt_preferences,
     };
 
-    ret.scan_config_type = parseInt(elem.type);
+    ret.scan_config_type = parseInt(element.type);
 
-    if (isDefined(elem.scanner)) {
+    if (isDefined(element.scanner)) {
       const scanner = {
-        ...elem.scanner,
-        name: elem.scanner.__text,
+        ...element.scanner,
+        name: element.scanner.__text,
       };
       ret.scanner = new Model(scanner, 'scanner');
     }
 
-    if (isDefined(elem.tasks)) {
-      ret.tasks = map(elem.tasks.task, task => new Model(task, 'task'));
+    if (isDefined(element.tasks)) {
+      ret.tasks = map(element.tasks.task, task => new Model(task, 'task'));
     } else {
       ret.tasks = [];
     }

--- a/gsa/src/gmp/models/scanner.js
+++ b/gsa/src/gmp/models/scanner.js
@@ -75,10 +75,14 @@ const parse_scanner_info = (info = {}) => {
 class Scanner extends Model {
   static entityType = 'scanner';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return Scanner.parseElement(element);
+  }
 
-    ret.scannerType = parseInt(elem.type);
+  static parseElement(element) {
+    const ret = super.parseElement(element);
+
+    ret.scannerType = parseInt(element.type);
 
     ret.credential =
       isDefined(ret.credential) && !isEmpty(ret.credential._id)

--- a/gsa/src/gmp/models/scanner.js
+++ b/gsa/src/gmp/models/scanner.js
@@ -75,10 +75,6 @@ const parse_scanner_info = (info = {}) => {
 class Scanner extends Model {
   static entityType = 'scanner';
 
-  parseProperties(element) {
-    return Scanner.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/scanner.js
+++ b/gsa/src/gmp/models/scanner.js
@@ -24,7 +24,7 @@ import {map} from '../utils/array';
 
 import {parseInt, parseYesNo, parseDate} from '../parser';
 
-import Model from '../model';
+import Model, {parseModelFromElement} from '../model';
 
 import Credential from './credential';
 
@@ -86,7 +86,7 @@ class Scanner extends Model {
 
     ret.credential =
       isDefined(ret.credential) && !isEmpty(ret.credential._id)
-        ? new Credential(ret.credential)
+        ? Credential.fromElement(ret.credential)
         : undefined;
 
     if (isEmpty(ret.ca_pub)) {
@@ -111,7 +111,9 @@ class Scanner extends Model {
     }
 
     if (isDefined(ret.tasks)) {
-      ret.tasks = map(ret.tasks.task, task => new Model(task, 'task'));
+      ret.tasks = map(ret.tasks.task, task =>
+        parseModelFromElement(task, 'task'),
+      );
     } else {
       ret.tasks = [];
     }
@@ -119,9 +121,8 @@ class Scanner extends Model {
     if (isEmpty(ret.configs)) {
       ret.configs = [];
     } else {
-      ret.configs = map(
-        ret.configs.config,
-        config => new Model(config, 'scanconfig'),
+      ret.configs = map(ret.configs.config, config =>
+        parseModelFromElement(config, 'scanconfig'),
       );
     }
 

--- a/gsa/src/gmp/models/schedule.js
+++ b/gsa/src/gmp/models/schedule.js
@@ -26,10 +26,14 @@ import Event from './event';
 class Schedule extends Model {
   static entityType = 'schedule';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return Schedule.parseElement(element);
+  }
 
-    const {timezone, icalendar} = elem;
+  static parseElement(element) {
+    const ret = super.parseElement(element);
+
+    const {timezone, icalendar} = element;
 
     if (isDefined(icalendar)) {
       ret.event = Event.fromIcal(icalendar, timezone);

--- a/gsa/src/gmp/models/schedule.js
+++ b/gsa/src/gmp/models/schedule.js
@@ -26,10 +26,6 @@ import Event from './event';
 class Schedule extends Model {
   static entityType = 'schedule';
 
-  parseProperties(element) {
-    return Schedule.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/schedule.js
+++ b/gsa/src/gmp/models/schedule.js
@@ -19,7 +19,7 @@
 import {isDefined} from '../utils/identity';
 import {map} from '../utils/array';
 
-import Model from '../model';
+import Model, {parseModelFromElement} from '../model';
 
 import Event from './event';
 
@@ -52,7 +52,9 @@ class Schedule extends Model {
     delete ret.simple_period;
 
     if (isDefined(ret.tasks)) {
-      ret.tasks = map(ret.tasks.task, task => new Model(task, 'task'));
+      ret.tasks = map(ret.tasks.task, task =>
+        parseModelFromElement(task, 'task'),
+      );
     } else {
       ret.tasks = [];
     }

--- a/gsa/src/gmp/models/secinfo.js
+++ b/gsa/src/gmp/models/secinfo.js
@@ -52,12 +52,16 @@ export const secInfoType = entity => entity.infoType;
 class SecInfo extends Info {
   static entityType = 'allinfo';
 
-  parseProperties(elem) {
-    let ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return SecInfo.parseElement(element);
+  }
 
-    if (elem.allinfo) {
+  static parseElement(element) {
+    let ret = super.parseElement(element);
+
+    if (element.allinfo) {
       // we have an info element
-      const {type, ...other} = elem.allinfo; // filter out type
+      const {type, ...other} = element.allinfo; // filter out type
       ret = {
         ...ret,
         ...other,

--- a/gsa/src/gmp/models/secinfo.js
+++ b/gsa/src/gmp/models/secinfo.js
@@ -52,10 +52,6 @@ export const secInfoType = entity => entity.infoType;
 class SecInfo extends Info {
   static entityType = 'allinfo';
 
-  parseProperties(element) {
-    return SecInfo.parseElement(element);
-  }
-
   static parseElement(element) {
     let ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/setting.js
+++ b/gsa/src/gmp/models/setting.js
@@ -28,6 +28,10 @@ class Setting {
         ? element.value
         : undefined;
   }
+
+  static fromElement(element) {
+    return new Setting(element);
+  }
 }
 
 export default Setting;

--- a/gsa/src/gmp/models/tag.js
+++ b/gsa/src/gmp/models/tag.js
@@ -27,10 +27,6 @@ import Model from '../model';
 class Tag extends Model {
   static entityType = 'tag';
 
-  parseProperties(element) {
-    return Tag.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/tag.js
+++ b/gsa/src/gmp/models/tag.js
@@ -27,16 +27,20 @@ import Model from '../model';
 class Tag extends Model {
   static entityType = 'tag';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return Tag.parseElement(element);
+  }
 
-    if (isDefined(elem.resources)) {
-      ret.resourceType = normalizeType(elem.resources.type);
-      ret.resourceCount = parseInt(elem.resources.count.total);
+  static parseElement(element) {
+    const ret = super.parseElement(element);
+
+    if (isDefined(element.resources)) {
+      ret.resourceType = normalizeType(element.resources.type);
+      ret.resourceCount = parseInt(element.resources.count.total);
     } else {
       ret.resourceCount = 0;
     }
-    ret.value = isEmpty(elem.value) ? undefined : elem.value;
+    ret.value = isEmpty(element.value) ? undefined : element.value;
 
     return ret;
   }

--- a/gsa/src/gmp/models/target.js
+++ b/gsa/src/gmp/models/target.js
@@ -36,10 +36,14 @@ export const TARGET_CREDENTIAL_NAMES = [
 class Target extends Model {
   static entityType = 'target';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return Target.parseElement(element);
+  }
 
-    if (isDefined(elem.port_list) && !isEmpty(elem.port_list._id)) {
+  static parseElement(element) {
+    const ret = super.parseElement(element);
+
+    if (isDefined(element.port_list) && !isEmpty(element.port_list._id)) {
       ret.port_list = new PortList(ret.port_list);
     } else {
       delete ret.port_list;
@@ -54,16 +58,16 @@ class Target extends Model {
       }
     }
 
-    ret.hosts = parseCsv(elem.hosts);
-    ret.exclude_hosts = parseCsv(elem.exclude_hosts);
+    ret.hosts = parseCsv(element.hosts);
+    ret.exclude_hosts = parseCsv(element.exclude_hosts);
 
-    ret.max_hosts = parseInt(elem.max_hosts);
+    ret.max_hosts = parseInt(element.max_hosts);
 
-    ret.reverse_lookup_only = parseYesNo(elem.reverse_lookup_only);
-    ret.reverse_lookup_unify = parseYesNo(elem.reverse_lookup_unify);
+    ret.reverse_lookup_only = parseYesNo(element.reverse_lookup_only);
+    ret.reverse_lookup_unify = parseYesNo(element.reverse_lookup_unify);
 
-    if (isDefined(elem.tasks)) {
-      ret.tasks = map(elem.tasks.task, task => new Model(task, 'task'));
+    if (isDefined(element.tasks)) {
+      ret.tasks = map(element.tasks.task, task => new Model(task, 'task'));
     }
 
     return ret;

--- a/gsa/src/gmp/models/target.js
+++ b/gsa/src/gmp/models/target.js
@@ -16,7 +16,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-import Model from '../model';
+import Model, {parseModelFromElement} from '../model';
 
 import {isDefined} from '../utils/identity';
 import {isEmpty} from '../utils/string';
@@ -44,7 +44,7 @@ class Target extends Model {
     const ret = super.parseElement(element);
 
     if (isDefined(element.port_list) && !isEmpty(element.port_list._id)) {
-      ret.port_list = new PortList(ret.port_list);
+      ret.port_list = PortList.fromElement(ret.port_list);
     } else {
       delete ret.port_list;
     }
@@ -52,7 +52,7 @@ class Target extends Model {
     for (const name of TARGET_CREDENTIAL_NAMES) {
       const cred = ret[name];
       if (isDefined(cred) && !isEmpty(cred._id)) {
-        ret[name] = new Model(cred, 'credential');
+        ret[name] = parseModelFromElement(cred, 'credential');
       } else {
         delete ret[name];
       }
@@ -67,7 +67,9 @@ class Target extends Model {
     ret.reverse_lookup_unify = parseYesNo(element.reverse_lookup_unify);
 
     if (isDefined(element.tasks)) {
-      ret.tasks = map(element.tasks.task, task => new Model(task, 'task'));
+      ret.tasks = map(element.tasks.task, task =>
+        parseModelFromElement(task, 'task'),
+      );
     }
 
     return ret;

--- a/gsa/src/gmp/models/target.js
+++ b/gsa/src/gmp/models/target.js
@@ -36,10 +36,6 @@ export const TARGET_CREDENTIAL_NAMES = [
 class Target extends Model {
   static entityType = 'target';
 
-  parseProperties(element) {
-    return Target.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/task.js
+++ b/gsa/src/gmp/models/task.js
@@ -132,10 +132,6 @@ class Task extends Model {
     return getTranslatableTaskStatus(this.status);
   }
 
-  parseProperties(elem) {
-    return Task.parseElement(elem);
-  }
-
   static parseElement(element) {
     const copy = super.parseElement(element);
 

--- a/gsa/src/gmp/models/task.js
+++ b/gsa/src/gmp/models/task.js
@@ -32,7 +32,7 @@ import {
   YES_VALUE,
 } from '../parser';
 
-import Model from '../model';
+import Model, {parseModelFromElement} from '../model';
 
 import Report from './report';
 import Schedule from './schedule';
@@ -160,35 +160,38 @@ class Task extends Model {
     reports.forEach(name => {
       const report = element[name];
       if (isDefined(report)) {
-        copy[name] = new Report(report.report);
+        copy[name] = Report.fromElement(report.report);
       }
     });
 
+    // slave isn't really an entity type but it has an id
     const models = ['config', 'slave', 'target'];
     models.forEach(item => {
       const name = item;
 
       const data = element[name];
       if (isDefined(data) && !isEmpty(data._id)) {
-        copy[name] = new Model(data, normalizeType(name));
+        copy[name] = parseModelFromElement(data, normalizeType(name));
       } else {
         delete copy[name];
       }
     });
 
     if (isDefined(element.alert)) {
-      copy.alerts = map(element.alert, alert => new Model(alert, 'alert'));
+      copy.alerts = map(element.alert, alert =>
+        parseModelFromElement(alert, 'alert'),
+      );
       delete copy.alert;
     }
 
     if (isDefined(element.scanner) && !isEmpty(element.scanner._id)) {
-      copy.scanner = new Scanner(element.scanner);
+      copy.scanner = Scanner.fromElement(element.scanner);
     } else {
       delete copy.scanner;
     }
 
     if (isDefined(element.schedule) && !isEmpty(element.schedule._id)) {
-      copy.schedule = new Schedule(element.schedule);
+      copy.schedule = Schedule.fromElement(element.schedule);
     } else {
       delete copy.schedule;
     }

--- a/gsa/src/gmp/models/task.js
+++ b/gsa/src/gmp/models/task.js
@@ -133,9 +133,13 @@ class Task extends Model {
   }
 
   parseProperties(elem) {
-    const copy = super.parseProperties(elem);
+    return Task.parseElement(elem);
+  }
 
-    const {report_count} = elem;
+  static parseElement(element) {
+    const copy = super.parseElement(element);
+
+    const {report_count} = element;
 
     if (isDefined(report_count)) {
       copy.report_count = {...report_count};
@@ -143,8 +147,8 @@ class Task extends Model {
       copy.report_count.finished = parseInt(report_count.finished);
     }
 
-    copy.alterable = parseYesNo(elem.alterable);
-    copy.result_count = parseInt(elem.result_count);
+    copy.alterable = parseYesNo(element.alterable);
+    copy.result_count = parseInt(element.result_count);
 
     const reports = [
       'first_report',
@@ -154,7 +158,7 @@ class Task extends Model {
     ];
 
     reports.forEach(name => {
-      const report = elem[name];
+      const report = element[name];
       if (isDefined(report)) {
         copy[name] = new Report(report.report);
       }
@@ -164,7 +168,7 @@ class Task extends Model {
     models.forEach(item => {
       const name = item;
 
-      const data = elem[name];
+      const data = element[name];
       if (isDefined(data) && !isEmpty(data._id)) {
         copy[name] = new Model(data, normalizeType(name));
       } else {
@@ -172,31 +176,31 @@ class Task extends Model {
       }
     });
 
-    if (isDefined(elem.alert)) {
-      copy.alerts = map(elem.alert, alert => new Model(alert, 'alert'));
+    if (isDefined(element.alert)) {
+      copy.alerts = map(element.alert, alert => new Model(alert, 'alert'));
       delete copy.alert;
     }
 
-    if (isDefined(elem.scanner) && !isEmpty(elem.scanner._id)) {
-      copy.scanner = new Scanner(elem.scanner);
+    if (isDefined(element.scanner) && !isEmpty(element.scanner._id)) {
+      copy.scanner = new Scanner(element.scanner);
     } else {
       delete copy.scanner;
     }
 
-    if (isDefined(elem.schedule) && !isEmpty(elem.schedule._id)) {
-      copy.schedule = new Schedule(elem.schedule);
+    if (isDefined(element.schedule) && !isEmpty(element.schedule._id)) {
+      copy.schedule = new Schedule(element.schedule);
     } else {
       delete copy.schedule;
     }
 
-    copy.schedule_periods = parseInt(elem.schedule_periods);
+    copy.schedule_periods = parseInt(element.schedule_periods);
 
-    copy.progress = parseProgressElement(elem.progress);
+    copy.progress = parseProgressElement(element.progress);
 
     const prefs = {};
 
-    if (copy.preferences && isArray(elem.preferences.preference)) {
-      for (const pref of elem.preferences.preference) {
+    if (copy.preferences && isArray(element.preferences.preference)) {
+      for (const pref of element.preferences.preference) {
         switch (pref.scanner_name) {
           case 'in_assets':
             copy.in_assets = parse_yes(pref.value);
@@ -235,8 +239,8 @@ class Task extends Model {
 
     copy.preferences = prefs;
 
-    if (isDefined(elem.average_duration)) {
-      copy.average_duration = parseDuration(elem.average_duration);
+    if (isDefined(element.average_duration)) {
+      copy.average_duration = parseDuration(element.average_duration);
     }
 
     if (

--- a/gsa/src/gmp/models/testing.js
+++ b/gsa/src/gmp/models/testing.js
@@ -34,16 +34,6 @@ const testId = modelClass => {
   });
 };
 
-const testNvtId = modelClass => {
-  test('NVT ID test', () => {
-    const nvt1 = new modelClass({_oid: '42.1337'});
-    const nvt2 = new modelClass({});
-
-    expect(nvt1.id).toEqual('42.1337');
-    expect(nvt2.id).toBeUndefined();
-  });
-};
-
 export const testModelProperties = (
   modelClass,
   type,
@@ -296,12 +286,6 @@ export const testModel = (modelClass, type, options) => {
   testModelProperties(modelClass, type, options);
   testModelMethods(modelClass, type);
   testId(modelClass);
-};
-
-export const testNvtModel = (modelClass, options) => {
-  testModelProperties(modelClass, 'nvt', options);
-  testModelMethods(modelClass, 'nvt');
-  testNvtId(modelClass);
 };
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/gmp/models/testing.js
+++ b/gsa/src/gmp/models/testing.js
@@ -233,9 +233,59 @@ export const testModelMethods = (modelClass, {testIsActive = true} = {}) => {
   }
 };
 
+const testModelSetProperties = modelClass => {
+  test('should ignore setting undefinied properties', () => {
+    const model = new modelClass();
+    model.setProperties();
+  });
+
+  test('should ignore setting empty properties', () => {
+    const model = new modelClass();
+    model.setProperties({});
+  });
+
+  test('should allow to set arbitrary properties', () => {
+    const model = new modelClass();
+    model.setProperties({foo: 'bar', bar: 1});
+
+    expect(model.foo).toEqual('bar');
+    expect(model.bar).toEqual(1);
+  });
+
+  test('should not allow to override properties', () => {
+    const model = new modelClass();
+    model.setProperties({foo: 'bar', bar: 1});
+
+    expect(model.foo).toEqual('bar');
+    expect(model.bar).toEqual(1);
+
+    expect(() => {
+      model.setProperties({bar: 2});
+    }).toThrow();
+
+    expect(model.foo).toEqual('bar');
+    expect(model.bar).toEqual(1);
+  });
+
+  test('should not allow to set additional properties', () => {
+    const model = new modelClass();
+    model.setProperties({foo: 'bar', bar: 1});
+
+    expect(model.foo).toEqual('bar');
+    expect(model.bar).toEqual(1);
+
+    model.setProperties({lorem: {}});
+
+    expect(model.foo).toEqual('bar');
+    expect(model.bar).toEqual(1);
+    expect(model.lorem).toEqual({});
+  });
+};
+
 export const testModel = (modelClass, type, options) => {
   testModelFromElement(modelClass, type);
   testModelMethods(modelClass, options);
+  testModelSetProperties(modelClass);
   testId(modelClass);
 };
 

--- a/gsa/src/gmp/models/testing.js
+++ b/gsa/src/gmp/models/testing.js
@@ -234,12 +234,12 @@ export const testModelMethods = (modelClass, {testIsActive = true} = {}) => {
 };
 
 const testModelSetProperties = modelClass => {
-  test('should ignore setting undefinied properties', () => {
+  test('should not throw when setting undefined properties', () => {
     const model = new modelClass();
     model.setProperties();
   });
 
-  test('should ignore setting empty properties', () => {
+  test('should not throw when setting empty properties', () => {
     const model = new modelClass();
     model.setProperties({});
   });

--- a/gsa/src/gmp/models/testing.js
+++ b/gsa/src/gmp/models/testing.js
@@ -32,259 +32,207 @@ const testId = modelClass => {
     expect(model2.id).toBeUndefined();
     expect(model3.id).toBeUndefined();
   });
-};
 
-export const testModelProperties = (
-  modelClass,
-  type,
-  {testIsActive = true} = {},
-) => {
-  describe(`${type} Model tests`, () => {
-    test('end_time is parsed correctly', () => {
-      const elem = {
-        end_time: '2018-10-10T11:41:23.022Z',
-      };
-      const model = new modelClass(elem);
+  test('should not allow to overwrite id', () => {
+    const model = new modelClass({_id: 'foo'});
 
-      expect(model.endTime).toBeDefined();
-      expect(model.end_time).toBeUndefined();
-      expect(isDate(model.endTime)).toBe(true);
-    });
-
-    test('permissions are parsed correctly', () => {
-      const elem = {
-        permissions: {
-          permission: [{name: 'everything'}, {name: 'may_foo'}],
-        },
-      };
-      const model = new modelClass(elem);
-
-      expect(model.userCapabilities).toBeDefined();
-      expect(model.user_capabilities).toBeUndefined();
-      expect(model.userCapabilities.length).toEqual(2);
-      expect(model.userCapabilities.mayAccess('foo')).toEqual(true);
-    });
-
-    test('should return undefined for userCapabilities if no permissions are given', () => {
-      const model = new modelClass();
-
-      expect(model.userCapabilities).toBeUndefined();
-    });
-
-    test('user_tags are parsed correctly', () => {
-      const elem = {
-        user_tags: {
-          tag: [{name: 'foo'}],
-        },
-      };
-      const model = new modelClass(elem);
-
-      expect(model.userTags).toBeDefined();
-      expect(model.user_tags).toBeUndefined();
-      expect(model.userTags[0].name).toEqual('foo');
-      expect(model.userTags[0].entityType).toEqual('tag');
-    });
-
-    test('should return empty array for userTags if no tags are given', () => {
-      const model = new modelClass({});
-
-      expect(model.userTags).toEqual([]);
-    });
-
-    test('should delete owner if owners name is empty', () => {
-      const elem = {owner: {name: ''}};
-      const model = new modelClass(elem);
-
-      expect(model.owner).toBeUndefined();
-    });
-
-    test('should delete comment if comment is empty', () => {
-      const elem = {comment: ''};
-      const model = new modelClass(elem);
-
-      expect(model.comment).toBeUndefined();
-    });
-
-    test('entityType is applied correctly', () => {
-      const model = new modelClass({});
-
-      expect(model.entityType).toEqual(type);
-    });
-
-    test('entityType equals type of entity that was used to initialize', () => {
-      const model = new modelClass({}, 'foo');
-
-      expect(model.entityType).toBe('foo');
-    });
-
-    test('should parse props as YES_VALUE/NO_VALUE', () => {
-      const elem = {
-        writable: '0',
-        orphan: '1',
-        active: '0',
-        trash: '1',
-      };
-      const model = new modelClass(elem);
-
-      expect(model.writable).toEqual(NO_VALUE);
-      expect(model.orphan).toEqual(YES_VALUE);
-      expect(model.active).toEqual(NO_VALUE);
-      expect(model.trash).toEqual(YES_VALUE);
-    });
-
-    test('should parse in_use', () => {
-      const model1 = new modelClass({in_use: '1'});
-      const model2 = new modelClass({in_use: '0'});
-      const model3 = new modelClass({in_use: '2'});
-      const model4 = new modelClass();
-
-      expect(model1.isInUse()).toBe(true);
-      expect(model2.isInUse()).toBe(false);
-      expect(model3.isInUse()).toBe(true);
-      expect(model4.isInUse()).toBe(false);
-    });
-
-    test('isInTrash() should return correct true/false', () => {
-      const model1 = new modelClass({trash: '1'});
-      const model2 = new modelClass({trash: '0'});
-      const model3 = new modelClass({trash: '2'});
-      const model4 = new modelClass();
-
-      expect(model1.isInTrash()).toBe(true);
-      expect(model2.isInTrash()).toBe(false);
-      expect(model3.isInTrash()).toBe(false);
-      expect(model4.isInTrash()).toBe(false);
-    });
-
-    test('isWritable() should return correct true/false', () => {
-      const model1 = new modelClass({writable: '1'});
-      const model2 = new modelClass({writable: '0'});
-      const model3 = new modelClass({writable: '2'});
-      const model4 = new modelClass();
-
-      expect(model1.isWritable()).toBe(true);
-      expect(model2.isWritable()).toBe(false);
-      expect(model3.isWritable()).toBe(false);
-      expect(model4.isWritable()).toBe(true);
-    });
-
-    test('isOrphan() should return correct true/false', () => {
-      const model1 = new modelClass({orphan: '1'});
-      const model2 = new modelClass({orphan: '0'});
-      const model3 = new modelClass({orphan: '2'});
-      const model4 = new modelClass();
-
-      expect(model1.isOrphan()).toBe(true);
-      expect(model2.isOrphan()).toBe(false);
-      expect(model3.isOrphan()).toBe(false);
-      expect(model4.isOrphan()).toBe(false);
-    });
-
-    if (testIsActive) {
-      test('isActive() should return correct true/false', () => {
-        const model1 = new modelClass({active: '1'});
-        const model2 = new modelClass({active: '0'});
-        const model3 = new modelClass({active: '2'});
-        const model4 = new modelClass();
-
-        expect(model1.isActive()).toBe(true);
-        expect(model2.isActive()).toBe(false);
-        expect(model3.isActive()).toBe(false);
-        expect(model4.isActive()).toBe(true);
-      });
-    }
-  });
-
-  describe(`${type} Model parse_properties function test`, () => {
-    test('should parse creation_time as date', () => {
-      const model = new modelClass({creation_time: '2018-10-10T08:48:46Z'});
-
-      expect(model.creationTime).toEqual(parseDate('2018-10-10T08:48:46Z'));
-      expect(model.creation_time).toBeUndefined();
-    });
-
-    test('should parse no given creation_time as undefined', () => {
-      const model = new modelClass({});
-
-      expect(model.creationTime).toBeUndefined();
-    });
-
-    test('should parse modification_time as date', () => {
-      const model = new modelClass({modification_time: '2018-10-10T08:48:46Z'});
-
-      expect(model.modificationTime).toEqual(parseDate('2018-10-10T08:48:46Z'));
-      expect(model.modification_time).toBeUndefined();
-    });
-
-    test('should parse no given modification_time as undefined', () => {
-      const model = new modelClass({});
-
-      expect(model.modificationTime).toBeUndefined();
-    });
-
-    test('should privatize type from Model', () => {
-      const model = new modelClass({type: 'foo'});
-
-      expect(model.type).toBeUndefined();
-    });
-  });
-
-  describe(`${type} Model set_properties function test`, () => {
-    test('should not allow to overwrite id', () => {
-      const model = new modelClass({_id: 'foo'});
-
-      expect(() => (model.id = 'bar')).toThrow();
-    });
+    expect(() => (model.id = 'bar')).toThrow();
   });
 };
 
-export const testModelMethods = (modelClass, type) => {
-  describe(`${type} Model methods tests`, () => {
-    test('isInUse() should return correct true/false', () => {
-      const model1 = new modelClass({in_use: '1'});
-      const model2 = new modelClass({in_use: '0'});
+export const testModelProperties = (modelClass, type) => {
+  test('end_time is parsed correctly', () => {
+    const elem = {
+      end_time: '2018-10-10T11:41:23.022Z',
+    };
+    const model = new modelClass(elem);
 
-      expect(model1.isInUse()).toBe(true);
-      expect(model2.isInUse()).toBe(false);
-    });
+    expect(model.endTime).toBeDefined();
+    expect(model.end_time).toBeUndefined();
+    expect(isDate(model.endTime)).toBe(true);
+  });
 
-    test('isInTrash() should return correct true/false', () => {
-      const model1 = new modelClass({trash: '1'});
-      const model2 = new modelClass({trash: '0'});
+  test('permissions are parsed correctly', () => {
+    const elem = {
+      permissions: {
+        permission: [{name: 'everything'}, {name: 'may_foo'}],
+      },
+    };
+    const model = new modelClass(elem);
 
-      expect(model1.isInTrash()).toBe(true);
-      expect(model2.isInTrash()).toBe(false);
-    });
+    expect(model.userCapabilities).toBeDefined();
+    expect(model.user_capabilities).toBeUndefined();
+    expect(model.userCapabilities.length).toEqual(2);
+    expect(model.userCapabilities.mayAccess('foo')).toEqual(true);
+  });
 
-    test('isWritable() should return correct true/false', () => {
-      const model1 = new modelClass({writable: '1'});
-      const model2 = new modelClass({writable: '0'});
+  test('should return undefined for userCapabilities if no permissions are given', () => {
+    const model = new modelClass();
 
-      expect(model1.isWritable()).toBe(true);
-      expect(model2.isWritable()).toBe(false);
-    });
+    expect(model.userCapabilities).toBeUndefined();
+  });
 
-    test('isOrphan() should return correct true/false', () => {
-      const model1 = new modelClass({orphan: '1'});
-      const model2 = new modelClass({orphan: '0'});
+  test('user_tags are parsed correctly', () => {
+    const elem = {
+      user_tags: {
+        tag: [{name: 'foo'}],
+      },
+    };
+    const model = new modelClass(elem);
 
-      expect(model1.isOrphan()).toBe(true);
-      expect(model2.isOrphan()).toBe(false);
-    });
+    expect(model.userTags).toBeDefined();
+    expect(model.user_tags).toBeUndefined();
+    expect(model.userTags[0].name).toEqual('foo');
+    expect(model.userTags[0].entityType).toEqual('tag');
+  });
 
+  test('should return empty array for userTags if no tags are given', () => {
+    const model = new modelClass({});
+
+    expect(model.userTags).toEqual([]);
+  });
+
+  test('should delete owner if owners name is empty', () => {
+    const elem = {owner: {name: ''}};
+    const model = new modelClass(elem);
+
+    expect(model.owner).toBeUndefined();
+  });
+
+  test('should delete comment if comment is empty', () => {
+    const elem = {comment: ''};
+    const model = new modelClass(elem);
+
+    expect(model.comment).toBeUndefined();
+  });
+
+  test('entityType is applied correctly', () => {
+    const model = new modelClass({});
+
+    expect(model.entityType).toEqual(type);
+  });
+
+  test('entityType equals type of entity that was used to initialize', () => {
+    const model = new modelClass({}, 'foo');
+
+    expect(model.entityType).toBe('foo');
+  });
+
+  test('should parse props as YES_VALUE/NO_VALUE', () => {
+    const elem = {
+      writable: '0',
+      orphan: '1',
+      active: '0',
+      trash: '1',
+    };
+    const model = new modelClass(elem);
+
+    expect(model.writable).toEqual(NO_VALUE);
+    expect(model.orphan).toEqual(YES_VALUE);
+    expect(model.active).toEqual(NO_VALUE);
+    expect(model.trash).toEqual(YES_VALUE);
+  });
+
+  test('should parse creation_time as date', () => {
+    const model = new modelClass({creation_time: '2018-10-10T08:48:46Z'});
+
+    expect(model.creationTime).toEqual(parseDate('2018-10-10T08:48:46Z'));
+    expect(model.creation_time).toBeUndefined();
+  });
+
+  test('should parse no given creation_time as undefined', () => {
+    const model = new modelClass({});
+
+    expect(model.creationTime).toBeUndefined();
+  });
+
+  test('should parse modification_time as date', () => {
+    const model = new modelClass({modification_time: '2018-10-10T08:48:46Z'});
+
+    expect(model.modificationTime).toEqual(parseDate('2018-10-10T08:48:46Z'));
+    expect(model.modification_time).toBeUndefined();
+  });
+
+  test('should parse no given modification_time as undefined', () => {
+    const model = new modelClass({});
+
+    expect(model.modificationTime).toBeUndefined();
+  });
+
+  test('should privatize type from Model', () => {
+    const model = new modelClass({type: 'foo'});
+
+    expect(model.type).toBeUndefined();
+  });
+};
+
+export const testModelMethods = (modelClass, {testIsActive = true} = {}) => {
+  test('isInUse() should return correct true/false', () => {
+    const model1 = new modelClass({in_use: '1'});
+    const model2 = new modelClass({in_use: '0'});
+    const model3 = new modelClass({in_use: '2'});
+    const model4 = new modelClass();
+
+    expect(model1.isInUse()).toBe(true);
+    expect(model2.isInUse()).toBe(false);
+    expect(model3.isInUse()).toBe(true);
+    expect(model4.isInUse()).toBe(false);
+  });
+
+  test('isInTrash() should return correct true/false', () => {
+    const model1 = new modelClass({trash: '1'});
+    const model2 = new modelClass({trash: '0'});
+    const model3 = new modelClass({trash: '2'});
+    const model4 = new modelClass();
+
+    expect(model1.isInTrash()).toBe(true);
+    expect(model2.isInTrash()).toBe(false);
+    expect(model3.isInTrash()).toBe(false);
+    expect(model4.isInTrash()).toBe(false);
+  });
+
+  test('isWritable() should return correct true/false', () => {
+    const model1 = new modelClass({writable: '1'});
+    const model2 = new modelClass({writable: '0'});
+    const model3 = new modelClass({writable: '2'});
+    const model4 = new modelClass();
+
+    expect(model1.isWritable()).toBe(true);
+    expect(model2.isWritable()).toBe(false);
+    expect(model3.isWritable()).toBe(false);
+    expect(model4.isWritable()).toBe(true);
+  });
+
+  test('isOrphan() should return correct true/false', () => {
+    const model1 = new modelClass({orphan: '1'});
+    const model2 = new modelClass({orphan: '0'});
+    const model3 = new modelClass({orphan: '2'});
+    const model4 = new modelClass();
+
+    expect(model1.isOrphan()).toBe(true);
+    expect(model2.isOrphan()).toBe(false);
+    expect(model3.isOrphan()).toBe(false);
+    expect(model4.isOrphan()).toBe(false);
+  });
+
+  if (testIsActive) {
     test('isActive() should return correct true/false', () => {
       const model1 = new modelClass({active: '1'});
       const model2 = new modelClass({active: '0'});
+      const model3 = new modelClass({active: '2'});
+      const model4 = new modelClass();
 
       expect(model1.isActive()).toBe(true);
       expect(model2.isActive()).toBe(false);
+      expect(model3.isActive()).toBe(false);
+      expect(model4.isActive()).toBe(true);
     });
-  });
+  }
 };
 
 export const testModel = (modelClass, type, options) => {
-  testModelProperties(modelClass, type, options);
-  testModelMethods(modelClass, type);
+  testModelProperties(modelClass, type);
+  testModelMethods(modelClass, options);
   testId(modelClass);
 };
 

--- a/gsa/src/gmp/models/testing.js
+++ b/gsa/src/gmp/models/testing.js
@@ -24,9 +24,9 @@ import {parseDate, NO_VALUE, YES_VALUE} from 'gmp/parser';
 
 const testId = modelClass => {
   test('should set ID only for proper ID', () => {
-    const model1 = new modelClass({_id: '1337'});
-    const model2 = new modelClass({});
-    const model3 = new modelClass({_id: ''});
+    const model1 = modelClass.fromElement({_id: '1337'});
+    const model2 = modelClass.fromElement({});
+    const model3 = modelClass.fromElement({_id: ''});
 
     expect(model1.id).toEqual('1337');
     expect(model2.id).toBeUndefined();
@@ -34,16 +34,15 @@ const testId = modelClass => {
   });
 
   test('should not allow to overwrite id', () => {
-    const model = new modelClass({_id: 'foo'});
+    const model = modelClass.fromElement({_id: 'foo'});
 
     expect(() => (model.id = 'bar')).toThrow();
   });
 };
 
-export const testModelProperties = (modelClass, type) => {
+export const testModelFromElement = (modelClass, type) => {
   test('should create instance of modelclass in fromElement', () => {
     const model = modelClass.fromElement();
-    console.log(model, typeof model);
     expect(model).toBeInstanceOf(modelClass);
   });
 
@@ -51,7 +50,7 @@ export const testModelProperties = (modelClass, type) => {
     const elem = {
       end_time: '2018-10-10T11:41:23.022Z',
     };
-    const model = new modelClass(elem);
+    const model = modelClass.fromElement(elem);
 
     expect(model.endTime).toBeDefined();
     expect(model.end_time).toBeUndefined();
@@ -64,7 +63,7 @@ export const testModelProperties = (modelClass, type) => {
         permission: [{name: 'everything'}, {name: 'may_foo'}],
       },
     };
-    const model = new modelClass(elem);
+    const model = modelClass.fromElement(elem);
 
     expect(model.userCapabilities).toBeDefined();
     expect(model.user_capabilities).toBeUndefined();
@@ -72,7 +71,7 @@ export const testModelProperties = (modelClass, type) => {
     expect(model.userCapabilities.mayAccess('foo')).toEqual(true);
   });
 
-  test('should return undefined for userCapabilities if no permissions are given', () => {
+  test('should return undefined for userCapabilities if no permissions are given to the constructor', () => {
     const model = new modelClass();
 
     expect(model.userCapabilities).toBeUndefined();
@@ -84,7 +83,7 @@ export const testModelProperties = (modelClass, type) => {
         tag: [{name: 'foo'}],
       },
     };
-    const model = new modelClass(elem);
+    const model = modelClass.fromElement(elem);
 
     expect(model.userTags).toBeDefined();
     expect(model.user_tags).toBeUndefined();
@@ -93,35 +92,29 @@ export const testModelProperties = (modelClass, type) => {
   });
 
   test('should return empty array for userTags if no tags are given', () => {
-    const model = new modelClass({});
+    const model = modelClass.fromElement({});
 
     expect(model.userTags).toEqual([]);
   });
 
   test('should delete owner if owners name is empty', () => {
     const elem = {owner: {name: ''}};
-    const model = new modelClass(elem);
+    const model = modelClass.fromElement(elem);
 
     expect(model.owner).toBeUndefined();
   });
 
   test('should delete comment if comment is empty', () => {
     const elem = {comment: ''};
-    const model = new modelClass(elem);
+    const model = modelClass.fromElement(elem);
 
     expect(model.comment).toBeUndefined();
   });
 
   test('entityType is applied correctly', () => {
-    const model = new modelClass({});
+    const model = modelClass.fromElement({});
 
     expect(model.entityType).toEqual(type);
-  });
-
-  test('entityType equals type of entity that was used to initialize', () => {
-    const model = new modelClass({}, 'foo');
-
-    expect(model.entityType).toBe('foo');
   });
 
   test('should parse props as YES_VALUE/NO_VALUE', () => {
@@ -131,7 +124,7 @@ export const testModelProperties = (modelClass, type) => {
       active: '0',
       trash: '1',
     };
-    const model = new modelClass(elem);
+    const model = modelClass.fromElement(elem);
 
     expect(model.writable).toEqual(NO_VALUE);
     expect(model.orphan).toEqual(YES_VALUE);
@@ -140,33 +133,37 @@ export const testModelProperties = (modelClass, type) => {
   });
 
   test('should parse creation_time as date', () => {
-    const model = new modelClass({creation_time: '2018-10-10T08:48:46Z'});
+    const model = modelClass.fromElement({
+      creation_time: '2018-10-10T08:48:46Z',
+    });
 
     expect(model.creationTime).toEqual(parseDate('2018-10-10T08:48:46Z'));
     expect(model.creation_time).toBeUndefined();
   });
 
   test('should parse no given creation_time as undefined', () => {
-    const model = new modelClass({});
+    const model = modelClass.fromElement({});
 
     expect(model.creationTime).toBeUndefined();
   });
 
   test('should parse modification_time as date', () => {
-    const model = new modelClass({modification_time: '2018-10-10T08:48:46Z'});
+    const model = modelClass.fromElement({
+      modification_time: '2018-10-10T08:48:46Z',
+    });
 
     expect(model.modificationTime).toEqual(parseDate('2018-10-10T08:48:46Z'));
     expect(model.modification_time).toBeUndefined();
   });
 
   test('should parse no given modification_time as undefined', () => {
-    const model = new modelClass({});
+    const model = modelClass.fromElement({});
 
     expect(model.modificationTime).toBeUndefined();
   });
 
   test('should privatize type from Model', () => {
-    const model = new modelClass({type: 'foo'});
+    const model = modelClass.fromElement({type: 'foo'});
 
     expect(model.type).toBeUndefined();
   });
@@ -174,10 +171,10 @@ export const testModelProperties = (modelClass, type) => {
 
 export const testModelMethods = (modelClass, {testIsActive = true} = {}) => {
   test('isInUse() should return correct true/false', () => {
-    const model1 = new modelClass({in_use: '1'});
-    const model2 = new modelClass({in_use: '0'});
-    const model3 = new modelClass({in_use: '2'});
-    const model4 = new modelClass();
+    const model1 = modelClass.fromElement({in_use: '1'});
+    const model2 = modelClass.fromElement({in_use: '0'});
+    const model3 = modelClass.fromElement({in_use: '2'});
+    const model4 = modelClass.fromElement();
 
     expect(model1.isInUse()).toBe(true);
     expect(model2.isInUse()).toBe(false);
@@ -186,10 +183,10 @@ export const testModelMethods = (modelClass, {testIsActive = true} = {}) => {
   });
 
   test('isInTrash() should return correct true/false', () => {
-    const model1 = new modelClass({trash: '1'});
-    const model2 = new modelClass({trash: '0'});
-    const model3 = new modelClass({trash: '2'});
-    const model4 = new modelClass();
+    const model1 = modelClass.fromElement({trash: '1'});
+    const model2 = modelClass.fromElement({trash: '0'});
+    const model3 = modelClass.fromElement({trash: '2'});
+    const model4 = modelClass.fromElement();
 
     expect(model1.isInTrash()).toBe(true);
     expect(model2.isInTrash()).toBe(false);
@@ -198,10 +195,10 @@ export const testModelMethods = (modelClass, {testIsActive = true} = {}) => {
   });
 
   test('isWritable() should return correct true/false', () => {
-    const model1 = new modelClass({writable: '1'});
-    const model2 = new modelClass({writable: '0'});
-    const model3 = new modelClass({writable: '2'});
-    const model4 = new modelClass();
+    const model1 = modelClass.fromElement({writable: '1'});
+    const model2 = modelClass.fromElement({writable: '0'});
+    const model3 = modelClass.fromElement({writable: '2'});
+    const model4 = modelClass.fromElement();
 
     expect(model1.isWritable()).toBe(true);
     expect(model2.isWritable()).toBe(false);
@@ -210,10 +207,10 @@ export const testModelMethods = (modelClass, {testIsActive = true} = {}) => {
   });
 
   test('isOrphan() should return correct true/false', () => {
-    const model1 = new modelClass({orphan: '1'});
-    const model2 = new modelClass({orphan: '0'});
-    const model3 = new modelClass({orphan: '2'});
-    const model4 = new modelClass();
+    const model1 = modelClass.fromElement({orphan: '1'});
+    const model2 = modelClass.fromElement({orphan: '0'});
+    const model3 = modelClass.fromElement({orphan: '2'});
+    const model4 = modelClass.fromElement();
 
     expect(model1.isOrphan()).toBe(true);
     expect(model2.isOrphan()).toBe(false);
@@ -223,10 +220,10 @@ export const testModelMethods = (modelClass, {testIsActive = true} = {}) => {
 
   if (testIsActive) {
     test('isActive() should return correct true/false', () => {
-      const model1 = new modelClass({active: '1'});
-      const model2 = new modelClass({active: '0'});
-      const model3 = new modelClass({active: '2'});
-      const model4 = new modelClass();
+      const model1 = modelClass.fromElement({active: '1'});
+      const model2 = modelClass.fromElement({active: '0'});
+      const model3 = modelClass.fromElement({active: '2'});
+      const model4 = modelClass.fromElement();
 
       expect(model1.isActive()).toBe(true);
       expect(model2.isActive()).toBe(false);
@@ -237,7 +234,7 @@ export const testModelMethods = (modelClass, {testIsActive = true} = {}) => {
 };
 
 export const testModel = (modelClass, type, options) => {
-  testModelProperties(modelClass, type);
+  testModelFromElement(modelClass, type);
   testModelMethods(modelClass, options);
   testId(modelClass);
 };

--- a/gsa/src/gmp/models/testing.js
+++ b/gsa/src/gmp/models/testing.js
@@ -41,6 +41,12 @@ const testId = modelClass => {
 };
 
 export const testModelProperties = (modelClass, type) => {
+  test('should create instance of modelclass in fromElement', () => {
+    const model = modelClass.fromElement();
+    console.log(model, typeof model);
+    expect(model).toBeInstanceOf(modelClass);
+  });
+
   test('end_time is parsed correctly', () => {
     const elem = {
       end_time: '2018-10-10T11:41:23.022Z',

--- a/gsa/src/gmp/models/testing.js
+++ b/gsa/src/gmp/models/testing.js
@@ -282,10 +282,35 @@ const testModelSetProperties = modelClass => {
   });
 };
 
+const testModelGetProperties = (modelClass, type) => {
+  test('should return set properties', () => {
+    const model = new modelClass();
+    model.setProperties({foo: 'bar', bar: 1});
+
+    const props = model.getProperties();
+
+    expect(props.foo).toEqual('bar');
+    expect(props.bar).toEqual(1);
+    expect(props.entityType).toEqual(type);
+  });
+
+  test('should return parsed default element properties', () => {
+    const model = modelClass.fromElement();
+
+    const props = model.getProperties();
+
+    expect(props.userCapabilities).toBeDefined();
+    expect(props.userCapabilities.areDefined()).toEqual(false);
+    expect(props.userTags).toEqual([]);
+    expect(props.entityType).toEqual(type);
+  });
+};
+
 export const testModel = (modelClass, type, options) => {
   testModelFromElement(modelClass, type);
   testModelMethods(modelClass, options);
   testModelSetProperties(modelClass);
+  testModelGetProperties(modelClass, type);
   testId(modelClass);
 };
 

--- a/gsa/src/gmp/models/ticket.js
+++ b/gsa/src/gmp/models/ticket.js
@@ -45,10 +45,6 @@ export const getTranslatableTicketStatus = status =>
 class Ticket extends Model {
   static entityType = 'ticket';
 
-  parseProperties(element) {
-    return Ticket.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/ticket.js
+++ b/gsa/src/gmp/models/ticket.js
@@ -45,75 +45,79 @@ export const getTranslatableTicketStatus = status =>
 class Ticket extends Model {
   static entityType = 'ticket';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return Ticket.parseElement(element);
+  }
 
-    if (isDefined(elem.assigned_to) && isDefined(elem.assigned_to.user)) {
-      ret.assignedTo = {user: new Model(elem.assigned_to.user, 'user')};
+  static parseElement(element) {
+    const ret = super.parseElement(element);
+
+    if (isDefined(element.assigned_to) && isDefined(element.assigned_to.user)) {
+      ret.assignedTo = {user: new Model(element.assigned_to.user, 'user')};
     }
     delete ret.assigned_to;
 
-    if (isModelElement(elem.result)) {
-      ret.result = new Model(elem.result, 'result');
+    if (isModelElement(element.result)) {
+      ret.result = new Model(element.result, 'result');
     } else {
       delete ret.result;
     }
 
-    if (isModelElement(elem.report)) {
-      ret.report = new Model(elem.report, 'report');
+    if (isModelElement(element.report)) {
+      ret.report = new Model(element.report, 'report');
     } else {
       delete ret.report;
     }
 
-    if (isModelElement(elem.task)) {
-      ret.task = new Model(elem.task, 'task');
+    if (isModelElement(element.task)) {
+      ret.task = new Model(element.task, 'task');
     } else {
       delete ret.task;
     }
 
-    if (isModelElement(elem.fix_verified_report)) {
-      ret.fixVerifiedReport = new Model(elem.fix_verified_report, 'report');
+    if (isModelElement(element.fix_verified_report)) {
+      ret.fixVerifiedReport = new Model(element.fix_verified_report, 'report');
     }
     delete ret.fix_verified_report;
 
-    if (isDefined(elem.severity)) {
-      ret.severity = parseSeverity(elem.severity);
+    if (isDefined(element.severity)) {
+      ret.severity = parseSeverity(element.severity);
     }
 
-    if (isDefined(elem.nvt) && !isEmpty(elem.nvt._oid)) {
-      ret.nvt = {oid: elem.nvt._oid};
+    if (isDefined(element.nvt) && !isEmpty(element.nvt._oid)) {
+      ret.nvt = {oid: element.nvt._oid};
     }
 
-    if (!isEmpty(elem.open_time)) {
-      ret.openTime = parseDate(elem.open_time);
+    if (!isEmpty(element.open_time)) {
+      ret.openTime = parseDate(element.open_time);
     }
     delete ret.open_time;
 
-    if (!isEmpty(elem.fix_verified_time)) {
-      ret.fixVerifiedTime = parseDate(elem.fix_verified_time);
+    if (!isEmpty(element.fix_verified_time)) {
+      ret.fixVerifiedTime = parseDate(element.fix_verified_time);
     }
     delete ret.fix_verified_time;
 
-    if (!isEmpty(elem.fixed_time)) {
-      ret.fixedTime = parseDate(elem.fixed_time);
+    if (!isEmpty(element.fixed_time)) {
+      ret.fixedTime = parseDate(element.fixed_time);
     }
     delete ret.fixed_time;
 
-    if (!isEmpty(elem.closed_time)) {
-      ret.closedTime = parseDate(elem.closed_time);
+    if (!isEmpty(element.closed_time)) {
+      ret.closedTime = parseDate(element.closed_time);
     }
     delete ret.closed_time;
 
-    ret.solutionType = elem.solution_type;
+    ret.solutionType = element.solution_type;
     delete ret.solution_type;
 
-    const openNote = parseText(elem.open_note);
+    const openNote = parseText(element.open_note);
     if (!isEmpty(openNote)) {
       ret.openNote = openNote;
     }
     delete ret.open_note;
 
-    const closedNote = parseText(elem.closed_note);
+    const closedNote = parseText(element.closed_note);
     if (!isEmpty(closedNote)) {
       ret.closedNote = closedNote;
     }

--- a/gsa/src/gmp/models/ticket.js
+++ b/gsa/src/gmp/models/ticket.js
@@ -23,7 +23,7 @@ import {parseSeverity, parseDate, parseText} from 'gmp/parser';
 import {isDefined, isModelElement} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
 
-import Model from '../model';
+import Model, {parseModelFromElement} from '../model';
 
 export const TICKET_STATUS = {
   open: 'Open',
@@ -53,30 +53,35 @@ class Ticket extends Model {
     const ret = super.parseElement(element);
 
     if (isDefined(element.assigned_to) && isDefined(element.assigned_to.user)) {
-      ret.assignedTo = {user: new Model(element.assigned_to.user, 'user')};
+      ret.assignedTo = {
+        user: parseModelFromElement(element.assigned_to.user, 'user'),
+      };
     }
     delete ret.assigned_to;
 
     if (isModelElement(element.result)) {
-      ret.result = new Model(element.result, 'result');
+      ret.result = parseModelFromElement(element.result, 'result');
     } else {
       delete ret.result;
     }
 
     if (isModelElement(element.report)) {
-      ret.report = new Model(element.report, 'report');
+      ret.report = parseModelFromElement(element.report, 'report');
     } else {
       delete ret.report;
     }
 
     if (isModelElement(element.task)) {
-      ret.task = new Model(element.task, 'task');
+      ret.task = parseModelFromElement(element.task, 'task');
     } else {
       delete ret.task;
     }
 
     if (isModelElement(element.fix_verified_report)) {
-      ret.fixVerifiedReport = new Model(element.fix_verified_report, 'report');
+      ret.fixVerifiedReport = parseModelFromElement(
+        element.fix_verified_report,
+        'report',
+      );
     }
     delete ret.fix_verified_report;
 

--- a/gsa/src/gmp/models/user.js
+++ b/gsa/src/gmp/models/user.js
@@ -35,10 +35,6 @@ export const ACCESS_DENY_ALL = '1';
 class User extends Model {
   static entityType = 'user';
 
-  parseProperties(element) {
-    return User.parseElement(element);
-  }
-
   static parseElement(element) {
     const ret = super.parseElement(element);
 

--- a/gsa/src/gmp/models/user.js
+++ b/gsa/src/gmp/models/user.js
@@ -21,7 +21,7 @@ import {isDefined} from '../utils/identity';
 import {isEmpty} from '../utils/string';
 import {map} from '../utils/array';
 
-import Model from '../model.js';
+import Model, {parseModelFromElement} from '../model.js';
 import {parseCsv} from '../parser';
 
 export const AUTH_METHOD_PASSWORD = 'password';
@@ -42,18 +42,16 @@ class User extends Model {
   static parseElement(element) {
     const ret = super.parseElement(element);
 
-    ret.roles = map(element.role, role => {
-      return new Model(role, 'role');
-    });
+    ret.roles = map(element.role, role => parseModelFromElement(role, 'role'));
 
     delete ret.role;
 
     if (isEmpty(element.groups)) {
       ret.groups = [];
     } else {
-      ret.groups = map(element.groups.group, group => {
-        return new Model(group, 'group');
-      });
+      ret.groups = map(element.groups.group, group =>
+        parseModelFromElement(group, 'group'),
+      );
     }
 
     if (isDefined(element.hosts)) {

--- a/gsa/src/gmp/models/user.js
+++ b/gsa/src/gmp/models/user.js
@@ -35,27 +35,31 @@ export const ACCESS_DENY_ALL = '1';
 class User extends Model {
   static entityType = 'user';
 
-  parseProperties(elem) {
-    const ret = super.parseProperties(elem);
+  parseProperties(element) {
+    return User.parseElement(element);
+  }
 
-    ret.roles = map(elem.role, role => {
+  static parseElement(element) {
+    const ret = super.parseElement(element);
+
+    ret.roles = map(element.role, role => {
       return new Model(role, 'role');
     });
 
     delete ret.role;
 
-    if (isEmpty(elem.groups)) {
+    if (isEmpty(element.groups)) {
       ret.groups = [];
     } else {
-      ret.groups = map(elem.groups.group, group => {
+      ret.groups = map(element.groups.group, group => {
         return new Model(group, 'group');
       });
     }
 
-    if (isDefined(elem.hosts)) {
+    if (isDefined(element.hosts)) {
       ret.hosts = {
-        addresses: parseCsv(elem.hosts.__text),
-        allow: elem.hosts._allow,
+        addresses: parseCsv(element.hosts.__text),
+        allow: element.hosts._allow,
       };
     } else {
       ret.hosts = {
@@ -63,10 +67,10 @@ class User extends Model {
       };
     }
 
-    if (isDefined(elem.ifaces)) {
+    if (isDefined(element.ifaces)) {
       ret.ifaces = {
-        addresses: parseCsv(elem.ifaces.__text),
-        allow: elem.ifaces._allow,
+        addresses: parseCsv(element.ifaces.__text),
+        allow: element.ifaces._allow,
       };
     } else {
       ret.ifaces = {
@@ -74,8 +78,8 @@ class User extends Model {
       };
     }
 
-    if (isDefined(elem.sources)) {
-      const {source} = elem.sources;
+    if (isDefined(element.sources)) {
+      const {source} = element.sources;
       if (source === 'ldap_connect') {
         ret.auth_method = AUTH_METHOD_LDAP;
       } else if (source === 'radius_connect') {

--- a/gsa/src/gmp/utils/__tests__/entitytype.js
+++ b/gsa/src/gmp/utils/__tests__/entitytype.js
@@ -16,7 +16,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-import Model from 'gmp/model';
+import {parseModelFromElement} from 'gmp/model';
 import Nvt from 'gmp/models/nvt';
 import Host from 'gmp/models/host';
 
@@ -40,19 +40,19 @@ describe('getEntityType function tests', () => {
   });
 
   test('should return entity type of model', () => {
-    const model = new Model({}, 'foo');
+    const model = parseModelFromElement({}, 'foo');
 
     expect(getEntityType(model)).toEqual('foo');
   });
 
   test('should return entity type for info models', () => {
-    const model = new Nvt({});
+    const model = Nvt.fromElement({});
 
     expect(getEntityType(model)).toEqual('nvt');
   });
 
   test('should return entity type for asset models', () => {
-    const model = new Host({});
+    const model = Host.fromElement({});
 
     expect(getEntityType(model)).toEqual('host');
   });

--- a/gsa/src/web/entity/icon/__tests__/cloneicon.js
+++ b/gsa/src/web/entity/icon/__tests__/cloneicon.js
@@ -31,7 +31,9 @@ import CloneIcon from '../cloneicon';
 describe('Entity CloneIcon component tests', () => {
   test('should render in active state with correct permissions', () => {
     const caps = new Capabilities(['everything']);
-    const entity = new Task({permissions: {permission: [{name: 'get_tasks'}]}});
+    const entity = Task.fromElement({
+      permissions: {permission: [{name: 'get_tasks'}]},
+    });
     const clickHandler = jest.fn();
 
     const {render} = rendererWith({capabilities: caps});
@@ -53,7 +55,9 @@ describe('Entity CloneIcon component tests', () => {
 
   test('should deactivate if wrong command level permissions are given', () => {
     const caps = new Capabilities(['authenticate']);
-    const entity = new Task({permissions: {permission: [{name: 'get_tasks'}]}});
+    const entity = Task.fromElement({
+      permissions: {permission: [{name: 'get_tasks'}]},
+    });
     const clickHandler = jest.fn();
 
     const {render} = rendererWith({capabilities: caps});
@@ -74,7 +78,7 @@ describe('Entity CloneIcon component tests', () => {
 
   test('should deactivate if wrong resource level permissions are given', () => {
     const caps = new Capabilities(['everything']);
-    const entity = new Task({
+    const entity = Task.fromElement({
       permissions: {permission: [{name: 'get_schedule'}]},
     });
     const clickHandler = jest.fn();

--- a/gsa/src/web/entity/icon/__tests__/createicon.js
+++ b/gsa/src/web/entity/icon/__tests__/createicon.js
@@ -31,7 +31,7 @@ import CreateIcon from '../createicon';
 describe('Entity CreateIcon component tests', () => {
   test('should render in active state with correct permissions', () => {
     const caps = new Capabilities(['everything']);
-    const entity = new Task({});
+    const entity = Task.fromElement({});
     const clickHandler = jest.fn();
 
     const {render} = rendererWith({capabilities: caps});
@@ -53,7 +53,7 @@ describe('Entity CreateIcon component tests', () => {
 
   test('should not be rendered if wrong command level permissions are given', () => {
     const caps = new Capabilities(['authenticate']);
-    const entity = new Task({});
+    const entity = Task.fromElement({});
 
     const {render} = rendererWith({capabilities: caps});
 

--- a/gsa/src/web/entity/icon/__tests__/deleteicon.js
+++ b/gsa/src/web/entity/icon/__tests__/deleteicon.js
@@ -31,7 +31,7 @@ import DeleteIcon from '../deleteicon';
 describe('Entity DeleteIcon component tests', () => {
   test('should render in active state with correct permissions', () => {
     const caps = new Capabilities(['everything']);
-    const entity = new Task({
+    const entity = Task.fromElement({
       permissions: {permission: [{name: 'delete_task'}]},
     });
     const clickHandler = jest.fn();
@@ -56,7 +56,7 @@ describe('Entity DeleteIcon component tests', () => {
 
   test('should deactivate if wrong command level permissions are given', () => {
     const caps = new Capabilities(['authenticate']);
-    const entity = new Task({
+    const entity = Task.fromElement({
       permissions: {permission: [{name: 'delete_task'}]},
     });
     const clickHandler = jest.fn();
@@ -80,7 +80,7 @@ describe('Entity DeleteIcon component tests', () => {
 
   test('should deactivate if wrong resource level permissions are given', () => {
     const caps = new Capabilities(['everything']);
-    const entity = new Task({
+    const entity = Task.fromElement({
       permissions: {permission: [{name: 'delete_schedule'}]},
     });
     const clickHandler = jest.fn();

--- a/gsa/src/web/entity/icon/__tests__/editicon.js
+++ b/gsa/src/web/entity/icon/__tests__/editicon.js
@@ -31,7 +31,7 @@ import EditIcon from '../editicon';
 describe('Entity EditIcon component tests', () => {
   test('should render in active state with correct permissions', () => {
     const caps = new Capabilities(['everything']);
-    const entity = new Task({
+    const entity = Task.fromElement({
       permissions: {permission: [{name: 'modify_task'}]},
     });
     const clickHandler = jest.fn();
@@ -55,7 +55,7 @@ describe('Entity EditIcon component tests', () => {
 
   test('should deactivate if wrong command level permissions are given', () => {
     const caps = new Capabilities(['authenticate']);
-    const entity = new Task({
+    const entity = Task.fromElement({
       permissions: {permission: [{name: 'modify_task'}]},
     });
     const clickHandler = jest.fn();
@@ -78,7 +78,7 @@ describe('Entity EditIcon component tests', () => {
 
   test('should deactivate if wrong resource level permissions are given', () => {
     const caps = new Capabilities(['everything']);
-    const entity = new Task({
+    const entity = Task.fromElement({
       permissions: {permission: [{name: 'modify_schedule'}]},
     });
     const clickHandler = jest.fn();

--- a/gsa/src/web/entity/icon/__tests__/observericon.js
+++ b/gsa/src/web/entity/icon/__tests__/observericon.js
@@ -26,7 +26,7 @@ import ObserverIcon from '../observericon';
 
 describe('Entity ObserverIcon component tests', () => {
   test('should render if the owner is not the current user', () => {
-    const entity = new Task({owner: {name: 'foo'}});
+    const entity = Task.fromElement({owner: {name: 'foo'}});
 
     const {element} = render(<ObserverIcon entity={entity} userName={'bar'} />);
 
@@ -34,7 +34,7 @@ describe('Entity ObserverIcon component tests', () => {
   });
 
   test('should not render if the owner is the current user', () => {
-    const entity = new Task({owner: {name: 'foo'}});
+    const entity = Task.fromElement({owner: {name: 'foo'}});
 
     const {element} = render(<ObserverIcon entity={entity} userName={'foo'} />);
 

--- a/gsa/src/web/entity/icon/__tests__/trashicon.js
+++ b/gsa/src/web/entity/icon/__tests__/trashicon.js
@@ -31,7 +31,7 @@ import TrashIcon from '../trashicon';
 describe('Entity TrashIcon component tests', () => {
   test('should render in active state with correct permissions', () => {
     const caps = new Capabilities(['everything']);
-    const entity = new Task({
+    const entity = Task.fromElement({
       permissions: {permission: [{name: 'delete_task'}]},
     });
     const clickHandler = jest.fn();
@@ -56,7 +56,7 @@ describe('Entity TrashIcon component tests', () => {
 
   test('should deactivate if wrong command level permissions are given', () => {
     const caps = new Capabilities(['authenticate']);
-    const entity = new Task({
+    const entity = Task.fromElement({
       permissions: {permission: [{name: 'delete_task'}]},
     });
     const clickHandler = jest.fn();
@@ -80,7 +80,7 @@ describe('Entity TrashIcon component tests', () => {
 
   test('should deactivate if wrong resource level permissions are given', () => {
     const caps = new Capabilities(['everything']);
-    const entity = new Task({
+    const entity = Task.fromElement({
       permissions: {permission: [{name: 'delete_schedule'}]},
     });
     const clickHandler = jest.fn();

--- a/gsa/src/web/entity/icon/__tests__/verifyicon.js
+++ b/gsa/src/web/entity/icon/__tests__/verifyicon.js
@@ -31,7 +31,7 @@ import VerifyIcon from '../verifyicon';
 describe('Entity VerifyIcon component tests', () => {
   test('should render in active state with correct permissions', () => {
     const caps = new Capabilities(['everything']);
-    const entity = new ReportFormat({
+    const entity = ReportFormat.fromElement({
       permissions: {permission: [{name: 'verify_report_format'}]},
     });
     const clickHandler = jest.fn();
@@ -55,7 +55,7 @@ describe('Entity VerifyIcon component tests', () => {
 
   test('should render in active state with correct permissions and name given', () => {
     const caps = new Capabilities(['everything']);
-    const entity = new ReportFormat({
+    const entity = ReportFormat.fromElement({
       permissions: {permission: [{name: 'verify_report_format'}]},
     });
     const clickHandler = jest.fn();
@@ -83,7 +83,7 @@ describe('Entity VerifyIcon component tests', () => {
 
   test('should deactivate if wrong command level permissions are given', () => {
     const caps = new Capabilities(['authenticate']);
-    const entity = new ReportFormat({
+    const entity = ReportFormat.fromElement({
       permissions: {permission: [{name: 'verify_report_format'}]},
     });
     const clickHandler = jest.fn();
@@ -106,7 +106,7 @@ describe('Entity VerifyIcon component tests', () => {
 
   test('should deactivate if wrong resource level permissions are given', () => {
     const caps = new Capabilities(['everything']);
-    const entity = new ReportFormat({
+    const entity = ReportFormat.fromElement({
       permissions: {permission: [{name: 'verify_scanner'}]},
     });
     const clickHandler = jest.fn();

--- a/gsa/src/web/pages/permissions/dialog.js
+++ b/gsa/src/web/pages/permissions/dialog.js
@@ -183,7 +183,7 @@ const PermissionDialog = ({
 
         const [type] = split(name, '_', 1);
         const resource = isDefined(state.resourceType)
-          ? new Model(
+          ? Model.fromElement(
               {
                 name: isDefined(state.resourceName)
                   ? state.resourceName

--- a/gsa/src/web/pages/tasks/__tests__/containerdialog.js
+++ b/gsa/src/web/pages/tasks/__tests__/containerdialog.js
@@ -40,7 +40,7 @@ describe('ContainerDialog tests', () => {
   });
 
   test('should render edit dialog', () => {
-    const task = new Task({name: 'foo', _id: 't1'});
+    const task = Task.fromElement({name: 'foo', _id: 't1'});
     const handleClose = jest.fn();
     const handleSave = jest.fn();
 
@@ -84,7 +84,7 @@ describe('ContainerDialog tests', () => {
   });
 
   test('should change fields in edit dialog', () => {
-    const task = new Task({name: 'foo', _id: 't1'});
+    const task = Task.fromElement({name: 'foo', _id: 't1'});
     const handleClose = jest.fn();
     const handleSave = jest.fn();
 

--- a/gsa/src/web/pages/tickets/__tests__/createdialog.js
+++ b/gsa/src/web/pages/tickets/__tests__/createdialog.js
@@ -23,11 +23,11 @@ import {render, fireEvent, queryAllByTestId} from 'web/utils/testing';
 import CreateTicketDialog from '../createdialog';
 import User from 'gmp/models/user';
 
-const u1 = new User({
+const u1 = User.fromElement({
   _id: 'u1',
   name: 'foo',
 });
-const u2 = new User({
+const u2 = User.fromElement({
   _id: 'u2',
   name: 'bar',
 });

--- a/gsa/src/web/pages/tickets/__tests__/editdialog.js
+++ b/gsa/src/web/pages/tickets/__tests__/editdialog.js
@@ -25,11 +25,11 @@ import User from 'gmp/models/user';
 
 import EditTicketDialog from '../editdialog';
 
-const u1 = new User({
+const u1 = User.fromElement({
   _id: 'u1',
   name: 'foo',
 });
-const u2 = new User({
+const u2 = User.fromElement({
   _id: 'u2',
   name: 'bar',
 });

--- a/gsa/src/web/store/entities/utils/__tests__/selectors.js
+++ b/gsa/src/web/store/entities/utils/__tests__/selectors.js
@@ -338,7 +338,7 @@ describe('EntitiesSelector getAllEntities tests', () => {
   });
 
   test('getAllEntities should return entities with all-filter if filter is undefined', () => {
-    const filter = new Filter({});
+    const filter = new Filter();
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       byId: {


### PR DESCRIPTION
Update model classes to not expect the element properties from the responses in the constructor.

In future models should be simple wrappers around immutable data. It should be allowed to set only specific properties once. These properties may come from a parsed element or directly from an object.

This PR implements a first step by adding a static methods `parseElement` and `fromElement` to implement the first part. It is still allowed to set **any** properties via `setProperties` once. It adds a draft for a `getProperties` method which doesn't handle sub-model properties (like task.scanner) carefully yet.

**Checklist**:

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
