### PR TITLE
Fix getting an error from the store for a report request

### DIFF
--- a/gsa/src/web/store/entities/report/__tests__/selectors.js
+++ b/gsa/src/web/store/entities/report/__tests__/selectors.js
@@ -154,7 +154,7 @@ describe('report selector tests', () => {
     const filter = Filter.fromString('foo=bar rows=10');
     const state = createState('report', {
       errors: {
-        [simplifiedReportIdentifier('foo', filter)]: 'An error',
+        [reportIdentifier('foo', filter)]: 'An error',
       },
     });
     const selector = reportSelector(state);

--- a/gsa/src/web/store/entities/report/selectors.js
+++ b/gsa/src/web/store/entities/report/selectors.js
@@ -51,7 +51,7 @@ class ReportSelector {
 
   getEntityError(id, filter) {
     return isDefined(this.state.errors)
-      ? this.state.errors[simplifiedReportIdentifier(id, filter)]
+      ? this.state.errors[reportIdentifier(id, filter)]
       : undefined;
   }
 


### PR DESCRIPTION
When requesting a report the report is put into the store with the full
filter. Therefore the selector needs to use the full filter to get the
error too.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry n/a
