### PR TITLE
Make reload via GMP optional for list pages

### DIFF
--- a/gsa/src/web/entities/withEntitiesContainer.js
+++ b/gsa/src/web/entities/withEntitiesContainer.js
@@ -107,10 +107,13 @@ const withEntitiesContainer = (
       loadedFilter = filter;
     }
 
+    const reloadFunc = isDefined(loadEntities)
+      ? (newFilter = filter) => loadEntities(newFilter)
+      : undefined;
     return (
       <Reload
         reloadInterval={() => reloadInterval(props)}
-        reload={(newFilter = filter) => loadEntities(newFilter)}
+        reload={reloadFunc}
         name={gmpname}
       >
         {({reload}) => (
@@ -137,7 +140,7 @@ const withEntitiesContainer = (
     entitiesCounts: PropTypes.counts,
     entitiesError: PropTypes.error,
     filter: PropTypes.filter,
-    loadEntities: PropTypes.func.isRequired,
+    loadEntities: PropTypes.func,
     loadedFilter: PropTypes.filter,
     notify: PropTypes.func.isRequired,
   };
@@ -155,11 +158,17 @@ const withEntitiesContainer = (
     };
   };
 
-  const mapDispatchToProps = (dispatch, {gmp}) => ({
-    loadEntities: filter => dispatch(loadEntitiesFunc(gmp)(filter)),
-    updateFilter: filter => dispatch(pageFilter(gmpname, filter)),
-    onInteraction: () => dispatch(renewSessionTimeout(gmp)()),
-  });
+  const mapDispatchToProps = (dispatch, {gmp}) => {
+    const loadEntities = isDefined(loadEntitiesFunc)
+      ? filter => dispatch(loadEntitiesFunc(gmp)(filter))
+      : undefined;
+
+    return {
+      loadEntities,
+      updateFilter: filter => dispatch(pageFilter(gmpname, filter)),
+      onInteraction: () => dispatch(renewSessionTimeout(gmp)()),
+    };
+  };
 
   EntitiesContainerWrapper = compose(
     withDialogNotification,


### PR DESCRIPTION
Before it was required to pass a loadEntities function to
withEntitiesContainer. This commit changes the withEntitiesContainer to
make the loadEntities function optional. As a result not passing a
loadEntities functions deactivates the reloading via the Reload
component.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
