### PR TITLE
Remove ReportFormat export/download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 ### Removed
+- Removed export/download for report formats [#2427](https://github.com/greenbone/gsa/pull/2427)
 
 [20.8.1]: https://github.com/greenbone/gsa/compare/v20.8.0...gsa-20.08
 

--- a/gsa/src/web/pages/reportformats/component.js
+++ b/gsa/src/web/pages/reportformats/component.js
@@ -126,14 +126,7 @@ class ReportFormatComponent extends React.Component {
   }
 
   render() {
-    const {
-      children,
-      onDeleted,
-      onDeleteError,
-      onDownloaded,
-      onDownloadError,
-      onInteraction,
-    } = this.props;
+    const {children, onDeleted, onDeleteError, onInteraction} = this.props;
 
     const {dialogVisible, reportformat, title} = this.state;
 
@@ -142,8 +135,6 @@ class ReportFormatComponent extends React.Component {
         name="reportformat"
         onDeleted={onDeleted}
         onDeleteError={onDeleteError}
-        onDownloaded={onDownloaded}
-        onDownloadError={onDownloadError}
         onInteraction={onInteraction}
       >
         {other => (
@@ -173,8 +164,6 @@ ReportFormatComponent.propTypes = {
   gmp: PropTypes.gmp.isRequired,
   onDeleteError: PropTypes.func,
   onDeleted: PropTypes.func,
-  onDownloadError: PropTypes.func,
-  onDownloaded: PropTypes.func,
   onImportError: PropTypes.func,
   onImported: PropTypes.func.isRequired,
   onInteraction: PropTypes.func.isRequired,

--- a/gsa/src/web/pages/reportformats/detailspage.js
+++ b/gsa/src/web/pages/reportformats/detailspage.js
@@ -26,7 +26,6 @@ import CreateIcon from 'web/entity/icon/createicon';
 import DeleteIcon from 'web/entity/icon/deleteicon';
 import Divider from 'web/components/layout/divider';
 import EditIcon from 'web/entity/icon/editicon';
-import ExportIcon from 'web/components/icon/exporticon';
 import IconDivider from 'web/components/layout/icondivider';
 import Layout from 'web/components/layout/layout';
 import PageTitle from 'web/components/layout/pagetitle';

--- a/gsa/src/web/pages/reportformats/detailspage.js
+++ b/gsa/src/web/pages/reportformats/detailspage.js
@@ -76,7 +76,6 @@ const ToolBarIcons = withCapabilities(
     entity,
     onReportFormatImportClick,
     onReportFormatDeleteClick,
-    onReportFormatDownloadClick,
     onReportFormatEditClick,
   }) => (
     <Divider margin="10px">
@@ -105,11 +104,6 @@ const ToolBarIcons = withCapabilities(
           entity={entity}
           onClick={onReportFormatDeleteClick}
         />
-        <ExportIcon
-          value={entity}
-          title={_('Export Report Format as XML')}
-          onClick={onReportFormatDownloadClick}
-        />
       </IconDivider>
     </Divider>
   ),
@@ -118,7 +112,6 @@ const ToolBarIcons = withCapabilities(
 ToolBarIcons.propTypes = {
   entity: PropTypes.model.isRequired,
   onReportFormatDeleteClick: PropTypes.func.isRequired,
-  onReportFormatDownloadClick: PropTypes.func.isRequired,
   onReportFormatEditClick: PropTypes.func.isRequired,
   onReportFormatImportClick: PropTypes.func.isRequired,
 };
@@ -173,7 +166,6 @@ const Page = ({
   links = true,
   permissions = [],
   onChanged,
-  onDownloaded,
   onError,
   onInteraction,
   ...props
@@ -181,13 +173,11 @@ const Page = ({
   <ReportFormatComponent
     onDeleted={goto_list('reportformats', props)}
     onDeleteError={onError}
-    onDownloaded={onDownloaded}
-    onDownloadError={onError}
     onImported={goto_details('reportformat', props)}
     onInteraction={onInteraction}
     onSaved={onChanged}
   >
-    {({delete: delete_func, download, edit, import: import_func, save}) => (
+    {({delete: delete_func, edit, import: import_func, save}) => (
       <EntityPage
         {...props}
         entity={entity}
@@ -197,7 +187,6 @@ const Page = ({
         onInteraction={onInteraction}
         onReportFormatImportClick={import_func}
         onReportFormatDeleteClick={delete_func}
-        onReportFormatDownloadClick={download}
         onReportFormatEditClick={edit}
         onReportFormatSaveClick={save}
       >
@@ -248,7 +237,6 @@ const Page = ({
                         entity={entity}
                         permissions={permissions}
                         onChanged={onChanged}
-                        onDownloaded={onDownloaded}
                         onError={onError}
                         onInteraction={onInteraction}
                       />
@@ -269,7 +257,6 @@ Page.propTypes = {
   links: PropTypes.bool,
   permissions: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
-  onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
   onInteraction: PropTypes.func.isRequired,
 };

--- a/gsa/src/web/pages/reportformats/listpage.js
+++ b/gsa/src/web/pages/reportformats/listpage.js
@@ -72,7 +72,6 @@ const ReportFormatsFilterDialog = createFilterDialog({
 
 const ReportFormatsPage = ({
   onChanged,
-  onDownloaded,
   onError,
   onInteraction,
   showSuccess,
@@ -82,12 +81,10 @@ const ReportFormatsPage = ({
     onSaved={onChanged}
     onDeleted={onChanged}
     onDeleteError={onError}
-    onDownloaded={onDownloaded}
-    onDownloadError={onError}
     onImported={onChanged}
     onInteraction={onInteraction}
   >
-    {({delete: delete_func, download, edit, import: import_func, save}) => (
+    {({delete: delete_func, edit, import: import_func, save}) => (
       <React.Fragment>
         <PageTitle title={_('Report Formats')} />
         <EntitiesPage
@@ -99,12 +96,10 @@ const ReportFormatsPage = ({
           title={_('Report Formats')}
           toolBarIcons={ToolBarIcons}
           onChanged={onChanged}
-          onDownloaded={onDownloaded}
           onError={onError}
           onInteraction={onInteraction}
           onReportFormatImportClick={import_func}
           onReportFormatDeleteClick={delete_func}
-          onReportFormatDownloadClick={download}
           onReportFormatEditClick={edit}
         />
       </React.Fragment>
@@ -115,7 +110,6 @@ const ReportFormatsPage = ({
 ReportFormatsPage.propTypes = {
   showSuccess: PropTypes.func.isRequired,
   onChanged: PropTypes.func.isRequired,
-  onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
   onInteraction: PropTypes.func.isRequired,
 };

--- a/gsa/src/web/pages/reportformats/row.js
+++ b/gsa/src/web/pages/reportformats/row.js
@@ -28,7 +28,6 @@ import EntityNameTableData from 'web/entities/entitynametabledata';
 import Comment from 'web/components/comment/comment';
 
 import EditIcon from 'web/entity/icon/editicon';
-import ExportIcon from 'web/components/icon/exporticon';
 import TrashIcon from 'web/entity/icon/trashicon';
 
 import IconDivider from 'web/components/layout/icondivider';
@@ -50,7 +49,6 @@ const Actions = compose(
     capabilities,
     entity,
     onReportFormatDeleteClick,
-    onReportFormatDownloadClick,
     onReportFormatEditClick,
   }) => (
     <IconDivider align={['center', 'center']} grow>
@@ -67,11 +65,6 @@ const Actions = compose(
         entity={entity}
         onClick={onReportFormatEditClick}
       />
-      <ExportIcon
-        value={entity}
-        title={_('Export Report Format')}
-        onClick={onReportFormatDownloadClick}
-      />
     </IconDivider>
   ),
 );
@@ -79,7 +72,6 @@ const Actions = compose(
 Actions.propTypes = {
   entity: PropTypes.model.isRequired,
   onReportFormatDeleteClick: PropTypes.func.isRequired,
-  onReportFormatDownloadClick: PropTypes.func.isRequired,
   onReportFormatEditClick: PropTypes.func.isRequired,
 };
 

--- a/gsa/src/web/pages/reportformats/table.js
+++ b/gsa/src/web/pages/reportformats/table.js
@@ -59,7 +59,6 @@ const ReportFormatsTable = createEntitiesTable({
   row: Row,
   rowDetails: withRowDetails('reportformat', 10)(ReportFormatDetails),
   footer: createEntitiesFooter({
-    download: 'reportformats.xml',
     span: 6,
     trash: true,
   }),


### PR DESCRIPTION
**What**:
This PR removes export/download functionalities from listpage and detailspage, and bulk export for report formats.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Report formats can only be used, if signed correctly. Exported and reimported report formats are not signed correctly anymore and are therefore unusable, making the whole idea of exporting report formats obsolete.

<!-- Why are these changes necessary? -->

**How**:
Icons and unnecessary props have been removed. The user can no longer click on those icons.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
