### PR TITLE
Minor systemd / config files updates:

### DIFF
--- a/gsad/config/gsad.default
+++ b/gsad/config/gsad.default
@@ -1,12 +1,12 @@
 #
 # The address the Greenbone Security Assistant daemon will listen on.
 #
-GSA_ADDRESS=127.0.0.1
+GSAD_ADDRESS=127.0.0.1
 
 #
 # The port the Greenbone Security Assistant daemon will listen on.
 #
-GSA_PORT=9392
+GSAD_PORT=9392
 
 #
 # The user for running the Greenbone Security Assistant daemon in the gsad.service systemd file
@@ -21,4 +21,4 @@ GSAD_GROUP="gvm"
 #
 # Additional options
 #
-OPTIONS=""
+GSAD_OPTIONS=""

--- a/gsad/config/gsad.default
+++ b/gsad/config/gsad.default
@@ -1,9 +1,4 @@
 #
-# Additional options
-#
-OPTIONS=""
-
-#
 # The address the Greenbone Security Assistant daemon will listen on.
 #
 GSA_ADDRESS=127.0.0.1
@@ -12,3 +7,18 @@ GSA_ADDRESS=127.0.0.1
 # The port the Greenbone Security Assistant daemon will listen on.
 #
 GSA_PORT=9392
+
+#
+# The user for running the Greenbone Security Assistant daemon in the gsad.service systemd file
+#
+GSAD_USER="gvm"
+
+#
+# The group for running the Greenbone Security Assistant daemon in the gsad.service systemd file
+#
+GSAD_GROUP="gvm"
+
+#
+# Additional options
+#
+OPTIONS=""

--- a/gsad/config/gsad.service.in
+++ b/gsad/config/gsad.service.in
@@ -16,4 +16,3 @@ TimeoutStopSec=10
 
 [Install]
 WantedBy=multi-user.target
-Alias=gsad.service

--- a/gsad/config/gsad.service.in
+++ b/gsad/config/gsad.service.in
@@ -10,7 +10,7 @@ User=$GSAD_USER
 Group=$GSAD_GROUP
 PIDFile=${GVM_RUN_DIR}/gsad.pid
 EnvironmentFile=${DEFAULT_CONFIG_DIR}/gsad
-ExecStart=${SBINDIR}/gsad --listen $GSA_ADDRESS --port $GSA_PORT $OPTIONS
+ExecStart=${SBINDIR}/gsad --listen $GSAD_ADDRESS --port $GSAD_PORT $GSAD_OPTIONS
 Restart=always
 TimeoutStopSec=10
 

--- a/gsad/config/gsad.service.in
+++ b/gsad/config/gsad.service.in
@@ -1,16 +1,19 @@
 [Unit]
-Description=Greenbone Security Assistant
+Description=Greenbone Security Assistant daemon (gsad)
 After=network.target networking.service gvmd.service
 Documentation=man:gsad(8)
 ConditionKernelCommandLine=!recovery
 
 [Service]
 Type=forking
-EnvironmentFile=-${DEFAULT_CONFIG_DIR}/gsad
+User=$GSAD_USER
+Group=$GSAD_GROUP
+PIDFile=${GVM_RUN_DIR}/gsad.pid
+EnvironmentFile=${DEFAULT_CONFIG_DIR}/gsad
 ExecStart=${SBINDIR}/gsad --listen $GSA_ADDRESS --port $GSA_PORT $OPTIONS
 Restart=always
 TimeoutStopSec=10
 
 [Install]
 WantedBy=multi-user.target
-Alias=greenbone-security-assistant.service
+Alias=gsad.service


### PR DESCRIPTION
- Mention "daemon" and "gsad" in systemd unit description
- Allow to configure a user / group in gsad.default
- Remove the "Alias" which isn't required
- Add PIDFile call to systemd unit
- Make the EnvironmentFile mandatory
- Renamed a few variables

Changing `EnvironmentFile=${DEFAULT_CONFIG_DIR}/gsad` to `EnvironmentFile=-${DEFAULT_CONFIG_DIR}/gsad` is making the file mandatory:

https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=

This was done because the `gsad.service` is using the following:

```
ExecStart=${SBINDIR}/gsad --listen $GSA_ADDRESS --port $GSA_PORT $OPTIONS
```

which makes the gsad.default mandatory for the `$GSA_ADDRESS` and `$GSA_PORT`


Related: https://github.com/greenbone/gvmd/pull/1240, https://github.com/greenbone/ospd-openvas/pull/312