### PR TITLE
Fix displaying login errors for gsad based logins

### DIFF
--- a/gsa/src/web/app.js
+++ b/gsa/src/web/app.js
@@ -125,7 +125,6 @@ class App extends React.Component {
   handleGmpErrorResponse(xhr) {
     if (xhr.status === 401) {
       this.logout();
-      return Promise.resolve(xhr);
     }
     return Promise.reject(xhr);
   }


### PR DESCRIPTION
Always return failing promise from gmp error handler to allow the login
method handle the error. Returning Promise.resolve here would not call
the catch case for the login promise.
