### PR TITLE
fix missing delete button for host identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Lower memory usage when getting a report [#1858](https://github.com/greenbone/gvmd/pull/1858)
 
 ### Fixed
+- Fixed missing delete button for host identifiers [#1959](https://github.com/greenbone/gsa/pull/1959)
 - Fixed sorting columns with empty string values [#1936](https://github.com/greenbone/gsa/pull/1936)
 - Fixed broken entity links for reportformat, scanconfig and portlist [#1934](https://github.com/greenbone/gsa/pull/1934)
 - Fixed removing levels filter keyword if all severity levels are unchecked [#1869](https://github.com/greenbone/gsa/pull/1869)

--- a/gsa/src/web/pages/hosts/detailspage.js
+++ b/gsa/src/web/pages/hosts/detailspage.js
@@ -295,7 +295,6 @@ const Page = ({
           onHostDeleteClick={delete_func}
           onHostDownloadClick={download}
           onHostEditClick={edit}
-          onHostIdentifierDeleteClick={deleteidentifier}
         >
           {({activeTab = 0, onActivateTab}) => {
             return (
@@ -319,7 +318,10 @@ const Page = ({
                 <Tabs active={activeTab}>
                   <TabPanels>
                     <TabPanel>
-                      <Details entity={entity} />
+                      <Details
+                        entity={entity}
+                        onHostIdentifierDeleteClick={deleteidentifier}
+                      />
                     </TabPanel>
                     <TabPanel>
                       <EntityTags


### PR DESCRIPTION
Fix missing delete button for host identifiers. Click handler needs to be passed to details directly because entity page does not forward props like entities page does.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
