### PR TITLE
Allow to delete process without having had edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use <predefined> to disable feed object editing and filter creation on feed status page [#2398](https://github.com/greenbone/gsa/pull/2398)
 
 ### Fixed
+- Allow to delete processes without having had edges in BPM [#2507](https://github.com/greenbone/gsa/pull/2507)
 - Fixed TLS certificate download for users with permissions [#2496](https://github.com/greenbone/gsa/pull/2496)
 - Fixed form validation error tooltips [#2478](https://github.com/greenbone/gsa/pull/2478)
 - Only show schedule options in advanced and modify task wizard if user has correct permissions [#2472](https://github.com/greenbone/gsa/pull/2472)

--- a/gsa/src/web/components/processmap/processmap.js
+++ b/gsa/src/web/components/processmap/processmap.js
@@ -296,7 +296,7 @@ class ProcessMap extends React.Component {
   handleDeleteElement() {
     if (isDefined(this.selectedElement)) {
       const {id} = this.selectedElement;
-      const {processes, edges} = this.state;
+      const {processes, edges = {}} = this.state;
       if (isDefined(id)) {
         if (this.selectedElement && this.selectedElement.type === 'edge') {
           delete edges[id];


### PR DESCRIPTION
**What**:
For a new process map it was not possible to delete a process without having had an edge created first. BPM crashed in that case. The crash now no longer happens.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
To fix above mentioned bug
<!-- Why are these changes necessary? -->

**How**:
Created a new user and go to BPM. Created a process and _no_ edge. Deleted that process and saw BPM not crash.
An automated test was not written for this functionality, because it would only be possible to get an very indirect test _at best_.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
