### PR TITLE
Don't run c code format check on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - c_check_format
       - build_gsad
       - build_gsa
       - js_lint


### PR DESCRIPTION
It seems clang-format is formatting the code very differently with newer
versions. It doesn't make sense to run a check without being able to
format the code automatically.