### PR TITLE
Fix missing scanconfig type hyperion

### DIFF
--- a/gsa/src/gmp/models/__tests__/scanconfig.js
+++ b/gsa/src/gmp/models/__tests__/scanconfig.js
@@ -208,7 +208,7 @@ describe('ScanConfig model tests', () => {
   test('should parse type', () => {
     const scanConfig = ScanConfig.fromElement({type: '21'});
 
-    expect(scanConfig.scan_config_type).toEqual(21);
+    expect(scanConfig.scanConfigType).toEqual(21);
   });
 
   test('should parse scanner', () => {
@@ -262,16 +262,16 @@ describe('ScanConfigs model function test', () => {
   });
 
   test('openVasScanConfigsFilter() should return filter with correct true/false', () => {
-    const config1 = {scan_config_type: 1}; // OSP scanconfig type
-    const config2 = {scan_config_type: 0}; // OpenVAS scanconfig type
+    const config1 = {scanConfigType: 1}; // OSP scanconfig type
+    const config2 = {scanConfigType: 0}; // OpenVAS scanconfig type
 
     expect(openVasScanConfigsFilter(config1)).toEqual(false);
     expect(openVasScanConfigsFilter(config2)).toEqual(true);
   });
 
   test('ospScanConfigsFilter() should return filter with correct true/false', () => {
-    const config1 = {scan_config_type: 1}; // OSP scanconfig type
-    const config2 = {scan_config_type: 0}; // OpenVAS scanconfig type
+    const config1 = {scanConfigType: 1}; // OSP scanconfig type
+    const config2 = {scanConfigType: 0}; // OpenVAS scanconfig type
 
     expect(ospScanConfigsFilter(config1)).toEqual(true);
     expect(ospScanConfigsFilter(config2)).toEqual(false);

--- a/gsa/src/gmp/models/__tests__/scanconfig.js
+++ b/gsa/src/gmp/models/__tests__/scanconfig.js
@@ -23,6 +23,8 @@ import ScanConfig, {
   filterEmptyScanConfig,
   openVasScanConfigsFilter,
   ospScanConfigsFilter,
+  OPENVAS_SCAN_CONFIG_TYPE,
+  OSP_SCAN_CONFIG_TYPE,
   SCANCONFIG_TREND_DYNAMIC,
 } from 'gmp/models/scanconfig';
 import {testModel} from 'gmp/models/testing';
@@ -262,16 +264,16 @@ describe('ScanConfigs model function test', () => {
   });
 
   test('openVasScanConfigsFilter() should return filter with correct true/false', () => {
-    const config1 = {scanConfigType: 1}; // OSP scanconfig type
-    const config2 = {scanConfigType: 0}; // OpenVAS scanconfig type
+    const config1 = {scanConfigType: OSP_SCAN_CONFIG_TYPE};
+    const config2 = {scanConfigType: OPENVAS_SCAN_CONFIG_TYPE};
 
     expect(openVasScanConfigsFilter(config1)).toEqual(false);
     expect(openVasScanConfigsFilter(config2)).toEqual(true);
   });
 
   test('ospScanConfigsFilter() should return filter with correct true/false', () => {
-    const config1 = {scanConfigType: 1}; // OSP scanconfig type
-    const config2 = {scanConfigType: 0}; // OpenVAS scanconfig type
+    const config1 = {scanConfigType: OSP_SCAN_CONFIG_TYPE};
+    const config2 = {scanConfigType: OPENVAS_SCAN_CONFIG_TYPE};
 
     expect(ospScanConfigsFilter(config1)).toEqual(true);
     expect(ospScanConfigsFilter(config2)).toEqual(false);

--- a/gsa/src/gmp/models/scanconfig.js
+++ b/gsa/src/gmp/models/scanconfig.js
@@ -38,7 +38,7 @@ export const SCANCONFIG_TREND_DYNAMIC = 1;
 export const SCANCONFIG_TREND_STATIC = 0;
 
 export const getTranslatedType = config => {
-  return config.scan_config_type === OSP_SCAN_CONFIG_TYPE
+  return config.scanConfigType === OSP_SCAN_CONFIG_TYPE
     ? _('OSP')
     : _('OpenVAS');
 };
@@ -51,9 +51,9 @@ export const filterEmptyScanConfig = config =>
   config.id !== EMPTY_SCAN_CONFIG_ID;
 
 export const openVasScanConfigsFilter = config =>
-  config.scan_config_type === OPENVAS_SCAN_CONFIG_TYPE;
+  config.scanConfigType === OPENVAS_SCAN_CONFIG_TYPE;
 export const ospScanConfigsFilter = config =>
-  config.scan_config_type === OSP_SCAN_CONFIG_TYPE;
+  config.scanConfigType === OSP_SCAN_CONFIG_TYPE;
 
 export const parseTrend = parseInt;
 
@@ -149,7 +149,7 @@ class ScanConfig extends Model {
       nvt: nvt_preferences,
     };
 
-    ret.scan_config_type = parseInt(element.type);
+    ret.scanConfigType = parseInt(element.type);
 
     if (isDefined(element.scanner)) {
       const scanner = {

--- a/gsa/src/gmp/models/task.js
+++ b/gsa/src/gmp/models/task.js
@@ -177,7 +177,7 @@ class Task extends Model {
     }
 
     if (hasValue(object.scanConfig)) {
-      copy.config = ScanConfig.fromObject(object.scanConfig);
+      copy.config = ScanConfig.fromElement(object.scanConfig);
     }
 
     delete copy.scanConfig;

--- a/gsa/src/web/pages/scanconfigs/component.js
+++ b/gsa/src/web/pages/scanconfigs/component.js
@@ -496,7 +496,7 @@ class ScanConfigComponent extends React.Component {
                   configFamilies={config.families}
                   configId={config.id}
                   configIsInUse={config.isInUse()}
-                  configType={config.scan_config_type}
+                  configType={config.scanConfigType}
                   editNvtDetailsTitle={_('Edit Scan Config NVT Details')}
                   editNvtFamiliesTitle={_('Edit Scan Config Family')}
                   families={families}

--- a/gsa/src/web/pages/scanconfigs/details.js
+++ b/gsa/src/web/pages/scanconfigs/details.js
@@ -38,7 +38,7 @@ import TableRow from 'web/components/table/row';
 import {Col} from 'web/entity/page';
 
 const ScanConfigDetails = ({entity}) => {
-  const {comment, scan_config_type, scanner, tasks = []} = entity;
+  const {comment, scanConfigType, scanner, tasks = []} = entity;
   return (
     <Layout flex="column" grow>
       <InfoTable>
@@ -53,7 +53,7 @@ const ScanConfigDetails = ({entity}) => {
               <TableData>{comment}</TableData>
             </TableRow>
           )}
-          {scan_config_type === OSP_SCAN_CONFIG_TYPE && isDefined(scanner) && (
+          {scanConfigType === OSP_SCAN_CONFIG_TYPE && isDefined(scanner) && (
             <TableRow>
               <TableData>{_('Scanner')}</TableData>
               <TableData>

--- a/gsa/src/web/pages/scanconfigs/row.js
+++ b/gsa/src/web/pages/scanconfigs/row.js
@@ -99,7 +99,7 @@ const ScanConfigRow = ({
       displayName={_('Scan Config')}
       onToggleDetailsClick={onToggleDetailsClick}
     />
-    <TableData>{getTranslatedType(entity.scan_config_type)}</TableData>
+    <TableData>{getTranslatedType(entity.scanConfigType)}</TableData>
     <TableData>{na(entity.families.count)}</TableData>
     <TableData>
       <Trend

--- a/gsa/src/web/pages/tasks/__mocks__/mocktasks.js
+++ b/gsa/src/web/pages/tasks/__mocks__/mocktasks.js
@@ -139,6 +139,16 @@ const preferences = [
     name: 'auto_delete_data',
     value: '5',
   },
+  {
+    description: 'Maximum concurrently executed NVTs per host',
+    name: 'max_checks',
+    value: '4',
+  },
+  {
+    description: 'Maximum concurrently scanned hosts',
+    name: 'max_hosts',
+    value: '20',
+  },
 ];
 
 // Tasks

--- a/gsa/src/web/pages/tasks/__tests__/__snapshots__/details.js.snap
+++ b/gsa/src/web/pages/tasks/__tests__/__snapshots__/details.js.snap
@@ -269,6 +269,68 @@ exports[`Task Details tests should render full task details 1`] = `
               </div>
             </td>
           </tr>
+          <tr>
+            <td>
+              <div
+                class="c1"
+              >
+                Order for target hosts
+              </div>
+            </td>
+            <td>
+              <div
+                class="c1"
+              >
+                sequential
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <div
+                class="c1"
+              >
+                Network Source Interface
+              </div>
+            </td>
+            <td>
+              <div
+                class="c1"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <div
+                class="c1"
+              >
+                Maximum concurrently executed NVTs per host
+              </div>
+            </td>
+            <td>
+              <div
+                class="c1"
+              >
+                4
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <div
+                class="c1"
+              >
+                Maximum concurrently scanned hosts
+              </div>
+            </td>
+            <td>
+              <div
+                class="c1"
+              >
+                20
+              </div>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/gsa/src/web/pages/tasks/__tests__/details.js
+++ b/gsa/src/web/pages/tasks/__tests__/details.js
@@ -105,6 +105,12 @@ describe('Task Details tests', () => {
     expect(element).toHaveTextContent('OpenVAS Scanner');
     expect(element).toHaveTextContent('Scan Configfoo');
     expect(detailslinks[3]).toHaveAttribute('href', '/scanconfig/314');
+    expect(element).toHaveTextContent('Order for target hostssequential');
+    expect(element).toHaveTextContent('Network Source Interface');
+    expect(element).toHaveTextContent(
+      'Maximum concurrently executed NVTs per host4',
+    );
+    expect(element).toHaveTextContent('Maximum concurrently scanned hosts20');
 
     expect(headings[3]).toHaveTextContent('Assets');
     expect(element).toHaveTextContent('Add to AssetsYes');

--- a/gsa/src/web/pages/tasks/dialog.js
+++ b/gsa/src/web/pages/tasks/dialog.js
@@ -81,7 +81,7 @@ const sort_scan_configs = (scan_configs = []) => {
   scan_configs = scan_configs.filter(filterEmptyScanConfig);
 
   forEach(scan_configs, config => {
-    const type = config.scan_config_type;
+    const type = config.scanConfigType;
     if (!isArray(sorted_scan_configs[type])) {
       sorted_scan_configs[type] = [];
     }


### PR DESCRIPTION
Due to the scan config type missing in tasks in hyperion-gsa some of the preferences on the task details page are not displayed. Fix missing scan config type and update tests to ensure the preferences are displayed correctly.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
