### PR TITLE
Add usage_type param to get_aggregate_gmp in gsad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix TLS certificate download [#1704](https://github.com/greenbone/gsa/pull/1704)
 - Import additional polyfills for IE11 [#1702](https://github.com/greenbone/gsa/pull/1702)
 - Handle authentication errors in gsad more carefully [#1700](https://github.com/greenbone/gsa/pull/1700)
+- Add usage_type param to get_aggregate [#1872](https://github.com/greenbone/gsa/pull/1872)
 
 ### Removed
 - Removed auto delete field from container task dialog [#1784](https://github.com/greenbone/gsa/pull/1784)

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -4490,6 +4490,7 @@ get_aggregate_gmp (gvm_connection_t *connection, credentials_t *credentials,
   const char *filter, *filter_id;
   const char *first_group, *max_groups;
   const char *mode;
+  const char *usage_type;
   gchar *filter_escaped, *command_escaped, *response;
   entity_t entity;
   GString *xml, *command;
@@ -4509,6 +4510,7 @@ get_aggregate_gmp (gvm_connection_t *connection, credentials_t *credentials,
   first_group = params_value (params, "first_group");
   max_groups = params_value (params, "max_groups");
   mode = params_value (params, "aggregate_mode");
+  usage_type = params_value (params, "usage_type");
 
   if (filter && !str_equal (filter, ""))
     filter_escaped = g_markup_escape_text (filter, -1);
@@ -4548,6 +4550,9 @@ get_aggregate_gmp (gvm_connection_t *connection, credentials_t *credentials,
 
   if (mode && strcmp (mode, ""))
     g_string_append_printf (command, " mode=\"%s\"", mode);
+
+  if (usage_type && strcmp (usage_type, ""))
+    g_string_append_printf (command, " usage_type=\"%s\"", usage_type);
 
   g_string_append (command, ">");
 


### PR DESCRIPTION
This allows limiting the aggregate data for task and config charts to
their scan and compliance usage types.

**Checklist**:
- [] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
