### PR TITLE
Improve performance of form fields in edit scan config dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added handling of queued task status [#2208](https://github.com/greenbone/gsa/pull/2208)
 
 ### Changed
+- Improve performance of form fields in edit scan config dialog [#2354](https://github.com/greenbone/gsa/pull/2354)
 - Default to sorting nvts by "Created", newest first [#2352](https://github.com/greenbone/gsa/pull/2352)
 - Disable EditIcons for data objects from feed [#2346](https://github.com/greenbone/gsa/pull/2346)
 - EmptyResultsReport uses the same counts as the results tab title in normal reports, when filtering for nonexistent results [#2335](https://github.com/greenbone/gsa/pull/2335)

--- a/gsa/src/web/pages/nvts/nvtpreference.js
+++ b/gsa/src/web/pages/nvts/nvtpreference.js
@@ -37,7 +37,6 @@ import Layout from 'web/components/layout/layout';
 
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
-import Preferences from './preferences';
 
 const noop_convert = value => value;
 

--- a/gsa/src/web/pages/nvts/nvtpreference.js
+++ b/gsa/src/web/pages/nvts/nvtpreference.js
@@ -55,7 +55,7 @@ class NvtPreference extends React.Component {
 
   onPreferenceChange(value) {
     const {onChange, preference} = this.props;
-    onChange({type: 'setState', newState: {name: preference.name, value}});
+    onChange({type: 'setValue', newState: {name: preference.name, value}});
   }
 
   onCheckedChange(value) {

--- a/gsa/src/web/pages/nvts/nvtpreference.js
+++ b/gsa/src/web/pages/nvts/nvtpreference.js
@@ -37,6 +37,7 @@ import Layout from 'web/components/layout/layout';
 
 import TableData from 'web/components/table/data';
 import TableRow from 'web/components/table/row';
+import Preferences from './preferences';
 
 const noop_convert = value => value;
 
@@ -54,7 +55,7 @@ class NvtPreference extends React.Component {
 
   onPreferenceChange(value) {
     const {onChange, preference} = this.props;
-    onChange({value, type: preference.type}, preference.name);
+    onChange({type: 'setState', newState: {name: preference.name, value}});
   }
 
   onCheckedChange(value) {

--- a/gsa/src/web/pages/scanconfigs/editdialog.js
+++ b/gsa/src/web/pages/scanconfigs/editdialog.js
@@ -91,8 +91,8 @@ const reducer = (state, action) => {
         ...newState,
       };
     case 'setAll':
-      const {stateObject} = action;
-      return stateObject;
+      const {formValues} = action;
+      return formValues;
     default:
       return state;
   }
@@ -131,7 +131,7 @@ const EditScanConfigDialog = ({
   useEffect(() => {
     dispatch({
       type: 'setAll',
-      stateObject: createScannerPreferenceValues(scannerPreferences),
+      formValues: createScannerPreferenceValues(scannerPreferences),
     });
   }, [scannerPreferences]);
 

--- a/gsa/src/web/pages/scanconfigs/editdialog.js
+++ b/gsa/src/web/pages/scanconfigs/editdialog.js
@@ -84,7 +84,7 @@ const createScannerPreferenceValues = (preferences = []) => {
 
 const reducer = (state, action) => {
   switch (action.type) {
-    case 'setState':
+    case 'setValue':
       const {newState} = action;
       return {
         ...state,

--- a/gsa/src/web/pages/scanconfigs/editdialog.js
+++ b/gsa/src/web/pages/scanconfigs/editdialog.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, {useState, useEffect} from 'react';
+import React, {useReducer, useState, useEffect} from 'react';
 
 import _ from 'gmp/locale';
 
@@ -82,6 +82,22 @@ const createScannerPreferenceValues = (preferences = []) => {
   return values;
 };
 
+const reducer = (state, action) => {
+  switch (action.type) {
+    case 'setState':
+      const {newState} = action;
+      return {
+        ...state,
+        ...newState,
+      };
+    case 'setAll':
+      const {stateObject} = action;
+      return stateObject;
+    default:
+      return state;
+  }
+};
+
 const EditScanConfigDialog = ({
   comment = '',
   configId,
@@ -105,16 +121,18 @@ const EditScanConfigDialog = ({
   onEditNvtDetailsClick,
   onSave,
 }) => {
-  const [scannerPreferenceValues, setScannerPreferenceValues] = useState(
+  const [scannerPreferenceValues, dispatch] = useReducer(
+    reducer,
     createScannerPreferenceValues(scannerPreferences),
   );
-  const [trendValues, setTrendValues] = useState(undefined);
-  const [selectValues, setSelectValues] = useState(undefined);
+  const [trendValues, setTrendValues] = useState();
+  const [selectValues, setSelectValues] = useState();
 
   useEffect(() => {
-    setScannerPreferenceValues(
-      createScannerPreferenceValues(scannerPreferences),
-    );
+    dispatch({
+      type: 'setAll',
+      stateObject: createScannerPreferenceValues(scannerPreferences),
+    });
   }, [scannerPreferences]);
 
   // trend and select are created only once and only after the whole config is loaded
@@ -206,7 +224,7 @@ const EditScanConfigDialog = ({
                 <ScannerPreferences
                   values={scannerPreferenceValues}
                   preferences={scannerPreferences}
-                  onValuesChange={values => setScannerPreferenceValues(values)}
+                  onValuesChange={dispatch}
                 />
               )}
 

--- a/gsa/src/web/pages/scanconfigs/editnvtdetailsdialog.js
+++ b/gsa/src/web/pages/scanconfigs/editnvtdetailsdialog.js
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useReducer, useState} from 'react';
 
 import _ from 'gmp/locale';
 
@@ -74,6 +74,31 @@ const createPrefValues = (preferences = []) => {
 const convertTimeout = value =>
   !isDefined(value) || value.trim().length === 0 ? undefined : value;
 
+const reducer = (state, action) => {
+  switch (action.type) {
+    case 'setState':
+      const {newState} = action;
+      const {name, value} = newState;
+
+      const oldState = state[name];
+
+      const updatedState = {
+        ...state,
+        [name]: {
+          ...oldState,
+          value,
+        },
+      };
+
+      return updatedState;
+    case 'setAll':
+      const {stateObject} = action;
+      return stateObject;
+    default:
+      return state;
+  }
+};
+
 const EditNvtDetailsDialog = ({
   configId,
   configName,
@@ -96,7 +121,8 @@ const EditNvtDetailsDialog = ({
 }) => {
   timeout = convertTimeout(timeout);
 
-  const [preferenceValues, setPreferenceValues] = useState(
+  const [preferenceValues, dispatch] = useReducer(
+    reducer,
     createPrefValues(preferences),
   );
 
@@ -106,7 +132,10 @@ const EditNvtDetailsDialog = ({
   );
 
   useEffect(() => {
-    setPreferenceValues(createPrefValues(preferences));
+    dispatch({
+      type: 'setAll',
+      stateObject: createPrefValues(preferences),
+    });
   }, [preferences]);
 
   useEffect(() => {
@@ -268,9 +297,7 @@ const EditNvtDetailsDialog = ({
                       key={pref.name}
                       preference={pref}
                       value={prefValue}
-                      onChange={value => {
-                        preferenceValues[pref.name].value = value.value;
-                      }}
+                      onChange={dispatch}
                     />
                   );
                 })}

--- a/gsa/src/web/pages/scanconfigs/editnvtdetailsdialog.js
+++ b/gsa/src/web/pages/scanconfigs/editnvtdetailsdialog.js
@@ -92,8 +92,8 @@ const reducer = (state, action) => {
 
       return updatedState;
     case 'setAll':
-      const {stateObject} = action;
-      return stateObject;
+      const {formValues} = action;
+      return formValues;
     default:
       return state;
   }
@@ -134,7 +134,7 @@ const EditNvtDetailsDialog = ({
   useEffect(() => {
     dispatch({
       type: 'setAll',
-      stateObject: createPrefValues(preferences),
+      formValues: createPrefValues(preferences),
     });
   }, [preferences]);
 

--- a/gsa/src/web/pages/scanconfigs/editnvtdetailsdialog.js
+++ b/gsa/src/web/pages/scanconfigs/editnvtdetailsdialog.js
@@ -76,7 +76,7 @@ const convertTimeout = value =>
 
 const reducer = (state, action) => {
   switch (action.type) {
-    case 'setState':
+    case 'setValue':
       const {newState} = action;
       const {name, value} = newState;
 

--- a/gsa/src/web/pages/scanconfigs/editnvtdetailsdialog.js
+++ b/gsa/src/web/pages/scanconfigs/editnvtdetailsdialog.js
@@ -82,6 +82,7 @@ const reducer = (state, action) => {
 
       const oldState = state[name];
 
+      // preference has other attributes like id, type, etc. those must be kept so its not as simple as [name]: value
       const updatedState = {
         ...state,
         [name]: {

--- a/gsa/src/web/pages/scanconfigs/editnvtdetailsdialog.js
+++ b/gsa/src/web/pages/scanconfigs/editnvtdetailsdialog.js
@@ -80,13 +80,13 @@ const reducer = (state, action) => {
       const {newState} = action;
       const {name, value} = newState;
 
-      const oldState = state[name];
+      const prefAttributes = state[name];
 
       // preference has other attributes like id, type, etc. those must be kept so its not as simple as [name]: value
       const updatedState = {
         ...state,
         [name]: {
-          ...oldState,
+          ...prefAttributes,
           value,
         },
       };

--- a/gsa/src/web/pages/scanconfigs/scannerpreferences.js
+++ b/gsa/src/web/pages/scanconfigs/scannerpreferences.js
@@ -76,7 +76,7 @@ const ScannerPreference = ({
       <TableData>
         {is_radio ? (
           <Layout>
-            <YesNoRadio
+            <YesNoRadio // booleans are now 1 and 0 and not yes/no.
               yesValue={1}
               noValue={0}
               name={name}

--- a/gsa/src/web/pages/scanconfigs/scannerpreferences.js
+++ b/gsa/src/web/pages/scanconfigs/scannerpreferences.js
@@ -18,6 +18,7 @@
 import React from 'react';
 
 import _ from 'gmp/locale';
+import {parseInt} from 'gmp/parser';
 
 import {FoldState} from 'web/components/folding/folding';
 
@@ -36,8 +37,6 @@ import TableHead from 'web/components/table/head';
 import TableRow from 'web/components/table/row';
 
 import PropTypes from 'web/utils/proptypes';
-
-const noop_convert = value => value;
 
 const ScannerPreference = ({
   displayName,
@@ -78,11 +77,11 @@ const ScannerPreference = ({
         {is_radio ? (
           <Layout>
             <YesNoRadio
-              yesValue="yes"
-              noValue="no"
+              yesValue={1}
+              noValue={0}
               name={name}
               value={value}
-              convert={noop_convert}
+              convert={parseInt}
               onChange={onPreferenceChange}
             />
           </Layout>
@@ -107,40 +106,41 @@ const ScannerPreferences = ({
   preferences = [],
   values = {},
   onValuesChange,
-}) => (
-  <Section
-    foldable
-    initialFoldState={FoldState.FOLDED}
-    title={_('Edit Scanner Preferences ({{counts}})', {
-      counts: preferences.length,
-    })}
-  >
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead>{_('Name')}</TableHead>
-          <TableHead>{_('New Value')}</TableHead>
-          <TableHead>{_('Default Value')}</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {preferences.map(pref => (
-          <ScannerPreference
-            key={pref.name}
-            defaultValue={pref.default}
-            displayName={pref.hr_name}
-            name={pref.name}
-            value={values[pref.name]}
-            onPreferenceChange={(value, name) => {
-              values[name] = value;
-              onValuesChange(values);
-            }}
-          />
-        ))}
-      </TableBody>
-    </Table>
-  </Section>
-);
+}) => {
+  return (
+    <Section
+      foldable
+      initialFoldState={FoldState.FOLDED}
+      title={_('Edit Scanner Preferences ({{counts}})', {
+        counts: preferences.length,
+      })}
+    >
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>{_('Name')}</TableHead>
+            <TableHead>{_('New Value')}</TableHead>
+            <TableHead>{_('Default Value')}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {preferences.map(pref => (
+            <ScannerPreference
+              key={pref.name}
+              defaultValue={pref.default}
+              displayName={pref.hr_name}
+              name={pref.name}
+              value={values[pref.name]}
+              onPreferenceChange={(value, name) =>
+                onValuesChange({type: 'setState', newState: {[name]: value}})
+              }
+            />
+          ))}
+        </TableBody>
+      </Table>
+    </Section>
+  );
+};
 
 export const ScannerPreferencePropType = PropTypes.shape({
   default: PropTypes.any,

--- a/gsa/src/web/pages/scanconfigs/scannerpreferences.js
+++ b/gsa/src/web/pages/scanconfigs/scannerpreferences.js
@@ -132,7 +132,7 @@ const ScannerPreferences = ({
               name={pref.name}
               value={values[pref.name]}
               onPreferenceChange={(value, name) =>
-                onValuesChange({type: 'setState', newState: {[name]: value}})
+                onValuesChange({type: 'setValue', newState: {[name]: value}})
               }
             />
           ))}


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
In edit scan config dialog: Currently, if we change any value in scanner preferences, or open the edit nvt preferences dialog and edit the values there, the radio buttons are extremely slow to react (take 10-15s for me). This is because there are a lot of form fields, and they are ALL updated whenever one is changed. This is from setting form state using `useState`. Use `useReducer` instead, to set a single value in the state object instead of updating all the form values.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
