### PR TITLE
Parse xml rejection message (unescape)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Deleting a single entity now removes its ID from store [#1839](https://github.com/greenbone/gsa/pull/1839)
 
 ### Fixed
+- Fix parsing xml rejection messages [#1970](https://github.com/greenbone/gsa/pull/1970)
 - Fix returning bulk_delete response [#1969](https://github.com/greenbone/gsa/pull/1969)
 - Fix parsing DFN-Cert CVE entries [#1965](https://github.com/greenbone/gsa/pull/1965)
 

--- a/gsa/src/gmp/http/transform/fastxml.js
+++ b/gsa/src/gmp/http/transform/fastxml.js
@@ -42,7 +42,7 @@ const transformXmlData = response => {
 
 const transformRejection = rej => {
   const xmlString = rej.plainData('text');
-  return isDefined(xmlString) ? parse(xmlString) : undefined;
+  return isDefined(xmlString) ? parse(xmlString, PARSER_OPTIONS) : undefined;
 };
 
 export default {


### PR DESCRIPTION
Error messages like "Failed to find task &apos;foo&apos;" are now handled correctly. This concerned xml gsad_response and action_result messages.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
