### PR TITLE
Override: Make host/port/task fields editable even when fixed, and display oid when no name is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#1507](https://github.com/greenbone/gsa/pull/1507)
 
 ### Changed
+- Override dialog: Make host/port/task fields editable even when fixed, and display oid when no name is defined [#1814](https://github.com/greenbone/gsa/pull/1814)
 - Use consistent setting naming [#1774](https://github.com/greenbone/gsa/pull/1774)
 - Consider visibility status of page for calculating the reload interval [#1761](https://github.com/greenbone/gsa/pull/1761)
 - Do not simplify filterString in content composer for report download [#1733](https://github.com/greenbone/gsa/pull/1733)

--- a/gsa/src/web/pages/overrides/dialog.js
+++ b/gsa/src/web/pages/overrides/dialog.js
@@ -169,9 +169,14 @@ const OverrideDialog = ({
       {({values: state, onValueChange}) => {
         return (
           <Layout flex="column">
-            {fixed && (
+            {fixed && isDefined(oid) && (
               <FormGroup title={_('NVT')} flex="column">
                 <span>{renderNvtName(oid, nvt_name)}</span>
+              </FormGroup>
+            )}
+            {fixed && !isDefined(oid) && (
+              <FormGroup title={_('NVT')} flex="column">
+                <span>{renderNvtName(state.oid, nvt_name)}</span>
               </FormGroup>
             )}
             {is_edit && !fixed && (
@@ -270,19 +275,16 @@ const OverrideDialog = ({
               <Layout>
                 <Radio
                   name="hosts"
-                  title={fixed ? state.hosts_manual : ''}
                   checked={state.hosts === MANUAL}
                   value={MANUAL}
                   onChange={onValueChange}
                 />
-                {!fixed && (
-                  <TextField
-                    name="hosts_manual"
-                    value={state.hosts_manual}
-                    disabled={state.hosts !== MANUAL}
-                    onChange={onValueChange}
-                  />
-                )}
+                <TextField
+                  name="hosts_manual"
+                  value={state.hosts_manual}
+                  disabled={state.hosts !== MANUAL}
+                  onChange={onValueChange}
+                />
               </Layout>
             </FormGroup>
 
@@ -297,19 +299,16 @@ const OverrideDialog = ({
               <Layout>
                 <Radio
                   name="port"
-                  title={fixed ? state.port_manual : ''}
                   checked={state.port === MANUAL}
                   value={MANUAL}
                   onChange={onValueChange}
                 />
-                {!fixed && (
-                  <TextField
-                    name="port_manual"
-                    disabled={state.port !== MANUAL}
-                    value={state.port_manual}
-                    onChange={onValueChange}
-                  />
-                )}
+                <TextField
+                  name="port_manual"
+                  disabled={state.port !== MANUAL}
+                  value={state.port_manual}
+                  onChange={onValueChange}
+                />
               </Layout>
             </FormGroup>
 
@@ -412,20 +411,18 @@ const OverrideDialog = ({
               <Layout>
                 <Radio
                   name="task_id"
-                  title={fixed ? state.task_name : ''}
                   checked={state.task_id === TASK_SELECTED}
                   value={TASK_SELECTED}
                   onChange={onValueChange}
                 />
-                {!fixed && (
-                  <Select
-                    name="task_uuid"
-                    disabled={state.task_id !== TASK_SELECTED}
-                    items={renderSelectItems(tasks)}
-                    value={state.task_uuid}
-                    onChange={onValueChange}
-                  />
-                )}
+
+                <Select
+                  name="task_uuid"
+                  disabled={state.task_id !== TASK_SELECTED}
+                  items={renderSelectItems(tasks)}
+                  value={state.task_uuid}
+                  onChange={onValueChange}
+                />
               </Layout>
             </FormGroup>
 

--- a/gsa/src/web/utils/render.js
+++ b/gsa/src/web/utils/render.js
@@ -65,7 +65,7 @@ export const severityFormat = format('0.1f');
 
 export const renderNvtName = (oid, name, length = 70) => {
   if (!isDefined(name)) {
-    return '';
+    return oid;
   }
 
   if (name.length < length) {


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
