### PR TITLE
Use uuid to get greenbone compliance report format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#1466](https://github.com/greenbone/gsa/pull/1466) [#1467](https://github.com/greenbone/gsa/pull/1467)
 
 ### Changed
+- Use uuid to get greenbone compliance report format [#1643](https://github.com/greenbone/gsa/pull/1643)
 - Add details=1 to report download command [#1642](https://github.com/greenbone/gsa/pull/1642)
 - Adjust gsa to send details=1 for get_report and change gsad to forward details to gvmd [1640](https://github.com/greenbone/gsa/pull/1640)
 - Switch tooltips for fold and unfold icon, change task trend options in filter dialog to make them easier to understand [#1627](https://github.com/greenbone/gsa/pull/1627)

--- a/gsa/src/web/pages/audits/component.js
+++ b/gsa/src/web/pages/audits/component.js
@@ -83,9 +83,8 @@ import TargetComponent from 'web/pages/targets/component';
 
 import AuditDialog from 'web/pages/audits/dialog';
 
-// TODO: use id instead of name when a unique id becomes available
 const REPORT_FORMATS_FILTER = Filter.fromString(
-  'name="GCR PDF" and active=1 and trust=1 and rows=-1',
+  'uuid="dc51a40a-c022-11e9-b02d-3f7ca5bdcb11" and active=1 and trust=1',
 );
 
 class AuditComponent extends React.Component {


### PR DESCRIPTION
Use the uuid of the greenbone compliance report format in GOS 6 to check if the format is available. This means that using an imported version of the format will not work anymore, only the standard that is available in GOS 6 is supported.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
