### PR TITLE
fix disappearing scanned hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Deleting a single entity now removes its ID from store [#1839](https://github.com/greenbone/gsa/pull/1839)
 
 ### Fixed
+- Fixed "Hosts scanned" in report details disappearing during page refresh [#2357](https://github.com/greenbone/gsa/pull/2357)
 - Fixed schedule_periods not forwarded if there is no schedule [#2331](https://github.com/greenbone/gsa/pull/2331)
 - Fixed broken radio buttons in alert dialog [#2326](https://github.com/greenbone/gsa/pull/2326)
 - Fixed report formats undeletable and unrestorable [#2321](https://github.com/greenbone/gsa/pull/2321)

--- a/gsa/src/web/pages/reports/details/summary.js
+++ b/gsa/src/web/pages/reports/details/summary.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 
 import styled from 'styled-components';
 
@@ -102,9 +102,11 @@ const Summary = ({
 
   const [hostsCount, setHostsCount] = useState(0);
 
-  if (hosts?.counts?.all > hostsCount) {
-    setHostsCount(hosts.counts.all);
-  }
+  useEffect(() => {
+    if (isDefined(hosts?.counts?.all)) {
+      setHostsCount(hosts.counts.all);
+    }
+  }, [hosts]);
 
   const filterString = isDefined(filter)
     ? filter.simple().toFilterString()

--- a/gsa/src/web/pages/reports/details/summary.js
+++ b/gsa/src/web/pages/reports/details/summary.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import React, {useState} from 'react';
 
 import styled from 'styled-components';
 
@@ -100,8 +100,11 @@ const Summary = ({
 
   const {id, name, comment, progress} = task;
 
-  const hosts_count =
-    isDefined(hosts) && isDefined(hosts.counts) ? hosts.counts.all : 0;
+  const [hostsCount, setHostsCount] = useState(0);
+
+  if (hosts?.counts?.all > hostsCount) {
+    setHostsCount(hosts.counts.all);
+  }
 
   const filterString = isDefined(filter)
     ? filter.simple().toFilterString()
@@ -244,10 +247,10 @@ const Summary = ({
               <TableData>{slave.name}</TableData>
             </TableRow>
           )}
-          {hosts_count > 0 && (
+          {hostsCount > 0 && (
             <TableRow>
               <TableData>{_('Hosts scanned')}</TableData>
-              <TableData>{hosts_count}</TableData>
+              <TableData>{hostsCount}</TableData>
             </TableRow>
           )}
           <TableRow>


### PR DESCRIPTION
The "Hosts scanned" row in the report details was disappearing every time the page was reloading. Store count for scanned hosts in state to be able to display it the whole time.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
