### PR TITLE
[8.0] Reload on inactive tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#1507](https://github.com/greenbone/gsa/pull/1507)
 
 ### Changed
+- Consider visibility status of page for calculating the reload interval [#1761](https://github.com/greenbone/gsa/pull/1761)
 - Do not simplify filterString in content composer for report download [#1733](https://github.com/greenbone/gsa/pull/1733)
 - Use single component for reloading data [#1722](https://github.com/greenbone/gsa/pull/1722)
 - Use last chars of a label string in BarChart [#1713](https://github.com/greenbone/gsa/pull/1713)

--- a/gsa/src/gmp/__tests__/gmpsettings.js
+++ b/gsa/src/gmp/__tests__/gmpsettings.js
@@ -21,6 +21,8 @@ import GmpSettings, {
   DEFAULT_RELOAD_INTERVAL,
   DEFAULT_PROTOCOLDOC_URL,
   DEFAULT_LOG_LEVEL,
+  DEFAULT_RELOAD_INTERVAL_ACTIVE,
+  DEFAULT_RELOAD_INTERVAL_INACTIVE,
 } from 'gmp/gmpsettings';
 
 const createStorage = state => {
@@ -48,6 +50,12 @@ describe('GmpSettings tests', () => {
     expect(settings.protocol).toEqual('http:');
     expect(settings.protocoldocurl).toEqual(DEFAULT_PROTOCOLDOC_URL);
     expect(settings.reloadInterval).toEqual(DEFAULT_RELOAD_INTERVAL);
+    expect(settings.reloadIntervalActive).toEqual(
+      DEFAULT_RELOAD_INTERVAL_ACTIVE,
+    );
+    expect(settings.reloadIntervalInactive).toEqual(
+      DEFAULT_RELOAD_INTERVAL_INACTIVE,
+    );
     expect(settings.server).toEqual('localhost');
     expect(settings.token).toBeUndefined();
     expect(settings.timeout).toBeUndefined();
@@ -76,6 +84,8 @@ describe('GmpSettings tests', () => {
       protocol: 'http',
       protocoldocurl: 'http://protocol',
       reloadInterval: 10,
+      reloadIntervalActive: 5,
+      reloadIntervalInactive: 60,
       server: 'localhost',
       token: 'atoken',
       timeout: 30000,
@@ -96,6 +106,8 @@ describe('GmpSettings tests', () => {
     expect(settings.protocol).toEqual('http');
     expect(settings.protocoldocurl).toEqual('http://protocol');
     expect(settings.reloadInterval).toEqual(10);
+    expect(settings.reloadIntervalActive).toEqual(5);
+    expect(settings.reloadIntervalInactive).toEqual(60);
     expect(settings.server).toEqual('localhost');
     expect(settings.token).toBeUndefined();
     expect(settings.timeout).toEqual(30000);
@@ -138,6 +150,12 @@ describe('GmpSettings tests', () => {
     expect(settings.protocol).toEqual('http');
     expect(settings.protocoldocurl).toEqual(DEFAULT_PROTOCOLDOC_URL);
     expect(settings.reloadInterval).toEqual(DEFAULT_RELOAD_INTERVAL);
+    expect(settings.reloadIntervalActive).toEqual(
+      DEFAULT_RELOAD_INTERVAL_ACTIVE,
+    );
+    expect(settings.reloadIntervalInactive).toEqual(
+      DEFAULT_RELOAD_INTERVAL_INACTIVE,
+    );
     expect(settings.server).toEqual('foo');
     expect(settings.token).toEqual('atoken');
     expect(settings.timeout).toBeUndefined();
@@ -158,6 +176,8 @@ describe('GmpSettings tests', () => {
       protocol: 'https',
       protocoldocurl: 'http://lorem',
       reloadInterval: 20,
+      reloadIntervalActive: 20,
+      reloadIntervalInactive: 20,
       server: 'foo.bar',
       token: 'btoken',
       timeout: 10000,
@@ -176,6 +196,8 @@ describe('GmpSettings tests', () => {
       protocol: 'http',
       protocoldocurl: 'http://protocol',
       reloadInterval: 10,
+      reloadIntervalActive: 5,
+      reloadIntervalInactive: 60,
       server: 'localhost',
       token: 'atoken',
       timeout: 30000,
@@ -193,6 +215,8 @@ describe('GmpSettings tests', () => {
     expect(settings.protocol).toEqual('http');
     expect(settings.protocoldocurl).toEqual('http://protocol');
     expect(settings.reloadInterval).toEqual(10);
+    expect(settings.reloadIntervalActive).toEqual(5);
+    expect(settings.reloadIntervalInactive).toEqual(60);
     expect(settings.server).toEqual('localhost');
     expect(settings.token).toEqual('btoken');
     expect(settings.timeout).toEqual(30000);

--- a/gsa/src/gmp/gmpsettings.js
+++ b/gsa/src/gmp/gmpsettings.js
@@ -19,6 +19,8 @@
 import {isDefined} from './utils/identity';
 
 export const DEFAULT_RELOAD_INTERVAL = 15 * 1000; // fifteen seconds
+export const DEFAULT_RELOAD_INTERVAL_ACTIVE = 3 * 1000; // three seconds
+export const DEFAULT_RELOAD_INTERVAL_INACTIVE = 60 * 1000; // one minute
 export const DEFAULT_MANUAL_URL = 'http://docs.greenbone.net/GSM-Manual/gos-5/';
 export const DEFAULT_PROTOCOLDOC_URL =
   'https://docs.greenbone.net/API/GMP/gmp-8.0.html';
@@ -52,6 +54,8 @@ class GmpSettings {
       protocol = global.location.protocol,
       protocoldocurl = DEFAULT_PROTOCOLDOC_URL,
       reloadInterval = DEFAULT_RELOAD_INTERVAL,
+      reloadIntervalActive = DEFAULT_RELOAD_INTERVAL_ACTIVE,
+      reloadIntervalInactive = DEFAULT_RELOAD_INTERVAL_INACTIVE,
       server = global.location.host,
       timeout,
       vendorVersion,
@@ -65,6 +69,8 @@ class GmpSettings {
 
     this.loglevel = isDefined(loglevel) ? loglevel : DEFAULT_LOG_LEVEL;
     this.reloadInterval = reloadInterval;
+    this.reloadIntervalActive = reloadIntervalActive;
+    this.reloadIntervalInactive = reloadIntervalInactive;
     this.timeout = timeout;
 
     setAndFreeze(this, 'disableLoginForm', disableLoginForm);

--- a/gsa/src/web/components/loading/__tests__/reload.js
+++ b/gsa/src/web/components/loading/__tests__/reload.js
@@ -20,7 +20,12 @@ import React from 'react';
 
 import {act, fireEvent, rendererWith} from 'web/utils/testing';
 
-import Reload from '../reload';
+import Reload, {
+  NO_RELOAD,
+  USE_DEFAULT_RELOAD_INTERVAL,
+  USE_DEFAULT_RELOAD_INTERVAL_ACTIVE,
+  USE_DEFAULT_RELOAD_INTERVAL_INACTIVE,
+} from '../reload';
 
 // eslint-disable-next-line react/prop-types
 const TestComponent = ({reload, id, reloadOptions}) => (
@@ -421,7 +426,184 @@ describe('Reload component tests', () => {
     expect(queryByTestId('two')).not.toBeInTheDocument();
   });
 
-  test('should fall back to defaultReloadInterval if reloadInterval returns undefined', async () => {
+  test(
+    'should fall back to defaultReloadInterval if reloadInterval returns ' +
+      'USE_DEFAULT_RELOAD_INTERVAL',
+    async () => {
+      jest.useFakeTimers();
+
+      const renderFunc = jest
+        .fn()
+        .mockReturnValueOnce(<div data-testid="one" />)
+        .mockReturnValueOnce(<div data-testid="two" />);
+      const loadFunc = jest.fn().mockResolvedValue();
+      const reloadFunc = jest.fn().mockResolvedValue();
+
+      const reloadInterval = jest
+        .fn()
+        .mockReturnValue(USE_DEFAULT_RELOAD_INTERVAL);
+
+      const gmp = {
+        settings: {
+          reloadInterval: 5000,
+        },
+      };
+
+      const {render} = rendererWith({gmp});
+
+      const {queryByTestId} = render(
+        <Reload
+          defaultReloadInterval={NO_RELOAD}
+          load={loadFunc}
+          reload={reloadFunc}
+          reloadInterval={reloadInterval}
+          name="foo"
+        >
+          {renderFunc}
+        </Reload>,
+      );
+
+      expect(loadFunc).toHaveBeenCalled();
+      expect(reloadFunc).not.toHaveBeenCalled();
+      expect(renderFunc).toHaveBeenCalled();
+      expect(reloadInterval).not.toHaveBeenCalled();
+
+      expect(queryByTestId('one')).toBeInTheDocument();
+
+      loadFunc.mockClear();
+      renderFunc.mockClear();
+
+      await runTimers();
+
+      expect(loadFunc).not.toHaveBeenCalled();
+      expect(reloadFunc).not.toHaveBeenCalled();
+      expect(renderFunc).not.toHaveBeenCalled();
+      expect(reloadInterval).toHaveBeenCalled();
+
+      expect(queryByTestId('one')).toBeInTheDocument();
+      expect(queryByTestId('two')).not.toBeInTheDocument();
+    },
+  );
+
+  test(
+    'should fall back to defaultReloadIntervalActive if reloadInterval ' +
+      'returns USE_DEFAULT_RELOAD_INTERVAL_ACTIVE',
+    async () => {
+      jest.useFakeTimers();
+
+      const renderFunc = jest
+        .fn()
+        .mockReturnValueOnce(<div data-testid="one" />)
+        .mockReturnValueOnce(<div data-testid="two" />);
+      const loadFunc = jest.fn().mockResolvedValue();
+      const reloadFunc = jest.fn().mockResolvedValue();
+
+      const reloadInterval = jest
+        .fn()
+        .mockReturnValue(USE_DEFAULT_RELOAD_INTERVAL_ACTIVE);
+
+      const gmp = {
+        settings: {
+          reloadInterval: 5000,
+        },
+      };
+
+      const {render} = rendererWith({gmp});
+
+      const {queryByTestId} = render(
+        <Reload
+          defaultReloadIntervalActive={NO_RELOAD}
+          load={loadFunc}
+          reload={reloadFunc}
+          reloadInterval={reloadInterval}
+          name="foo"
+        >
+          {renderFunc}
+        </Reload>,
+      );
+
+      expect(loadFunc).toHaveBeenCalled();
+      expect(reloadFunc).not.toHaveBeenCalled();
+      expect(renderFunc).toHaveBeenCalled();
+      expect(reloadInterval).not.toHaveBeenCalled();
+
+      expect(queryByTestId('one')).toBeInTheDocument();
+
+      loadFunc.mockClear();
+      renderFunc.mockClear();
+
+      await runTimers();
+
+      expect(loadFunc).not.toHaveBeenCalled();
+      expect(reloadFunc).not.toHaveBeenCalled();
+      expect(renderFunc).not.toHaveBeenCalled();
+      expect(reloadInterval).toHaveBeenCalled();
+
+      expect(queryByTestId('one')).toBeInTheDocument();
+      expect(queryByTestId('two')).not.toBeInTheDocument();
+    },
+  );
+
+  test(
+    'should fall back to defaultReloadIntervalInactive if reloadInterval ' +
+      'returns USE_DEFAULT_RELOAD_INTERVAL_INACTIVE',
+    async () => {
+      jest.useFakeTimers();
+
+      const renderFunc = jest
+        .fn()
+        .mockReturnValueOnce(<div data-testid="one" />)
+        .mockReturnValueOnce(<div data-testid="two" />);
+      const loadFunc = jest.fn().mockResolvedValue();
+      const reloadFunc = jest.fn().mockResolvedValue();
+
+      const reloadInterval = jest
+        .fn()
+        .mockReturnValue(USE_DEFAULT_RELOAD_INTERVAL_INACTIVE);
+
+      const gmp = {
+        settings: {
+          reloadInterval: 5000,
+        },
+      };
+
+      const {render} = rendererWith({gmp});
+
+      const {queryByTestId} = render(
+        <Reload
+          defaultReloadIntervalActive={NO_RELOAD}
+          load={loadFunc}
+          reload={reloadFunc}
+          reloadInterval={reloadInterval}
+          name="foo"
+        >
+          {renderFunc}
+        </Reload>,
+      );
+
+      expect(loadFunc).toHaveBeenCalled();
+      expect(reloadFunc).not.toHaveBeenCalled();
+      expect(renderFunc).toHaveBeenCalled();
+      expect(reloadInterval).not.toHaveBeenCalled();
+
+      expect(queryByTestId('one')).toBeInTheDocument();
+
+      loadFunc.mockClear();
+      renderFunc.mockClear();
+
+      await runTimers();
+
+      expect(loadFunc).not.toHaveBeenCalled();
+      expect(reloadFunc).not.toHaveBeenCalled();
+      expect(renderFunc).not.toHaveBeenCalled();
+      expect(reloadInterval).toHaveBeenCalled();
+
+      expect(queryByTestId('one')).toBeInTheDocument();
+      expect(queryByTestId('two')).not.toBeInTheDocument();
+    },
+  );
+
+  test('should use reloadInterval from settings', async () => {
     jest.useFakeTimers();
 
     const renderFunc = jest
@@ -431,62 +613,9 @@ describe('Reload component tests', () => {
     const loadFunc = jest.fn().mockResolvedValue();
     const reloadFunc = jest.fn().mockResolvedValue();
 
-    const reloadInterval = jest.fn().mockReturnValue(undefined);
-
     const gmp = {
       settings: {
-        reloadInterval: 5000,
-      },
-    };
-
-    const {render} = rendererWith({gmp});
-
-    const {queryByTestId} = render(
-      <Reload
-        defaultReloadInterval={-1}
-        load={loadFunc}
-        reload={reloadFunc}
-        reloadInterval={reloadInterval}
-        name="foo"
-      >
-        {renderFunc}
-      </Reload>,
-    );
-
-    expect(loadFunc).toHaveBeenCalled();
-    expect(reloadFunc).not.toHaveBeenCalled();
-    expect(renderFunc).toHaveBeenCalled();
-    expect(reloadInterval).not.toHaveBeenCalled();
-
-    expect(queryByTestId('one')).toBeInTheDocument();
-
-    loadFunc.mockClear();
-    renderFunc.mockClear();
-
-    await runTimers();
-
-    expect(loadFunc).not.toHaveBeenCalled();
-    expect(reloadFunc).not.toHaveBeenCalled();
-    expect(renderFunc).not.toHaveBeenCalled();
-    expect(reloadInterval).toHaveBeenCalled();
-
-    expect(queryByTestId('one')).toBeInTheDocument();
-    expect(queryByTestId('two')).not.toBeInTheDocument();
-  });
-
-  test('should use defaultReloadInterval for reload timer', async () => {
-    jest.useFakeTimers();
-
-    const renderFunc = jest
-      .fn()
-      .mockReturnValueOnce(<div data-testid="one" />)
-      .mockReturnValueOnce(<div data-testid="two" />);
-    const loadFunc = jest.fn().mockResolvedValue();
-    const reloadFunc = jest.fn().mockResolvedValue();
-
-    const gmp = {
-      settings: {
-        reloadInterval: -1,
+        reloadInterval: NO_RELOAD,
       },
     };
 
@@ -512,6 +641,112 @@ describe('Reload component tests', () => {
     expect(loadFunc).not.toHaveBeenCalled();
     expect(reloadFunc).not.toHaveBeenCalled();
     expect(renderFunc).not.toHaveBeenCalled();
+
+    expect(queryByTestId('one')).toBeInTheDocument();
+    expect(queryByTestId('two')).not.toBeInTheDocument();
+  });
+
+  test('should use reloadIntervalActive from settings', async () => {
+    jest.useFakeTimers();
+
+    const renderFunc = jest
+      .fn()
+      .mockReturnValueOnce(<div data-testid="one" />)
+      .mockReturnValueOnce(<div data-testid="two" />);
+    const loadFunc = jest.fn().mockResolvedValue();
+    const reloadFunc = jest.fn().mockResolvedValue();
+    const reloadIntervalFunc = jest
+      .fn()
+      .mockReturnValue(USE_DEFAULT_RELOAD_INTERVAL_ACTIVE);
+
+    const gmp = {
+      settings: {
+        reloadIntervalActive: NO_RELOAD,
+      },
+    };
+
+    const {render} = rendererWith({gmp});
+
+    const {queryByTestId} = render(
+      <Reload
+        load={loadFunc}
+        reloadInterval={reloadIntervalFunc}
+        reload={reloadFunc}
+        name="foo"
+      >
+        {renderFunc}
+      </Reload>,
+    );
+
+    expect(loadFunc).toHaveBeenCalled();
+    expect(reloadFunc).not.toHaveBeenCalled();
+    expect(renderFunc).toHaveBeenCalled();
+    expect(reloadIntervalFunc).not.toHaveBeenCalled();
+
+    expect(queryByTestId('one')).toBeInTheDocument();
+
+    loadFunc.mockClear();
+    renderFunc.mockClear();
+
+    await runTimers();
+
+    expect(loadFunc).not.toHaveBeenCalled();
+    expect(reloadFunc).not.toHaveBeenCalled();
+    expect(renderFunc).not.toHaveBeenCalled();
+    expect(reloadIntervalFunc).toHaveBeenCalled();
+
+    expect(queryByTestId('one')).toBeInTheDocument();
+    expect(queryByTestId('two')).not.toBeInTheDocument();
+  });
+
+  test('should use reloadIntervalInactive from settings', async () => {
+    jest.useFakeTimers();
+
+    const renderFunc = jest
+      .fn()
+      .mockReturnValueOnce(<div data-testid="one" />)
+      .mockReturnValueOnce(<div data-testid="two" />);
+    const loadFunc = jest.fn().mockResolvedValue();
+    const reloadFunc = jest.fn().mockResolvedValue();
+    const reloadIntervalFunc = jest
+      .fn()
+      .mockReturnValue(USE_DEFAULT_RELOAD_INTERVAL_INACTIVE);
+
+    const gmp = {
+      settings: {
+        reloadIntervalInactive: NO_RELOAD,
+      },
+    };
+
+    const {render} = rendererWith({gmp});
+
+    const {queryByTestId} = render(
+      <Reload
+        load={loadFunc}
+        reloadInterval={reloadIntervalFunc}
+        reload={reloadFunc}
+        name="foo"
+      >
+        {renderFunc}
+      </Reload>,
+    );
+
+    expect(loadFunc).toHaveBeenCalled();
+    expect(reloadFunc).not.toHaveBeenCalled();
+    expect(renderFunc).toHaveBeenCalled();
+    expect(reloadIntervalFunc).not.toHaveBeenCalled();
+
+    expect(queryByTestId('one')).toBeInTheDocument();
+
+    loadFunc.mockClear();
+    renderFunc.mockClear();
+
+    await runTimers();
+
+    expect(loadFunc).not.toHaveBeenCalled();
+    expect(reloadFunc).not.toHaveBeenCalled();
+    expect(renderFunc).not.toHaveBeenCalled();
+    expect(reloadIntervalFunc).toHaveBeenCalled();
 
     expect(queryByTestId('one')).toBeInTheDocument();
     expect(queryByTestId('two')).not.toBeInTheDocument();

--- a/gsa/src/web/components/loading/reload.js
+++ b/gsa/src/web/components/loading/reload.js
@@ -84,8 +84,12 @@ class Reload extends React.Component {
     return defaultReloadInterval;
   }
 
+  hasTimer() {
+    return isDefined(this.timer);
+  }
+
   startTimer() {
-    if (!this.isRunning || isDefined(this.timer)) {
+    if (!this.isRunning || this.hasTimer()) {
       log.debug('Not starting timer. A timer is already running.', {
         isRunning: this.isRunning,
         timer: this.timer,
@@ -126,7 +130,7 @@ class Reload extends React.Component {
   }
 
   clearTimer() {
-    if (isDefined(this.timer)) {
+    if (this.hasTimer()) {
       log.debug(
         'Clearing reload timer with id',
         this.timer,

--- a/gsa/src/web/components/loading/reload.js
+++ b/gsa/src/web/components/loading/reload.js
@@ -50,7 +50,7 @@ class Reload extends React.Component {
     this.isRunning = false;
 
     this.clearTimer(); // remove possible running timer
-    this.removeVisibilityListender();
+    this.removeVisibilityListener();
   }
 
   componentDidMount() {
@@ -183,7 +183,7 @@ class Reload extends React.Component {
     document.addEventListener('visibilitychange', this.handleVisibilityChange);
   }
 
-  removeVisibilityListender() {
+  removeVisibilityListener() {
     document.removeEventListener(
       'visibilitychange',
       this.handleVisibilityChange,

--- a/gsa/src/web/components/loading/reload.js
+++ b/gsa/src/web/components/loading/reload.js
@@ -37,17 +37,20 @@ class Reload extends React.Component {
   constructor(...args) {
     super(...args);
 
-    this.isVisible = true;
+    this.isVisible = !document.hidden; // the browser window is active and visible to the user
 
     this.handleTimer = this.handleTimer.bind(this);
 
     this.reload = this.reload.bind(this);
+
+    this.handleVisibilityChange = this.handleVisibilityChange.bind(this);
   }
 
   componentWillUnmount() {
     this.isRunning = false;
 
     this.clearTimer(); // remove possible running timer
+    this.removeVisibilityListender();
   }
 
   componentDidMount() {
@@ -56,6 +59,7 @@ class Reload extends React.Component {
 
     log.debug('Initial loading.');
 
+    this.activateVisibilityListener();
     this.internalLoad(loadFunc); // initial loading
   }
 
@@ -173,6 +177,29 @@ class Reload extends React.Component {
     this.resetTimer();
 
     this.internalLoad();
+  }
+
+  activateVisibilityListener() {
+    document.addEventListener('visibilitychange', this.handleVisibilityChange);
+  }
+
+  removeVisibilityListender() {
+    document.removeEventListener(
+      'visibilitychange',
+      this.handleVisibilityChange,
+    );
+  }
+
+  handleVisibilityChange() {
+    this.isVisible = !document.hidden;
+
+    if (this.isVisible && this.hasTimer()) {
+      // browser tab is visible again
+      // restart timer to get a possible shorter interval as the remaining time
+
+      this.clearTimer();
+      this.startTimer();
+    }
   }
 
   reload(options) {

--- a/gsa/src/web/pages/reports/detailspage.js
+++ b/gsa/src/web/pages/reports/detailspage.js
@@ -36,8 +36,8 @@ import {isDefined, hasValue} from 'gmp/utils/identity';
 import withDownload from 'web/components/form/withDownload';
 
 import Reload, {
-  DEFAULT_RELOAD_INTERVAL_ACTIVE,
   NO_RELOAD,
+  USE_DEFAULT_RELOAD_INTERVAL_ACTIVE,
 } from 'web/components/loading/reload';
 
 import withDialogNotification from 'web/components/notification/withDialogNotifiaction'; // eslint-disable-line max-len
@@ -676,7 +676,7 @@ const mapStateToProps = (rootState, {match}) => {
 
 const reloadInterval = report =>
   isDefined(report) && isActive(report.report.scan_run_status)
-    ? DEFAULT_RELOAD_INTERVAL_ACTIVE
+    ? USE_DEFAULT_RELOAD_INTERVAL_ACTIVE
     : NO_RELOAD; // report doesn't change anymore. no need to reload
 
 const load = ({

--- a/gsa/src/web/pages/reports/listpage.js
+++ b/gsa/src/web/pages/reports/listpage.js
@@ -42,7 +42,7 @@ import IconDivider from 'web/components/layout/icondivider';
 
 import {
   USE_DEFAULT_RELOAD_INTERVAL,
-  DEFAULT_RELOAD_INTERVAL_ACTIVE,
+  USE_DEFAULT_RELOAD_INTERVAL_ACTIVE,
 } from 'web/components/loading/reload';
 
 import ContainerTaskDialog from 'web/pages/tasks/containerdialog';
@@ -273,7 +273,7 @@ Page.propTypes = {
 
 const reportsReloadInterval = ({entities = []}) =>
   entities.some(entity => isActive(entity.report.scan_run_status))
-    ? DEFAULT_RELOAD_INTERVAL_ACTIVE
+    ? USE_DEFAULT_RELOAD_INTERVAL_ACTIVE
     : USE_DEFAULT_RELOAD_INTERVAL;
 
 const mapStateToProps = rootState => {

--- a/gsa/src/web/pages/tasks/detailspage.js
+++ b/gsa/src/web/pages/tasks/detailspage.js
@@ -50,7 +50,7 @@ import TaskIcon from 'web/components/icon/taskicon';
 import {
   NO_RELOAD,
   USE_DEFAULT_RELOAD_INTERVAL,
-  DEFAULT_RELOAD_INTERVAL_ACTIVE,
+  USE_DEFAULT_RELOAD_INTERVAL_ACTIVE,
 } from 'web/components/loading/reload';
 
 import Tab from 'web/components/tab/tab';
@@ -504,7 +504,7 @@ const reloadInterval = ({entity}) => {
     return NO_RELOAD;
   }
   return entity.isActive()
-    ? DEFAULT_RELOAD_INTERVAL_ACTIVE
+    ? USE_DEFAULT_RELOAD_INTERVAL_ACTIVE
     : USE_DEFAULT_RELOAD_INTERVAL;
 };
 

--- a/gsa/src/web/pages/tasks/listpage.js
+++ b/gsa/src/web/pages/tasks/listpage.js
@@ -43,7 +43,7 @@ import IconDivider from 'web/components/layout/icondivider';
 
 import {
   USE_DEFAULT_RELOAD_INTERVAL,
-  DEFAULT_RELOAD_INTERVAL_ACTIVE,
+  USE_DEFAULT_RELOAD_INTERVAL_ACTIVE,
 } from 'web/components/loading/reload';
 
 import IconMenu from 'web/components/menu/iconmenu';
@@ -208,7 +208,7 @@ Page.propTypes = {
 
 const taskReloadInterval = ({entities = []}) =>
   entities.some(task => task.isActive())
-    ? DEFAULT_RELOAD_INTERVAL_ACTIVE
+    ? USE_DEFAULT_RELOAD_INTERVAL_ACTIVE
     : USE_DEFAULT_RELOAD_INTERVAL;
 
 export default withEntitiesContainer('task', {


### PR DESCRIPTION
Improve Reload component to consider hidden status of the current browser tab for calculating the reload interval.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
