### PR TITLE
Fix report result filter determination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Deleting a single entity now removes its ID from store [#1839](https://github.com/greenbone/gsa/pull/1839)
 
 ### Fixed
+- Don't use stored result list page filter at report results tab [#2366](https://github.com/greenbone/gsa/pull/2366)
 - Fixed flickering reports [#2359](https://github.com/greenbone/gsa/pull/2359)
 - Fixed "Hosts scanned" in report details disappearing during page refresh [#2357](https://github.com/greenbone/gsa/pull/2357)
 - Fixed schedule_periods not forwarded if there is no schedule [#2331](https://github.com/greenbone/gsa/pull/2331)

--- a/gsa/src/web/entities/__tests__/filterprovider.js
+++ b/gsa/src/web/entities/__tests__/filterprovider.js
@@ -111,6 +111,52 @@ describe('FilterProvider component tests', () => {
     expect(renderFunc).not.toHaveBeenCalledWith({filter: emptyFilter});
   });
 
+  test('should allow to set a pageName for loading the pageFilter', async () => {
+    const gmpName = 'task';
+    const pageName = 'foo-bar-baz';
+    const resultingFilter = Filter.fromString('page=filter rows=42');
+
+    const pFilter = Filter.fromString('page=filter');
+
+    const emptyFilter = Filter.fromString('rows=42');
+
+    const defaultSettingFilter = Filter.fromString('foo=bar');
+
+    const getSetting = jest.fn().mockResolvedValue({});
+    const gmp = {
+      user: {
+        getSetting,
+      },
+    };
+
+    const {render, store} = rendererWith({
+      gmp,
+      store: true,
+      router: true,
+    });
+
+    store.dispatch(loadingActions.success({rowsperpage: {value: '42'}}));
+    store.dispatch(
+      defaultFilterLoadingActions.success(gmpName, defaultSettingFilter),
+    );
+    store.dispatch(pageFilter(pageName, pFilter));
+
+    const renderFunc = jest
+      .fn()
+      .mockReturnValue(<span data-testid="awaiting-span" />);
+
+    const {getByTestId} = render(
+      <FilterProvider gmpname={gmpName} pageName={pageName}>
+        {renderFunc}
+      </FilterProvider>,
+    );
+
+    await waitForElement(() => getByTestId('awaiting-span'));
+
+    expect(renderFunc).toHaveBeenCalledWith({filter: resultingFilter});
+    expect(renderFunc).not.toHaveBeenCalledWith({filter: emptyFilter});
+  });
+
   test('should use defaultSettingFilter', async () => {
     const resultingFilter = Filter.fromString('foo=bar rows=42');
 

--- a/gsa/src/web/entities/__tests__/filterprovider.js
+++ b/gsa/src/web/entities/__tests__/filterprovider.js
@@ -33,7 +33,7 @@ describe('FilterProvider component tests', () => {
 
     const locationQuery = {filter: 'location=query'};
 
-    const defaultSettingfilter = Filter.fromString('foo=bar');
+    const defaultSettingFilter = Filter.fromString('foo=bar');
 
     const getSetting = jest.fn().mockResolvedValue({});
     const gmp = {
@@ -50,7 +50,7 @@ describe('FilterProvider component tests', () => {
 
     store.dispatch(loadingActions.success({rowsperpage: {value: '42'}}));
     store.dispatch(
-      defaultFilterLoadingActions.success('task', defaultSettingfilter),
+      defaultFilterLoadingActions.success('task', defaultSettingFilter),
     );
 
     const renderFunc = jest
@@ -76,7 +76,7 @@ describe('FilterProvider component tests', () => {
 
     const emptyFilter = Filter.fromString('rows=42');
 
-    const defaultSettingfilter = Filter.fromString('foo=bar');
+    const defaultSettingFilter = Filter.fromString('foo=bar');
 
     const getSetting = jest.fn().mockResolvedValue({});
     const gmp = {
@@ -93,7 +93,7 @@ describe('FilterProvider component tests', () => {
 
     store.dispatch(loadingActions.success({rowsperpage: {value: '42'}}));
     store.dispatch(
-      defaultFilterLoadingActions.success('task', defaultSettingfilter),
+      defaultFilterLoadingActions.success('task', defaultSettingFilter),
     );
     store.dispatch(pageFilter('task', pFilter));
 
@@ -114,7 +114,7 @@ describe('FilterProvider component tests', () => {
   test('should use defaultSettingFilter', async () => {
     const resultingFilter = Filter.fromString('foo=bar rows=42');
 
-    const defaultSettingfilter = Filter.fromString('foo=bar');
+    const defaultSettingFilter = Filter.fromString('foo=bar');
 
     const emptyFilter = Filter.fromString('rows=42');
 
@@ -133,7 +133,7 @@ describe('FilterProvider component tests', () => {
 
     store.dispatch(loadingActions.success({rowsperpage: {value: '42'}}));
     store.dispatch(
-      defaultFilterLoadingActions.success('task', defaultSettingfilter),
+      defaultFilterLoadingActions.success('task', defaultSettingFilter),
     );
 
     const renderFunc = jest
@@ -150,7 +150,7 @@ describe('FilterProvider component tests', () => {
     expect(renderFunc).not.toHaveBeenCalledWith({filter: emptyFilter});
   });
 
-  test('should use fallbackfilter if defaultSettingFilter could not be loaded', async () => {
+  test('should use fallbackFilter if defaultSettingFilter could not be loaded', async () => {
     const resultingFilter = Filter.fromString('fall=back rows=42');
 
     const fallbackFilter = Filter.fromString('fall=back');

--- a/gsa/src/web/entities/__tests__/filterprovider.js
+++ b/gsa/src/web/entities/__tests__/filterprovider.js
@@ -231,7 +231,7 @@ describe('FilterProvider component tests', () => {
   });
 
   test('should use default fallbackFilter as last resort', async () => {
-    const resultingFilter = DEFAULT_FALLBACK_FILTER.set('rows', 42);
+    const resultingFilter = DEFAULT_FALLBACK_FILTER.copy().set('rows', 42);
 
     const getSetting = jest.fn().mockResolvedValue({});
     const subscribe = jest.fn();

--- a/gsa/src/web/entities/filterprovider.js
+++ b/gsa/src/web/entities/filterprovider.js
@@ -45,6 +45,7 @@ const FilterProvider = ({
   children,
   fallbackFilter,
   gmpname,
+  pageName = gmpname,
   locationQuery = {},
 }) => {
   const gmp = useGmp();
@@ -96,12 +97,14 @@ const FilterProvider = ({
 
   useEffect(() => {
     if (isDefined(locationQuery.filter)) {
-      dispatch(setPageFilter(gmpname, Filter.fromString(locationQuery.filter)));
+      dispatch(
+        setPageFilter(pageName, Filter.fromString(locationQuery.filter)),
+      );
     }
     setLocationQueryFilter(undefined);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const pageFilter = useSelector(state => getPage(state).getFilter(gmpname));
+  const pageFilter = useSelector(state => getPage(state).getFilter(pageName));
 
   if (isDefined(locationQueryFilter)) {
     returnedFilter = locationQueryFilter;
@@ -146,6 +149,7 @@ FilterProvider.propTypes = {
   locationQuery: PropTypes.shape({
     filter: PropTypes.string,
   }),
+  pageName: PropTypes.string,
 };
 
 export default FilterProvider;

--- a/gsa/src/web/pages/reports/detailspage.js
+++ b/gsa/src/web/pages/reports/detailspage.js
@@ -715,6 +715,11 @@ const load = ({
   }
 
   if (!hasValue(filter)) {
+    // use filter from user setting
+    filter = defaultFilter;
+  }
+
+  if (!hasValue(filter)) {
     // use fallback filter
     filter = DEFAULT_FILTER;
   }

--- a/gsa/src/web/pages/reports/detailspage.js
+++ b/gsa/src/web/pages/reports/detailspage.js
@@ -706,12 +706,18 @@ const load = ({
   reportId,
   // eslint-disable-next-line no-shadow
   loadReportWithThreshold,
+  pageFilter,
   reportFilter,
   updateFilter,
 }) => filter => {
   if (!hasValue(filter)) {
     // use loaded filter after initial loading
     filter = reportFilter;
+  }
+
+  if (!hasValue(filter)) {
+    // use filter from store
+    filter = pageFilter;
   }
 
   if (!hasValue(filter)) {

--- a/gsa/src/web/pages/reports/detailspage.js
+++ b/gsa/src/web/pages/reports/detailspage.js
@@ -735,7 +735,11 @@ const load = ({
 };
 
 const ReportDetailsWrapper = ({reportFilter, ...props}) => (
-  <FilterProvider fallbackFilter={DEFAULT_FILTER} gmpname="result">
+  <FilterProvider
+    fallbackFilter={DEFAULT_FILTER}
+    gmpname="result"
+    pageName={`report-${props.reportId}`}
+  >
     {({filter}) => (
       <Reload
         name={`report-${props.reportId}`}


### PR DESCRIPTION
Don't use the current stored filter of the results list page for loading results at the report details page.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
