### PR TITLE
Change tooltip of override icon in result details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added option for "Start Task" event upon "New SecInfo arrived" condition in alerts dialog [#2418](https://github.com/greenbone/gsa/pull/2418)
 
 ### Changed
+- Change tooltip of override icon in result details [#2467](https://github.com/greenbone/gsa/pull/2467)
 - Changed visual appearance of compliance status bar [#2457](https://github.com/greenbone/gsa/pull/2457)
 - Changed delete icons on report format detailspage and schedule detailspage to trashcan icons [#2459](https://github.com/greenbone/gsa/pull/2459)
 - Use <predefined> to disable feed object editing and filter creation on feed status page [#2398](https://github.com/greenbone/gsa/pull/2398)

--- a/gsa/src/web/pages/results/detailspage.js
+++ b/gsa/src/web/pages/results/detailspage.js
@@ -202,7 +202,9 @@ const Details = ({entity, ...props}) => {
                       <SeverityBar severity={entity.severity} />
                       {active_overrides.length > 0 && (
                         <InnerLink to="overrides">
-                          <OverrideIcon title={_('Overrides are applied')} />
+                          <OverrideIcon
+                            title={_('There are overrides for this result')}
+                          />
                         </InnerLink>
                       )}
                     </Divider>
@@ -438,10 +440,7 @@ export default compose(
     entitySelector: selector,
     load: loadEntity,
   }),
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  ),
+  connect(mapStateToProps, mapDispatchToProps),
 )(Page);
 
 // vim: set ts=2 sw=2 tw=80:


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Change tooltip of override icon in result details.

**Why**:

<!-- Why are these changes necessary? -->

Currently, the tooltip is "Overrides are applied.". This shows even on the result details, but that is misleading because we do not apply the new severity etc. on the result detailspage. 

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->
Manual testing in web app.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
