### PR TITLE
sort schedule days numerically instead of alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Deleting a single entity now removes its ID from store [#1839](https://github.com/greenbone/gsa/pull/1839)
 
 ### Fixed
+- Fixed sort order for recurring days for custom monthly schedule [#2188](https://github.com/greenbone/gsa/pull/2188)
 - Fix missing loading indicator for test alert button [#2156](https://github.com/greenbone/gsa/pull/2156)
 - Close dialog for ExternalLink when following link [#2148](https://github.com/greenbone/gsa/pull/2148)
 - Fixed license information on AboutPage [#2118](https://github.com/greenbone/gsa/pull/2118) [#2148](https://github.com/greenbone/gsa/pull/2148)

--- a/gsa/src/gmp/models/event.js
+++ b/gsa/src/gmp/models/event.js
@@ -104,7 +104,7 @@ const getMonthDaysFromRRule = rrule => {
   }
 
   const bymonthday = rrule.getComponent('bymonthday');
-  return bymonthday.length > 0 ? bymonthday.sort() : undefined;
+  return bymonthday.length > 0 ? bymonthday.sort((a, b) => a - b) : undefined;
 };
 
 export class WeekDays {


### PR DESCRIPTION
Days for custom monthly schedules appear in wrong order. Change sorting from alphabetical to numerical to get the days in the right order.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
