### PR TITLE
Toggle hyperion for development

### DIFF
--- a/gsa/src/gmp/gmpsettings.js
+++ b/gsa/src/gmp/gmpsettings.js
@@ -82,6 +82,7 @@ class GmpSettings {
       apiServer = server,
       graphqlApiProtocol,
       graphqlApiServer,
+      enableHyperionOnly = false, // default to false if not found in config
       logLevel = loglevel,
     } = options;
 
@@ -138,6 +139,7 @@ class GmpSettings {
     setAndFreeze(this, 'graphqlApiLocation', graphqlApiLocation);
     setAndFreeze(this, 'graphqlApiProtocol', graphqlApiProtocol);
     setAndFreeze(this, 'graphqlApiServer', graphqlApiServer);
+    setAndFreeze(this, 'enableHyperionOnly', enableHyperionOnly);
     setAndFreeze(this, 'manualUrl', manualUrl);
     setAndFreeze(this, 'manualLanguageMapping', manualLanguageMapping);
     setAndFreeze(this, 'protocolDocUrl', protocolDocUrl);

--- a/gsa/src/web/pages/login/__tests__/loginpage.js
+++ b/gsa/src/web/pages/login/__tests__/loginpage.js
@@ -198,7 +198,9 @@ describe('LoginPagetests', () => {
       login,
       isLoggedIn,
       clearToken,
-      settings: {},
+      settings: {
+        enableHyperionOnly: true,
+      },
     };
     const {render} = rendererWith({gmp, router: true, store: true});
 


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
Right now our hyperion branch and master are mutually exclusive- one only works with `gsad` on and one only works with it off. I amended the gmpsettings module to allow a variable called `enableHyperionOnly` and adjust the login function accordingly. If the value is true, then `hyperion-gsa` should not work with `gsad` on and with `gsad` off, only hyperion-related features will work.

Should that value be false, then we use both hyperion and gsad login, and should be running a hybrid system with both backends. Task related functions will be hyperion only, and the rest use `gsad`. Turning off `gsad` in this case will have the same effect, you get an Unknown Error.

I also edited a loginpage test that was updated for hyperion only. I set `enableHyperionOnly` to true for that test, because there will be an error if not true.
**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
