### PR TITLE
Adjust #1975 after PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Lower memory usage when getting a report [#1857](https://github.com/greenbone/gvmd/pull/1857)
 
 ### Fixed
-- Do not crash if osCpe or osTxt are undefined in OsIcon [#1975](https://github.com/greenbone/gsa/pull/1975)
+- Do not crash if osCpe or osTxt are undefined in OsIcon [#1975](https://github.com/greenbone/gsa/pull/1975) [#1978](https://github.com/greenbone/gsa/pull/1978)
 - Fix task listpage observer tooltip [#1949](https://github.com/greenbone/gsa/pull/1949)
 - Fix broken entity links for reportformat, scanconfig and portlist [#1937](https://github.com/greenbone/gsa/pull/1937)
 - Fix showing resource as orphaned when it's not [#1921](https://github.com/greenbone/gsa/pull/1921)

--- a/gsa/src/web/components/icon/osicon.js
+++ b/gsa/src/web/components/icon/osicon.js
@@ -22,7 +22,7 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
+import {isDefined, isString} from 'gmp/utils/identity';
 
 import OperatingSystems from 'web/utils/os';
 
@@ -36,16 +36,16 @@ import Img from 'web/components/img/img';
 const OsIcon = ({
   displayOsCpe = true,
   displayOsName = false,
-  osTxt = '',
-  osCpe = '',
+  osTxt,
+  osCpe,
   ...props
 }) => {
-  const os = OperatingSystems.find(osCpe);
+  const os = isString(osCpe) ? OperatingSystems.find(osCpe) : undefined;
 
   let title;
   let os_icon;
 
-  if (osTxt.includes('[possible conflict]')) {
+  if (isString(osTxt) && osTxt.includes('[possible conflict]')) {
     os_icon = 'os_conflict.svg';
     if (displayOsCpe) {
       title = _('OS Conflict: {{best_os_txt}} ({{best_os_cpe}})', {


### PR DESCRIPTION
Don't crash OsIcon when osCpe or osTxt is undefined

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
