### PR TITLE
 Use read_string_c for the XML get_report case (8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Adjust clickable areas for Select and MultiSelect [#1545](https://github.com/greenbone/gsa/pull/1545)
 - Redirect to main page when visiting the login page and the user is already
   logged in [#1508](https://github.com/greenbone/gsa/pull/1508)
+- Lower memory usage when getting a report [#1858](https://github.com/greenbone/gvmd/pull/1858)
 
 ### Fixed
 - Fixed displaying update indication at all report details tabs [#1849](https://github.com/greenbone/gsa/pull/1849)

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -9914,12 +9914,72 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
         g_string_append (xml, extra_xml);
 
       if (delta_report_id)
-        g_string_append_printf (xml,
-                                "<delta>%s</delta>",
-                                delta_report_id);
+        {
+          g_string_append_printf (xml,
+                                  "<delta>%s</delta>",
+                                  delta_report_id);
 
-      entity = NULL;
-      if (read_entity_and_string_c (connection, &entity, &xml))
+          entity = NULL;
+          if (read_entity_and_string_c (connection, &entity, &xml))
+            {
+              cmd_response_data_set_status_code (response_data,
+                                                 MHD_HTTP_INTERNAL_SERVER_ERROR);
+              return gsad_message (
+                credentials, "Internal error", __FUNCTION__, __LINE__,
+                "An internal error occurred while getting a report. "
+                "The report could not be delivered. "
+                "Diagnostics: Failure to receive response from manager daemon.",
+                response_data);
+            }
+
+          if (gmp_success (entity) != 1)
+            {
+              gchar *message;
+
+              set_http_status_from_entity (entity, response_data);
+
+              message =
+                gsad_message (credentials, "Error", __FUNCTION__, __LINE__,
+                              entity_attribute (entity, "status_text"), response_data);
+
+              g_string_free (xml, TRUE);
+              free_entity (entity);
+              return message;
+            }
+
+          report_entity = entity_child (entity, "report");
+          if (report_entity)
+            report_entity = entity_child (report_entity, "report");
+          if (report_entity)
+            {
+              const char *id;
+              entity_t task_entity, name;
+
+              id = NULL;
+              task_entity = entity_child (report_entity, "task");
+              if (task_entity)
+                {
+                  id = entity_attribute (task_entity, "id");
+                  name = entity_child (task_entity, "name");
+                }
+              else
+                name = NULL;
+
+              if (delta_report_id && id && name)
+                g_string_append_printf (xml,
+                                        "<task id=\"%s\"><name>%s</name></task>",
+                                        id, entity_text (name));
+
+              free_entity (entity);
+            }
+
+          g_string_append (xml, "</get_report>");
+
+          return envelope_gmp (connection, credentials, params,
+                               g_string_free (xml, FALSE), response_data);
+        }
+
+      if (read_string_c (connection, &xml))
         {
           cmd_response_data_set_status_code (response_data,
                                              MHD_HTTP_INTERNAL_SERVER_ERROR);
@@ -9929,47 +9989,6 @@ get_report (gvm_connection_t *connection, credentials_t *credentials,
             "The report could not be delivered. "
             "Diagnostics: Failure to receive response from manager daemon.",
             response_data);
-        }
-
-    if (gmp_success (entity) != 1)
-      {
-        gchar *message;
-
-        set_http_status_from_entity (entity, response_data);
-
-        message =
-          gsad_message (credentials, "Error", __FUNCTION__, __LINE__,
-                        entity_attribute (entity, "status_text"), response_data);
-
-        g_string_free (xml, TRUE);
-        free_entity (entity);
-        return message;
-      }
-
-      report_entity = entity_child (entity, "report");
-      if (report_entity)
-        report_entity = entity_child (report_entity, "report");
-      if (report_entity)
-        {
-          const char *id;
-          entity_t task_entity, name;
-
-          id = NULL;
-          task_entity = entity_child (report_entity, "task");
-          if (task_entity)
-            {
-              id = entity_attribute (task_entity, "id");
-              name = entity_child (task_entity, "name");
-            }
-          else
-            name = NULL;
-
-          if (delta_report_id && id && name)
-            g_string_append_printf (xml,
-                                    "<task id=\"%s\"><name>%s</name></task>",
-                                    id, entity_text (name));
-
-          free_entity (entity);
         }
 
       g_string_append (xml, "</get_report>");


### PR DESCRIPTION
Requires https://github.com/greenbone/gvm-libs/pull/306.

read_string_c is faster and uses less memory than read_entity_and_string_c.

The delta report case still uses read_entity_and_string_c.  This could also be converted with a little support from the JS side.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
