### PR TITLE
Increase clickable area for Logout / Adjust menubar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
-- Increase clickable area for Logout [#1711](https://github.com/greenbone/gsa/pull/1711)
-- Don't show mepty menu section 
+- Don't show empty menu section [#1711](https://github.com/greenbone/gsa/pull/1711)
 - Increase clickable area for Logout [#1711](https://github.com/greenbone/gsa/pull/1711)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- Increase clickable area for Logout [#1711](https://github.com/greenbone/gsa/pull/1711)
 
 ### Fixed
 - Improve filter handling in report details [#1708](https://github.com/greenbone/gsa/pull/1708)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Increase clickable area for Logout [#1711](https://github.com/greenbone/gsa/pull/1711)
+- Don't show mepty menu section 
+- Increase clickable area for Logout [#1711](https://github.com/greenbone/gsa/pull/1711)
 
 ### Fixed
 - Improve filter handling in report details [#1708](https://github.com/greenbone/gsa/pull/1708)

--- a/gsa/src/web/components/bar/__tests__/__snapshots__/titlebar.js.snap
+++ b/gsa/src/web/components/bar/__tests__/__snapshots__/titlebar.js.snap
@@ -477,13 +477,13 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
             </li>
             <li
               class="c13"
+              data-testid="usermenu-logout"
             >
               <div
                 class="c14"
               >
                 <div
                   class="c15"
-                  data-testid="usermenu-logout"
                   margin="5px"
                 >
                   <span

--- a/gsa/src/web/components/bar/menubar.js
+++ b/gsa/src/web/components/bar/menubar.js
@@ -273,16 +273,16 @@ const MenuBar = ({isLoggedIn, capabilities}) => {
                 />
               )}
             </MenuSection>
-            <MenuSection>
-              {capabilities.mayOp('describe_auth') &&
-                capabilities.mayOp('modify_auth') && (
+            {capabilities.mayOp('describe_auth') && (
+              <MenuSection>
+                {capabilities.mayOp('modify_auth') && (
                   <MenuEntry title={_('LDAP')} to="ldap" />
                 )}
-              {capabilities.mayOp('describe_auth') &&
-                capabilities.mayOp('modify_auth') && (
+                {capabilities.mayOp('modify_auth') && (
                   <MenuEntry title={_('Radius')} to="radius" />
                 )}
-            </MenuSection>
+              </MenuSection>
+            )}
           </Menu>
           <Menu title={_('Help')}>
             <MenuHelpEntry title={_('User Manual')} />

--- a/gsa/src/web/components/menu/__tests__/__snapshots__/usermenu.js.snap
+++ b/gsa/src/web/components/menu/__tests__/__snapshots__/usermenu.js.snap
@@ -285,13 +285,13 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
       </li>
       <li
         class="c7"
+        data-testid="usermenu-logout"
       >
         <div
           class="c8"
         >
           <div
             class="c9"
-            data-testid="usermenu-logout"
             margin="5px"
           >
             <span

--- a/gsa/src/web/components/menu/usermenu.js
+++ b/gsa/src/web/components/menu/usermenu.js
@@ -178,11 +178,11 @@ class UserMenuContainer extends React.Component {
                 </Divider>
               </StyledLink>
             </Entry>
-            <Entry>
-              <Divider
-                data-testid="usermenu-logout"
-                onClick={event => this.handleLogout(event)}
-              >
+            <Entry
+              data-testid="usermenu-logout"
+              onClick={event => this.handleLogout(event)}
+            >
+              <Divider>
                 <LogoutIcon />
                 <span>{_('Log Out')}</span>
               </Divider>


### PR DESCRIPTION
Instead of the inner Divider component the click handler is now set to the menu Entry itself.

The empty menu section is removed, when the user doesn't have the correct permissions in the Administration menu

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
