### PR TITLE
Load Notes via graphql into task detailspage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [21.04] - unreleased
 
 ### Added
+- Added getNotes query [#2485](https://github.com/greenbone/gsa/pull/2485)
 - Support more enum types for create alert [#2462](https://github.com/greenbone/gsa/pull/2462)
 - Added getSchedule and getSchedules via graphQL [#2450](https://github.com/greenbone/gsa/pull/2450)
 - Create alerts in task dialog via graphql [#2425](https://github.com/greenbone/gsa/pull/2425)

--- a/gsa/src/web/graphql/__mocks__/notes.js
+++ b/gsa/src/web/graphql/__mocks__/notes.js
@@ -1,0 +1,72 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+import {deepFreeze} from 'web/utils/testing';
+
+import {GET_NOTES} from '../notes';
+
+const note1 = deepFreeze({
+  id: '123',
+});
+
+const note2 = deepFreeze({
+  id: '456',
+});
+
+const mockNotes = {
+  edges: [
+    {
+      node: note1,
+    },
+    {
+      node: note2,
+    },
+  ],
+  counts: {
+    total: 2,
+    filtered: 2,
+    offset: 0,
+    limit: 10,
+    length: 2,
+  },
+  pageInfo: {
+    hasNextPage: false,
+    hasPreviousPage: false,
+    startCursor: 'note:0',
+    endCursor: 'note:1',
+    lastPageCursor: 'note:3',
+  },
+};
+
+export const createGetNotesQueryMock = (variables = {}) => {
+  const queryResult = {
+    data: {
+      notes: mockNotes,
+    },
+  };
+
+  const resultFunc = jest.fn().mockReturnValue(queryResult);
+
+  const queryMock = {
+    request: {
+      query: GET_NOTES,
+      variables,
+    },
+    newData: resultFunc,
+  };
+  return [queryMock, resultFunc];
+};

--- a/gsa/src/web/graphql/__tests__/notes.js
+++ b/gsa/src/web/graphql/__tests__/notes.js
@@ -1,0 +1,102 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import React from 'react';
+
+import {isDefined} from 'gmp/utils/identity';
+
+import {rendererWith, fireEvent, wait, screen} from 'web/utils/testing';
+
+import {useLazyGetNotes} from '../notes';
+
+import {createGetNotesQueryMock} from '../__mocks__/notes';
+
+const GetLazyNotesComponent = () => {
+  const [getNotes, {counts, loading, notes}] = useLazyGetNotes();
+
+  if (loading) {
+    return <span data-testid="loading">Loading</span>;
+  }
+  return (
+    <div>
+      <button data-testid="load" onClick={() => getNotes()} />
+      {isDefined(counts) ? (
+        <div data-testid="counts">
+          <span data-testid="total">{counts.all}</span>
+          <span data-testid="filtered">{counts.filtered}</span>
+          <span data-testid="first">{counts.first}</span>
+          <span data-testid="limit">{counts.rows}</span>
+          <span data-testid="length">{counts.length}</span>
+        </div>
+      ) : (
+        <div data-testid="no-counts" />
+      )}
+      {isDefined(notes) ? (
+        notes.map(note => {
+          return (
+            <div key={note.id} data-testid="note">
+              {note.id}
+            </div>
+          );
+        })
+      ) : (
+        <div data-testid="no-notes" />
+      )}
+    </div>
+  );
+};
+
+describe('useLazyGetNotes tests', () => {
+  test('should query notes after user interaction', async () => {
+    const [mock, resultFunc] = createGetNotesQueryMock();
+    const {render} = rendererWith({queryMocks: [mock]});
+
+    render(<GetLazyNotesComponent />);
+
+    let noteElements = screen.queryAllByTestId('note');
+    expect(noteElements).toHaveLength(0);
+
+    expect(screen.queryByTestId('no-notes')).toBeInTheDocument();
+    expect(screen.queryByTestId('no-counts')).toBeInTheDocument();
+
+    const button = screen.getByTestId('load');
+    fireEvent.click(button);
+
+    const loading = await screen.findByTestId('loading');
+    expect(loading).toHaveTextContent('Loading');
+
+    await wait();
+
+    expect(resultFunc).toHaveBeenCalled();
+
+    noteElements = screen.getAllByTestId('note');
+    expect(noteElements).toHaveLength(2);
+
+    expect(noteElements[0]).toHaveTextContent('123');
+    expect(noteElements[1]).toHaveTextContent('456');
+
+    expect(screen.queryByTestId('no-notes')).not.toBeInTheDocument();
+
+    expect(screen.getByTestId('total')).toHaveTextContent(2);
+    expect(screen.getByTestId('filtered')).toHaveTextContent(2);
+    expect(screen.getByTestId('first')).toHaveTextContent(1);
+    expect(screen.getByTestId('limit')).toHaveTextContent(10);
+    expect(screen.getByTestId('length')).toHaveTextContent(2);
+  });
+});

--- a/gsa/src/web/graphql/notes.js
+++ b/gsa/src/web/graphql/notes.js
@@ -1,0 +1,98 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {useCallback} from 'react';
+
+import {useLazyQuery} from '@apollo/client';
+
+import gql from 'graphql-tag';
+
+import CollectionCounts from 'gmp/collection/collectioncounts';
+
+import Note from 'gmp/models/note';
+
+import {isDefined} from 'gmp/utils/identity';
+
+export const GET_NOTES = gql`
+  query Notes(
+    $filterString: FilterString
+    $after: String
+    $before: String
+    $first: Int
+    $last: Int
+  ) {
+    notes(
+      filterString: $filterString
+      after: $after
+      before: $before
+      first: $first
+      last: $last
+    ) {
+      edges {
+        node {
+          id
+        }
+      }
+      counts {
+        total
+        filtered
+        offset
+        limit
+        length
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+        lastPageCursor
+      }
+    }
+  }
+`;
+
+export const useLazyGetNotes = (variables, options) => {
+  const [queryNotes, {data, ...other}] = useLazyQuery(GET_NOTES, {
+    ...options,
+    variables,
+  });
+  const notes = isDefined(data?.notes)
+    ? data.notes.edges.map(entity => Note.fromObject(entity.node))
+    : undefined;
+
+  const {total, filtered, offset = -1, limit, length} =
+    data?.notes?.counts || {};
+  const counts = isDefined(data?.notes?.counts)
+    ? new CollectionCounts({
+        all: total,
+        filtered: filtered,
+        first: offset + 1,
+        length: length,
+        rows: limit,
+      })
+    : undefined;
+  const getNotes = useCallback(
+    // eslint-disable-next-line no-shadow
+    (variables, options) => queryNotes({...options, variables}),
+    [queryNotes],
+  );
+  const pageInfo = data?.notes?.pageInfo;
+  return [getNotes, {...other, counts, notes, pageInfo}];
+};
+
+// vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/tasks/__tests__/detailspage.js
+++ b/gsa/src/web/pages/tasks/__tests__/detailspage.js
@@ -39,6 +39,7 @@ import {
 } from 'web/graphql/__mocks__/tasks';
 
 import {createGetScheduleQueryMock} from 'web/graphql/__mocks__/schedules';
+import {createGetNotesQueryMock} from 'web/graphql/__mocks__/notes';
 import {createGetOverridesQueryMock} from 'web/graphql/__mocks__/overrides';
 
 import {getMockTasks} from 'web/pages/tasks/__mocks__/mocktasks';
@@ -121,9 +122,6 @@ describe('Task Detailspage tests', () => {
       reportformats: {
         get: getEntities,
       },
-      notes: {
-        get: getEntities,
-      },
       settings: {
         manualUrl,
         reloadInterval,
@@ -135,6 +133,9 @@ describe('Task Detailspage tests', () => {
 
     const id = '12345';
     const [mock, resultFunc] = createGetTaskQueryMock(id);
+    const [notesMock, notesResultFunc] = createGetNotesQueryMock({
+      filterString: 'task_id:12345',
+    });
     const [overridesMock, overridesResultFunc] = createGetOverridesQueryMock({
       filterString: 'task_id:12345',
     });
@@ -147,7 +148,7 @@ describe('Task Detailspage tests', () => {
       gmp,
       router: true,
       store: true,
-      queryMocks: [mock, overridesMock, scheduleMock],
+      queryMocks: [mock, notesMock, overridesMock, scheduleMock],
     });
 
     store.dispatch(setTimezone('CET'));
@@ -161,6 +162,7 @@ describe('Task Detailspage tests', () => {
 
     expect(resultFunc).toHaveBeenCalled();
     expect(scheduleResultFunc).toHaveBeenCalled();
+    expect(notesResultFunc).toHaveBeenCalled();
     expect(overridesResultFunc).toHaveBeenCalled();
 
     expect(baseElement).toHaveTextContent('Task: foo');
@@ -267,9 +269,6 @@ describe('Task Detailspage tests', () => {
       reportformats: {
         get: getEntities,
       },
-      notes: {
-        get: getEntities,
-      },
       settings: {
         manualUrl,
         reloadInterval,
@@ -282,6 +281,9 @@ describe('Task Detailspage tests', () => {
 
     const id = '12345';
     const [mock, resultFunc] = createGetTaskQueryMock(id);
+    const [notesMock, notesResultFunc] = createGetNotesQueryMock({
+      filterString: 'task_id:12345',
+    });
     const [overridesMock, overridesResultFunc] = createGetOverridesQueryMock({
       filterString: 'task_id:12345',
     });
@@ -294,7 +296,7 @@ describe('Task Detailspage tests', () => {
       gmp,
       router: true,
       store: true,
-      queryMocks: [mock, overridesMock, scheduleMock],
+      queryMocks: [mock, notesMock, overridesMock, scheduleMock],
     });
 
     store.dispatch(setTimezone('CET'));
@@ -308,6 +310,7 @@ describe('Task Detailspage tests', () => {
 
     expect(resultFunc).toHaveBeenCalled();
     expect(scheduleResultFunc).toHaveBeenCalled();
+    expect(notesResultFunc).toHaveBeenCalled();
     expect(overridesResultFunc).toHaveBeenCalled();
 
     const tabs = screen.getAllByTestId('entities-tab-title');
@@ -336,9 +339,6 @@ describe('Task Detailspage tests', () => {
       reportformats: {
         get: getEntities,
       },
-      notes: {
-        get: getEntities,
-      },
       settings: {
         manualUrl,
         reloadInterval,
@@ -351,6 +351,9 @@ describe('Task Detailspage tests', () => {
 
     const id = '12345';
     const [mock, resultFunc] = createGetTaskQueryMock(id);
+    const [notesMock, notesResultFunc] = createGetNotesQueryMock({
+      filterString: 'task_id:12345',
+    });
     const [overridesMock, overridesResultFunc] = createGetOverridesQueryMock({
       filterString: 'task_id:12345',
     });
@@ -363,7 +366,7 @@ describe('Task Detailspage tests', () => {
       gmp,
       router: true,
       store: true,
-      queryMocks: [mock, overridesMock, scheduleMock],
+      queryMocks: [mock, notesMock, overridesMock, scheduleMock],
     });
 
     store.dispatch(setTimezone('CET'));
@@ -377,6 +380,7 @@ describe('Task Detailspage tests', () => {
 
     expect(resultFunc).toHaveBeenCalled();
     expect(scheduleResultFunc).toHaveBeenCalled();
+    expect(notesResultFunc).toHaveBeenCalled();
     expect(overridesResultFunc).toHaveBeenCalled();
 
     const tabs = screen.getAllByTestId('entities-tab-title');
@@ -405,9 +409,6 @@ describe('Task Detailspage tests', () => {
       reportformats: {
         get: getEntities,
       },
-      notes: {
-        get: getEntities,
-      },
       settings: {
         manualUrl,
         reloadInterval,
@@ -424,6 +425,9 @@ describe('Task Detailspage tests', () => {
     const [deleteTaskMock, deleteTaskResultFunc] = createDeleteTaskQueryMock(
       id,
     );
+    const [notesMock, notesResultFunc] = createGetNotesQueryMock({
+      filterString: 'task_id:12345',
+    });
     const [overridesMock, overridesResultFunc] = createGetOverridesQueryMock({
       filterString: 'task_id:12345',
     });
@@ -440,6 +444,7 @@ describe('Task Detailspage tests', () => {
         getTaskMock,
         cloneTaskMock,
         deleteTaskMock,
+        notesMock,
         overridesMock,
         scheduleMock,
       ],
@@ -456,6 +461,7 @@ describe('Task Detailspage tests', () => {
 
     expect(getTaskResultFunc).toHaveBeenCalled();
     expect(scheduleResultFunc).toHaveBeenCalled();
+    expect(notesResultFunc).toHaveBeenCalled();
     expect(overridesResultFunc).toHaveBeenCalled();
 
     const icons = screen.getAllByTestId('svg-icon');

--- a/gsa/src/web/pages/tasks/detailspage.js
+++ b/gsa/src/web/pages/tasks/detailspage.js
@@ -23,8 +23,6 @@ import {useParams} from 'react-router-dom';
 import _ from 'gmp/locale';
 import {shortDate} from 'gmp/locale/date';
 
-import Filter from 'gmp/models/filter';
-
 import {hasValue} from 'gmp/utils/identity';
 
 import {TARGET_CREDENTIAL_NAMES} from 'gmp/models/target';

--- a/gsa/src/web/pages/tasks/detailspage.js
+++ b/gsa/src/web/pages/tasks/detailspage.js
@@ -82,14 +82,11 @@ import CloneIcon from 'web/entity/icon/cloneicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
 
+import {useLazyGetNotes} from 'web/graphql/notes';
 import {useLazyGetOverrides} from 'web/graphql/overrides';
 
 import {useCloneTask, useDeleteTask, useGetTask} from 'web/graphql/tasks';
 
-import {
-  selector as notesSelector,
-  loadEntities as loadNotes,
-} from 'web/store/entities/notes';
 import {
   selector as permissionsSelector,
   loadEntities as loadPermissions,
@@ -381,11 +378,16 @@ const Page = ({
     }
   }, [history]);
 
+  const [loadNotes, {notes}] = useLazyGetNotes({
+    filterString: 'task_id:' + id,
+  });
+
   const [loadOverrides, {overrides}] = useLazyGetOverrides({
     filterString: 'task_id:' + id,
   });
 
   useEffect(() => {
+    loadNotes();
     loadOverrides();
   }, [id]);
 
@@ -425,6 +427,7 @@ const Page = ({
             {...props}
             entity={task}
             isLoading={loading}
+            notes={notes}
             overrides={overrides}
             sectionIcon={<TaskIcon size="large" />}
             title={_('Task')}
@@ -547,13 +550,9 @@ export const TaskPermissions = withComponentDefaults({
   ],
 })(EntityPermissions);
 
-const taskIdFilter = id => Filter.fromString('task_id=' + id).all();
-
 const mapStateToProps = (rootState, {id}) => {
   const permSel = permissionsSelector(rootState);
-  const notesSel = notesSelector(rootState);
   return {
-    notes: notesSel.getEntities(taskIdFilter(id)),
     permissions: permSel.getEntities(permissionsResourceFilter(id)),
   };
 };
@@ -561,7 +560,6 @@ const mapStateToProps = (rootState, {id}) => {
 const load = gmp => {
   const loadTaskFunc = loadTask(gmp);
   const loadPermissionsFunc = loadPermissions(gmp);
-  const loadNotesFunc = loadNotes(gmp);
 
   if (gmp.settings.enableHyperionOnly) {
     return id => dispatch => Promise.resolve(); // promise is required by withEntityContainer
@@ -571,7 +569,6 @@ const load = gmp => {
     Promise.all([
       dispatch(loadTaskFunc(id)),
       dispatch(loadPermissionsFunc(permissionsResourceFilter(id))),
-      dispatch(loadNotesFunc(taskIdFilter(id))),
     ]);
 };
 


### PR DESCRIPTION
**What**:
Implement useLazyGetNotes query for GSA and load notes at task detailspage
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
In order to use the new backend
<!-- Why are these changes necessary? -->

**How**:
Correct number of notes is shown at the notes icon, link is working, automatic tests were adjusted and passed
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
