### PR TITLE
Use normalizeType in entities container to ensure correct command for secinfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
 - Lower memory usage when getting a report [#1857](https://github.com/greenbone/gvmd/pull/1857)
 
 ### Fixed
+- Fixed broken bulk export for AllSecInfo [#2269](https://github.com/greenbone/gsa/pull/2269)
 - Fixed passing threshold prop in AlertActions for ThresholdMessage [#2114](https://github.com/greenbone/gsa/pull/2114)
 - Fixed audit listpage observer tooltip [#2048](https://github.com/greenbone/gsa/pull/2048)
 - Fixed showing errors in CredentialDialog when opened from AlertDialog [#2041](https://github.com/greenbone/gsa/pull/2041)

--- a/gsa/src/gmp/utils/__tests__/entitytype.js
+++ b/gsa/src/gmp/utils/__tests__/entitytype.js
@@ -89,6 +89,7 @@ describe('normalizeType function tests', () => {
     expect(normalizeType('report_format')).toEqual('reportformat');
     expect(normalizeType('config')).toEqual('scanconfig');
     expect(normalizeType('vuln')).toEqual('vulnerability');
+    expect(normalizeType('allinfo')).toEqual('secinfo');
   });
 
   test('should pass through already normalize types', () => {

--- a/gsa/src/gmp/utils/entitytype.js
+++ b/gsa/src/gmp/utils/entitytype.js
@@ -56,6 +56,7 @@ const TYPES = {
   report_format: 'reportformat',
   tls_certificate: 'tlscertificate',
   vuln: 'vulnerability',
+  allinfo: 'secinfo',
 };
 
 /**

--- a/gsa/src/web/entities/container.js
+++ b/gsa/src/web/entities/container.js
@@ -36,6 +36,7 @@ import {
   apiType,
   typeName,
   pluralizeType,
+  normalizeType,
 } from 'gmp/utils/entitytype';
 import {debounce} from 'gmp/utils/event';
 
@@ -83,7 +84,7 @@ class EntitiesContainer extends React.Component {
 
     const {gmpname, gmp, notify} = this.props;
 
-    const entitiesCommandName = pluralizeType(gmpname);
+    const entitiesCommandName = pluralizeType(normalizeType(gmpname));
 
     this.entitiesCommand = gmp[entitiesCommandName];
 


### PR DESCRIPTION
AllSecInfo bulk export was broken because it was calling the wrong command. Use normalizeType in entities container to change "allinfo" to "secinfo" to be able to call the proper command.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
