### PR TITLE
Fix handling error response during gmp authentication in gsad

### DIFF
--- a/gsad/src/gsad_http.c
+++ b/gsad/src/gsad_http.c
@@ -464,6 +464,9 @@ handler_send_reauthentication (http_connection_t *connection,
     case LOGOUT:
       msg = "Successfully logged out.";
       break;
+    case UNKOWN_ERROR:
+      msg = "Unknown error.";
+      break;
     default:
       msg = "";
     }

--- a/gsad/src/gsad_http.h
+++ b/gsad/src/gsad_http.h
@@ -163,6 +163,7 @@ enum authentication_reason
   SESSION_EXPIRED,
   BAD_MISSING_COOKIE,
   BAD_MISSING_TOKEN,
+  UNKOWN_ERROR,
 };
 
 typedef enum authentication_reason authentication_reason_t;

--- a/gsad/src/gsad_http_handler.c
+++ b/gsad/src/gsad_http_handler.c
@@ -604,19 +604,16 @@ handle_system_report (http_connection_t *connection, const char *method,
                                    response_data);
       gvm_connection_close (&con);
       break;
-    case -1:
-      return handler_send_reauthentication (
-        connection, MHD_HTTP_SERVICE_UNAVAILABLE, GMP_SERVICE_DOWN);
+    case 2:
+      cmd_response_data_free (response_data);
+      credentials_free (credentials);
+      return handler_send_reauthentication (connection, MHD_HTTP_UNAUTHORIZED,
+                                            LOGIN_FAILED);
 
       break;
-    case -2:
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
-                          "An internal error occurred. "
-                          "Diagnostics: Could not authenticate to manager "
-                          "daemon.",
-                          response_data);
-      break;
     default:
+      cmd_response_data_set_status_code (response_data,
+                                         MHD_HTTP_INTERNAL_SERVER_ERROR);
       res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
                           "An internal error occurred. "
                           "Diagnostics: Failure to connect to manager daemon.",


### PR DESCRIPTION
Handle errors while trying to authenticate against gvmd mode carefully.

**Checklist**:

- [n/a] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
