### PR TITLE
handle undefined trash in case of an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [20.04] - unreleased
 
 ### Added
+- Added handling possible undefined trash in case of an error on the trashcanpage [#1908](https://github.com/greenbone/gsa/pull/1908)
 - Added translation using babel-plugin-i18next-extract [#1808](https://github.com/greenbone/gsa/pull/1808)
 - Multistep dialog feature, implemented on scanner dialog [#1725](https://github.com/greenbone/gsa/pull/1725)
 

--- a/gsa/src/web/pages/extras/trashcanpage.js
+++ b/gsa/src/web/pages/extras/trashcanpage.js
@@ -352,15 +352,13 @@ class Trashcan extends React.Component {
     }
 
     const {scan: tasks, compliance: audits} = separateByUsageType(
-      isDefined(trash) ? trash.task_list : undefined,
+      trash.task_list,
     );
     const {scan: configs, compliance: policies} = separateByUsageType(
-      isDefined(trash) ? trash.config_list : undefined,
+      trash.config_list,
     );
 
-    const contents_table = isDefined(trash)
-      ? this.createContentsTable(trash)
-      : undefined;
+    const contents_table = this.createContentsTable(trash);
 
     const table_props = {
       links: false,

--- a/gsa/src/web/pages/extras/trashcanpage.js
+++ b/gsa/src/web/pages/extras/trashcanpage.js
@@ -342,20 +342,25 @@ class Trashcan extends React.Component {
   }
 
   render() {
-    const {error, trash, loading} = this.state;
+    const {error, loading} = this.state;
+    let {trash} = this.state;
 
     if (!isDefined(trash) && !isDefined(error)) {
       return <Loading />;
+    } else if (!isDefined(trash) && isDefined(error)) {
+      trash = {};
     }
 
     const {scan: tasks, compliance: audits} = separateByUsageType(
-      trash.task_list,
+      isDefined(trash) ? trash.task_list : undefined,
     );
     const {scan: configs, compliance: policies} = separateByUsageType(
-      trash.config_list,
+      isDefined(trash) ? trash.config_list : undefined,
     );
 
-    const contents_table = this.createContentsTable(trash);
+    const contents_table = isDefined(trash)
+      ? this.createContentsTable(trash)
+      : undefined;
 
     const table_props = {
       links: false,


### PR DESCRIPTION
In case of an error on the trashcanpage the trash might be undefined which would cause the trashcanpage to break. This PR should fix that by catching this special case.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
