### PR TITLE
Fix port range check when editing portlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use <predefined> to disable feed object editing and filter creation on feed status page [#2398](https://github.com/greenbone/gsa/pull/2398)
 
 ### Fixed
+- Fixed sanity check for port ranges [#2566](https://github.com/greenbone/gsa/pull/2566)
 - Allow to delete processes without having had edges in BPM [#2507](https://github.com/greenbone/gsa/pull/2507)
 - Fixed TLS certificate download for users with permissions [#2496](https://github.com/greenbone/gsa/pull/2496)
 - Fixed form validation error tooltips [#2478](https://github.com/greenbone/gsa/pull/2478)

--- a/gsa/src/web/pages/portlists/component.js
+++ b/gsa/src/web/pages/portlists/component.js
@@ -202,7 +202,10 @@ class PortListComponent extends React.Component {
 
   handleTmpAddPortRange(values) {
     const {port_ranges} = this.state;
-    const {port_range_end, port_range_start, port_type} = values;
+    let {port_range_end, port_range_start, port_type} = values;
+
+    port_range_end = parseInt(port_range_end);
+    port_range_start = parseInt(port_range_start);
 
     this.handleInteraction();
 
@@ -216,7 +219,7 @@ class PortListComponent extends React.Component {
     }
 
     // reject port ranges with start value lower than end value
-    if (parseInt(port_range_start) > parseInt(port_range_end)) {
+    if (port_range_start > port_range_end) {
       return Promise.reject(
         new Error(_('The end of the port range can not be below its start!')),
       );

--- a/gsa/src/web/pages/portlists/component.js
+++ b/gsa/src/web/pages/portlists/component.js
@@ -216,7 +216,7 @@ class PortListComponent extends React.Component {
     }
 
     // reject port ranges with start value lower than end value
-    if (port_range_start > port_range_end) {
+    if (parseInt(port_range_start) > parseInt(port_range_end)) {
       return Promise.reject(
         new Error(_('The end of the port range can not be below its start!')),
       );

--- a/gsa/src/web/pages/portlists/component.js
+++ b/gsa/src/web/pages/portlists/component.js
@@ -172,8 +172,8 @@ class PortListComponent extends React.Component {
     let promises = created_port_ranges_copy.map(range => {
       const saveData = {
         ...range,
-        port_range_start: range.start,
-        port_range_end: range.end,
+        port_range_start: parseInt(range.start),
+        port_range_end: parseInt(range.end),
         port_type: range.protocol_type,
       };
       return this.handleSavePortRange(saveData).then(id => {


### PR DESCRIPTION
**What**:
Compare port range start and end via their integer value instead of their string value.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Comparing strings is plain wrong here. It probably happened because of the change of the xml parser.
<!-- Why are these changes necessary? -->

**How**:
Confirmed by adding a new port range that has a higher first digit at the start than the first digit of its end. No error was thrown and no existing automated test failed.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
