### PR TITLE
Change TrashIcon to DeleteIcon on host detailspage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added option for "Start Task" event upon "New SecInfo arrived" condition in alerts dialog [#2418](https://github.com/greenbone/gsa/pull/2418)
 
 ### Changed
+- Changed trash icon to delete icon on host detailspage [#2565](https://github.com/greenbone/gsa/pull/2565)
 - Change tooltip of override icon in result details [#2467](https://github.com/greenbone/gsa/pull/2467)
 - For edit config/policy dialog, only send name and comment if config or policy is in use, and add in use notification [#2463](https://github.com/greenbone/gsa/pull/2463)
 - Changed visual appearance of compliance status bar [#2457](https://github.com/greenbone/gsa/pull/2457)

--- a/gsa/src/web/pages/hosts/detailspage.js
+++ b/gsa/src/web/pages/hosts/detailspage.js
@@ -64,8 +64,8 @@ import withEntityContainer, {
 } from 'web/entity/withEntityContainer';
 
 import CreateIcon from 'web/entity/icon/createicon';
+import DeleteIcon from 'web/entity/icon/deleteicon';
 import EditIcon from 'web/entity/icon/editicon';
-import TrashIcon from 'web/entity/icon/trashicon';
 
 import {selector as hostsSelector, loadEntity} from 'web/store/entities/hosts';
 
@@ -107,7 +107,7 @@ const ToolBarIcons = ({
           displayName={_('Host')}
           onClick={onHostEditClick}
         />
-        <TrashIcon
+        <DeleteIcon
           entity={entity}
           displayName={_('Host')}
           onClick={onHostDeleteClick}


### PR DESCRIPTION
**What**:
Exchange the icon
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Hosts don't get moved to the trashcan, therefore the icon is misleading.
<!-- Why are these changes necessary? -->

**How**:
Visual inspection that the icon was properly replaced.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
