### PR TITLE
Adjust parsing in cve model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Display timezone for session timeout in user menu [#1764](https://github.com/greenbone/gsa/pull/1764)
 
 ### Changed
+- Adjusted parsing of cve model and removed cwe id as it seems not to be needed anymore [#2294](https://github.com/greenbone/gsa/pull/2294)
 - Adjusted parsing of filter strings to deal with strings with double quotes [#2051](https://github.com/greenbone/gsa/pull/2051)
 - Changed report TlsCertificate table headers to match TlsCertificate assets
 table headers [#2044](https://github.com/greenbone/gsa/pull/2044)

--- a/gsa/src/gmp/models/__tests__/cve.js
+++ b/gsa/src/gmp/models/__tests__/cve.js
@@ -172,22 +172,17 @@ describe('CVE model tests', () => {
     expect(cve.products).toEqual([]);
   });
 
-  test('should parse cwe, published, and modified date from raw data', () => {
+  test('should parse published and modified date from raw data', () => {
     const elem = {
-      cwe: 'foo',
       raw_data: {
         entry: {
-          cwe: {
-            _id: '123abc',
-          },
-          'published-datetime': {__text: '2018-10-10T11:41:23.022Z'},
-          'last-modified-datetime': {__text: '2018-10-10T11:41:23.022Z'},
+          'published-datetime': '2018-10-10T11:41:23.022Z',
+          'last-modified-datetime': '2018-10-10T11:41:23.022Z',
         },
       },
     };
     const cve = Cve.fromElement(elem);
 
-    expect(cve.cweId).toEqual('123abc');
     expect(isDate(cve.publishedTime)).toBe(true);
     expect(isDate(cve.lastModifiedTime)).toBe(true);
   });
@@ -196,12 +191,10 @@ describe('CVE model tests', () => {
     const elem = {
       raw_data: {
         entry: {
-          'published-datetime': {__text: '2018-10-10T11:41:23.022Z'},
-          'last-modified-datetime': {__text: '2018-10-10T11:41:23.022Z'},
+          'published-datetime': '2018-10-10T11:41:23.022Z',
+          'last-modified-datetime': '2018-10-10T11:41:23.022Z',
           references: {
-            source: {
-              __text: 'foo',
-            },
+            source: 'foo',
             _reference_type: 'bar',
             reference: {
               __text: 'lorem',
@@ -227,13 +220,11 @@ describe('CVE model tests', () => {
     const elem = {
       raw_data: {
         entry: {
-          'published-datetime': {__text: '2018-10-10T11:41:23.022Z'},
-          'last-modified-datetime': {__text: '2018-10-10T11:41:23.022Z'},
+          'published-datetime': '2018-10-10T11:41:23.022Z',
+          'last-modified-datetime': '2018-10-10T11:41:23.022Z',
           cvss: {
             base_metrics: {
-              source: {
-                __text: 'prot://url',
-              },
+              source: 'prot://url',
             },
           },
         },
@@ -248,11 +239,9 @@ describe('CVE model tests', () => {
     const elem = {
       raw_data: {
         entry: {
-          'published-datetime': {__text: '2018-10-10T11:41:23.022Z'},
-          'last-modified-datetime': {__text: '2018-10-10T11:41:23.022Z'},
-          summary: {
-            __text: 'lorem ipsum',
-          },
+          'published-datetime': '2018-10-10T11:41:23.022Z',
+          'last-modified-datetime': '2018-10-10T11:41:23.022Z',
+          summary: 'lorem ipsum',
         },
       },
     };
@@ -265,10 +254,10 @@ describe('CVE model tests', () => {
     const elem = {
       raw_data: {
         entry: {
-          'published-datetime': {__text: '2018-10-10T11:41:23.022Z'},
-          'last-modified-datetime': {__text: '2018-10-10T11:41:23.022Z'},
+          'published-datetime': '2018-10-10T11:41:23.022Z',
+          'last-modified-datetime': '2018-10-10T11:41:23.022Z',
           'vulnerable-software-list': {
-            product: [{__text: 'lorem'}, {__text: 'ipsum'}],
+            product: ['lorem', 'ipsum'],
           },
         },
       },

--- a/gsa/src/gmp/models/cve.js
+++ b/gsa/src/gmp/models/cve.js
@@ -18,7 +18,7 @@
  */
 import 'core-js/features/object/entries';
 
-import {isDefined} from 'gmp/utils/identity';
+import {isArray, isDefined} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
 import {map} from 'gmp/utils/array';
 
@@ -151,7 +151,9 @@ class Cve extends Info {
 
       const products = entry['vulnerable-software-list'];
       if (isDefined(products)) {
-        ret.products = products.product;
+        ret.products = isArray(products.product)
+          ? products.product
+          : [products.product];
       }
 
       delete ret.raw_data;

--- a/gsa/src/gmp/models/cve.js
+++ b/gsa/src/gmp/models/cve.js
@@ -124,17 +124,13 @@ class Cve extends Info {
     if (isDefined(ret.raw_data) && isDefined(ret.raw_data.entry)) {
       const {entry} = ret.raw_data;
 
-      if (isDefined(ret.cwe)) {
-        ret.cweId = entry.cwe._id;
-      }
-
-      ret.publishedTime = parseDate(entry['published-datetime'].__text);
-      ret.lastModifiedTime = parseDate(entry['last-modified-datetime'].__text);
+      ret.publishedTime = parseDate(entry['published-datetime']);
+      ret.lastModifiedTime = parseDate(entry['last-modified-datetime']);
 
       ret.references = map(entry.references, ref => ({
         name: ref.reference.__text,
         href: ref.reference._href,
-        source: ref.source.__text,
+        source: ref.source,
         reference_type: ref._reference_type,
       }));
 
@@ -143,19 +139,19 @@ class Cve extends Info {
         isDefined(entry.cvss.base_metrics) &&
         isDefined(entry.cvss.base_metrics.source)
       ) {
-        ret.source = entry.cvss.base_metrics.source.__text;
+        ret.source = entry.cvss.base_metrics.source;
       }
 
-      if (isDefined(entry.summary) && !isEmpty(entry.summary.__text)) {
+      if (isDefined(entry.summary)) {
         // really don't know why entry.summary and ret.description can differ
         // but xslt did use the summary and and e.g. the description of
         // CVE-2017-2988 was empty but summary not
-        ret.description = entry.summary.__text;
+        ret.description = entry.summary;
       }
 
       const products = entry['vulnerable-software-list'];
       if (isDefined(products)) {
-        ret.products = map(products.product, product => product.__text);
+        ret.products = products.product;
       }
 
       delete ret.raw_data;

--- a/gsa/src/web/pages/cves/details.js
+++ b/gsa/src/web/pages/cves/details.js
@@ -50,27 +50,10 @@ const CVSS_PROPS = {
 };
 
 const CveDetails = ({entity}) => {
-  const {
-    cvssBaseVector,
-    cweId,
-    description,
-    references = [],
-    severity,
-  } = entity;
+  const {cvssBaseVector, description, references = [], severity} = entity;
 
   return (
     <Layout flex="column" grow="1">
-      {isDefined(cweId) && (
-        <InfoTable>
-          <TableBody>
-            <TableRow>
-              <TableData>{_('CWE ID')}</TableData>
-              <TableData>{entity.cweId}</TableData>
-            </TableRow>
-          </TableBody>
-        </InfoTable>
-      )}
-
       {isDefined(description) && (
         <DetailsBlock title={_('Description')}>
           <p>{description}</p>


### PR DESCRIPTION
Fix parsing in cve model. 

This fixes
- missing reference identifiers
- disappearing vulnerable products section
- missing published and last updated dates

It also removes the cwe id as this has not been displayed starting with GOS 5 and seems not to be needed anymore.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
