### PR TITLE
Adjust DEFAULT_OID_VALUE for use with new oid scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Display timezone for session timeout in user menu [#1764](https://github.com/greenbone/gsa/pull/1764)
 
 ### Changed
+- Adjusted DEFAULT_OID_VALUE for use with new oid scheme [#1974](https://github.com/greenbone/gsa/pull/1974)
 - Made delta report diffs more explicit [#1950](https://github.com/greenbone/gsa/pull/1950)
 - Changed default port to 22 for scanner dialog [#1768](https://github.com/greenbone/gsa/pull/1768)
 - Improved Delta Report Details [#1748](https://github.com/greenbone/gsa/pull/1748)

--- a/gsa/src/gmp/models/override.js
+++ b/gsa/src/gmp/models/override.js
@@ -39,7 +39,7 @@ export const ACTIVE_YES_ALWAYS_VALUE = '-1';
 export const ACTIVE_YES_UNTIL_VALUE = '-2';
 
 export const DEFAULT_DAYS = 30;
-export const DEFAULT_OID_VALUE = '1.3.6.1.4.1.25623.1.0.';
+export const DEFAULT_OID_VALUE = '1.3.6.1.4.1.25623.1.';
 
 export const TASK_ANY = '';
 export const TASK_SELECTED = '0';

--- a/gsa/src/web/pages/results/details.js
+++ b/gsa/src/web/pages/results/details.js
@@ -29,6 +29,8 @@ import {isEmpty} from 'gmp/utils/string';
 
 import {TAG_NA} from 'gmp/models/nvt';
 
+import {DEFAULT_OID_VALUE} from 'gmp/models/override';
+
 import Layout from 'web/components/layout/layout';
 
 import PropTypes from 'web/utils/proptypes';
@@ -299,7 +301,7 @@ const ResultDetails = ({className, links = true, entity}) => {
                       {oid}
                     </DetailsLink>
                   )}
-                  {isDefined(oid) && oid.startsWith('1.3.6.1.4.1.25623.1.0.') && (
+                  {isDefined(oid) && oid.startsWith(DEFAULT_OID_VALUE) && (
                     <span>
                       <DetailsLink type="nvt" id={oid} textOnly={!links}>
                         {renderNvtName(oid, nvt.name)}


### PR DESCRIPTION
With the new scheme as introduced in [this community post](https://community.greenbone.net/t/extending-oid-scheme/4420) the old DEFAULT_OID_VALUE was too strict to work with newer VTs.
This goes together with https://github.com/greenbone/gvmd/pull/984.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
