### PR TITLE
Do not use image loading indicator for feed status updates

### DIFF
--- a/gsa/public/locales/gsa-de.json
+++ b/gsa/public/locales/gsa-de.json
@@ -1759,6 +1759,7 @@
   "Unreliable rem. banner": "Unzuverlässiger Banner",
   "Update": "Aktualisieren",
   "Update Filter": "Filter aktualisieren",
+  "Update in progress...": "Aktualisierung läuft...",
   "Updated": "Aktualisiert",
   "Updated {{secinfo_type}} arrived": "Aktualisierte {{secinfo_type}} eingetroffen",
   "Updated: ": "Aktualisiert: ",

--- a/gsa/src/web/pages/extras/__tests__/feedstatuspage.js
+++ b/gsa/src/web/pages/extras/__tests__/feedstatuspage.js
@@ -79,7 +79,7 @@ const gmp = {
 describe('Feed status page tests', () => {
   test('should render', async () => {
     const {render} = rendererWith({gmp, router: true});
-    const {element, getAllByTestId, getByTestId} = render(<FeedStatus />);
+    const {element, getAllByTestId} = render(<FeedStatus />);
 
     await wait();
 
@@ -172,12 +172,7 @@ describe('Feed status page tests', () => {
     expect(ageText[0]).toHaveTextContent('Current');
     expect(ageText[1]).toHaveTextContent('2 days old');
     expect(ageText[2]).toHaveTextContent('Current');
-
-    const loadingIndicator = getByTestId('loading-indicator');
-
-    expect(loadingIndicator).toHaveAttribute('title', 'Update in progress');
-    expect(loadingIndicator).toHaveAttribute('src', '/img/loading.gif');
-    expect(loadingIndicator).toHaveAttribute('alt', 'Loading Indicator');
+    expect(ageText[3]).toHaveTextContent('Update in progress...');
   });
 });
 

--- a/gsa/src/web/pages/extras/feedstatuspage.js
+++ b/gsa/src/web/pages/extras/feedstatuspage.js
@@ -85,16 +85,7 @@ const renderCheck = feed => {
 
 const renderFeedStatus = feed => {
   if (hasValue(feed.currentlySyncing)) {
-    return (
-      <span style={{paddingLeft: '10px'}}>
-        <img
-          data-testid="loading-indicator"
-          src="/img/loading.gif"
-          title={_('Update in progress')}
-          alt={_('Loading Indicator')}
-        ></img>
-      </span>
-    );
+    return _('Update in progress...');
   }
 
   const age = parseInt(feed.age.asDays());


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Our previous implementation of the image loading indicator is not explicitly enough to explain what is happening. We should use text instead. Should not require a changelog entry because it doesn't contradict the previous one, and this is as "new feature"

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
