### PR TITLE
Adjust parsing of filter strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Display timezone for session timeout in user menu [#1764](https://github.com/greenbone/gsa/pull/1764)
 
 ### Changed
+- Adjusted parsing of filter strings to deal with strings with double quotes [#2051](https://github.com/greenbone/gsa/pull/2051)
 - Changed report TlsCertificate table headers to match TlsCertificate assets
 table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
 - Unify source reports and hosts in TlsCertficateModel [#2040](https://github.com/greenbone/gsa/pull/2040)

--- a/gsa/src/gmp/models/__tests__/filter.js
+++ b/gsa/src/gmp/models/__tests__/filter.js
@@ -21,6 +21,147 @@ import {isArray} from '../../utils/identity';
 import Filter, {UNKNOWN_FILTER_ID} from '../filter';
 import FilterTerm from '../filter/filterterm';
 
+describe('Filter parse filter terms from string', () => {
+  test('should parse terms from string', () => {
+    const filter = Filter.fromString('foo=bar lorem~ipsum');
+    expect(filter.toFilterString()).toEqual('foo=bar lorem~ipsum');
+    expect(filter.terms.length).toBe(2);
+    expect(filter.terms[0]).toEqual({
+      keyword: 'foo',
+      relation: '=',
+      value: 'bar',
+    });
+    expect(filter.terms[1]).toEqual({
+      keyword: 'lorem',
+      relation: '~',
+      value: 'ipsum',
+    });
+  });
+
+  test('should parse filter strings with compound statements', () => {
+    // should parse filter strings with and
+    let filter = Filter.fromString('foo=bar and lorem~ipsum');
+    expect(filter.toFilterString()).toEqual('foo=bar and lorem~ipsum');
+    expect(filter.terms.length).toBe(3);
+    expect(filter.terms[0]).toEqual({
+      keyword: 'foo',
+      relation: '=',
+      value: 'bar',
+    });
+    expect(filter.terms[1]).toEqual({
+      keyword: undefined,
+      relation: undefined,
+      value: 'and',
+    });
+    expect(filter.terms[2]).toEqual({
+      keyword: 'lorem',
+      relation: '~',
+      value: 'ipsum',
+    });
+
+    // should parse filter strings with or
+    filter = Filter.fromString('foo=bar or lorem~ipsum');
+    expect(filter.toFilterString()).toEqual('foo=bar or lorem~ipsum');
+    expect(filter.terms.length).toBe(3);
+    expect(filter.terms[0]).toEqual({
+      keyword: 'foo',
+      relation: '=',
+      value: 'bar',
+    });
+    expect(filter.terms[1]).toEqual({
+      keyword: undefined,
+      relation: undefined,
+      value: 'or',
+    });
+    expect(filter.terms[2]).toEqual({
+      keyword: 'lorem',
+      relation: '~',
+      value: 'ipsum',
+    });
+
+    // should parse filter strings with not
+    filter = Filter.fromString('not foo=bar');
+    expect(filter.toFilterString()).toEqual('not foo=bar');
+    expect(filter.terms.length).toBe(2);
+    expect(filter.terms[0]).toEqual({
+      keyword: undefined,
+      relation: undefined,
+      value: 'not',
+    });
+    expect(filter.terms[1]).toEqual({
+      keyword: 'foo',
+      relation: '=',
+      value: 'bar',
+    });
+  });
+
+  test('should parse strings with double quotes', () => {
+    const filter = Filter.fromString('name="foo bar" comment~"lorem ipsum"');
+    expect(filter.toFilterString()).toEqual(
+      'name="foo bar" comment~"lorem ipsum"',
+    );
+    expect(filter.terms.length).toBe(2);
+    expect(filter.terms[0]).toEqual({
+      keyword: 'name',
+      relation: '=',
+      value: '"foo bar"',
+    });
+    expect(filter.terms.length).toBe(2);
+    expect(filter.terms[1]).toEqual({
+      keyword: 'comment',
+      relation: '~',
+      value: '"lorem ipsum"',
+    });
+  });
+
+  test('should parse strings with double quotes and without columns', () => {
+    const filter = Filter.fromString('="foo bar" ~"lorem ipsum"');
+    expect(filter.toFilterString()).toEqual('="foo bar" ~"lorem ipsum"');
+    expect(filter.terms.length).toBe(2);
+    expect(filter.terms[0]).toEqual({
+      keyword: undefined,
+      relation: '=',
+      value: '"foo bar"',
+    });
+    expect(filter.terms.length).toBe(2);
+    expect(filter.terms[1]).toEqual({
+      keyword: undefined,
+      relation: '~',
+      value: '"lorem ipsum"',
+    });
+  });
+
+  test('should parse strings with double quotes and special characters', () => {
+    const filter = Filter.fromString(
+      'name="foo <= bar" ~"foo & bar" and comment="hello : world ?"',
+    );
+    expect(filter.toFilterString()).toEqual(
+      'name="foo <= bar" ~"foo & bar" and comment="hello : world ?"',
+    );
+    expect(filter.terms.length).toBe(4);
+    expect(filter.terms[0]).toEqual({
+      keyword: 'name',
+      relation: '=',
+      value: '"foo <= bar"',
+    });
+    expect(filter.terms[1]).toEqual({
+      keyword: undefined,
+      relation: '~',
+      value: '"foo & bar"',
+    });
+    expect(filter.terms[2]).toEqual({
+      keyword: undefined,
+      relation: undefined,
+      value: 'and',
+    });
+    expect(filter.terms[3]).toEqual({
+      keyword: 'comment',
+      relation: '=',
+      value: '"hello : world ?"',
+    });
+  });
+});
+
 describe('Filter parse from string tests', () => {
   test('should parse aprox relation without column', () => {
     const filter = Filter.fromString('~abc');
@@ -40,6 +181,11 @@ describe('Filter parse from string tests', () => {
   test('should parse equal relation without column and with quotes', () => {
     const filter = Filter.fromString('="abc def"');
     expect(filter.toFilterString()).toEqual('="abc def"');
+  });
+
+  test('should parse equal relation without column and with special characters in quotes', () => {
+    const filter = Filter.fromString('="abc : def"');
+    expect(filter.toFilterString()).toEqual('="abc : def"');
   });
 
   test('should parse above relation without column', () => {

--- a/gsa/src/gmp/models/filter.js
+++ b/gsa/src/gmp/models/filter.js
@@ -19,7 +19,7 @@
 import 'core-js/features/array/find-index';
 import 'core-js/features/array/includes';
 
-import {isDefined, isString, hasValue} from '../utils/identity';
+import {isDefined, isString, isArray, hasValue} from '../utils/identity';
 import {forEach, map} from '../utils/array';
 
 import Model, {parseModelFromElement} from '../model.js';
@@ -42,10 +42,29 @@ export const UNKNOWN_FILTER_ID = '0';
 const parseFilterTermsFromString = filterString => {
   const terms = [];
   if (isString(filterString)) {
-    const filterTerms = filterString.split(' ');
+    // replace whitespace between double quotes with placeholders
+    let modifiedFilterString = filterString;
+    const quotes = filterString.match(/".+?"/g); // find all substrings between double quotes
+    if (isArray(quotes)) {
+      for (const quotedString of quotes) {
+        const newQuotedString = quotedString.replace(/\s/g, '####'); // replace all " " with "####"
+        modifiedFilterString = modifiedFilterString.replace(
+          quotedString,
+          newQuotedString,
+        );
+      }
+    }
+
+    // get filter terms by splitting at whitespace
+    const filterTerms = modifiedFilterString.split(' ');
+
     for (let filterTerm of filterTerms) {
       // strip whitespace
       filterTerm = filterTerm.trim();
+
+      // remove placeholders
+      filterTerm = filterTerm.replace(/####/g, ' '); // replace all "####" with " "
+
       if (filterTerm.length > 0 && !filterTerm.startsWith('_')) {
         terms.push(FilterTerm.fromString(filterTerm));
       }

--- a/gsa/src/gmp/models/filter/__tests__/filterterm.js
+++ b/gsa/src/gmp/models/filter/__tests__/filterterm.js
@@ -123,6 +123,30 @@ describe('FilterTerm fromString', () => {
     expect(term2.value).toEqual(1);
     expect(term2.relation).toEqual('>');
   });
+
+  test('should parse value with double quotes', () => {
+    const term = FilterTerm.fromString('foo="abc def"');
+
+    expect(term.keyword).toEqual('foo');
+    expect(term.value).toEqual('"abc def"');
+    expect(term.relation).toEqual('=');
+  });
+
+  test('should parse value with double quotes and special characters', () => {
+    const term = FilterTerm.fromString('foo="abc : def"');
+
+    expect(term.keyword).toEqual('foo');
+    expect(term.value).toEqual('"abc : def"');
+    expect(term.relation).toEqual('=');
+  });
+
+  test('should parse correct relation with double quotes and special characters', () => {
+    const term = FilterTerm.fromString('foo~"abc = def"');
+
+    expect(term.keyword).toEqual('foo');
+    expect(term.value).toEqual('"abc = def"');
+    expect(term.relation).toEqual('~');
+  });
 });
 
 describe('Compound statement parsing', () => {

--- a/gsa/src/gmp/models/filter/filterterm.js
+++ b/gsa/src/gmp/models/filter/filterterm.js
@@ -112,8 +112,11 @@ class FilterTerm {
    * @return {String} a new FilterTerm created from termstring
    */
   static fromString(termstring) {
+    // use placeholder to ignore content in double quotes
+    const modifiedTermString = termstring.replace(/".+?"/g, '####');
+
     for (const rel of RELATIONS) {
-      if (termstring.includes(rel)) {
+      if (modifiedTermString.includes(rel)) {
         const index = termstring.indexOf(rel);
         const key = termstring.slice(0, index);
         const value = termstring.slice(index + 1);


### PR DESCRIPTION
Parsing filter strings that include substrings in double quotes is causing issues. Adjust parsing functions to be able to handle double quotes.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
