### PR TITLE
Remove secinfo filter from user settings dialog and elsewhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Only show schedule options in advanced and modify task wizard if user has correct permissions [#2472](https://github.com/greenbone/gsa/pull/2472)
 
 ### Removed
+- Remove secinfo filter from user settings dialog and elsewhere [#2495](https://github.com/greenbone/gsa/pull/2495)
 - Removed export/download for report formats [#2427](https://github.com/greenbone/gsa/pull/2427)
 
 [20.8.1]: https://github.com/greenbone/gsa/compare/v20.8.0...gsa-20.08

--- a/gsa/public/locales/gsa-de.json
+++ b/gsa/public/locales/gsa-de.json
@@ -1438,7 +1438,6 @@
   "Search by content": "Suche nach Inhalt",
   "SecInfo": "Sicherheitsinfos",
   "SecInfo Displays": "SecInfo-Anzeigen",
-  "SecInfo Filter": "Alle-Sicherheitsinfos-Filter",
   "Secret Key": "Geheimer Schlüssel",
   "Security note: The SMB protocol does not offer a fingerprint to establish complete mutual trust. Thus a man-in-the-middle attack can not be fully prevented.": "Sicherheitshinweis: Das SMB-Protokoll bietet keinen Fingerprint an, um komplettes gegenseitiges Vertrauen herzustellen. Ein Man-in-the-Middle-Angriff kann somit nicht völlig ausgeschlossen werden.",
   "Select": "Auswählen",

--- a/gsa/src/web/pages/usersettings/dialog.js
+++ b/gsa/src/web/pages/usersettings/dialog.js
@@ -115,7 +115,6 @@ let UserSettingsDialog = ({
   ovalFilter,
   certBundFilter,
   dfnCertFilter,
-  secInfoFilter,
   onClose,
   onSave,
   capabilities,
@@ -177,7 +176,6 @@ let UserSettingsDialog = ({
     ovalFilter,
     certBundFilter,
     dfnCertFilter,
-    secInfoFilter,
   };
 
   const validationSchema = {
@@ -297,7 +295,6 @@ let UserSettingsDialog = ({
                     ovalFilter={values.ovalFilter}
                     certBundFilter={values.certBundFilter}
                     dfnCertFilter={values.dfnCertFilter}
-                    secInfoFilter={values.secInfoFilter}
                     filters={filters}
                     onChange={onValueChange}
                   />
@@ -367,7 +364,6 @@ UserSettingsDialog.propTypes = {
   scannersFilter: PropTypes.string,
   schedules: PropTypes.array,
   schedulesFilter: PropTypes.string,
-  secInfoFilter: PropTypes.string,
   severityClass: PropTypes.string,
   tagsFilter: PropTypes.string,
   targets: PropTypes.array,

--- a/gsa/src/web/pages/usersettings/filterpart.js
+++ b/gsa/src/web/pages/usersettings/filterpart.js
@@ -61,7 +61,6 @@ const FilterPart = ({
   ovalFilter,
   certBundFilter,
   dfnCertFilter,
-  secInfoFilter,
   filters = [],
   onChange,
 }) => {
@@ -355,14 +354,6 @@ const FilterPart = ({
           onChange={onChange}
         />
       </FormGroup>
-      <FormGroup title={_('SecInfo Filter')} titleSize="3">
-        <Select
-          name="secInfoFilter"
-          value={secInfoFilter}
-          items={renderSelectItems(filterFilters(filters, 'info'), UNSET_VALUE)}
-          onChange={onChange}
-        />
-      </FormGroup>
     </React.Fragment>
   );
 };
@@ -392,7 +383,6 @@ FilterPart.propTypes = {
   rolesFilter: PropTypes.string,
   scannersFilter: PropTypes.string,
   schedulesFilter: PropTypes.string,
-  secInfoFilter: PropTypes.string,
   tagsFilter: PropTypes.string,
   targetsFilter: PropTypes.string,
   tasksFilter: PropTypes.string,


### PR DESCRIPTION
**What**:

Remove the "Secinfo Filter" form part form user settings dialog and remove instances of the `secInfoFilter` variable. Also remove translations for that form field.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

Because we no longer have all secinfo and it's confusing to leave that in the dialog.

**How**:

Tests are still passing and it is visually verified to be gone.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
