### PR TITLE
No state update in unmounted SvgIcons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Deleting a single entity now removes its ID from store [#1839](https://github.com/greenbone/gsa/pull/1839)
 
 ### Fixed
+- Fixed state updates on unmounted SvgIcons [#2063](https://github.com/greenbone/gsa/pull/2063)
 - Fixed parsing xml rejection messages [#1970](https://github.com/greenbone/gsa/pull/1970)
 - Fixed returning bulk_delete response [#1969](https://github.com/greenbone/gsa/pull/1969)
 - Fixed parsing DFN-Cert CVE entries [#1965](https://github.com/greenbone/gsa/pull/1965)

--- a/gsa/src/web/components/icon/svgicon.js
+++ b/gsa/src/web/components/icon/svgicon.js
@@ -56,12 +56,12 @@ const Styled = styled.span`
   }
 `;
 
-const useIsMountedRef = () => {
+export const useIsMountedRef = () => {
   const ref = useRef();
   ref.current = true;
   // if the ref changes, which is the case when the component unmounts
   // set the ref.current to false in order to prevent state updates in
-  // useStateWithRefCheck()
+  // useStateWithMountCheck()
   useEffect(() => {
     return () => {
       ref.current = false;
@@ -73,7 +73,7 @@ const useIsMountedRef = () => {
 
 // only update state if the component is mounted
 // use useIsMountedRef() to track mounted status across renders
-const useStateWithMountCheck = (...args) => {
+export const useStateWithMountCheck = (...args) => {
   const isMountedRef = useIsMountedRef();
   const [state, nativeSetState] = useState(...args);
   const setState = (...arg) => {

--- a/gsa/src/web/components/icon/svgicon.js
+++ b/gsa/src/web/components/icon/svgicon.js
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React, {useState} from 'react';
+import React, {useEffect, useState, useRef} from 'react';
 
 import styled from 'styled-components';
 
@@ -56,6 +56,34 @@ const Styled = styled.span`
   }
 `;
 
+const useIsMountedRef = () => {
+  const ref = useRef();
+  ref.current = true;
+  // if the ref changes, which is the case when the component unmounts
+  // set the ref.current to false in order to prevent state updates in
+  // useStateWithRefCheck()
+  useEffect(() => {
+    return () => {
+      ref.current = false;
+    };
+  }, [ref]);
+
+  return ref;
+};
+
+// only update state if the component is mounted
+// use useIsMountedRef() to track mounted status across renders
+const useStateWithMountCheck = (...args) => {
+  const isMountedRef = useIsMountedRef();
+  const [state, nativeSetState] = useState(...args);
+  const setState = (...arg) => {
+    if (isMountedRef.current) {
+      nativeSetState(...arg);
+    }
+  };
+  return [state, setState];
+};
+
 const SvgIcon = ({
   disabled = false,
   active = !disabled,
@@ -67,7 +95,7 @@ const SvgIcon = ({
   onClick,
   ...other
 }) => {
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useStateWithMountCheck(false);
 
   const handleClick = event => {
     event.preventDefault();


### PR DESCRIPTION
This PR introduces two custom hooks to the SvgIcon component.

useStateWithMountCheck() replaces the normal useState() hook in the SvgIcon to set isLoading. It checks whether the component is actually mounted before trying to set state.

Whether the component is mounted is stored in a ref (with useRef()). ref.current will be consistent across renders and will not define a new handleClick() if the icon is rerendered, leading to an inconsistent state use, basically breaking the isLoading functionality.

The whole idea is based in the clean-up function at the end of the hook. Normally, the state update on unmounted components is fixed with a useEffect() hook, like this:

useEffect(() => {
  let isMounted = true;
  if (isMounted) {setState(...)};
  return () => isMounted = false;
})

The definition of handleClick would have to be placed inside the if, as the handler's setState takes place there.
So the useEffect does not work when wrapped around the handleClick, as both should be defined top-level in SvgIcon.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
