### PR TITLE
Remove componentWillReceiveProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Multistep dialog feature, implemented on scanner dialog [#1725](https://github.com/greenbone/gsa/pull/1725)
 
 ### Changed
+- Adjust multiselect and report listpage to use getDerivedStateFromProps instead of deprecated componentWillReceiveProps [#1935](https://github.com/greenbone/gsa/pull/1935)
 - Update react-beautiful-dnd to version 12.2.0 and fix dragging into empty row [#1837](https://github.com/greenbone/gsa/pull/1837)
 - Deleting a single entity now removes its ID from store [#1839](https://github.com/greenbone/gsa/pull/1839)
 

--- a/gsa/src/web/components/form/__tests__/multiselect.js
+++ b/gsa/src/web/components/form/__tests__/multiselect.js
@@ -219,7 +219,7 @@ describe('MultiSelect component tests', () => {
     expect(domItems.length).toEqual(1);
   });
 
-  test('should remove selected item', () => {
+  test('should call onChange handler to remove selected item', () => {
     const items = [
       {
         value: 'bar',
@@ -237,15 +237,12 @@ describe('MultiSelect component tests', () => {
       <MultiSelect items={items} value={['bar', 'foo']} onChange={onChange} />,
     );
 
-    let selectedItems = getAllByTestId('multiselect-selected-label');
+    const selectedItems = getAllByTestId('multiselect-selected-label');
     expect(selectedItems.length).toEqual(2);
 
     const deleteIcons = getAllByTestId('multiselect-selected-delete');
     expect(deleteIcons.length).toEqual(2);
     fireEvent.click(deleteIcons[0]);
-
-    selectedItems = getAllByTestId('multiselect-selected-label');
-    expect(selectedItems.length).toEqual(1);
 
     expect(onChange).toHaveBeenCalledWith(['foo'], undefined);
   });

--- a/gsa/src/web/components/form/multiselect.js
+++ b/gsa/src/web/components/form/multiselect.js
@@ -83,6 +83,7 @@ class MultiSelect extends React.Component {
     const {value} = this.props;
 
     this.state = {
+      value,
       search: '',
       selectedItems: isArray(value) ? value : [],
     };
@@ -144,12 +145,12 @@ class MultiSelect extends React.Component {
     this.notifyChange(copy);
   }
 
-  componentWillReceiveProps(nextProps) {
-    const {value} = nextProps;
-
-    if (isDefined(value) && !arraysEqual(value, this.state.selectedItems)) {
-      this.setState({selectedItems: value});
+  static getDerivedStateFromProps(props, state) {
+    const {value} = props;
+    if (isDefined(value) && !arraysEqual(value, state.value)) {
+      return {selectedItems: value, value};
     }
+    return null;
   }
 
   renderItem(value, items) {

--- a/gsa/src/web/pages/reports/listpage.js
+++ b/gsa/src/web/pages/reports/listpage.js
@@ -106,9 +106,9 @@ class Page extends React.Component {
     this.openCreateTaskDialog = this.openCreateTaskDialog.bind(this);
   }
 
-  componentWillReceiveProps(next) {
-    const {filter} = next;
-    const {selectedDeltaReport} = this.state;
+  static getDerivedStateFromProps(props, state) {
+    const {filter} = props;
+    const {selectedDeltaReport} = state;
 
     if (
       isDefined(selectedDeltaReport) &&
@@ -116,8 +116,9 @@ class Page extends React.Component {
         filter.get('task_id') !== selectedDeltaReport.task.id)
     ) {
       // filter has changed. reset delta report selection
-      this.setState({selectedDeltaReport: undefined});
+      return {selectedDeltaReport: undefined};
     }
+    return null;
   }
 
   openCreateTaskDialog() {


### PR DESCRIPTION
ComponentWillReceiveProps is deprecated. Update components that still use it to use getDerivedStateFromProps instead.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
