### PR TITLE
Correctly pluralizing type "vulnerability"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Lower memory usage when getting a report [#1857](https://github.com/greenbone/gvmd/pull/1857)
 
 ### Fixed
+- Fixed pluralizing type 'vulnerability' [#1984](https://github.com/greenbone/gsa/pull/1984)
 - Do not crash if osCpe or osTxt are undefined in OsIcon [#1975](https://github.com/greenbone/gsa/pull/1975) [#1978](https://github.com/greenbone/gsa/pull/1978)
 - Fix task listpage observer tooltip [#1949](https://github.com/greenbone/gsa/pull/1949)
 - Fix broken entity links for reportformat, scanconfig and portlist [#1937](https://github.com/greenbone/gsa/pull/1937)

--- a/gsa/src/gmp/utils/__tests__/entitytype.js
+++ b/gsa/src/gmp/utils/__tests__/entitytype.js
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018-2019 Greenbone Networks GmbH
+/* Copyright (C) 2018-2020 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -71,6 +71,11 @@ describe('pluralizeType function tests', () => {
   test('should pluralize term', () => {
     expect(pluralizeType('foo')).toEqual('foos');
     expect(pluralizeType('task')).toEqual('tasks');
+  });
+
+  test('should pluralize special plural types', () => {
+    expect(pluralizeType('vulnerability')).toEqual('vulns');
+    expect(pluralizeType('policy')).toEqual('policies');
   });
 });
 

--- a/gsa/src/gmp/utils/entitytype.js
+++ b/gsa/src/gmp/utils/entitytype.js
@@ -41,6 +41,8 @@ export const pluralizeType = type => {
     return type;
   } else if (type === 'policy') {
     return 'policies';
+  } else if (type === 'vulnerability') {
+    return 'vulns';
   }
   return type + 's';
 };


### PR DESCRIPTION
Fixes all functions that use gmp.vulns commands
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
