### PR TITLE
fix: severity field within gmp_authenticate_info_opts_t got deleted

### DIFF
--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -16651,7 +16651,6 @@ authenticate_gmp (const gchar *username, const gchar *password, gchar **role,
   auth_opts.username = username;
   auth_opts.password = password;
   auth_opts.role = role;
-  auth_opts.severity = severity;
   auth_opts.timezone = timezone;
   auth_opts.pw_warning = pw_warning;
 


### PR DESCRIPTION
**What**:

severity class got deleted within gmp_authenticate_info_opts_t; hence gsad
cannot use auth.severity within authentication.

This is just a fix gsad building the other occurrences of severity should
be checked as well.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Unable to build gsad based on gvm-libs based on master

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->
1. build and install newest gvm-libs from master branch
2. build gsad

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
