### PR TITLE
Change visual appearance of compliance status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added option for "Start Task" event upon "New SecInfo arrived" condition in alerts dialog [#2418](https://github.com/greenbone/gsa/pull/2418)
 
 ### Changed
+- Changed visual appearance of compliance status bar [#2457](https://github.com/greenbone/gsa/pull/2457)
 - Changed delete icons on report format detailspage and schedule detailspage to trashcan icons [#2459](https://github.com/greenbone/gsa/pull/2459)
 - Use <predefined> to disable feed object editing and filter creation on feed status page [#2398](https://github.com/greenbone/gsa/pull/2398)
 

--- a/gsa/src/web/components/bar/__tests__/__snapshots__/compliancestatusbar.js.snap
+++ b/gsa/src/web/components/bar/__tests__/__snapshots__/compliancestatusbar.js.snap
@@ -6,7 +6,7 @@ exports[`ComplianceStatusBar tests should render 1`] = `
   box-sizing: content-box;
   display: inline-block;
   width: 100px;
-  background: #393637;
+  background: #c83814;
   vertical-align: middle;
   text-align: center;
 }
@@ -25,7 +25,7 @@ exports[`ComplianceStatusBar tests should render 1`] = `
 .c1 {
   height: 13px;
   width: 75%;
-  background: #fdc300;
+  background: #70c000;
 }
 
 @media print {

--- a/gsa/src/web/components/bar/__tests__/compliancestatusbar.js
+++ b/gsa/src/web/components/bar/__tests__/compliancestatusbar.js
@@ -68,26 +68,25 @@ describe('ComplianceStatusBar tests', () => {
     expect(element).toHaveTextContent('N/A');
   });
 
-  test('should render background for high compliance', () => {
+  test('should render colors', () => {
     const {getByTestId} = render(
       <ComplianceStatusBar complianceStatus={100} />,
     );
     const progress = getByTestId('progress');
+    const progressbarBox = getByTestId('progressbar-box');
 
-    expect(progress).toHaveStyleRule('background', Theme.paleGreen);
+    expect(progress).toHaveStyleRule('background', Theme.statusRunGreen);
+    expect(progressbarBox).toHaveStyleRule('background', Theme.errorRed);
   });
 
-  test('should render background for medium compliance', () => {
-    const {getByTestId} = render(<ComplianceStatusBar complianceStatus={75} />);
+  test('should render gray background for N/A', () => {
+    const {getByTestId} = render(<ComplianceStatusBar complianceStatus={-1} />);
     const progress = getByTestId('progress');
+    const progressbarBox = getByTestId('progressbar-box');
 
-    expect(progress).toHaveStyleRule('background', Theme.goldYellow);
-  });
+    expect(progress).toHaveStyleRule('background', Theme.statusRunGreen);
+    expect(progress).toHaveStyleRule('width', '0%');
 
-  test('should render background for low compliance', () => {
-    const {getByTestId} = render(<ComplianceStatusBar complianceStatus={25} />);
-    const progress = getByTestId('progress');
-
-    expect(progress).toHaveStyleRule('background', Theme.errorRed);
+    expect(progressbarBox).toHaveStyleRule('background', Theme.darkGray);
   });
 });

--- a/gsa/src/web/components/bar/__tests__/progressbar.js
+++ b/gsa/src/web/components/bar/__tests__/progressbar.js
@@ -120,4 +120,27 @@ describe('ProgressBar tests', () => {
 
     expect(progress).toHaveStyleRule('background', 'gray');
   });
+
+  test('should render box background', () => {
+    const {getByTestId} = render(
+      <ProgressBar
+        boxBackground={Theme.errorRed}
+        background="run"
+        progress="10"
+        title="Progress"
+      />,
+    );
+    const progressbarBox = getByTestId('progressbar-box');
+
+    expect(progressbarBox).toHaveStyleRule('background', Theme.errorRed);
+  });
+
+  test('should render gray box background by default', () => {
+    const {getByTestId} = render(
+      <ProgressBar background="run" progress="10" title="Progress" />,
+    );
+    const progressbarBox = getByTestId('progressbar-box');
+
+    expect(progressbarBox).toHaveStyleRule('background', Theme.darkGray);
+  });
 });

--- a/gsa/src/web/components/bar/compliancestatusbar.js
+++ b/gsa/src/web/components/bar/compliancestatusbar.js
@@ -26,24 +26,22 @@ import ProgressBar from 'web/components/bar/progressbar';
 
 const ComplianceStatusBar = ({complianceStatus}) => {
   let text;
+  let boxBackground;
   if (complianceStatus < 0 || complianceStatus > 100) {
     text = _('N/A');
+    boxBackground = Theme.darkGrey;
   } else {
     text = complianceStatus + '%';
+    boxBackground = Theme.errorRed;
   }
 
-  let type;
-  if (complianceStatus < 0 || complianceStatus > 100) {
-    type = 'log';
-  } else if (complianceStatus === 100) {
-    type = Theme.paleGreen;
-  } else if (complianceStatus <= 50) {
-    type = Theme.errorRed;
-  } else {
-    type = Theme.goldYellow;
-  }
   return (
-    <ProgressBar title={text} progress={complianceStatus} background={type}>
+    <ProgressBar
+      title={text}
+      progress={complianceStatus}
+      background={Theme.statusRunGreen}
+      boxBackground={boxBackground}
+    >
       {text}
     </ProgressBar>
   );

--- a/gsa/src/web/components/bar/progressbar.js
+++ b/gsa/src/web/components/bar/progressbar.js
@@ -28,7 +28,7 @@ const ProgressBarBox = styled.div`
   box-sizing: content-box; /* height includes border */
   display: inline-block;
   width: 100px;
-  background: ${Theme.darkGray};
+  background: ${props => props.boxBackground};
   vertical-align: middle;
   text-align: center;
 
@@ -95,9 +95,19 @@ const Progress = styled.div`
   }};
 `;
 
-const ProgressBar = ({background, children, progress, title}) => {
+const ProgressBar = ({
+  background,
+  boxBackground = Theme.darkGray,
+  children,
+  progress,
+  title,
+}) => {
   return (
-    <ProgressBarBox data-testid="progressbar-box" title={title}>
+    <ProgressBarBox
+      data-testid="progressbar-box"
+      title={title}
+      boxBackground={boxBackground}
+    >
       <Progress
         data-testid="progress"
         progress={progress}
@@ -110,6 +120,7 @@ const ProgressBar = ({background, children, progress, title}) => {
 
 ProgressBar.propTypes = {
   background: PropTypes.string,
+  boxBackground: PropTypes.string,
   progress: PropTypes.numberOrNumberString,
   title: PropTypes.string,
 };

--- a/gsa/src/web/pages/audits/__tests__/__snapshots__/listpage.js.snap
+++ b/gsa/src/web/pages/audits/__tests__/__snapshots__/listpage.js.snap
@@ -326,7 +326,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   justify-content: space-between;
 }
 
-.c56 {
+.c57 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -411,7 +411,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   margin-left: 5px;
 }
 
-.c55 {
+.c56 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -434,14 +434,14 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   margin-left: -5px;
 }
 
-.c55 > * {
+.c56 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c55 > * {
+.c56 > * {
   margin-left: 5px;
 }
 
@@ -467,7 +467,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   display: inline-flex;
 }
 
-.c54 {
+.c55 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -678,7 +678,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 150px;
 }
 
-.c57 {
+.c58 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -818,7 +818,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   margin-right: 5px;
 }
 
-.c58 {
+.c59 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -937,6 +937,16 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   text-align: center;
 }
 
+.c53 {
+  height: 13px;
+  box-sizing: content-box;
+  display: inline-block;
+  width: 100px;
+  background: #c83814;
+  vertical-align: middle;
+  text-align: center;
+}
+
 .c51 {
   z-index: 1;
   font-weight: bold;
@@ -954,10 +964,10 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   background: #4f91c7;
 }
 
-.c53 {
+.c54 {
   height: 13px;
   width: 50%;
-  background: #c83814;
+  background: #70c000;
 }
 
 .c52 {
@@ -1062,6 +1072,13 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
 }
 
 @media print {
+  .c53 {
+    background: none;
+    border: 0;
+  }
+}
+
+@media print {
   .c51 {
     color: black;
   }
@@ -1074,7 +1091,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
 }
 
 @media print {
-  .c53 {
+  .c54 {
     background: none;
   }
 }
@@ -1554,12 +1571,12 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       class="c44"
                     >
                       <div
-                        class="c49"
+                        class="c53"
                         data-testid="progressbar-box"
                         title="50%"
                       >
                         <div
-                          class="c53"
+                          class="c54"
                           data-testid="progress"
                         />
                         <div
@@ -1575,10 +1592,10 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       class="c0"
                     >
                       <div
-                        class="c54"
+                        class="c55"
                       >
                         <div
-                          class="c55"
+                          class="c56"
                           margin="5px"
                         >
                           <span
@@ -1671,7 +1688,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     colspan="5"
                   >
                     <div
-                      class="c56"
+                      class="c57"
                     >
                       <div
                         class="c2"
@@ -1688,7 +1705,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             role="combobox"
                           >
                             <div
-                              class="c57"
+                              class="c58"
                               width="180px"
                             >
                               <div
@@ -1767,7 +1784,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               class="c45"
             >
               <div
-                class="c58"
+                class="c59"
               >
                 (Applied filter: )
               </div>

--- a/gsa/src/web/pages/audits/__tests__/__snapshots__/row.js.snap
+++ b/gsa/src/web/pages/audits/__tests__/__snapshots__/row.js.snap
@@ -33,7 +33,7 @@ exports[`Audit Row tests should render 1`] = `
   justify-content: space-between;
 }
 
-.c12 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -92,7 +92,7 @@ exports[`Audit Row tests should render 1`] = `
   margin-left: 5px;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -115,14 +115,14 @@ exports[`Audit Row tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c14 > * {
+.c15 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c14 > * {
+.c15 > * {
   margin-left: 5px;
 }
 
@@ -148,7 +148,7 @@ exports[`Audit Row tests should render 1`] = `
   display: inline-flex;
 }
 
-.c13 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -174,21 +174,21 @@ exports[`Audit Row tests should render 1`] = `
   display: inline-flex;
 }
 
-.c15 {
+.c16 {
   cursor: pointer;
 }
 
-.c17 svg path {
+.c18 svg path {
   fill: #aaaaaa;
 }
 
-.c16 {
+.c17 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c16 * {
+.c17 * {
   height: inherit;
   width: inherit;
 }
@@ -216,6 +216,16 @@ exports[`Audit Row tests should render 1`] = `
   text-align: center;
 }
 
+.c11 {
+  height: 13px;
+  box-sizing: content-box;
+  display: inline-block;
+  width: 100px;
+  background: #c83814;
+  vertical-align: middle;
+  text-align: center;
+}
+
 .c9 {
   z-index: 1;
   font-weight: bold;
@@ -233,10 +243,10 @@ exports[`Audit Row tests should render 1`] = `
   background: #4f91c7;
 }
 
-.c11 {
+.c12 {
   height: 13px;
   width: 50%;
-  background: #c83814;
+  background: #70c000;
 }
 
 .c10 {
@@ -249,7 +259,7 @@ exports[`Audit Row tests should render 1`] = `
 }
 
 @media print {
-  .c15 {
+  .c16 {
     display: none;
   }
 }
@@ -268,6 +278,13 @@ exports[`Audit Row tests should render 1`] = `
 }
 
 @media print {
+  .c11 {
+    background: none;
+    border: 0;
+  }
+}
+
+@media print {
   .c9 {
     color: black;
   }
@@ -280,7 +297,7 @@ exports[`Audit Row tests should render 1`] = `
 }
 
 @media print {
-  .c11 {
+  .c12 {
     background: none;
   }
 }
@@ -373,12 +390,12 @@ exports[`Audit Row tests should render 1`] = `
           class="c0"
         >
           <div
-            class="c7"
+            class="c11"
             data-testid="progressbar-box"
             title="50%"
           >
             <div
-              class="c11"
+              class="c12"
               data-testid="progress"
             />
             <div
@@ -391,17 +408,17 @@ exports[`Audit Row tests should render 1`] = `
       </td>
       <td>
         <div
-          class="c12"
+          class="c13"
         >
           <div
-            class="c13"
+            class="c14"
           >
             <div
-              class="c14"
+              class="c15"
               margin="5px"
             >
               <span
-                class="c15 c16"
+                class="c16 c17"
                 data-testid="svg-icon"
                 title="Start"
               >
@@ -413,7 +430,7 @@ exports[`Audit Row tests should render 1`] = `
               </span>
               <span
                 alt="Resume"
-                class="c17 c16"
+                class="c18 c17"
                 data-testid="svg-icon"
                 title="Audit is not stopped"
               >
@@ -424,7 +441,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c15 c16"
+                class="c16 c17"
                 data-testid="svg-icon"
                 title="Move Audit to trashcan"
               >
@@ -435,7 +452,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c15 c16"
+                class="c16 c17"
                 data-testid="svg-icon"
                 title="Edit Audit"
               >
@@ -446,7 +463,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c15 c16"
+                class="c16 c17"
                 data-testid="svg-icon"
                 title="Clone Audit"
               >
@@ -457,7 +474,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c15 c16"
+                class="c16 c17"
                 data-testid="svg-icon"
                 title="Export Audit"
               >
@@ -468,7 +485,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c15 c16"
+                class="c16 c17"
                 data-testid="svg-icon"
                 title="Download Greenbone Compliance Report"
               >

--- a/gsa/src/web/pages/audits/__tests__/__snapshots__/table.js.snap
+++ b/gsa/src/web/pages/audits/__tests__/__snapshots__/table.js.snap
@@ -83,7 +83,7 @@ exports[`Audits table tests should render 1`] = `
   justify-content: space-between;
 }
 
-.c28 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -105,7 +105,7 @@ exports[`Audits table tests should render 1`] = `
   align-items: stretch;
 }
 
-.c33 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -123,7 +123,7 @@ exports[`Audits table tests should render 1`] = `
   align-items: center;
 }
 
-.c38 {
+.c39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -178,7 +178,7 @@ exports[`Audits table tests should render 1`] = `
   margin-left: 5px;
 }
 
-.c30 {
+.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -201,14 +201,14 @@ exports[`Audits table tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c30 > * {
+.c31 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c30 > * {
+.c31 > * {
   margin-left: 5px;
 }
 
@@ -234,7 +234,7 @@ exports[`Audits table tests should render 1`] = `
   display: inline-flex;
 }
 
-.c29 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -279,7 +279,7 @@ exports[`Audits table tests should render 1`] = `
   width: inherit;
 }
 
-.c39 {
+.c40 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -304,18 +304,18 @@ exports[`Audits table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c40 {
+.c41 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c40 * {
+.c41 * {
   height: inherit;
   width: inherit;
 }
 
-.c36 {
+.c37 {
   border: 1px solid #aaaaaa;
   border-radius: 2px;
   display: -webkit-box;
@@ -339,7 +339,7 @@ exports[`Audits table tests should render 1`] = `
   font-weight: normal;
 }
 
-.c35 {
+.c36 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -351,7 +351,7 @@ exports[`Audits table tests should render 1`] = `
   width: 180px;
 }
 
-.c41 {
+.c42 {
   color: #a94442;
   font-weight: bold;
   font-size: 19px;
@@ -360,7 +360,7 @@ exports[`Audits table tests should render 1`] = `
   display: none;
 }
 
-.c37 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -380,7 +380,7 @@ exports[`Audits table tests should render 1`] = `
   cursor: default;
 }
 
-.c34 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -431,7 +431,7 @@ exports[`Audits table tests should render 1`] = `
   width: 10em;
 }
 
-.c42 {
+.c43 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -550,6 +550,16 @@ exports[`Audits table tests should render 1`] = `
   text-align: center;
 }
 
+.c27 {
+  height: 13px;
+  box-sizing: content-box;
+  display: inline-block;
+  width: 100px;
+  background: #c83814;
+  vertical-align: middle;
+  text-align: center;
+}
+
 .c25 {
   z-index: 1;
   font-weight: bold;
@@ -567,19 +577,19 @@ exports[`Audits table tests should render 1`] = `
   background: #4f91c7;
 }
 
-.c27 {
+.c28 {
   height: 13px;
   width: 50%;
-  background: #c83814;
+  background: #70c000;
 }
 
-.c31 {
+.c32 {
   height: 13px;
   width: 100%;
   background: #99be48;
 }
 
-.c32 {
+.c33 {
   height: 13px;
   width: 0%;
   background: #70c000;
@@ -687,6 +697,13 @@ exports[`Audits table tests should render 1`] = `
 }
 
 @media print {
+  .c27 {
+    background: none;
+    border: 0;
+  }
+}
+
+@media print {
   .c25 {
     color: black;
   }
@@ -699,19 +716,19 @@ exports[`Audits table tests should render 1`] = `
 }
 
 @media print {
-  .c27 {
-    background: none;
-  }
-}
-
-@media print {
-  .c31 {
+  .c28 {
     background: none;
   }
 }
 
 @media print {
   .c32 {
+    background: none;
+  }
+}
+
+@media print {
+  .c33 {
     background: none;
   }
 }
@@ -950,12 +967,12 @@ exports[`Audits table tests should render 1`] = `
                 class="c18"
               >
                 <div
-                  class="c23"
+                  class="c27"
                   data-testid="progressbar-box"
                   title="50%"
                 >
                   <div
-                    class="c27"
+                    class="c28"
                     data-testid="progress"
                   />
                   <div
@@ -968,13 +985,13 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c28"
+                class="c29"
               >
                 <div
-                  class="c29"
+                  class="c30"
                 >
                   <div
-                    class="c30"
+                    class="c31"
                     margin="5px"
                   >
                     <span
@@ -1118,7 +1135,7 @@ exports[`Audits table tests should render 1`] = `
                     title="New"
                   >
                     <div
-                      class="c31"
+                      class="c32"
                       data-testid="progress"
                     />
                     <div
@@ -1146,13 +1163,13 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c28"
+                class="c29"
               >
                 <div
-                  class="c29"
+                  class="c30"
                 >
                   <div
-                    class="c30"
+                    class="c31"
                     margin="5px"
                   >
                     <span
@@ -1298,7 +1315,7 @@ exports[`Audits table tests should render 1`] = `
                     title="Running"
                   >
                     <div
-                      class="c32"
+                      class="c33"
                       data-testid="progress"
                     />
                     <div
@@ -1334,12 +1351,12 @@ exports[`Audits table tests should render 1`] = `
                 class="c18"
               >
                 <div
-                  class="c23"
+                  class="c27"
                   data-testid="progressbar-box"
                   title="50%"
                 >
                   <div
-                    class="c27"
+                    class="c28"
                     data-testid="progress"
                   />
                   <div
@@ -1352,13 +1369,13 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c28"
+                class="c29"
               >
                 <div
-                  class="c29"
+                  class="c30"
                 >
                   <div
-                    class="c30"
+                    class="c31"
                     margin="5px"
                   >
                     <span
@@ -1451,7 +1468,7 @@ exports[`Audits table tests should render 1`] = `
               colspan="5"
             >
               <div
-                class="c33"
+                class="c34"
               >
                 <div
                   class="c6"
@@ -1464,30 +1481,30 @@ exports[`Audits table tests should render 1`] = `
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-labelledby="downshift-0-label"
-                      class="c34"
+                      class="c35"
                       role="combobox"
                     >
                       <div
-                        class="c35"
+                        class="c36"
                         width="180px"
                       >
                         <div
                           aria-haspopup="true"
                           aria-label="open menu"
-                          class="c36"
+                          class="c37"
                           data-toggle="true"
                           role="button"
                           type="button"
                         >
                           <div
-                            class="c37"
+                            class="c38"
                             data-testid="select-selected-value"
                           />
                           <div
-                            class="c38"
+                            class="c39"
                           >
                             <span
-                              class="c39 c40"
+                              class="c40 c41"
                               data-testid="select-open-button"
                             >
                               ▼
@@ -1496,7 +1513,7 @@ exports[`Audits table tests should render 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c41"
+                        class="c42"
                         data-testid="error-marker"
                       >
                         ×
@@ -1538,7 +1555,7 @@ exports[`Audits table tests should render 1`] = `
         class="c19"
       >
         <div
-          class="c42"
+          class="c43"
         >
           (Applied filter: rows=2)
         </div>


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
Change compliance status bar to always show the ratio of compliant and none compliant results in red and green. 

**Why**:

<!-- Why are these changes necessary? -->
Before, we used different colors for the bar for low, medium and high compliance. A compliance of 0% would just have a dark background since there were no compliant results. This made it seem as if 0% was not as bad as a low percentage which would be shown in red.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry


Example of the new compliance status bar:
![new_compliance_status](https://user-images.githubusercontent.com/25639852/93318190-afbf4580-f80e-11ea-9327-af18efb975dd.png)
