### PR TITLE
change dependabot target branch to 21.04

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,31 +1,32 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/gsa"
-  schedule:
-    interval: weekly
-    time: "04:00"
-  open-pull-requests-limit: 10
-  versioning-strategy: increase
-  ignore:
-  - dependency-name: husky
-    versions:
-    - "> 2.7.0"
-  - dependency-name: lint-staged
-    versions:
-    - "> 8.2.1"
-  - dependency-name: react-datepicker
-    versions:
-    - "> 1.8.0"
-  - dependency-name: "@testing-library/react"
-    versions:
-    - ">= 10.a, < 11"
-  - dependency-name: "@vx/axis"
-    versions:
-    - "> 0.0.183"
-  - dependency-name: "@vx/gradient"
-    versions:
-    - "> 0.0.183"
-  - dependency-name: "@vx/shape"
-    versions:
-    - "> 0.0.179"
+  - package-ecosystem: npm
+    directory: "/gsa"
+    schedule:
+      interval: weekly
+      time: "04:00"
+    target-branch: "gsa-21.04"
+    open-pull-requests-limit: 10
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: husky
+        versions:
+          - "> 2.7.0"
+      - dependency-name: lint-staged
+        versions:
+          - "> 8.2.1"
+      - dependency-name: react-datepicker
+        versions:
+          - "> 1.8.0"
+      - dependency-name: "@testing-library/react"
+        versions:
+          - ">= 10.a, < 11"
+      - dependency-name: "@vx/axis"
+        versions:
+          - "> 0.0.183"
+      - dependency-name: "@vx/gradient"
+        versions:
+          - "> 0.0.183"
+      - dependency-name: "@vx/shape"
+        versions:
+          - "> 0.0.179"


### PR DESCRIPTION
**What**:

Change target branch for dependabot to 21.04.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

21.04 needs almost the same dependency updates as master. Since we cannot use dependabot for 2 branches at once, moving it to 21.04 and then later merging the changes into master seems to be the solution that will cost the least time and effort.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
