### PR TITLE
Add new useGetTasks query

### DIFF
--- a/gsa/src/web/graphql/__mocks__/tasks.js
+++ b/gsa/src/web/graphql/__mocks__/tasks.js
@@ -30,27 +30,11 @@ const target = deepFreeze({
   name: 'target 1',
 });
 
-const target2 = deepFreeze({
-  id: '265',
-  name: 'target 2',
-});
-
-const target3 = deepFreeze({
-  id: '358',
-  name: 'target 3',
-});
-
 // Scanner
 const scanner = deepFreeze({
   id: '212223',
   name: 'scanner 1',
   type: 'OPENVAS_SCANNER_TYPE',
-});
-
-const gmpScanner = deepFreeze({
-  id: '242526',
-  name: 'scanner 2',
-  type: 'GMP_SCANNER_TYPE',
 });
 
 // ScanConfig
@@ -63,12 +47,6 @@ const scanConfig = deepFreeze({
   type: OPENVAS_SCAN_CONFIG_TYPE,
 });
 
-// Schedule
-const schedule = deepFreeze({id: '121314', name: 'schedule 1'});
-
-// Alert
-const alert = deepFreeze({id: '151617', name: 'alert 1'});
-
 // Reports
 const lastReport = deepFreeze({
   id: '1234',
@@ -77,15 +55,6 @@ const lastReport = deepFreeze({
   scanStart: '2019-07-30T13:23:34Z',
   scanEnd: '2019-07-30T13:25:43Z',
 });
-
-const currentReport = deepFreeze({
-  id: '5678',
-  timestamp: '2019-08-30T13:23:30Z',
-  scanStart: '2019-08-30T13:23:34Z',
-});
-
-// Permissions
-const limitedPermissions = deepFreeze([{name: 'get_tasks'}]);
 
 const allPermissions = deepFreeze([
   {
@@ -153,143 +122,6 @@ const preferences = deepFreeze([
   },
 ]);
 
-// Tasks
-const task = deepFreeze({
-  id: '12345',
-  name: 'foo',
-  comment: 'bar',
-  owner: 'admin',
-  alterable: 1,
-  creationTime: '2019-07-30T13:00:00Z',
-  modificationTime: '2019-08-30T13:23:30Z',
-  status: TASK_STATUS.stopped,
-  reports: {
-    lastReport,
-    currentReport,
-    counts: {
-      total: 2,
-      finished: 1,
-    },
-  },
-  permissions: allPermissions,
-  target: target,
-  schedule: schedule,
-  alerts: [alert],
-  scanner: gmpScanner,
-  scanConfig: scanConfig,
-  preferences: preferences,
-  hostsOrdering: 'sequential',
-  observers: observers,
-});
-
-const newTask = deepFreeze({
-  id: '12345',
-  name: 'foo',
-  comment: 'bar',
-  owner: 'admin',
-  alterable: 0,
-  status: TASK_STATUS.new,
-  reports: {
-    counts: {
-      total: 0,
-      finished: 0,
-    },
-  },
-  permissions: allPermissions,
-  target: target2,
-});
-
-const finishedTask = deepFreeze({
-  id: '12345',
-  name: 'foo',
-  comment: 'bar',
-  owner: 'admin',
-  status: TASK_STATUS.done,
-  reports: {
-    lastReport,
-    counts: {
-      total: 1,
-      finished: 1,
-    },
-  },
-  permissions: allPermissions,
-  target,
-});
-
-const runningTask = deepFreeze({
-  id: '12345',
-  name: 'foo',
-  comment: 'bar',
-  owner: 'admin',
-  alterable: 0,
-  inUse: true,
-  status: TASK_STATUS.running,
-  reports: {
-    lastReport,
-    currentReport,
-    counts: {
-      total: 2,
-      finished: 1,
-    },
-  },
-  permissions: allPermissions,
-  target: target3,
-});
-
-const stoppedTask = deepFreeze({
-  id: '12345',
-  name: 'foo',
-  comment: 'bar',
-  owner: 'admin',
-  alterable: 0,
-  status: TASK_STATUS.stopped,
-  reports: {
-    lastReport,
-    currentReport,
-    counts: {
-      total: 2,
-      finished: 1,
-    },
-  },
-  permissions: allPermissions,
-  target: target,
-});
-
-const observedTask = deepFreeze({
-  id: '12345',
-  name: 'foo',
-  comment: 'bar',
-  owner: 'admin',
-  alterable: 0,
-  status: TASK_STATUS.done,
-  reports: {
-    lastReport,
-    counts: {
-      total: 1,
-      finished: 1,
-    },
-  },
-  permissions: limitedPermissions,
-  target: target,
-});
-
-const containerTask = deepFreeze({
-  id: '12345',
-  name: 'foo',
-  comment: 'bar',
-  owner: 'admin',
-  alterable: 0,
-  status: TASK_STATUS.done,
-  reports: {
-    lastReport,
-    counts: {
-      total: 1,
-      finished: 1,
-    },
-  },
-  permissions: allPermissions,
-});
-
 const listMockTask = deepFreeze({
   name: 'foo',
   id: '12345',
@@ -313,37 +145,6 @@ const listMockTask = deepFreeze({
   scanConfig,
   scanner,
   hostsOrdering: null,
-  observers,
-});
-
-const detailsMockTask = deepFreeze({
-  name: 'foo',
-  id: '12345',
-  creationTime: '2019-07-30T13:00:00Z',
-  modificationTime: '2019-08-30T13:23:30Z',
-  permissions: allPermissions,
-  reports: {
-    lastReport,
-    currentReport,
-    counts: {
-      total: 1,
-      finished: 1,
-    },
-  },
-  status: TASK_STATUS.stopped,
-  target,
-  alterable: 0,
-  trend: null,
-  comment: 'bar',
-  owner: 'admin',
-  preferences,
-  schedule: schedule,
-  alerts: [alert],
-  scanConfig,
-  scanner,
-  schedulePeriods: null,
-  hostsOrdering: 'sequential',
-  userTags: null,
   observers,
 });
 

--- a/gsa/src/web/graphql/__mocks__/tasks.js
+++ b/gsa/src/web/graphql/__mocks__/tasks.js
@@ -1,0 +1,388 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {TASK_STATUS} from 'gmp/models/task';
+import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
+
+import {isDefined} from 'gmp/utils/identity';
+
+import {deepFreeze} from 'web/utils/testing';
+
+import {GET_TASKS} from '../tasks';
+
+const target = deepFreeze({
+  id: '159',
+  name: 'target 1',
+});
+
+const target2 = deepFreeze({
+  id: '265',
+  name: 'target 2',
+});
+
+const target3 = deepFreeze({
+  id: '358',
+  name: 'target 3',
+});
+
+// Scanner
+const scanner = deepFreeze({
+  id: '212223',
+  name: 'scanner 1',
+  type: 'OPENVAS_SCANNER_TYPE',
+});
+
+const gmpScanner = deepFreeze({
+  id: '242526',
+  name: 'scanner 2',
+  type: 'GMP_SCANNER_TYPE',
+});
+
+// ScanConfig
+const scanConfig = deepFreeze({
+  id: '314',
+  name: 'foo',
+  comment: 'bar',
+  trash: false,
+  scanner: scanner,
+  type: OPENVAS_SCAN_CONFIG_TYPE,
+});
+
+// Schedule
+const schedule = deepFreeze({id: '121314', name: 'schedule 1'});
+
+// Alert
+const alert = deepFreeze({id: '151617', name: 'alert 1'});
+
+// Reports
+const lastReport = deepFreeze({
+  id: '1234',
+  severity: '5.0',
+  timestamp: '2019-07-30T13:23:30Z',
+  scanStart: '2019-07-30T13:23:34Z',
+  scanEnd: '2019-07-30T13:25:43Z',
+});
+
+const currentReport = deepFreeze({
+  id: '5678',
+  timestamp: '2019-08-30T13:23:30Z',
+  scanStart: '2019-08-30T13:23:34Z',
+});
+
+// Permissions
+const limitedPermissions = deepFreeze([{name: 'get_tasks'}]);
+
+const allPermissions = deepFreeze([
+  {
+    name: 'Everything',
+  },
+]);
+
+// Observers
+const observers = deepFreeze({
+  users: ['john', 'jane'],
+  roles: [
+    {
+      name: 'admin role',
+    },
+    {
+      name: 'user role',
+    },
+  ],
+  groups: [
+    {
+      name: 'group 1',
+    },
+    {
+      name: 'group 2',
+    },
+  ],
+});
+
+// Preferences
+const preferences = deepFreeze([
+  {
+    description: 'Add results to Asset Management',
+    name: 'in_assets',
+    value: 'yes',
+  },
+  {
+    description: 'Apply Overrides when adding Assets',
+    name: 'assets_apply_overrides',
+    value: 'yes',
+  },
+  {
+    description: 'Min QOD when adding Assets',
+    name: 'assets_min_qod',
+    value: '70',
+  },
+  {
+    description: 'Auto Delete Reports',
+    name: 'auto_delete',
+    value: 'no',
+  },
+  {
+    description: 'Auto Delete Reports Data',
+    name: 'auto_delete_data',
+    value: '5',
+  },
+  {
+    description: 'Maximum concurrently executed NVTs per host',
+    name: 'max_checks',
+    value: '4',
+  },
+  {
+    description: 'Maximum concurrently scanned hosts',
+    name: 'max_hosts',
+    value: '20',
+  },
+]);
+
+// Tasks
+const task = deepFreeze({
+  id: '12345',
+  name: 'foo',
+  comment: 'bar',
+  owner: 'admin',
+  alterable: 1,
+  creationTime: '2019-07-30T13:00:00Z',
+  modificationTime: '2019-08-30T13:23:30Z',
+  status: TASK_STATUS.stopped,
+  reports: {
+    lastReport,
+    currentReport,
+    counts: {
+      total: 2,
+      finished: 1,
+    },
+  },
+  permissions: allPermissions,
+  target: target,
+  schedule: schedule,
+  alerts: [alert],
+  scanner: gmpScanner,
+  scanConfig: scanConfig,
+  preferences: preferences,
+  hostsOrdering: 'sequential',
+  observers: observers,
+});
+
+const newTask = deepFreeze({
+  id: '12345',
+  name: 'foo',
+  comment: 'bar',
+  owner: 'admin',
+  alterable: 0,
+  status: TASK_STATUS.new,
+  reports: {
+    counts: {
+      total: 0,
+      finished: 0,
+    },
+  },
+  permissions: allPermissions,
+  target: target2,
+});
+
+const finishedTask = deepFreeze({
+  id: '12345',
+  name: 'foo',
+  comment: 'bar',
+  owner: 'admin',
+  status: TASK_STATUS.done,
+  reports: {
+    lastReport,
+    counts: {
+      total: 1,
+      finished: 1,
+    },
+  },
+  permissions: allPermissions,
+  target,
+});
+
+const runningTask = deepFreeze({
+  id: '12345',
+  name: 'foo',
+  comment: 'bar',
+  owner: 'admin',
+  alterable: 0,
+  inUse: true,
+  status: TASK_STATUS.running,
+  reports: {
+    lastReport,
+    currentReport,
+    counts: {
+      total: 2,
+      finished: 1,
+    },
+  },
+  permissions: allPermissions,
+  target: target3,
+});
+
+const stoppedTask = deepFreeze({
+  id: '12345',
+  name: 'foo',
+  comment: 'bar',
+  owner: 'admin',
+  alterable: 0,
+  status: TASK_STATUS.stopped,
+  reports: {
+    lastReport,
+    currentReport,
+    counts: {
+      total: 2,
+      finished: 1,
+    },
+  },
+  permissions: allPermissions,
+  target: target,
+});
+
+const observedTask = deepFreeze({
+  id: '12345',
+  name: 'foo',
+  comment: 'bar',
+  owner: 'admin',
+  alterable: 0,
+  status: TASK_STATUS.done,
+  reports: {
+    lastReport,
+    counts: {
+      total: 1,
+      finished: 1,
+    },
+  },
+  permissions: limitedPermissions,
+  target: target,
+});
+
+const containerTask = deepFreeze({
+  id: '12345',
+  name: 'foo',
+  comment: 'bar',
+  owner: 'admin',
+  alterable: 0,
+  status: TASK_STATUS.done,
+  reports: {
+    lastReport,
+    counts: {
+      total: 1,
+      finished: 1,
+    },
+  },
+  permissions: allPermissions,
+});
+
+const listMockTask = deepFreeze({
+  name: 'foo',
+  id: '12345',
+  permissions: allPermissions,
+  reports: {
+    lastReport,
+    counts: {
+      total: 1,
+      finished: 1,
+    },
+  },
+  status: TASK_STATUS.done,
+  target,
+  trend: 'up',
+  alterable: 0,
+  comment: 'bar',
+  owner: 'admin',
+  preferences,
+  schedule: null,
+  alerts: [],
+  scanConfig,
+  scanner,
+  hostsOrdering: null,
+  observers,
+});
+
+const detailsMockTask = deepFreeze({
+  name: 'foo',
+  id: '12345',
+  creationTime: '2019-07-30T13:00:00Z',
+  modificationTime: '2019-08-30T13:23:30Z',
+  permissions: allPermissions,
+  reports: {
+    lastReport,
+    currentReport,
+    counts: {
+      total: 1,
+      finished: 1,
+    },
+  },
+  status: TASK_STATUS.stopped,
+  target,
+  alterable: 0,
+  trend: null,
+  comment: 'bar',
+  owner: 'admin',
+  preferences,
+  schedule: schedule,
+  alerts: [alert],
+  scanConfig,
+  scanner,
+  schedulePeriods: null,
+  hostsOrdering: 'sequential',
+  userTags: null,
+  observers,
+});
+
+const mockTasks = {
+  edges: [
+    {
+      node: listMockTask,
+    },
+  ],
+  counts: {
+    total: 1,
+    filtered: 1,
+    offset: 0,
+    limit: 10,
+    length: 1,
+  },
+};
+
+export const createGetTaskQueryMock = filterString => {
+  const queryResult = {
+    data: {
+      tasks: mockTasks,
+    },
+  };
+
+  const resultFunc = jest.fn().mockReturnValue(queryResult);
+
+  const variables = {};
+
+  if (isDefined(filterString)) {
+    variables.filterString = filterString;
+  }
+
+  const queryMock = {
+    request: {
+      query: GET_TASKS,
+      variables,
+    },
+    newData: resultFunc,
+  };
+  return [queryMock, resultFunc];
+};

--- a/gsa/src/web/graphql/__mocks__/tasks.js
+++ b/gsa/src/web/graphql/__mocks__/tasks.js
@@ -362,7 +362,7 @@ const mockTasks = {
   },
 };
 
-export const createGetTaskQueryMock = filterString => {
+export const createGetTaskQueryMock = ({filterString} = {}) => {
   const queryResult = {
     data: {
       tasks: mockTasks,

--- a/gsa/src/web/graphql/__tests__/tasks.js
+++ b/gsa/src/web/graphql/__tests__/tasks.js
@@ -1,0 +1,75 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+
+import {useGetTasks} from '../tasks';
+import {createGetTaskQueryMock} from '../__mocks__/tasks';
+
+import {rendererWith, screen, wait} from 'web/utils/testing';
+
+const TestComponent = () => {
+  const {counts, loading, tasks} = useGetTasks();
+  if (loading) {
+    return <span>Loading</span>;
+  }
+  return (
+    <div>
+      <div data-testid="counts">
+        <span data-testid="total">{counts.all}</span>
+        <span data-testid="filtered">{counts.filtered}</span>
+        <span data-testid="offset">{counts.first}</span>
+        <span data-testid="limit">{counts.rows}</span>
+        <span data-testid="length">{counts.length}</span>
+      </div>
+      {tasks.map(task => {
+        return (
+          <div key={task.id} data-testid="task">
+            {task.name}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+describe('useGetTask tests', () => {
+  test('should query a task', async () => {
+    const [mock, resultFunc] = createGetTaskQueryMock();
+    const {render} = rendererWith({queryMocks: [mock]});
+
+    const {element} = render(<TestComponent />);
+
+    expect(element).toHaveTextContent('Loading');
+
+    await wait();
+
+    expect(resultFunc).toHaveBeenCalled();
+
+    const taskElements = screen.getAllByTestId('task');
+    expect(taskElements).toHaveLength(1);
+
+    expect(taskElements[0]).toHaveTextContent('foo');
+
+    expect(screen.getByTestId('total')).toHaveTextContent(1);
+    expect(screen.getByTestId('filtered')).toHaveTextContent(1);
+    expect(screen.getByTestId('offset')).toHaveTextContent(1);
+    expect(screen.getByTestId('limit')).toHaveTextContent(10);
+    expect(screen.getByTestId('length')).toHaveTextContent(1);
+  });
+});

--- a/gsa/src/web/graphql/tasks.js
+++ b/gsa/src/web/graphql/tasks.js
@@ -1,0 +1,124 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {useQuery} from '@apollo/react-hooks';
+
+import gql from 'graphql-tag';
+
+import CollectionCounts from 'gmp/collection/collectioncounts';
+
+import Task from 'gmp/models/task';
+
+import {isDefined} from 'gmp/utils/identity';
+
+export const GET_TASKS = gql`
+  query Task($filterString: String) {
+    tasks(filterString: $filterString) {
+      edges {
+        node {
+          name
+          id
+          permissions {
+            name
+          }
+          reports {
+            lastReport {
+              id
+              severity
+              timestamp
+            }
+            counts {
+              total
+              finished
+            }
+          }
+          status
+          target {
+            name
+            id
+          }
+          trend
+          alterable
+          comment
+          owner
+          preferences {
+            name
+            value
+            description
+          }
+          schedule {
+            name
+            id
+            icalendar
+            timezone
+            duration
+          }
+          alerts {
+            name
+            id
+          }
+          scanConfig {
+            id
+            name
+            trash
+          }
+          scanner {
+            id
+            name
+            type
+          }
+          hostsOrdering
+          observers {
+            users
+            roles {
+              name
+            }
+            groups {
+              name
+            }
+          }
+        }
+      }
+      counts {
+        total
+        filtered
+        offset
+        limit
+        length
+      }
+    }
+  }
+`;
+
+export const useGetTasks = (variables, options) => {
+  const {data, ...other} = useQuery(GET_TASKS, {...options, variables});
+  const tasks = isDefined(data?.tasks)
+    ? data.tasks.edges.map(entity => Task.fromObject(entity.node))
+    : [];
+
+  const {total, filtered, offset = -1, limit, length} =
+    data?.tasks?.counts || {};
+  const counts = new CollectionCounts({
+    all: total,
+    filtered: filtered,
+    first: offset + 1,
+    length: length,
+    rows: limit,
+  });
+  return {...other, data, counts, tasks};
+};


### PR DESCRIPTION
The mock objects should be put into the `web/graphql/__mocks__`
directory now. For now the task objects are copied from
`web/pages/tasks/__mocks__/mocktasks.js`. This file should be removed
at the end.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
