### PR TITLE
use trash icons instead of delete icons for report formats and schedules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added option for "Start Task" event upon "New SecInfo arrived" condition in alerts dialog [#2418](https://github.com/greenbone/gsa/pull/2418)
 
 ### Changed
+- Changed delete icons on report format detailspage and schedule detailspage to trashcan icons [#2459](https://github.com/greenbone/gsa/pull/2459)
 - Use <predefined> to disable feed object editing and filter creation on feed status page [#2398](https://github.com/greenbone/gsa/pull/2398)
 
 ### Fixed

--- a/gsa/src/web/pages/reportformats/detailspage.js
+++ b/gsa/src/web/pages/reportformats/detailspage.js
@@ -23,7 +23,7 @@ import React from 'react';
 import _ from 'gmp/locale';
 
 import CreateIcon from 'web/entity/icon/createicon';
-import DeleteIcon from 'web/entity/icon/deleteicon';
+import TrashIcon from 'web/entity/icon/trashicon';
 import Divider from 'web/components/layout/divider';
 import EditIcon from 'web/entity/icon/editicon';
 import IconDivider from 'web/components/layout/icondivider';
@@ -98,7 +98,7 @@ const ToolBarIcons = withCapabilities(
           entity={entity}
           onClick={onReportFormatEditClick}
         />
-        <DeleteIcon
+        <TrashIcon
           displayName={_('Report Format')}
           entity={entity}
           onClick={onReportFormatDeleteClick}

--- a/gsa/src/web/pages/schedules/detailspage.js
+++ b/gsa/src/web/pages/schedules/detailspage.js
@@ -23,7 +23,7 @@ import ExportIcon from 'web/components/icon/exporticon';
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
-import DeleteIcon from 'web/entity/icon/deleteicon';
+import TrashIcon from 'web/entity/icon/trashicon';
 
 import ManualIcon from 'web/components/icon/manualicon';
 import ListIcon from 'web/components/icon/listicon';
@@ -83,7 +83,7 @@ const ToolBarIcons = ({
       <CreateIcon entity={entity} onClick={onScheduleCreateClick} />
       <CloneIcon entity={entity} onClick={onScheduleCloneClick} />
       <EditIcon entity={entity} onClick={onScheduleEditClick} />
-      <DeleteIcon entity={entity} onClick={onScheduleDeleteClick} />
+      <TrashIcon entity={entity} onClick={onScheduleDeleteClick} />
       <ExportIcon
         value={entity}
         title={_('Export Schedule as XML')}


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
Change delete icons on report format detailspage and schedule detailspage to trashcan icons.

**Why**:

<!-- Why are these changes necessary? -->
The report format detailspage and the schedule detailspage misleadingly show delete icons when it should be trashcan icons instead. Clicking on the icon moves the entities to the trashcan.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
