### PR TITLE
Avoid InvalidStateError when creating xhr on IE 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   logged in [#1508](https://github.com/greenbone/gsa/pull/1508)
 
 ### Fixed
+- Fixed getting InvalidStateError with IE 11 on XHR creation [#1769](https://github.com/greenbone/gsa/pull/1769)
 - Fixed filtering general command permissions in roles [#1734](https://github.com/greenbone/gsa/pull/1734)
 - Fix getting details in delta report [#1732](https://github.com/greenbone/gsa/pull/1732)
 - Include results (details=1) in report download [#1731](https://github.com/greenbone/gsa/pull/1731)

--- a/gsa/src/gmp/http/http.js
+++ b/gsa/src/gmp/http/http.js
@@ -115,9 +115,12 @@ class Http {
     const promise = new Promise(function(resolve, reject) {
       xhr = new XMLHttpRequest();
 
-      if (isDefined(responseType)) {
-        xhr.responseType = responseType;
-      }
+      xhr.onloadstart = function() {
+        // defer setting the responseType to avoid InvalidStateError with IE 11
+        if (isDefined(responseType)) {
+          xhr.responseType = responseType;
+        }
+      };
 
       xhr.open(method, url, true);
 


### PR DESCRIPTION
It seems it is not possible to set the responseType of the xhr object
before the loading hasn't started with IE 11.

https://stackoverflow.com/questions/29677339/invalidstateerror-in-internet-explorer-11-during-blob-creation

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
