### PR TITLE
Fix filter reset a list pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Increased clickable area for Logout [#1711](https://github.com/greenbone/gsa/pull/1711)
 
 ### Fixed
+- Fixed resetting to default filter at list pages [#1828](https://github.com/greenbone/gsa/pull/1828)
 - Fixed error when parsing invalid hosts for overrides and notes [#1810](https://github.com/greenbone/gsa/pull/1810)
 - Fixed displaying icon titles [#1809](https://github.com/greenbone/gsa/pull/1809)
 - Fixed svg icon cursor is always a pointer [#1800](https://github.com/greenbone/gsa/pull/1800)

--- a/gsa/src/web/entities/container.js
+++ b/gsa/src/web/entities/container.js
@@ -20,6 +20,8 @@ import 'core-js/features/set';
 
 import React from 'react';
 
+import {withRouter} from 'react-router-dom';
+
 import {connect} from 'react-redux';
 
 import _ from 'gmp/locale';
@@ -618,6 +620,7 @@ const mapDispatchToProps = (dispatch, {gmp}) => ({
 });
 
 export default compose(
+  withRouter,
   connect(
     mapStateToProps,
     mapDispatchToProps,

--- a/gsa/src/web/entities/filterprovider.js
+++ b/gsa/src/web/entities/filterprovider.js
@@ -21,8 +21,6 @@ import React, {useEffect, useState} from 'react';
 
 import {useSelector, useDispatch} from 'react-redux';
 
-import {withRouter} from 'react-router-dom';
-
 import {ROWS_PER_PAGE_SETTING_ID} from 'gmp/commands/users';
 
 import Filter, {
@@ -153,9 +151,6 @@ FilterProvider.propTypes = {
   }),
 };
 
-export default compose(
-  withGmp,
-  withRouter,
-)(FilterProvider);
+export default compose(withGmp)(FilterProvider);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/entities/filterprovider.js
+++ b/gsa/src/web/entities/filterprovider.js
@@ -40,16 +40,15 @@ import {loadUserSettingsDefaultFilter} from 'web/store/usersettings/defaultfilte
 import {getUserSettingsDefaultFilter} from 'web/store/usersettings/defaultfilters/selectors';
 
 import PropTypes from 'web/utils/proptypes';
-import withGmp from 'web/utils/withGmp';
-import compose from 'web/utils/compose';
+import useGmp from 'web/utils/useGmp';
 
 const FilterProvider = ({
   children,
   fallbackFilter,
-  gmp,
   gmpname,
   locationQuery = {},
 }) => {
+  const gmp = useGmp();
   const dispatch = useDispatch();
 
   let returnedFilter;
@@ -144,13 +143,12 @@ const FilterProvider = ({
 
 FilterProvider.propTypes = {
   fallbackFilter: PropTypes.filter,
-  gmp: PropTypes.gmp.isRequired,
   gmpname: PropTypes.string,
   locationQuery: PropTypes.shape({
     filter: PropTypes.string,
   }),
 };
 
-export default compose(withGmp)(FilterProvider);
+export default FilterProvider;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/entities/withEntitiesContainer.js
+++ b/gsa/src/web/entities/withEntitiesContainer.js
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 
-import {withRouter} from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 
 import {connect} from 'react-redux';
 
@@ -93,32 +93,34 @@ const withEntitiesContainer = (
     withDialogNotification,
     withDownload,
     withGmp,
-    withRouter,
     connect(
       mapStateToProps,
       mapDispatchToProps,
     ),
   )(EntitiesContainerWrapper);
 
-  return props => (
-    <SubscriptionProvider>
-      {({notify}) => (
-        <FilterProvider
-          fallbackFilter={fallbackFilter}
-          gmpname={gmpname}
-          locationQuery={props.location.query}
-        >
-          {({filter}) => (
-            <EntitiesContainerWrapper
-              {...props}
-              filter={filter}
-              notify={notify}
-            />
-          )}
-        </FilterProvider>
-      )}
-    </SubscriptionProvider>
-  );
+  return props => {
+    const location = useLocation();
+    return (
+      <SubscriptionProvider>
+        {({notify}) => (
+          <FilterProvider
+            fallbackFilter={fallbackFilter}
+            gmpname={gmpname}
+            locationQuery={location.query}
+          >
+            {({filter}) => (
+              <EntitiesContainerWrapper
+                {...props}
+                filter={filter}
+                notify={notify}
+              />
+            )}
+          </FilterProvider>
+        )}
+      </SubscriptionProvider>
+    );
+  };
 };
 
 export default withEntitiesContainer;

--- a/gsa/src/web/entities/withEntitiesContainer.js
+++ b/gsa/src/web/entities/withEntitiesContainer.js
@@ -42,12 +42,23 @@ const noop = () => {};
 
 const withEntitiesContainer = (
   gmpname,
-  {entitiesSelector, loadEntities, reloadInterval = noop, fallbackFilter},
+  {
+    entitiesSelector,
+    loadEntities: loadEntitiesFunc,
+    reloadInterval = noop,
+    fallbackFilter,
+  },
 ) => Component => {
-  let EntitiesContainerWrapper = ({children, filter, notify, ...props}) => (
+  let EntitiesContainerWrapper = ({
+    children,
+    filter,
+    loadEntities,
+    notify,
+    ...props
+  }) => (
     <Reload
       reloadInterval={() => reloadInterval(props)}
-      reload={(newFilter = filter) => props.loadEntities(newFilter)}
+      reload={(newFilter = filter) => loadEntities(newFilter)}
       name={gmpname}
     >
       {({reload}) => (
@@ -84,7 +95,7 @@ const withEntitiesContainer = (
   };
 
   const mapDispatchToProps = (dispatch, {gmp}) => ({
-    loadEntities: filter => dispatch(loadEntities(gmp)(filter)),
+    loadEntities: filter => dispatch(loadEntitiesFunc(gmp)(filter)),
     updateFilter: filter => dispatch(pageFilter(gmpname, filter)),
     onInteraction: () => dispatch(renewSessionTimeout(gmp)()),
   });


### PR DESCRIPTION
Change order of components. The FilterProvider needs to be a parent of
the EntitiesContainerWrapper because it specifies the to be used filter.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
