### PR TITLE
Use correct capabilities for task icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Lower memory usage when getting a report [#1858](https://github.com/greenbone/gvmd/pull/1858)
 
 ### Fixed
+- Use correct capabilities for task icons [#1973](https://github.com/greenbone/gsa/pull/1973)
 - Fixed ProvideViewIcon for tasks is only shown for users but not for groups and roles [#1968](https://github.com/greenbone/gsa/pull/1968)
 - Fixed missing delete button for host identifiers [#1959](https://github.com/greenbone/gsa/pull/1959)
 - Fixed sorting columns with empty string values [#1936](https://github.com/greenbone/gsa/pull/1936)

--- a/gsa/src/web/pages/tasks/icons/__tests__/resumeicon.js
+++ b/gsa/src/web/pages/tasks/icons/__tests__/resumeicon.js
@@ -1,0 +1,163 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import React from 'react';
+
+import Capabilities from 'gmp/capabilities/capabilities';
+
+import Task, {TASK_STATUS} from 'gmp/models/task';
+
+import {rendererWith, fireEvent} from 'web/utils/testing';
+
+import Theme from 'web/utils/theme';
+
+import ResumeIcon from '../resumeicon';
+
+describe('Task ResumeIcon component tests', () => {
+  test('should render in active state with correct permissions', () => {
+    const caps = new Capabilities(['everything']);
+    const task = Task.fromElement({
+      status: TASK_STATUS.stopped,
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'everything'}]},
+    });
+    const clickHandler = jest.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<ResumeIcon task={task} onClick={clickHandler} />);
+
+    expect(caps.mayOp('resume_task')).toEqual(true);
+    expect(task.userCapabilities.mayOp('resume_task')).toEqual(true);
+
+    fireEvent.click(element);
+
+    expect(clickHandler).toHaveBeenCalled();
+    expect(element).toHaveAttribute('title', 'Resume');
+    expect(element).not.toHaveStyleRule('fill', Theme.inputBorderGray, {
+      modifier: `svg path`,
+    });
+  });
+
+  test('should render in inactive state if wrong command level permissions are given', () => {
+    const caps = new Capabilities(['everything']);
+    const task = Task.fromElement({
+      status: TASK_STATUS.stopped,
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'get_task'}]},
+    });
+    const clickHandler = jest.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<ResumeIcon task={task} />);
+
+    expect(caps.mayOp('resume_task')).toEqual(true);
+    expect(task.userCapabilities.mayOp('resume_task')).toEqual(false);
+
+    fireEvent.click(element);
+
+    expect(clickHandler).not.toHaveBeenCalled();
+    expect(element).toHaveAttribute(
+      'title',
+      'Permission to resume task denied',
+    );
+    expect(element).toHaveStyleRule('fill', Theme.inputBorderGray, {
+      modifier: `svg path`,
+    });
+  });
+
+  test('should render in inactive state if task is not stopped', () => {
+    const caps = new Capabilities(['everything']);
+    const task = Task.fromElement({
+      status: TASK_STATUS.new,
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'everything'}]},
+    });
+    const clickHandler = jest.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<ResumeIcon task={task} />);
+
+    expect(caps.mayOp('resume_task')).toEqual(true);
+    expect(task.userCapabilities.mayOp('resume_task')).toEqual(true);
+
+    fireEvent.click(element);
+
+    expect(clickHandler).not.toHaveBeenCalled();
+    expect(element).toHaveAttribute('title', 'Task is not stopped');
+    expect(element).toHaveStyleRule('fill', Theme.inputBorderGray, {
+      modifier: `svg path`,
+    });
+  });
+
+  test('should render in inactive state if task is scheduled', () => {
+    const caps = new Capabilities(['everything']);
+    const elem = {
+      status: TASK_STATUS.new,
+      schedule: {
+        _id: 'schedule1',
+      },
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'everything'}]},
+    };
+    const task = Task.fromElement(elem);
+    const clickHandler = jest.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<ResumeIcon task={task} />);
+
+    expect(caps.mayOp('resume_task')).toEqual(true);
+    expect(task.userCapabilities.mayOp('resume_task')).toEqual(true);
+
+    fireEvent.click(element);
+
+    expect(clickHandler).not.toHaveBeenCalled();
+    expect(element).toHaveAttribute('title', 'Task is scheduled');
+    expect(element).toHaveStyleRule('fill', Theme.inputBorderGray, {
+      modifier: `svg path`,
+    });
+  });
+
+  test('should render in inactive state if task is a container', () => {
+    const caps = new Capabilities(['everything']);
+    const elem = {
+      status: TASK_STATUS.new,
+      permissions: {permission: [{name: 'everything'}]},
+    };
+    const task = Task.fromElement(elem);
+    const clickHandler = jest.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<ResumeIcon task={task} />);
+
+    expect(caps.mayOp('resume_task')).toEqual(true);
+    expect(task.userCapabilities.mayOp('resume_task')).toEqual(true);
+
+    fireEvent.click(element);
+
+    expect(clickHandler).not.toHaveBeenCalled();
+    expect(element).toHaveAttribute('title', 'Task is a container');
+    expect(element).toHaveStyleRule('fill', Theme.inputBorderGray, {
+      modifier: `svg path`,
+    });
+  });
+});

--- a/gsa/src/web/pages/tasks/icons/__tests__/starticon.js
+++ b/gsa/src/web/pages/tasks/icons/__tests__/starticon.js
@@ -1,0 +1,141 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import React from 'react';
+
+import Capabilities from 'gmp/capabilities/capabilities';
+
+import Task, {TASK_STATUS} from 'gmp/models/task';
+
+import {rendererWith, fireEvent} from 'web/utils/testing';
+
+import Theme from 'web/utils/theme';
+
+import StartIcon from '../starticon';
+
+describe('Task StartIcon component tests', () => {
+  test('should render in active state with correct permissions', () => {
+    const caps = new Capabilities(['everything']);
+    const task = Task.fromElement({
+      status: TASK_STATUS.new,
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'everything'}]},
+    });
+    const clickHandler = jest.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<StartIcon task={task} onClick={clickHandler} />);
+
+    expect(caps.mayOp('start_task')).toEqual(true);
+    expect(task.userCapabilities.mayOp('start_task')).toEqual(true);
+
+    fireEvent.click(element);
+
+    expect(clickHandler).toHaveBeenCalled();
+    expect(element).toHaveAttribute('title', 'Start');
+    expect(element).not.toHaveStyleRule('fill', Theme.inputBorderGray, {
+      modifier: `svg path`,
+    });
+  });
+
+  test('should render in inactive state if wrong command level permissions are given', () => {
+    const caps = new Capabilities(['everything']);
+    const task = Task.fromElement({
+      status: TASK_STATUS.new,
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'get_task'}]},
+    });
+    const clickHandler = jest.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<StartIcon task={task} />);
+
+    expect(caps.mayOp('start_task')).toEqual(true);
+    expect(task.userCapabilities.mayOp('start_task')).toEqual(false);
+
+    fireEvent.click(element);
+
+    expect(clickHandler).not.toHaveBeenCalled();
+    expect(element).toHaveAttribute('title', 'Permission to start Task denied');
+    expect(element).toHaveStyleRule('fill', Theme.inputBorderGray, {
+      modifier: `svg path`,
+    });
+  });
+
+  test('should render in inactive state if task is already active', () => {
+    const caps = new Capabilities(['everything']);
+    const task = Task.fromElement({
+      status: TASK_STATUS.requested,
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'everything'}]},
+    });
+    const clickHandler = jest.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<StartIcon task={task} />);
+
+    expect(caps.mayOp('start_task')).toEqual(true);
+    expect(task.userCapabilities.mayOp('start_task')).toEqual(true);
+
+    fireEvent.click(element);
+
+    expect(clickHandler).not.toHaveBeenCalled();
+    expect(element).toHaveAttribute('title', 'Task is already active');
+    expect(element).toHaveStyleRule('fill', Theme.inputBorderGray, {
+      modifier: `svg path`,
+    });
+  });
+
+  test('should not be rendered if task is running', () => {
+    const caps = new Capabilities(['everything']);
+    const task = Task.fromElement({
+      status: TASK_STATUS.running,
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'everything'}]},
+    });
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<StartIcon task={task} />);
+
+    expect(caps.mayOp('start_task')).toEqual(true);
+    expect(task.userCapabilities.mayOp('start_task')).toEqual(true);
+    expect(element).toEqual(null);
+  });
+
+  test('should not be rendered if task is a container', () => {
+    const caps = new Capabilities(['everything']);
+    const task = Task.fromElement({
+      status: TASK_STATUS.new,
+      permissions: {permission: [{name: 'everything'}]},
+    });
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<StartIcon task={task} />);
+
+    expect(caps.mayOp('start_task')).toEqual(true);
+    expect(task.userCapabilities.mayOp('start_task')).toEqual(true);
+    expect(element).toEqual(null);
+  });
+});
+
+// vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/tasks/icons/__tests__/stopicon.js
+++ b/gsa/src/web/pages/tasks/icons/__tests__/stopicon.js
@@ -1,0 +1,119 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+import React from 'react';
+
+import Capabilities from 'gmp/capabilities/capabilities';
+
+import Task, {TASK_STATUS} from 'gmp/models/task';
+
+import {rendererWith, fireEvent} from 'web/utils/testing';
+
+import Theme from 'web/utils/theme';
+
+import StopIcon from '../stopicon';
+
+describe('Task StopIcon component tests', () => {
+  test('should render in active state with correct permissions', () => {
+    const caps = new Capabilities(['everything']);
+    const task = Task.fromElement({
+      status: TASK_STATUS.running,
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'everything'}]},
+    });
+    const clickHandler = jest.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<StopIcon task={task} onClick={clickHandler} />);
+
+    expect(caps.mayOp('stop_task')).toEqual(true);
+    expect(task.userCapabilities.mayOp('stop_task')).toEqual(true);
+
+    fireEvent.click(element);
+
+    expect(clickHandler).toHaveBeenCalled();
+    expect(element).toHaveAttribute('title', 'Stop');
+    expect(element).not.toHaveStyleRule('fill', Theme.inputBorderGray, {
+      modifier: `svg path`,
+    });
+  });
+
+  test('should render in inactive state if wrong command level permissions are given', () => {
+    const caps = new Capabilities(['everything']);
+    const task = Task.fromElement({
+      status: TASK_STATUS.running,
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'get_task'}]},
+    });
+    const clickHandler = jest.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<StopIcon task={task} onClick={clickHandler} />);
+
+    expect(caps.mayOp('stop_task')).toEqual(true);
+    expect(task.userCapabilities.mayOp('stop_task')).toEqual(false);
+    fireEvent.click(element);
+
+    expect(clickHandler).not.toHaveBeenCalled();
+    expect(element).toHaveAttribute('title', 'Permission to stop Task denied');
+    expect(element).toHaveStyleRule('fill', Theme.inputBorderGray, {
+      modifier: `svg path`,
+    });
+  });
+
+  test('should not be rendered if task is not running', () => {
+    const caps = new Capabilities(['everything']);
+    const task = Task.fromElement({
+      status: TASK_STATUS.new,
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'everything'}]},
+    });
+    const clickHandler = jest.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<StopIcon task={task} onClick={clickHandler} />);
+
+    expect(caps.mayOp('stop_task')).toEqual(true);
+    expect(task.userCapabilities.mayOp('stop_task')).toEqual(true);
+
+    expect(element).toEqual(null);
+  });
+
+  test('should not be rendered if task is a container', () => {
+    const caps = new Capabilities(['everything']);
+    const task = Task.fromElement({
+      status: TASK_STATUS.running,
+      permissions: {permission: [{name: 'everything'}]},
+    });
+    const clickHandler = jest.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<StopIcon task={task} onClick={clickHandler} />);
+
+    expect(caps.mayOp('stop_task')).toEqual(true);
+    expect(task.userCapabilities.mayOp('stop_task')).toEqual(true);
+
+    expect(element).toEqual(null);
+  });
+});
+
+// vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/tasks/icons/resumeicon.js
+++ b/gsa/src/web/pages/tasks/icons/resumeicon.js
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2019 Greenbone Networks GmbH
+/* Copyright (C) 2017-2020 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -49,7 +49,10 @@ const TaskResumeIcon = ({capabilities, task, onClick}) => {
   }
 
   if (task.isStopped() || task.isInterrupted()) {
-    if (capabilities.mayOp('resume_task')) {
+    if (
+      capabilities.mayOp('start_task') &&
+      task.userCapabilities.mayOp('start_task')
+    ) {
       return <ResumeIcon title={_('Resume')} value={task} onClick={onClick} />;
     }
     return (

--- a/gsa/src/web/pages/tasks/icons/starticon.js
+++ b/gsa/src/web/pages/tasks/icons/starticon.js
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2019 Greenbone Networks GmbH
+/* Copyright (C) 2017-2020 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -30,7 +30,10 @@ const TaskStartIcon = ({capabilities, task, onClick}) => {
     return null;
   }
 
-  if (!capabilities.mayOp('start_task')) {
+  if (
+    !capabilities.mayOp('start_task') ||
+    !task.userCapabilities.mayOp('start_task')
+  ) {
     return (
       <StartIcon active={false} title={_('Permission to start Task denied')} />
     );

--- a/gsa/src/web/pages/tasks/icons/stopicon.js
+++ b/gsa/src/web/pages/tasks/icons/stopicon.js
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2019 Greenbone Networks GmbH
+/* Copyright (C) 2017-2020 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -21,11 +21,20 @@ import React from 'react';
 import _ from 'gmp/locale';
 
 import PropTypes from 'web/utils/proptypes';
+import withCapabilities from 'web/utils/withCapabilities';
 
 import StopIcon from 'web/components/icon/stopicon';
 
-const TaskStopIcon = ({size, task, onClick}) => {
+const TaskStopIcon = ({capabilities, size, task, onClick}) => {
   if (task.isRunning() && !task.isContainer()) {
+    if (
+      !capabilities.mayOp('stop_task') ||
+      !task.userCapabilities.mayOp('stop_task')
+    ) {
+      return (
+        <StopIcon active={false} title={_('Permission to stop Task denied')} />
+      );
+    }
     return (
       <StopIcon size={size} title={_('Stop')} value={task} onClick={onClick} />
     );
@@ -34,11 +43,12 @@ const TaskStopIcon = ({size, task, onClick}) => {
 };
 
 TaskStopIcon.propTypes = {
+  capabilities: PropTypes.capabilities.isRequired,
   size: PropTypes.iconSize,
   task: PropTypes.model.isRequired,
   onClick: PropTypes.func,
 };
 
-export default TaskStopIcon;
+export default withCapabilities(TaskStopIcon);
 
 // vim: set ts=2 sw=2 tw=80:


### PR DESCRIPTION
The icons for start task, stop task and resume task were only checking if the user had permission to start/stop/resume tasks in general but not if he had permissions for that task in particular.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
