### PR TITLE
Keep schedule_periods even if there is no schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Deleting a single entity now removes its ID from store [#1839](https://github.com/greenbone/gsa/pull/1839)
 
 ### Fixed
+- Fixed schedule_periods not forwarded if there is no schedule [#2331](https://github.com/greenbone/gsa/pull/2331)
 - Fixed broken radio buttons in alert dialog [#2326](https://github.com/greenbone/gsa/pull/2326)
 - Fixed report formats undeletable and unrestorable [#2321](https://github.com/greenbone/gsa/pull/2321)
 - Fixed loading delta report detailspage [#2320](https://github.com/greenbone/gsa/pull/2320)

--- a/gsa/src/web/pages/tasks/component.js
+++ b/gsa/src/web/pages/tasks/component.js
@@ -396,8 +396,6 @@ class TaskComponent extends React.Component {
   }
 
   openStandardTaskDialog(task) {
-    const {capabilities} = this.props;
-
     this.props.loadAlerts();
     this.props.loadScanConfigs();
     this.props.loadScanners();
@@ -406,13 +404,6 @@ class TaskComponent extends React.Component {
     this.props.loadTags();
 
     if (isDefined(task)) {
-      const canAccessSchedules =
-        capabilities.mayAccess('schedules') && isDefined(task.schedule);
-      const schedule_id = canAccessSchedules ? task.schedule.id : UNSET_VALUE;
-      const schedule_periods = canAccessSchedules
-        ? task.schedule_periods
-        : undefined;
-
       this.setState({
         taskDialogVisible: true,
         alert_ids: map(task.alerts, alert => alert.id),
@@ -430,8 +421,8 @@ class TaskComponent extends React.Component {
         min_qod: task.min_qod,
         name: task.name,
         scanner_id: hasId(task.scanner) ? task.scanner.id : undefined,
-        schedule_id,
-        schedule_periods,
+        schedule_id: isDefined(task.schedule) ? task.schedule.id : UNSET_VALUE,
+        schedule_periods: task.schedule_periods,
         source_iface: task.source_iface,
         target_id: hasId(task.target) ? task.target.id : undefined,
         task,
@@ -1044,8 +1035,5 @@ const mapDispatchToProp = (dispatch, {gmp}) => ({
 export default compose(
   withGmp,
   withCapabilities,
-  connect(
-    mapStateToProps,
-    mapDispatchToProp,
-  ),
+  connect(mapStateToProps, mapDispatchToProp),
 )(TaskComponent);


### PR DESCRIPTION
Always forward schedule and schedule_periods to task dialog. This should ensure checkbox for "once" stays checked after the task was run.

The check for capabilities is removed because the input for the dialog should not depend on capabilities (only the visibility does and that is taken care of in the dialog itself)

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
