### PR TITLE
Decide whether to default to full and fast scan config (task dialog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#1466](https://github.com/greenbone/gsa/pull/1466) [#1467](https://github.com/greenbone/gsa/pull/1467)
 
 ### Changed
+- Decide whether to default to full and fast scan config (task dialog)[#1671](https://github.com/greenbone/gsa/pull/1671)
 - Determine the to be applied filter of a list page in GSA and don't rely on the
   backend [#1631](https://github.com/greenbone/gsa/pull/1631), [#1653](https://github.com/greenbone/gsa/pull/1653)
 - Change gmpname for vulnerability and secinfo pages [#1652](https://github.com/greenbone/gsa/pull/1652)

--- a/gsa/src/web/pages/tasks/dialog.js
+++ b/gsa/src/web/pages/tasks/dialog.js
@@ -21,8 +21,6 @@ import React, {useState} from 'react';
 
 import _ from 'gmp/locale';
 
-import logger from 'gmp/log';
-
 import {forEach, first} from 'gmp/utils/array';
 import {isDefined, isArray} from 'gmp/utils/identity';
 import {selectSaveId} from 'gmp/utils/id';
@@ -74,8 +72,6 @@ import Layout from 'web/components/layout/layout';
 
 import AddResultsToAssetsGroup from './addresultstoassetsgroup';
 import AutoDeleteReportsGroup from './autodeletereportsgroup';
-
-const log = logger.getLogger('web.tasks.dialog');
 
 const sort_scan_configs = (scan_configs = []) => {
   const sorted_scan_configs = {
@@ -202,8 +198,6 @@ const TaskDialog = ({
     } else {
       setConfigType('other');
     }
-
-    log.debug('on scanner change', value, scanner);
 
     if (isDefined(onScannerChange)) {
       onScannerChange(value);


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
Summary of changes:
- moved handleScannerChange out of ScannerSelect
- Refactored ScannerSelect into function
- Added state variables configType and prevConfigType, and calculate/update them in handleScannerChange, and upon onScanConfigChange.

Expected behavior:
- Changing between scanners of the same config type should not change displayed scan config selection
- Edit dialog should show correct scan config
- Scan config should default to "Full and Fast" when 1. creating a new task 2. changing configType from something else TO openvas config type.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
