### PR TITLE
Use the same counts in EmptyResultsReport as the TabTitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added handling of queued task status [#2208](https://github.com/greenbone/gsa/pull/2208)
 
 ### Changed
+- EmptyResultsReport uses the same counts as the results tab title in normal reports, when filtering for nonexistent results [#2335](https://github.com/greenbone/gsa/pull/2335)
 - Improve error 503 message at login [#2310](https://github.com/greenbone/gsa/pull/2310)
 - Use unified solution type instead of solution type nvt tag [#2268](https://github.com/greenbone/gsa/pull/2268)
 - Changed queued status color [#2227](https://github.com/greenbone/gsa/pull/2227)

--- a/gsa/src/web/pages/reports/details/resultstab.js
+++ b/gsa/src/web/pages/reports/details/resultstab.js
@@ -364,7 +364,6 @@ const mapStateToProps = (state, {reportId}) => {
     resultsFilter,
     resultsError: selector.getEntitiesError(resultsFilter),
     results: selector.getEntities(resultsFilter),
-    resultsCounts: selector.getEntitiesCounts(resultsFilter),
     isLoading: selector.isLoadingEntities(resultsFilter),
   };
 };
@@ -379,10 +378,7 @@ const mapDispatchToProps = (dispatch, {reportId, gmp}) => {
 
 export default compose(
   withGmp,
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  ),
+  connect(mapStateToProps, mapDispatchToProps),
 )(ResultsTabWrapper);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/reports/detailscontent.js
+++ b/gsa/src/web/pages/reports/detailscontent.js
@@ -309,6 +309,7 @@ const PageContent = ({
                       reportFilter={reportFilter}
                       reportId={reportId}
                       results={results.entities}
+                      resultsCounts={resultsCounts}
                       sortField={sorting.results.sortField}
                       sortReverse={sorting.results.sortReverse}
                       onFilterAddLogLevelClick={onFilterAddLogLevelClick}


### PR DESCRIPTION
Our ResultsTab fetches a different CollectionCounts from store to use with the EmptyResultsReport and this causes a significantly different number to be displayed in the EmptyResultsReport when the user filters for a nonexistent result from what is shown on the Results TabTitle component. They should use the same props and be consistent.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
