### PR TITLE
Fix setting error message

### DIFF
--- a/gsa/src/gmp/http/__tests__/rejection.js
+++ b/gsa/src/gmp/http/__tests__/rejection.js
@@ -15,14 +15,18 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {setLocale} from 'gmp/locale/lang';
+
 import Rejection from '../rejection';
+
+setLocale('en');
 
 describe('Rejection tests', () => {
   test('should create error rejection by default', () => {
     const rejection = new Rejection();
 
     expect(rejection.reason).toEqual(Rejection.REASON_ERROR);
-    expect(rejection.message).toEqual('');
+    expect(rejection.message).toEqual('Unknown Error');
     expect(rejection.error).toBeUndefined();
     expect(rejection.stack).toBeDefined();
     expect(rejection.isError()).toEqual(true);
@@ -49,10 +53,14 @@ describe('Rejection tests', () => {
 
   test('should create unauthorized rejection', () => {
     const xhr = {status: 123};
-    const rejection = new Rejection(xhr, Rejection.REASON_UNAUTHORIZED);
+    const rejection = new Rejection(
+      xhr,
+      Rejection.REASON_UNAUTHORIZED,
+      'Unauthorized',
+    );
 
     expect(rejection.reason).toEqual(Rejection.REASON_UNAUTHORIZED);
-    expect(rejection.message).toEqual('');
+    expect(rejection.message).toEqual('Unauthorized');
     expect(rejection.error).toBeUndefined();
     expect(rejection.stack).toBeDefined();
     expect(rejection.isError()).toEqual(false);

--- a/gsa/src/gmp/http/rejection.js
+++ b/gsa/src/gmp/http/rejection.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import _ from '../locale';
+
 import {isDefined} from '../utils/identity';
 
 class Rejection {
@@ -23,7 +25,12 @@ class Rejection {
   static REASON_CANCEL = 'cancel';
   static REASON_UNAUTHORIZED = 'unauthorized';
 
-  constructor(xhr, reason = Rejection.REASON_ERROR, message = '', error) {
+  constructor(
+    xhr,
+    reason = Rejection.REASON_ERROR,
+    message = _('Unknown Error'),
+    error,
+  ) {
     this.name = 'Rejection';
     this.message = message;
     this.reason = reason;

--- a/gsa/src/gmp/http/transform/__tests__/xml.js
+++ b/gsa/src/gmp/http/transform/__tests__/xml.js
@@ -117,15 +117,12 @@ describe('xml base transform tests', () => {
     });
     const transform = rejection(fakeTransform);
     const isError = jest.fn().mockReturnValue(true);
-    const setMessage = jest.fn(() => errorRejection);
     const errorRejection = {
       isError,
-      setMessage,
     };
 
     expect(transform(errorRejection)).toBe(errorRejection);
     expect(fakeTransform).toHaveBeenCalledWith(errorRejection);
     expect(isError).toHaveBeenCalled();
-    expect(setMessage).toHaveBeenCalledWith('Unknown Error');
   });
 });

--- a/gsa/src/gmp/http/transform/xml.js
+++ b/gsa/src/gmp/http/transform/xml.js
@@ -58,7 +58,7 @@ export const rejection = transform => (rej, options) => {
       }
     }
 
-    return rej.setMessage(_('Unknown Error'));
+    return rej;
   }
 
   return rej;


### PR DESCRIPTION
Don't override error message with Unknown Error. If the error didn't had
any response or the repsonse didn't contain xml data it is very likely
that the rejection already contains a more useful error message.
