### PR TITLE
Fix missing loading indicator for test alert icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Deleting a single entity now removes its ID from store [#1839](https://github.com/greenbone/gsa/pull/1839)
 
 ### Fixed
+- Fix missing loading indicator for test alert button [#2156](https://github.com/greenbone/gsa/pull/2156)
 - Close dialog for ExternalLink when following link [#2148](https://github.com/greenbone/gsa/pull/2148)
 - Fixed license information on AboutPage [#2118](https://github.com/greenbone/gsa/pull/2118) [#2148](https://github.com/greenbone/gsa/pull/2148)
 - Fixed state updates on unmounted SvgIcons [#2063](https://github.com/greenbone/gsa/pull/2063)

--- a/gsa/src/web/pages/alerts/component.js
+++ b/gsa/src/web/pages/alerts/component.js
@@ -801,7 +801,7 @@ class AlertComponent extends React.Component {
 
     this.handleInteraction();
 
-    gmp.alert
+    return gmp.alert
       .test(alert)
       .then(response => {
         if (isDefined(onTestSuccess)) {
@@ -1243,10 +1243,7 @@ const mapStateToProps = rootState => {
 
 export default compose(
   withGmp,
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  ),
+  connect(mapStateToProps, mapDispatchToProps),
 )(AlertComponent);
 
 // vim: set ts=2 sw=2 tw=80:


### PR DESCRIPTION
The test alert button is missing a loading indicator. Return a promise for handleTestAlert to make the loading indicator show up.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
