### PR TITLE
Always send sort=name with delta report request filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added option for "Start Task" event upon "New SecInfo arrived" condition in alerts dialog [#2418](https://github.com/greenbone/gsa/pull/2418)
 
 ### Changed
+- Always send sort=name with delta report request filters [#2570](https://github.com/greenbone/gsa/pull/2570)
 - Changed trash icon to delete icon on host detailspage [#2565](https://github.com/greenbone/gsa/pull/2565)
 - Change tooltip of override icon in result details [#2467](https://github.com/greenbone/gsa/pull/2467)
 - For edit config/policy dialog, only send name and comment if config or policy is in use, and add in use notification [#2463](https://github.com/greenbone/gsa/pull/2463)

--- a/gsa/src/web/pages/reports/deltadetailspage.js
+++ b/gsa/src/web/pages/reports/deltadetailspage.js
@@ -683,6 +683,11 @@ const load = ({
     filter = DEFAULT_FILTER;
   }
 
+  // to avoid confusion of loaded results with different sort terms and
+  // directions, always load the report with sort=name from gvmd (the user's
+  // sort term will be handled by GSA in the browser)
+  filter.delete('sort-reverse');
+  filter.set('sort', 'name');
   return loadReportIfNeeded(reportId, deltaReportId, filter).then(() =>
     loadReport(reportId, deltaReportId, filter),
   );
@@ -717,10 +722,7 @@ export default compose(
   withGmp,
   withDialogNotification,
   withDownload,
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  ),
+  connect(mapStateToProps, mapDispatchToProps),
 )(DeltaReportDetailsWrapper);
 
 // vim: set ts=2 sw=2 tw=80:


### PR DESCRIPTION
**What**:
Always send sort=name with delta report request filters.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
To avoid confusion due to differing numbers of results and broken sort-reverse terms.
<!-- Why are these changes necessary? -->

**How**:
Check whether the filter sent to gvmd always includes sort=name and never anything else or a sort-reverse term.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
