### PR TITLE
Allow relative paths for reverse proxy

### DIFF
--- a/gsa/package.json
+++ b/gsa/package.json
@@ -1,6 +1,7 @@
 {
   "name": "gsa",
   "version": "20.08",
+  "homepage": ".",
   "description": "Greenbone Security Assistant",
   "keywords": [
     "openvas",

--- a/gsa/src/web/routes.js
+++ b/gsa/src/web/routes.js
@@ -17,7 +17,7 @@
  */
 import React from 'react';
 
-import {Router, Route, Switch} from 'react-router-dom';
+import {HashRouter, Route, Switch} from 'react-router-dom';
 
 import {createBrowserHistory} from 'history';
 import {stringify, parse} from 'qs';
@@ -117,7 +117,7 @@ export const createQueryHistory = (history = createBrowserHistory()) =>
 const HISTORY = createQueryHistory();
 
 const Routes = () => (
-  <Router history={HISTORY}>
+  <HashRouter history={HISTORY}>
     <Switch>
       <Route path="/login" component={LoginPage} />
       <Route path="/omp" component={LegacyOmpPage} />
@@ -231,7 +231,7 @@ const Routes = () => (
         </LocationObserver>
       </Authorized>
     </Switch>
-  </Router>
+  </HashRouter>
 );
 
 export default Routes;


### PR DESCRIPTION
Support relative paths for reverse proxy

Issue https://github.com/greenbone/gsa/issues/652

For example:
`	<Location "/GVM">`
`		ProxyPass https://127.0.0.1:8443`
`		ProxyPassReverse https://127.0.0.1:8443`
`		RedirectMatch ^/GVM$ /GVM/`
`	</Location>`
`	ProxyPass /gmp https://127.0.0.1:8443/gmp`


**Checklist**:

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
