### PR TITLE
Refactor task component and stateReducer

### DIFF
--- a/gsa/src/web/entities/bulkactions.js
+++ b/gsa/src/web/entities/bulkactions.js
@@ -30,7 +30,7 @@ import {useBulkTag, ENTITY_TYPES} from 'web/graphql/tags';
 
 import TagDialog from 'web/pages/tags/dialog';
 
-import reducer from 'web/utils/stateReducer';
+import reducer, {updateState} from 'web/utils/stateReducer';
 import PropTypes from 'web/utils/proptypes';
 import SelectionType, {getEntityIds} from 'web/utils/selectiontype';
 import useGmp from 'web/utils/useGmp';
@@ -69,7 +69,7 @@ export const BulkTagComponent = ({
 
     return gmp.tags.getAll({filter: tagFilter}).then(resp => {
       const {data} = resp;
-      dispatch({tags: data});
+      dispatch(updateState({tags: data}));
     });
   }, [gmp.tags, entitiesType]);
 
@@ -101,12 +101,12 @@ export const BulkTagComponent = ({
   );
 
   const closeTagDialog = () => {
-    dispatch({tagDialogVisible: false});
+    dispatch(updateState({tagDialogVisible: false}));
   };
 
   const openTagDialog = () => {
     renewSession();
-    dispatch({tagDialogVisible: true});
+    dispatch(updateState({tagDialogVisible: true}));
   };
 
   const handleCreateTag = data => {
@@ -117,10 +117,12 @@ export const BulkTagComponent = ({
       .then(response => gmp.tag.get(response.data))
       .then(response => {
         const newTags = [...tags, response.data];
-        dispatch({
-          tag: response.data,
-          tags: newTags,
-        });
+        dispatch(
+          updateState({
+            tag: response.data,
+            tags: newTags,
+          }),
+        );
       })
       .then(closeTagDialog);
   };
@@ -133,7 +135,7 @@ export const BulkTagComponent = ({
   const handleTagChange = id => {
     renewSession();
     return gmp.tag.get({id}).then(resp => {
-      dispatch({tag: resp.data});
+      dispatch(updateState({tag: resp.data}));
     });
   };
 

--- a/gsa/src/web/entities/bulkactions.js
+++ b/gsa/src/web/entities/bulkactions.js
@@ -30,6 +30,7 @@ import {useBulkTag, ENTITY_TYPES} from 'web/graphql/tags';
 
 import TagDialog from 'web/pages/tags/dialog';
 
+import reducer from 'web/utils/stateReducer';
 import PropTypes from 'web/utils/proptypes';
 import SelectionType, {getEntityIds} from 'web/utils/selectiontype';
 import useGmp from 'web/utils/useGmp';
@@ -42,19 +43,6 @@ const initialState = {
   tag: {},
   tags: [],
   tagDialogVisible: false,
-};
-
-const reducer = (state, action) => {
-  switch (action.type) {
-    case 'setState':
-      const {newState} = action;
-      return {
-        ...state,
-        ...newState,
-      };
-    default:
-      return state;
-  }
 };
 
 export const BulkTagComponent = ({
@@ -81,7 +69,7 @@ export const BulkTagComponent = ({
 
     return gmp.tags.getAll({filter: tagFilter}).then(resp => {
       const {data} = resp;
-      dispatch({type: 'setState', newState: {tags: data}});
+      dispatch({tags: data});
     });
   }, [gmp.tags, entitiesType]);
 
@@ -113,12 +101,12 @@ export const BulkTagComponent = ({
   );
 
   const closeTagDialog = () => {
-    dispatch({type: 'setState', newState: {tagDialogVisible: false}});
+    dispatch({tagDialogVisible: false});
   };
 
   const openTagDialog = () => {
     renewSession();
-    dispatch({type: 'setState', newState: {tagDialogVisible: true}});
+    dispatch({tagDialogVisible: true});
   };
 
   const handleCreateTag = data => {
@@ -130,11 +118,8 @@ export const BulkTagComponent = ({
       .then(response => {
         const newTags = [...tags, response.data];
         dispatch({
-          type: 'setState',
-          newState: {
-            tag: response.data,
-            tags: newTags,
-          },
+          tag: response.data,
+          tags: newTags,
         });
       })
       .then(closeTagDialog);
@@ -148,7 +133,7 @@ export const BulkTagComponent = ({
   const handleTagChange = id => {
     renewSession();
     return gmp.tag.get({id}).then(resp => {
-      dispatch({type: 'setState', newState: {tag: resp.data}});
+      dispatch({tag: resp.data});
     });
   };
 

--- a/gsa/src/web/pages/alerts/component.js
+++ b/gsa/src/web/pages/alerts/component.js
@@ -59,7 +59,7 @@ import {
 } from 'web/store/usersettings/actions';
 import {getReportComposerDefaults} from 'web/store/usersettings/selectors';
 
-import reducer from 'web/utils/stateReducer';
+import reducer, {updateState} from 'web/utils/stateReducer';
 import PropTypes from 'web/utils/proptypes';
 import {UNSET_VALUE} from 'web/utils/render';
 import useGmp from 'web/utils/useGmp';
@@ -199,61 +199,77 @@ const AlertComponent = ({
       .then(response => {
         const {data: credentials} = response;
         if (state.credentialType === 'scp') {
-          dispatchState({
-            method_data_scp_credential: credential_id,
-            credentials,
-          });
+          dispatchState(
+            updateState({
+              method_data_scp_credential: credential_id,
+              credentials,
+            }),
+          );
         } else if (state.credentialType === 'smb') {
-          dispatchState({
-            method_data_smb_credential: credential_id,
-            credentials,
-          });
+          dispatchState(
+            updateState({
+              method_data_smb_credential: credential_id,
+              credentials,
+            }),
+          );
         } else if (state.credentialType === 'verinice') {
-          dispatchState({
-            method_data_verinice_server_credential: credential_id,
-            credentials,
-          });
+          dispatchState(
+            updateState({
+              method_data_verinice_server_credential: credential_id,
+              credentials,
+            }),
+          );
         } else if (state.credentialType === 'vfire') {
-          dispatchState({
-            method_data_vfire_credential: credential_id,
-            credentials,
-          });
+          dispatchState(
+            updateState({
+              method_data_vfire_credential: credential_id,
+              credentials,
+            }),
+          );
         } else if (state.credentialType === 'tippingpoint') {
-          dispatchState({
-            method_data_tp_sms_credential: credential_id,
-            credentials,
-          });
+          dispatchState(
+            updateState({
+              method_data_tp_sms_credential: credential_id,
+              credentials,
+            }),
+          );
         } else if (state.credentialType === 'email') {
-          dispatchState({
-            method_data_recipient_credential: credential_id,
-            credentials,
-          });
+          dispatchState(
+            updateState({
+              method_data_recipient_credential: credential_id,
+              credentials,
+            }),
+          );
         } else if (state.credentialType === 'pw') {
-          dispatchState({
-            method_data_pkcs12_credential: credential_id,
-            credentials,
-          });
+          dispatchState(
+            updateState({
+              method_data_pkcs12_credential: credential_id,
+              credentials,
+            }),
+          );
         }
       })
       .catch(error => {
-        dispatchState({credentialError: error.message});
+        dispatchState(updateState({credentialError: error.message}));
       });
   };
 
   const openCredentialDialog = ({type, types}) => {
     state.credentialType = type;
-    dispatchState({
-      credentialDialogVisible: true,
-      credentialDialogTitle: _('New Credential'),
-      credentialTypes: types,
-      credentialType: type,
-    });
+    dispatchState(
+      updateState({
+        credentialDialogVisible: true,
+        credentialDialogTitle: _('New Credential'),
+        credentialTypes: types,
+        credentialType: type,
+      }),
+    );
 
     handleInteraction();
   };
 
   const closeCredentialDialog = () => {
-    dispatchState({credentialDialogVisible: false});
+    dispatchState(updateState({credentialDialogVisible: false}));
   };
 
   const handleCloseCredentialDialog = () => {
@@ -262,7 +278,7 @@ const AlertComponent = ({
   };
 
   const openContentComposerDialog = () => {
-    dispatchState({contentComposerDialogVisible: true});
+    dispatchState(updateState({contentComposerDialogVisible: true}));
   };
 
   const handleOpenContentComposerDialog = () => {
@@ -277,13 +293,15 @@ const AlertComponent = ({
       method_data_composer_include_overrides,
       filter_id,
     } = state;
-    dispatchState({
-      composerIncludeNotes: method_data_composer_include_notes,
-      composerIncludeOverrides: method_data_composer_include_overrides,
-      composerFilterId: filter_id,
-      composerStoreAsDefault: NO_VALUE,
-      contentComposerDialogVisible: false,
-    });
+    dispatchState(
+      updateState({
+        composerIncludeNotes: method_data_composer_include_notes,
+        composerIncludeOverrides: method_data_composer_include_overrides,
+        composerFilterId: filter_id,
+        composerStoreAsDefault: NO_VALUE,
+        contentComposerDialogVisible: false,
+      }),
+    );
   };
 
   const handleSaveComposerContent = ({
@@ -301,13 +319,15 @@ const AlertComponent = ({
       };
       saveReportComposerDefaults(defaults);
     }
-    dispatchState({
-      filter_id: filterId,
-      method_data_composer_include_notes: includeNotes,
-      method_data_composer_include_overrides: includeOverrides,
-      composerStoreAsDefault: NO_VALUE,
-      contentComposerDialogVisible: false,
-    });
+    dispatchState(
+      updateState({
+        filter_id: filterId,
+        method_data_composer_include_notes: includeNotes,
+        method_data_composer_include_overrides: includeOverrides,
+        composerStoreAsDefault: NO_VALUE,
+        contentComposerDialogVisible: false,
+      }),
+    );
     handleInteraction();
   };
 
@@ -505,230 +525,245 @@ const AlertComponent = ({
             ? getValue(method.data.vfire_credential)
             : undefined;
 
-          dispatchState({
-            alertDialogVisible: true,
-            id: alert.id,
-            alert,
-            active: alert.active,
-            name: alert.name,
-            comment: alert.comment,
-            filters,
-            filter_id: isDefined(alert.filter) ? alert.filter.id : undefined,
-            composerFilterId: isDefined(alert.filter)
-              ? alert.filter.id
-              : undefined,
-            composerIncludeNotes: getValue(method.data.composer_include_notes),
-            composerIncludeOverrides: getValue(
-              method.data.composer_include_overrides,
-            ),
-            composerStoreAsDefault: NO_VALUE,
-            credentials,
-            result_filters,
-            secinfo_filters,
-            report_formats,
-            report_format_ids: method.data.report_formats,
-
-            condition: condition.type,
-            condition_data_count: parseInt(getValue(condition.data.count, 1)),
-            condition_data_direction: getValue(
-              condition.data.direction,
-              DEFAULT_DIRECTION,
-            ),
-            condition_data_filters,
-            condition_data_filter_id,
-            condition_data_at_least_filter_id: condition_data_filter_id,
-            condition_data_at_least_count: parseInt(
-              getValue(condition.data.count, 1),
-            ),
-            condition_data_severity: parseSeverity(
-              getValue(condition.data.severity, DEFAULT_SEVERITY),
-            ),
-
-            event: event_type,
-            event_data_status: getValue(
-              event.data.status,
-              DEFAULT_EVENT_STATUS,
-            ),
-            event_data_feed_event: feed_event,
-            event_data_secinfo_type: getValue(
-              event.data.secinfo_type,
-              DEFAULT_SECINFO_TYPE,
-            ),
-
-            method: alert.method.type,
-
-            method_data_composer_include_notes: getValue(
-              method.data.composer_include_notes,
-            ),
-            method_data_composer_include_overrides: getValue(
-              method.data.composer_include_overrides,
-            ),
-
-            method_data_defense_center_ip: getValue(
-              method.data.defense_center_ip,
-              '',
-            ),
-            method_data_defense_center_port: parseInt(
-              getValue(
-                method.data.defense_center_port,
-                DEFAULT_DEFENSE_CENTER_PORT,
+          dispatchState(
+            updateState({
+              alertDialogVisible: true,
+              id: alert.id,
+              alert,
+              active: alert.active,
+              name: alert.name,
+              comment: alert.comment,
+              filters,
+              filter_id: isDefined(alert.filter) ? alert.filter.id : undefined,
+              composerFilterId: isDefined(alert.filter)
+                ? alert.filter.id
+                : undefined,
+              composerIncludeNotes: getValue(
+                method.data.composer_include_notes,
               ),
-            ),
-
-            method_data_details_url: getValue(
-              method.data.details_url,
-              DEFAULT_DETAILS_URL,
-            ),
-            method_data_recipient_credential: selectSaveId(
-              emailCredentials,
-              recipient_credential_id,
-              UNSET_VALUE,
-            ),
-            method_data_to_address: getValue(alert.method.data.to_address, ''),
-            method_data_from_address: getValue(
-              alert.method.data.from_address,
-              '',
-            ),
-            method_data_subject,
-            method_data_message,
-            method_data_message_attach,
-            method_data_notice,
-            method_data_notice_report_format: selectSaveId(
-              report_formats,
-              getValue(
-                method.data.notice_report_format,
-                DEFAULT_NOTICE_REPORT_FORMAT,
+              composerIncludeOverrides: getValue(
+                method.data.composer_include_overrides,
               ),
-            ),
-            method_data_notice_attach_format: selectSaveId(
-              report_formats,
-              getValue(
-                method.data.notice_attach_format,
-                DEFAULT_NOTICE_ATTACH_FORMAT,
-              ),
-            ),
-
-            method_data_scp_credential: selectSaveId(
+              composerStoreAsDefault: NO_VALUE,
               credentials,
-              scp_credential_id,
-            ),
-            method_data_scp_report_format: selectSaveId(
+              result_filters,
+              secinfo_filters,
               report_formats,
-              getValue(method.data.scp_report_format),
-            ),
-            method_data_scp_path: getValue(
-              method.data.scp_path,
-              DEFAULT_SCP_PATH,
-            ),
-            method_data_scp_host: getValue(method.data.scp_host, ''),
-            method_data_scp_known_hosts: getValue(
-              method.data.scp_known_hosts,
-              '',
-            ),
+              report_format_ids: method.data.report_formats,
 
-            method_data_send_port: getValue(method.data.send_port, ''),
-            method_data_send_host: getValue(method.data.send_host, ''),
-            method_data_send_report_format: selectSaveId(
-              report_formats,
-              getValue(method.data.send_report_format),
-            ),
+              condition: condition.type,
+              condition_data_count: parseInt(getValue(condition.data.count, 1)),
+              condition_data_direction: getValue(
+                condition.data.direction,
+                DEFAULT_DIRECTION,
+              ),
+              condition_data_filters,
+              condition_data_filter_id,
+              condition_data_at_least_filter_id: condition_data_filter_id,
+              condition_data_at_least_count: parseInt(
+                getValue(condition.data.count, 1),
+              ),
+              condition_data_severity: parseSeverity(
+                getValue(condition.data.severity, DEFAULT_SEVERITY),
+              ),
 
-            method_data_smb_credential: getValue(
-              method.data.smb_credential,
-              '',
-            ),
-            method_data_smb_file_path: getValue(method.data.smb_file_path, ''),
-            method_data_smb_file_path_type: getValue(
-              method.data.smb_file_path_type,
-              '',
-            ),
-            method_data_smb_report_format: getValue(
-              method.data.smb_report_format,
-              '',
-            ),
-            method_data_smb_share_path: getValue(
-              method.data.smb_share_path,
-              '',
-            ),
+              event: event_type,
+              event_data_status: getValue(
+                event.data.status,
+                DEFAULT_EVENT_STATUS,
+              ),
+              event_data_feed_event: feed_event,
+              event_data_secinfo_type: getValue(
+                event.data.secinfo_type,
+                DEFAULT_SECINFO_TYPE,
+              ),
 
-            method_data_snmp_agent: getValue(method.data.snmp_agent, ''),
-            method_data_snmp_community: getValue(
-              method.data.snmp_community,
-              '',
-            ),
-            method_data_snmp_message: getValue(method.data.snmp_message, ''),
+              method: alert.method.type,
 
-            method_data_start_task_task: selectSaveId(
+              method_data_composer_include_notes: getValue(
+                method.data.composer_include_notes,
+              ),
+              method_data_composer_include_overrides: getValue(
+                method.data.composer_include_overrides,
+              ),
+
+              method_data_defense_center_ip: getValue(
+                method.data.defense_center_ip,
+                '',
+              ),
+              method_data_defense_center_port: parseInt(
+                getValue(
+                  method.data.defense_center_port,
+                  DEFAULT_DEFENSE_CENTER_PORT,
+                ),
+              ),
+
+              method_data_details_url: getValue(
+                method.data.details_url,
+                DEFAULT_DETAILS_URL,
+              ),
+              method_data_recipient_credential: selectSaveId(
+                emailCredentials,
+                recipient_credential_id,
+                UNSET_VALUE,
+              ),
+              method_data_to_address: getValue(
+                alert.method.data.to_address,
+                '',
+              ),
+              method_data_from_address: getValue(
+                alert.method.data.from_address,
+                '',
+              ),
+              method_data_subject,
+              method_data_message,
+              method_data_message_attach,
+              method_data_notice,
+              method_data_notice_report_format: selectSaveId(
+                report_formats,
+                getValue(
+                  method.data.notice_report_format,
+                  DEFAULT_NOTICE_REPORT_FORMAT,
+                ),
+              ),
+              method_data_notice_attach_format: selectSaveId(
+                report_formats,
+                getValue(
+                  method.data.notice_attach_format,
+                  DEFAULT_NOTICE_ATTACH_FORMAT,
+                ),
+              ),
+
+              method_data_scp_credential: selectSaveId(
+                credentials,
+                scp_credential_id,
+              ),
+              method_data_scp_report_format: selectSaveId(
+                report_formats,
+                getValue(method.data.scp_report_format),
+              ),
+              method_data_scp_path: getValue(
+                method.data.scp_path,
+                DEFAULT_SCP_PATH,
+              ),
+              method_data_scp_host: getValue(method.data.scp_host, ''),
+              method_data_scp_known_hosts: getValue(
+                method.data.scp_known_hosts,
+                '',
+              ),
+
+              method_data_send_port: getValue(method.data.send_port, ''),
+              method_data_send_host: getValue(method.data.send_host, ''),
+              method_data_send_report_format: selectSaveId(
+                report_formats,
+                getValue(method.data.send_report_format),
+              ),
+
+              method_data_smb_credential: getValue(
+                method.data.smb_credential,
+                '',
+              ),
+              method_data_smb_file_path: getValue(
+                method.data.smb_file_path,
+                '',
+              ),
+              method_data_smb_file_path_type: getValue(
+                method.data.smb_file_path_type,
+                '',
+              ),
+              method_data_smb_report_format: getValue(
+                method.data.smb_report_format,
+                '',
+              ),
+              method_data_smb_share_path: getValue(
+                method.data.smb_share_path,
+                '',
+              ),
+
+              method_data_snmp_agent: getValue(method.data.snmp_agent, ''),
+              method_data_snmp_community: getValue(
+                method.data.snmp_community,
+                '',
+              ),
+              method_data_snmp_message: getValue(method.data.snmp_message, ''),
+
+              method_data_start_task_task: selectSaveId(
+                tasks,
+                getValue(method.data.start_task_task),
+              ),
+
+              method_data_tp_sms_credential: selectSaveId(
+                credentials,
+                tp_sms_credential_id,
+              ),
+              method_data_tp_sms_hostname: getValue(
+                method.data.tp_sms_hostname,
+                '',
+              ),
+              method_data_tp_sms_tls_workaround: parseYesNo(
+                getValue(method.data.tp_sms_hostname, NO_VALUE),
+              ),
+
+              method_data_verinice_server_report_format: select_verinice_report_id(
+                report_formats,
+                getValue(method.data.verinice_server_report_format),
+              ),
+              method_data_verinice_server_url: getValue(
+                method.data.verinice_server_url,
+              ),
+              method_data_verinice_server_credential: selectSaveId(
+                credentials,
+                verinice_credential_id,
+              ),
+
+              method_data_pkcs12_credential: selectSaveId(
+                passwordOnlyCredentials,
+                pkcs12_credential_id,
+                '0',
+              ),
+              method_data_vfire_credential: selectSaveId(
+                vFireCredentials,
+                vfire_credential_id,
+              ),
+              method_data_vfire_base_url: getValue(method.data.vfire_base_url),
+              method_data_vfire_call_description: getValue(
+                method.data.vfire_call_description,
+              ),
+              method_data_vfire_call_impact_name: getValue(
+                method.data.vfire_call_impact_name,
+              ),
+              method_data_vfire_call_partition_name: getValue(
+                method.data.vfire_call_partition_name,
+              ),
+              method_data_vfire_call_template_name: getValue(
+                method.data.vfire_call_template_name,
+              ),
+              method_data_vfire_call_type_name: getValue(
+                method.data.vfire_call_type_name,
+              ),
+              method_data_vfire_call_urgency_name: getValue(
+                method.data.vfire_call_urgency_name,
+              ),
+              method_data_vfire_client_id: getValue(
+                method.data.vfire_client_id,
+              ),
+              method_data_vfire_session_type: getValue(
+                method.data.vfire_session_type,
+              ),
+
+              method_data_URL: getValue(method.data.URL, ''),
+              method_data_delta_type: getValue(
+                alert.method.data.delta_type,
+                '',
+              ),
+              method_data_delta_report_id: getValue(
+                alert.method.data.delta_report_id,
+                '',
+              ),
               tasks,
-              getValue(method.data.start_task_task),
-            ),
-
-            method_data_tp_sms_credential: selectSaveId(
-              credentials,
-              tp_sms_credential_id,
-            ),
-            method_data_tp_sms_hostname: getValue(
-              method.data.tp_sms_hostname,
-              '',
-            ),
-            method_data_tp_sms_tls_workaround: parseYesNo(
-              getValue(method.data.tp_sms_hostname, NO_VALUE),
-            ),
-
-            method_data_verinice_server_report_format: select_verinice_report_id(
-              report_formats,
-              getValue(method.data.verinice_server_report_format),
-            ),
-            method_data_verinice_server_url: getValue(
-              method.data.verinice_server_url,
-            ),
-            method_data_verinice_server_credential: selectSaveId(
-              credentials,
-              verinice_credential_id,
-            ),
-
-            method_data_pkcs12_credential: selectSaveId(
-              passwordOnlyCredentials,
-              pkcs12_credential_id,
-              '0',
-            ),
-            method_data_vfire_credential: selectSaveId(
-              vFireCredentials,
-              vfire_credential_id,
-            ),
-            method_data_vfire_base_url: getValue(method.data.vfire_base_url),
-            method_data_vfire_call_description: getValue(
-              method.data.vfire_call_description,
-            ),
-            method_data_vfire_call_impact_name: getValue(
-              method.data.vfire_call_impact_name,
-            ),
-            method_data_vfire_call_partition_name: getValue(
-              method.data.vfire_call_partition_name,
-            ),
-            method_data_vfire_call_template_name: getValue(
-              method.data.vfire_call_template_name,
-            ),
-            method_data_vfire_call_type_name: getValue(
-              method.data.vfire_call_type_name,
-            ),
-            method_data_vfire_call_urgency_name: getValue(
-              method.data.vfire_call_urgency_name,
-            ),
-            method_data_vfire_client_id: getValue(method.data.vfire_client_id),
-            method_data_vfire_session_type: getValue(
-              method.data.vfire_session_type,
-            ),
-
-            method_data_URL: getValue(method.data.URL, ''),
-            method_data_delta_type: getValue(alert.method.data.delta_type, ''),
-            method_data_delta_report_id: getValue(
-              alert.method.data.delta_report_id,
-              '',
-            ),
-            tasks,
-            title: _('Edit Alert {{name}}', {name: shorten(alert.name)}),
-          });
+              title: _('Edit Alert {{name}}', {name: shorten(alert.name)}),
+            }),
+          );
         },
       );
     } else {
@@ -750,117 +785,123 @@ const AlertComponent = ({
             ? reportComposerDefaults.reportResultFilterId
             : undefined;
 
-          dispatchState({
-            active: undefined,
-            alert: undefined,
-            alertDialogVisible: true,
-            name: undefined,
-            comment: undefined,
-            condition: undefined,
-            condition_data_at_least_count: undefined,
-            condition_data_at_least_filter_id: result_filter_id,
-            condition_data_count: undefined,
-            condition_data_direction: undefined,
-            condition_data_filters: result_filters,
-            condition_data_filt_id: result_filter_id,
-            condition_data_severity: undefined,
-            credentials,
-            event: undefined,
-            event_data_status: DEFAULT_EVENT_STATUS,
-            event_data_feed_event: undefined,
-            event_data_secinfo_type: undefined,
-            filter_id: filterId,
-            filters,
-            composerFilterId: reportComposerDefaults.reportResultFilterId,
-            composerIncludeNotes: reportComposerDefaults.includeNotes,
-            composerIncludeOverrides: reportComposerDefaults.includeOverrides,
-            composerStoreAsDefault: NO_VALUE,
-            id: undefined,
-            method: undefined,
-            method_data_composer_include_notes: undefined,
-            method_data_composer_include_overrides: undefined,
-            method_data_defense_center_ip: undefined,
-            method_data_defense_center_port: undefined,
-            method_data_details_url: undefined,
-            method_data_to_address: undefined,
-            method_data_from_address: undefined,
-            method_data_subject: undefined,
-            method_data_message: undefined,
-            method_data_message_attach: undefined,
-            method_data_notice: undefined,
-            method_data_notice_report_format: selectSaveId(
+          dispatchState(
+            updateState({
+              active: undefined,
+              alert: undefined,
+              alertDialogVisible: true,
+              name: undefined,
+              comment: undefined,
+              condition: undefined,
+              condition_data_at_least_count: undefined,
+              condition_data_at_least_filter_id: result_filter_id,
+              condition_data_count: undefined,
+              condition_data_direction: undefined,
+              condition_data_filters: result_filters,
+              condition_data_filt_id: result_filter_id,
+              condition_data_severity: undefined,
+              credentials,
+              event: undefined,
+              event_data_status: DEFAULT_EVENT_STATUS,
+              event_data_feed_event: undefined,
+              event_data_secinfo_type: undefined,
+              filter_id: filterId,
+              filters,
+              composerFilterId: reportComposerDefaults.reportResultFilterId,
+              composerIncludeNotes: reportComposerDefaults.includeNotes,
+              composerIncludeOverrides: reportComposerDefaults.includeOverrides,
+              composerStoreAsDefault: NO_VALUE,
+              id: undefined,
+              method: undefined,
+              method_data_composer_include_notes: undefined,
+              method_data_composer_include_overrides: undefined,
+              method_data_defense_center_ip: undefined,
+              method_data_defense_center_port: undefined,
+              method_data_details_url: undefined,
+              method_data_to_address: undefined,
+              method_data_from_address: undefined,
+              method_data_subject: undefined,
+              method_data_message: undefined,
+              method_data_message_attach: undefined,
+              method_data_notice: undefined,
+              method_data_notice_report_format: selectSaveId(
+                report_formats,
+                DEFAULT_NOTICE_REPORT_FORMAT,
+              ),
+              method_data_notice_attach_format: selectSaveId(
+                report_formats,
+                DEFAULT_NOTICE_ATTACH_FORMAT,
+              ),
+              method_data_scp_credential: undefined,
+              method_data_scp_path: DEFAULT_SCP_PATH,
+              method_data_scp_report_format: report_format_id,
+              method_data_scp_host: undefined,
+              method_data_scp_known_hosts: undefined,
+              method_data_send_port: undefined,
+              method_data_send_host: undefined,
+              method_data_snmp_agent: undefined,
+              method_data_snmp_community: undefined,
+              method_data_snmp_message: undefined,
+              method_data_tp_sms_credential: undefined,
+              method_data_tp_sms_hostname: undefined,
+              method_data_tp_sms_tls_workaround: undefined,
+              method_data_verinice_server_url: undefined,
+              method_data_verinice_server_credential: undefined,
+              method_data_URL: undefined,
+              method_data_delta_type: undefined,
+              method_data_delta_report_id: undefined,
+              method_data_recipient_credential: UNSET_VALUE,
+              method_data_send_report_format: report_format_id,
+              method_data_start_task_task: selectSaveId(tasks),
+              method_data_smb_credential: selectSaveId(smbCredentials),
+              method_data_smb_share_path: undefined,
+              method_data_smb_file_path: undefined,
+              method_data_smb_file_path_type: undefined,
+              method_data_verinice_server_report_format: select_verinice_report_id(
+                report_formats,
+              ),
+              method_data_pkcs12_credential: UNSET_VALUE,
+              method_data_vfire_credential: undefined,
+              method_data_vfire_base_url: undefined,
+              method_data_vfire_call_description: undefined,
+              method_data_vfire_call_impact_name: undefined,
+              method_data_vfire_call_partition_name: undefined,
+              method_data_vfire_call_template_name: undefined,
+              method_data_vfire_call_type_name: undefined,
+              method_data_vfire_call_urgency_name: undefined,
+              method_data_vfire_client_id: undefined,
+              method_data_vfire_session_type: undefined,
+              result_filters,
+              secinfo_filters,
               report_formats,
-              DEFAULT_NOTICE_REPORT_FORMAT,
-            ),
-            method_data_notice_attach_format: selectSaveId(
-              report_formats,
-              DEFAULT_NOTICE_ATTACH_FORMAT,
-            ),
-            method_data_scp_credential: undefined,
-            method_data_scp_path: DEFAULT_SCP_PATH,
-            method_data_scp_report_format: report_format_id,
-            method_data_scp_host: undefined,
-            method_data_scp_known_hosts: undefined,
-            method_data_send_port: undefined,
-            method_data_send_host: undefined,
-            method_data_snmp_agent: undefined,
-            method_data_snmp_community: undefined,
-            method_data_snmp_message: undefined,
-            method_data_tp_sms_credential: undefined,
-            method_data_tp_sms_hostname: undefined,
-            method_data_tp_sms_tls_workaround: undefined,
-            method_data_verinice_server_url: undefined,
-            method_data_verinice_server_credential: undefined,
-            method_data_URL: undefined,
-            method_data_delta_type: undefined,
-            method_data_delta_report_id: undefined,
-            method_data_recipient_credential: UNSET_VALUE,
-            method_data_send_report_format: report_format_id,
-            method_data_start_task_task: selectSaveId(tasks),
-            method_data_smb_credential: selectSaveId(smbCredentials),
-            method_data_smb_share_path: undefined,
-            method_data_smb_file_path: undefined,
-            method_data_smb_file_path_type: undefined,
-            method_data_verinice_server_report_format: select_verinice_report_id(
-              report_formats,
-            ),
-            method_data_pkcs12_credential: UNSET_VALUE,
-            method_data_vfire_credential: undefined,
-            method_data_vfire_base_url: undefined,
-            method_data_vfire_call_description: undefined,
-            method_data_vfire_call_impact_name: undefined,
-            method_data_vfire_call_partition_name: undefined,
-            method_data_vfire_call_template_name: undefined,
-            method_data_vfire_call_type_name: undefined,
-            method_data_vfire_call_urgency_name: undefined,
-            method_data_vfire_client_id: undefined,
-            method_data_vfire_session_type: undefined,
-            result_filters,
-            secinfo_filters,
-            report_formats,
-            report_format_ids: [],
-            tasks,
-            title: _('New Alert'),
-          });
+              report_format_ids: [],
+              tasks,
+              title: _('New Alert'),
+            }),
+          );
         },
       );
     }
   };
 
   const closeAlertDialog = () => {
-    dispatchState({
-      alertDialogVisible: false,
-    });
+    dispatchState(
+      updateState({
+        alertDialogVisible: false,
+      }),
+    );
   };
 
   const handleCloseAlertDialog = () => {
-    dispatchState({
-      composerIncludeNotes: undefined,
-      composerIncludeOverrides: undefined,
-      composerFilterId: undefined,
-      composerFilterString: undefined,
-      composerStoreAsDefault: NO_VALUE,
-    });
+    dispatchState(
+      updateState({
+        composerIncludeNotes: undefined,
+        composerIncludeOverrides: undefined,
+        composerFilterId: undefined,
+        composerFilterString: undefined,
+        composerStoreAsDefault: NO_VALUE,
+      }),
+    );
 
     closeAlertDialog();
     handleInteraction();
@@ -913,65 +954,85 @@ const AlertComponent = ({
   };
 
   const handlePasswordOnlyCredentialChange = credential => {
-    dispatchState({
-      method_data_pkcs12_credential: credential,
-    });
+    dispatchState(
+      updateState({
+        method_data_pkcs12_credential: credential,
+      }),
+    );
   };
 
   const handleScpCredentialChange = credential => {
-    dispatchState({
-      method_data_scp_credential: credential,
-    });
+    dispatchState(
+      updateState({
+        method_data_scp_credential: credential,
+      }),
+    );
   };
 
   const handleSmbCredentialChange = credential => {
-    dispatchState({
-      method_data_smb_credential: credential,
-    });
+    dispatchState(
+      updateState({
+        method_data_smb_credential: credential,
+      }),
+    );
   };
 
   const handleTippingPointCredentialChange = credential => {
-    dispatchState({
-      method_data_tp_sms_credential: credential,
-    });
+    dispatchState(
+      updateState({
+        method_data_tp_sms_credential: credential,
+      }),
+    );
   };
 
   const handleVeriniceCredentialChange = credential => {
-    dispatchState({
-      method_data_verinice_server_credential: credential,
-    });
+    dispatchState(
+      updateState({
+        method_data_verinice_server_credential: credential,
+      }),
+    );
   };
 
   const handleEmailCredentialChange = credential => {
-    dispatchState({
-      method_data_recipient_credential: credential,
-    });
+    dispatchState(
+      updateState({
+        method_data_recipient_credential: credential,
+      }),
+    );
   };
 
   const handleVfireCredentialChange = credential => {
-    dispatchState({
-      method_data_vfire_credential: credential,
-    });
+    dispatchState(
+      updateState({
+        method_data_vfire_credential: credential,
+      }),
+    );
   };
 
   const handleReportFormatsChange = report_format_ids => {
-    dispatchState({
-      report_format_ids,
-    });
+    dispatchState(
+      updateState({
+        report_format_ids,
+      }),
+    );
   };
 
   const handleValueChange = (value, name) => {
     handleInteraction();
     name = capitalizeFirstLetter(name);
-    dispatchState({
-      [`composer${name}`]: value,
-    });
+    dispatchState(
+      updateState({
+        [`composer${name}`]: value,
+      }),
+    );
   };
 
   const handleFilterIdChange = value => {
-    dispatchState({
-      composerFilterId: value === UNSET_VALUE ? undefined : value,
-    });
+    dispatchState(
+      updateState({
+        composerFilterId: value === UNSET_VALUE ? undefined : value,
+      }),
+    );
 
     handleInteraction();
   };
@@ -1235,7 +1296,9 @@ const AlertComponent = ({
               title={credentialDialogTitle}
               types={credentialTypes}
               onClose={handleCloseCredentialDialog}
-              onErrorClose={() => dispatchState({credentialError: undefined})}
+              onErrorClose={() =>
+                dispatchState(updateState({credentialError: undefined}))
+              }
               onSave={handleCreateCredential}
             />
           )}

--- a/gsa/src/web/pages/alerts/component.js
+++ b/gsa/src/web/pages/alerts/component.js
@@ -200,90 +200,60 @@ const AlertComponent = ({
         const {data: credentials} = response;
         if (state.credentialType === 'scp') {
           dispatchState({
-            type: 'setState',
-            newState: {
-              method_data_scp_credential: credential_id,
-              credentials,
-            },
+            method_data_scp_credential: credential_id,
+            credentials,
           });
         } else if (state.credentialType === 'smb') {
           dispatchState({
-            type: 'setState',
-            newState: {
-              method_data_smb_credential: credential_id,
-              credentials,
-            },
+            method_data_smb_credential: credential_id,
+            credentials,
           });
         } else if (state.credentialType === 'verinice') {
           dispatchState({
-            type: 'setState',
-            newState: {
-              method_data_verinice_server_credential: credential_id,
-              credentials,
-            },
+            method_data_verinice_server_credential: credential_id,
+            credentials,
           });
         } else if (state.credentialType === 'vfire') {
           dispatchState({
-            type: 'setState',
-            newState: {
-              method_data_vfire_credential: credential_id,
-              credentials,
-            },
+            method_data_vfire_credential: credential_id,
+            credentials,
           });
         } else if (state.credentialType === 'tippingpoint') {
           dispatchState({
-            type: 'setState',
-            newState: {
-              method_data_tp_sms_credential: credential_id,
-              credentials,
-            },
+            method_data_tp_sms_credential: credential_id,
+            credentials,
           });
         } else if (state.credentialType === 'email') {
           dispatchState({
-            type: 'setState',
-            newState: {
-              method_data_recipient_credential: credential_id,
-              credentials,
-            },
+            method_data_recipient_credential: credential_id,
+            credentials,
           });
         } else if (state.credentialType === 'pw') {
           dispatchState({
-            type: 'setState',
-            newState: {
-              method_data_pkcs12_credential: credential_id,
-              credentials,
-            },
+            method_data_pkcs12_credential: credential_id,
+            credentials,
           });
         }
       })
       .catch(error => {
-        dispatchState({
-          type: 'setState',
-          newState: {credentialError: error.message},
-        });
+        dispatchState({credentialError: error.message});
       });
   };
 
   const openCredentialDialog = ({type, types}) => {
     state.credentialType = type;
     dispatchState({
-      type: 'setState',
-      newState: {
-        credentialDialogVisible: true,
-        credentialDialogTitle: _('New Credential'),
-        credentialTypes: types,
-        credentialType: type,
-      },
+      credentialDialogVisible: true,
+      credentialDialogTitle: _('New Credential'),
+      credentialTypes: types,
+      credentialType: type,
     });
 
     handleInteraction();
   };
 
   const closeCredentialDialog = () => {
-    dispatchState({
-      type: 'setState',
-      newState: {credentialDialogVisible: false},
-    });
+    dispatchState({credentialDialogVisible: false});
   };
 
   const handleCloseCredentialDialog = () => {
@@ -292,10 +262,7 @@ const AlertComponent = ({
   };
 
   const openContentComposerDialog = () => {
-    dispatchState({
-      type: 'setState',
-      newState: {contentComposerDialogVisible: true},
-    });
+    dispatchState({contentComposerDialogVisible: true});
   };
 
   const handleOpenContentComposerDialog = () => {
@@ -311,14 +278,11 @@ const AlertComponent = ({
       filter_id,
     } = state;
     dispatchState({
-      type: 'setState',
-      newState: {
-        composerIncludeNotes: method_data_composer_include_notes,
-        composerIncludeOverrides: method_data_composer_include_overrides,
-        composerFilterId: filter_id,
-        composerStoreAsDefault: NO_VALUE,
-        contentComposerDialogVisible: false,
-      },
+      composerIncludeNotes: method_data_composer_include_notes,
+      composerIncludeOverrides: method_data_composer_include_overrides,
+      composerFilterId: filter_id,
+      composerStoreAsDefault: NO_VALUE,
+      contentComposerDialogVisible: false,
     });
   };
 
@@ -338,14 +302,11 @@ const AlertComponent = ({
       saveReportComposerDefaults(defaults);
     }
     dispatchState({
-      type: 'setState',
-      newState: {
-        filter_id: filterId,
-        method_data_composer_include_notes: includeNotes,
-        method_data_composer_include_overrides: includeOverrides,
-        composerStoreAsDefault: NO_VALUE,
-        contentComposerDialogVisible: false,
-      },
+      filter_id: filterId,
+      method_data_composer_include_notes: includeNotes,
+      method_data_composer_include_overrides: includeOverrides,
+      composerStoreAsDefault: NO_VALUE,
+      contentComposerDialogVisible: false,
     });
     handleInteraction();
   };
@@ -545,244 +506,228 @@ const AlertComponent = ({
             : undefined;
 
           dispatchState({
-            type: 'setState',
-            newState: {
-              alertDialogVisible: true,
-              id: alert.id,
-              alert,
-              active: alert.active,
-              name: alert.name,
-              comment: alert.comment,
-              filters,
-              filter_id: isDefined(alert.filter) ? alert.filter.id : undefined,
-              composerFilterId: isDefined(alert.filter)
-                ? alert.filter.id
-                : undefined,
-              composerIncludeNotes: getValue(
-                method.data.composer_include_notes,
+            alertDialogVisible: true,
+            id: alert.id,
+            alert,
+            active: alert.active,
+            name: alert.name,
+            comment: alert.comment,
+            filters,
+            filter_id: isDefined(alert.filter) ? alert.filter.id : undefined,
+            composerFilterId: isDefined(alert.filter)
+              ? alert.filter.id
+              : undefined,
+            composerIncludeNotes: getValue(method.data.composer_include_notes),
+            composerIncludeOverrides: getValue(
+              method.data.composer_include_overrides,
+            ),
+            composerStoreAsDefault: NO_VALUE,
+            credentials,
+            result_filters,
+            secinfo_filters,
+            report_formats,
+            report_format_ids: method.data.report_formats,
+
+            condition: condition.type,
+            condition_data_count: parseInt(getValue(condition.data.count, 1)),
+            condition_data_direction: getValue(
+              condition.data.direction,
+              DEFAULT_DIRECTION,
+            ),
+            condition_data_filters,
+            condition_data_filter_id,
+            condition_data_at_least_filter_id: condition_data_filter_id,
+            condition_data_at_least_count: parseInt(
+              getValue(condition.data.count, 1),
+            ),
+            condition_data_severity: parseSeverity(
+              getValue(condition.data.severity, DEFAULT_SEVERITY),
+            ),
+
+            event: event_type,
+            event_data_status: getValue(
+              event.data.status,
+              DEFAULT_EVENT_STATUS,
+            ),
+            event_data_feed_event: feed_event,
+            event_data_secinfo_type: getValue(
+              event.data.secinfo_type,
+              DEFAULT_SECINFO_TYPE,
+            ),
+
+            method: alert.method.type,
+
+            method_data_composer_include_notes: getValue(
+              method.data.composer_include_notes,
+            ),
+            method_data_composer_include_overrides: getValue(
+              method.data.composer_include_overrides,
+            ),
+
+            method_data_defense_center_ip: getValue(
+              method.data.defense_center_ip,
+              '',
+            ),
+            method_data_defense_center_port: parseInt(
+              getValue(
+                method.data.defense_center_port,
+                DEFAULT_DEFENSE_CENTER_PORT,
               ),
-              composerIncludeOverrides: getValue(
-                method.data.composer_include_overrides,
-              ),
-              composerStoreAsDefault: NO_VALUE,
-              credentials,
-              result_filters,
-              secinfo_filters,
+            ),
+
+            method_data_details_url: getValue(
+              method.data.details_url,
+              DEFAULT_DETAILS_URL,
+            ),
+            method_data_recipient_credential: selectSaveId(
+              emailCredentials,
+              recipient_credential_id,
+              UNSET_VALUE,
+            ),
+            method_data_to_address: getValue(alert.method.data.to_address, ''),
+            method_data_from_address: getValue(
+              alert.method.data.from_address,
+              '',
+            ),
+            method_data_subject,
+            method_data_message,
+            method_data_message_attach,
+            method_data_notice,
+            method_data_notice_report_format: selectSaveId(
               report_formats,
-              report_format_ids: method.data.report_formats,
+              getValue(
+                method.data.notice_report_format,
+                DEFAULT_NOTICE_REPORT_FORMAT,
+              ),
+            ),
+            method_data_notice_attach_format: selectSaveId(
+              report_formats,
+              getValue(
+                method.data.notice_attach_format,
+                DEFAULT_NOTICE_ATTACH_FORMAT,
+              ),
+            ),
 
-              condition: condition.type,
-              condition_data_count: parseInt(getValue(condition.data.count, 1)),
-              condition_data_direction: getValue(
-                condition.data.direction,
-                DEFAULT_DIRECTION,
-              ),
-              condition_data_filters,
-              condition_data_filter_id,
-              condition_data_at_least_filter_id: condition_data_filter_id,
-              condition_data_at_least_count: parseInt(
-                getValue(condition.data.count, 1),
-              ),
-              condition_data_severity: parseSeverity(
-                getValue(condition.data.severity, DEFAULT_SEVERITY),
-              ),
+            method_data_scp_credential: selectSaveId(
+              credentials,
+              scp_credential_id,
+            ),
+            method_data_scp_report_format: selectSaveId(
+              report_formats,
+              getValue(method.data.scp_report_format),
+            ),
+            method_data_scp_path: getValue(
+              method.data.scp_path,
+              DEFAULT_SCP_PATH,
+            ),
+            method_data_scp_host: getValue(method.data.scp_host, ''),
+            method_data_scp_known_hosts: getValue(
+              method.data.scp_known_hosts,
+              '',
+            ),
 
-              event: event_type,
-              event_data_status: getValue(
-                event.data.status,
-                DEFAULT_EVENT_STATUS,
-              ),
-              event_data_feed_event: feed_event,
-              event_data_secinfo_type: getValue(
-                event.data.secinfo_type,
-                DEFAULT_SECINFO_TYPE,
-              ),
+            method_data_send_port: getValue(method.data.send_port, ''),
+            method_data_send_host: getValue(method.data.send_host, ''),
+            method_data_send_report_format: selectSaveId(
+              report_formats,
+              getValue(method.data.send_report_format),
+            ),
 
-              method: alert.method.type,
+            method_data_smb_credential: getValue(
+              method.data.smb_credential,
+              '',
+            ),
+            method_data_smb_file_path: getValue(method.data.smb_file_path, ''),
+            method_data_smb_file_path_type: getValue(
+              method.data.smb_file_path_type,
+              '',
+            ),
+            method_data_smb_report_format: getValue(
+              method.data.smb_report_format,
+              '',
+            ),
+            method_data_smb_share_path: getValue(
+              method.data.smb_share_path,
+              '',
+            ),
 
-              method_data_composer_include_notes: getValue(
-                method.data.composer_include_notes,
-              ),
-              method_data_composer_include_overrides: getValue(
-                method.data.composer_include_overrides,
-              ),
+            method_data_snmp_agent: getValue(method.data.snmp_agent, ''),
+            method_data_snmp_community: getValue(
+              method.data.snmp_community,
+              '',
+            ),
+            method_data_snmp_message: getValue(method.data.snmp_message, ''),
 
-              method_data_defense_center_ip: getValue(
-                method.data.defense_center_ip,
-                '',
-              ),
-              method_data_defense_center_port: parseInt(
-                getValue(
-                  method.data.defense_center_port,
-                  DEFAULT_DEFENSE_CENTER_PORT,
-                ),
-              ),
-
-              method_data_details_url: getValue(
-                method.data.details_url,
-                DEFAULT_DETAILS_URL,
-              ),
-              method_data_recipient_credential: selectSaveId(
-                emailCredentials,
-                recipient_credential_id,
-                UNSET_VALUE,
-              ),
-              method_data_to_address: getValue(
-                alert.method.data.to_address,
-                '',
-              ),
-              method_data_from_address: getValue(
-                alert.method.data.from_address,
-                '',
-              ),
-              method_data_subject,
-              method_data_message,
-              method_data_message_attach,
-              method_data_notice,
-              method_data_notice_report_format: selectSaveId(
-                report_formats,
-                getValue(
-                  method.data.notice_report_format,
-                  DEFAULT_NOTICE_REPORT_FORMAT,
-                ),
-              ),
-              method_data_notice_attach_format: selectSaveId(
-                report_formats,
-                getValue(
-                  method.data.notice_attach_format,
-                  DEFAULT_NOTICE_ATTACH_FORMAT,
-                ),
-              ),
-
-              method_data_scp_credential: selectSaveId(
-                credentials,
-                scp_credential_id,
-              ),
-              method_data_scp_report_format: selectSaveId(
-                report_formats,
-                getValue(method.data.scp_report_format),
-              ),
-              method_data_scp_path: getValue(
-                method.data.scp_path,
-                DEFAULT_SCP_PATH,
-              ),
-              method_data_scp_host: getValue(method.data.scp_host, ''),
-              method_data_scp_known_hosts: getValue(
-                method.data.scp_known_hosts,
-                '',
-              ),
-
-              method_data_send_port: getValue(method.data.send_port, ''),
-              method_data_send_host: getValue(method.data.send_host, ''),
-              method_data_send_report_format: selectSaveId(
-                report_formats,
-                getValue(method.data.send_report_format),
-              ),
-
-              method_data_smb_credential: getValue(
-                method.data.smb_credential,
-                '',
-              ),
-              method_data_smb_file_path: getValue(
-                method.data.smb_file_path,
-                '',
-              ),
-              method_data_smb_file_path_type: getValue(
-                method.data.smb_file_path_type,
-                '',
-              ),
-              method_data_smb_report_format: getValue(
-                method.data.smb_report_format,
-                '',
-              ),
-              method_data_smb_share_path: getValue(
-                method.data.smb_share_path,
-                '',
-              ),
-
-              method_data_snmp_agent: getValue(method.data.snmp_agent, ''),
-              method_data_snmp_community: getValue(
-                method.data.snmp_community,
-                '',
-              ),
-              method_data_snmp_message: getValue(method.data.snmp_message, ''),
-
-              method_data_start_task_task: selectSaveId(
-                tasks,
-                getValue(method.data.start_task_task),
-              ),
-
-              method_data_tp_sms_credential: selectSaveId(
-                credentials,
-                tp_sms_credential_id,
-              ),
-              method_data_tp_sms_hostname: getValue(
-                method.data.tp_sms_hostname,
-                '',
-              ),
-              method_data_tp_sms_tls_workaround: parseYesNo(
-                getValue(method.data.tp_sms_hostname, NO_VALUE),
-              ),
-
-              method_data_verinice_server_report_format: select_verinice_report_id(
-                report_formats,
-                getValue(method.data.verinice_server_report_format),
-              ),
-              method_data_verinice_server_url: getValue(
-                method.data.verinice_server_url,
-              ),
-              method_data_verinice_server_credential: selectSaveId(
-                credentials,
-                verinice_credential_id,
-              ),
-
-              method_data_pkcs12_credential: selectSaveId(
-                passwordOnlyCredentials,
-                pkcs12_credential_id,
-                '0',
-              ),
-              method_data_vfire_credential: selectSaveId(
-                vFireCredentials,
-                vfire_credential_id,
-              ),
-              method_data_vfire_base_url: getValue(method.data.vfire_base_url),
-              method_data_vfire_call_description: getValue(
-                method.data.vfire_call_description,
-              ),
-              method_data_vfire_call_impact_name: getValue(
-                method.data.vfire_call_impact_name,
-              ),
-              method_data_vfire_call_partition_name: getValue(
-                method.data.vfire_call_partition_name,
-              ),
-              method_data_vfire_call_template_name: getValue(
-                method.data.vfire_call_template_name,
-              ),
-              method_data_vfire_call_type_name: getValue(
-                method.data.vfire_call_type_name,
-              ),
-              method_data_vfire_call_urgency_name: getValue(
-                method.data.vfire_call_urgency_name,
-              ),
-              method_data_vfire_client_id: getValue(
-                method.data.vfire_client_id,
-              ),
-              method_data_vfire_session_type: getValue(
-                method.data.vfire_session_type,
-              ),
-
-              method_data_URL: getValue(method.data.URL, ''),
-              method_data_delta_type: getValue(
-                alert.method.data.delta_type,
-                '',
-              ),
-              method_data_delta_report_id: getValue(
-                alert.method.data.delta_report_id,
-                '',
-              ),
+            method_data_start_task_task: selectSaveId(
               tasks,
-              title: _('Edit Alert {{name}}', {name: shorten(alert.name)}),
-            },
+              getValue(method.data.start_task_task),
+            ),
+
+            method_data_tp_sms_credential: selectSaveId(
+              credentials,
+              tp_sms_credential_id,
+            ),
+            method_data_tp_sms_hostname: getValue(
+              method.data.tp_sms_hostname,
+              '',
+            ),
+            method_data_tp_sms_tls_workaround: parseYesNo(
+              getValue(method.data.tp_sms_hostname, NO_VALUE),
+            ),
+
+            method_data_verinice_server_report_format: select_verinice_report_id(
+              report_formats,
+              getValue(method.data.verinice_server_report_format),
+            ),
+            method_data_verinice_server_url: getValue(
+              method.data.verinice_server_url,
+            ),
+            method_data_verinice_server_credential: selectSaveId(
+              credentials,
+              verinice_credential_id,
+            ),
+
+            method_data_pkcs12_credential: selectSaveId(
+              passwordOnlyCredentials,
+              pkcs12_credential_id,
+              '0',
+            ),
+            method_data_vfire_credential: selectSaveId(
+              vFireCredentials,
+              vfire_credential_id,
+            ),
+            method_data_vfire_base_url: getValue(method.data.vfire_base_url),
+            method_data_vfire_call_description: getValue(
+              method.data.vfire_call_description,
+            ),
+            method_data_vfire_call_impact_name: getValue(
+              method.data.vfire_call_impact_name,
+            ),
+            method_data_vfire_call_partition_name: getValue(
+              method.data.vfire_call_partition_name,
+            ),
+            method_data_vfire_call_template_name: getValue(
+              method.data.vfire_call_template_name,
+            ),
+            method_data_vfire_call_type_name: getValue(
+              method.data.vfire_call_type_name,
+            ),
+            method_data_vfire_call_urgency_name: getValue(
+              method.data.vfire_call_urgency_name,
+            ),
+            method_data_vfire_client_id: getValue(method.data.vfire_client_id),
+            method_data_vfire_session_type: getValue(
+              method.data.vfire_session_type,
+            ),
+
+            method_data_URL: getValue(method.data.URL, ''),
+            method_data_delta_type: getValue(alert.method.data.delta_type, ''),
+            method_data_delta_report_id: getValue(
+              alert.method.data.delta_report_id,
+              '',
+            ),
+            tasks,
+            title: _('Edit Alert {{name}}', {name: shorten(alert.name)}),
           });
         },
       );
@@ -806,99 +751,96 @@ const AlertComponent = ({
             : undefined;
 
           dispatchState({
-            type: 'setState',
-            newState: {
-              active: undefined,
-              alert: undefined,
-              alertDialogVisible: true,
-              name: undefined,
-              comment: undefined,
-              condition: undefined,
-              condition_data_at_least_count: undefined,
-              condition_data_at_least_filter_id: result_filter_id,
-              condition_data_count: undefined,
-              condition_data_direction: undefined,
-              condition_data_filters: result_filters,
-              condition_data_filt_id: result_filter_id,
-              condition_data_severity: undefined,
-              credentials,
-              event: undefined,
-              event_data_status: DEFAULT_EVENT_STATUS,
-              event_data_feed_event: undefined,
-              event_data_secinfo_type: undefined,
-              filter_id: filterId,
-              filters,
-              composerFilterId: reportComposerDefaults.reportResultFilterId,
-              composerIncludeNotes: reportComposerDefaults.includeNotes,
-              composerIncludeOverrides: reportComposerDefaults.includeOverrides,
-              composerStoreAsDefault: NO_VALUE,
-              id: undefined,
-              method: undefined,
-              method_data_composer_include_notes: undefined,
-              method_data_composer_include_overrides: undefined,
-              method_data_defense_center_ip: undefined,
-              method_data_defense_center_port: undefined,
-              method_data_details_url: undefined,
-              method_data_to_address: undefined,
-              method_data_from_address: undefined,
-              method_data_subject: undefined,
-              method_data_message: undefined,
-              method_data_message_attach: undefined,
-              method_data_notice: undefined,
-              method_data_notice_report_format: selectSaveId(
-                report_formats,
-                DEFAULT_NOTICE_REPORT_FORMAT,
-              ),
-              method_data_notice_attach_format: selectSaveId(
-                report_formats,
-                DEFAULT_NOTICE_ATTACH_FORMAT,
-              ),
-              method_data_scp_credential: undefined,
-              method_data_scp_path: DEFAULT_SCP_PATH,
-              method_data_scp_report_format: report_format_id,
-              method_data_scp_host: undefined,
-              method_data_scp_known_hosts: undefined,
-              method_data_send_port: undefined,
-              method_data_send_host: undefined,
-              method_data_snmp_agent: undefined,
-              method_data_snmp_community: undefined,
-              method_data_snmp_message: undefined,
-              method_data_tp_sms_credential: undefined,
-              method_data_tp_sms_hostname: undefined,
-              method_data_tp_sms_tls_workaround: undefined,
-              method_data_verinice_server_url: undefined,
-              method_data_verinice_server_credential: undefined,
-              method_data_URL: undefined,
-              method_data_delta_type: undefined,
-              method_data_delta_report_id: undefined,
-              method_data_recipient_credential: UNSET_VALUE,
-              method_data_send_report_format: report_format_id,
-              method_data_start_task_task: selectSaveId(tasks),
-              method_data_smb_credential: selectSaveId(smbCredentials),
-              method_data_smb_share_path: undefined,
-              method_data_smb_file_path: undefined,
-              method_data_smb_file_path_type: undefined,
-              method_data_verinice_server_report_format: select_verinice_report_id(
-                report_formats,
-              ),
-              method_data_pkcs12_credential: UNSET_VALUE,
-              method_data_vfire_credential: undefined,
-              method_data_vfire_base_url: undefined,
-              method_data_vfire_call_description: undefined,
-              method_data_vfire_call_impact_name: undefined,
-              method_data_vfire_call_partition_name: undefined,
-              method_data_vfire_call_template_name: undefined,
-              method_data_vfire_call_type_name: undefined,
-              method_data_vfire_call_urgency_name: undefined,
-              method_data_vfire_client_id: undefined,
-              method_data_vfire_session_type: undefined,
-              result_filters,
-              secinfo_filters,
+            active: undefined,
+            alert: undefined,
+            alertDialogVisible: true,
+            name: undefined,
+            comment: undefined,
+            condition: undefined,
+            condition_data_at_least_count: undefined,
+            condition_data_at_least_filter_id: result_filter_id,
+            condition_data_count: undefined,
+            condition_data_direction: undefined,
+            condition_data_filters: result_filters,
+            condition_data_filt_id: result_filter_id,
+            condition_data_severity: undefined,
+            credentials,
+            event: undefined,
+            event_data_status: DEFAULT_EVENT_STATUS,
+            event_data_feed_event: undefined,
+            event_data_secinfo_type: undefined,
+            filter_id: filterId,
+            filters,
+            composerFilterId: reportComposerDefaults.reportResultFilterId,
+            composerIncludeNotes: reportComposerDefaults.includeNotes,
+            composerIncludeOverrides: reportComposerDefaults.includeOverrides,
+            composerStoreAsDefault: NO_VALUE,
+            id: undefined,
+            method: undefined,
+            method_data_composer_include_notes: undefined,
+            method_data_composer_include_overrides: undefined,
+            method_data_defense_center_ip: undefined,
+            method_data_defense_center_port: undefined,
+            method_data_details_url: undefined,
+            method_data_to_address: undefined,
+            method_data_from_address: undefined,
+            method_data_subject: undefined,
+            method_data_message: undefined,
+            method_data_message_attach: undefined,
+            method_data_notice: undefined,
+            method_data_notice_report_format: selectSaveId(
               report_formats,
-              report_format_ids: [],
-              tasks,
-              title: _('New Alert'),
-            },
+              DEFAULT_NOTICE_REPORT_FORMAT,
+            ),
+            method_data_notice_attach_format: selectSaveId(
+              report_formats,
+              DEFAULT_NOTICE_ATTACH_FORMAT,
+            ),
+            method_data_scp_credential: undefined,
+            method_data_scp_path: DEFAULT_SCP_PATH,
+            method_data_scp_report_format: report_format_id,
+            method_data_scp_host: undefined,
+            method_data_scp_known_hosts: undefined,
+            method_data_send_port: undefined,
+            method_data_send_host: undefined,
+            method_data_snmp_agent: undefined,
+            method_data_snmp_community: undefined,
+            method_data_snmp_message: undefined,
+            method_data_tp_sms_credential: undefined,
+            method_data_tp_sms_hostname: undefined,
+            method_data_tp_sms_tls_workaround: undefined,
+            method_data_verinice_server_url: undefined,
+            method_data_verinice_server_credential: undefined,
+            method_data_URL: undefined,
+            method_data_delta_type: undefined,
+            method_data_delta_report_id: undefined,
+            method_data_recipient_credential: UNSET_VALUE,
+            method_data_send_report_format: report_format_id,
+            method_data_start_task_task: selectSaveId(tasks),
+            method_data_smb_credential: selectSaveId(smbCredentials),
+            method_data_smb_share_path: undefined,
+            method_data_smb_file_path: undefined,
+            method_data_smb_file_path_type: undefined,
+            method_data_verinice_server_report_format: select_verinice_report_id(
+              report_formats,
+            ),
+            method_data_pkcs12_credential: UNSET_VALUE,
+            method_data_vfire_credential: undefined,
+            method_data_vfire_base_url: undefined,
+            method_data_vfire_call_description: undefined,
+            method_data_vfire_call_impact_name: undefined,
+            method_data_vfire_call_partition_name: undefined,
+            method_data_vfire_call_template_name: undefined,
+            method_data_vfire_call_type_name: undefined,
+            method_data_vfire_call_urgency_name: undefined,
+            method_data_vfire_client_id: undefined,
+            method_data_vfire_session_type: undefined,
+            result_filters,
+            secinfo_filters,
+            report_formats,
+            report_format_ids: [],
+            tasks,
+            title: _('New Alert'),
           });
         },
       );
@@ -907,23 +849,17 @@ const AlertComponent = ({
 
   const closeAlertDialog = () => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        alertDialogVisible: false,
-      },
+      alertDialogVisible: false,
     });
   };
 
   const handleCloseAlertDialog = () => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        composerIncludeNotes: undefined,
-        composerIncludeOverrides: undefined,
-        composerFilterId: undefined,
-        composerFilterString: undefined,
-        composerStoreAsDefault: NO_VALUE,
-      },
+      composerIncludeNotes: undefined,
+      composerIncludeOverrides: undefined,
+      composerFilterId: undefined,
+      composerFilterString: undefined,
+      composerStoreAsDefault: NO_VALUE,
     });
 
     closeAlertDialog();
@@ -978,73 +914,49 @@ const AlertComponent = ({
 
   const handlePasswordOnlyCredentialChange = credential => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        method_data_pkcs12_credential: credential,
-      },
+      method_data_pkcs12_credential: credential,
     });
   };
 
   const handleScpCredentialChange = credential => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        method_data_scp_credential: credential,
-      },
+      method_data_scp_credential: credential,
     });
   };
 
   const handleSmbCredentialChange = credential => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        method_data_smb_credential: credential,
-      },
+      method_data_smb_credential: credential,
     });
   };
 
   const handleTippingPointCredentialChange = credential => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        method_data_tp_sms_credential: credential,
-      },
+      method_data_tp_sms_credential: credential,
     });
   };
 
   const handleVeriniceCredentialChange = credential => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        method_data_verinice_server_credential: credential,
-      },
+      method_data_verinice_server_credential: credential,
     });
   };
 
   const handleEmailCredentialChange = credential => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        method_data_recipient_credential: credential,
-      },
+      method_data_recipient_credential: credential,
     });
   };
 
   const handleVfireCredentialChange = credential => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        method_data_vfire_credential: credential,
-      },
+      method_data_vfire_credential: credential,
     });
   };
 
   const handleReportFormatsChange = report_format_ids => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        report_format_ids,
-      },
+      report_format_ids,
     });
   };
 
@@ -1052,19 +964,13 @@ const AlertComponent = ({
     handleInteraction();
     name = capitalizeFirstLetter(name);
     dispatchState({
-      type: 'setState',
-      newState: {
-        [`composer${name}`]: value,
-      },
+      [`composer${name}`]: value,
     });
   };
 
   const handleFilterIdChange = value => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        composerFilterId: value === UNSET_VALUE ? undefined : value,
-      },
+      composerFilterId: value === UNSET_VALUE ? undefined : value,
     });
 
     handleInteraction();
@@ -1329,12 +1235,7 @@ const AlertComponent = ({
               title={credentialDialogTitle}
               types={credentialTypes}
               onClose={handleCloseCredentialDialog}
-              onErrorClose={() =>
-                dispatchState({
-                  type: 'setState',
-                  newState: {credentialError: undefined},
-                })
-              }
+              onErrorClose={() => dispatchState({credentialError: undefined})}
               onSave={handleCreateCredential}
             />
           )}

--- a/gsa/src/web/pages/alerts/dialog.js
+++ b/gsa/src/web/pages/alerts/dialog.js
@@ -49,7 +49,7 @@ import {
   isSecinfoEvent,
 } from 'gmp/models/alert';
 
-import reducer from 'web/utils/stateReducer';
+import reducer, {updateState} from 'web/utils/stateReducer';
 import PropTypes from 'web/utils/proptypes';
 import SaveDialog from 'web/components/dialog/savedialog';
 
@@ -241,14 +241,16 @@ const StyledDivider = styled(Divider)`
 const AlertDialog = props => {
   const capabilities = useCapabilities();
 
-  const [state, dispatchState] = useReducer(reducer, DEFAULTS);
+  const [state, dispatch] = useReducer(reducer, DEFAULTS);
 
   useEffect(() => {
-    dispatchState({
-      stateEvent: isDefined(props.event)
-        ? props.event
-        : EVENT_TYPE_TASK_RUN_STATUS_CHANGED,
-    });
+    dispatch(
+      updateState({
+        stateEvent: isDefined(props.event)
+          ? props.event
+          : EVENT_TYPE_TASK_RUN_STATUS_CHANGED,
+      }),
+    );
   }, [props.event]);
 
   const handleEventChange = (value, onValueChange) => {
@@ -290,7 +292,7 @@ const AlertDialog = props => {
     }
     // in addition to changing the event in the dialog, change it here as well
     // to have it handy in render()
-    dispatchState({stateEvent: value});
+    dispatch(updateState({stateEvent: value}));
   };
 
   const {

--- a/gsa/src/web/pages/alerts/dialog.js
+++ b/gsa/src/web/pages/alerts/dialog.js
@@ -245,12 +245,9 @@ const AlertDialog = props => {
 
   useEffect(() => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        stateEvent: isDefined(props.event)
-          ? props.event
-          : EVENT_TYPE_TASK_RUN_STATUS_CHANGED,
-      },
+      stateEvent: isDefined(props.event)
+        ? props.event
+        : EVENT_TYPE_TASK_RUN_STATUS_CHANGED,
     });
   }, [props.event]);
 
@@ -293,7 +290,7 @@ const AlertDialog = props => {
     }
     // in addition to changing the event in the dialog, change it here as well
     // to have it handy in render()
-    dispatchState({type: 'setState', newState: {stateEvent: value}});
+    dispatchState({stateEvent: value});
   };
 
   const {

--- a/gsa/src/web/pages/portlists/component.js
+++ b/gsa/src/web/pages/portlists/component.js
@@ -26,7 +26,7 @@ import {shorten} from 'gmp/utils/string';
 
 import PropTypes from 'web/utils/proptypes';
 import useGmp from 'web/utils/useGmp';
-import reducer from 'web/utils/stateReducer';
+import reducer, {updateState} from 'web/utils/stateReducer';
 import readFileToText from 'web/utils/readFileToText.js';
 
 import EntityComponent from 'web/entity/component';
@@ -73,9 +73,8 @@ const PortListComponent = ({
         setCreatedPortRanges([]);
         setDeletedPortRanges([]);
 
-        dispatch({
-          type: 'setState',
-          newState: {
+        dispatch(
+          updateState({
             comment: portList.comment,
             id: portList.id,
             portList,
@@ -85,33 +84,29 @@ const PortListComponent = ({
             title: _('Edit Port List {{name}}', {
               name: shorten(portList.name),
             }),
-          },
-        });
+          }),
+        );
       });
     } else {
       setCreatedPortRanges([]);
       setDeletedPortRanges([]);
-      dispatch({
-        type: 'setState',
-        newState: {
+      dispatch(
+        updateState({
           comment: undefined,
           id: undefined,
           name: undefined,
           portList: undefined,
           portListDialogVisible: true,
           title: _('New Port List'),
-        },
-      });
+        }),
+      );
     }
 
     handleInteraction();
   };
 
   const closePortListDialog = () => {
-    dispatch({
-      type: 'setState',
-      newState: {portListDialogVisible: false},
-    });
+    dispatch(updateState({portListDialogVisible: false}));
   };
 
   const handleClosePortListDialog = () => {
@@ -120,18 +115,12 @@ const PortListComponent = ({
   };
 
   const openImportDialog = () => {
-    dispatch({
-      type: 'setState',
-      newState: {importDialogVisible: true},
-    });
+    dispatch(updateState({importDialogVisible: true}));
     handleInteraction();
   };
 
   const closeImportDialog = () => {
-    dispatch({
-      type: 'setState',
-      newState: {importDialogVisible: false},
-    });
+    dispatch(updateState({importDialogVisible: false}));
   };
 
   const handleCloseImportDialog = () => {
@@ -140,21 +129,17 @@ const PortListComponent = ({
   };
 
   const openNewPortRangeDialog = portList => {
-    dispatch({
-      type: 'setState',
-      newState: {
+    dispatch(
+      updateState({
         portRangeDialogVisible: true,
         id: portList.id,
-      },
-    });
+      }),
+    );
     handleInteraction();
   };
 
   const closeNewPortRangeDialog = () => {
-    dispatch({
-      type: 'setState',
-      newState: {portRangeDialogVisible: false},
-    });
+    dispatch(updateState({portRangeDialogVisible: false}));
   };
 
   const handleCloseNewPortRangeDialog = () => {
@@ -165,10 +150,7 @@ const PortListComponent = ({
   const handleDeletePortRange = range => {
     return gmp.portlist.deletePortRange(range).then(response => {
       const {data} = response;
-      dispatch({
-        type: 'setState',
-        newState: {portList: data},
-      });
+      dispatch(updateState({portList: data}));
     });
   };
 
@@ -298,12 +280,11 @@ const PortListComponent = ({
     };
     // was this.created_port_ranges.push() therefore cannot be set directly
     setCreatedPortRanges(oldRanges => [...oldRanges, newRange]);
-    dispatch({
-      type: 'setState',
-      newState: {
+    dispatch(
+      updateState({
         portRanges: [...portRanges, newRange],
-      },
-    });
+      }),
+    );
     closeNewPortRangeDialog();
   };
 
@@ -321,7 +302,7 @@ const PortListComponent = ({
 
     newPortRanges = portRanges.filter(range => range !== portRange);
 
-    dispatch({type: 'setState', newState: {portRanges: newPortRanges}});
+    dispatch(updateState({portRanges: newPortRanges}));
 
     handleInteraction();
   };

--- a/gsa/src/web/pages/reports/detailspage.js
+++ b/gsa/src/web/pages/reports/detailspage.js
@@ -72,6 +72,7 @@ import {
   getUsername,
 } from 'web/store/usersettings/selectors';
 
+import stateReducer, {updateState} from 'web/utils/stateReducer';
 import {create_pem_certificate} from 'web/utils/cert';
 import compose from 'web/utils/compose';
 import {generateFilename} from 'web/utils/render';
@@ -213,13 +214,8 @@ const reducer = (state, action) => {
           ? errors.counts
           : state.errorsCounts,
       };
-    case 'setPageState':
-      const {newState} = action;
-
-      return {
-        ...state,
-        ...newState,
-      };
+    case 'setState':
+      return stateReducer(state, action);
     default:
       return state;
   }
@@ -265,10 +261,7 @@ const ReportDetails = ({
   useEffect(() => {
     if (isDefined(entityFromProps)) {
       dispatchState({type: 'updateReport', entity: entityFromProps});
-      dispatchState({
-        type: 'setPageState',
-        newState: {reportFilter: filterFromProps},
-      });
+      dispatchState(updateState({reportFilter: filterFromProps}));
       setIsUpdating(false);
     } else {
       // report is not in the store and is currently loaded
@@ -324,7 +317,7 @@ const ReportDetails = ({
         // ensure the report format id is only set if we really have one
         // if no report format id is available we would create an infinite
         // render loop here
-        dispatchState({type: 'setPageState', newState: {reportFormatId}});
+        dispatchState(updateState({reportFormatId}));
       }
     }
 
@@ -368,7 +361,7 @@ const ReportDetails = ({
   const handleActivateTab = index => {
     renewSession();
 
-    dispatchState({type: 'setPageState', newState: {activeTab: index}});
+    dispatchState(updateState({activeTab: index}));
   };
 
   const handleAddToAssets = () => {
@@ -396,27 +389,21 @@ const ReportDetails = ({
   const handleFilterEditClick = () => {
     renewSession();
 
-    dispatchState({type: 'setPageState', newState: {showFilterDialog: true}});
+    dispatchState(updateState({showFilterDialog: true}));
   };
 
   const handleFilterDialogClose = () => {
     renewSession();
 
-    dispatchState({type: 'setPageState', newState: {showFilterDialog: false}});
+    dispatchState(updateState({showFilterDialog: false}));
   };
 
   const handleOpenDownloadReportDialog = () => {
-    dispatchState({
-      type: 'setPageState',
-      newState: {showDownloadReportDialog: true},
-    });
+    dispatchState(updateState({showDownloadReportDialog: true}));
   };
 
   const handleCloseDownloadReportDialog = () => {
-    dispatchState({
-      type: 'setPageState',
-      newState: {showDownloadReportDialog: false},
-    });
+    dispatchState(updateState({showDownloadReportDialog: false}));
   };
 
   const handleReportDownload = reportState => {
@@ -457,10 +444,7 @@ const ReportDetails = ({
         filter: newFilter,
       })
       .then(response => {
-        dispatchState({
-          type: 'setPageState',
-          newState: {showDownloadReportDialog: false},
-        });
+        dispatchState(updateState({showDownloadReportDialog: false}));
         const {data} = response;
         const filename = generateFilename({
           creationTime: entityFromProps.creationTime,

--- a/gsa/src/web/pages/scanconfigs/editdialog.js
+++ b/gsa/src/web/pages/scanconfigs/editdialog.js
@@ -43,6 +43,8 @@ import Loading from 'web/components/loading/loading';
 
 import Layout from 'web/components/layout/layout';
 
+import stateReducer from 'web/utils/stateReducer';
+
 import NvtFamilies from './nvtfamilies';
 import NvtPreferences, {NvtPreferencePropType} from './nvtpreferences';
 import ScannerPreferences, {
@@ -85,12 +87,8 @@ const createScannerPreferenceValues = (preferences = []) => {
 
 const reducer = (state, action) => {
   switch (action.type) {
-    case 'setValue':
-      const {newState} = action;
-      return {
-        ...state,
-        ...newState,
-      };
+    case 'setState':
+      return stateReducer(state, action);
     case 'setAll':
       const {formValues} = action;
       return formValues;

--- a/gsa/src/web/pages/scanconfigs/scannerpreferences.js
+++ b/gsa/src/web/pages/scanconfigs/scannerpreferences.js
@@ -37,6 +37,7 @@ import TableHead from 'web/components/table/head';
 import TableRow from 'web/components/table/row';
 
 import PropTypes from 'web/utils/proptypes';
+import {updateState} from 'web/utils/stateReducer';
 
 const ScannerPreference = ({
   displayName,
@@ -132,7 +133,7 @@ const ScannerPreferences = ({
               name={pref.name}
               value={values[pref.name]}
               onPreferenceChange={(value, name) =>
-                onValuesChange({type: 'setValue', newState: {[name]: value}})
+                onValuesChange(updateState({[name]: value}))
               }
             />
           ))}

--- a/gsa/src/web/pages/schedules/component.js
+++ b/gsa/src/web/pages/schedules/component.js
@@ -61,39 +61,33 @@ const ScheduleComponent = ({
       const {interval, freq, monthdays, weekdays} = recurrence;
 
       dispatch({
-        type: 'setState',
-        newState: {
-          comment: schedule.comment,
-          startDate,
-          dialogVisible: true,
-          duration: durationInSeconds > 0 ? duration : undefined,
-          freq,
-          id: schedule.id,
-          interval,
-          monthdays,
-          name: schedule.name,
-          title: _('Edit Schedule {{name}}', {name: schedule.name}),
-          timezone: schedule.timezone,
-          weekdays,
-        },
+        comment: schedule.comment,
+        startDate,
+        dialogVisible: true,
+        duration: durationInSeconds > 0 ? duration : undefined,
+        freq,
+        id: schedule.id,
+        interval,
+        monthdays,
+        name: schedule.name,
+        title: _('Edit Schedule {{name}}', {name: schedule.name}),
+        timezone: schedule.timezone,
+        weekdays,
       });
     } else {
       dispatch({
-        type: 'setState',
-        newState: {
-          comment: undefined,
-          dialogVisible: true,
-          duration: undefined,
-          freq: undefined,
-          id: undefined,
-          interval: undefined,
-          monthdays: undefined,
-          name: undefined,
-          startDate: undefined,
-          timezone,
-          title: undefined,
-          weekdays: undefined,
-        },
+        comment: undefined,
+        dialogVisible: true,
+        duration: undefined,
+        freq: undefined,
+        id: undefined,
+        interval: undefined,
+        monthdays: undefined,
+        name: undefined,
+        startDate: undefined,
+        timezone,
+        title: undefined,
+        weekdays: undefined,
       });
     }
 
@@ -101,7 +95,7 @@ const ScheduleComponent = ({
   };
 
   const closeScheduleDialog = () => {
-    dispatch({type: 'setState', newState: {dialogVisible: false}});
+    dispatch({dialogVisible: false});
   };
 
   const handleCloseScheduleDialog = () => {

--- a/gsa/src/web/pages/schedules/component.js
+++ b/gsa/src/web/pages/schedules/component.js
@@ -29,7 +29,7 @@ import {useCreateSchedule, useModifySchedule} from 'web/graphql/schedules';
 
 import {getTimezone} from 'web/store/usersettings/selectors';
 
-import reducer from 'web/utils/stateReducer';
+import reducer, {updateState} from 'web/utils/stateReducer';
 import PropTypes from 'web/utils/proptypes';
 
 import ScheduleDialog from './dialog';
@@ -60,42 +60,46 @@ const ScheduleComponent = ({
 
       const {interval, freq, monthdays, weekdays} = recurrence;
 
-      dispatch({
-        comment: schedule.comment,
-        startDate,
-        dialogVisible: true,
-        duration: durationInSeconds > 0 ? duration : undefined,
-        freq,
-        id: schedule.id,
-        interval,
-        monthdays,
-        name: schedule.name,
-        title: _('Edit Schedule {{name}}', {name: schedule.name}),
-        timezone: schedule.timezone,
-        weekdays,
-      });
+      dispatch(
+        updateState({
+          comment: schedule.comment,
+          startDate,
+          dialogVisible: true,
+          duration: durationInSeconds > 0 ? duration : undefined,
+          freq,
+          id: schedule.id,
+          interval,
+          monthdays,
+          name: schedule.name,
+          title: _('Edit Schedule {{name}}', {name: schedule.name}),
+          timezone: schedule.timezone,
+          weekdays,
+        }),
+      );
     } else {
-      dispatch({
-        comment: undefined,
-        dialogVisible: true,
-        duration: undefined,
-        freq: undefined,
-        id: undefined,
-        interval: undefined,
-        monthdays: undefined,
-        name: undefined,
-        startDate: undefined,
-        timezone,
-        title: undefined,
-        weekdays: undefined,
-      });
+      dispatch(
+        updateState({
+          comment: undefined,
+          dialogVisible: true,
+          duration: undefined,
+          freq: undefined,
+          id: undefined,
+          interval: undefined,
+          monthdays: undefined,
+          name: undefined,
+          startDate: undefined,
+          timezone,
+          title: undefined,
+          weekdays: undefined,
+        }),
+      );
     }
 
     handleInteraction();
   };
 
   const closeScheduleDialog = () => {
-    dispatch({dialogVisible: false});
+    dispatch(updateState({dialogVisible: false}));
   };
 
   const handleCloseScheduleDialog = () => {

--- a/gsa/src/web/pages/tasks/component.js
+++ b/gsa/src/web/pages/tasks/component.js
@@ -253,12 +253,9 @@ const TaskComponent = ({
   useEffect(() => {
     if (isDefined(scanConfigData)) {
       dispatchState({
-        type: 'setState',
-        newState: {
-          scanConfigs: scanConfigData.scanConfigs.nodes.map(scanConfig =>
-            ScanConfig.fromElement(scanConfig),
-          ),
-        },
+        scanConfigs: scanConfigData.scanConfigs.nodes.map(scanConfig =>
+          ScanConfig.fromElement(scanConfig),
+        ),
       });
     }
   }, [scanConfigData]);
@@ -274,15 +271,15 @@ const TaskComponent = ({
 
   // Handlers
   const handleTargetChange = targetId => {
-    dispatchState({type: 'setState', newState: {target_id: targetId}});
+    dispatchState({target_id: targetId});
   };
 
   const handleAlertsChange = alertIds => {
-    dispatchState({type: 'setState', newState: {alert_ids: alertIds}});
+    dispatchState({alert_ids: alertIds});
   };
 
   const handleScheduleChange = scheduleId => {
-    dispatchState({type: 'setState', newState: {schedule_id: scheduleId}});
+    dispatchState({schedule_id: scheduleId});
   };
 
   const handleTaskStart = task => {
@@ -304,7 +301,7 @@ const TaskComponent = ({
   };
 
   const closeTaskWizard = () => {
-    dispatchState({type: 'setState', newState: {taskWizardVisible: false}});
+    dispatchState({taskWizardVisible: false});
   };
 
   const handleTaskWizardNewClick = () => {
@@ -320,48 +317,36 @@ const TaskComponent = ({
     const {data} = resp;
 
     refetchSchedules();
-    dispatchState({
-      type: 'setState',
-      newState: {schedule_id: data.createSchedule?.id},
-    });
+    dispatchState({schedule_id: data.createSchedule?.id});
   };
 
   const handleTargetCreated = resp => {
     const {data} = resp;
     refetchTargets();
 
-    dispatchState({
-      type: 'setState',
-      newState: {target_id: data?.createTarget?.id},
-    });
+    dispatchState({target_id: data?.createTarget?.id});
   };
 
   const openContainerTaskDialog = inputTask => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        containerTaskDialogVisible: true,
-        task: inputTask,
-        name: inputTask ? inputTask.name : _('Unnamed'),
-        comment: inputTask ? inputTask.comment : '',
-        id: inputTask ? inputTask.id : undefined,
-        in_assets: inputTask ? inputTask.inAssets : undefined,
-        auto_delete: inputTask ? inputTask.autoDelete : undefined,
-        auto_delete_data: inputTask ? inputTask.autoDeleteData : undefined,
-        title: inputTask
-          ? _('Edit Container Task {{name}}', inputTask)
-          : _('New Container Task'),
-      },
+      containerTaskDialogVisible: true,
+      task: inputTask,
+      name: inputTask ? inputTask.name : _('Unnamed'),
+      comment: inputTask ? inputTask.comment : '',
+      id: inputTask ? inputTask.id : undefined,
+      in_assets: inputTask ? inputTask.inAssets : undefined,
+      auto_delete: inputTask ? inputTask.autoDelete : undefined,
+      auto_delete_data: inputTask ? inputTask.autoDeleteData : undefined,
+      title: inputTask
+        ? _('Edit Container Task {{name}}', inputTask)
+        : _('New Container Task'),
     });
 
     handleInteraction();
   };
 
   const closeContainerTaskDialog = () => {
-    dispatchState({
-      type: 'setState',
-      newState: {containerTaskDialogVisible: false},
-    });
+    dispatchState({containerTaskDialogVisible: false});
   };
 
   const handleCloseContainerTaskDialog = () => {
@@ -419,12 +404,9 @@ const TaskComponent = ({
         // arguments need to be undefined if the task is not changeable
 
         dispatchState({
-          type: 'setState',
-          newState: {
-            target_id: undefined,
-            scanner_id: undefined,
-            config_id: undefined,
-          },
+          target_id: undefined,
+          scanner_id: undefined,
+          config_id: undefined,
         });
       }
 
@@ -490,7 +472,7 @@ const TaskComponent = ({
   };
 
   const closeTaskDialog = () => {
-    dispatchState({type: 'setState', newState: {taskDialogVisible: false}});
+    dispatchState({taskDialogVisible: false});
   };
 
   const handleCloseTaskDialog = () => {
@@ -515,32 +497,29 @@ const TaskComponent = ({
         : undefined;
 
       dispatchState({
-        type: 'setState',
-        newState: {
-          taskDialogVisible: true,
-          error: undefined, // remove old errors
-          min_qod: task.minQod,
-          source_iface: task.sourceIface,
-          schedule_periods,
-          scanner_id: hasId(task.scanner) ? task.scanner.id : undefined,
-          name: task.name,
-          schedule_id,
-          target_id: hasId(task.target) ? task.target.id : undefined,
-          alert_ids: map(task.alerts, alert => alert.id),
-          alterable: task.alterable,
-          apply_overrides: task.applyOverrides,
-          auto_delete: task.autoDelete,
-          auto_delete_data: task.autoDeleteData,
-          comment: task.comment,
-          config_id: hasId(task.config) ? task.config.id : undefined,
-          hosts_ordering: task.hostsOrdering,
-          id: task.id,
-          in_assets: task.inAssets,
-          max_checks: task.maxChecks,
-          max_hosts: task.maxHosts,
-          title: _('Edit Task {{name}}', task),
-          task,
-        },
+        taskDialogVisible: true,
+        error: undefined, // remove old errors
+        min_qod: task.minQod,
+        source_iface: task.sourceIface,
+        schedule_periods,
+        scanner_id: hasId(task.scanner) ? task.scanner.id : undefined,
+        name: task.name,
+        schedule_id,
+        target_id: hasId(task.target) ? task.target.id : undefined,
+        alert_ids: map(task.alerts, alert => alert.id),
+        alterable: task.alterable,
+        apply_overrides: task.applyOverrides,
+        auto_delete: task.autoDelete,
+        auto_delete_data: task.autoDeleteData,
+        comment: task.comment,
+        config_id: hasId(task.config) ? task.config.id : undefined,
+        hosts_ordering: task.hostsOrdering,
+        id: task.id,
+        in_assets: task.inAssets,
+        max_checks: task.maxChecks,
+        max_hosts: task.maxHosts,
+        title: _('Edit Task {{name}}', task),
+        task,
       });
     } else {
       const alertIds = isDefined(defaultAlertId) ? [defaultAlertId] : [];
@@ -552,29 +531,26 @@ const TaskComponent = ({
         : FULL_AND_FAST_SCAN_CONFIG_ID;
 
       dispatchState({
-        type: 'setState',
-        newState: {
-          taskDialogVisible: true,
-          alert_ids: alertIds,
-          config_id: configId,
-          scanner_id: scannerId,
-          schedule_id: defaultScheduleId,
-          target_id: defaultTargetId,
-          title: _('New Task'),
-          apply_overrides: undefined,
-          auto_delete: undefined,
-          auto_delete_data: undefined,
-          comment: undefined,
-          hosts_ordering: undefined,
-          id: undefined,
-          max_checks: undefined,
-          max_hosts: undefined,
-          min_qod: undefined,
-          name: undefined,
-          schedule_periods: undefined,
-          source_iface: undefined,
-          task: undefined,
-        },
+        taskDialogVisible: true,
+        alert_ids: alertIds,
+        config_id: configId,
+        scanner_id: scannerId,
+        schedule_id: defaultScheduleId,
+        target_id: defaultTargetId,
+        title: _('New Task'),
+        apply_overrides: undefined,
+        auto_delete: undefined,
+        auto_delete_data: undefined,
+        comment: undefined,
+        hosts_ordering: undefined,
+        id: undefined,
+        max_checks: undefined,
+        max_hosts: undefined,
+        min_qod: undefined,
+        name: undefined,
+        schedule_periods: undefined,
+        source_iface: undefined,
+        task: undefined,
       });
 
       handleInteraction();
@@ -585,18 +561,15 @@ const TaskComponent = ({
     gmp.wizard.task().then(response => {
       const settings = response.data;
       dispatchState({
-        type: 'setState',
-        newState: {
-          taskWizardVisible: true,
-          hosts: settings.client_address,
-          port_list_id: defaultPortListId,
-          alert_id: defaultAlertId,
-          config_id: defaultScanConfigId,
-          ssh_credential: defaultSshCredential,
-          smb_credential: defaultSmbCredential,
-          esxi_credential: defaultEsxiCredential,
-          scanner_id: defaultScannerId,
-        },
+        taskWizardVisible: true,
+        hosts: settings.client_address,
+        port_list_id: defaultPortListId,
+        alert_id: defaultAlertId,
+        config_id: defaultScanConfigId,
+        ssh_credential: defaultSshCredential,
+        smb_credential: defaultSmbCredential,
+        esxi_credential: defaultEsxiCredential,
+        scanner_id: defaultScannerId,
       });
     });
     handleInteraction();
@@ -630,33 +603,27 @@ const TaskComponent = ({
       const now = date().tz(timezone);
 
       dispatchState({
-        type: 'setState',
-        newState: {
-          advancedTaskWizardVisible: true,
-          alert_id: defaultAlertId,
-          task_name: _('New Quick Task'),
-          target_hosts: settings.client_address,
-          port_list_id: defaultPortListId,
-          config_id: configId,
-          ssh_credential: defaultSshCredential,
-          smb_credential: defaultSmbCredential,
-          esxi_credential: defaultEsxiCredential,
-          scanner_id: defaultScannerId,
-          start_date: now,
-          start_minute: now.minutes(),
-          start_hour: now.hours(),
-          start_timezone: timezone,
-        },
+        advancedTaskWizardVisible: true,
+        alert_id: defaultAlertId,
+        task_name: _('New Quick Task'),
+        target_hosts: settings.client_address,
+        port_list_id: defaultPortListId,
+        config_id: configId,
+        ssh_credential: defaultSshCredential,
+        smb_credential: defaultSmbCredential,
+        esxi_credential: defaultEsxiCredential,
+        scanner_id: defaultScannerId,
+        start_date: now,
+        start_minute: now.minutes(),
+        start_hour: now.hours(),
+        start_timezone: timezone,
       });
     });
     handleInteraction();
   };
 
   const closeAdvancedTaskWizard = () => {
-    dispatchState({
-      type: 'setState',
-      newState: {advancedTaskWizardVisible: false},
-    });
+    dispatchState({advancedTaskWizardVisible: false});
   };
 
   const handleCloseAdvancedTaskWizard = () => {
@@ -679,29 +646,21 @@ const TaskComponent = ({
       const now = date().tz(timezone);
 
       dispatchState({
-        type: 'setState',
-        newState: {
-          modifyTaskWizardVisible: true,
-          tasks: settings.tasks,
-          reschedule: NO_VALUE,
-          task_id: selectSaveId(settings.tasks),
-          start_date: now,
-          start_minute: now.minutes(),
-          start_hour: now.hours(),
-          start_timezone: timezone,
-        },
+        modifyTaskWizardVisible: true,
+        tasks: settings.tasks,
+        reschedule: NO_VALUE,
+        task_id: selectSaveId(settings.tasks),
+        start_date: now,
+        start_minute: now.minutes(),
+        start_hour: now.hours(),
+        start_timezone: timezone,
       });
     });
     handleInteraction();
   };
 
   const closeModifyTaskWizard = () => {
-    dispatchState({
-      type: 'setState',
-      newState: {
-        modifyTaskWizardVisible: false,
-      },
-    });
+    dispatchState({modifyTaskWizardVisible: false});
   };
 
   const handleCloseModifyTaskWizard = () => {
@@ -720,12 +679,9 @@ const TaskComponent = ({
 
   const openReportImportDialog = task => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        reportImportDialogVisible: true,
-        tasks: [task],
-        task_id: task.id,
-      },
+      reportImportDialogVisible: true,
+      tasks: [task],
+      task_id: task.id,
     });
 
     handleInteraction();
@@ -733,10 +689,7 @@ const TaskComponent = ({
 
   const closeReportImportDialog = () => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        reportImportDialogVisible: false,
-      },
+      reportImportDialogVisible: false,
     });
   };
 
@@ -756,28 +709,19 @@ const TaskComponent = ({
 
   const handleScanConfigChange = configId => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        config_id: configId,
-      },
+      config_id: configId,
     });
   };
 
   const handleScannerChange = scannerId => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        scanner_id: scannerId,
-      },
+      scanner_id: scannerId,
     });
   };
 
   const handleTaskDialogErrorClose = () => {
     dispatchState({
-      type: 'setState',
-      newState: {
-        error: undefined,
-      },
+      error: undefined,
     });
   };
 
@@ -785,45 +729,27 @@ const TaskComponent = ({
     // display first loading error in the dialog
     if (scanConfigError) {
       dispatchState({
-        type: 'setState',
-        newState: {
-          error: _('Error while loading scan configs.'),
-        },
+        error: _('Error while loading scan configs.'),
       });
     } else if (scannerError) {
       dispatchState({
-        type: 'setState',
-        newState: {
-          error: _('Error while loading scanners.'),
-        },
+        error: _('Error while loading scanners.'),
       });
     } else if (scheduleError) {
       dispatchState({
-        type: 'setState',
-        newState: {
-          error: _('Error while loading schedules.'),
-        },
+        error: _('Error while loading schedules.'),
       });
     } else if (targetError) {
       dispatchState({
-        type: 'setState',
-        newState: {
-          error: _('Error while loading targets.'),
-        },
+        error: _('Error while loading targets.'),
       });
     } else if (alertError) {
       dispatchState({
-        type: 'setState',
-        newState: {
-          error: _('Error while loading alerts.'),
-        },
+        error: _('Error while loading alerts.'),
       });
     } else if (credentialError) {
       dispatchState({
-        type: 'setState',
-        newState: {
-          error: _('Error while loading credentials.'),
-        },
+        error: _('Error while loading credentials.'),
       });
     }
 

--- a/gsa/src/web/pages/tasks/component.js
+++ b/gsa/src/web/pages/tasks/component.js
@@ -47,7 +47,7 @@ import {getTimezone} from 'web/store/usersettings/selectors';
 import {loadUserSettingDefaults as loadUserSettingsDefaultsAction} from 'web/store/usersettings/defaults/actions';
 import {getUserSettingsDefaults} from 'web/store/usersettings/defaults/selectors';
 
-import stateReducer from 'web/utils/stateReducer';
+import stateReducer, {updateState} from 'web/utils/stateReducer';
 import PropTypes from 'web/utils/proptypes';
 import useGmp from 'web/utils/useGmp';
 import {UNSET_VALUE} from 'web/utils/render';
@@ -252,11 +252,13 @@ const TaskComponent = ({
 
   useEffect(() => {
     if (isDefined(scanConfigData)) {
-      dispatchState({
-        scanConfigs: scanConfigData.scanConfigs.nodes.map(scanConfig =>
-          ScanConfig.fromElement(scanConfig),
-        ),
-      });
+      dispatchState(
+        updateState({
+          scanConfigs: scanConfigData.scanConfigs.nodes.map(scanConfig =>
+            ScanConfig.fromElement(scanConfig),
+          ),
+        }),
+      );
     }
   }, [scanConfigData]);
 
@@ -271,15 +273,15 @@ const TaskComponent = ({
 
   // Handlers
   const handleTargetChange = targetId => {
-    dispatchState({targetId});
+    dispatchState(updateState({targetId}));
   };
 
   const handleAlertsChange = alertIds => {
-    dispatchState({alertIds});
+    dispatchState(updateState({alertIds}));
   };
 
   const handleScheduleChange = scheduleId => {
-    dispatchState({scheduleId});
+    dispatchState(updateState({scheduleId}));
   };
 
   const handleTaskStart = task => {
@@ -301,7 +303,7 @@ const TaskComponent = ({
   };
 
   const closeTaskWizard = () => {
-    dispatchState({taskWizardVisible: false});
+    dispatchState(updateState({taskWizardVisible: false}));
   };
 
   const handleTaskWizardNewClick = () => {
@@ -317,36 +319,38 @@ const TaskComponent = ({
     const {data} = resp;
 
     refetchSchedules();
-    dispatchState({scheduleId: data.createSchedule?.id});
+    dispatchState(updateState({scheduleId: data.createSchedule?.id}));
   };
 
   const handleTargetCreated = resp => {
     const {data} = resp;
     refetchTargets();
 
-    dispatchState({targetId: data?.createTarget?.id});
+    dispatchState(updateState({targetId: data?.createTarget?.id}));
   };
 
   const openContainerTaskDialog = inputTask => {
-    dispatchState({
-      containerTaskDialogVisible: true,
-      task: inputTask,
-      name: inputTask ? inputTask.name : _('Unnamed'),
-      comment: inputTask ? inputTask.comment : '',
-      id: inputTask ? inputTask.id : undefined,
-      inAssets: inputTask ? inputTask.inAssets : undefined,
-      autoDelete: inputTask ? inputTask.autoDelete : undefined,
-      autoDeleteData: inputTask ? inputTask.autoDeleteData : undefined,
-      title: inputTask
-        ? _('Edit Container Task {{name}}', inputTask)
-        : _('New Container Task'),
-    });
+    dispatchState(
+      updateState({
+        containerTaskDialogVisible: true,
+        task: inputTask,
+        name: inputTask ? inputTask.name : _('Unnamed'),
+        comment: inputTask ? inputTask.comment : '',
+        id: inputTask ? inputTask.id : undefined,
+        inAssets: inputTask ? inputTask.inAssets : undefined,
+        autoDelete: inputTask ? inputTask.autoDelete : undefined,
+        autoDeleteData: inputTask ? inputTask.autoDeleteData : undefined,
+        title: inputTask
+          ? _('Edit Container Task {{name}}', inputTask)
+          : _('New Container Task'),
+      }),
+    );
 
     handleInteraction();
   };
 
   const closeContainerTaskDialog = () => {
-    dispatchState({containerTaskDialogVisible: false});
+    dispatchState(updateState({containerTaskDialogVisible: false}));
   };
 
   const handleCloseContainerTaskDialog = () => {
@@ -403,11 +407,13 @@ const TaskComponent = ({
       if (isDefined(task) && !task.isChangeable()) {
         // arguments need to be undefined if the task is not changeable
 
-        dispatchState({
-          targetId: undefined,
-          scannerId: undefined,
-          configId: undefined,
-        });
+        dispatchState(
+          updateState({
+            targetId: undefined,
+            scannerId: undefined,
+            configId: undefined,
+          }),
+        );
       }
 
       const mutationData = {
@@ -472,7 +478,7 @@ const TaskComponent = ({
   };
 
   const closeTaskDialog = () => {
-    dispatchState({taskDialogVisible: false});
+    dispatchState(updateState({taskDialogVisible: false}));
   };
 
   const handleCloseTaskDialog = () => {
@@ -496,31 +502,33 @@ const TaskComponent = ({
         ? task.schedulePeriods
         : undefined;
 
-      dispatchState({
-        taskDialogVisible: true,
-        error: undefined, // remove old errors
-        minQod: task.minQod,
-        sourceIface: task.sourceIface,
-        schedulePeriods,
-        scannerId: hasId(task.scanner) ? task.scanner.id : undefined,
-        name: task.name,
-        scheduleId,
-        target_id: hasId(task.target) ? task.target.id : undefined,
-        alertIds: map(task.alerts, alert => alert.id),
-        alterable: task.alterable,
-        applyOverrides: task.applyOverrides,
-        autoDelete: task.autoDelete,
-        autoDeleteData: task.autoDeleteData,
-        comment: task.comment,
-        configId: hasId(task.config) ? task.config.id : undefined,
-        hostsOrdering: task.hostsOrdering,
-        id: task.id,
-        inAssets: task.inAssets,
-        maxChecks: task.maxChecks,
-        maxHosts: task.maxHosts,
-        title: _('Edit Task {{name}}', task),
-        task,
-      });
+      dispatchState(
+        updateState({
+          taskDialogVisible: true,
+          error: undefined, // remove old errors
+          minQod: task.minQod,
+          sourceIface: task.sourceIface,
+          schedulePeriods,
+          scannerId: hasId(task.scanner) ? task.scanner.id : undefined,
+          name: task.name,
+          scheduleId,
+          target_id: hasId(task.target) ? task.target.id : undefined,
+          alertIds: map(task.alerts, alert => alert.id),
+          alterable: task.alterable,
+          applyOverrides: task.applyOverrides,
+          autoDelete: task.autoDelete,
+          autoDeleteData: task.autoDeleteData,
+          comment: task.comment,
+          configId: hasId(task.config) ? task.config.id : undefined,
+          hostsOrdering: task.hostsOrdering,
+          id: task.id,
+          inAssets: task.inAssets,
+          maxChecks: task.maxChecks,
+          maxHosts: task.maxHosts,
+          title: _('Edit Task {{name}}', task),
+          task,
+        }),
+      );
     } else {
       const alertIds = isDefined(defaultAlertId) ? [defaultAlertId] : [];
       const scannerId = isDefined(defaultScannerId)
@@ -530,28 +538,30 @@ const TaskComponent = ({
         ? defaultScanConfigId
         : FULL_AND_FAST_SCAN_CONFIG_ID;
 
-      dispatchState({
-        taskDialogVisible: true,
-        alertIds,
-        configId: configId,
-        scannerId: scannerId,
-        scheduleId: defaultScheduleId,
-        targetId: defaultTargetId,
-        title: _('New Task'),
-        applyOverrides: undefined,
-        autoDelete: undefined,
-        autoDeleteData: undefined,
-        comment: undefined,
-        hostsOrdering: undefined,
-        id: undefined,
-        maxChecks: undefined,
-        maxHosts: undefined,
-        minQod: undefined,
-        name: undefined,
-        schedulePeriods: undefined,
-        sourceIface: undefined,
-        task: undefined,
-      });
+      dispatchState(
+        updateState({
+          taskDialogVisible: true,
+          alertIds,
+          configId: configId,
+          scannerId: scannerId,
+          scheduleId: defaultScheduleId,
+          targetId: defaultTargetId,
+          title: _('New Task'),
+          applyOverrides: undefined,
+          autoDelete: undefined,
+          autoDeleteData: undefined,
+          comment: undefined,
+          hostsOrdering: undefined,
+          id: undefined,
+          maxChecks: undefined,
+          maxHosts: undefined,
+          minQod: undefined,
+          name: undefined,
+          schedulePeriods: undefined,
+          sourceIface: undefined,
+          task: undefined,
+        }),
+      );
 
       handleInteraction();
     }
@@ -560,17 +570,19 @@ const TaskComponent = ({
   const openTaskWizard = () => {
     gmp.wizard.task().then(response => {
       const settings = response.data;
-      dispatchState({
-        taskWizardVisible: true,
-        hosts: settings.client_address,
-        portListId: defaultPortListId,
-        alertId: defaultAlertId,
-        configId: defaultScanConfigId,
-        sshCredential: defaultSshCredential,
-        smbCredential: defaultSmbCredential,
-        esxiCredential: defaultEsxiCredential,
-        scannerId: defaultScannerId,
-      });
+      dispatchState(
+        updateState({
+          taskWizardVisible: true,
+          hosts: settings.client_address,
+          portListId: defaultPortListId,
+          alertId: defaultAlertId,
+          configId: defaultScanConfigId,
+          sshCredential: defaultSshCredential,
+          smbCredential: defaultSmbCredential,
+          esxiCredential: defaultEsxiCredential,
+          scannerId: defaultScannerId,
+        }),
+      );
     });
     handleInteraction();
   };
@@ -602,28 +614,30 @@ const TaskComponent = ({
 
       const now = date().tz(timezone);
 
-      dispatchState({
-        advancedTaskWizardVisible: true,
-        alertId: defaultAlertId,
-        taskName: _('New Quick Task'),
-        targetHosts: settings.client_address,
-        portListId: defaultPortListId,
-        configId,
-        sshCredential: defaultSshCredential,
-        smbCredential: defaultSmbCredential,
-        esxiCredential: defaultEsxiCredential,
-        scannerId: defaultScannerId,
-        startDate: now,
-        startMinute: now.minutes(),
-        startHour: now.hours(),
-        startTimezone: timezone,
-      });
+      dispatchState(
+        updateState({
+          advancedTaskWizardVisible: true,
+          alertId: defaultAlertId,
+          taskName: _('New Quick Task'),
+          targetHosts: settings.client_address,
+          portListId: defaultPortListId,
+          configId,
+          sshCredential: defaultSshCredential,
+          smbCredential: defaultSmbCredential,
+          esxiCredential: defaultEsxiCredential,
+          scannerId: defaultScannerId,
+          startDate: now,
+          startMinute: now.minutes(),
+          startHour: now.hours(),
+          startTimezone: timezone,
+        }),
+      );
     });
     handleInteraction();
   };
 
   const closeAdvancedTaskWizard = () => {
-    dispatchState({advancedTaskWizardVisible: false});
+    dispatchState(updateState({advancedTaskWizardVisible: false}));
   };
 
   const handleCloseAdvancedTaskWizard = () => {
@@ -645,22 +659,24 @@ const TaskComponent = ({
       const settings = response.data;
       const now = date().tz(timezone);
 
-      dispatchState({
-        modifyTaskWizardVisible: true,
-        tasks: settings.tasks,
-        reschedule: NO_VALUE,
-        taskId: selectSaveId(settings.tasks),
-        startDate: now,
-        startMinute: now.minutes(),
-        startHour: now.hours(),
-        startTimezone: timezone,
-      });
+      dispatchState(
+        updateState({
+          modifyTaskWizardVisible: true,
+          tasks: settings.tasks,
+          reschedule: NO_VALUE,
+          taskId: selectSaveId(settings.tasks),
+          startDate: now,
+          startMinute: now.minutes(),
+          startHour: now.hours(),
+          startTimezone: timezone,
+        }),
+      );
     });
     handleInteraction();
   };
 
   const closeModifyTaskWizard = () => {
-    dispatchState({modifyTaskWizardVisible: false});
+    dispatchState(updateState({modifyTaskWizardVisible: false}));
   };
 
   const handleCloseModifyTaskWizard = () => {
@@ -678,19 +694,23 @@ const TaskComponent = ({
   };
 
   const openReportImportDialog = task => {
-    dispatchState({
-      reportImportDialogVisible: true,
-      tasks: [task],
-      taskId: task.id,
-    });
+    dispatchState(
+      updateState({
+        reportImportDialogVisible: true,
+        tasks: [task],
+        taskId: task.id,
+      }),
+    );
 
     handleInteraction();
   };
 
   const closeReportImportDialog = () => {
-    dispatchState({
-      reportImportDialogVisible: false,
-    });
+    dispatchState(
+      updateState({
+        reportImportDialogVisible: false,
+      }),
+    );
   };
 
   const handleCloseReportImportDialog = () => {
@@ -708,49 +728,55 @@ const TaskComponent = ({
   };
 
   const handleScanConfigChange = configId => {
-    dispatchState({
-      configId,
-    });
+    dispatchState(updateState({configId}));
   };
 
   const handleScannerChange = scannerId => {
-    dispatchState({
-      scannerId,
-    });
+    dispatchState(updateState({scannerId}));
   };
 
   const handleTaskDialogErrorClose = () => {
-    dispatchState({
-      error: undefined,
-    });
+    dispatchState(updateState({error: undefined}));
   };
 
   useEffect(() => {
     // display first loading error in the dialog
     if (scanConfigError) {
-      dispatchState({
-        error: _('Error while loading scan configs.'),
-      });
+      dispatchState(
+        updateState({
+          error: _('Error while loading scan configs.'),
+        }),
+      );
     } else if (scannerError) {
-      dispatchState({
-        error: _('Error while loading scanners.'),
-      });
+      dispatchState(
+        updateState({
+          error: _('Error while loading scanners.'),
+        }),
+      );
     } else if (scheduleError) {
-      dispatchState({
-        error: _('Error while loading schedules.'),
-      });
+      dispatchState(
+        updateState({
+          error: _('Error while loading schedules.'),
+        }),
+      );
     } else if (targetError) {
-      dispatchState({
-        error: _('Error while loading targets.'),
-      });
+      dispatchState(
+        updateState({
+          error: _('Error while loading targets.'),
+        }),
+      );
     } else if (alertError) {
-      dispatchState({
-        error: _('Error while loading alerts.'),
-      });
+      dispatchState(
+        updateState({
+          error: _('Error while loading alerts.'),
+        }),
+      );
     } else if (credentialError) {
-      dispatchState({
-        error: _('Error while loading credentials.'),
-      });
+      dispatchState(
+        updateState({
+          error: _('Error while loading credentials.'),
+        }),
+      );
     }
 
     // log error all objects to be able to inspect them the console

--- a/gsa/src/web/pages/tasks/component.js
+++ b/gsa/src/web/pages/tasks/component.js
@@ -241,12 +241,12 @@ const TaskComponent = ({
     taskDialogVisible: false,
     taskWizardVisible: false,
     reportImportDialogVisible: false,
-    target_id: UNSET_VALUE,
+    targetId: UNSET_VALUE,
     alertIds: [],
-    scanner_id: UNSET_VALUE,
-    schedule_id: UNSET_VALUE,
+    scannerId: UNSET_VALUE,
+    scheduleId: UNSET_VALUE,
     configId: defaultScanConfigId,
-    tag_id: undefined,
+    tagId: undefined,
     scanConfigs: undefined,
   });
 
@@ -271,7 +271,7 @@ const TaskComponent = ({
 
   // Handlers
   const handleTargetChange = targetId => {
-    dispatchState({target_id: targetId});
+    dispatchState({targetId});
   };
 
   const handleAlertsChange = alertIds => {
@@ -279,7 +279,7 @@ const TaskComponent = ({
   };
 
   const handleScheduleChange = scheduleId => {
-    dispatchState({schedule_id: scheduleId});
+    dispatchState({scheduleId});
   };
 
   const handleTaskStart = task => {
@@ -317,14 +317,14 @@ const TaskComponent = ({
     const {data} = resp;
 
     refetchSchedules();
-    dispatchState({schedule_id: data.createSchedule?.id});
+    dispatchState({scheduleId: data.createSchedule?.id});
   };
 
   const handleTargetCreated = resp => {
     const {data} = resp;
     refetchTargets();
 
-    dispatchState({target_id: data?.createTarget?.id});
+    dispatchState({targetId: data?.createTarget?.id});
   };
 
   const openContainerTaskDialog = inputTask => {
@@ -404,8 +404,8 @@ const TaskComponent = ({
         // arguments need to be undefined if the task is not changeable
 
         dispatchState({
-          target_id: undefined,
-          scanner_id: undefined,
+          targetId: undefined,
+          scannerId: undefined,
           configId: undefined,
         });
       }
@@ -491,20 +491,20 @@ const TaskComponent = ({
     if (isDefined(task)) {
       const canAccessSchedules =
         capabilities.mayAccess('schedules') && isDefined(task.schedule);
-      const schedule_id = canAccessSchedules ? task.schedule.id : UNSET_VALUE;
-      const schedule_periods = canAccessSchedules
+      const scheduleId = canAccessSchedules ? task.schedule.id : UNSET_VALUE;
+      const schedulePeriods = canAccessSchedules
         ? task.schedulePeriods
         : undefined;
 
       dispatchState({
         taskDialogVisible: true,
         error: undefined, // remove old errors
-        min_qod: task.minQod,
-        source_iface: task.sourceIface,
-        schedule_periods,
-        scanner_id: hasId(task.scanner) ? task.scanner.id : undefined,
+        minQod: task.minQod,
+        sourceIface: task.sourceIface,
+        schedulePeriods,
+        scannerId: hasId(task.scanner) ? task.scanner.id : undefined,
         name: task.name,
-        schedule_id,
+        scheduleId,
         target_id: hasId(task.target) ? task.target.id : undefined,
         alertIds: map(task.alerts, alert => alert.id),
         alterable: task.alterable,
@@ -516,8 +516,8 @@ const TaskComponent = ({
         hostsOrdering: task.hostsOrdering,
         id: task.id,
         inAssets: task.inAssets,
-        max_checks: task.maxChecks,
-        max_hosts: task.maxHosts,
+        maxChecks: task.maxChecks,
+        maxHosts: task.maxHosts,
         title: _('Edit Task {{name}}', task),
         task,
       });
@@ -534,9 +534,9 @@ const TaskComponent = ({
         taskDialogVisible: true,
         alertIds,
         configId: configId,
-        scanner_id: scannerId,
-        schedule_id: defaultScheduleId,
-        target_id: defaultTargetId,
+        scannerId: scannerId,
+        scheduleId: defaultScheduleId,
+        targetId: defaultTargetId,
         title: _('New Task'),
         applyOverrides: undefined,
         autoDelete: undefined,
@@ -544,12 +544,12 @@ const TaskComponent = ({
         comment: undefined,
         hostsOrdering: undefined,
         id: undefined,
-        max_checks: undefined,
-        max_hosts: undefined,
-        min_qod: undefined,
+        maxChecks: undefined,
+        maxHosts: undefined,
+        minQod: undefined,
         name: undefined,
-        schedule_periods: undefined,
-        source_iface: undefined,
+        schedulePeriods: undefined,
+        sourceIface: undefined,
         task: undefined,
       });
 
@@ -563,13 +563,13 @@ const TaskComponent = ({
       dispatchState({
         taskWizardVisible: true,
         hosts: settings.client_address,
-        port_list_id: defaultPortListId,
+        portListId: defaultPortListId,
         alert_id: defaultAlertId,
         configId: defaultScanConfigId,
         ssh_credential: defaultSshCredential,
         smb_credential: defaultSmbCredential,
         esxi_credential: defaultEsxiCredential,
-        scanner_id: defaultScannerId,
+        scannerId: defaultScannerId,
       });
     });
     handleInteraction();
@@ -607,12 +607,12 @@ const TaskComponent = ({
         alert_id: defaultAlertId,
         task_name: _('New Quick Task'),
         target_hosts: settings.client_address,
-        port_list_id: defaultPortListId,
+        portListId: defaultPortListId,
         configId,
         ssh_credential: defaultSshCredential,
         smb_credential: defaultSmbCredential,
         esxi_credential: defaultEsxiCredential,
-        scanner_id: defaultScannerId,
+        scannerId: defaultScannerId,
         start_date: now,
         start_minute: now.minutes(),
         start_hour: now.hours(),
@@ -715,7 +715,7 @@ const TaskComponent = ({
 
   const handleScannerChange = scannerId => {
     dispatchState({
-      scanner_id: scannerId,
+      scannerId,
     });
   };
 
@@ -791,11 +791,11 @@ const TaskComponent = ({
     alterable,
     applyOverrides,
     error,
-    max_checks,
-    max_hosts,
-    min_qod,
-    schedule_periods,
-    source_iface,
+    maxChecks,
+    maxHosts,
+    minQod,
+    schedulePeriods,
+    sourceIface,
     autoDelete,
     autoDelteData,
     comment,
@@ -805,7 +805,7 @@ const TaskComponent = ({
     title,
     name,
     hostsOrdering,
-    port_list_id,
+    portListId,
     alert_id,
     ssh_credential,
     smb_credential,
@@ -819,10 +819,10 @@ const TaskComponent = ({
     reschedule,
     alertIds,
     configId,
-    scanner_id,
-    schedule_id,
-    tag_id,
-    target_id,
+    scannerId,
+    scheduleId,
+    tagId,
+    targetId,
     tasks,
     task_id,
     start_timezone,
@@ -894,20 +894,20 @@ const TaskComponent = ({
                             isLoadingSchedules={isLoadingSchedules}
                             isLoadingTargets={isLoadingTargets}
                             isLoadingTags={isLoadingTags}
-                            max_checks={max_checks}
-                            max_hosts={max_hosts}
-                            min_qod={min_qod}
+                            max_checks={maxChecks}
+                            max_hosts={maxHosts}
+                            min_qod={minQod}
                             name={name}
                             scan_configs={scanConfigs}
-                            scanner_id={scanner_id}
+                            scanner_id={scannerId}
                             scanners={scanners}
-                            schedule_id={schedule_id}
-                            schedule_periods={schedule_periods}
+                            schedule_id={scheduleId}
+                            schedule_periods={schedulePeriods}
                             schedules={schedules}
-                            source_iface={source_iface}
-                            tag_id={tag_id}
+                            source_iface={sourceIface}
+                            tag_id={tagId}
                             tags={tags}
-                            target_id={target_id}
+                            target_id={targetId}
                             targets={targets}
                             task={task}
                             title={title}
@@ -952,13 +952,13 @@ const TaskComponent = ({
       {taskWizardVisible && (
         <TaskWizard
           hosts={hosts}
-          port_list_id={port_list_id}
+          port_list_id={portListId}
           alert_id={alert_id}
           config_id={configId}
           ssh_credential={ssh_credential}
           smb_credential={smb_credential}
           esxi_credential={esxi_credential}
-          scanner_id={scanner_id}
+          scanner_id={scannerId}
           onClose={handleCloseTaskWizard}
           onSave={handleSaveTaskWizard}
           onNewClick={handleTaskWizardNewClick}
@@ -972,13 +972,13 @@ const TaskComponent = ({
           start_date={start_date}
           task_name={task_name}
           target_hosts={target_hosts}
-          port_list_id={port_list_id}
+          port_list_id={portListId}
           alert_id={alert_id}
           config_id={configId}
           ssh_credential={ssh_credential}
           smb_credential={smb_credential}
           esxi_credential={esxi_credential}
-          scanner_id={scanner_id}
+          scanner_id={scannerId}
           start_minute={start_minute}
           start_hour={start_hour}
           start_timezone={start_timezone}

--- a/gsa/src/web/pages/tasks/component.js
+++ b/gsa/src/web/pages/tasks/component.js
@@ -242,10 +242,10 @@ const TaskComponent = ({
     taskWizardVisible: false,
     reportImportDialogVisible: false,
     target_id: UNSET_VALUE,
-    alert_ids: [],
+    alertIds: [],
     scanner_id: UNSET_VALUE,
     schedule_id: UNSET_VALUE,
-    config_id: defaultScanConfigId,
+    configId: defaultScanConfigId,
     tag_id: undefined,
     scanConfigs: undefined,
   });
@@ -275,7 +275,7 @@ const TaskComponent = ({
   };
 
   const handleAlertsChange = alertIds => {
-    dispatchState({alert_ids: alertIds});
+    dispatchState({alertIds});
   };
 
   const handleScheduleChange = scheduleId => {
@@ -334,9 +334,9 @@ const TaskComponent = ({
       name: inputTask ? inputTask.name : _('Unnamed'),
       comment: inputTask ? inputTask.comment : '',
       id: inputTask ? inputTask.id : undefined,
-      in_assets: inputTask ? inputTask.inAssets : undefined,
-      auto_delete: inputTask ? inputTask.autoDelete : undefined,
-      auto_delete_data: inputTask ? inputTask.autoDeleteData : undefined,
+      inAssets: inputTask ? inputTask.inAssets : undefined,
+      autoDelete: inputTask ? inputTask.autoDelete : undefined,
+      autoDelteData: inputTask ? inputTask.autoDeleteData : undefined,
       title: inputTask
         ? _('Edit Container Task {{name}}', inputTask)
         : _('New Container Task'),
@@ -406,7 +406,7 @@ const TaskComponent = ({
         dispatchState({
           target_id: undefined,
           scanner_id: undefined,
-          config_id: undefined,
+          configId: undefined,
         });
       }
 
@@ -506,16 +506,16 @@ const TaskComponent = ({
         name: task.name,
         schedule_id,
         target_id: hasId(task.target) ? task.target.id : undefined,
-        alert_ids: map(task.alerts, alert => alert.id),
+        alertIds: map(task.alerts, alert => alert.id),
         alterable: task.alterable,
-        apply_overrides: task.applyOverrides,
-        auto_delete: task.autoDelete,
-        auto_delete_data: task.autoDeleteData,
+        applyOverrides: task.applyOverrides,
+        autoDelete: task.autoDelete,
+        autoDelteData: task.autoDeleteData,
         comment: task.comment,
-        config_id: hasId(task.config) ? task.config.id : undefined,
-        hosts_ordering: task.hostsOrdering,
+        configId: hasId(task.config) ? task.config.id : undefined,
+        hostsOrdering: task.hostsOrdering,
         id: task.id,
-        in_assets: task.inAssets,
+        inAssets: task.inAssets,
         max_checks: task.maxChecks,
         max_hosts: task.maxHosts,
         title: _('Edit Task {{name}}', task),
@@ -532,17 +532,17 @@ const TaskComponent = ({
 
       dispatchState({
         taskDialogVisible: true,
-        alert_ids: alertIds,
-        config_id: configId,
+        alertIds,
+        configId: configId,
         scanner_id: scannerId,
         schedule_id: defaultScheduleId,
         target_id: defaultTargetId,
         title: _('New Task'),
-        apply_overrides: undefined,
-        auto_delete: undefined,
-        auto_delete_data: undefined,
+        applyOverrides: undefined,
+        autoDelete: undefined,
+        autoDelteData: undefined,
         comment: undefined,
-        hosts_ordering: undefined,
+        hostsOrdering: undefined,
         id: undefined,
         max_checks: undefined,
         max_hosts: undefined,
@@ -565,7 +565,7 @@ const TaskComponent = ({
         hosts: settings.client_address,
         port_list_id: defaultPortListId,
         alert_id: defaultAlertId,
-        config_id: defaultScanConfigId,
+        configId: defaultScanConfigId,
         ssh_credential: defaultSshCredential,
         smb_credential: defaultSmbCredential,
         esxi_credential: defaultEsxiCredential,
@@ -608,7 +608,7 @@ const TaskComponent = ({
         task_name: _('New Quick Task'),
         target_hosts: settings.client_address,
         port_list_id: defaultPortListId,
-        config_id: configId,
+        configId,
         ssh_credential: defaultSshCredential,
         smb_credential: defaultSmbCredential,
         esxi_credential: defaultEsxiCredential,
@@ -709,7 +709,7 @@ const TaskComponent = ({
 
   const handleScanConfigChange = configId => {
     dispatchState({
-      config_id: configId,
+      configId,
     });
   };
 
@@ -789,22 +789,22 @@ const TaskComponent = ({
     taskWizardVisible,
     reportImportDialogVisible,
     alterable,
-    apply_overrides,
+    applyOverrides,
     error,
     max_checks,
     max_hosts,
     min_qod,
     schedule_periods,
     source_iface,
-    auto_delete,
-    auto_delete_data,
+    autoDelete,
+    autoDelteData,
     comment,
     id,
-    in_assets,
+    inAssets,
     task,
     title,
     name,
-    hosts_ordering,
+    hostsOrdering,
     port_list_id,
     alert_id,
     ssh_credential,
@@ -817,8 +817,8 @@ const TaskComponent = ({
     start_minute,
     start_hour,
     reschedule,
-    alert_ids,
-    config_id,
+    alertIds,
+    configId,
     scanner_id,
     schedule_id,
     tag_id,
@@ -877,17 +877,17 @@ const TaskComponent = ({
                         {({create: createschedule}) => (
                           <TaskDialog
                             alerts={alerts}
-                            alert_ids={alert_ids}
+                            alert_ids={alertIds}
                             alterable={alterable}
-                            apply_overrides={apply_overrides}
-                            auto_delete={auto_delete}
-                            auto_delete_data={auto_delete_data}
+                            apply_overrides={applyOverrides}
+                            auto_delete={autoDelete}
+                            auto_delete_data={autoDelteData}
                             comment={comment}
-                            config_id={config_id}
+                            config_id={configId}
                             error={error}
-                            hosts_ordering={hosts_ordering}
+                            hosts_ordering={hostsOrdering}
                             id={id}
-                            in_assets={in_assets}
+                            in_assets={inAssets}
                             isLoadingAlerts={isLoadingAlerts}
                             isLoadingConfigs={isLoadingConfigs}
                             isLoadingScanners={isLoadingScanners}
@@ -940,9 +940,9 @@ const TaskComponent = ({
           name={name}
           comment={comment}
           id={id}
-          in_assets={in_assets}
-          auto_delete={auto_delete}
-          auto_delete_data={auto_delete_data}
+          in_assets={inAssets}
+          auto_delete={autoDelete}
+          auto_delete_data={autoDelteData}
           title={title}
           onClose={handleCloseContainerTaskDialog}
           onSave={handleSaveContainerTask}
@@ -954,7 +954,7 @@ const TaskComponent = ({
           hosts={hosts}
           port_list_id={port_list_id}
           alert_id={alert_id}
-          config_id={config_id}
+          config_id={configId}
           ssh_credential={ssh_credential}
           smb_credential={smb_credential}
           esxi_credential={esxi_credential}
@@ -974,7 +974,7 @@ const TaskComponent = ({
           target_hosts={target_hosts}
           port_list_id={port_list_id}
           alert_id={alert_id}
-          config_id={config_id}
+          config_id={configId}
           ssh_credential={ssh_credential}
           smb_credential={smb_credential}
           esxi_credential={esxi_credential}

--- a/gsa/src/web/pages/tasks/component.js
+++ b/gsa/src/web/pages/tasks/component.js
@@ -336,7 +336,7 @@ const TaskComponent = ({
       id: inputTask ? inputTask.id : undefined,
       inAssets: inputTask ? inputTask.inAssets : undefined,
       autoDelete: inputTask ? inputTask.autoDelete : undefined,
-      autoDelteData: inputTask ? inputTask.autoDeleteData : undefined,
+      autoDeleteData: inputTask ? inputTask.autoDeleteData : undefined,
       title: inputTask
         ? _('Edit Container Task {{name}}', inputTask)
         : _('New Container Task'),
@@ -510,7 +510,7 @@ const TaskComponent = ({
         alterable: task.alterable,
         applyOverrides: task.applyOverrides,
         autoDelete: task.autoDelete,
-        autoDelteData: task.autoDeleteData,
+        autoDeleteData: task.autoDeleteData,
         comment: task.comment,
         configId: hasId(task.config) ? task.config.id : undefined,
         hostsOrdering: task.hostsOrdering,
@@ -540,7 +540,7 @@ const TaskComponent = ({
         title: _('New Task'),
         applyOverrides: undefined,
         autoDelete: undefined,
-        autoDelteData: undefined,
+        autoDeleteData: undefined,
         comment: undefined,
         hostsOrdering: undefined,
         id: undefined,
@@ -566,9 +566,9 @@ const TaskComponent = ({
         portListId: defaultPortListId,
         alert_id: defaultAlertId,
         configId: defaultScanConfigId,
-        ssh_credential: defaultSshCredential,
-        smb_credential: defaultSmbCredential,
-        esxi_credential: defaultEsxiCredential,
+        sshCredential: defaultSshCredential,
+        smbCredential: defaultSmbCredential,
+        esxiCredential: defaultEsxiCredential,
         scannerId: defaultScannerId,
       });
     });
@@ -609,9 +609,9 @@ const TaskComponent = ({
         target_hosts: settings.client_address,
         portListId: defaultPortListId,
         configId,
-        ssh_credential: defaultSshCredential,
-        smb_credential: defaultSmbCredential,
-        esxi_credential: defaultEsxiCredential,
+        sshCredential: defaultSshCredential,
+        smbCredential: defaultSmbCredential,
+        esxiCredential: defaultEsxiCredential,
         scannerId: defaultScannerId,
         start_date: now,
         start_minute: now.minutes(),
@@ -797,7 +797,7 @@ const TaskComponent = ({
     schedulePeriods,
     sourceIface,
     autoDelete,
-    autoDelteData,
+    autoDeleteData,
     comment,
     id,
     inAssets,
@@ -807,9 +807,9 @@ const TaskComponent = ({
     hostsOrdering,
     portListId,
     alert_id,
-    ssh_credential,
-    smb_credential,
-    esxi_credential,
+    sshCredential,
+    smbCredential,
+    esxiCredential,
     task_name,
     target_hosts,
     scanConfigs,
@@ -881,7 +881,7 @@ const TaskComponent = ({
                             alterable={alterable}
                             apply_overrides={applyOverrides}
                             auto_delete={autoDelete}
-                            auto_delete_data={autoDelteData}
+                            auto_delete_data={autoDeleteData}
                             comment={comment}
                             config_id={configId}
                             error={error}
@@ -942,7 +942,7 @@ const TaskComponent = ({
           id={id}
           in_assets={inAssets}
           auto_delete={autoDelete}
-          auto_delete_data={autoDelteData}
+          auto_delete_data={autoDeleteData}
           title={title}
           onClose={handleCloseContainerTaskDialog}
           onSave={handleSaveContainerTask}
@@ -955,9 +955,9 @@ const TaskComponent = ({
           port_list_id={portListId}
           alert_id={alert_id}
           config_id={configId}
-          ssh_credential={ssh_credential}
-          smb_credential={smb_credential}
-          esxi_credential={esxi_credential}
+          ssh_credential={sshCredential}
+          smb_credential={smbCredential}
+          esxi_credential={esxiCredential}
           scanner_id={scannerId}
           onClose={handleCloseTaskWizard}
           onSave={handleSaveTaskWizard}
@@ -975,9 +975,9 @@ const TaskComponent = ({
           port_list_id={portListId}
           alert_id={alert_id}
           config_id={configId}
-          ssh_credential={ssh_credential}
-          smb_credential={smb_credential}
-          esxi_credential={esxi_credential}
+          ssh_credential={sshCredential}
+          smb_credential={smbCredential}
+          esxi_credential={esxiCredential}
           scanner_id={scannerId}
           start_minute={start_minute}
           start_hour={start_hour}

--- a/gsa/src/web/pages/tasks/component.js
+++ b/gsa/src/web/pages/tasks/component.js
@@ -128,6 +128,7 @@ const TaskComponent = ({
   const gmp = useGmp();
   const dispatch = useDispatch();
 
+  // Loaders
   const loadTags = useCallback(
     () => dispatch(loadTagsAction(gmp)(TAGS_FILTER)),
     [gmp, dispatch],
@@ -138,6 +139,7 @@ const TaskComponent = ({
     [dispatch, gmp],
   );
 
+  // Selectors
   const tagsSel = useSelector(tagsSelector);
   const userDefaults = useSelector(getUserSettingsDefaults);
 

--- a/gsa/src/web/pages/tasks/component.js
+++ b/gsa/src/web/pages/tasks/component.js
@@ -92,7 +92,38 @@ const log = logger.getLogger('web.pages.tasks.component');
 
 const TAGS_FILTER = ALL_FILTER.copy().set('resource_type', 'task');
 
-const TaskComponent = props => {
+const TaskComponent = ({
+  children,
+  onAdvancedTaskWizardError,
+  onAdvancedTaskWizardSaved,
+  onCloneError,
+  onCloned,
+  onContainerCreateError,
+  onContainerCreated,
+  onContainerSaveError,
+  onContainerSaved,
+  onCreateError,
+  onCreated,
+  onDeleteError,
+  onDeleted,
+  onDownloadError,
+  onDownloaded,
+  onInteraction,
+  onModifyTaskWizardError,
+  onModifyTaskWizardSaved,
+  onReportImportError,
+  onReportImported,
+  onResumeError,
+  onResumed,
+  onSaveError,
+  onSaved,
+  onStartError,
+  onStarted,
+  onStopError,
+  onStopped,
+  onTaskWizardError,
+  onTaskWizardSaved,
+}) => {
   // GMP and Redux
   const gmp = useGmp();
   const dispatch = useDispatch();
@@ -244,7 +275,6 @@ const TaskComponent = props => {
     loadUserSettingsDefaults();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
   const handleInteraction = () => {
-    const {onInteraction} = props;
     if (isDefined(onInteraction)) {
       onInteraction();
     }
@@ -272,24 +302,18 @@ const TaskComponent = props => {
   };
 
   const handleTaskStart = task => {
-    const {onStarted, onStartError} = props;
-
     handleInteraction();
 
     return startTask(task.id).then(onStarted, onStartError);
   };
 
   const handleTaskStop = task => {
-    const {onStopped, onStopError} = props;
-
     handleInteraction();
 
     return stopTask(task.id).then(onStopped, onStopError);
   };
 
   const handleTaskResume = task => {
-    const {onResumed, onResumeError} = props;
-
     handleInteraction();
 
     return resumeTask(task.id).then(onResumed, onResumeError);
@@ -361,7 +385,6 @@ const TaskComponent = props => {
     handleInteraction();
 
     if (isDefined(data.id)) {
-      const {onContainerSaved, onContainerSaveError} = props;
       return modifyTask({
         id: data.id,
         name: data.name,
@@ -370,7 +393,6 @@ const TaskComponent = props => {
         .then(onContainerSaved, onContainerSaveError)
         .then(() => closeContainerTaskDialog());
     }
-    const {onContainerCreated, onContainerCreateError} = props;
     return createContainerTask({name: data.name, comment: data.comment})
       .then(result => onContainerCreated(result), onContainerCreateError) // queries return a promise and result is what gets returned by django
       .then(() => closeContainerTaskDialog());
@@ -415,7 +437,6 @@ const TaskComponent = props => {
           config_id: undefined,
         }));
       }
-      const {onSaved, onSaveError} = props;
 
       const mutationData = {
         alertIds: alert_ids,
@@ -465,7 +486,6 @@ const TaskComponent = props => {
       sourceIface: source_iface,
       targetId: target_id,
     };
-    const {onCreated, onCreateError} = props;
     return createTask(mutationData)
       .then(result => onCreated(result), onCreateError)
       .then(() => closeTaskDialog());
@@ -595,8 +615,6 @@ const TaskComponent = props => {
   };
 
   const handleSaveTaskWizard = data => {
-    const {onTaskWizardSaved, onTaskWizardError} = props;
-
     handleInteraction();
 
     return gmp.wizard
@@ -649,8 +667,6 @@ const TaskComponent = props => {
   };
 
   const handleSaveAdvancedTaskWizard = data => {
-    const {onAdvancedTaskWizardSaved, onAdvancedTaskWizardError} = props;
-
     handleInteraction();
 
     return gmp.wizard
@@ -660,8 +676,6 @@ const TaskComponent = props => {
   };
 
   const openModifyTaskWizard = () => {
-    const {timezone} = props;
-
     gmp.wizard.modifyTask().then(response => {
       const settings = response.data;
       const now = date().tz(timezone);
@@ -692,8 +706,6 @@ const TaskComponent = props => {
   };
 
   const handleSaveModifyTaskWizard = data => {
-    const {onModifyTaskWizardSaved, onModifyTaskWizardError} = props;
-
     handleInteraction();
 
     return gmp.wizard
@@ -723,8 +735,6 @@ const TaskComponent = props => {
   };
 
   const handleReportImport = data => {
-    const {onReportImported, onReportImportError} = props;
-
     handleInteraction();
 
     return gmp.report
@@ -812,19 +822,6 @@ const TaskComponent = props => {
     alertError,
     credentialError,
   ]);
-
-  const {
-    children,
-    onCloned,
-    onCloneError,
-    onCreated,
-    onCreateError,
-    onDeleted,
-    onDeleteError,
-    onDownloaded,
-    onDownloadError,
-    onInteraction,
-  } = props;
 
   const {
     alterable,

--- a/gsa/src/web/pages/tasks/component.js
+++ b/gsa/src/web/pages/tasks/component.js
@@ -564,7 +564,7 @@ const TaskComponent = ({
         taskWizardVisible: true,
         hosts: settings.client_address,
         portListId: defaultPortListId,
-        alert_id: defaultAlertId,
+        alertId: defaultAlertId,
         configId: defaultScanConfigId,
         sshCredential: defaultSshCredential,
         smbCredential: defaultSmbCredential,
@@ -604,19 +604,19 @@ const TaskComponent = ({
 
       dispatchState({
         advancedTaskWizardVisible: true,
-        alert_id: defaultAlertId,
-        task_name: _('New Quick Task'),
-        target_hosts: settings.client_address,
+        alertId: defaultAlertId,
+        taskName: _('New Quick Task'),
+        targetHosts: settings.client_address,
         portListId: defaultPortListId,
         configId,
         sshCredential: defaultSshCredential,
         smbCredential: defaultSmbCredential,
         esxiCredential: defaultEsxiCredential,
         scannerId: defaultScannerId,
-        start_date: now,
-        start_minute: now.minutes(),
-        start_hour: now.hours(),
-        start_timezone: timezone,
+        startDate: now,
+        startMinute: now.minutes(),
+        startHour: now.hours(),
+        startTimezone: timezone,
       });
     });
     handleInteraction();
@@ -649,11 +649,11 @@ const TaskComponent = ({
         modifyTaskWizardVisible: true,
         tasks: settings.tasks,
         reschedule: NO_VALUE,
-        task_id: selectSaveId(settings.tasks),
-        start_date: now,
-        start_minute: now.minutes(),
-        start_hour: now.hours(),
-        start_timezone: timezone,
+        taskId: selectSaveId(settings.tasks),
+        startDate: now,
+        startMinute: now.minutes(),
+        startHour: now.hours(),
+        startTimezone: timezone,
       });
     });
     handleInteraction();
@@ -681,7 +681,7 @@ const TaskComponent = ({
     dispatchState({
       reportImportDialogVisible: true,
       tasks: [task],
-      task_id: task.id,
+      taskId: task.id,
     });
 
     handleInteraction();
@@ -806,16 +806,16 @@ const TaskComponent = ({
     name,
     hostsOrdering,
     portListId,
-    alert_id,
+    alertId,
     sshCredential,
     smbCredential,
     esxiCredential,
-    task_name,
-    target_hosts,
+    taskName,
+    targetHosts,
     scanConfigs,
-    start_date,
-    start_minute,
-    start_hour,
+    startDate,
+    startMinute,
+    startHour,
     reschedule,
     alertIds,
     configId,
@@ -824,8 +824,8 @@ const TaskComponent = ({
     tagId,
     targetId,
     tasks,
-    task_id,
-    start_timezone,
+    taskId,
+    startTimezone,
     hosts,
   } = state;
 
@@ -953,7 +953,7 @@ const TaskComponent = ({
         <TaskWizard
           hosts={hosts}
           port_list_id={portListId}
-          alert_id={alert_id}
+          alert_id={alertId}
           config_id={configId}
           ssh_credential={sshCredential}
           smb_credential={smbCredential}
@@ -969,19 +969,19 @@ const TaskComponent = ({
         <AdvancedTaskWizard
           credentials={credentials}
           scan_configs={scanConfigs}
-          start_date={start_date}
-          task_name={task_name}
-          target_hosts={target_hosts}
+          start_date={startDate}
+          task_name={taskName}
+          target_hosts={targetHosts}
           port_list_id={portListId}
-          alert_id={alert_id}
+          alert_id={alertId}
           config_id={configId}
           ssh_credential={sshCredential}
           smb_credential={smbCredential}
           esxi_credential={esxiCredential}
           scanner_id={scannerId}
-          start_minute={start_minute}
-          start_hour={start_hour}
-          start_timezone={start_timezone}
+          start_minute={startMinute}
+          start_hour={startHour}
+          start_timezone={startTimezone}
           onClose={handleCloseAdvancedTaskWizard}
           onSave={handleSaveAdvancedTaskWizard}
         />
@@ -989,13 +989,13 @@ const TaskComponent = ({
 
       {modifyTaskWizardVisible && (
         <ModifyTaskWizard
-          start_date={start_date}
+          start_date={startDate}
           tasks={tasks}
           reschedule={reschedule}
-          task_id={task_id}
-          start_minute={start_minute}
-          start_hour={start_hour}
-          start_timezone={start_timezone}
+          task_id={taskId}
+          start_minute={startMinute}
+          start_hour={startHour}
+          start_timezone={startTimezone}
           onClose={handleCloseModifyTaskWizard}
           onSave={handleSaveModifyTaskWizard}
         />
@@ -1004,7 +1004,7 @@ const TaskComponent = ({
       {reportImportDialogVisible && (
         <ImportReportDialog
           newContainerTask={false}
-          task_id={task_id}
+          task_id={taskId}
           tasks={tasks}
           onClose={handleCloseReportImportDialog}
           onSave={handleReportImport}

--- a/gsa/src/web/pages/tasks/component.js
+++ b/gsa/src/web/pages/tasks/component.js
@@ -49,7 +49,7 @@ import {getUserSettingsDefaults} from 'web/store/usersettings/defaults/selectors
 
 import compose from 'web/utils/compose';
 import PropTypes from 'web/utils/proptypes';
-import withGmp from 'web/utils/withGmp';
+import useGmp from 'web/utils/useGmp';
 import {UNSET_VALUE} from 'web/utils/render';
 import useCapabilities from 'web/utils/useCapabilities';
 
@@ -92,6 +92,9 @@ import ContainerTaskDialog from './containerdialog';
 const log = logger.getLogger('web.pages.tasks.component');
 
 const TaskComponent = props => {
+  //GMP and Redux
+  const gmp = useGmp();
+
   // GraphQL Queries and Mutations
   const [modifyTask] = useModifyTask();
   const [createTask] = useCreateTask();
@@ -543,7 +546,7 @@ const TaskComponent = props => {
   };
 
   const openTaskWizard = () => {
-    const {gmp, defaultScanConfigId, defaultScannerId} = props;
+    const {defaultScanConfigId, defaultScannerId} = props;
 
     gmp.wizard.task().then(response => {
       const settings = response.data;
@@ -570,7 +573,7 @@ const TaskComponent = props => {
   };
 
   const handleSaveTaskWizard = data => {
-    const {onTaskWizardSaved, onTaskWizardError, gmp} = props;
+    const {onTaskWizardSaved, onTaskWizardError} = props;
 
     handleInteraction();
 
@@ -582,7 +585,6 @@ const TaskComponent = props => {
 
   const openAdvancedTaskWizard = () => {
     const {
-      gmp,
       timezone,
       defaultScanConfigId = FULL_AND_FAST_SCAN_CONFIG_ID,
       defaultScannerId,
@@ -627,7 +629,7 @@ const TaskComponent = props => {
   };
 
   const handleSaveAdvancedTaskWizard = data => {
-    const {gmp, onAdvancedTaskWizardSaved, onAdvancedTaskWizardError} = props;
+    const {onAdvancedTaskWizardSaved, onAdvancedTaskWizardError} = props;
 
     handleInteraction();
 
@@ -638,7 +640,7 @@ const TaskComponent = props => {
   };
 
   const openModifyTaskWizard = () => {
-    const {gmp, timezone} = props;
+    const {timezone} = props;
 
     gmp.wizard.modifyTask().then(response => {
       const settings = response.data;
@@ -670,7 +672,7 @@ const TaskComponent = props => {
   };
 
   const handleSaveModifyTaskWizard = data => {
-    const {onModifyTaskWizardSaved, onModifyTaskWizardError, gmp} = props;
+    const {onModifyTaskWizardSaved, onModifyTaskWizardError} = props;
 
     handleInteraction();
 
@@ -701,7 +703,7 @@ const TaskComponent = props => {
   };
 
   const handleReportImport = data => {
-    const {onReportImported, onReportImportError, gmp} = props;
+    const {onReportImported, onReportImportError} = props;
 
     handleInteraction();
 
@@ -1044,7 +1046,6 @@ TaskComponent.propTypes = {
   defaultSmbCredential: PropTypes.id,
   defaultSshCredential: PropTypes.id,
   defaultTargetId: PropTypes.id,
-  gmp: PropTypes.gmp.isRequired,
   isLoadingAlerts: PropTypes.bool,
   isLoadingConfigs: PropTypes.bool,
   isLoadingScanners: PropTypes.bool,
@@ -1119,7 +1120,6 @@ const mapDispatchToProp = (dispatch, {gmp}) => ({
   loadUserSettingsDefaults: () => dispatch(loadUserSettingDefaults(gmp)()),
 });
 
-export default compose(
-  withGmp,
-  connect(mapStateToProps, mapDispatchToProp),
-)(TaskComponent);
+export default compose(connect(mapStateToProps, mapDispatchToProp))(
+  TaskComponent,
+);

--- a/gsa/src/web/utils/__tests__/stateReducer.js
+++ b/gsa/src/web/utils/__tests__/stateReducer.js
@@ -1,0 +1,79 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import React, {useReducer} from 'react';
+import stateReducer from 'web/utils/stateReducer';
+import {render, screen, fireEvent} from 'web/utils/testing';
+
+const TestComponent = () => {
+  const [state, dispatch] = useReducer(stateReducer, {foo: ''});
+
+  const handleSetFoo = () => dispatch({foo: 'bar'});
+  const handleSetLorem = () => dispatch({lorem: 'ipsum'});
+  const handleSetUndef = () => dispatch();
+
+  const {foo, lorem, undef} = state;
+
+  return (
+    <div>
+      <button data-testid="set-foo" onClick={handleSetFoo} />
+      <button data-testid="set-lorem" onClick={handleSetLorem} />
+      <button data-testid="set-undef" onClick={handleSetUndef} />
+      <span data-testid="foo">{foo}</span>
+      <span data-testid="lorem">{lorem}</span>
+      <span data-testid="undef">{undef}</span>
+    </div>
+  );
+};
+
+describe('stateReducer tests', () => {
+  test('Should set correct states', async () => {
+    render(<TestComponent />);
+
+    const foo = await screen.findByTestId('foo');
+    const lorem = await screen.findByTestId('lorem');
+    const undef = await screen.findByTestId('undef');
+
+    expect(foo).toHaveTextContent('');
+    expect(lorem).toHaveTextContent('');
+    expect(undef).toHaveTextContent('');
+
+    const setFoo = await screen.findByTestId('set-foo');
+    fireEvent.click(setFoo);
+
+    expect(foo).toHaveTextContent('bar');
+    expect(lorem).toHaveTextContent('');
+    expect(undef).toHaveTextContent('');
+
+    const setLorem = await screen.findByTestId('set-lorem');
+    fireEvent.click(setLorem);
+
+    expect(foo).toHaveTextContent('bar');
+    expect(lorem).toHaveTextContent('ipsum');
+    expect(undef).toHaveTextContent('');
+
+    const setUndef = await screen.findByTestId('set-undef');
+    fireEvent.click(setUndef);
+
+    // Should do nothing
+    expect(foo).toHaveTextContent('bar');
+    expect(lorem).toHaveTextContent('ipsum');
+    expect(undef).toHaveTextContent('');
+  });
+});

--- a/gsa/src/web/utils/__tests__/stateReducer.js
+++ b/gsa/src/web/utils/__tests__/stateReducer.js
@@ -18,15 +18,15 @@
  */
 
 import React, {useReducer} from 'react';
-import stateReducer from 'web/utils/stateReducer';
+import stateReducer, {updateState} from 'web/utils/stateReducer';
 import {render, screen, fireEvent} from 'web/utils/testing';
 
 const TestComponent = () => {
   const [state, dispatch] = useReducer(stateReducer, {foo: ''});
 
-  const handleSetFoo = () => dispatch({foo: 'bar'});
-  const handleSetLorem = () => dispatch({lorem: 'ipsum'});
-  const handleSetUndef = () => dispatch();
+  const handleSetFoo = () => dispatch(updateState({foo: 'bar'}));
+  const handleSetLorem = () => dispatch(updateState({lorem: 'ipsum'}));
+  const handleSetUndef = () => dispatch(updateState());
 
   const {foo, lorem, undef} = state;
 

--- a/gsa/src/web/utils/__tests__/stateReducer.js
+++ b/gsa/src/web/utils/__tests__/stateReducer.js
@@ -1,20 +1,19 @@
 /* Copyright (C) 2020 Greenbone Networks GmbH
  *
- * SPDX-License-Identifier: GPL-2.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
  * of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 import React, {useReducer} from 'react';

--- a/gsa/src/web/utils/__tests__/stateReducer.js
+++ b/gsa/src/web/utils/__tests__/stateReducer.js
@@ -21,6 +21,16 @@ import React, {useReducer} from 'react';
 import stateReducer, {updateState} from 'web/utils/stateReducer';
 import {render, screen, fireEvent} from 'web/utils/testing';
 
+describe('updateState tests', () => {
+  test('Should return correct action object', () => {
+    expect(updateState()).toEqual({type: 'setState', newState: {}});
+    expect(updateState({foo: 'bar'})).toEqual({
+      type: 'setState',
+      newState: {foo: 'bar'},
+    });
+  });
+});
+
 const TestComponent = () => {
   const [state, dispatch] = useReducer(stateReducer, {foo: ''});
 

--- a/gsa/src/web/utils/stateReducer.js
+++ b/gsa/src/web/utils/stateReducer.js
@@ -17,17 +17,11 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-const stateReducer = (state, action) => {
-  switch (action.type) {
-    case 'setState':
-      const {newState} = action;
-      return {
-        ...state,
-        ...newState,
-      };
-    default:
-      return state;
-  }
+const stateReducer = (state, newState) => {
+  return {
+    ...state,
+    ...newState,
+  };
 };
 
 export default stateReducer;

--- a/gsa/src/web/utils/stateReducer.js
+++ b/gsa/src/web/utils/stateReducer.js
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-const stateReducer = (state, newState) => {
+const stateReducer = (state, newState = {}) => {
   return {
     ...state,
     ...newState,

--- a/gsa/src/web/utils/stateReducer.js
+++ b/gsa/src/web/utils/stateReducer.js
@@ -17,11 +17,19 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-const stateReducer = (state, newState = {}) => {
-  return {
-    ...state,
-    ...newState,
-  };
+export const updateState = (newState = {}) => ({type: 'setState', newState});
+
+const stateReducer = (state, action) => {
+  switch (action.type) {
+    case 'setState':
+      const {newState} = action;
+      return {
+        ...state,
+        ...newState,
+      };
+    default:
+      return state;
+  }
 };
 
 export default stateReducer;

--- a/gsa/src/web/utils/stateReducer.js
+++ b/gsa/src/web/utils/stateReducer.js
@@ -1,20 +1,19 @@
 /* Copyright (C) 2020 Greenbone Networks GmbH
  *
- * SPDX-License-Identifier: GPL-2.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  *
  * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
  * of the License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 export const updateState = (newState = {}) => ({type: 'setState', newState});


### PR DESCRIPTION
**What**:

This PR refactors the TaskComponent to unify the state object into one with `useReducer`. It also refactors `stateReducer` to reduce boilerplate, as this function is mostly for replacing `this.setState` for setting large states and will never have any other usecase, I thought all of the boilerplate e.g. `dispatch({type: 'setState', newState: {...}})` is unnecessary. Now we have an action creator `updateState` and pure state updates (with no other logic) can be called with `dispatch(updateState({stateA: 'foo', stateB: 'bar'}))` etc. Adds a test suite for `stateReducer`.

Also, adjusted other components using `stateReducer` to the new syntax. Composed certain (not all. See editnvtdetailsdialog for example of reducer that doesn't need stateReducer logic) custom reducers with stateReducer.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

`TaskComponent` was implemented in the early days of the hyperion branch and thus contains some outdated syntax and messy code (like using multiple `useState`s for visibility flags, a separate `dialogState`, etc.). This PR brings the code in line with later refactors for hyperion.

<!-- Why are these changes necessary? -->

**How**:

Manual and jest tests.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
