### PR TITLE
Fix broken radio buttons in alert dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Deleting a single entity now removes its ID from store [#1839](https://github.com/greenbone/gsa/pull/1839)
 
 ### Fixed
+- Fixed broken radio buttons in alert dialog [#2326](https://github.com/greenbone/gsa/pull/2326)
 - Fixed report formats undeletable and unrestorable [#2321](https://github.com/greenbone/gsa/pull/2321)
 - Fixed loading delta report detailspage [#2320](https://github.com/greenbone/gsa/pull/2320)
 - Fixed spacing between radio buttons and input field in override dialog [#2286](https://github.com/greenbone/gsa/pull/2286)

--- a/gsa/src/gmp/models/__tests__/alert.js
+++ b/gsa/src/gmp/models/__tests__/alert.js
@@ -155,6 +155,20 @@ describe('Alert Model tests', () => {
     expect(alert.method.data.report_formats).toEqual([]);
   });
 
+  test('should parse notice as String', () => {
+    const elem = {
+      method: {
+        data: {
+          __text: 1,
+          name: 'notice',
+        },
+      },
+    };
+    const alert = Alert.fromElement(elem);
+
+    expect(alert.method.data.notice.value).toEqual('1');
+  });
+
   test('isActive() should return correct true/false', () => {
     const alert1 = Alert.fromElement({active: '0'});
     const alert2 = Alert.fromElement({active: '1'});

--- a/gsa/src/gmp/models/alert.js
+++ b/gsa/src/gmp/models/alert.js
@@ -138,6 +138,10 @@ class Alert extends Model {
       ret.method.data.report_formats = [];
     }
 
+    if (isDefined(ret.method.data.notice?.value)) {
+      ret.method.data.notice.value = ret.method.data.notice.value.toString();
+    }
+
     ret.active = parseYesNo(element.active);
 
     return ret;


### PR DESCRIPTION
The radio buttons for email alerts in the alert dialog were not working. The corresponding value from the model was a number but the dialog was expecting a string.

Fix parsing in the alert model to return a string as expected.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
