### PR TITLE
Implement get_alerts on alerts listpage via graphql, and implement parseObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [21.04] - unreleased
 
 ### Added
+- Implemented parseObject for alert model implement [#2552](https://github.com/greenbone/gsa/pull/2552)
 - Added getNotes query [#2485](https://github.com/greenbone/gsa/pull/2485)
 - Create and modify schedule from graphql [#2477](https://github.com/greenbone/gsa/pull/2477)
 - Support more enum types for create alert [#2462](https://github.com/greenbone/gsa/pull/2462)
@@ -16,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added missing fields for getScanners query and parseObject() for scanner model [#2301](https://github.com/greenbone/gsa/pull/2301)
 
 ### Changed
+- Implement get_alerts on alerts listpage via graphql [#2552](https://github.com/greenbone/gsa/pull/2552)
 - Implement modify alert via graphql [#2549](https://github.com/greenbone/gsa/pull/2549)
 - Implement advanced task wizard via graphql [#2523](https://github.com/greenbone/gsa/pull/2523)
 - Implement modify task wizard via graphql [#2514](https://github.com/greenbone/gsa/pull/2514)

--- a/gsa/src/gmp/models/__tests__/alert.js
+++ b/gsa/src/gmp/models/__tests__/alert.js
@@ -75,7 +75,16 @@ describe('Alert Model parseObject tests', () => {
 
   // event/condition/method data will not have subvalues from hyperion, therefore this test is removed.
 
-  // alert.filter does not exist in hyperion
+  test('should return given filter as instance of filter model', () => {
+    const obj = {filter: {id: '1', name: 'foo', trash: 0}};
+    const alert = Alert.fromObject(obj);
+
+    expect(alert.filter).toBeInstanceOf(Model);
+    expect(alert.filter.entityType).toEqual('filter');
+    expect(alert.filter.id).toEqual('1');
+    expect(alert.filter.name).toEqual('foo');
+    expect(alert.filter.trash).toEqual(0);
+  });
 
   test('should return given tasks as array of instances of task model', () => {
     const obj = {

--- a/gsa/src/gmp/models/__tests__/alert.js
+++ b/gsa/src/gmp/models/__tests__/alert.js
@@ -32,7 +32,114 @@ import {testModel} from 'gmp/models/testing';
 
 testModel(Alert, 'alert', {testIsActive: false});
 
-describe('Alert Model tests', () => {
+describe('Alert Model parseObject tests', () => {
+  test('should parse condition, event, and method', () => {
+    const obj = {
+      condition: {
+        type: 'text',
+      },
+      event: {
+        type: 'lorem',
+        data: {
+          value: 'ipsum',
+          name: 'dolor',
+        },
+      },
+      method: {
+        type: 'foo',
+        data: {
+          value: '42',
+          name: 'bar',
+        },
+      },
+    };
+    const alert = Alert.fromObject(obj);
+
+    expect(alert.condition).toEqual({
+      data: {},
+      type: 'text',
+    });
+    expect(alert.event).toEqual({
+      data: {
+        dolor: {value: 'ipsum'},
+      },
+      type: 'lorem',
+    });
+    expect(alert.method).toEqual({
+      data: {
+        bar: {value: '42'},
+      },
+      type: 'foo',
+    });
+  });
+
+  // event/condition/method data will not have subvalues from hyperion, therefore this test is removed.
+
+  // alert.filter does not exist in hyperion
+
+  test('should return given tasks as array of instances of task model', () => {
+    const obj = {
+      tasks: [{id: 't1'}],
+    };
+    const alert = Alert.fromObject(obj);
+
+    expect(alert.tasks.length).toEqual(1);
+
+    const [task] = alert.tasks;
+    expect(task).toBeInstanceOf(Model);
+    expect(task.entityType).toEqual('task');
+    expect(task.id).toEqual('t1');
+  });
+
+  test('should return empty array if no tasks are given', () => {
+    const alert = Alert.fromObject({});
+
+    expect(alert.tasks).toEqual([]);
+  });
+
+  test('should parse report format ids', () => {
+    const obj = {
+      method: {
+        data: {
+          value: ['123', '456', '789'],
+          name: 'report_formats',
+        },
+      },
+    };
+    const alert = Alert.fromObject(obj);
+
+    expect(alert.method.data.report_formats.value).toEqual([
+      '123',
+      '456',
+      '789',
+    ]);
+  });
+
+  test('should return undefined if no report format ids are given', () => {
+    const alert = Alert.fromObject({
+      method: {
+        data: {
+          value: 'bar',
+          name: 'foo',
+        },
+      },
+    });
+
+    expect(alert.method.data.report_formats).toBeUndefined();
+  });
+
+  // notice is already string from Hyperion
+
+  test('isActive() should return correct true/false', () => {
+    const alert1 = Alert.fromObject({active: '0'});
+    const alert2 = Alert.fromObject({active: '1'});
+
+    expect(alert1.isActive()).toBe(false);
+    expect(alert2.isActive()).toBe(true);
+  });
+});
+
+describe('Alert Model parseElement tests', () => {
   test('should parse condition, event, and method', () => {
     const elem = {
       condition: {

--- a/gsa/src/gmp/models/alert.js
+++ b/gsa/src/gmp/models/alert.js
@@ -24,6 +24,7 @@ import {parseYesNo, YES_VALUE} from '../parser.js';
 
 import Model, {parseModelFromElement} from '../model.js';
 import Task from './task';
+import Filter from './filter';
 
 export const EVENT_TYPE_UPDATED_SECINFO = 'Updated SecInfo arrived';
 export const EVENT_TYPE_NEW_SECINFO = 'New SecInfo arrived';
@@ -122,6 +123,10 @@ class Alert extends Model {
       ret.tasks = map(object.tasks, task => Task.fromObject(task));
     } else {
       ret.tasks = [];
+    }
+
+    if (hasValue(object.filter)) {
+      ret.filter = Filter.fromObject(object.filter);
     }
 
     return ret;

--- a/gsa/src/gmp/models/alert.js
+++ b/gsa/src/gmp/models/alert.js
@@ -94,7 +94,7 @@ class Alert extends Model {
   static entityType = 'alert';
 
   static parseObject(object) {
-    const ret = super.parseElement(object);
+    const ret = super.parseObject(object);
 
     const types = ['condition', 'method', 'event'];
 

--- a/gsa/src/gmp/models/alert.js
+++ b/gsa/src/gmp/models/alert.js
@@ -123,6 +123,7 @@ class Alert extends Model {
     } else {
       ret.tasks = [];
     }
+
     return ret;
   }
 

--- a/gsa/src/gmp/models/alert.js
+++ b/gsa/src/gmp/models/alert.js
@@ -16,13 +16,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {isDefined, isObject} from '../utils/identity';
+import {hasValue, isDefined, isObject} from '../utils/identity';
 import {isEmpty} from '../utils/string';
 import {forEach, map} from '../utils/array';
 
 import {parseYesNo, YES_VALUE} from '../parser.js';
 
 import Model, {parseModelFromElement} from '../model.js';
+import Task from './task';
 
 export const EVENT_TYPE_UPDATED_SECINFO = 'Updated SecInfo arrived';
 export const EVENT_TYPE_NEW_SECINFO = 'New SecInfo arrived';
@@ -91,6 +92,39 @@ const create_values = data => {
 
 class Alert extends Model {
   static entityType = 'alert';
+
+  static parseObject(object) {
+    const ret = super.parseElement(object);
+
+    const types = ['condition', 'method', 'event'];
+
+    for (const type of types) {
+      if (isObject(ret[type])) {
+        const data = {};
+
+        forEach(ret[type].data, value => {
+          data[value.name] = {value: value.value};
+        });
+
+        ret[type] = {
+          type: ret[type].type,
+          data,
+        };
+      } else {
+        ret[type] = {
+          type: ret[type],
+          data: {},
+        };
+      }
+    }
+
+    if (hasValue(object.tasks)) {
+      ret.tasks = map(object.tasks, task => Task.fromObject(task));
+    } else {
+      ret.tasks = [];
+    }
+    return ret;
+  }
 
   static parseElement(element) {
     const ret = super.parseElement(element);

--- a/gsa/src/web/entity/icon/observericon.js
+++ b/gsa/src/web/entity/icon/observericon.js
@@ -26,9 +26,11 @@ import PropTypes from 'web/utils/proptypes';
 
 import ViewOtherIcon from 'web/components/icon/viewothericon';
 
+const hyperionEntityTypes = ['task', 'alert'];
+
 const ObserverIcon = ({entity, userName, displayName = _('Entity')}) => {
   let owner;
-  if (entity.entityType === 'task') {
+  if (hyperionEntityTypes.includes(entity.entityType)) {
     owner = hasValue(entity.owner) ? entity.owner : undefined;
   } else {
     owner = isDefined(entity.owner) ? entity.owner.name : undefined;

--- a/gsa/src/web/graphql/__mocks__/alerts.js
+++ b/gsa/src/web/graphql/__mocks__/alerts.js
@@ -67,6 +67,7 @@ export const alert2 = deepFreeze({
   inUse: true,
   writable: false,
   active: true,
+  comment: 'lorem',
   creationTime: '2020-08-06T11:30:41+00:00',
   modificationTime: '2020-08-07T09:26:05+00:00',
   owner: 'admin',

--- a/gsa/src/web/graphql/__mocks__/alerts.js
+++ b/gsa/src/web/graphql/__mocks__/alerts.js
@@ -30,6 +30,11 @@ export const alert1 = deepFreeze({
   creationTime: '2020-08-06T11:34:15+00:00',
   modificationTime: '2020-08-06T11:34:15+00:00',
   owner: 'admin',
+  filter: {
+    trash: 0,
+    name: 'resultFilter',
+    id: '75c8145d-b00c-408f-8907-6664d5ce6108',
+  },
   method: {
     type: 'Alemba vFire',
     data: [
@@ -71,6 +76,7 @@ export const alert2 = deepFreeze({
   creationTime: '2020-08-06T11:30:41+00:00',
   modificationTime: '2020-08-07T09:26:05+00:00',
   owner: 'admin',
+  filter: null,
   method: {
     type: 'Email',
     data: [

--- a/gsa/src/web/graphql/__mocks__/alerts.js
+++ b/gsa/src/web/graphql/__mocks__/alerts.js
@@ -20,12 +20,13 @@ import {deepFreeze, createGenericQueryMock} from 'web/utils/testing';
 
 import {GET_ALERTS, CREATE_ALERT, MODIFY_ALERT} from '../alerts';
 
-const alert1 = deepFreeze({
+export const alert1 = deepFreeze({
   id: '1',
   name: 'alert 1',
-  inUse: true,
+  inUse: false,
   writable: true,
   active: true,
+  comment: 'bar',
   creationTime: '2020-08-06T11:34:15+00:00',
   modificationTime: '2020-08-06T11:34:15+00:00',
   owner: 'admin',
@@ -60,7 +61,7 @@ const alert1 = deepFreeze({
   ],
 });
 
-const alert2 = deepFreeze({
+export const alert2 = deepFreeze({
   id: '2',
   name: 'alert 2',
   inUse: true,

--- a/gsa/src/web/graphql/__mocks__/alerts.js
+++ b/gsa/src/web/graphql/__mocks__/alerts.js
@@ -118,8 +118,8 @@ const mockAlerts = {
   },
 };
 
-export const createGetAlertsQueryMock = () =>
-  createGenericQueryMock(GET_ALERTS, {alerts: mockAlerts});
+export const createGetAlertsQueryMock = variables =>
+  createGenericQueryMock(GET_ALERTS, {alerts: mockAlerts}, variables);
 
 const createAlertResult = {
   createAlert: {

--- a/gsa/src/web/graphql/alerts.js
+++ b/gsa/src/web/graphql/alerts.js
@@ -51,6 +51,11 @@ export const GET_ALERTS = gql`
           owner
           creationTime
           modificationTime
+          filter {
+            trash
+            name
+            id
+          }
           tasks {
             id
             name

--- a/gsa/src/web/graphql/alerts.js
+++ b/gsa/src/web/graphql/alerts.js
@@ -47,6 +47,7 @@ export const GET_ALERTS = gql`
           id
           inUse
           writable
+          comment
           owner
           creationTime
           modificationTime

--- a/gsa/src/web/pages/alerts/__tests__/listpage.js
+++ b/gsa/src/web/pages/alerts/__tests__/listpage.js
@@ -166,20 +166,23 @@ describe('Alert listpage tests', () => {
     const row = baseElement.querySelectorAll('tr');
 
     expect(row[1]).toHaveTextContent('alert 1');
-    // somehow querying comment will cause things to fail
-    // expect(row[1]).toHaveTextContent('(bar)');
+    expect(row[1]).toHaveTextContent('(bar)');
     expect(row[1]).toHaveTextContent('Task run status changed to Done');
     expect(row[1]).toHaveTextContent('Always');
     expect(row[1]).toHaveTextContent('Alemba vFire');
 
+    expect(row[1]).toHaveTextContent('Yes');
+
     expect(row[2]).toHaveTextContent('alert 2');
+    expect(row[2]).toHaveTextContent('(lorem)');
     expect(row[2]).toHaveTextContent('Updated NVT arrived');
     expect(row[2]).toHaveTextContent('Filter matches at least 3 NVTs');
     expect(row[2]).toHaveTextContent('Email to foo@bar.com');
 
+    expect(row[2]).toHaveTextContent('Yes');
+
     // Hyperion currently does not support filter
     // expect(row[1]).toHaveTextContent('report results filter');
-    expect(row[1]).toHaveTextContent('Yes');
 
     expect(icons[13]).toHaveAttribute('title', 'Move Alert to trashcan');
     expect(icons[14]).toHaveAttribute('title', 'Edit Alert');

--- a/gsa/src/web/pages/alerts/__tests__/listpage.js
+++ b/gsa/src/web/pages/alerts/__tests__/listpage.js
@@ -182,7 +182,7 @@ describe('Alert listpage tests', () => {
     expect(row[2]).toHaveTextContent('Yes');
 
     // Hyperion currently does not support filter
-    // expect(row[1]).toHaveTextContent('report results filter');
+    expect(row[1]).toHaveTextContent('report results filter');
 
     expect(icons[13]).toHaveAttribute('title', 'Move Alert to trashcan');
     expect(icons[14]).toHaveAttribute('title', 'Edit Alert');

--- a/gsa/src/web/pages/alerts/__tests__/listpage.js
+++ b/gsa/src/web/pages/alerts/__tests__/listpage.js
@@ -165,6 +165,8 @@ describe('Alert listpage tests', () => {
 
     const row = baseElement.querySelectorAll('tr');
 
+    expect(row[1]).toHaveTextContent('resultFilter');
+
     expect(row[1]).toHaveTextContent('alert 1');
     expect(row[1]).toHaveTextContent('(bar)');
     expect(row[1]).toHaveTextContent('Task run status changed to Done');
@@ -180,9 +182,6 @@ describe('Alert listpage tests', () => {
     expect(row[2]).toHaveTextContent('Email to foo@bar.com');
 
     expect(row[2]).toHaveTextContent('Yes');
-
-    // Hyperion currently does not support filter
-    expect(row[1]).toHaveTextContent('report results filter');
 
     expect(icons[13]).toHaveAttribute('title', 'Move Alert to trashcan');
     expect(icons[14]).toHaveAttribute('title', 'Edit Alert');

--- a/gsa/src/web/pages/alerts/__tests__/listpage.js
+++ b/gsa/src/web/pages/alerts/__tests__/listpage.js
@@ -172,6 +172,11 @@ describe('Alert listpage tests', () => {
     expect(row[1]).toHaveTextContent('Always');
     expect(row[1]).toHaveTextContent('Alemba vFire');
 
+    expect(row[2]).toHaveTextContent('alert 2');
+    expect(row[2]).toHaveTextContent('Updated NVT arrived');
+    expect(row[2]).toHaveTextContent('Filter matches at least 3 NVTs');
+    expect(row[2]).toHaveTextContent('Email to foo@bar.com');
+
     // Hyperion currently does not support filter
     // expect(row[1]).toHaveTextContent('report results filter');
     expect(row[1]).toHaveTextContent('Yes');

--- a/gsa/src/web/pages/alerts/__tests__/listpage.js
+++ b/gsa/src/web/pages/alerts/__tests__/listpage.js
@@ -25,6 +25,7 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 import Filter from 'gmp/models/filter';
 import Alert from 'gmp/models/alert';
 
+import {createGetAlertsQueryMock} from 'web/graphql/__mocks__/alerts';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 
 import {entitiesLoadingActions} from 'web/store/entities/alerts';
@@ -100,7 +101,7 @@ const renewSession = jest.fn().mockResolvedValue({
 });
 
 describe('Alert listpage tests', () => {
-  test('should render full alert listpage', async () => {
+  test.only('should render full alert listpage', async () => {
     const gmp = {
       alerts: {
         get: getAlerts,
@@ -112,11 +113,17 @@ describe('Alert listpage tests', () => {
       user: {currentSettings},
     };
 
+    const [mock, resultFunc] = createGetAlertsQueryMock({
+      filterString: 'foo=bar rows=2',
+      first: 2,
+    });
+
     const {render, store} = rendererWith({
       gmp,
       capabilities: true,
       store: true,
       router: true,
+      queryMocks: [mock],
     });
 
     store.dispatch(setTimezone('CET'));
@@ -144,6 +151,8 @@ describe('Alert listpage tests', () => {
     const {baseElement} = render(<AlertPage />);
 
     await wait();
+
+    expect(resultFunc).toHaveBeenCalled();
 
     const icons = screen.getAllByTestId('svg-icon');
     const inputs = baseElement.querySelectorAll('input');
@@ -176,7 +185,7 @@ describe('Alert listpage tests', () => {
 
     const row = baseElement.querySelectorAll('tr');
 
-    expect(row[1]).toHaveTextContent('foo');
+    expect(row[1]).toHaveTextContent('alert 1');
     expect(row[1]).toHaveTextContent('(bar)');
     expect(row[1]).toHaveTextContent('Task run status changed to Done');
     expect(row[1]).toHaveTextContent('Always');

--- a/gsa/src/web/pages/alerts/component.js
+++ b/gsa/src/web/pages/alerts/component.js
@@ -545,8 +545,8 @@ const AlertComponent = ({
               name: alert.name,
               comment: alert.comment,
               filters,
-              filter_id: isDefined(alert.filter) ? alert.filter.id : undefined,
-              composerFilterId: isDefined(alert.filter)
+              filter_id: hasValue(alert.filter) ? alert.filter.id : undefined,
+              composerFilterId: hasValue(alert.filter)
                 ? alert.filter.id
                 : undefined,
               composerIncludeNotes: getValue(

--- a/gsa/src/web/pages/alerts/listpage.js
+++ b/gsa/src/web/pages/alerts/listpage.js
@@ -87,7 +87,7 @@ const AlertsPage = ({
   // Task list state variables and methods
   const [
     getAlerts,
-    {counts, alerts, error, loading: isLoading, refetch, called, pageInfo},
+    {counts, alerts, error, loading: isLoading, refetch, called},
   ] = useLazyGetAlerts();
 
   // Side effects

--- a/gsa/src/web/pages/alerts/listpage.js
+++ b/gsa/src/web/pages/alerts/listpage.js
@@ -84,7 +84,7 @@ const AlertsPage = ({
 }) => {
   const [filter, isLoadingFilter] = usePageFilter('alert');
 
-  // Task list state variables and methods
+  // Alert list state variables and methods
   const [
     getAlerts,
     {counts, alerts, error, loading: isLoading, refetch, called},
@@ -92,7 +92,7 @@ const AlertsPage = ({
 
   // Side effects
   useEffect(() => {
-    // load tasks initially after the filter is resolved
+    // load alerts initially after the filter is resolved
     if (!isLoadingFilter && hasValue(filter) && !called) {
       getAlerts({
         filterString: filter.toFilterString(),

--- a/gsa/src/web/pages/alerts/listpage.js
+++ b/gsa/src/web/pages/alerts/listpage.js
@@ -45,10 +45,10 @@ import {
   loadEntities,
   selector as entitiesSelector,
 } from 'web/store/entities/alerts';
+import usePageFilter from 'web/utils/usePageFilter.js';
 
 import AlertComponent from './component.js';
 import AlertTable, {SORT_FIELDS} from './table.js';
-import usePageFilter from 'web/utils/usePageFilter.js';
 
 export const ToolBarIcons = withCapabilities(
   ({capabilities, onAlertCreateClick}) => (

--- a/gsa/src/web/pages/alerts/row.js
+++ b/gsa/src/web/pages/alerts/row.js
@@ -19,7 +19,7 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
+import {hasValue} from 'gmp/utils/identity';
 
 import ExportIcon from 'web/components/icon/exporticon';
 import StartIcon from 'web/components/icon/starticon';
@@ -100,7 +100,7 @@ Actions.propTypes = {
 };
 
 const render_filter = (filter, caps, links = true) => {
-  if (!isDefined(filter)) {
+  if (!hasValue(filter)) {
     return null;
   }
 


### PR DESCRIPTION
**What**:

Convert alerts listpage to use graphql get_alerts and implement parseObject for alerts.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

Manual and unit testing.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
