### PR TITLE
Get capabilities from graphql into context

### DIFF
--- a/gsa/src/web/components/link/detailslink.js
+++ b/gsa/src/web/components/link/detailslink.js
@@ -18,20 +18,12 @@
 import React from 'react';
 
 import PropTypes from 'web/utils/proptypes';
-import withCapabilities from 'web/utils/withCapabilities';
-
-import {useGqlCapabilities} from 'web/utils/useGqlCapabilities';
+import useCapabilities from 'web/utils/useCapabilities';
 
 import Link from './link';
 
-const DetailsLink = ({
-  capabilities: caps,
-  id,
-  type,
-  textOnly = false,
-  ...props
-}) => {
-  const capabilities = useGqlCapabilities(caps);
+const DetailsLink = ({id, type, textOnly = false, ...props}) => {
+  const capabilities = useCapabilities();
 
   textOnly = textOnly || !capabilities.mayAccess(type);
 
@@ -46,12 +38,11 @@ const DetailsLink = ({
 };
 
 DetailsLink.propTypes = {
-  capabilities: PropTypes.capabilities.isRequired,
   id: PropTypes.id.isRequired,
   textOnly: PropTypes.bool,
   type: PropTypes.string.isRequired,
 };
 
-export default withCapabilities(DetailsLink);
+export default DetailsLink;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/entity/icon/cloneicon.js
+++ b/gsa/src/web/entity/icon/cloneicon.js
@@ -25,8 +25,7 @@ import {getEntityType, typeName} from 'gmp/utils/entitytype';
 import PropTypes from 'web/utils/proptypes';
 
 import CloneIcon from 'web/components/icon/cloneicon';
-import withCapabilities from 'web/utils/withCapabilities';
-import {useGqlCapabilities} from 'web/utils/useGqlCapabilities';
+import useCapabilities from 'web/utils/useCapabilities';
 
 const EntityCloneIcon = ({
   displayName,
@@ -37,7 +36,7 @@ const EntityCloneIcon = ({
   onClick,
   ...props
 }) => {
-  const capabilities = useGqlCapabilities(props.capabilities);
+  const capabilities = useCapabilities();
 
   if (!isDefined(name)) {
     name = getEntityType(entity);
@@ -73,7 +72,6 @@ const EntityCloneIcon = ({
 };
 
 EntityCloneIcon.propTypes = {
-  capabilities: PropTypes.capabilities.isRequired,
   displayName: PropTypes.string,
   entity: PropTypes.model.isRequired,
   mayClone: PropTypes.bool,
@@ -82,6 +80,6 @@ EntityCloneIcon.propTypes = {
   onClick: PropTypes.func,
 };
 
-export default withCapabilities(EntityCloneIcon);
+export default EntityCloneIcon;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/entity/icon/editicon.js
+++ b/gsa/src/web/entity/icon/editicon.js
@@ -23,8 +23,7 @@ import {isDefined} from 'gmp/utils/identity';
 import {getEntityType, typeName} from 'gmp/utils/entitytype';
 
 import PropTypes from 'web/utils/proptypes';
-import withCapabilities from 'web/utils/withCapabilities';
-import {useGqlCapabilities} from 'web/utils/useGqlCapabilities';
+import useCapabilities from 'web/utils/useCapabilities';
 import EditIcon from 'web/components/icon/editicon';
 
 const EntityEditIcon = ({
@@ -35,7 +34,7 @@ const EntityEditIcon = ({
   onClick,
   ...props
 }) => {
-  const capabilities = useGqlCapabilities(props.capabilities);
+  const capabilities = useCapabilities();
 
   if (!isDefined(name)) {
     name = getEntityType(entity);
@@ -74,7 +73,6 @@ const EntityEditIcon = ({
 };
 
 EntityEditIcon.propTypes = {
-  capabilities: PropTypes.capabilities.isRequired,
   displayName: PropTypes.string,
   entity: PropTypes.model.isRequired,
   name: PropTypes.string,
@@ -82,6 +80,6 @@ EntityEditIcon.propTypes = {
   onClick: PropTypes.func,
 };
 
-export default withCapabilities(EntityEditIcon);
+export default EntityEditIcon;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/entity/icon/trashicon.js
+++ b/gsa/src/web/entity/icon/trashicon.js
@@ -22,11 +22,10 @@ import _ from 'gmp/locale';
 import {isDefined} from 'gmp/utils/identity';
 
 import PropTypes from 'web/utils/proptypes';
-import withCapabilities from 'web/utils/withCapabilities';
+import useCapabilities from 'web/utils/useCapabilities';
 
 import TrashcanIcon from 'web/components/icon/trashcanicon';
 import {getEntityType, typeName} from 'gmp/utils/entitytype';
-import {useGqlCapabilities} from 'web/utils/useGqlCapabilities';
 
 const EntityTrashIcon = ({
   displayName,
@@ -44,7 +43,7 @@ const EntityTrashIcon = ({
     displayName = typeName(name);
   }
 
-  const capabilities = useGqlCapabilities(props.capabilities);
+  const capabilities = useCapabilities();
 
   const mayDelete =
     capabilities.mayDelete(name) && entity.userCapabilities.mayDelete(name);
@@ -78,7 +77,6 @@ const EntityTrashIcon = ({
 };
 
 EntityTrashIcon.propTypes = {
-  capabilities: PropTypes.capabilities.isRequired,
   displayName: PropTypes.string,
   entity: PropTypes.model.isRequired,
   name: PropTypes.string,
@@ -86,10 +84,6 @@ EntityTrashIcon.propTypes = {
   onClick: PropTypes.func,
 };
 
-// withCapabilities is not necessary technically
-// for the poc I want to keep as much of the code/tests unchanged
-// and getting rid of it will cause many tests to fail
-// hence it stays until graphql can be further integrated
-export default withCapabilities(EntityTrashIcon);
+export default EntityTrashIcon;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/page.js
+++ b/gsa/src/web/pages/page.js
@@ -18,7 +18,7 @@
 
 import React, {useState, useEffect} from 'react';
 
-import {withRouter, useLocation} from 'react-router-dom';
+import {useLocation} from 'react-router-dom';
 
 import styled from 'styled-components';
 
@@ -113,10 +113,6 @@ const Page = ({children}) => {
   );
 };
 
-Page.propTypes = {
-  children: PropTypes.func.isRequired,
-};
-
-export default withRouter(Page);
+export default Page;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/page.js
+++ b/gsa/src/web/pages/page.js
@@ -46,7 +46,7 @@ import Footer from 'web/components/structure/footer';
 import Header from 'web/components/structure/header';
 import Main from 'web/components/structure/main';
 
-import {useGetCapabilities} from 'web/utils/useGqlCapabilities';
+import {useGqlCapabilities} from 'web/utils/useGqlCapabilities';
 
 const log = logger.getLogger('web.page');
 
@@ -56,7 +56,7 @@ const StyledLayout = styled(Layout)`
 
 const Page = props => {
   const [capabilities, setCapabilities] = useState();
-  const query = useGetCapabilities();
+  const query = useGqlCapabilities();
   const {data, error} = query();
 
   useEffect(() => {

--- a/gsa/src/web/pages/page.js
+++ b/gsa/src/web/pages/page.js
@@ -18,7 +18,7 @@
 
 import React, {useState, useEffect} from 'react';
 
-import {withRouter} from 'react-router-dom';
+import {withRouter, useLocation} from 'react-router-dom';
 
 import styled from 'styled-components';
 
@@ -31,8 +31,8 @@ import {isDefined} from 'gmp/utils/identity';
 import Capabilities from 'gmp/capabilities/capabilities';
 
 import PropTypes from 'web/utils/proptypes';
-import withGmp from 'web/utils/withGmp';
-import compose from 'web/utils/compose';
+import useGmp from 'web/utils/useGmp';
+import {useGqlCapabilities} from 'web/utils/useGqlCapabilities';
 
 import MenuBar from 'web/components/bar/menubar';
 
@@ -46,15 +46,16 @@ import Footer from 'web/components/structure/footer';
 import Header from 'web/components/structure/header';
 import Main from 'web/components/structure/main';
 
-import {useGqlCapabilities} from 'web/utils/useGqlCapabilities';
-
 const log = logger.getLogger('web.page');
 
 const StyledLayout = styled(Layout)`
   height: 100%;
 `;
 
-const Page = props => {
+const Page = ({children}) => {
+  const gmp = useGmp();
+  const location = useLocation();
+
   const [capabilities, setCapabilities] = useState();
   const query = useGqlCapabilities();
   const {data, error} = query();
@@ -67,8 +68,6 @@ const Page = props => {
         'An error during fetching capabilities from hyperion. Trying gmp...',
         error,
       );
-
-      const {gmp} = props;
 
       gmp.user
         .currentCapabilities()
@@ -88,7 +87,6 @@ const Page = props => {
     }
   }, [data]); // eslint-disable-line react-hooks/exhaustive-deps
   // if we don't wait for data to become defined, undefined caps will be saved.
-  const {children, location} = props;
 
   if (!isDefined(capabilities)) {
     // only show content after caps have been loaded
@@ -116,9 +114,9 @@ const Page = props => {
 };
 
 Page.propTypes = {
-  gmp: PropTypes.gmp.isRequired,
+  children: PropTypes.func.isRequired,
 };
 
-export default compose(withGmp, withRouter)(Page);
+export default withRouter(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/page.js
+++ b/gsa/src/web/pages/page.js
@@ -73,9 +73,9 @@ const Page = props => {
       gmp.user
         .currentCapabilities()
         .then(response => {
-          const capabilities = response.data;
-          log.debug('User capabilities', capabilities);
-          setCapabilities(capabilities);
+          const caps = response.data;
+          log.debug('User capabilities', caps);
+          setCapabilities(caps);
         })
         .catch(rejection => {
           log.error(
@@ -86,8 +86,8 @@ const Page = props => {
           setCapabilities(new Capabilities());
         });
     }
-  }, [data]);
-
+  }, [data]); // eslint-disable-line react-hooks/exhaustive-deps
+  // if we don't wait for data to become defined, undefined caps will be saved.
   const {children, location} = props;
 
   if (!isDefined(capabilities)) {

--- a/gsa/src/web/pages/page.js
+++ b/gsa/src/web/pages/page.js
@@ -67,6 +67,7 @@ const Page = props => {
         'An error during fetching capabilities from hyperion. Trying gmp...',
         error,
       );
+
       const {gmp} = props;
 
       gmp.user
@@ -85,7 +86,7 @@ const Page = props => {
           setCapabilities(new Capabilities());
         });
     }
-  }, []);
+  }, [data]);
 
   const {children, location} = props;
 

--- a/gsa/src/web/pages/page.js
+++ b/gsa/src/web/pages/page.js
@@ -30,7 +30,6 @@ import {isDefined} from 'gmp/utils/identity';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
-import PropTypes from 'web/utils/proptypes';
 import useGmp from 'web/utils/useGmp';
 import {useGqlCapabilities} from 'web/utils/useGqlCapabilities';
 

--- a/gsa/src/web/pages/tasks/component.js
+++ b/gsa/src/web/pages/tasks/component.js
@@ -81,6 +81,7 @@ import compose from 'web/utils/compose';
 import PropTypes from 'web/utils/proptypes';
 import withGmp from 'web/utils/withGmp';
 import {UNSET_VALUE} from 'web/utils/render';
+import useCapabilities from 'web/utils/useCapabilities';
 
 import EntityComponent from 'web/entity/component';
 
@@ -94,25 +95,17 @@ import ScheduleComponent from 'web/pages/schedules/component';
 import AlertComponent from 'web/pages/alerts/component';
 import TargetComponent from 'web/pages/targets/component';
 
-import Capabilities from 'gmp/capabilities/capabilities';
 import TaskDialog from './dialog';
 import ContainerTaskDialog from './containerdialog';
 import {setTimezone} from 'web/store/usersettings/actions';
 import {useModifyTask, useCreateContainerTask, useCreateTask} from './graphql';
-import {useGetCapabilities} from 'web/utils/useGqlCapabilities';
 
 const TaskComponent = props => {
   const modifyTask = useModifyTask();
   const createTask = useCreateTask();
   const createContainerTask = useCreateContainerTask();
-  const query = useGetCapabilities();
-  const {data} = query();
 
-  let capabilities;
-
-  if (isDefined(data)) {
-    capabilities = new Capabilities(data.capabilities);
-  }
+  const capabilities = useCapabilities();
 
   const {
     defaultPortListId,

--- a/gsa/src/web/pages/tasks/icons/importreporticon.js
+++ b/gsa/src/web/pages/tasks/icons/importreporticon.js
@@ -20,12 +20,11 @@ import React from 'react';
 import _ from 'gmp/locale';
 
 import PropTypes from 'web/utils/proptypes';
-import withCapabilities from 'web/utils/withCapabilities';
-import {useGqlCapabilities} from 'web/utils/useGqlCapabilities';
+import useCapabilities from 'web/utils/useCapabilities';
 import ImportIcon from 'web/components/icon/importicon';
 
-const ImportReportIcon = ({size, task, onClick, ...props}) => {
-  const capabilities = useGqlCapabilities(props.capabilities);
+const ImportReportIcon = ({size, task, onClick}) => {
+  const capabilities = useCapabilities();
 
   if (!task.isContainer() || !capabilities.mayCreate('report')) {
     return null;
@@ -43,12 +42,11 @@ const ImportReportIcon = ({size, task, onClick, ...props}) => {
 };
 
 ImportReportIcon.propTypes = {
-  capabilities: PropTypes.capabilities.isRequired,
   size: PropTypes.iconSize,
   task: PropTypes.model.isRequired,
   onClick: PropTypes.func,
 };
 
-export default withCapabilities(ImportReportIcon);
+export default ImportReportIcon;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/tasks/icons/newiconmenu.js
+++ b/gsa/src/web/pages/tasks/icons/newiconmenu.js
@@ -25,11 +25,10 @@ import IconMenu from 'web/components/menu/iconmenu';
 import MenuEntry from 'web/components/menu/menuentry';
 
 import PropTypes from 'web/utils/proptypes';
-import withCapabilities from 'web/utils/withCapabilities';
-import {useGqlCapabilities} from 'web/utils/useGqlCapabilities';
+import useCapabilities from 'web/utils/useCapabilities';
 
-const NewIconMenu = ({onNewClick, onNewContainerClick, ...props}) => {
-  const capabilities = useGqlCapabilities(props.capabilities);
+const NewIconMenu = ({onNewClick, onNewContainerClick}) => {
+  const capabilities = useCapabilities();
 
   if (capabilities.mayCreate('task')) {
     return (
@@ -46,11 +45,10 @@ const NewIconMenu = ({onNewClick, onNewContainerClick, ...props}) => {
 };
 
 NewIconMenu.propTypes = {
-  capabilities: PropTypes.capabilities.isRequired,
   onNewClick: PropTypes.func,
   onNewContainerClick: PropTypes.func,
 };
 
-export default withCapabilities(NewIconMenu);
+export default NewIconMenu;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/tasks/listpage.js
+++ b/gsa/src/web/pages/tasks/listpage.js
@@ -58,7 +58,7 @@ import TaskFilterDialog from './filterdialog';
 import Table from './table';
 import {useGetTasks, useDeleteTask, useCloneTask} from './graphql';
 import {queryWithRefetch} from 'web/utils/graphql';
-import {useGqlCapabilities} from 'web/utils/useGqlCapabilities';
+import useCapabilities from 'web/utils/useCapabilities';
 
 export const ToolBarIcons = withCapabilities(
   ({
@@ -67,9 +67,8 @@ export const ToolBarIcons = withCapabilities(
     onContainerTaskCreateClick,
     onTaskCreateClick,
     onTaskWizardClick,
-    ...props
   }) => {
-    const capabilities = useGqlCapabilities(props.capabilities);
+    const capabilities = useCapabilities();
 
     return (
       <IconDivider>

--- a/gsa/src/web/utils/useGqlCapabilities.js
+++ b/gsa/src/web/utils/useGqlCapabilities.js
@@ -19,9 +19,6 @@
 import gql from 'graphql-tag';
 
 import {useQuery} from '@apollo/react-hooks';
-import {isDefined} from 'gmp/utils/identity';
-
-import Capabilities from 'gmp/capabilities/capabilities';
 
 import {toFruitfulQuery} from 'web/utils/graphql';
 
@@ -31,16 +28,6 @@ export const GET_CAPS = gql`
   }
 `;
 
-export const useGetCapabilities = () => {
+export const useGqlCapabilities = () => {
   return toFruitfulQuery(useQuery)(GET_CAPS);
-};
-
-export const useGqlCapabilities = caps => {
-  const query = useGetCapabilities();
-  const {data} = query();
-
-  if (isDefined(data)) {
-    return new Capabilities(data.capabilities);
-  }
-  return caps; // fallback to HOC
 };


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
Pages can now fetch capabilities from graphql, and falls back to gmp if hyperion has as problem. Also gets rid of unnecessary function from earlier, and replaced the withCapabilities HOC with useCapabilities() context hook.
**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
