### PR TITLE
Add option for "Start task" on "new secinfo arrived" for alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [20.8.1] - unreleased
 
 ### Added
+- Added option for "Start Task" event upon "New SecInfo arrived" condition in alerts dialog [#2418](https://github.com/greenbone/gsa/pull/2418)
 
 ### Changed
 - Use <predefined> to disable feed object editing and filter creation on feed status page [#2398](https://github.com/greenbone/gsa/pull/2398)

--- a/gsa/src/web/pages/alerts/dialog.js
+++ b/gsa/src/web/pages/alerts/dialog.js
@@ -438,6 +438,10 @@ class AlertDialog extends React.Component {
           label: _('SNMP'),
         },
         {
+          value: METHOD_TYPE_START_TASK,
+          label: _('Start Task'),
+        },
+        {
           value: METHOD_TYPE_SYSLOG,
           label: _('System Logger'),
         },


### PR DESCRIPTION
**What**:
There is the new alerts feature of starting a task upon the arrival of new secinfo. gvmd has it implemented in https://github.com/greenbone/gvmd/pull/957 and https://github.com/greenbone/gvmd/pull/960. This PR adds the start task option to the corresponding method selection.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Without these changes, the new feature would not be available in GSA.
<!-- Why are these changes necessary? -->

**How**:
The "Start Task" event is pushed into the list of possible methods. From this list I chose the 'Start task' together with the secinfo event condition and clicked on "test alert". The corresponding task started.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
