### PR TITLE
Updated systemd unit file:

### DIFF
--- a/gsad/config/gsad.service.in
+++ b/gsad/config/gsad.service.in
@@ -1,6 +1,8 @@
 [Unit]
 Description=Greenbone Security Assistant
-After=network.target
+After=network.target networking.service gvmd.service
+Documentation=man:gsad(8)
+ConditionKernelCommandLine=!recovery
 
 [Service]
 Type=forking


### PR DESCRIPTION
`Documentation=` is described here:

https://www.freedesktop.org/software/systemd/man/systemd.unit.html#%5BUnit%5D%20Section%20Options

The `networking.service` and `ConditionKernelCommandLine` was picked from https://github.com/greenbone/ospd-openvas/blob/ospd-openvas-20.08/config/ospd-openvas.service

`gvmd.service` was added because no login within the GSA will work until the manager is up.