### PR TITLE
Fix Modify Task Wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
 - Lower memory usage when getting a report [#1857](https://github.com/greenbone/gvmd/pull/1857)
 
 ### Fixed
+- Fixed broken radio buttons and wrong date for schedule in Modify Task Wizard [#2340](https://github.com/greenbone/gsa/pull/2340)
 - Fixed missing nextDate for schedules with recurrence "once" [#2336](https://github.com/greenbone/gsa/pull/2336)
 - Don't crash if dashboard getSetting returns duplicate setting [#2290](https://github.com/greenbone/gsa/pull/2290)
 - Fixed broken bulk export for AllSecInfo [#2269](https://github.com/greenbone/gsa/pull/2269)

--- a/gsa/src/gmp/commands/wizard.js
+++ b/gsa/src/gmp/commands/wizard.js
@@ -211,7 +211,7 @@ class WizardCommand extends HttpCommand {
       event_data_modify_task_fields,
     );
 
-    event_data['event_data:start_day'] = start_date.day();
+    event_data['event_data:start_day'] = start_date.date();
     event_data['event_data:start_month'] = start_date.month() + 1;
     event_data['event_data:start_year'] = start_date.year();
 

--- a/gsa/src/web/wizard/modifytaskwizard.js
+++ b/gsa/src/web/wizard/modifytaskwizard.js
@@ -20,7 +20,7 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {NO_VALUE, YES_VALUE} from 'gmp/parser';
+import {parseYesNo, NO_VALUE, YES_VALUE} from 'gmp/parser';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -127,6 +127,7 @@ const ModifyTaskWizard = ({
                   title={_('Do not change')}
                   value={NO_VALUE}
                   checked={state.reschedule === NO_VALUE}
+                  convert={parseYesNo}
                   name="reschedule"
                   onChange={onValueChange}
                 />
@@ -136,6 +137,7 @@ const ModifyTaskWizard = ({
                   title={_('Create Schedule')}
                   value={YES_VALUE}
                   checked={state.reschedule === YES_VALUE}
+                  convert={parseYesNo}
                   name="reschedule"
                   onChange={onValueChange}
                 />


### PR DESCRIPTION
The radio buttons in the Modify Task Wizard were not working due to a missing convert function. 

Also the calculated date of the schedule was wrong since day() returns the day of the week and not the day of the month. Use date() instead. (See also https://momentjs.com/docs/#/get-set/date/)

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
