### PR TITLE
handle undefined trash in case of an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [9.0.1] - 2020-05-13
 
 ### Added
+- Added handling possible undefined trash in case of an error on the trashcanpage [#2348](https://github.com/greenbone/gsa/pull/2348)
 - Added scanner selection to audit dialog
   [#2031](https://github.com/greenbone/gsa/pull/2031)
   [#2105](https://github.com/greenbone/gsa/pull/2105)

--- a/gsa/src/web/pages/extras/trashcanpage.js
+++ b/gsa/src/web/pages/extras/trashcanpage.js
@@ -334,10 +334,13 @@ class Trashcan extends React.Component {
   }
 
   render() {
-    const {error, trash, loading} = this.state;
+    const {error, loading} = this.state;
+    let {trash} = this.state;
 
     if (!isDefined(trash) && !isDefined(error)) {
       return <Loading />;
+    } else if (!isDefined(trash) && isDefined(error)) {
+      trash = {};
     }
 
     const {scan: tasks, compliance: audits} = separateByUsageType(
@@ -557,7 +560,10 @@ const mapDispatchToProps = (dispatch, {gmp}) => ({
 
 export default compose(
   withGmp,
-  connect(undefined, mapDispatchToProps),
+  connect(
+    undefined,
+    mapDispatchToProps,
+  ),
 )(Trashcan);
 
 // vim: set ts=2 sw=2 tw=80:


### PR DESCRIPTION
Backport of https://github.com/greenbone/gsa/pull/1908 

In case of an error on the trashcanpage the trash might be undefined which would cause the trashcanpage to break. This PR should fix that by catching this special case.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
