### PR TITLE
Fix changelog entry for next 9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-### [9.0.1] - unreleased
+## [9.0.1] - unreleased
 
 ### Added
 
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
-[9.0.1]: https://github.com/greenbone/gsa/compare/v9.0.0...gsad-9.0
+[9.0.1]: https://github.com/greenbone/gsa/compare/v9.0.0...gsa-9.0
 
 ## [9.0.0] - 2019-10-14
 


### PR DESCRIPTION
The level of the heading was wrong and also the url for the diff.