### PR TITLE
Fix bulk tagging by selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Lower memory usage when getting a report [#1857](https://github.com/greenbone/gvmd/pull/1857)
 
 ### Fixed
+- Fixed bulk tagging by user selection (send IDs as array) [#1985](https://github.com/greenbone/gsa/pull/1985)
 - Fixed pluralizing type 'vulnerability' [#1984](https://github.com/greenbone/gsa/pull/1984)
 - Do not crash if osCpe or osTxt are undefined in OsIcon [#1975](https://github.com/greenbone/gsa/pull/1975) [#1978](https://github.com/greenbone/gsa/pull/1978)
 - Fix task listpage observer tooltip [#1949](https://github.com/greenbone/gsa/pull/1949)

--- a/gsa/src/web/entities/container.js
+++ b/gsa/src/web/entities/container.js
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2019 Greenbone Networks GmbH
+/* Copyright (C) 2017-2020 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -388,10 +388,12 @@ class EntitiesContainer extends React.Component {
 
     const entitiesType = getEntityType(entities[0]);
 
-    let resource_ids;
+    let resourceIds;
+    let resourceIdsArray;
     let filter;
     if (selectionType === SelectionType.SELECTION_USER) {
-      resource_ids = map(selected, res => res.id);
+      resourceIds = map(selected, res => res.id);
+      resourceIdsArray = [...resourceIds];
       filter = undefined;
     } else if (selectionType === SelectionType.SELECTION_PAGE_CONTENTS) {
       filter = loadedFilter;
@@ -408,7 +410,7 @@ class EntitiesContainer extends React.Component {
         filter,
         id,
         name,
-        resource_ids,
+        resource_ids: resourceIdsArray,
         resource_type: entitiesType,
         resources_action: 'add',
         value,


### PR DESCRIPTION
Instead of sending the resource_ids for the save_tag command as a set, send it as array. Sets don't work as command parameter.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
