### PR TITLE
fix missing oval def subsections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Deleting a single entity now removes its ID from store [#1839](https://github.com/greenbone/gsa/pull/1839)
 
 ### Fixed
+- Fixed empty subsections on oval def details page [#2396](https://github.com/greenbone/gsa/pull/2396)
 - Fixed missing NVT solution [#2388](https://github.com/greenbone/gsa/pull/2388)
 - EmptyResultsReport uses the same counts as the results tab title in normal reports, when filtering for nonexistent results
   [#2335](https://github.com/greenbone/gsa/pull/2335), [#2365](https://github.com/greenbone/gsa/pull/2365)

--- a/gsa/src/gmp/models/ovaldef.js
+++ b/gsa/src/gmp/models/ovaldef.js
@@ -75,10 +75,10 @@ class Ovaldef extends Info {
   static parseElement(element) {
     const ret = super.parseElement(element, 'ovaldef');
 
-    ret.severity = parseSeverity(element.max_cvss);
+    ret.severity = parseSeverity(ret.max_cvss);
     delete ret.max_cvss;
 
-    const {raw_data} = element;
+    const {raw_data} = ret;
 
     if (isDefined(raw_data) && isDefined(raw_data.definition)) {
       const {definition} = raw_data;


### PR DESCRIPTION
On the oval def details page the sub sections were all empty because of a parsing error in the oval def model.

(The error was similar to the one that caused https://github.com/greenbone/gsa/pull/2388)

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
