### PR TITLE
Fix request and locale for login

### DIFF
--- a/gsa/src/web/pages/login/loginpage.js
+++ b/gsa/src/web/pages/login/loginpage.js
@@ -66,6 +66,7 @@ export const LOGIN = gql`
   mutation login($username: String!, $password: String!) {
     login(username: $username, password: $password) {
       ok
+      locale
       sessionTimeout
       timezone
     }


### PR DESCRIPTION
The locale is already expected in the response. Therefore add it to the
actual graphql request.