### PR TITLE
Drop dynamic severity classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 ### Removed
+- Drop dynamic severity classes [#2448](https://github.com/greenbone/gsa/pull/2448)
 - Removed severity class 'bsi' [#2434](https://github.com/greenbone/gsa/pull/2434)
 - Removed Edge <= 18 support [#2408](https://github.com/greenbone/gsa/pull/2408)
 - Removed Internet Explorer 11 support [#2399](https://github.com/greenbone/gsa/pull/2399)

--- a/gsa/src/gmp/commands/users.js
+++ b/gsa/src/gmp/commands/users.js
@@ -279,7 +279,6 @@ export class UserCommand extends EntityCommand {
       details_fname: data.detailsExportFileName,
       list_fname: data.listExportFileName,
       report_fname: data.reportExportFileName,
-      severity_class: data.severityClass,
       dynamic_severity: data.dynamicSeverity,
       default_severity: severityValue(data.defaultSeverity),
       'settings_default:f9f5a546-8018-48d0-bef5-5ad4926ea899':

--- a/gsa/src/web/components/chart/topology.js
+++ b/gsa/src/web/components/chart/topology.js
@@ -68,7 +68,7 @@ const Circle = styled.circle`
 `;
 
 const severityColorsGradientScale = type => {
-  const severity_levels = getSeverityLevels(type);
+  const severity_levels = getSeverityLevels();
   return scaleLinear()
     .domain([
       FALSE_POSITIVE_VALUE,

--- a/gsa/src/web/components/dashboard/display/cvss/cvsstransform.js
+++ b/gsa/src/web/components/dashboard/display/cvss/cvsstransform.js
@@ -97,7 +97,7 @@ const transformCvssData = (data = {}, {severityClass}) => {
 
       const value = parseFloat(key);
 
-      const riskFactor = resultSeverityRiskFactor(value, severityClass);
+      const riskFactor = resultSeverityRiskFactor(value);
       const label = translateRiskFactor(riskFactor);
 
       let toolTip;

--- a/gsa/src/web/components/dashboard/display/cvss/cvsstransform.js
+++ b/gsa/src/web/components/dashboard/display/cvss/cvsstransform.js
@@ -53,7 +53,7 @@ const getSeverityClassLabel = value => {
   }
 };
 
-const transformCvssData = (data = {}, {severityClass}) => {
+const transformCvssData = (data = {}) => {
   const {groups = []} = data;
 
   const sum = totalCount(groups);

--- a/gsa/src/web/components/dashboard/display/severity/severityclasstransform.js
+++ b/gsa/src/web/components/dashboard/display/severity/severityclasstransform.js
@@ -57,7 +57,7 @@ const transformSeverityData = (
       value = NA_VALUE;
     }
 
-    const riskFactor = resultSeverityRiskFactor(value, severityClassType);
+    const riskFactor = resultSeverityRiskFactor(value);
     const severityClass = allSeverityClasses[riskFactor] || {};
 
     let {count = 0} = severityClass;

--- a/gsa/src/web/components/dashboard/display/severity/severityclasstransform.js
+++ b/gsa/src/web/components/dashboard/display/severity/severityclasstransform.js
@@ -43,7 +43,6 @@ export const severityClassDataRow = row => [row.label, row.value];
 
 const transformSeverityData = (
   data = {},
-  {severityClass: severityClassType},
 ) => {
   const {groups = []} = data;
 

--- a/gsa/src/web/components/dashboard/display/severity/severityclasstransform.js
+++ b/gsa/src/web/components/dashboard/display/severity/severityclasstransform.js
@@ -71,7 +71,7 @@ const transformSeverityData = (
     return allSeverityClasses;
   }, {});
 
-  const {high, medium, low} = getSeverityLevels(severityClassType);
+  const {high, medium, low} = getSeverityLevels();
 
   const tdata = Object.values(severityClasses).map(severityClass => {
     const {count, riskFactor} = severityClass;

--- a/gsa/src/web/pages/nvts/dashboard/familydisplay.js
+++ b/gsa/src/web/pages/nvts/dashboard/familydisplay.js
@@ -43,7 +43,7 @@ import {registerDisplay} from 'web/components/dashboard/registry';
 
 import {NvtsFamilyLoader} from './loaders';
 
-const transformFamilyData = (data = {}, {severityClass}) => {
+const transformFamilyData = (data = {}) => {
   const {groups = []} = data;
   const totalNvts = groups.reduce(
     (prev, current) => prev + parseFloat(current.count),

--- a/gsa/src/web/pages/nvts/dashboard/familydisplay.js
+++ b/gsa/src/web/pages/nvts/dashboard/familydisplay.js
@@ -53,7 +53,7 @@ const transformFamilyData = (data = {}, {severityClass}) => {
   const tdata = groups.map(family => {
     const {count, value} = family;
     const severity = parseSeverity(family.stats.severity.mean);
-    const riskFactor = resultSeverityRiskFactor(severity, severityClass);
+    const riskFactor = resultSeverityRiskFactor(severity);
     const formattedSeverity = severityFormat(severity);
     const toolTip = _('{{value}}: {{count}} (severity: {{severity}})', {
       value: value,

--- a/gsa/src/web/pages/tasks/dashboard/highresults.js
+++ b/gsa/src/web/pages/tasks/dashboard/highresults.js
@@ -61,7 +61,7 @@ const transformHighResultsData = (data = {}, {severityClass}) => {
       const {name} = text;
       const high_per_host = parseFloat(text.high_per_host);
       const severity = parseSeverity(text.severity);
-      const riskFactor = resultSeverityRiskFactor(severity, severityClass);
+      const riskFactor = resultSeverityRiskFactor(severity);
       const displaySeverity = isDefined(severity)
         ? severityFormat(severity)
         : `${_NA}`;

--- a/gsa/src/web/pages/tasks/dashboard/highresults.js
+++ b/gsa/src/web/pages/tasks/dashboard/highresults.js
@@ -47,7 +47,7 @@ import {TasksHighResultsLoader} from './loaders';
 
 const format = d3format('0.2f');
 
-const transformHighResultsData = (data = {}, {severityClass}) => {
+const transformHighResultsData = (data = {}) => {
   const {groups = []} = data;
 
   return groups

--- a/gsa/src/web/pages/tasks/dashboard/mosthighresults.js
+++ b/gsa/src/web/pages/tasks/dashboard/mosthighresults.js
@@ -58,7 +58,7 @@ const transformHighResultsData = (data = {}, {severityClass}) => {
       const {name} = text;
       const high_per_host = parseFloat(text.high_per_host);
       const severity = parseSeverity(text.severity);
-      const riskFactor = resultSeverityRiskFactor(severity, severityClass);
+      const riskFactor = resultSeverityRiskFactor(severity);
       return {
         y: high_per_host,
         x: name,

--- a/gsa/src/web/pages/tasks/dashboard/mosthighresults.js
+++ b/gsa/src/web/pages/tasks/dashboard/mosthighresults.js
@@ -44,7 +44,7 @@ import {TasksHighResultsLoader} from './loaders';
 
 const format = d3format('0.2f');
 
-const transformHighResultsData = (data = {}, {severityClass}) => {
+const transformHighResultsData = (data = {}) => {
   const {groups = []} = data;
 
   return groups

--- a/gsa/src/web/pages/usersettings/dialog.js
+++ b/gsa/src/web/pages/usersettings/dialog.js
@@ -65,7 +65,6 @@ let UserSettingsDialog = ({
   listExportFileName,
   reportExportFileName,
   autoCacheRebuild,
-  severityClass,
   dynamicSeverity,
   defaultSeverity,
   defaultAlert,
@@ -127,7 +126,6 @@ let UserSettingsDialog = ({
     listExportFileName,
     reportExportFileName,
     autoCacheRebuild,
-    severityClass,
     dynamicSeverity: parseYesNo(dynamicSeverity),
     defaultSeverity: parseFloat(defaultSeverity),
     defaultAlert,
@@ -206,7 +204,6 @@ let UserSettingsDialog = ({
             <Section title={_('Severity Settings')} foldable>
               <FormGroupSizer>
                 <SeverityPart
-                  severityClass={values.severityClass}
                   dynamicSeverity={values.dynamicSeverity}
                   defaultSeverity={values.defaultSeverity}
                   onChange={onValueChange}
@@ -348,7 +345,6 @@ UserSettingsDialog.propTypes = {
   schedules: PropTypes.array,
   schedulesFilter: PropTypes.string,
   secInfoFilter: PropTypes.string,
-  severityClass: PropTypes.string,
   tagsFilter: PropTypes.string,
   targets: PropTypes.array,
   targetsFilter: PropTypes.string,
@@ -370,9 +366,6 @@ UserSettingsDialog = connect(rootState => {
   };
 })(UserSettingsDialog);
 
-export default compose(
-  withGmp,
-  withCapabilities,
-)(UserSettingsDialog);
+export default compose(withGmp, withCapabilities)(UserSettingsDialog);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/usersettings/severitypart.js
+++ b/gsa/src/web/pages/usersettings/severitypart.js
@@ -27,12 +27,7 @@ import Spinner from 'web/components/form/spinner';
 
 import PropTypes from 'web/utils/proptypes';
 
-const SeverityPart = ({
-  defaultSeverity,
-  dynamicSeverity,
-  severityClass,
-  onChange,
-}) => (
+const SeverityPart = ({defaultSeverity, dynamicSeverity, onChange}) => (
   <React.Fragment>
     <FormGroup title={_('Dynamic Severity')} titleSize="3">
       <Checkbox
@@ -60,7 +55,6 @@ const SeverityPart = ({
 SeverityPart.propTypes = {
   defaultSeverity: PropTypes.number,
   dynamicSeverity: PropTypes.yesno,
-  severityClass: PropTypes.string,
   onChange: PropTypes.func.isRequired,
 };
 

--- a/gsa/src/web/pages/usersettings/severitypart.js
+++ b/gsa/src/web/pages/usersettings/severitypart.js
@@ -23,13 +23,9 @@ import {YES_VALUE, NO_VALUE} from 'gmp/parser';
 
 import Checkbox from 'web/components/form/checkbox';
 import FormGroup from 'web/components/form/formgroup';
-import Select from 'web/components/form/select';
 import Spinner from 'web/components/form/spinner';
 
 import PropTypes from 'web/utils/proptypes';
-import {renderSelectItems} from 'web/utils/render';
-
-import {SEVERITY_CLASSES} from './usersettingspage';
 
 const SeverityPart = ({
   defaultSeverity,
@@ -38,14 +34,6 @@ const SeverityPart = ({
   onChange,
 }) => (
   <React.Fragment>
-    <FormGroup title={_('Severity Class')} titleSize="3">
-      <Select
-        name="severityClass"
-        value={severityClass}
-        items={renderSelectItems(SEVERITY_CLASSES)}
-        onChange={onChange}
-      />
-    </FormGroup>
     <FormGroup title={_('Dynamic Severity')} titleSize="3">
       <Checkbox
         name="dynamicSeverity"

--- a/gsa/src/web/pages/usersettings/usersettingspage.js
+++ b/gsa/src/web/pages/usersettings/usersettingspage.js
@@ -114,17 +114,12 @@ import TableRow from 'web/components/table/row';
 import compose from 'web/utils/compose';
 import Languages, {BROWSER_LANGUAGE} from 'web/utils/languages';
 import PropTypes from 'web/utils/proptypes';
-import {SEVERITY_CLASS_NIST, SEVERITY_CLASS_PCI_DSS} from 'web/utils/severity';
 import withCapabilities from 'web/utils/withCapabilities';
 import withGmp from 'web/utils/withGmp';
 
 import SettingsDialog from './dialog';
 
 const FIRST_COL_WIDTH = '250px';
-export const SEVERITY_CLASSES = [
-  {id: SEVERITY_CLASS_NIST, name: 'NVD Vulnerability Severity Ratings'},
-  {id: SEVERITY_CLASS_PCI_DSS, name: 'PCI-DSS'},
-];
 
 const getLangNameByCode = code => {
   const language = Languages[code];
@@ -260,13 +255,6 @@ class UserSettings extends React.Component {
     }
   }
 
-  getSeverityClassNameById(id) {
-    const specifiedClass = SEVERITY_CLASSES.find(clas => {
-      return clas.id === id;
-    });
-    return isDefined(specifiedClass) ? specifiedClass.name : undefined;
-  }
-
   handleSaveSettings(data) {
     const {gmp} = this.props;
     const {userInterfaceLanguage = BROWSER_LANGUAGE, timezone} = data;
@@ -311,7 +299,6 @@ class UserSettings extends React.Component {
       detailsExportFileName = {},
       listExportFileName = {},
       reportExportFileName = {},
-      severityClass = {},
       dynamicSeverity = {},
       defaultSeverity = {},
       defaultAlert = {},
@@ -495,12 +482,6 @@ class UserSettings extends React.Component {
                     <Table>
                       <colgroup width={FIRST_COL_WIDTH} />
                       <TableBody>
-                        <TableRow title={severityClass.comment}>
-                          <TableData>{_('Severity Class')}</TableData>
-                          <TableData>
-                            {this.getSeverityClassNameById(severityClass.value)}
-                          </TableData>
-                        </TableRow>
                         <TableRow title={dynamicSeverity.comment}>
                           <TableData>{_('Dynamic Severity')}</TableData>
                           <TableData>
@@ -802,9 +783,6 @@ class UserSettings extends React.Component {
               listExportFileName={listExportFileName.value}
               reportExportFileName={reportExportFileName.value}
               autoCacheRebuild={autoCacheRebuild.value}
-              severityClass={
-                severityClass.value === '' ? undefined : severityClass.value
-              }
               dynamicSeverity={dynamicSeverity.value}
               defaultSeverity={defaultSeverity.value}
               defaultAlert={defaultAlert.id}
@@ -930,7 +908,6 @@ UserSettings.propTypes = {
   schedulesFilter: PropTypes.object,
   setLocale: PropTypes.func.isRequired,
   setTimezone: PropTypes.func.isRequired,
-  severityClass: PropTypes.object,
   tagsFilter: PropTypes.object,
   targets: PropTypes.array,
   targetsFilter: PropTypes.object,
@@ -964,7 +941,6 @@ const mapStateToProps = rootState => {
   const maxRowsPerPage = userDefaultsSelector.getByName('maxrowsperpage');
   const autoCacheRebuild = userDefaultsSelector.getByName('autocacherebuild');
 
-  const severityClass = userDefaultsSelector.getByName('severityclass');
   const defaultSeverity = userDefaultsSelector.getByName('defaultseverity');
   const dynamicSeverity = userDefaultsSelector.getByName('dynamicseverity');
 
@@ -1096,7 +1072,6 @@ const mapStateToProps = rootState => {
     listExportFileName,
     reportExportFileName,
     maxRowsPerPage,
-    severityClass,
     defaultSeverity,
     dynamicSeverity,
     isLoading: userDefaultsSelector.isLoading(),
@@ -1200,10 +1175,7 @@ const mapDispatchToProps = (dispatch, {gmp}) => ({
 export default compose(
   withGmp,
   withCapabilities,
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  ),
+  connect(mapStateToProps, mapDispatchToProps),
 )(UserSettings);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/utils/proptypes.js
+++ b/gsa/src/web/utils/proptypes.js
@@ -32,7 +32,6 @@ import Capabilities from 'gmp/capabilities/capabilities';
 import Filter from 'gmp/models/filter';
 import Settings from 'gmp/models/settings';
 
-import {SEVERITY_CLASS_NIST, SEVERITY_CLASS_PCI_DSS} from './severity';
 import warning from './warning';
 
 export const mayRequire = validator => {
@@ -210,11 +209,6 @@ const toStringValidator = (props, prop_name, component_name) => {
 
 const toString = mayRequire(toStringValidator);
 
-const severityClass = ReactPropTypes.objectOf([
-  SEVERITY_CLASS_NIST,
-  SEVERITY_CLASS_PCI_DSS,
-]);
-
 const ref = ReactPropTypes.oneOfType([
   ReactPropTypes.func,
   // React.createRef() returns an object with a current property
@@ -264,7 +258,6 @@ export default {
   ref,
   set,
   settings,
-  severityClass,
   stringOrFalse,
   timeunit,
   toString,

--- a/gsa/src/web/utils/severity.js
+++ b/gsa/src/web/utils/severity.js
@@ -48,8 +48,8 @@ export const FALSE_POSITIVE_VALUE = -1;
 export const DEBUG_VALUE = -2;
 export const ERROR_VALUE = -3;
 
-export const severityRiskFactor = (value, type) => {
-  const {low, medium, high} = getSeverityLevels(type);
+export const severityRiskFactor = value => {
+  const {low, medium, high} = getSeverityLevels();
 
   if (value >= LOG_VALUE && isDefined(low) && value < low) {
     return LOG;
@@ -88,7 +88,7 @@ export const extraRiskFactor = (value = NA_VALUE) => {
 
 export const resultSeverityRiskFactor = (value, type) => {
   if (value > LOG_VALUE) {
-    return severityRiskFactor(value, type);
+    return severityRiskFactor(value);
   }
 
   return extraRiskFactor(value);

--- a/gsa/src/web/utils/severity.js
+++ b/gsa/src/web/utils/severity.js
@@ -86,7 +86,7 @@ export const extraRiskFactor = (value = NA_VALUE) => {
   }
 };
 
-export const resultSeverityRiskFactor = (value, type) => {
+export const resultSeverityRiskFactor = value => {
   if (value > LOG_VALUE) {
     return severityRiskFactor(value);
   }

--- a/gsa/src/web/utils/severity.js
+++ b/gsa/src/web/utils/severity.js
@@ -129,20 +129,15 @@ export const translatedResultSeverityRiskFactor = value =>
  *  - high range from 6.5 to 10 [6.5, 10]
  */
 
-const SEVERITY_LEVELS_DEFAULT = {
-  high: 7.0,
-  medium: 4.0,
-  low: 0.1,
+export const getSeverityLevels = () => {
+  return {
+    high: 7.0,
+    medium: 4.0,
+    low: 0.1,
+  };
 };
 
-export const getSeverityLevels = type => {
-  switch (type) {
-    default:
-      return SEVERITY_LEVELS_DEFAULT;
-  }
-};
-
-export const getSeverityLevelsOld = type => {
+export const getSeverityLevelsOld = () => {
   return {
     max_high: 10.0,
     min_high: 7.0,

--- a/gsa/src/web/utils/severity.js
+++ b/gsa/src/web/utils/severity.js
@@ -111,9 +111,6 @@ export const translateRiskFactor = factor =>
 export const translatedResultSeverityRiskFactor = value =>
   translateRiskFactor(resultSeverityRiskFactor(value));
 
-export const SEVERITY_CLASS_PCI_DSS = 'pci-dss';
-export const SEVERITY_CLASS_NIST = 'nist';
-
 /*
  * The severity levels define the lower limit
  *
@@ -132,21 +129,6 @@ export const SEVERITY_CLASS_NIST = 'nist';
  *  - high range from 6.5 to 10 [6.5, 10]
  */
 
-/*
- The original version form xslt used
-  {
-    high: 4.0,
-    medium: 3.9,
-    low: 3.9,
-  }
-  for PCI-DSS
-*/
-const SEVERITY_LEVELS_PCI_DSS = {
-  high: 7.0,
-  medium: 4.0,
-  low: 0.1,
-};
-
 const SEVERITY_LEVELS_DEFAULT = {
   high: 7.0,
   medium: 4.0,
@@ -155,26 +137,12 @@ const SEVERITY_LEVELS_DEFAULT = {
 
 export const getSeverityLevels = type => {
   switch (type) {
-    case SEVERITY_CLASS_PCI_DSS:
-      return SEVERITY_LEVELS_PCI_DSS;
     default:
       return SEVERITY_LEVELS_DEFAULT;
   }
 };
 
 export const getSeverityLevelsOld = type => {
-  if (type === SEVERITY_CLASS_PCI_DSS) {
-    return {
-      max_high: 10.0,
-      min_high: 4.0,
-      max_medium: 3.9,
-      min_medium: 3.9,
-      max_low: 3.9,
-      min_low: 3.9,
-      max_log: 3.9,
-    };
-  }
-
   return {
     max_high: 10.0,
     min_high: 7.0,

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -709,7 +709,6 @@ init_validator ()
   gvm_validator_add (validator, "schedule_id", "^[a-z0-9\\-]+$");
   gvm_validator_add (validator, "severity",
                      "^(-1(\\.0)?|[0-9](\\.[0-9])?|10(\\.0)?)$");
-  gvm_validator_add (validator, "severity_class", "^(nist|pci\\-dss)$");
   gvm_validator_add (validator, "severity_optional",
                      "^(-1(\\.0)?|[0-9](\\.[0-9])?|10(\\.0)?)?$");
   gvm_validator_add (validator, "source_iface", "^(.*){1,16}$");

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -11481,69 +11481,6 @@ save_my_settings_gmp (gvm_connection_t *connection, credentials_t *credentials,
         response_data);
     }
 
-  /* Send Severity Class. */
-
-  changed_value = params_value (changed, "severity_class");
-  if (changed_value == NULL
-      || (strcmp (changed_value, "") && strcmp (changed_value, "0")))
-    {
-      text = params_value (params, "severity_class");
-      text_64 = (text ? g_base64_encode ((guchar *) text, strlen (text))
-                      : g_strdup (""));
-
-      if (gvm_connection_sendf (connection,
-                                "<modify_setting"
-                                " setting_id"
-                                "=\"f16bb236-a32d-4cd5-a880-e0fcf2599f59\">"
-                                "<value>%s</value>"
-                                "</modify_setting>",
-                                text_64 ? text_64 : "")
-          == -1)
-        {
-          g_free (text_64);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
-            "An internal error occurred while saving settings. "
-            "It is unclear whether all the settings were saved. "
-            "Diagnostics: Failure to send command to manager daemon.",
-            response_data);
-        }
-      g_free (text_64);
-
-      entity = NULL;
-      xml_string_append (xml, "<save_setting id=\"%s\">",
-                         "f16bb236-a32d-4cd5-a880-e0fcf2599f59");
-      if (read_entity_and_string_c (connection, &entity, &xml))
-        {
-          g_string_free (xml, TRUE);
-          cmd_response_data_set_status_code (response_data,
-                                             MHD_HTTP_INTERNAL_SERVER_ERROR);
-          return gsad_message (
-            credentials, "Internal error", __func__, __LINE__,
-            "An internal error occurred while saving settings. "
-            "It is unclear whether all the settings were saved. "
-            "Diagnostics: Failure to receive response from manager daemon.",
-            response_data);
-        }
-      xml_string_append (xml, "</save_setting>");
-
-      if (gmp_success (entity) == 1)
-        {
-          if ((text != NULL) && (strlen (text) > 0))
-            {
-              user_set_severity (user, text);
-              user_changed = 1;
-            }
-        }
-      else
-        {
-          set_http_status_from_entity (entity, response_data);
-          modify_failed = 1;
-        }
-    }
-
   /* Send Dynamic Severity setting. */
 
   changed_value = params_value (changed, "dynamic_severity");

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2009-2019 Greenbone Networks GmbH
+/* Copyright (C) 2009-2020 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
@@ -16561,7 +16561,6 @@ gvm_connection_open (gvm_connection_t *connection, const gchar *address,
  * @param[in]  password      Password.
  * @param[out] role          Role.
  * @param[out] timezone      Timezone.
- * @param[out] severity      Severity class.
  * @param[out] capabilities  Capabilities of manager.
  * @param[out] language      User Interface Language, or NULL.
  * @param[out] pw_warning    Password warning message, NULL if password is OK.
@@ -16570,7 +16569,7 @@ gvm_connection_open (gvm_connection_t *connection, const gchar *address,
  */
 int
 authenticate_gmp (const gchar *username, const gchar *password, gchar **role,
-                  gchar **timezone, gchar **severity, gchar **capabilities,
+                  gchar **timezone, gchar **capabilities,
                   gchar **language, gchar **pw_warning)
 {
   gvm_connection_t connection;
@@ -16587,7 +16586,6 @@ authenticate_gmp (const gchar *username, const gchar *password, gchar **role,
   auth_opts.username = username;
   auth_opts.password = password;
   auth_opts.role = role;
-  auth_opts.severity = severity;
   auth_opts.timezone = timezone;
   auth_opts.pw_warning = pw_warning;
 
@@ -16700,7 +16698,6 @@ login (http_connection_t *con, params_t *params,
   gchar *timezone;
   gchar *role;
   gchar *capabilities;
-  gchar *severity;
   gchar *language;
   gchar *pw_warning;
 
@@ -16713,7 +16710,7 @@ login (http_connection_t *con, params_t *params,
 
   if (login && password)
     {
-      ret = authenticate_gmp (login, password, &role, &timezone, &severity,
+      ret = authenticate_gmp (login, password, &role, &timezone,
                               &capabilities, &language, &pw_warning);
       if (ret)
         {
@@ -16761,7 +16758,6 @@ login (http_connection_t *con, params_t *params,
           credentials_free (credentials);
 
           g_free (timezone);
-          g_free (severity);
           g_free (capabilities);
           g_free (language);
           g_free (role);

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -342,14 +342,13 @@ envelope_gmp (gvm_connection_t *connection, credentials_t *credentials,
     "<login>%s</login>"
     "<session>%ld</session>"
     "<role>%s</role>"
-    "<severity>%s</severity>"
     "<i18n>%s</i18n>"
     "<client_address>%s</client_address>"
     "<backend_operation>%.2f</backend_operation>",
     GSAD_VERSION, vendor_version_get (), user_get_token (user), ctime_now,
     timezone ? timezone : "", user_get_username (user),
     user_get_session_timeout (user), user_get_role (user),
-    user_get_severity (user), credentials_get_language (credentials),
+    credentials_get_language (credentials),
     user_get_client_address (user), credentials_get_cmd_duration (credentials));
 
   g_string_append (string, res);

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -16742,7 +16742,7 @@ login (http_connection_t *con, params_t *params,
       else
         {
           user_t *user;
-          user = user_add (login, password, timezone, severity, role,
+          user = user_add (login, password, timezone, role,
                            capabilities, language, pw_warning, client_address);
 
           g_message ("Authentication success for '%s' from %s", login ?: "",

--- a/gsad/src/gsad_user.c
+++ b/gsad/src/gsad_user.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2018 Greenbone Networks GmbH
+/* Copyright (C) 2016-2020 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
@@ -46,7 +46,6 @@ struct user
   gchar *password;     ///< Password.
   gchar *role;         ///< Role.
   gchar *timezone;     ///< Timezone.
-  gchar *severity;     ///< Severity class.
   gchar *capabilities; ///< Capabilities.
   gchar *language;     ///< User Interface Language.
   gchar *pw_warning;   ///< Password policy warning.
@@ -69,7 +68,7 @@ user_new ()
 
 user_t *
 user_new_with_data (const gchar *username, const gchar *password,
-                    const gchar *timezone, const gchar *severity,
+                    const gchar *timezone,
                     const gchar *role, const gchar *capabilities,
                     const gchar *language, const gchar *pw_warning,
                     const gchar *address)
@@ -82,7 +81,6 @@ user_new_with_data (const gchar *username, const gchar *password,
   user->username = g_strdup (username);
   user->password = g_strdup (password);
   user->timezone = g_strdup (timezone);
-  user->severity = g_strdup (severity);
   user->role = g_strdup (role);
   user->capabilities = g_strdup (capabilities);
   user->language = g_strdup (language);
@@ -109,7 +107,6 @@ user_free (user_t *user)
   g_free (user->password);
   g_free (user->role);
   g_free (user->timezone);
-  g_free (user->severity);
   g_free (user->capabilities);
   g_free (user->language);
   g_free (user->pw_warning);
@@ -133,7 +130,6 @@ user_copy (user_t *user)
   copy->password = g_strdup (user->password);
   copy->role = g_strdup (user->role);
   copy->timezone = g_strdup (user->timezone);
-  copy->severity = g_strdup (user->severity);
   copy->capabilities = g_strdup (user->capabilities);
   copy->language = g_strdup (user->language);
   copy->pw_warning = g_strdup (user->pw_warning);
@@ -198,12 +194,6 @@ user_get_client_address (user_t *user)
 }
 
 const gchar *
-user_get_severity (user_t *user)
-{
-  return user->severity;
-}
-
-const gchar *
 user_get_role (user_t *user)
 {
   return user->role;
@@ -251,21 +241,6 @@ user_set_password (user_t *user, const gchar *password)
 
   user->password = g_strdup (password);
   user->pw_warning = NULL;
-}
-
-/**
- * @brief Set severity class of user.
- *
- * @param[in]   user      User.
- * @param[in]   severity  Severity class.
- *
- */
-void
-user_set_severity (user_t *user, const gchar *severity)
-{
-  g_free (user->severity);
-
-  user->severity = g_strdup (severity);
 }
 
 /**
@@ -336,7 +311,6 @@ user_logout (user_t *user)
  * @param[in]  username      Name of user.
  * @param[in]  password      Password for user.
  * @param[in]  timezone      Timezone of user.
- * @param[in]  severity      Severity class setting of user.
  * @param[in]  role          Role of user.
  * @param[in]  capabilities  Capabilities of manager.
  * @param[in]  language      User Interface Language (language name or code)
@@ -347,7 +321,7 @@ user_logout (user_t *user)
  */
 user_t *
 user_add (const gchar *username, const gchar *password, const gchar *timezone,
-          const gchar *severity, const gchar *role, const gchar *capabilities,
+          const gchar *role, const gchar *capabilities,
           const gchar *language, const gchar *pw_warning, const char *address)
 {
   user_t *user = session_get_user_by_username (username);
@@ -358,7 +332,7 @@ user_add (const gchar *username, const gchar *password, const gchar *timezone,
       user_free (user);
     }
 
-  user = user_new_with_data (username, password, timezone, severity, role,
+  user = user_new_with_data (username, password, timezone, role,
                              capabilities, language, pw_warning, address);
 
   session_add_user (user->token, user);

--- a/gsad/src/gsad_user.h
+++ b/gsad/src/gsad_user.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2018 Greenbone Networks GmbH
+/* Copyright (C) 2016-2020 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
@@ -53,7 +53,7 @@ user_find (const gchar *cookie, const gchar *token, const char *address,
 
 user_t *
 user_add (const gchar *username, const gchar *password, const gchar *timezone,
-          const gchar *severity, const gchar *role, const gchar *capabilities,
+          const gchar *role, const gchar *capabilities,
           const gchar *language, const gchar *pw_warning, const char *address);
 
 void
@@ -64,9 +64,6 @@ user_set_username (user_t *user, const gchar *username);
 
 void
 user_set_password (user_t *user, const gchar *password);
-
-void
-user_set_severity (user_t *user, const gchar *severity);
 
 void
 user_set_language (user_t *user, const gchar *language);
@@ -94,9 +91,6 @@ user_get_client_address (user_t *user);
 
 const gchar *
 user_get_role (user_t *user);
-
-const gchar *
-user_get_severity (user_t *user);
 
 const gchar *
 user_get_password_warning (user_t *user);


### PR DESCRIPTION
**What**:

The support for multiple severity class ranges is removed.
There is now only one classification scheme (then one previously
called "nist"). Actually there was only one other classification scheme called
"pci-dss". It wasn't used or needed.

For the user, this essentially means that in "My Settings", the option
to select a severity classification scheme is not there anymore and that
the default is now applied mandatory.

This PR requires: https://github.com/greenbone/gvmd/pull/1288


**Why**:

Removing the overhead about a dynamic handling where actually only static
class ranges are used simplifies code.
  

**How**:

Basically all aspects are removed, on gsa side, and on gvmd side.
While gvmd appears pretty clean now, in gsa there are some special
handlings with an old range style due to compatibility with older dashboard elements.

**Checklist**:

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
