### PR TITLE
Schedules with recurrence "once" are missing nextDate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
 - Lower memory usage when getting a report [#1857](https://github.com/greenbone/gvmd/pull/1857)
 
 ### Fixed
+- Fixed missing nextDate for schedules with recurrence "once" [#2336](https://github.com/greenbone/gsa/pull/2336)
 - Don't crash if dashboard getSetting returns duplicate setting [#2290](https://github.com/greenbone/gsa/pull/2290)
 - Fixed broken bulk export for AllSecInfo [#2269](https://github.com/greenbone/gsa/pull/2269)
 - Fixed passing threshold prop in AlertActions for ThresholdMessage [#2114](https://github.com/greenbone/gsa/pull/2114)

--- a/gsa/src/gmp/models/__tests__/event.js
+++ b/gsa/src/gmp/models/__tests__/event.js
@@ -137,4 +137,60 @@ END:VCALENDAR
     const rDate = startDate.clone().add(1, 'day');
     expect(nextDate.isSame(rDate)).toEqual(true);
   });
+
+  test('should calculate start date as next date for no recurrence', () => {
+    const now = date
+      .tz('utc')
+      .minutes(0)
+      .seconds(0)
+      .milliseconds(0);
+    const startDate = now.clone().add(1, 'hour');
+    const icalendar = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Greenbone.net//NONSGML Greenbone Security Manager 8.0.0//EN
+BEGIN:VEVENT
+UID:c35f82f1-7798-4b84-b2c4-761a33068956
+DTSTART:${startDate.format(ICAL_FORMAT)}
+DTSTAMP:${now.format(ICAL_FORMAT)}
+END:VEVENT
+END:VCALENDAR
+`;
+
+    const event = Event.fromIcal(icalendar, 'Europe/Berlin');
+
+    expect(event).toBeDefined();
+
+    const {nextDate} = event;
+
+    // next event should be start date
+    expect(nextDate.isSame(startDate)).toEqual(true);
+  });
+
+  test('should calculate no next date for no recurrence if start date is already over', () => {
+    const startDate = date
+      .tz('utc')
+      .minutes(0)
+      .seconds(0)
+      .milliseconds(0);
+    const now = startDate.clone().add(1, 'hour');
+    const icalendar = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Greenbone.net//NONSGML Greenbone Security Manager 8.0.0//EN
+BEGIN:VEVENT
+UID:c35f82f1-7798-4b84-b2c4-761a33068956
+DTSTART:${startDate.format(ICAL_FORMAT)}
+DTSTAMP:${now.format(ICAL_FORMAT)}
+END:VEVENT
+END:VCALENDAR
+`;
+
+    const event = Event.fromIcal(icalendar, 'Europe/Berlin');
+
+    expect(event).toBeDefined();
+
+    const {nextDate} = event;
+
+    // there should be no next event
+    expect(nextDate).toBeUndefined();
+  });
 });

--- a/gsa/src/gmp/models/event.js
+++ b/gsa/src/gmp/models/event.js
@@ -379,6 +379,14 @@ class Event {
           }
         }
       }
+    } else if (isDefined(this.event) && isDefined(this.event.startDate)) {
+      // the event is not recurring
+      // it should only occur once on its start date
+      const now = date();
+
+      if (this.event.startDate.toUnixTime() >= now.unix()) {
+        return convertIcalDate(this.event.startDate, this.timezone);
+      }
     }
     return undefined;
   }

--- a/gsa/src/web/pages/schedules/details.js
+++ b/gsa/src/web/pages/schedules/details.js
@@ -61,7 +61,7 @@ const ScheduleDetails = ({entity, links = true}) => {
           <TableRow>
             <TableData>{_('First Run')}</TableData>
             <TableData>
-              {isDefined(nextDate) ? (
+              {isDefined(startDate) ? (
                 <DateTime date={startDate} timezone={timezone} />
               ) : (
                 '-'


### PR DESCRIPTION
Schedules with recurrence "once" do not have a nextDate. Therefore, tasks with these kinds of schedules are not started.

Calculate nextDate for schedules with recurrence "once" and adjust tests accordingly.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
