### PR TITLE
Try to fix permission of circleci cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,25 +69,28 @@ jobs:
           paths:
             - ./gsa/node_modules
   build_gsad:
-    working_directory: ~/gsa
+    working_directory: /home/circleci/gsa
     docker:
       - image: greenbone/build-env-gsa-master-debian-stretch-gcc-gsad
     steps:
       - run:
-          working_directory: ~/gvm-libs
+          working_directory: /home/circleci/gvm-libs
           name: Checkout gvm-libs
           command: git clone --depth 1 https://github.com/greenbone/gvm-libs.git -b gvm-libs-10.0
       - run:
-          working_directory: ~/gvm-libs
+          working_directory: /home/circleci/gvm-libs
           name: Configure and compile gvm-libs
           command: pushd gvm-libs && mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release .. && make install && popd
       - checkout
       - run:
-          working_directory: ~/gsa/gsad
+          name: Fix permissions
+          command: chmod -R o+rw .
+      - run:
+          working_directory: /home/circleci/gsa/gsad
           name: Configure and compile
           command: mkdir build && rm -rf .git && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release .. && make install
   build_gsa:
-    working_directory: ~/gsa
+    working_directory: /home/circleci/gsa
     docker:
       - image: greenbone/build-env-gsa-debian-buster-node10-ng
     steps:
@@ -95,6 +98,9 @@ jobs:
       - restore_cache:
           keys:
             - v1-deps-{{ checksum "./gsa/yarn.lock"  }}
+      - run:
+          name: Fix permissions
+          command: chmod -R o+rw .
       - run:
           name: Configure and compile
           command: mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release ../gsa && make install


### PR DESCRIPTION
We are currently using two different images for the circleci jobs. For
building gsa and gsad we are using our own images that run under the
root user. For the js jobs we are are using images from circleci which
run under a circleci user. If the yarn.lock file is changed and the
build_gsa job is run before a js job the circle ci cache contains files
where root is the owner and with a wrong directory. Afterwards the js
jons will fail during restoring the cache because the circleci user
can't access the files from the cache.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
