### PR TITLE
Fix flaky policies list page test

### DIFF
--- a/gsa/src/web/pages/policies/__tests__/listpage.js
+++ b/gsa/src/web/pages/policies/__tests__/listpage.js
@@ -146,6 +146,8 @@ describe('PoliciesPage tests', () => {
       foo: 'bar',
     });
 
+    const renewSession = jest.fn().mockResolvedValue({data: {}});
+
     const gmp = {
       policies: {
         get: getPolicies,
@@ -157,7 +159,7 @@ describe('PoliciesPage tests', () => {
       },
       reloadInterval,
       settings: {manualUrl},
-      user: {currentSettings, getSetting: getSetting},
+      user: {currentSettings, getSetting: getSetting, renewSession},
     };
 
     const {render, store} = rendererWith({


### PR DESCRIPTION
Under some race conditions renewSession may be called and causes an
exception. Therefore don't crash if a click handler is called.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [n/a] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
