### PR TITLE
Fix tls certificate download 20.08

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use <predefined> to disable feed object editing and filter creation on feed status page [#2398](https://github.com/greenbone/gsa/pull/2398)
 
 ### Fixed
+- Fixed TLS certificate download for users with permissions [#2496](https://github.com/greenbone/gsa/pull/2496)
 - Fixed form validation error tooltips [#2478](https://github.com/greenbone/gsa/pull/2478)
 - Only show schedule options in advanced and modify task wizard if user has correct permissions [#2472](https://github.com/greenbone/gsa/pull/2472)
 

--- a/gsa/src/gmp/models/__tests__/tlscertificate.js
+++ b/gsa/src/gmp/models/__tests__/tlscertificate.js
@@ -285,6 +285,12 @@ describe('TlsCertificate Model tests', () => {
               },
             },
           },
+          {
+            origin: {
+              origin_id: 'ID789',
+              origin_type: 'Report',
+            },
+          },
         ],
       },
     };
@@ -296,6 +302,9 @@ describe('TlsCertificate Model tests', () => {
       {
         id: 'ID456',
         timestamp: '2019-10-10T11:09:23.022Z',
+      },
+      {
+        id: 'ID789',
       },
     ];
     const tlsCertificate = TlsCertificate.fromElement(element);

--- a/gsa/src/gmp/models/tlscertificate.js
+++ b/gsa/src/gmp/models/tlscertificate.js
@@ -108,7 +108,7 @@ class TlsCertificate extends Model {
       const originObject = JSON.parse(report);
       return {
         id: originObject.origin_id,
-        timestamp: originObject.report.date,
+        timestamp: originObject?.report?.date,
       };
     });
     ret.sourceHosts = [...sourceHosts].map(host => {


### PR DESCRIPTION
**What**:

The TLS certificates model needs to be able to parse the certificate without errors even if the report sub element is not defined.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

If a user tries to download a TLS certificate that he is not the owner of it will cause an error in gsa. This happens because the report sub element is missing from the get_tls_certificates response. gsa needs to be able to deal with this case.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Tested in gsa. There is no error any more and the TLS certificate is downloaded successfully. The tests for the TLS certificate model have also been adjusted.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
