### PR TITLE
Allow to not run timers

### DIFF
--- a/gsa/src/web/pages/tasks/__tests__/detailspage.js
+++ b/gsa/src/web/pages/tasks/__tests__/detailspage.js
@@ -137,8 +137,10 @@ describe('Task Detailspage tests', () => {
       overrides: {
         get: getEntities,
       },
-      reloadInterval,
-      settings: {manualUrl},
+      settings: {
+        manualUrl,
+        reloadInterval,
+      },
       user: {
         currentSettings,
       },
@@ -275,8 +277,10 @@ describe('Task Detailspage tests', () => {
       overrides: {
         get: getEntities,
       },
-      reloadInterval,
-      settings: {manualUrl},
+      settings: {
+        manualUrl,
+        reloadInterval,
+      },
       user: {
         currentSettings,
         renewSession,
@@ -340,8 +344,10 @@ describe('Task Detailspage tests', () => {
       overrides: {
         get: getEntities,
       },
-      reloadInterval,
-      settings: {manualUrl},
+      settings: {
+        manualUrl,
+        reloadInterval,
+      },
       user: {
         currentSettings,
         renewSession,
@@ -403,8 +409,10 @@ describe('Task Detailspage tests', () => {
       overrides: {
         get: getEntities,
       },
-      reloadInterval,
-      settings: {manualUrl},
+      settings: {
+        manualUrl,
+        reloadInterval,
+      },
       user: {
         currentSettings,
         renewSession,

--- a/gsa/src/web/pages/tasks/__tests__/detailspage.js
+++ b/gsa/src/web/pages/tasks/__tests__/detailspage.js
@@ -58,7 +58,7 @@ setLocale('en');
 
 const caps = new Capabilities(['everything']);
 
-const reloadInterval = 1;
+const reloadInterval = null; // do not reload by default
 const manualUrl = 'test/';
 
 // create mock task

--- a/gsa/src/web/utils/__tests__/useTiming.js
+++ b/gsa/src/web/utils/__tests__/useTiming.js
@@ -167,4 +167,17 @@ describe('useTiming tests', () => {
     expect(screen.getByTestId('isRunning')).toHaveTextContent('yes');
     expect(screen.getByTestId('value')).toHaveTextContent(2);
   });
+
+  test('should not start timer if timeout value is null', async () => {
+    const {render} = rendererWith();
+
+    render(<TestComponent onMount={true} timeout={null} />);
+
+    expect(screen.getByTestId('value')).toHaveTextContent(0);
+
+    await wait();
+
+    expect(screen.getByTestId('value')).toHaveTextContent(0);
+    expect(screen.getByTestId('isRunning')).toHaveTextContent('no');
+  });
 });

--- a/gsa/src/web/utils/__tests__/useTiming.js
+++ b/gsa/src/web/utils/__tests__/useTiming.js
@@ -34,7 +34,7 @@ const TestComponent = ({onMount = false, timeout = 100, promise = false}) => {
     [],
   );
 
-  const [startTimer, clearTimer] = useTiming(
+  const [startTimer, clearTimer, isRunning] = useTiming(
     promise ? stateUpdatePromise : stateUpdate,
     timeout,
   );
@@ -49,6 +49,7 @@ const TestComponent = ({onMount = false, timeout = 100, promise = false}) => {
       <button data-testid="start" onClick={startTimer} />
       <button data-testid="stop" onClick={clearTimer} />
       <div data-testid="value">{value}</div>
+      <div data-testid="isRunning">{isRunning ? 'yes' : 'no'}</div>
     </div>
   );
 };
@@ -153,14 +154,17 @@ describe('useTiming tests', () => {
 
     render(<TestComponent promise={true} onMount={true} />);
 
+    expect(screen.getByTestId('isRunning')).toHaveTextContent('no');
     expect(screen.getByTestId('value')).toHaveTextContent(0);
 
     await wait(100);
 
+    expect(screen.getByTestId('isRunning')).toHaveTextContent('yes');
     expect(screen.getByTestId('value')).toHaveTextContent(1);
 
     await wait(100);
 
+    expect(screen.getByTestId('isRunning')).toHaveTextContent('yes');
     expect(screen.getByTestId('value')).toHaveTextContent(2);
   });
 });

--- a/gsa/src/web/utils/__tests__/useTiming.js
+++ b/gsa/src/web/utils/__tests__/useTiming.js
@@ -24,8 +24,6 @@ import {rendererWith, screen, act, fireEvent, wait} from '../testing';
 
 import useTiming from '../useTiming';
 
-jest.useFakeTimers();
-
 const TestComponent = ({onMount = false, timeout = 100, promise = false}) => {
   const [value, setValue] = useState(0);
 
@@ -54,6 +52,14 @@ const TestComponent = ({onMount = false, timeout = 100, promise = false}) => {
     </div>
   );
 };
+
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
 
 describe('useTiming tests', () => {
   test('should start a timer during mount', async () => {

--- a/gsa/src/web/utils/useTiming.js
+++ b/gsa/src/web/utils/useTiming.js
@@ -39,6 +39,11 @@ const useTiming = (doFunc, timeout) => {
 
     const timeoutValue = isFunction(timeout) ? timeout() : timeout;
 
+    if (!hasValue(timeoutValue) || timeoutValue < 0) {
+      log.debug('Not starting timer because timeout value was', timeoutValue);
+      return;
+    }
+
     timer.timerId = setTimeout(() => {
       log.debug('Timer with id', timer.timerId, 'fired.');
 


### PR DESCRIPTION
**What**:

Allow to disable timers e.g. for reloading data like the tasks in the background

**Why**:

For testing purposes it should be possible to deactivate the reloading because most of the time reloading should not be part of a specific test and at the end running the timer function may lead to *randomly* failing test.

**How**:

Added new a new test for useTiming and run all task detail page tests.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
