### PR TITLE
fix missing scanner when creating audit from policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [9.0.1] - unreleased
 
 ### Added
-- Added scanner selection to audit dialog [#2031](https://github.com/greenbone/gsa/pull/2031)
+- Added scanner selection to audit dialog 
+  [#2031](https://github.com/greenbone/gsa/pull/2031) 
+  [#2105](https://github.com/greenbone/gsa/pull/2105)
 - Added base config to create scanconfig dialog, make it new default base for scanconfigs and new base for policies [#1789](https://github.com/greenbone/gsa/pull/1789)
 - Display timezone for session timeout in user menu [#1764](https://github.com/greenbone/gsa/pull/1764)
 


### PR DESCRIPTION
Audits created directly from a policy are not useable right now because the scanner is undefined. Adjust policy component to forward appropriate scanners to dialog to fix this

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
