### PR TITLE
Make some Families selectable as a whole only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Use unified solution type instead of solution type nvt tag [#2268](https://github.com/greenbone/gsa/pull/2268)
 - Changed queued status color [#2227](https://github.com/greenbone/gsa/pull/2227)
+- Make several NVT families selectable as a whole only in scan configs [#2222](https://github.com/greenbone/gsa/pull/2222)
 - Changed future release version from 20.04 to 20.08 [#2118](https://github.com/greenbone/gsa/pull/2118)
 - Adjusted task icons to use them for both tasks and audits and removed audit icons [#2070](https://github.com/greenbone/gsa/pull/2070)
 - Don't use DetailsLink in ClosedCvesTable if host does not have an ID [#2055](ttps://github.com/greenbone/gsa/pull/2055)

--- a/gsa/src/web/pages/scanconfigs/nvtfamilies.js
+++ b/gsa/src/web/pages/scanconfigs/nvtfamilies.js
@@ -49,6 +49,12 @@ import PropTypes from 'web/utils/proptypes';
 
 import Trend from './trend';
 
+const WHOLE_SELECTION_FAMILIES = [
+  'CentOS Local Security Checks',
+  'Fedora Local Security Checks',
+  'Huawei EulerOS Local Security Checks',
+];
+
 const NvtFamily = ({
   familyMaxNvtCount = 0,
   familyName,
@@ -59,56 +65,62 @@ const NvtFamily = ({
   onEditConfigFamilyClick,
   onSelectChange,
   onTrendChange,
-}) => (
-  <TableRow key={familyName}>
-    <TableData>{familyName}</TableData>
-    <TableData align="start">
-      {_('{{count}} of {{max}}', {
-        count: familyNvtCount,
-        max: familyMaxNvtCount,
-      })}
-    </TableData>
-    <TableData align={['center', 'start']}>
-      <Divider>
-        <Radio
+}) => {
+  const isToSelectWhole = WHOLE_SELECTION_FAMILIES.includes(familyName);
+  return (
+    <TableRow key={familyName}>
+      <TableData>{familyName}</TableData>
+      <TableData align="start">
+        {_('{{count}} of {{max}}', {
+          count: familyNvtCount,
+          max: familyMaxNvtCount,
+        })}
+      </TableData>
+      <TableData align={['center', 'start']}>
+        <Divider>
+          <Radio
+            flex
+            name={familyName}
+            checked={isToSelectWhole || trend === SCANCONFIG_TREND_DYNAMIC}
+            convert={parseTrend}
+            value={SCANCONFIG_TREND_DYNAMIC}
+            onChange={onTrendChange}
+          />
+          <Trend trend={SCANCONFIG_TREND_DYNAMIC} />
+          <Radio
+            flex
+            name={familyName}
+            checked={!isToSelectWhole && trend === SCANCONFIG_TREND_STATIC}
+            disabled={isToSelectWhole}
+            convert={parseTrend}
+            value={SCANCONFIG_TREND_STATIC}
+            onChange={onTrendChange}
+          />
+          <Trend active={!isToSelectWhole} trend={SCANCONFIG_TREND_STATIC} />
+        </Divider>
+      </TableData>
+      <TableData align={['start', 'center']}>
+        <Checkbox
           flex
           name={familyName}
-          checked={trend === SCANCONFIG_TREND_DYNAMIC}
-          convert={parseTrend}
-          value={SCANCONFIG_TREND_DYNAMIC}
-          onChange={onTrendChange}
+          checked={select === YES_VALUE}
+          checkedValue={YES_VALUE}
+          unCheckedValue={NO_VALUE}
+          onChange={onSelectChange}
         />
-        <Trend trend={SCANCONFIG_TREND_DYNAMIC} />
-        <Radio
-          flex
-          name={familyName}
-          checked={trend === SCANCONFIG_TREND_STATIC}
-          convert={parseTrend}
-          value={SCANCONFIG_TREND_STATIC}
-          onChange={onTrendChange}
-        />
-        <Trend trend={SCANCONFIG_TREND_STATIC} />
-      </Divider>
-    </TableData>
-    <TableData align={['start', 'center']}>
-      <Checkbox
-        flex
-        name={familyName}
-        checked={select === YES_VALUE}
-        checkedValue={YES_VALUE}
-        unCheckedValue={NO_VALUE}
-        onChange={onSelectChange}
-      />
-    </TableData>
-    <TableData align={['center', 'center']}>
-      <EditIcon
-        title={title}
-        value={familyName}
-        onClick={onEditConfigFamilyClick}
-      />
-    </TableData>
-  </TableRow>
-);
+      </TableData>
+      <TableData align={['center', 'center']}>
+        {!isToSelectWhole && (
+          <EditIcon
+            title={title}
+            value={familyName}
+            onClick={onEditConfigFamilyClick}
+          />
+        )}
+      </TableData>
+    </TableRow>
+  );
+};
 
 NvtFamily.propTypes = {
   familyMaxNvtCount: PropTypes.number,

--- a/gsa/src/web/pages/scanconfigs/nvtfamilies.js
+++ b/gsa/src/web/pages/scanconfigs/nvtfamilies.js
@@ -15,6 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+
+import 'core-js/features/array/includes';
+
 import React from 'react';
 
 import _ from 'gmp/locale';

--- a/gsa/src/web/pages/scanconfigs/nvtfamilies.js
+++ b/gsa/src/web/pages/scanconfigs/nvtfamilies.js
@@ -54,8 +54,13 @@ import Trend from './trend';
 
 const WHOLE_SELECTION_FAMILIES = [
   'CentOS Local Security Checks',
+  'Debian Local Security Checks',
   'Fedora Local Security Checks',
   'Huawei EulerOS Local Security Checks',
+  'Oracle Linux Local Security Checks',
+  'Red Hat Local Security Checks',
+  'SuSE Local Security Checks',
+  'Ubuntu Local Security Checks',
 ];
 
 const NvtFamily = ({


### PR DESCRIPTION
Several NVT families are now selectable as a whole only.
The trend is always set to dynamic, static is disabled, and the Edit Icon previously used to select individual NVTs is removed.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
