### PR TITLE
Replace __FUNCTION__ with __func__

### DIFF
--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -1314,7 +1314,7 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
 
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                           "An internal error occurred inside GSA daemon. "
                           "Diagnostics: Invalid command.",
                           response_data);
@@ -1333,12 +1333,12 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
 
       if (params_given (con_info->params, "token") == 0)
-        res = gsad_message (NULL, "Internal error", __FUNCTION__, __LINE__,
+        res = gsad_message (NULL, "Internal error", __func__, __LINE__,
                             "An internal error occurred inside GSA daemon. "
                             "Diagnostics: Token missing.",
                             response_data);
       else
-        res = gsad_message (NULL, "Internal error", __FUNCTION__, __LINE__,
+        res = gsad_message (NULL, "Internal error", __func__, __LINE__,
                             "An internal error occurred inside GSA daemon. "
                             "Diagnostics: Token bad.",
                             response_data);
@@ -1351,7 +1351,7 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
   if (ret == USER_BAD_TOKEN)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      res = gsad_message (NULL, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (NULL, "Internal error", __func__, __LINE__,
                           "An internal error occurred inside GSA daemon. "
                           "Diagnostics: Bad token.",
                           response_data);
@@ -1365,7 +1365,7 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
       if (caller && g_utf8_validate (caller, -1, NULL) == FALSE)
         {
           caller = NULL;
-          g_warning ("%s - caller is not valid UTF-8", __FUNCTION__);
+          g_warning ("%s - caller is not valid UTF-8", __func__);
         }
 
       /* @todo Validate caller. */
@@ -1412,7 +1412,7 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
     {
       if (setenv ("TZ", timezone, 1) == -1)
         {
-          g_critical ("%s: failed to set TZ\n", __FUNCTION__);
+          g_critical ("%s: failed to set TZ\n", __func__);
           exit (EXIT_FAILURE);
         }
       tzset ();
@@ -1426,7 +1426,7 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
     case 1: /* manager closed connection */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                           "An internal error occurred. "
                           "Diagnostics: Could not connect to manager daemon. "
                           "Manager closed the connection.",
@@ -1439,7 +1439,7 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
     case 3: /* timeout */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                           "An internal error occurred. "
                           "Diagnostics: Could not connect to manager daemon. "
                           "Connection timeout.",
@@ -1448,7 +1448,7 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
     case 4: /* can't connect to manager */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_SERVICE_UNAVAILABLE);
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                           "An internal error occurred. "
                           "Diagnostics: Could not connect to manager daemon. "
                           "Could not open a connection.",
@@ -1457,7 +1457,7 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
     default: /* unknown error */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                           "An internal error occurred. "
                           "Diagnostics: Could not connect to manager daemon. "
                           "Unknown error.",
@@ -1582,7 +1582,7 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
   else
   {
     cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-    res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+    res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                         "An internal error occurred inside GSA daemon. "
                         "Diagnostics: Unknown command.",
                         response_data);
@@ -1795,7 +1795,7 @@ watch_client_connection (void *data)
             {
               watcher_data->connection_closed = 1;
               active = 0;
-              g_debug ("%s: Client connection closed", __FUNCTION__);
+              g_debug ("%s: Client connection closed", __func__);
 
               if (watcher_data->gvm_connection->tls)
                 {
@@ -1866,7 +1866,7 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
   else
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                           "An internal error occurred inside GSA daemon. "
                           "Diagnostics: No valid command for gmp.",
                           response_data);
@@ -1882,7 +1882,7 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
     {
       if (setenv ("TZ", timezone, 1) == -1)
         {
-          g_critical ("%s: failed to set TZ\n", __FUNCTION__);
+          g_critical ("%s: failed to set TZ\n", __func__);
           exit (EXIT_FAILURE);
         }
       tzset ();
@@ -1896,7 +1896,7 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
     case 1: /* manager closed connection */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                           "An internal error occurred. "
                           "Diagnostics: Could not connect to manager daemon. "
                           "Manager closed the connection.",
@@ -1909,7 +1909,7 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
     case 3: /* timeout */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                           "An internal error occurred. "
                           "Diagnostics: Could not connect to manager daemon. "
                           "Connection timeout.",
@@ -1918,7 +1918,7 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
     case 4: /* can't connect to manager */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_SERVICE_UNAVAILABLE);
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                           "An internal error occurred. "
                           "Diagnostics: Could not connect to manager daemon. "
                           "Could not open a connection.",
@@ -1927,7 +1927,7 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
     default: /* unknown error */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                           "An internal error occurred. "
                           "Diagnostics: Could not connect to manager daemon. "
                           "Unknown error.",
@@ -2159,7 +2159,7 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
   else
   {
     cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-    res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+    res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                         "An internal error occurred inside GSA daemon. "
                         "Diagnostics: Unknown command.",
                         response_data);
@@ -2296,19 +2296,19 @@ drop_privileges (struct passwd *user_pw)
 {
   if (setgroups (0, NULL))
     {
-      g_critical ("%s: failed to set groups: %s\n", __FUNCTION__,
+      g_critical ("%s: failed to set groups: %s\n", __func__,
                   strerror (errno));
       return FALSE;
     }
   if (setgid (user_pw->pw_gid))
     {
-      g_critical ("%s: failed to drop group privileges: %s\n", __FUNCTION__,
+      g_critical ("%s: failed to drop group privileges: %s\n", __func__,
                   strerror (errno));
       return FALSE;
     }
   if (setuid (user_pw->pw_uid))
     {
-      g_critical ("%s: failed to drop user privileges: %s\n", __FUNCTION__,
+      g_critical ("%s: failed to drop user privileges: %s\n", __func__,
                   strerror (errno));
       return FALSE;
     }
@@ -2337,7 +2337,7 @@ chroot_drop_privileges (gboolean do_chroot, gchar *drop, const gchar *subdir)
         {
           g_critical ("%s: Failed to drop privileges."
                       "  Could not determine UID and GID for user \"%s\"!\n",
-                      __FUNCTION__, drop);
+                      __func__, drop);
           return 1;
         }
     }
@@ -2350,7 +2350,7 @@ chroot_drop_privileges (gboolean do_chroot, gchar *drop, const gchar *subdir)
 
       if (chroot (GSAD_DATA_DIR))
         {
-          g_critical ("%s: Failed to chroot to \"%s\": %s\n", __FUNCTION__,
+          g_critical ("%s: Failed to chroot to \"%s\": %s\n", __func__,
                       GSAD_DATA_DIR, strerror (errno));
           return 1;
         }
@@ -2359,7 +2359,7 @@ chroot_drop_privileges (gboolean do_chroot, gchar *drop, const gchar *subdir)
 
   if (user_pw && (drop_privileges (user_pw) == FALSE))
     {
-      g_critical ("%s: Failed to drop privileges\n", __FUNCTION__);
+      g_critical ("%s: Failed to drop privileges\n", __func__);
       return 1;
     }
 
@@ -2369,7 +2369,7 @@ chroot_drop_privileges (gboolean do_chroot, gchar *drop, const gchar *subdir)
       if (chdir (root_dir))
         {
           g_critical ("%s: failed change to chroot root directory (%s): %s\n",
-                      __FUNCTION__, root_dir, strerror (errno));
+                      __func__, root_dir, strerror (errno));
           g_free (root_dir);
           return 1;
         }
@@ -2380,7 +2380,7 @@ chroot_drop_privileges (gboolean do_chroot, gchar *drop, const gchar *subdir)
       gchar *data_dir = g_build_filename (GSAD_DATA_DIR, subdir, NULL);
       if (chdir (data_dir))
         {
-          g_critical ("%s: failed to change to \"%s\": %s\n", __FUNCTION__,
+          g_critical ("%s: failed to change to \"%s\": %s\n", __func__,
                       data_dir, strerror (errno));
           g_free (data_dir);
           return 1;
@@ -2426,7 +2426,7 @@ gsad_init ()
   /* Check for required files. */
   if (gvm_file_check_is_dir (GSAD_DATA_DIR) < 1)
     {
-      g_critical ("%s: Could not access %s!\n", __FUNCTION__, GSAD_DATA_DIR);
+      g_critical ("%s: Could not access %s!\n", __func__, GSAD_DATA_DIR);
       return MHD_NO;
     }
 
@@ -2442,7 +2442,7 @@ gsad_init ()
    * test. */
   if (!gcry_check_version (NULL))
     {
-      g_critical ("%s: libgcrypt version check failed\n", __FUNCTION__);
+      g_critical ("%s: libgcrypt version check failed\n", __func__);
       return MHD_NO;
     }
 
@@ -2471,7 +2471,7 @@ gsad_init ()
   int ret = gnutls_global_init ();
   if (ret < 0)
     {
-      g_critical ("%s: Failed to initialize GNUTLS.\n", __FUNCTION__);
+      g_critical ("%s: Failed to initialize GNUTLS.\n", __func__);
       return MHD_NO;
     }
 
@@ -2565,7 +2565,7 @@ start_unix_http_daemon (const char *unix_socket_path,
 
   if (unix_socket == -1)
     {
-      g_warning ("%s: Couldn't create UNIX socket", __FUNCTION__);
+      g_warning ("%s: Couldn't create UNIX socket", __func__);
       return NULL;
     }
 
@@ -2583,7 +2583,7 @@ start_unix_http_daemon (const char *unix_socket_path,
   if (bind (unix_socket, (struct sockaddr *) &addr, sizeof (struct sockaddr_un))
       == -1)
     {
-      g_warning ("%s: Error on bind(%s): %s", __FUNCTION__, unix_socket_path,
+      g_warning ("%s: Error on bind(%s): %s", __func__, unix_socket_path,
                  strerror (errno));
       return NULL;
     }
@@ -2591,7 +2591,7 @@ start_unix_http_daemon (const char *unix_socket_path,
     umask (oldmask);
   if (listen (unix_socket, 128) == -1)
     {
-      g_warning ("%s: Error on listen(): %s", __FUNCTION__, strerror (errno));
+      g_warning ("%s: Error on listen(): %s", __func__, strerror (errno));
       return NULL;
     }
 
@@ -2756,7 +2756,7 @@ main (int argc, char **argv)
 
   if (gsad_init () == MHD_NO)
     {
-      g_critical ("%s: Initialization failed!\nExiting...\n", __FUNCTION__);
+      g_critical ("%s: Initialization failed!\nExiting...\n", __func__);
       exit (EXIT_FAILURE);
     }
 
@@ -2881,7 +2881,7 @@ main (int argc, char **argv)
   g_option_context_add_main_entries (option_context, option_entries, NULL);
   if (!g_option_context_parse (option_context, &argc, &argv, &error))
     {
-      g_critical ("%s: %s\n\n", __FUNCTION__, error->message);
+      g_critical ("%s: %s\n\n", __func__, error->message);
       exit (EXIT_FAILURE);
     }
   g_option_context_free (option_context);
@@ -2935,7 +2935,7 @@ main (int argc, char **argv)
     {
     case 1:
       g_critical ("%s: libxml must be compiled with thread support\n",
-                  __FUNCTION__);
+                  __func__);
       exit (EXIT_FAILURE);
     }
 
@@ -2952,7 +2952,7 @@ main (int argc, char **argv)
 
   if (setenv ("TZ", "utc 0", 1) == -1)
     {
-      g_critical ("%s: failed to set timezone\n", __FUNCTION__);
+      g_critical ("%s: failed to set timezone\n", __func__);
       exit (EXIT_FAILURE);
     }
   tzset ();
@@ -2985,7 +2985,7 @@ main (int argc, char **argv)
 
   if ((timeout < 1) || (timeout > MAX_SESSION_TIMEOUT))
     {
-      g_critical ("%s: Timeout must be a number from 1 to %d\n", __FUNCTION__,
+      g_critical ("%s: Timeout must be a number from 1 to %d\n", __func__,
                   MAX_SESSION_TIMEOUT);
       exit (EXIT_FAILURE);
     }
@@ -3005,7 +3005,7 @@ main (int argc, char **argv)
       if (gsad_port <= 0 || gsad_port >= 65536)
         {
           g_critical ("%s: Port must be a number between 0 and 65536\n",
-                      __FUNCTION__);
+                      __func__);
           exit (EXIT_FAILURE);
         }
     }
@@ -3016,7 +3016,7 @@ main (int argc, char **argv)
       if (gsad_manager_port <= 0 || gsad_manager_port >= 65536)
         {
           g_critical ("%s: Manager port must be a number between 0 and 65536\n",
-                      __FUNCTION__);
+                      __func__);
           exit (EXIT_FAILURE);
         }
     }
@@ -3028,7 +3028,7 @@ main (int argc, char **argv)
         {
           g_critical (
             "%s: Redirect port must be a number between 0 and 65536\n",
-            __FUNCTION__);
+            __func__);
           exit (EXIT_FAILURE);
         }
     }
@@ -3045,7 +3045,7 @@ main (int argc, char **argv)
           break;
         case -1:
           /* Parent when error. */
-          g_critical ("%s: Failed to fork!\n", __FUNCTION__);
+          g_critical ("%s: Failed to fork!\n", __func__);
           exit (EXIT_FAILURE);
           break;
         default:
@@ -3072,12 +3072,12 @@ main (int argc, char **argv)
             g_warning ("%s: Failed to change parent death signal;"
                        " unix socket process will remain if parent is killed:"
                        " %s\n",
-                       __FUNCTION__, strerror (errno));
+                       __func__, strerror (errno));
 #endif
           break;
         case -1:
           /* Parent when error. */
-          g_warning ("%s: Failed to fork for unix socket!\n", __FUNCTION__);
+          g_warning ("%s: Failed to fork for unix socket!\n", __func__);
           exit (EXIT_FAILURE);
           break;
         default:
@@ -3102,13 +3102,13 @@ main (int argc, char **argv)
             g_warning ("%s: Failed to change parent death signal;"
                        " redirect process will remain if parent is killed:"
                        " %s\n",
-                       __FUNCTION__, strerror (errno));
+                       __func__, strerror (errno));
 #endif
           redirect_location = g_strdup_printf ("https://%%s:%i/", gsad_port);
           break;
         case -1:
           /* Parent when error. */
-          g_critical ("%s: Failed to fork for redirect!\n", __FUNCTION__);
+          g_critical ("%s: Failed to fork for redirect!\n", __func__);
           exit (EXIT_FAILURE);
           break;
         default:
@@ -3123,7 +3123,7 @@ main (int argc, char **argv)
 
   if (atexit (&gsad_cleanup))
     {
-      g_critical ("%s: Failed to register cleanup function!\n", __FUNCTION__);
+      g_critical ("%s: Failed to register cleanup function!\n", __func__);
       exit (EXIT_FAILURE);
     }
 
@@ -3131,7 +3131,7 @@ main (int argc, char **argv)
 
   if (pidfile_create ("gsad"))
     {
-      g_critical ("%s: Could not write PID file.\n", __FUNCTION__);
+      g_critical ("%s: Could not write PID file.\n", __func__);
       exit (EXIT_FAILURE);
     }
 
@@ -3162,7 +3162,7 @@ main (int argc, char **argv)
 
       if (gsad_daemon == NULL)
         {
-          g_warning ("%s: start_http_daemon redirect failed !", __FUNCTION__);
+          g_warning ("%s: start_http_daemon redirect failed !", __func__);
           return EXIT_FAILURE;
         }
       else
@@ -3183,7 +3183,7 @@ main (int argc, char **argv)
 
       if (gsad_daemon == NULL)
         {
-          g_warning ("%s: start_unix_http_daemon failed !", __FUNCTION__);
+          g_warning ("%s: start_unix_http_daemon failed !", __func__);
           return EXIT_FAILURE;
         }
       else
@@ -3234,7 +3234,7 @@ main (int argc, char **argv)
                                     NULL, &error))
             {
               g_critical ("%s: Could not load private SSL key from %s: %s\n",
-                          __FUNCTION__, ssl_private_key_filename,
+                          __func__, ssl_private_key_filename,
                           error->message);
               g_error_free (error);
               exit (EXIT_FAILURE);
@@ -3244,7 +3244,7 @@ main (int argc, char **argv)
                                     NULL, &error))
             {
               g_critical ("%s: Could not load SSL certificate from %s: %s\n",
-                          __FUNCTION__, ssl_certificate_filename,
+                          __func__, ssl_certificate_filename,
                           error->message);
               g_error_free (error);
               exit (EXIT_FAILURE);
@@ -3255,7 +3255,7 @@ main (int argc, char **argv)
                                        &error))
             {
               g_critical ("%s: Could not load SSL certificate from %s: %s\n",
-                          __FUNCTION__, dh_params_filename, error->message);
+                          __func__, dh_params_filename, error->message);
               g_error_free (error);
               exit (EXIT_FAILURE);
             }
@@ -3282,7 +3282,7 @@ main (int argc, char **argv)
 
       if (gsad_daemon == NULL)
         {
-          g_critical ("%s: start_https_daemon failed!\n", __FUNCTION__);
+          g_critical ("%s: start_https_daemon failed!\n", __func__);
           return EXIT_FAILURE;
         }
       else
@@ -3297,7 +3297,7 @@ main (int argc, char **argv)
   if (chroot_drop_privileges (do_chroot, drop, DEFAULT_WEB_DIRECTORY))
     {
       g_critical ("%s: Cannot use drop privileges for directory \"%s\"!\n",
-                  __FUNCTION__, DEFAULT_WEB_DIRECTORY);
+                  __func__, DEFAULT_WEB_DIRECTORY);
       exit (EXIT_FAILURE);
     }
 
@@ -3305,12 +3305,12 @@ main (int argc, char **argv)
 
   if (sigfillset (&sigmask_all))
     {
-      g_critical ("%s: Error filling signal set\n", __FUNCTION__);
+      g_critical ("%s: Error filling signal set\n", __func__);
       exit (EXIT_FAILURE);
     }
   if (pthread_sigmask (SIG_BLOCK, &sigmask_all, &sigmask_current))
     {
-      g_critical ("%s: Error setting signal mask\n", __FUNCTION__);
+      g_critical ("%s: Error setting signal mask\n", __func__);
       exit (EXIT_FAILURE);
     }
   while (1)
@@ -3328,7 +3328,7 @@ main (int argc, char **argv)
         {
           if (errno == EINTR)
             continue;
-          g_critical ("%s: pselect: %s\n", __FUNCTION__, strerror (errno));
+          g_critical ("%s: pselect: %s\n", __func__, strerror (errno));
           exit (EXIT_FAILURE);
         }
     }

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -457,7 +457,7 @@ check_modify_config (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a config. "
         "It is unclear whether the entire config has been saved. "
         "Diagnostics: Failure to read command to manager daemon.",
@@ -473,7 +473,7 @@ check_modify_config (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a config. "
         "It is unclear whether the entire config has been saved. "
         "Diagnostics: Failure to parse status_text from response.",
@@ -847,7 +847,7 @@ get_entity (gvm_connection_t *connection, const char *type,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a resource list. "
         "The current list of resources is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -864,7 +864,7 @@ get_entity (gvm_connection_t *connection, const char *type,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting resources list. "
         "The current list of resources is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -878,7 +878,7 @@ get_entity (gvm_connection_t *connection, const char *type,
       set_http_status_from_entity (entity, response_data);
 
       message =
-        gsad_message (credentials, "Error", __FUNCTION__, __LINE__,
+        gsad_message (credentials, "Error", __func__, __LINE__,
                       entity_attribute (entity, "status_text"), response_data);
 
       g_string_free (xml, TRUE);
@@ -980,7 +980,7 @@ get_entities (gvm_connection_t *connection, const char *type,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a resource list. "
         "The current list of resources is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -1000,7 +1000,7 @@ get_entities (gvm_connection_t *connection, const char *type,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting resources list. "
         "The current list of resources is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -1014,7 +1014,7 @@ get_entities (gvm_connection_t *connection, const char *type,
       set_http_status_from_entity (entity, response_data);
 
       message =
-        gsad_message (credentials, "Error", __FUNCTION__, __LINE__,
+        gsad_message (credentials, "Error", __func__, __LINE__,
                       entity_attribute (entity, "status_text"), response_data);
 
       g_free (cmd);
@@ -1116,7 +1116,7 @@ edit_resource (gvm_connection_t *connection, const char *type,
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while editing a resource. "
         "The resource remains as it was. "
         "Diagnostics: Required ID parameter was NULL.",
@@ -1135,7 +1135,7 @@ edit_resource (gvm_connection_t *connection, const char *type,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a resource. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -1154,7 +1154,7 @@ edit_resource (gvm_connection_t *connection, const char *type,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a resource. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
@@ -1306,7 +1306,7 @@ export_resource (gvm_connection_t *connection, const char *type,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a resource. "
         "The resource could not be delivered. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -1320,7 +1320,7 @@ export_resource (gvm_connection_t *connection, const char *type,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a resource. "
         "The resource could not be delivered. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -1340,7 +1340,7 @@ export_resource (gvm_connection_t *connection, const char *type,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a resource. "
         "The resource could not be delivered. "
         "Diagnostics: Failure to receive resource from manager daemon.",
@@ -1360,21 +1360,21 @@ export_resource (gvm_connection_t *connection, const char *type,
         {
         case 1:
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a setting. "
             "The setting could not be delivered. "
             "Diagnostics: Failure to send command to manager daemon.",
             response_data);
         case 2:
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a setting. "
             "The setting could not be delivered. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
         default:
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a setting. "
             "The setting could not be delivered. "
             "Diagnostics: Internal error.",
@@ -1384,7 +1384,7 @@ export_resource (gvm_connection_t *connection, const char *type,
 
   if (fname_format == NULL)
     {
-      g_warning ("%s : File name format setting not found.", __FUNCTION__);
+      g_warning ("%s : File name format setting not found.", __func__);
       fname_format = "%T-%U";
     }
 
@@ -1448,7 +1448,7 @@ export_many (gvm_connection_t *connection, const char *type,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a list. "
             "The list could not be delivered. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -1471,7 +1471,7 @@ export_many (gvm_connection_t *connection, const char *type,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a list. "
             "The list could not be delivered. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -1492,7 +1492,7 @@ export_many (gvm_connection_t *connection, const char *type,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a list. "
             "The list could not be delivered. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -1507,7 +1507,7 @@ export_many (gvm_connection_t *connection, const char *type,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a list. "
         "The list could not be delivered. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -1529,21 +1529,21 @@ export_many (gvm_connection_t *connection, const char *type,
         {
         case 1:
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a setting. "
             "The setting could not be delivered. "
             "Diagnostics: Failure to send command to manager daemon.",
             response_data);
         case 2:
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a setting. "
             "The setting could not be delivered. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
         default:
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a setting. "
             "The setting could not be delivered. "
             "Diagnostics: Internal error.",
@@ -1553,7 +1553,7 @@ export_many (gvm_connection_t *connection, const char *type,
 
   if (fname_format == NULL)
     {
-      g_warning ("%s : File name format setting not found.", __FUNCTION__);
+      g_warning ("%s : File name format setting not found.", __func__);
       fname_format = "%T-%D";
     }
 
@@ -1609,7 +1609,7 @@ delete_resource (gvm_connection_t *connection, const char *type,
       g_free (id_name);
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while deleting a resource. "
         "The resource was not deleted. "
         "Diagnostics: Required parameter resource_id was NULL.",
@@ -1648,7 +1648,7 @@ delete_resource (gvm_connection_t *connection, const char *type,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while deleting a resource. "
         "The resource is not deleted. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -1664,7 +1664,7 @@ delete_resource (gvm_connection_t *connection, const char *type,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while deleting a resource. "
         "It is unclear whether the resource has been deleted or not. "
         "Diagnostics: Failure to read response from manager daemon.",
@@ -1772,7 +1772,7 @@ resource_action (gvm_connection_t *connection, credentials_t *credentials,
         param_name);
       g_free (param_name);
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      html = gsad_message (credentials, "Internal error", __FUNCTION__,
+      html = gsad_message (credentials, "Internal error", __func__,
                            __LINE__, message, response_data);
       g_free (message);
       return html;
@@ -1792,7 +1792,7 @@ resource_action (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while performing an action. "
         "The resource remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -1801,7 +1801,7 @@ resource_action (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while performing an action. "
         "It is unclear whether the resource has been affected. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -1810,7 +1810,7 @@ resource_action (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while performing an action. "
         "It is unclear whether the resource has been affected. "
         "Diagnostics: Internal Error.",
@@ -1974,7 +1974,7 @@ create_report_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new report. "
         "No new report was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -1983,7 +1983,7 @@ create_report_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new report. "
         "It is unclear whether the report has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -1992,7 +1992,7 @@ create_report_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new report. "
         "It is unclear whether the report has been created or not. "
         "Diagnostics: Internal Error.",
@@ -2073,7 +2073,7 @@ create_container_task_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a container task. "
         "No task was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -2082,7 +2082,7 @@ create_container_task_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a container task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -2091,7 +2091,7 @@ create_container_task_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a container task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Internal Error.",
@@ -2331,7 +2331,7 @@ create_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new task. "
         "No new task was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -2340,7 +2340,7 @@ create_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -2349,7 +2349,7 @@ create_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Internal Error.",
@@ -2385,7 +2385,7 @@ create_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_message (
-                credentials, "Internal error", __FUNCTION__, __LINE__,
+                credentials, "Internal error", __func__, __LINE__,
                 "An internal error occurred while creating a new tag. "
                 "No new tag was created. "
                 "Diagnostics: Failure to send command to manager daemon.",
@@ -2396,7 +2396,7 @@ create_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_message (
-                credentials, "Internal error", __FUNCTION__, __LINE__,
+                credentials, "Internal error", __func__, __LINE__,
                 "An internal error occurred while creating a new tag. "
                 "It is unclear whether the tag has been created or not. "
                 "Diagnostics: Failure to receive response from manager daemon.",
@@ -2407,7 +2407,7 @@ create_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_message (
-                credentials, "Internal error", __FUNCTION__, __LINE__,
+                credentials, "Internal error", __func__, __LINE__,
                 "An internal error occurred while creating a new task. "
                 "It is unclear whether the tag has been created or not. "
                 "Diagnostics: Internal Error.",
@@ -2655,7 +2655,7 @@ save_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a task. "
         "The task was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -2664,7 +2664,7 @@ save_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a task. "
         "It is unclear whether the task has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -2673,7 +2673,7 @@ save_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a task. "
         "It is unclear whether the task has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -2758,7 +2758,7 @@ save_container_task_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a task. "
         "No new task was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -2767,7 +2767,7 @@ save_container_task_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -2776,7 +2776,7 @@ save_container_task_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a task. "
         "It is unclear whether the task has been created or not. "
         "Diagnostics: Internal Error.",
@@ -2921,7 +2921,7 @@ move_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while moving a task. "
         "The task was not moved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -2930,7 +2930,7 @@ move_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while moving a task. "
         "It is unclear whether the task has been moved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -2939,7 +2939,7 @@ move_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while moving a task. "
         "It is unclear whether the task has been moved or not. "
         "Diagnostics: Internal Error.",
@@ -3308,7 +3308,7 @@ create_credential_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while creating a new credential. "
             "The credential could not be created. "
             "Diagnostics: Unrecognized credential type.",
@@ -3326,7 +3326,7 @@ create_credential_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new credential. "
         "It is unclear whether the credential has been created or not. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -3335,7 +3335,7 @@ create_credential_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new credential. "
         "It is unclear whether the credential has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -3344,7 +3344,7 @@ create_credential_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new credential. "
         "It is unclear whether the credential has been created or not. "
         "Diagnostics: Internal Error.",
@@ -3433,7 +3433,7 @@ download_credential_gmp (gvm_connection_t *connection,
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
       *html =
-        gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+        gsad_message (credentials, "Internal error", __func__, __LINE__,
                       "An internal error occurred while getting a credential. "
                       "Diagnostics: Required parameter was NULL.",
                       response_data);
@@ -3450,7 +3450,7 @@ download_credential_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       *html =
-        gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+        gsad_message (credentials, "Internal error", __func__, __LINE__,
                       "An internal error occurred while getting a credential. "
                       "Diagnostics: Failure to send command to manager daemon.",
                       response_data);
@@ -3473,7 +3473,7 @@ download_credential_gmp (gvm_connection_t *connection,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           *html = gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a credential. "
             "The credential is not available. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -3525,7 +3525,7 @@ download_credential_gmp (gvm_connection_t *connection,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           *html = gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a credential. "
             "The credential could not be delivered. "
             "Diagnostics: Failure to receive credential from manager daemon.",
@@ -3545,7 +3545,7 @@ download_credential_gmp (gvm_connection_t *connection,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           *html = gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a credential. "
             "The credential could not be delivered. "
             "Diagnostics: Failure to receive credential from manager daemon.",
@@ -3578,7 +3578,7 @@ download_credential_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       *html = gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a credential. "
         "The credential could not be delivered. "
         "Diagnostics: Failure to parse credential from manager daemon.",
@@ -3870,7 +3870,7 @@ save_credential_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a Credential. "
         "The Credential was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -3879,7 +3879,7 @@ save_credential_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a Credential. "
         "It is unclear whether the Credential has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -3888,7 +3888,7 @@ save_credential_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a Credential. "
         "It is unclear whether the Credential has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -4003,7 +4003,7 @@ create_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new agent. "
         "No new agent was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -4012,7 +4012,7 @@ create_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new agent. "
         "It is unclear whether the agent has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -4021,7 +4021,7 @@ create_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new agent. "
         "It is unclear whether the agent has been created or not. "
         "Diagnostics: Internal Error.",
@@ -4084,7 +4084,7 @@ download_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
       *html =
-        gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+        gsad_message (credentials, "Internal error", __func__, __LINE__,
                       "An internal error occurred while downloading "
                       "an agent. "
                       "Diagnostics: Required parameter was NULL.",
@@ -4102,7 +4102,7 @@ download_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       *html =
-        gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+        gsad_message (credentials, "Internal error", __func__, __LINE__,
                       "An internal error occurred while getting agent list. "
                       "The current list of agents is not available. "
                       "Diagnostics: Failure to send command to manager daemon.",
@@ -4126,7 +4126,7 @@ download_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           *html = gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a agent. "
             "The agent is not available. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -4180,7 +4180,7 @@ download_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           *html = gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a agent. "
             "The agent could not be delivered. "
             "Diagnostics: Failure to receive agent from manager daemon.",
@@ -4198,7 +4198,7 @@ download_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           *html = gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a agent. "
             "The agent could not be delivered. "
             "Diagnostics: Failure to receive agent from manager daemon.",
@@ -4210,7 +4210,7 @@ download_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       *html = gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a agent. "
         "The agent could not be delivered. "
         "Diagnostics: Failure to parse agent from manager daemon.",
@@ -4266,7 +4266,7 @@ save_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a agent. "
         "The agent was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -4275,7 +4275,7 @@ save_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a agent. "
         "It is unclear whether the agent has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -4284,7 +4284,7 @@ save_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a agent. "
         "It is unclear whether the agent has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -4377,7 +4377,7 @@ verify_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while verifying an agent. "
         "Diagnostics: Required parameter was NULL.",
         response_data);
@@ -4396,7 +4396,7 @@ verify_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while verifying a agent. "
         "The agent was not verified. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -4405,7 +4405,7 @@ verify_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while verifying a agent. "
         "It is unclear whether the agent was verified or not. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -4414,7 +4414,7 @@ verify_agent_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while verifying a agent. "
         "It is unclear whether the agent was verified or not. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -4631,7 +4631,7 @@ get_aggregate_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting aggregates. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -4639,7 +4639,7 @@ get_aggregate_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting aggregates. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
@@ -4647,7 +4647,7 @@ get_aggregate_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting aggregates. "
         "Diagnostics: Internal Error.",
         response_data);
@@ -4706,7 +4706,7 @@ new_alert (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting Report "
         "Formats for new alert. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -4715,7 +4715,7 @@ new_alert (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting Report "
         "Formats for new alert. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -4723,7 +4723,7 @@ new_alert (gvm_connection_t *connection, credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while getting Report "
                            "Formats for new alert. It is unclear whether"
@@ -4749,7 +4749,7 @@ new_alert (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting Report "
         "Filters for new alert. "
         "The task was not saved. "
@@ -4759,7 +4759,7 @@ new_alert (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting Report "
         "Filters for new alert. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -4767,7 +4767,7 @@ new_alert (gvm_connection_t *connection, credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while getting Report "
                            "Filters for new alert. "
@@ -4794,7 +4794,7 @@ new_alert (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting Tasks"
         " for new alert. "
         "The task was not saved. "
@@ -4804,7 +4804,7 @@ new_alert (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting Tasks"
         " for new alert. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -4812,7 +4812,7 @@ new_alert (gvm_connection_t *connection, credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while getting Tasks"
                            " for new alert. "
@@ -4839,7 +4839,7 @@ new_alert (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting"
         " Credentials for new alert. "
         "The task was not saved. "
@@ -4849,7 +4849,7 @@ new_alert (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting"
         " Credentials for new alert. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -4857,7 +4857,7 @@ new_alert (gvm_connection_t *connection, credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while getting"
                            " Credentials for new alert. "
@@ -5246,7 +5246,7 @@ create_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new alert. "
         "No new alert was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -5255,7 +5255,7 @@ create_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new alert. "
         "It is unclear whether the alert has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -5264,7 +5264,7 @@ create_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new alert. "
         "It is unclear whether the alert has been created or not. "
         "Diagnostics: Internal Error.",
@@ -5385,7 +5385,7 @@ edit_alert (gvm_connection_t *connection, credentials_t *credentials,
   if (alert_id == NULL)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while editing an alert. "
                            "The alert remains as it was. "
@@ -5406,7 +5406,7 @@ edit_alert (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting alert info. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -5432,7 +5432,7 @@ edit_alert (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting alert info. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
@@ -5450,7 +5450,7 @@ edit_alert (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting report formats. "
             "The current list of report formats is not available. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -5463,7 +5463,7 @@ edit_alert (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting report formats. "
             "The current list of report formats is not available. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -5482,7 +5482,7 @@ edit_alert (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting the list "
             "of filters. "
             "The current list of filters is not available. "
@@ -5496,7 +5496,7 @@ edit_alert (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting the list "
             "of filters. "
             "The current list of filters is not available. "
@@ -5520,7 +5520,7 @@ edit_alert (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting the list "
             "of tasks. "
             "The current list of tasks is not available. "
@@ -5534,7 +5534,7 @@ edit_alert (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting the list "
             "of tasks. "
             "The current list of tasks is not available. "
@@ -5557,7 +5557,7 @@ edit_alert (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting the list "
             "of credentials. "
             "The current list of tasks is not available. "
@@ -5571,7 +5571,7 @@ edit_alert (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting the list "
             "of credentials. "
             "The current list of tasks is not available. "
@@ -5715,7 +5715,7 @@ save_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a new alert. "
         "No new alert was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -5724,7 +5724,7 @@ save_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a new alert. "
         "It is unclear whether the alert has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -5733,7 +5733,7 @@ save_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a new alert. "
         "It is unclear whether the alert has been created or not. "
         "Diagnostics: Internal Error.",
@@ -5771,7 +5771,7 @@ test_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          GSAD_STATUS_INVALID_REQUEST);
-      return gsad_message (credentials, "Invalid request", __FUNCTION__,
+      return gsad_message (credentials, "Invalid request", __func__,
                            __LINE__,
                            "Missing parameter alert_id."
                            "Diagnostics: Required parameter was NULL.",
@@ -5787,7 +5787,7 @@ test_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while testing an alert. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -5799,7 +5799,7 @@ test_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while testing an alert. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
@@ -6015,7 +6015,7 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new target. "
         "No new target was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -6024,7 +6024,7 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new target. "
         "It is unclear whether the target has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -6033,7 +6033,7 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new target. "
         "It is unclear whether the target has been created or not. "
         "Diagnostics: Internal Error.",
@@ -6089,7 +6089,7 @@ clone_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while cloning a resource. "
             "The resource was not cloned. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -6106,7 +6106,7 @@ clone_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while cloning a resource. "
         "The resource was not cloned. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -6119,7 +6119,7 @@ clone_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while cloning a resource. "
         "It is unclear whether the resource has been cloned or not. "
         "Diagnostics: Failure to read response from manager daemon.",
@@ -6192,7 +6192,7 @@ restore_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while restoring a resource. "
         "The resource was not deleted. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -6205,7 +6205,7 @@ restore_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while restoring a resource. "
         "It is unclear whether the resource has been restored or not. "
         "Diagnostics: Failure to read response from manager daemon.",
@@ -6249,7 +6249,7 @@ empty_trashcan_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while emptying the trashcan. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -6261,7 +6261,7 @@ empty_trashcan_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while emptying the trashcan. "
         "Diagnostics: Failure to read response from manager daemon.",
         response_data);
@@ -6355,7 +6355,7 @@ create_tag_gmp (gvm_connection_t *connection, credentials_t *credentials,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new tag. "
         "No new tag was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -6365,7 +6365,7 @@ create_tag_gmp (gvm_connection_t *connection, credentials_t *credentials,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new tag. "
         "It is unclear whether the tag has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -6375,7 +6375,7 @@ create_tag_gmp (gvm_connection_t *connection, credentials_t *credentials,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new tag. "
         "It is unclear whether the tag has been created or not. "
         "Diagnostics: Internal Error.",
@@ -6495,7 +6495,7 @@ save_tag_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while saving a tag. "
                            "The tag remains the same. "
@@ -6506,7 +6506,7 @@ save_tag_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while saving a tag. "
                            "It is unclear whether the tag has been saved "
@@ -6518,7 +6518,7 @@ save_tag_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       g_string_free (command, TRUE);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while saving a tag. "
                            "It is unclear whether the tag has been saved "
@@ -6663,7 +6663,7 @@ toggle_tag_gmp (gvm_connection_t *connection, credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while modifying a tag. "
                            "The tag is not modified. "
@@ -6677,7 +6677,7 @@ toggle_tag_gmp (gvm_connection_t *connection, credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while modifying a tag. "
                            "It is unclear whether the tag has been modified"
@@ -6822,7 +6822,7 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving a target. "
             "The target remains the same. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -6831,7 +6831,7 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving a target. "
             "It is unclear whether the target has been saved or not. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -6840,7 +6840,7 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving a target. "
             "It is unclear whether the target has been saved or not. "
             "Diagnostics: Internal Error.",
@@ -6966,7 +6966,7 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
         cmd_response_data_set_status_code (response_data,
                                            MHD_HTTP_INTERNAL_SERVER_ERROR);
         return gsad_message (
-          credentials, "Internal error", __FUNCTION__, __LINE__,
+          credentials, "Internal error", __func__, __LINE__,
           "An internal error occurred while modifying target. "
           "No target was modified. "
           "Diagnostics: Failure to send command to manager daemon.",
@@ -6979,7 +6979,7 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
         cmd_response_data_set_status_code (response_data,
                                            MHD_HTTP_INTERNAL_SERVER_ERROR);
         return gsad_message (
-          credentials, "Internal error", __FUNCTION__, __LINE__,
+          credentials, "Internal error", __func__, __LINE__,
           "An internal error occurred while modifying a target. "
           "It is unclear whether the target has been modified or not. "
           "Diagnostics: Failure to receive response from manager daemon.",
@@ -7083,7 +7083,7 @@ create_config_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new config. "
         "No new config was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -7092,7 +7092,7 @@ create_config_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new config. "
         "It is unclear whether the config has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -7101,7 +7101,7 @@ create_config_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new config. "
         "It is unclear whether the config has been created or not. "
         "Diagnostics: Internal Error.",
@@ -7156,7 +7156,7 @@ import_config_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while importing a config. "
         "The schedule remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -7165,7 +7165,7 @@ import_config_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while importing a config. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -7174,7 +7174,7 @@ import_config_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while importing a config. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -7301,7 +7301,7 @@ save_osp_prefs (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving a config. It is"
             " unclear whether the entire config has been saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -7371,7 +7371,7 @@ save_config_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a config. "
         "It is unclear whether the entire config has been saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -7418,7 +7418,7 @@ save_config_gmp (gvm_connection_t *connection, credentials_t *credentials,
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_message (
-                credentials, "Internal error", __FUNCTION__, __LINE__,
+                credentials, "Internal error", __func__, __LINE__,
                 "An internal error occurred while saving a config. "
                 "It is unclear whether the entire config has been saved. "
                 "Diagnostics: Failure to send command to manager daemon.",
@@ -7453,7 +7453,7 @@ save_config_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving a config. "
             "It is unclear whether the entire config has been saved. "
             "Diagnostics: save_osp_prefs returned NULL unexpectedly.",
@@ -7482,7 +7482,7 @@ save_config_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving a config. "
             "It is unclear whether the entire config has been saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -7510,7 +7510,7 @@ save_config_gmp (gvm_connection_t *connection, credentials_t *credentials,
                 cmd_response_data_set_status_code (
                   response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                 return gsad_message (
-                  credentials, "Internal error", __FUNCTION__, __LINE__,
+                  credentials, "Internal error", __func__, __LINE__,
                   "An internal error occurred while saving a config. "
                   "It is unclear whether the entire config has been saved. "
                   "Diagnostics: Failure to send command to manager daemon.",
@@ -7545,7 +7545,7 @@ save_config_gmp (gvm_connection_t *connection, credentials_t *credentials,
                   cmd_response_data_set_status_code (
                     response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                   return gsad_message (
-                    credentials, "Internal error", __FUNCTION__, __LINE__,
+                    credentials, "Internal error", __func__, __LINE__,
                     "An internal error occurred while saving a config. "
                     "It is unclear whether the entire config has been saved. "
                     "Diagnostics: Failure to send command to manager daemon.",
@@ -7561,7 +7561,7 @@ save_config_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving a config. "
             "It is unclear whether the entire config has been saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -7621,7 +7621,7 @@ get_config_family (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting list of configs. "
         "The current list of configs is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -7634,7 +7634,7 @@ get_config_family (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting list of configs. "
         "The current list of configs is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -7665,7 +7665,7 @@ get_config_family (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting list of configs. "
             "The current list of configs is not available. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -7678,7 +7678,7 @@ get_config_family (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting list of configs. "
             "The current list of configs is not available. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -7765,7 +7765,7 @@ save_config_family_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a config. "
         "It is unclear whether the entire config has been saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -7786,7 +7786,7 @@ save_config_family_gmp (gvm_connection_t *connection,
             cmd_response_data_set_status_code (response_data,
                                                MHD_HTTP_INTERNAL_SERVER_ERROR);
             return gsad_message (
-              credentials, "Internal error", __FUNCTION__, __LINE__,
+              credentials, "Internal error", __func__, __LINE__,
               "An internal error occurred while saving a config. "
               "It is unclear whether the entire config has been saved. "
               "Diagnostics: Failure to send command to manager daemon.",
@@ -7801,7 +7801,7 @@ save_config_family_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a config. "
         "It is unclear whether the entire config has been saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -7856,7 +7856,7 @@ get_config_nvt_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting list of configs. "
         "The current list of configs is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -7869,7 +7869,7 @@ get_config_nvt_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting list of configs. "
         "The current list of configs is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -8029,7 +8029,7 @@ save_config_nvt_gmp (gvm_connection_t *connection, credentials_t *credentials,
                   cmd_response_data_set_status_code (response_data,
                                                      MHD_HTTP_BAD_REQUEST);
                   return gsad_message (
-                    credentials, "Internal error", __FUNCTION__, __LINE__,
+                    credentials, "Internal error", __func__, __LINE__,
                     "An internal error occurred while saving a config. "
                     "It is unclear whether the entire config has been saved. "
                     "Diagnostics: Required parameter was NULL.",
@@ -8089,7 +8089,7 @@ save_config_nvt_gmp (gvm_connection_t *connection, credentials_t *credentials,
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_message (
-                credentials, "Internal error", __FUNCTION__, __LINE__,
+                credentials, "Internal error", __func__, __LINE__,
                 "An internal error occurred while saving a config. "
                 "It is unclear whether the entire config has been saved. "
                 "Diagnostics: Failure to send command to manager daemon.",
@@ -8323,7 +8323,7 @@ export_preference_file_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a preference file. "
         "The file could not be delivered. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -8337,7 +8337,7 @@ export_preference_file_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a preference file. "
         "The file could not be delivered. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -8366,7 +8366,7 @@ export_preference_file_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a preference file. "
         "The file could not be delivered. "
         "Diagnostics: Failure to receive file from manager daemon.",
@@ -8504,7 +8504,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a report. "
         "The report could not be delivered. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -8523,7 +8523,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_message (
-                credentials, "Internal error", __FUNCTION__, __LINE__,
+                credentials, "Internal error", __func__, __LINE__,
                 "An internal error occurred while getting a report. "
                 "The report could not be delivered. "
                 "Diagnostics: Failure to receive response from manager daemon.",
@@ -8536,7 +8536,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_message (
-                credentials, "Internal error", __FUNCTION__, __LINE__,
+                credentials, "Internal error", __func__, __LINE__,
                 "An internal error occurred while getting a report. "
                 "The report could not be delivered. "
                 "Diagnostics: Response from manager daemon did not contain a "
@@ -8559,7 +8559,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
                       cmd_response_data_set_status_code (
                         response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                       return gsad_message (
-                        credentials, "Internal error", __FUNCTION__, __LINE__,
+                        credentials, "Internal error", __func__, __LINE__,
                         "An internal error occurred while getting a setting. "
                         "The setting could not be delivered. "
                         "Diagnostics: Failure to send command to manager "
@@ -8569,7 +8569,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
                       cmd_response_data_set_status_code (
                         response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                       return gsad_message (
-                        credentials, "Internal error", __FUNCTION__, __LINE__,
+                        credentials, "Internal error", __func__, __LINE__,
                         "An internal error occurred while getting a setting. "
                         "The setting could not be delivered. "
                         "Diagnostics: Failure to receive response from manager "
@@ -8579,7 +8579,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
                       cmd_response_data_set_status_code (
                         response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                       return gsad_message (
-                        credentials, "Internal error", __FUNCTION__, __LINE__,
+                        credentials, "Internal error", __func__, __LINE__,
                         "An internal error occurred while getting a setting. "
                         "The setting could not be delivered. "
                         "Diagnostics: Internal error.",
@@ -8590,7 +8590,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
               if (fname_format == NULL)
                 {
                   g_warning ("%s : File name format setting not found.",
-                             __FUNCTION__);
+                             __func__);
                   fname_format = "%T-%U";
                 }
 
@@ -8623,7 +8623,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_message (
-                credentials, "Internal error", __FUNCTION__, __LINE__,
+                credentials, "Internal error", __func__, __LINE__,
                 "An internal error occurred while getting a report. "
                 "The report could not be delivered. "
                 "Diagnostics: Failure to receive response from manager daemon.",
@@ -8669,7 +8669,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
                           cmd_response_data_set_status_code (
                             response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                           return gsad_message (
-                            credentials, "Internal error", __FUNCTION__,
+                            credentials, "Internal error", __func__,
                             __LINE__,
                             "An internal error occurred while getting a "
                             "setting. "
@@ -8681,7 +8681,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
                           cmd_response_data_set_status_code (
                             response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                           return gsad_message (
-                            credentials, "Internal error", __FUNCTION__,
+                            credentials, "Internal error", __func__,
                             __LINE__,
                             "An internal error occurred while getting a "
                             "setting. "
@@ -8693,7 +8693,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
                           cmd_response_data_set_status_code (
                             response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                           return gsad_message (
-                            credentials, "Internal error", __FUNCTION__,
+                            credentials, "Internal error", __func__,
                             __LINE__,
                             "An internal error occurred while getting a "
                             "setting. "
@@ -8706,7 +8706,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
                   if (fname_format == NULL)
                     {
                       g_warning ("%s : File name format setting not found.",
-                                 __FUNCTION__);
+                                 __func__);
                       fname_format = "%T-%U";
                     }
 
@@ -8736,7 +8736,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_message (
-                credentials, "Internal error", __FUNCTION__, __LINE__,
+                credentials, "Internal error", __func__, __LINE__,
                 "An internal error occurred while getting a report. "
                 "The report could not be delivered. "
                 "Diagnostics: Failure to receive report from manager daemon.",
@@ -8762,7 +8762,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting a report. "
             "The report could not be delivered. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -8775,7 +8775,7 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
 
           set_http_status_from_entity (entity, response_data);
 
-          message = gsad_message (credentials, "Error", __FUNCTION__, __LINE__,
+          message = gsad_message (credentials, "Error", __func__, __LINE__,
                                   entity_attribute (entity, "status_text"),
                                   response_data);
 
@@ -8860,7 +8860,7 @@ report_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
   if ((alert_id == NULL) || (report_id == NULL))
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Bad Request", __FUNCTION__, __LINE__,
+      return gsad_message (credentials, "Bad Request", __func__, __LINE__,
                            "Missing parameter alert_id or report_id. "
                            "Diagnostics: Required parameter was NULL.",
                            response_data);
@@ -8887,7 +8887,7 @@ report_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a report. "
         "The report could not be delivered. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -8898,7 +8898,7 @@ report_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while getting a report. "
                            "The report could not be delivered. "
@@ -8915,7 +8915,7 @@ report_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting a report. "
         "The report could not be delivered. "
         "Diagnostics: Failure to parse response from manager daemon.",
@@ -8926,7 +8926,7 @@ report_alert_gmp (gvm_connection_t *connection, credentials_t *credentials,
       free_entity (entity);
       g_free (response);
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Failed", __FUNCTION__, __LINE__,
+      return gsad_message (credentials, "Failed", __func__, __LINE__,
                            "Running the report alert failed."
                            "The report could not be delivered.",
                            response_data);
@@ -9017,7 +9017,7 @@ download_ssl_cert (gvm_connection_t *connection, credentials_t *credentials,
   if (ssl_cert == NULL)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred."
                            " Diagnostics: ssl_cert was NULL.",
@@ -9057,7 +9057,7 @@ download_ca_pub (gvm_connection_t *connection, credentials_t *credentials,
   if (ca_pub == NULL)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred."
                            " Diagnostics: ca_pub was NULL.",
@@ -9090,7 +9090,7 @@ download_key_pub (gvm_connection_t *connection, credentials_t *credentials,
   if (key_pub == NULL)
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred."
                            " Diagnostics: key_pub was NULL.",
@@ -9427,7 +9427,7 @@ create_note_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new note. "
         "No new note was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -9436,7 +9436,7 @@ create_note_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new note. "
         "It is unclear whether the note has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -9445,7 +9445,7 @@ create_note_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new note. "
         "It is unclear whether the note has been created or not. "
         "Diagnostics: Internal Error.",
@@ -9546,7 +9546,7 @@ save_note_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a note. "
         "The note remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -9555,7 +9555,7 @@ save_note_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a note. "
         "It is unclear whether the note has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -9564,7 +9564,7 @@ save_note_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a note. "
         "It is unclear whether the note has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -9729,7 +9729,7 @@ create_override_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new override. "
         "No new override was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -9738,7 +9738,7 @@ create_override_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new override. "
         "It is unclear whether the override has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -9747,7 +9747,7 @@ create_override_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new override. "
         "It is unclear whether the override has been created or not. "
         "Diagnostics: Internal Error.",
@@ -9857,7 +9857,7 @@ save_override_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a override. "
         "The override remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -9866,7 +9866,7 @@ save_override_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a override. "
         "It is unclear whether the override has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -9875,7 +9875,7 @@ save_override_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a override. "
         "It is unclear whether the override has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -10017,7 +10017,7 @@ verify_scanner_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while verifying a scanner. "
         "The scanner was not verified. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -10026,7 +10026,7 @@ verify_scanner_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while verifying a scanner. "
         "It is unclear whether the scanner was verified or not. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -10035,7 +10035,7 @@ verify_scanner_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while verifying a scanner. "
         "It is unclear whether the scanner was verified or not. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -10112,7 +10112,7 @@ create_scanner_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new scanner. "
         "No new scanner was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -10121,7 +10121,7 @@ create_scanner_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new scanner. "
         "It is unclear whether the scanner has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -10130,7 +10130,7 @@ create_scanner_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new scanner. "
         "It is unclear whether the scanner has been created or not. "
         "Diagnostics: Internal Error.",
@@ -10286,7 +10286,7 @@ save_scanner_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a scanner. "
         "The scanner remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -10295,7 +10295,7 @@ save_scanner_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a scanner. "
         "It is unclear whether the scanner has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -10304,7 +10304,7 @@ save_scanner_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a scanner. "
         "It is unclear whether the scanner has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -10428,7 +10428,7 @@ create_schedule_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new schedule. "
         "No new schedule was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -10437,7 +10437,7 @@ create_schedule_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new schedule. "
         "It is unclear whether the schedule has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -10446,7 +10446,7 @@ create_schedule_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new schedule. "
         "It is unclear whether the schedule has been created or not. "
         "Diagnostics: Internal Error.",
@@ -10609,7 +10609,7 @@ get_system_reports_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting the system reports. "
         "The current list of system reports is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -10622,7 +10622,7 @@ get_system_reports_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting the system reports. "
         "The current list of system reports is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -10642,7 +10642,7 @@ get_system_reports_gmp (gvm_connection_t *connection,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting the system reports. "
             "The current list of system reports is not available. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -10655,7 +10655,7 @@ get_system_reports_gmp (gvm_connection_t *connection,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while getting the system reports. "
             "The current list of system reports is not available. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -10908,7 +10908,7 @@ import_report_format_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while importing a report format. "
         "The schedule remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -10917,7 +10917,7 @@ import_report_format_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while importing a report format. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -10926,7 +10926,7 @@ import_report_format_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while importing a report format. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -11054,7 +11054,7 @@ save_report_format_gmp (gvm_connection_t *connection,
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_message (
-                credentials, "Internal error", __FUNCTION__, __LINE__,
+                credentials, "Internal error", __func__, __LINE__,
                 "An internal error occurred while saving a Report Format. "
                 "The Report Format was not saved. "
                 "Diagnostics: Failure to send command to manager daemon.",
@@ -11063,7 +11063,7 @@ save_report_format_gmp (gvm_connection_t *connection,
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_message (
-                credentials, "Internal error", __FUNCTION__, __LINE__,
+                credentials, "Internal error", __func__, __LINE__,
                 "An internal error occurred while saving a Report Format. "
                 "It is unclear whether the Report Format has been saved or "
                 "not. "
@@ -11074,7 +11074,7 @@ save_report_format_gmp (gvm_connection_t *connection,
               cmd_response_data_set_status_code (
                 response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
               return gsad_message (
-                credentials, "Internal error", __FUNCTION__, __LINE__,
+                credentials, "Internal error", __func__, __LINE__,
                 "An internal error occurred while saving a Report Format. "
                 "It is unclear whether the Report Format has been saved or "
                 "not. "
@@ -11136,7 +11136,7 @@ save_report_format_gmp (gvm_connection_t *connection,
                     response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                   g_strfreev (splits);
                   return gsad_message (
-                    credentials, "Internal error", __FUNCTION__, __LINE__,
+                    credentials, "Internal error", __func__, __LINE__,
                     "An internal error occurred while saving a Report Format. "
                     "The Report Format was not saved. "
                     "Diagnostics: Failure to send command to manager daemon.",
@@ -11146,7 +11146,7 @@ save_report_format_gmp (gvm_connection_t *connection,
                     response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                   g_strfreev (splits);
                   return gsad_message (
-                    credentials, "Internal error", __FUNCTION__, __LINE__,
+                    credentials, "Internal error", __func__, __LINE__,
                     "An internal error occurred while saving a Report Format. "
                     "It is unclear whether the Report Format has been saved or "
                     "not. "
@@ -11159,7 +11159,7 @@ save_report_format_gmp (gvm_connection_t *connection,
                     response_data, MHD_HTTP_INTERNAL_SERVER_ERROR);
                   g_strfreev (splits);
                   return gsad_message (
-                    credentials, "Internal error", __FUNCTION__, __LINE__,
+                    credentials, "Internal error", __func__, __LINE__,
                     "An internal error occurred while saving a Report Format. "
                     "It is unclear whether the Report Format has been saved or "
                     "not. "
@@ -11194,7 +11194,7 @@ save_report_format_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a Report Format. "
         "The Report Format was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -11203,7 +11203,7 @@ save_report_format_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a Report Format. "
         "It is unclear whether the Report Format has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -11212,7 +11212,7 @@ save_report_format_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a Report Format. "
         "It is unclear whether the Report Format has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -11258,7 +11258,7 @@ run_wizard_gmp (gvm_connection_t *connection, credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while trying to start a wizard. "
         "Diagnostics: Required parameter 'name' was NULL.",
         response_data);
@@ -11299,7 +11299,7 @@ run_wizard_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while running a wizard. "
         "The wizard did not start. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -11308,7 +11308,7 @@ run_wizard_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while running a wizard. "
         "It is unclear whether the wizard started or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -11316,7 +11316,7 @@ run_wizard_gmp (gvm_connection_t *connection, credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while running a wizard. "
                            "It is unclear whether the wizard started or not. "
@@ -11343,7 +11343,7 @@ run_wizard_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,                   \
                                              MHD_HTTP_INTERNAL_SERVER_ERROR); \
           return gsad_message (                                               \
-            credentials, "Internal error", __FUNCTION__, __LINE__,            \
+            credentials, "Internal error", __func__, __LINE__,            \
             "An internal error occurred while getting " name                  \
             " list for trash."                                                \
             "Diagnostics: Failure to send command to"                         \
@@ -11357,7 +11357,7 @@ run_wizard_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,                   \
                                              MHD_HTTP_INTERNAL_SERVER_ERROR); \
           return gsad_message (                                               \
-            credentials, "Internal error", __FUNCTION__, __LINE__,            \
+            credentials, "Internal error", __func__, __LINE__,            \
             "An internal error occurred while getting " name " list."         \
             "Diagnostics: Failure to receive response from"                   \
             " manager daemon.",                                               \
@@ -11594,7 +11594,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "The settings remains the same. "
             "Diagnostics: Manager closed connection during authenticate.",
@@ -11603,7 +11603,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Invalid Password", __FUNCTION__, __LINE__,
+            credentials, "Invalid Password", __func__, __LINE__,
             "You tried to change your password, but the old"
             " password was not provided or was incorrect. "
             " Please enter the correct old password or remove"
@@ -11614,7 +11614,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "The settings remains the same. "
             "Diagnostics: Internal Error.",
@@ -11635,7 +11635,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -11651,7 +11651,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
@@ -11690,7 +11690,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -11706,7 +11706,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
@@ -11725,7 +11725,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
 
           if (setenv ("TZ", timezone, 1) == -1)
             {
-              g_critical ("%s: failed to set TZ\n", __FUNCTION__);
+              g_critical ("%s: failed to set TZ\n", __func__);
               exit (EXIT_FAILURE);
             }
           tzset ();
@@ -11757,7 +11757,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -11774,7 +11774,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -11809,7 +11809,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -11826,7 +11826,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -11860,7 +11860,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -11877,7 +11877,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -11912,7 +11912,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -11929,7 +11929,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -11963,7 +11963,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -11980,7 +11980,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -12008,7 +12008,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving settings. "
         "It is unclear whether all the settings were saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -12024,7 +12024,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving settings. "
         "It is unclear whether all the settings were saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -12054,7 +12054,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -12071,7 +12071,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -12117,7 +12117,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -12134,7 +12134,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -12170,7 +12170,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -12187,7 +12187,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -12225,7 +12225,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to send command to manager daemon.",
@@ -12243,7 +12243,7 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred while saving settings. "
             "It is unclear whether all the settings were saved. "
             "Diagnostics: Failure to receive response from manager daemon.",
@@ -12408,7 +12408,7 @@ create_group_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new group. "
         "No new group was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -12417,7 +12417,7 @@ create_group_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new group. "
         "It is unclear whether the group has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -12426,7 +12426,7 @@ create_group_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new group. "
         "It is unclear whether the group has been created or not. "
         "Diagnostics: Internal Error.",
@@ -12528,7 +12528,7 @@ save_group_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a group. "
         "The group was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -12537,7 +12537,7 @@ save_group_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a group. "
         "It is unclear whether the group has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -12546,7 +12546,7 @@ save_group_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a group. "
         "It is unclear whether the group has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -12710,7 +12710,7 @@ create_permission_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a permission. "
         "The permission was not created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -12719,7 +12719,7 @@ create_permission_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a permission. "
         "It is unclear whether the permission has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -12728,7 +12728,7 @@ create_permission_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a permission. "
         "It is unclear whether the permission has been created or not. "
         "Diagnostics: Internal Error.",
@@ -12756,7 +12756,7 @@ create_permission_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,                     \
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);   \
       return gsad_message (                                                 \
-        credentials, "Internal error", __FUNCTION__, __LINE__,              \
+        credentials, "Internal error", __func__, __LINE__,              \
         "An internal error occurred while creating a permission. "          \
         "The permission was not created. "                                  \
         "Diagnostics: Failure to send command to manager daemon.",          \
@@ -12765,7 +12765,7 @@ create_permission_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,                     \
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);   \
       return gsad_message (                                                 \
-        credentials, "Internal error", __FUNCTION__, __LINE__,              \
+        credentials, "Internal error", __func__, __LINE__,              \
         "An internal error occurred while creating a permission. "          \
         "It is unclear whether the permission has been created or not. "    \
         "Diagnostics: Failure to receive response from manager daemon.",    \
@@ -12774,7 +12774,7 @@ create_permission_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,                     \
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);   \
       return gsad_message (                                                 \
-        credentials, "Internal error", __FUNCTION__, __LINE__,              \
+        credentials, "Internal error", __func__, __LINE__,              \
         "An internal error occurred while creating a permission. "          \
         "It is unclear whether the permission has been created or not. "    \
         "Diagnostics: Internal Error.",                                     \
@@ -13281,7 +13281,7 @@ save_permission_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while modifying a permission. "
         "The permission was not modified. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -13290,7 +13290,7 @@ save_permission_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while modifying a permission. "
         "It is unclear whether the permission has been modified or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -13299,7 +13299,7 @@ save_permission_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while modifying a permission. "
         "It is unclear whether the permission has been modified or not. "
         "Diagnostics: Internal Error.",
@@ -13362,7 +13362,7 @@ create_port_list_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new port list. "
         "No new port list was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -13371,7 +13371,7 @@ create_port_list_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new port list. "
         "It is unclear whether the port list has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -13380,7 +13380,7 @@ create_port_list_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new port list. "
         "It is unclear whether the port list has been created or not. "
         "Diagnostics: Internal Error.",
@@ -13447,7 +13447,7 @@ create_port_range_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a Port Range. "
         "The Port Range was not created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -13456,7 +13456,7 @@ create_port_range_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a Port Range. "
         "It is unclear whether the Port Range has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -13465,7 +13465,7 @@ create_port_range_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a Port Range. "
         "It is unclear whether the Port Range has been created or not. "
         "Diagnostics: Internal Error.",
@@ -13587,7 +13587,7 @@ save_port_list_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a Port List. "
         "The Port List was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -13596,7 +13596,7 @@ save_port_list_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a Port List. "
         "It is unclear whether the Port List has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -13605,7 +13605,7 @@ save_port_list_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a Port List. "
         "It is unclear whether the Port List has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -13693,7 +13693,7 @@ import_port_list_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while importing a port_list. "
         "The schedule remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -13702,7 +13702,7 @@ import_port_list_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while importing a port_list. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -13711,7 +13711,7 @@ import_port_list_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while importing a port_list. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -13791,7 +13791,7 @@ create_role_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new role. "
         "No new role was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -13800,7 +13800,7 @@ create_role_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new role. "
         "It is unclear whether the role has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -13809,7 +13809,7 @@ create_role_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new role. "
         "It is unclear whether the role has been created or not. "
         "Diagnostics: Internal Error.",
@@ -13966,7 +13966,7 @@ save_role_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a role. "
         "The role was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -13975,7 +13975,7 @@ save_role_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a role. "
         "It is unclear whether the role has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -13984,7 +13984,7 @@ save_role_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a role. "
         "It is unclear whether the role has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -14026,7 +14026,7 @@ get_feeds_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting the feed list. "
         "The current list of feeds is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -14038,7 +14038,7 @@ get_feeds_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting the feed. "
         "The current list of feeds is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -14097,7 +14097,7 @@ sync_feed (gvm_connection_t *connection, credentials_t *credentials,
         "Feed synchronization is currently not available. "
         "Diagnostics: Failure to send command to manager daemon.",
         feed_name);
-      html = gsad_message (credentials, "Internal error", __FUNCTION__,
+      html = gsad_message (credentials, "Internal error", __func__,
                            __LINE__, msg, response_data);
       g_free (msg);
       return html;
@@ -14113,7 +14113,7 @@ sync_feed (gvm_connection_t *connection, credentials_t *credentials,
         "Feed synchronization is currently not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
         feed_name);
-      html = gsad_message (credentials, "Internal error", __FUNCTION__,
+      html = gsad_message (credentials, "Internal error", __func__,
                            __LINE__, msg, response_data);
       g_free (msg);
       return html;
@@ -14285,7 +14285,7 @@ create_filter_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new alert. "
         "No new alert was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -14294,7 +14294,7 @@ create_filter_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new alert. "
         "It is unclear whether the alert has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -14303,7 +14303,7 @@ create_filter_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new alert. "
         "It is unclear whether the alert has been created or not. "
         "Diagnostics: Internal Error.",
@@ -14420,7 +14420,7 @@ save_filter_gmp (gvm_connection_t *connection, credentials_t *credentials,
         cmd_response_data_set_status_code (response_data,
                                            MHD_HTTP_INTERNAL_SERVER_ERROR);
         return gsad_message (
-          credentials, "Internal error", __FUNCTION__, __LINE__,
+          credentials, "Internal error", __func__, __LINE__,
           "An internal error occurred while modifying a filter. "
           "The filter was not modified. "
           "Diagnostics: Failure to send command to manager daemon.",
@@ -14433,7 +14433,7 @@ save_filter_gmp (gvm_connection_t *connection, credentials_t *credentials,
         cmd_response_data_set_status_code (response_data,
                                            MHD_HTTP_INTERNAL_SERVER_ERROR);
         return gsad_message (
-          credentials, "Internal error", __FUNCTION__, __LINE__,
+          credentials, "Internal error", __func__, __LINE__,
           "An internal error occurred while modifying a filter. "
           "It is unclear whether the filter has been modified or not. "
           "Diagnostics: Failure to receive response from manager daemon.",
@@ -14539,7 +14539,7 @@ save_schedule_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a schedule. "
         "The schedule remains the same. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -14548,7 +14548,7 @@ save_schedule_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a schedule. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -14557,7 +14557,7 @@ save_schedule_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a schedule. "
         "It is unclear whether the schedule has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -14630,7 +14630,7 @@ get_user (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Failure to send command to manager daemon.",
             response_data);
@@ -14638,7 +14638,7 @@ get_user (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
@@ -14646,7 +14646,7 @@ get_user (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Internal Error.",
             response_data);
@@ -14836,7 +14836,7 @@ create_user_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new user. "
         "No new user was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -14845,7 +14845,7 @@ create_user_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new user. "
         "It is unclear whether the user has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -14854,7 +14854,7 @@ create_user_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new user. "
         "It is unclear whether the user has been created or not. "
         "Diagnostics: Internal Error.",
@@ -14920,7 +14920,7 @@ auth_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Failure to send command to manager daemon.",
             response_data);
@@ -14928,7 +14928,7 @@ auth_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
@@ -14936,7 +14936,7 @@ auth_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
           return gsad_message (
-            credentials, "Internal error", __FUNCTION__, __LINE__,
+            credentials, "Internal error", __func__, __LINE__,
             "An internal error occurred getting the auth list. "
             "Diagnostics: Internal Error.",
             response_data);
@@ -15143,7 +15143,7 @@ save_user_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a user. "
         "The user was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -15152,7 +15152,7 @@ save_user_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a user. "
         "It is unclear whether the user has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -15161,7 +15161,7 @@ save_user_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a user. "
         "It is unclear whether the user has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -15177,7 +15177,7 @@ save_user_gmp (gvm_connection_t *connection, credentials_t *credentials,
 
       cmd_response_data_set_status_code (response_data, MHD_HTTP_UNAUTHORIZED);
       return gsad_message (
-        credentials, "Authentication Required", __FUNCTION__, __LINE__,
+        credentials, "Authentication Required", __func__, __LINE__,
         "Authentication method changed. Please login with ", response_data);
     }
   else
@@ -15406,7 +15406,7 @@ save_auth_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving the auth settings. "
         "The settings were not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -15415,7 +15415,7 @@ save_auth_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving the auth settings. "
         "It is unclear whether the settings have been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -15424,7 +15424,7 @@ save_auth_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving the auth settings. "
         "It is unclear whether the settings have been saved or not. "
         "Diagnostics: Internal Error.",
@@ -15485,7 +15485,7 @@ get_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting the settings. "
         "The current list of settings is not available. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -15499,7 +15499,7 @@ get_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting the settings. "
         "The current list of settings is not available. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -15576,7 +15576,7 @@ save_setting_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving settings. "
         "It is unclear whether all the settings were saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -15586,7 +15586,7 @@ save_setting_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving settings. "
         "It is unclear whether all the settings were saved. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -15595,7 +15595,7 @@ save_setting_gmp (gvm_connection_t *connection, credentials_t *credentials,
 
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while saving settings. "
                            "It is unclear whether all the settings were saved. "
@@ -15625,7 +15625,7 @@ get_setting_gmp (gvm_connection_t *connection, credentials_t *credentials,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while getting the "
                            "dashboard settings"
@@ -15639,7 +15639,7 @@ get_setting_gmp (gvm_connection_t *connection, credentials_t *credentials,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while getting the "
                            "dashboard settings"
@@ -15678,7 +15678,7 @@ wizard (gvm_connection_t *connection, credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting the wizard. "
         "Given name was invalid",
         response_data);
@@ -15701,7 +15701,7 @@ wizard (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting the wizard. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -15712,7 +15712,7 @@ wizard (gvm_connection_t *connection, credentials_t *credentials,
       g_string_free (xml, TRUE);
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while getting the"
                            " wizard."
@@ -15732,7 +15732,7 @@ wizard (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting the wizard. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -15744,7 +15744,7 @@ wizard (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while the wizard. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
@@ -15809,7 +15809,7 @@ wizard_get (gvm_connection_t *connection, credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while trying to start a wizard. "
         "Diagnostics: Required parameter 'get_name' was NULL.",
         response_data);
@@ -15851,7 +15851,7 @@ wizard_get (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while running a wizard. "
         "The wizard did not start. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -15860,7 +15860,7 @@ wizard_get (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while running a wizard. "
         "It is unclear whether the wizard started or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -15868,7 +15868,7 @@ wizard_get (gvm_connection_t *connection, credentials_t *credentials,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while running a wizard. "
                            "It is unclear whether the wizard started or not. "
@@ -15929,7 +15929,7 @@ bulk_delete_gmp (gvm_connection_t *connection, credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while deleting resources. "
         "The resources were not deleted. "
         "Diagnostics: Required parameter 'resource_type' was NULL.",
@@ -15976,7 +15976,7 @@ bulk_delete_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while deleting resources. "
         "The resources were not deleted. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -15990,7 +15990,7 @@ bulk_delete_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while deleting resources. "
         "It is unclear whether the resources have been deleted or not. "
         "Diagnostics: Failure to read response from manager daemon.",
@@ -16112,7 +16112,7 @@ create_host_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new host. "
         "No new host was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -16121,7 +16121,7 @@ create_host_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new host. "
         "It is unclear whether the host has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -16130,7 +16130,7 @@ create_host_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a new host. "
         "It is unclear whether the host has been created or not. "
         "Diagnostics: Internal Error.",
@@ -16172,7 +16172,7 @@ get_asset (gvm_connection_t *connection, credentials_t *credentials,
   if (params_value (params, "asset_name") && params_value (params, "asset_id"))
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
-      return gsad_message (credentials, "Internal error", __FUNCTION__,
+      return gsad_message (credentials, "Internal error", __func__,
                            __LINE__,
                            "An internal error occurred while getting an asset. "
                            "Diagnostics: Both ID and Name set.",
@@ -16288,7 +16288,7 @@ create_asset_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating an asset. "
         "No new asset was created. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -16297,7 +16297,7 @@ create_asset_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating an asset. "
         "It is unclear whether the asset has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -16306,7 +16306,7 @@ create_asset_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating an asset. "
         "It is unclear whether the asset has been created or not. "
         "Diagnostics: Internal Error.",
@@ -16346,7 +16346,7 @@ delete_asset_gmp (gvm_connection_t *connection, credentials_t *credentials,
     {
       cmd_response_data_set_status_code (response_data, MHD_HTTP_BAD_REQUEST);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while deleting an asset. "
         "The asset was not deleted. "
         "Diagnostics: Required parameter was NULL.",
@@ -16376,7 +16376,7 @@ delete_asset_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while deleting an asset. "
         "The asset is not deleted. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -16391,7 +16391,7 @@ delete_asset_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while deleting an asset. "
         "It is unclear whether the asset has been deleted or not. "
         "Diagnostics: Failure to read response from manager daemon.",
@@ -16487,7 +16487,7 @@ save_asset_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving an asset. "
         "The asset was not saved. "
         "Diagnostics: Failure to send command to manager daemon.",
@@ -16496,7 +16496,7 @@ save_asset_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving an asset. "
         "It is unclear whether the asset has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -16505,7 +16505,7 @@ save_asset_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving an asset. "
         "It is unclear whether the asset has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -16599,7 +16599,7 @@ create_ticket_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a ticket. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -16607,7 +16607,7 @@ create_ticket_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a ticket. "
         "It is unclear whether the ticket has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -16616,7 +16616,7 @@ create_ticket_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a ticket. "
         "It is unclear whether the ticket has been created or not. "
         "Diagnostics: Internal Error.",
@@ -16682,7 +16682,7 @@ save_ticket_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a ticket. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -16690,7 +16690,7 @@ save_ticket_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a ticket. "
         "It is unclear whether the ticket has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -16699,7 +16699,7 @@ save_ticket_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a ticket. "
         "It is unclear whether the ticket has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -16847,7 +16847,7 @@ create_tls_certificate_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a TLS certificate. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -16855,7 +16855,7 @@ create_tls_certificate_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a TLS certificate. "
         "It is unclear whether the TLS certificate has been created or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -16864,7 +16864,7 @@ create_tls_certificate_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while creating a TLS certificate. "
         "It is unclear whether the TLS certificate has been created or not. "
         "Diagnostics: Internal Error.",
@@ -16935,7 +16935,7 @@ save_tls_certificate_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a TLS certificate. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -16943,7 +16943,7 @@ save_tls_certificate_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a TLS certificate. "
         "It is unclear whether the TLS certificate has been saved or not. "
         "Diagnostics: Failure to receive response from manager daemon.",
@@ -16952,7 +16952,7 @@ save_tls_certificate_gmp (gvm_connection_t *connection,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while saving a TLS certificate. "
         "It is unclear whether the TLS certificate has been saved or not. "
         "Diagnostics: Internal Error.",
@@ -17037,7 +17037,7 @@ get_capabilities_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting the user credentials. "
         "Diagnostics: Failure to send command to manager daemon.",
         response_data);
@@ -17053,7 +17053,7 @@ get_capabilities_gmp (gvm_connection_t *connection, credentials_t *credentials,
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
       return gsad_message (
-        credentials, "Internal error", __FUNCTION__, __LINE__,
+        credentials, "Internal error", __func__, __LINE__,
         "An internal error occurred while getting the user credentials. "
         "Diagnostics: Failure to receive response from manager daemon.",
         response_data);
@@ -17066,7 +17066,7 @@ get_capabilities_gmp (gvm_connection_t *connection, credentials_t *credentials,
       set_http_status_from_entity (entity, response_data);
 
       message =
-        gsad_message (credentials, "Error", __FUNCTION__, __LINE__,
+        gsad_message (credentials, "Error", __func__, __LINE__,
                       entity_attribute (entity, "status_text"), response_data);
 
       g_string_free (xml, TRUE);
@@ -17179,7 +17179,7 @@ authenticate_gmp (const gchar *username, const gchar *password, gchar **role,
 
   if (gvm_connection_open (&connection, manager_address, manager_port))
     {
-      g_debug ("%s failed to acquire socket!\n", __FUNCTION__);
+      g_debug ("%s failed to acquire socket!\n", __func__);
       return 1;
     }
 

--- a/gsad/src/gsad_http.c
+++ b/gsad/src/gsad_http.c
@@ -200,7 +200,7 @@ send_redirect_to_uri (http_connection_t *connection, const char *uri,
   if (!response)
     {
       g_warning ("%s: failed to create response, dropping request",
-                 __FUNCTION__);
+                 __func__);
       return MHD_NO;
     }
   ret = MHD_add_response_header (response, MHD_HTTP_HEADER_LOCATION, uri);
@@ -208,14 +208,14 @@ send_redirect_to_uri (http_connection_t *connection, const char *uri,
     {
       MHD_destroy_response (response);
       g_warning ("%s: failed to add location header, dropping request",
-                 __FUNCTION__);
+                 __func__);
       return MHD_NO;
     }
 
   if (attach_remove_sid (response, sid) == MHD_NO)
     {
       MHD_destroy_response (response);
-      g_warning ("%s: failed to attach SID, dropping request", __FUNCTION__);
+      g_warning ("%s: failed to attach SID, dropping request", __func__);
       return MHD_NO;
     }
 
@@ -253,7 +253,7 @@ send_response (http_connection_t *connection, const char *content,
     size = (content_length ? content_length : strlen (content));
   else
     {
-      g_warning ("%s: content is NULL", __FUNCTION__);
+      g_warning ("%s: content is NULL", __func__);
       status_code = MHD_HTTP_INTERNAL_SERVER_ERROR;
       size = 0;
     }
@@ -474,7 +474,7 @@ handler_send_reauthentication (http_connection_t *connection,
   cmd_response_data_t *response_data = cmd_response_data_new ();
   cmd_response_data_set_status_code (response_data, http_status_code);
 
-  gchar *xml = gsad_message (NULL, "Authentication required", __FUNCTION__,
+  gchar *xml = gsad_message (NULL, "Authentication required", __func__,
                              __LINE__, msg, response_data);
 
   return handler_create_response (connection, xml, response_data, REMOVE_SID);
@@ -550,7 +550,7 @@ attach_sid (http_response_t *response, const char *sid)
   tz = getenv ("TZ") ? g_strdup (getenv ("TZ")) : NULL;
   if (setenv ("TZ", "GMT", 1) == -1)
     {
-      g_critical ("%s: failed to set TZ\n", __FUNCTION__);
+      g_critical ("%s: failed to set TZ\n", __func__);
       g_free (tz);
       exit (EXIT_FAILURE);
     }
@@ -578,7 +578,7 @@ attach_sid (http_response_t *response, const char *sid)
     {
       if (setenv ("TZ", tz, 1) == -1)
         {
-          g_warning ("%s: Failed to switch to original TZ", __FUNCTION__);
+          g_warning ("%s: Failed to switch to original TZ", __func__);
           g_free (tz);
           exit (EXIT_FAILURE);
         }
@@ -622,7 +622,7 @@ attach_remove_sid (http_response_t *response, const gchar *sid)
             {
               MHD_destroy_response (response);
               g_warning ("%s: failed to remove SID, dropping request",
-                         __FUNCTION__);
+                         __func__);
               return MHD_NO;
             }
         }
@@ -632,7 +632,7 @@ attach_remove_sid (http_response_t *response, const gchar *sid)
             {
               MHD_destroy_response (response);
               g_warning ("%s: failed to attach SID, dropping request",
-                         __FUNCTION__);
+                         __func__);
               return MHD_NO;
             }
         }
@@ -706,7 +706,7 @@ file_content_response (http_connection_t *connection, const char *url,
   if (stat (path, &buf))
     {
       /* File information could not be retrieved. */
-      g_critical ("%s: file <%s> can not be stat'ed.\n", __FUNCTION__, path);
+      g_critical ("%s: file <%s> can not be stat'ed.\n", __func__, path);
       fclose (file);
       return create_not_found_response (response_data);
     }

--- a/gsad/src/gsad_http_handler.c
+++ b/gsad/src/gsad_http_handler.c
@@ -589,7 +589,7 @@ handle_system_report (http_connection_t *connection, const char *method,
     {
       credentials_free (credentials);
       g_warning ("%s: failed to validate slave_id, dropping request",
-                 __FUNCTION__);
+                 __func__);
       return MHD_NO;
     }
 
@@ -607,7 +607,7 @@ handle_system_report (http_connection_t *connection, const char *method,
     case 1: /* manager closed connection */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                           "An internal error occurred. "
                           "Diagnostics: Failure to connect to manager daemon. "
                           "Manager daemon doesn't respond.",
@@ -623,7 +623,7 @@ handle_system_report (http_connection_t *connection, const char *method,
     case 3: /* timeout */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                           "An internal error occurred. "
                           "Diagnostics: Failure to connect to manager daemon. "
                           "Timeout while waiting for manager response.",
@@ -632,7 +632,7 @@ handle_system_report (http_connection_t *connection, const char *method,
     case 4: /* failed to connect to manager */
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                           "An internal error occurred. "
                           "Diagnostics: Failure to connect to manager daemon. "
                           "Could not open a connection.",
@@ -641,7 +641,7 @@ handle_system_report (http_connection_t *connection, const char *method,
     default:
       cmd_response_data_set_status_code (response_data,
                                          MHD_HTTP_INTERNAL_SERVER_ERROR);
-      res = gsad_message (credentials, "Internal error", __FUNCTION__, __LINE__,
+      res = gsad_message (credentials, "Internal error", __func__, __LINE__,
                           "An internal error occurred. "
                           "Diagnostics: Failure to connect to manager daemon. "
                           "Unknown error.",
@@ -653,7 +653,7 @@ handle_system_report (http_connection_t *connection, const char *method,
     {
       credentials_free (credentials);
       g_warning ("%s: failed to get system reports, dropping request",
-                 __FUNCTION__);
+                 __func__);
       cmd_response_data_free (response_data);
       return MHD_NO;
     }

--- a/gsad/src/gsad_session.c
+++ b/gsad/src/gsad_session.c
@@ -194,7 +194,7 @@ session_remove_other_sessions (const gchar *id, user_t *user)
 
       if (str_equal (itemname, username) && !str_equal (id, itemtoken))
         {
-          g_debug ("%s: logging out user '%s', token '%s'", __FUNCTION__,
+          g_debug ("%s: logging out user '%s', token '%s'", __func__,
                    itemname, itemtoken);
           g_ptr_array_remove (users, (gpointer) item);
 

--- a/gsad/src/validator.c
+++ b/gsad/src/validator.c
@@ -200,11 +200,11 @@ gvm_validate (validator_t validator, const char *name, const char *value)
 
   if (name != NULL && g_utf8_validate (name, -1, NULL) == FALSE)
     {
-      g_debug ("%s: name is not valid UTF-8", __FUNCTION__);
+      g_debug ("%s: name is not valid UTF-8", __func__);
       return 1;
     }
 
-  g_debug ("%s: name %s value %s", __FUNCTION__, name, value);
+  g_debug ("%s: name %s value %s", __func__, name, value);
 
   if (g_hash_table_lookup_extended (validator, name, &key, &value_rule))
     {
@@ -222,7 +222,7 @@ gvm_validate (validator_t validator, const char *name, const char *value)
 
       if (value != NULL && g_utf8_validate (value, -1, NULL) == FALSE)
         {
-          g_debug ("%s: value is not valid UTF-8", __FUNCTION__);
+          g_debug ("%s: value is not valid UTF-8", __func__);
           return 2;
         }
 
@@ -230,30 +230,30 @@ gvm_validate (validator_t validator, const char *name, const char *value)
         {
           if (value == NULL)
             {
-              g_debug ("%s: matched, regex NULL", __FUNCTION__);
+              g_debug ("%s: matched, regex NULL", __func__);
               return 0;
             }
-          g_debug ("%s: failed to match, regex NULL", __FUNCTION__);
+          g_debug ("%s: failed to match, regex NULL", __func__);
           return 2;
         }
 
       if (value == NULL)
         {
-          g_debug ("%s: failed to match, value NULL", __FUNCTION__);
+          g_debug ("%s: failed to match, value NULL", __func__);
           return 2;
         }
 
       g_debug ("matching <%s> against <%s>: ", (char *) rule->regex, value);
       if (g_regex_match_simple (rule->regex, (const gchar *) value, 0, 0))
         {
-          g_debug ("%s: matched", __FUNCTION__);
+          g_debug ("%s: matched", __func__);
           return 0;
         }
-      g_debug ("%s: failed to match\n", __FUNCTION__);
+      g_debug ("%s: failed to match\n", __func__);
       return 2;
     }
 
-  g_debug ("%s: failed to find name: %s", __FUNCTION__, name);
+  g_debug ("%s: failed to find name: %s", __func__, name);
   return 1;
 }
 


### PR DESCRIPTION
We were mixing `__func__` and `__FUNCTION__`, so we're switching all to `__func__`.

GCC manual: `__FUNCTION__` is another name for `__func__`, provided for backward compatibility with old versions of GCC. 

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry N/A
