### PR TITLE
Replace deprecated sys_siglist with strsignal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed TLS certificate download for users with permissions [#2496](https://github.com/greenbone/gsa/pull/2496)
 - Fixed form validation error tooltips [#2478](https://github.com/greenbone/gsa/pull/2478)
 - Only show schedule options in advanced and modify task wizard if user has correct permissions [#2472](https://github.com/greenbone/gsa/pull/2472)
+- Replace deprecated sys_siglist with strsignal [#2513](https://github.com/greenbone/gsa/pull/2513)
 
 ### Removed
 - Remove secinfo filter from user settings dialog and elsewhere [#2495](https://github.com/greenbone/gsa/pull/2495)

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -3283,7 +3283,7 @@ main (int argc, char **argv)
     {
       if (termination_signal)
         {
-          g_debug ("Received %s signal.\n", sys_siglist[termination_signal]);
+          g_debug ("Received %s signal.\n", strsignal (termination_signal));
           gsad_cleanup ();
           /* Raise signal again, to exit with the correct return value. */
           signal (termination_signal, SIG_DFL);


### PR DESCRIPTION
Required to work with glibc >= 2.32.

https://sourceware.org/pipermail/libc-announce/2020/000029.html

  The deprecated arrays sys_siglist, _sys_siglist, and sys_sigabbrev
  are no longer available to newly linked binaries, and their declarations
  have been removed from <string.h>. They are exported solely as
  compatibility symbols to support old binaries. All programs should use
  strsignal instead.

**What**: Same as https://github.com/greenbone/gvmd/pull/1280

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**: Same as https://github.com/greenbone/gvmd/pull/1280

<!-- Why are these changes necessary? -->

**How**: Same as https://github.com/greenbone/gvmd/pull/1280

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
