### PR TITLE
Add Renew Session Timeout icon to usermenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [20.04] - unreleased
 
 ### Added
+- Added a renew session timeout icon to usermenu [#1966](https://github.com/greenbone/gsa/pull/1966)
 - Added new BPM feature [#1931](https://github.com/greenbone/gsa/pull/1931)
 - Added clean-up-translations script [#1948](https://github.com/greenbone/gsa/pull/1948)
 - Added handling possible undefined trash in case of an error on the trashcanpage [#1908](https://github.com/greenbone/gsa/pull/1908)

--- a/gsa/src/web/components/bar/__tests__/__snapshots__/titlebar.js.snap
+++ b/gsa/src/web/components/bar/__tests__/__snapshots__/titlebar.js.snap
@@ -171,6 +171,10 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   display: inline-flex;
 }
 
+.c16 {
+  cursor: pointer;
+}
+
 .c8 {
   height: 24px;
   width: 24px;
@@ -223,12 +227,12 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   z-index: 600;
   list-style: none;
   font-size: 10px;
-  width: 255px;
+  width: 280px;
 }
 
 .c12 {
   height: 30px;
-  width: 255px;
+  width: 280px;
   border-left: 1px solid #787878;
   border-right: 1px solid #787878;
   display: -webkit-box;
@@ -277,7 +281,7 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   margin-right: 10px;
 }
 
-.c16 {
+.c17 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -286,11 +290,11 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   height: 100%;
 }
 
-.c16:link,
-.c16:hover,
-.c16:active,
-.c16:visited,
-.c16:hover {
+.c17:link,
+.c17:hover,
+.c17:active,
+.c17:visited,
+.c17:hover {
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -335,6 +339,12 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
 
 .c0 {
   height: 42px;
+}
+
+@media print {
+  .c16 {
+    display: none;
+  }
 }
 
 <body>
@@ -432,6 +442,17 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
                   <span>
                     Session timeout: 
                   </span>
+                  <span
+                    class="c16 c15"
+                    data-testid="svg-icon"
+                    title="Renew session timeout"
+                  >
+                    <svg
+                      title="Renew session timeout"
+                    >
+                      refresh.svg
+                    </svg>
+                  </span>
                 </div>
               </div>
             </li>
@@ -439,7 +460,7 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
               class="c12"
             >
               <a
-                class="c16"
+                class="c17"
                 data-testid="usermenu-settings"
                 href="/usersettings"
               >

--- a/gsa/src/web/components/bar/__tests__/__snapshots__/titlebar.js.snap
+++ b/gsa/src/web/components/bar/__tests__/__snapshots__/titlebar.js.snap
@@ -227,12 +227,12 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   z-index: 600;
   list-style: none;
   font-size: 10px;
-  width: 280px;
+  width: 300px;
 }
 
 .c12 {
   height: 30px;
-  width: 280px;
+  width: 300px;
   border-left: 1px solid #787878;
   border-right: 1px solid #787878;
   display: -webkit-box;

--- a/gsa/src/web/components/menu/__tests__/__snapshots__/usermenu.js.snap
+++ b/gsa/src/web/components/menu/__tests__/__snapshots__/usermenu.js.snap
@@ -109,12 +109,12 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   z-index: 600;
   list-style: none;
   font-size: 10px;
-  width: 280px;
+  width: 300px;
 }
 
 .c6 {
   height: 30px;
-  width: 280px;
+  width: 300px;
   border-left: 1px solid #787878;
   border-right: 1px solid #787878;
   display: -webkit-box;

--- a/gsa/src/web/components/menu/__tests__/__snapshots__/usermenu.js.snap
+++ b/gsa/src/web/components/menu/__tests__/__snapshots__/usermenu.js.snap
@@ -53,6 +53,10 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   display: inline-flex;
 }
 
+.c10 {
+  cursor: pointer;
+}
+
 .c2 {
   height: 24px;
   width: 24px;
@@ -105,12 +109,12 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   z-index: 600;
   list-style: none;
   font-size: 10px;
-  width: 255px;
+  width: 280px;
 }
 
 .c6 {
   height: 30px;
-  width: 255px;
+  width: 280px;
   border-left: 1px solid #787878;
   border-right: 1px solid #787878;
   display: -webkit-box;
@@ -159,7 +163,7 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   margin-right: 10px;
 }
 
-.c10 {
+.c11 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -168,14 +172,20 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   height: 100%;
 }
 
-.c10:link,
-.c10:hover,
-.c10:active,
-.c10:visited,
-.c10:hover {
+.c11:link,
+.c11:hover,
+.c11:active,
+.c11:visited,
+.c11:hover {
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
+}
+
+@media print {
+  .c10 {
+    display: none;
+  }
 }
 
 <span
@@ -240,6 +250,17 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
             <span>
               Session timeout: 
             </span>
+            <span
+              class="c10 c9"
+              data-testid="svg-icon"
+              title="Renew session timeout"
+            >
+              <svg
+                title="Renew session timeout"
+              >
+                refresh.svg
+              </svg>
+            </span>
           </div>
         </div>
       </li>
@@ -247,7 +268,7 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
         class="c6"
       >
         <a
-          class="c10"
+          class="c11"
           data-testid="usermenu-settings"
           href="/usersettings"
         >

--- a/gsa/src/web/components/menu/__tests__/usermenu.js
+++ b/gsa/src/web/components/menu/__tests__/usermenu.js
@@ -78,6 +78,25 @@ describe('UserMenu component tests', () => {
 
     expect(gmp.doLogout).toHaveBeenCalled();
   });
+
+  test('should renew session timeout on click', () => {
+    const renewSession = jest
+      .fn()
+      .mockResolvedValue({data: '2019-10-10T12:00:00Z'});
+    const gmp = {
+      user: {
+        renewSession,
+      },
+    };
+    const {render} = rendererWith({gmp, store: true, router: true});
+
+    const {getAllByTestId} = render(<UserMenu />);
+    const icons = getAllByTestId('svg-icon');
+
+    fireEvent.click(icons[3]);
+
+    expect(gmp.user.renewSession).toHaveBeenCalled();
+  });
 });
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/components/menu/usermenu.js
+++ b/gsa/src/web/components/menu/usermenu.js
@@ -174,14 +174,11 @@ const UserMenuContainer = () => {
                   date: dateTimeWithTimeZone(sessionTimeout, userTimezone),
                 })}
               </span>
-              <span>
-                <RefreshIcon
-                  data-testid="usermenu-renewsession"
-                  title={_('Renew session timeout')}
-                  size="small"
-                  onClick={handleRenewSessionTimeout}
-                />
-              </span>
+              <RefreshIcon
+                title={_('Renew session timeout')}
+                size="small"
+                onClick={handleRenewSessionTimeout}
+              />
             </Divider>
           </Entry>
           <Entry>

--- a/gsa/src/web/components/menu/usermenu.js
+++ b/gsa/src/web/components/menu/usermenu.js
@@ -77,12 +77,12 @@ const List = styled.ul`
   z-index: ${Theme.Layers.menu};
   list-style: none;
   font-size: 10px;
-  width: 280px;
+  width: 300px;
 `;
 
 const Entry = styled.li`
   height: 30px;
-  width: 280px;
+  width: 300px;
   border-left: 1px solid ${Theme.mediumGray};
   border-right: 1px solid ${Theme.mediumGray};
   display: flex;

--- a/gsa/src/web/components/menu/usermenu.js
+++ b/gsa/src/web/components/menu/usermenu.js
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Greenbone Networks GmbH
+/* Copyright (C) 2019-2020 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -18,6 +18,8 @@
  */
 import React from 'react';
 
+import {useDispatch} from 'react-redux';
+
 import {useHistory} from 'react-router-dom';
 
 import styled, {keyframes} from 'styled-components';
@@ -27,11 +29,14 @@ import {dateTimeWithTimeZone} from 'gmp/locale/date';
 
 import LogoutIcon from 'web/components/icon/logouticon';
 import MySettingsIcon from 'web/components/icon/mysettingsicon';
+import RefreshIcon from 'web/components/icon/refreshicon';
 import ScheduleIcon from 'web/components/icon/scheduleicon';
 import UserIcon from 'web/components/icon/usericon';
 
 import Divider from 'web/components/layout/divider';
 import Link from 'web/components/link/link';
+
+import {setSessionTimeout} from 'web/store/usersettings/actions';
 
 import Theme from 'web/utils/theme';
 import useGmp from 'web/utils/useGmp';
@@ -72,12 +77,12 @@ const List = styled.ul`
   z-index: ${Theme.Layers.menu};
   list-style: none;
   font-size: 10px;
-  width: 255px;
+  width: 280px;
 `;
 
 const Entry = styled.li`
   height: 30px;
-  width: 255px;
+  width: 280px;
   border-left: 1px solid ${Theme.mediumGray};
   border-right: 1px solid ${Theme.mediumGray};
   display: flex;
@@ -129,6 +134,7 @@ const StyledLink = styled(Link)`
 `;
 
 const UserMenuContainer = () => {
+  const dispatch = useDispatch();
   const sessionTimeout = useUserSessionTimeout();
   const userTimezone = useUserTimezone();
   const userName = useUserName();
@@ -141,6 +147,12 @@ const UserMenuContainer = () => {
     gmp.doLogout().then(() => {
       history.push('/login?type=logout');
     });
+  };
+
+  const handleRenewSessionTimeout = () => {
+    gmp.user
+      .renewSession()
+      .then(response => dispatch(setSessionTimeout(response.data)));
   };
 
   return (
@@ -161,6 +173,14 @@ const UserMenuContainer = () => {
                 {_('Session timeout: {{date}}', {
                   date: dateTimeWithTimeZone(sessionTimeout, userTimezone),
                 })}
+              </span>
+              <span>
+                <RefreshIcon
+                  data-testid="usermenu-renewsession"
+                  title={_('Renew session timeout')}
+                  size="small"
+                  onClick={handleRenewSessionTimeout}
+                />
               </span>
             </Divider>
           </Entry>


### PR DESCRIPTION
This adds a small icon to the usermenu allowing to renew the session timeout without triggering another action in GSA.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
