### PR TITLE
New permission dialog: radio button for groups disabled if no groups available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#1507](https://github.com/greenbone/gsa/pull/1507)
 
 ### Changed
+- New permission dialog: radio button for groups disabled if no groups available [#1836](https://github.com/greenbone/gsa/pull/1836)
 - Changed new override dialog defaults [#1833](https://github.com/greenbone/gsa/pull/1833)
 - Refactored cvsscalculatorpage to function and parse vector from url [#1824](https://github.com/greenbone/gsa/pull/1824)
 - New override and note dialog: Make host/port/task fields editable even when fixed, and display oid when no name is defined [#1814](https://github.com/greenbone/gsa/pull/1814) [#1817](https://github.com/greenbone/gsa/pull/1817)

--- a/gsa/src/web/pages/permissions/dialog.js
+++ b/gsa/src/web/pages/permissions/dialog.js
@@ -276,6 +276,7 @@ const PermissionDialog = ({
                     <Radio
                       name="subjectType"
                       checked={state.subjectType === 'group'}
+                      disabled={groups.length === 0}
                       title={_('Group')}
                       value="group"
                       onChange={onValueChange}


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
I thought about doing the same for users and roles, but I can't imagine a situation where there are no users and roles.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
