### PR TITLE
Drop Edge <= 18 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 ### Removed
+- Removed Edge <= 18 support [#2408](https://github.com/greenbone/gsa/pull/2408)
 - Removed Internet Explorer 11 support [#2399](https://github.com/greenbone/gsa/pull/2399)
 - Removed parsing and testing of textExcerpt [#2316](https://github.com/greenbone/gsa/pull/2316)
 - Removed extra parsing of comment and summary in Model [#2309](https://github.com/greenbone/gsa/pull/2309)

--- a/gsa/package.json
+++ b/gsa/package.json
@@ -110,6 +110,7 @@
     "last 3 version",
     "not dead",
     "not ie <= 11",
+    "not edge <=18",
     "not op_mini all",
     "ff ESR"
   ],


### PR DESCRIPTION
d3-shape 2.0 and d3-color 2.0 are using ES6 and with the merge of those new dependency versions we will also drop support for the outdated Edge 18 and older versions.


<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
