### PR TITLE
Increase age for feed being too old

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added handling of queued task status [#2208](https://github.com/greenbone/gsa/pull/2208)
 
 ### Changed
+- Increase age for feed being too old [#2394](https://github.com/greenbone/gsa/pull/2394)
 - Do not use result filter from store on report detailspage by default [#2358](https://github.com/greenbone/gsa/pull/2358)
 - Improve performance of form fields in edit scan config dialog [#2354](https://github.com/greenbone/gsa/pull/2354)
 - Default to sorting nvts by "Created", newest first [#2352](https://github.com/greenbone/gsa/pull/2352)

--- a/gsa/src/web/pages/extras/__tests__/feedstatuspage.js
+++ b/gsa/src/web/pages/extras/__tests__/feedstatuspage.js
@@ -47,13 +47,13 @@ const scapFeed = new Feed({
 const certFeed = new Feed({
   name: 'Greenbone Community CERT Feed',
   type: 'CERT',
-  version: 202007231003,
+  version: 202005231003,
 });
 
 const gvmdDataFeed = new Feed({
   name: 'Greenbone Community gvmd Data Feed',
   type: 'GVMD_DATA',
-  version: 202007221009,
+  version: 202006221009,
   currently_syncing: {timestamp: 'foo'},
 });
 
@@ -161,18 +161,33 @@ describe('Feed status page tests', () => {
     // Feed versions
     expect(element).toHaveTextContent('20200724T1005');
     expect(element).toHaveTextContent('20200723T0130');
-    expect(element).toHaveTextContent('20200723T1003');
-    expect(element).toHaveTextContent('20200722T1009');
+    expect(element).toHaveTextContent('20200523T1003');
+    expect(element).toHaveTextContent('20200622T1009');
 
     // Feed Status
 
     const ageText = element.querySelectorAll('strong');
+    const updateMsgs = getAllByTestId('update-msg');
 
     expect(ageText.length).toEqual(4);
+    expect(updateMsgs.length).toEqual(4);
+
+    // Not too old and not currently syncing
     expect(ageText[0]).toHaveTextContent('Current');
+    expect(updateMsgs[0]).toHaveTextContent('');
+
     expect(ageText[1]).toHaveTextContent('2 days old');
-    expect(ageText[2]).toHaveTextContent('Current');
+    expect(updateMsgs[1]).toHaveTextContent('');
+
+    // CERT feed is too old but is not currently syncing
+    expect(ageText[2]).toHaveTextContent('Too old (62 days)');
+    expect(updateMsgs[2]).toHaveTextContent(
+      'Please check the automatic synchronization of your system.',
+    );
+
+    // GVMD_DATA feed is too old but IS currently syncing
     expect(ageText[3]).toHaveTextContent('Update in progress...');
+    expect(updateMsgs[3]).toHaveTextContent('');
   });
 });
 

--- a/gsa/src/web/pages/extras/feedstatuspage.js
+++ b/gsa/src/web/pages/extras/feedstatuspage.js
@@ -78,7 +78,7 @@ const ToolBarIcons = () => (
 const renderCheck = feed => {
   const age = feed.age.asDays();
 
-  return age >= 10
+  return age >= 30 && !hasValue(feed.currentlySyncing)
     ? _('Please check the automatic synchronization of your system.')
     : '';
 };
@@ -90,7 +90,7 @@ const renderFeedStatus = feed => {
 
   const age = parseInt(feed.age.asDays());
 
-  if (age >= 10) {
+  if (age >= 30) {
     return _('Too old ({{age}} days)', {age});
   }
 

--- a/gsa/src/web/pages/extras/feedstatuspage.js
+++ b/gsa/src/web/pages/extras/feedstatuspage.js
@@ -251,7 +251,7 @@ const FeedStatus = ({feeds}) => {
                 <TableData>
                   <Divider wrap>
                     <strong>{renderFeedStatus(feed)}</strong>
-                    <span>{renderCheck(feed)}</span>
+                    <span data-testid="update-msg">{renderCheck(feed)}</span>
                   </Divider>
                 </TableData>
               </TableRow>


### PR DESCRIPTION
Currently gsa decides a feed is too old if its last version was over 10 days old. GSA should not be deciding this unless it is really, really old, thus we changed it to 30 days.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
