### PR TITLE
Implement get_alert via graphql and preliminary refactor of alert detailspage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added missing fields for getScanners query and parseObject() for scanner model [#2301](https://github.com/greenbone/gsa/pull/2301)
 
 ### Changed
+-Implement get_alert via graphql and preliminary refactor of alert detailspage [#2571](https://github.com/greenbone/gsa/pull/2571)
 - Implement bulk actions for alerts via graphQL [#2569](https://github.com/greenbone/gsa/pull/2569)
 - Implement clone, delete and test alert via graphql [#2567](https://github.com/greenbone/gsa/pull/2567)
 - Implement get_alerts on alerts listpage via graphql [#2552](https://github.com/greenbone/gsa/pull/2552)

--- a/gsa/src/gmp/models/__tests__/alert.js
+++ b/gsa/src/gmp/models/__tests__/alert.js
@@ -101,7 +101,7 @@ describe('Alert Model parseObject tests', () => {
     expect(task.id).toEqual('t1');
   });
 
-  test('should return empty array if no alerts are given', () => {
+  test('should return empty array if no tasks are given', () => {
     const alert = Alert.fromObject({});
 
     expect(alert.tasks).toEqual([]);

--- a/gsa/src/web/entity/__tests__/useExportEntity.js
+++ b/gsa/src/web/entity/__tests__/useExportEntity.js
@@ -1,0 +1,97 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+/* eslint-disable react/prop-types */
+
+import React, {useState} from 'react';
+
+import {setLocale} from 'gmp/locale/lang';
+
+import {rendererWith, fireEvent, wait, screen} from 'web/utils/testing';
+
+import {useExportEntity} from 'web/entity/useExportEntity';
+
+jest.mock('web/utils/render', () => ({
+  ...jest.requireActual('web/utils/render'),
+  generateFilename: () => 'foo-20201113.xml',
+}));
+
+setLocale('en');
+
+const entity = {id: 'foo'};
+const onDownload = jest.fn();
+const onError = jest.fn();
+
+const exportFunc = jest.fn().mockResolvedValue({
+  data: {
+    exportIpsumByIds: {
+      exportedEntities: '<get_entities_response />',
+    },
+  },
+});
+
+const ExportEntityComponent = () => {
+  const [message, setMessage] = useState('Not called');
+
+  const exportEntity = useExportEntity();
+
+  const handleDownloadEntity = () => {
+    return exportEntity({
+      entity,
+      resourceType: 'ipsum',
+      exportFunc,
+      onDownload,
+      onError,
+    });
+  };
+
+  return (
+    <div>
+      <button
+        data-testid="load"
+        onClick={() =>
+          handleDownloadEntity().then(setMessage('Bulk export called!'))
+        }
+      />
+      <span data-testid="message">{message}</span>
+    </div>
+  );
+};
+
+describe('useBulkExportEntities tests', () => {
+  test('should call export on user interaction', async () => {
+    const {render} = rendererWith({store: true});
+
+    const {getByTestId} = render(<ExportEntityComponent />);
+
+    const message = getByTestId('message');
+
+    expect(message).toHaveTextContent('Not called');
+
+    const button = screen.getByTestId('load');
+    fireEvent.click(button);
+
+    await wait();
+
+    expect(exportFunc).toHaveBeenCalledWith(['foo']);
+    expect(onDownload).toHaveBeenCalledWith({
+      data: '<get_entities_response />',
+      filename: 'foo-20201113.xml',
+    });
+    expect(message).toHaveTextContent('Bulk export called!');
+  });
+});

--- a/gsa/src/web/entity/__tests__/useExportEntity.js
+++ b/gsa/src/web/entity/__tests__/useExportEntity.js
@@ -23,7 +23,7 @@ import {setLocale} from 'gmp/locale/lang';
 
 import {rendererWith, fireEvent, wait, screen} from 'web/utils/testing';
 
-import {useExportEntity} from 'web/entity/useExportEntity';
+import useExportEntity from 'web/entity/useExportEntity';
 
 jest.mock('web/utils/render', () => ({
   ...jest.requireActual('web/utils/render'),

--- a/gsa/src/web/entity/useExportEntity.js
+++ b/gsa/src/web/entity/useExportEntity.js
@@ -1,0 +1,57 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+import {useCallback} from 'react';
+
+import {useSelector} from 'react-redux';
+
+import {capitalizeFirstLetter} from 'gmp/utils/string';
+
+import {getUserSettingsDefaults} from 'web/store/usersettings/defaults/selectors';
+
+import {generateFilename} from 'web/utils/render';
+import useUserName from 'web/utils/useUserName';
+
+export const useExportEntity = () => {
+  const username = useUserName();
+  const userDefaultsSelector = useSelector(getUserSettingsDefaults);
+  const listExportFileName = userDefaultsSelector.getValueByName(
+    'listexportfilename',
+  );
+
+  const exportEntity = useCallback(
+    ({entity, exportFunc, resourceType, onDownload, onError}) => {
+      return exportFunc([entity.id]).then(response => {
+        const filename = generateFilename({
+          fileNameFormat: listExportFileName,
+          resourceType,
+          username,
+        });
+
+        const commandName =
+          'export' + capitalizeFirstLetter(resourceType) + 'ByIds';
+
+        const xml = response.data;
+        const {exportedEntities} = xml[commandName];
+        onDownload({filename, data: exportedEntities});
+      }, onError);
+    },
+    [listExportFileName, username],
+  );
+
+  return exportEntity;
+};

--- a/gsa/src/web/entity/useExportEntity.js
+++ b/gsa/src/web/entity/useExportEntity.js
@@ -26,7 +26,7 @@ import {getUserSettingsDefaults} from 'web/store/usersettings/defaults/selectors
 import {generateFilename} from 'web/utils/render';
 import useUserName from 'web/utils/useUserName';
 
-export const useExportEntity = () => {
+const useExportEntity = () => {
   const username = useUserName();
   const userDefaultsSelector = useSelector(getUserSettingsDefaults);
   const listExportFileName = userDefaultsSelector.getValueByName(
@@ -55,3 +55,5 @@ export const useExportEntity = () => {
 
   return exportEntity;
 };
+
+export default useExportEntity;

--- a/gsa/src/web/graphql/__mocks__/alerts.js
+++ b/gsa/src/web/graphql/__mocks__/alerts.js
@@ -152,8 +152,8 @@ const mockAlerts = {
 export const createGetAlertsQueryMock = variables =>
   createGenericQueryMock(GET_ALERTS, {alerts: mockAlerts}, variables);
 
-export const createGetAlertQueryMock = (alertIqd = 'foo') =>
-  createGenericQueryMock(GET_ALERT, {alert: alert1}, {id: '1'});
+export const createGetAlertQueryMock = (alertId = '1', alert = alert1) =>
+  createGenericQueryMock(GET_ALERT, {alert}, {id: alertId});
 
 const createAlertResult = {
   createAlert: {

--- a/gsa/src/web/graphql/__mocks__/alerts.js
+++ b/gsa/src/web/graphql/__mocks__/alerts.js
@@ -28,6 +28,7 @@ import {
   EXPORT_ALERTS_BY_IDS,
   EXPORT_ALERTS_BY_FILTER,
   DELETE_ALERTS_BY_FILTER,
+  GET_ALERT,
 } from '../alerts';
 
 export const alert1 = deepFreeze({
@@ -44,6 +45,17 @@ export const alert1 = deepFreeze({
     trash: 0,
     name: 'resultFilter',
     id: '75c8145d-b00c-408f-8907-6664d5ce6108',
+  },
+  userTags: {
+    count: 1,
+    tags: [
+      {
+        id: '66d6484d-1bdf-4b24-b5de-e358e0d115ec',
+        name: 'alert:unnamed',
+        value: null,
+        comment: null,
+      },
+    ],
   },
   method: {
     type: 'Alemba vFire',
@@ -87,6 +99,7 @@ export const alert2 = deepFreeze({
   modificationTime: '2020-08-07T09:26:05+00:00',
   owner: 'admin',
   filter: null,
+  userTags: null,
   method: {
     type: 'Email',
     data: [
@@ -138,6 +151,9 @@ const mockAlerts = {
 
 export const createGetAlertsQueryMock = variables =>
   createGenericQueryMock(GET_ALERTS, {alerts: mockAlerts}, variables);
+
+export const createGetAlertQueryMock = (alertId = 'foo') =>
+  createGenericQueryMock(GET_ALERT, {alert: alert1}, {id: alertId});
 
 const createAlertResult = {
   createAlert: {

--- a/gsa/src/web/graphql/__mocks__/alerts.js
+++ b/gsa/src/web/graphql/__mocks__/alerts.js
@@ -152,8 +152,8 @@ const mockAlerts = {
 export const createGetAlertsQueryMock = variables =>
   createGenericQueryMock(GET_ALERTS, {alerts: mockAlerts}, variables);
 
-export const createGetAlertQueryMock = (alertId = 'foo') =>
-  createGenericQueryMock(GET_ALERT, {alert: alert1}, {id: alertId});
+export const createGetAlertQueryMock = (alertIqd = 'foo') =>
+  createGenericQueryMock(GET_ALERT, {alert: alert1}, {id: '1'});
 
 const createAlertResult = {
   createAlert: {

--- a/gsa/src/web/graphql/__tests__/alerts.js
+++ b/gsa/src/web/graphql/__tests__/alerts.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+/* eslint-disable react/prop-types */
 
 import React, {useState} from 'react';
 

--- a/gsa/src/web/graphql/__tests__/alerts.js
+++ b/gsa/src/web/graphql/__tests__/alerts.js
@@ -34,6 +34,7 @@ import {
   useDeleteAlertsByFilter,
   useExportAlertsByIds,
   useExportAlertsByFilter,
+  useGetAlert,
 } from '../alerts';
 import {
   createGetAlertsQueryMock,
@@ -48,6 +49,7 @@ import {
   createExportAlertsByIdsQueryMock,
   createExportAlertsByFilterQueryMock,
   createDeleteAlertsByIdsQueryMock,
+  createGetAlertQueryMock,
 } from '../__mocks__/alerts';
 
 const GetLazyAlertsComponent = () => {
@@ -364,5 +366,47 @@ describe('useExportAlertsByFilter tests', () => {
     await wait();
 
     expect(resultFunc).toHaveBeenCalled();
+  });
+});
+
+const GetAlertComponent = ({id}) => {
+  const {loading, alert, error} = useGetAlert(id);
+  if (loading) {
+    return <span data-testid="loading">Loading</span>;
+  }
+  return (
+    <div>
+      {error && <div data-testid="error">{error.message}</div>}
+      {alert && (
+        <div data-testid="alert">
+          <span data-testid="id">{alert.id}</span>
+          <span data-testid="name">{alert.name}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+describe('useGetAlert tests', () => {
+  test('should load alert', async () => {
+    const [queryMock, resultFunc] = createGetAlertQueryMock('1');
+
+    const {render} = rendererWith({queryMocks: [queryMock]});
+
+    render(<GetAlertComponent id="1" />);
+
+    expect(screen.queryByTestId('loading')).toBeInTheDocument();
+
+    await wait();
+
+    expect(resultFunc).toHaveBeenCalled();
+
+    expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('error')).not.toBeInTheDocument();
+
+    expect(screen.getByTestId('alert')).toBeInTheDocument();
+
+    expect(screen.getByTestId('id')).toHaveTextContent('1');
+    expect(screen.getByTestId('name')).toHaveTextContent('alert 1');
   });
 });

--- a/gsa/src/web/graphql/__tests__/alerts.js
+++ b/gsa/src/web/graphql/__tests__/alerts.js
@@ -30,6 +30,10 @@ import {
   useCloneAlert,
   useDeleteAlert,
   useTestAlert,
+  useDeleteAlertsByIds,
+  useDeleteAlertsByFilter,
+  useExportAlertsByIds,
+  useExportAlertsByFilter,
 } from '../alerts';
 import {
   createGetAlertsQueryMock,
@@ -40,6 +44,10 @@ import {
   createDeleteAlertQueryMock,
   createTestAlertQueryMock,
   createCloneAlertQueryMock,
+  createDeleteAlertsByFilterQueryMock,
+  createExportAlertsByIdsQueryMock,
+  createExportAlertsByFilterQueryMock,
+  createDeleteAlertsByIdsQueryMock,
 } from '../__mocks__/alerts';
 
 const GetLazyAlertsComponent = () => {
@@ -256,5 +264,105 @@ describe('useCloneAlert tests', () => {
     expect(resultFunc).toHaveBeenCalled();
 
     expect(screen.getByTestId('cloned-alert')).toHaveTextContent('foo2');
+  });
+});
+
+const DeleteAlertsByIdsComponent = () => {
+  const [deleteAlertsByIds] = useDeleteAlertsByIds();
+  return (
+    <button
+      data-testid="bulk-delete"
+      onClick={() => deleteAlertsByIds(['foo', 'bar'])}
+    />
+  );
+};
+
+describe('useDeleteAlertsByIds tests', () => {
+  test('should delete a list of alerts after user interaction', async () => {
+    const [mock, resultFunc] = createDeleteAlertsByIdsQueryMock(['foo', 'bar']);
+    const {render} = rendererWith({queryMocks: [mock]});
+
+    render(<DeleteAlertsByIdsComponent />);
+    const button = screen.getByTestId('bulk-delete');
+    fireEvent.click(button);
+
+    await wait();
+
+    expect(resultFunc).toHaveBeenCalled();
+  });
+});
+
+const DeleteAlertsByFilterComponent = () => {
+  const [deleteAlertsByFilter] = useDeleteAlertsByFilter();
+  return (
+    <button
+      data-testid="filter-delete"
+      onClick={() => deleteAlertsByFilter('foo')}
+    />
+  );
+};
+
+describe('useDeleteAlertsByFilter tests', () => {
+  test('should delete a list of alerts by filter string after user interaction', async () => {
+    const [mock, resultFunc] = createDeleteAlertsByFilterQueryMock('foo');
+    const {render} = rendererWith({queryMocks: [mock]});
+
+    render(<DeleteAlertsByFilterComponent />);
+    const button = screen.getByTestId('filter-delete');
+    fireEvent.click(button);
+
+    await wait();
+
+    expect(resultFunc).toHaveBeenCalled();
+  });
+});
+
+const ExportAlertsByIdsComponent = () => {
+  const exportAlertsByIds = useExportAlertsByIds();
+  return (
+    <button
+      data-testid="bulk-export"
+      onClick={() => exportAlertsByIds(['foo'])}
+    />
+  );
+};
+
+describe('useExportAlertsByIds tests', () => {
+  test('should export a list of alerts after user interaction', async () => {
+    const [mock, resultFunc] = createExportAlertsByIdsQueryMock(['foo']);
+    const {render} = rendererWith({queryMocks: [mock]});
+
+    render(<ExportAlertsByIdsComponent />);
+    const button = screen.getByTestId('bulk-export');
+    fireEvent.click(button);
+
+    await wait();
+
+    expect(resultFunc).toHaveBeenCalled();
+  });
+});
+
+const ExportAlertsByFilterComponent = () => {
+  const exportAlertsByFilter = useExportAlertsByFilter();
+  return (
+    <button
+      data-testid="filter-export"
+      onClick={() => exportAlertsByFilter('foo')}
+    />
+  );
+};
+
+describe('useExportAlertsByFilter tests', () => {
+  test('should export a list of alerts by filter string after user interaction', async () => {
+    const [mock, resultFunc] = createExportAlertsByFilterQueryMock();
+    const {render} = rendererWith({queryMocks: [mock]});
+
+    render(<ExportAlertsByFilterComponent />);
+    const button = screen.getByTestId('filter-export');
+    fireEvent.click(button);
+
+    await wait();
+
+    expect(resultFunc).toHaveBeenCalled();
   });
 });

--- a/gsa/src/web/graphql/alerts.js
+++ b/gsa/src/web/graphql/alerts.js
@@ -47,6 +47,7 @@ export const GET_ALERTS = gql`
           id
           inUse
           writable
+          active
           comment
           owner
           creationTime
@@ -84,7 +85,6 @@ export const GET_ALERTS = gql`
           permissions {
             name
           }
-          active
         }
       }
       pageInfo {
@@ -112,6 +112,7 @@ export const GET_ALERT = gql`
       id
       inUse
       writable
+      active
       comment
       owner
       creationTime
@@ -149,7 +150,6 @@ export const GET_ALERT = gql`
       permissions {
         name
       }
-      active
       userTags {
         count
         tags {

--- a/gsa/src/web/pages/alerts/__tests__/detailspage.js
+++ b/gsa/src/web/pages/alerts/__tests__/detailspage.js
@@ -36,6 +36,7 @@ import {
   createGetAlertQueryMock,
   createCloneAlertQueryMock,
   createDeleteAlertQueryMock,
+  createExportAlertsByIdsQueryMock,
   alert1,
 } from 'web/graphql/__mocks__/alerts';
 
@@ -315,14 +316,9 @@ describe('Alert Detailspage tests', () => {
   });
 
   test('should call commands', async () => {
-    const exportFunc = jest.fn().mockResolvedValue({
-      foo: 'bar',
-    });
-
     const gmp = {
       alert: {
         get: getAlert,
-        export: exportFunc,
       },
       permissions: {
         get: getEntities,
@@ -340,13 +336,14 @@ describe('Alert Detailspage tests', () => {
     const [mock, resultFunc] = createGetAlertQueryMock('1');
     const [cloneMock, cloneResult] = createCloneAlertQueryMock();
     const [deleteMock, deleteResult] = createDeleteAlertQueryMock();
+    const [exportMock, exportResult] = createExportAlertsByIdsQueryMock(['1']);
 
     const {render, store} = rendererWith({
       capabilities: caps,
       gmp,
       router: true,
       store: true,
-      queryMocks: [renewQueryMock, mock, cloneMock, deleteMock],
+      queryMocks: [renewQueryMock, mock, cloneMock, deleteMock, exportMock],
     });
 
     store.dispatch(setTimezone('CET'));
@@ -374,14 +371,14 @@ describe('Alert Detailspage tests', () => {
 
     await wait();
 
-    expect(deleteResult).toHaveBeenCalledWith();
+    expect(deleteResult).toHaveBeenCalled();
 
     expect(icons[6]).toHaveAttribute('title', 'Export Alert as XML');
     fireEvent.click(icons[6]);
 
     await wait();
 
-    expect(exportFunc).toHaveBeenCalledWith(parsedAlert);
+    expect(exportResult).toHaveBeenCalled();
   });
 });
 

--- a/gsa/src/web/pages/alerts/__tests__/detailspage.js
+++ b/gsa/src/web/pages/alerts/__tests__/detailspage.js
@@ -145,7 +145,7 @@ describe('Alert Detailspage tests', () => {
       },
     };
 
-    const [mock, resultFunc] = createGetAlertQueryMock('1');
+    const [mock, resultFunc] = createGetAlertQueryMock('1', alert1);
 
     const {render, store} = rendererWith({
       capabilities: caps,
@@ -239,7 +239,7 @@ describe('Alert Detailspage tests', () => {
       },
     };
 
-    const [mock, resultFunc] = createGetAlertQueryMock('1');
+    const [mock, resultFunc] = createGetAlertQueryMock('1', alert1);
 
     const {render, store} = rendererWith({
       capabilities: caps,
@@ -286,7 +286,7 @@ describe('Alert Detailspage tests', () => {
       },
     };
 
-    const [mock, resultFunc] = createGetAlertQueryMock('1');
+    const [mock, resultFunc] = createGetAlertQueryMock('1', alert1);
 
     const {render, store} = rendererWith({
       capabilities: caps,
@@ -333,7 +333,7 @@ describe('Alert Detailspage tests', () => {
       },
     };
     const [renewQueryMock] = createRenewSessionQueryMock();
-    const [mock, resultFunc] = createGetAlertQueryMock('1');
+    const [mock, resultFunc] = createGetAlertQueryMock('1', alert1);
     const [cloneMock, cloneResult] = createCloneAlertQueryMock();
     const [deleteMock, deleteResult] = createDeleteAlertQueryMock();
     const [exportMock, exportResult] = createExportAlertsByIdsQueryMock(['1']);

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -130,11 +130,13 @@ const Page = ({
   onInteraction,
   ...props
 }) => {
+  // Page methods
   const {id} = useParams();
   const gmpSettings = useGmpSettings();
   const [downloadRef, handleDownload] = useDownload();
   const {alert, refetch, loading} = useGetAlert(id);
 
+  // Alert related mutations
   const exportEntity = useExportEntity();
 
   const [cloneAlert] = useCloneAlert();
@@ -142,7 +144,6 @@ const Page = ({
   const exportAlert = useExportAlertsByIds();
 
   // Alert methods
-
   const handleCloneAlert = clonedAlert => {
     return cloneAlert(clonedAlert.id)
       .then(alertId => goto_entity_details('alert', props)(alertId))
@@ -165,6 +166,7 @@ const Page = ({
     });
   };
 
+  // Timeout and reload
   const timeoutFunc = useCallback(
     ({isVisible}) => {
       if (!isVisible) {

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -19,6 +19,7 @@ import React, {useCallback, useEffect} from 'react';
 import {useParams} from 'react-router-dom';
 
 import _ from 'gmp/locale';
+import {hasValue} from 'gmp/utils/identity';
 
 import ManualIcon from 'web/components/icon/manualicon';
 import ListIcon from 'web/components/icon/listicon';
@@ -80,7 +81,6 @@ import AlertComponent from './component';
 import AlertDetails from './details';
 import useGmpSettings from 'web/utils/useGmpSettings';
 import useReload from 'web/components/loading/useReload';
-import {hasValue} from 'gmp/utils/identity';
 
 export const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -46,7 +46,7 @@ import EntityTags from 'web/entity/tags';
 import withEntityContainer, {
   permissionsResourceFilter,
 } from 'web/entity/withEntityContainer';
-import {useExportEntity} from 'web/entity/useExportEntity';
+import useExportEntity from 'web/entity/useExportEntity';
 
 import AlertIcon from 'web/components/icon/alerticon';
 import ExportIcon from 'web/components/icon/exporticon';

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -121,7 +121,6 @@ ToolBarIcons.propTypes = {
 };
 
 const Page = ({
-  history,
   permissions = [],
   reportFormats,
   onChanged,
@@ -144,13 +143,13 @@ const Page = ({
 
   const handleCloneAlert = clonedAlert => {
     return cloneAlert(clonedAlert.id)
-      .then(alertId => goto_entity_details('alert', {history})(alertId))
+      .then(alertId => goto_entity_details('alert', props)(alertId))
       .catch(onError);
   };
 
   const handleDeleteAlert = deletedAlert => {
     return deleteAlert(deletedAlert.id)
-      .then(goto_list('alerts', {history}))
+      .then(goto_list('alerts', props))
       .catch(onError);
   };
 

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -34,6 +34,8 @@ import TabList from 'web/components/tab/tablist';
 import TabPanel from 'web/components/tab/tabpanel';
 import TabPanels from 'web/components/tab/tabpanels';
 import Tabs from 'web/components/tab/tabs';
+import Download from 'web/components/form/download';
+import useDownload from 'web/components/form/useDownload';
 
 import EntityPage from 'web/entity/page';
 import {goto_details, goto_list} from 'web/entity/component';
@@ -124,13 +126,13 @@ const Page = ({
   permissions = [],
   reportFormats,
   onChanged,
-  onDownloaded,
   onError,
   onInteraction,
   ...props
 }) => {
   const {id} = useParams();
   const gmpSettings = useGmpSettings();
+  const [downloadRef, handleDownload] = useDownload();
   const {alert, refetch, loading} = useGetAlert(id);
 
   const exportEntity = useExportEntity();
@@ -158,7 +160,7 @@ const Page = ({
       entity: exportedAlert,
       exportFunc: exportAlert,
       resourceType: 'alerts',
-      onDownload: onDownloaded,
+      onDownload: handleDownload,
       onError,
     });
   };
@@ -198,12 +200,12 @@ const Page = ({
       onCreated={goto_entity_details('alert', props)}
       onDeleted={goto_list('alerts', props)}
       onDeleteError={onError}
-      onDownloaded={onDownloaded}
+      onDownloaded={handleDownload}
       onDownloadError={onError}
       onInteraction={onInteraction}
       onSaved={onChanged}
     >
-      {({create, download, edit, save}) => (
+      {({create, edit, save}) => (
         <EntityPage
           {...props}
           entity={alert}
@@ -260,7 +262,7 @@ const Page = ({
                           entity={alert}
                           permissions={permissions}
                           onChanged={onChanged}
-                          onDownloaded={onDownloaded}
+                          onDownloaded={handleDownload}
                           onError={onError}
                           onInteraction={onInteraction}
                         />
@@ -268,6 +270,7 @@ const Page = ({
                     </TabPanels>
                   </Tabs>
                 </Layout>
+                <Download ref={downloadRef} />
               </React.Fragment>
             );
           }}
@@ -282,7 +285,6 @@ Page.propTypes = {
   permissions: PropTypes.array,
   reportFormats: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
-  onDownloaded: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
   onInteraction: PropTypes.func.isRequired,
 };

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -43,6 +43,7 @@ import EntityTags from 'web/entity/tags';
 import withEntityContainer, {
   permissionsResourceFilter,
 } from 'web/entity/withEntityContainer';
+import {useExportEntity} from 'web/entity/useExportEntity';
 
 import AlertIcon from 'web/components/icon/alerticon';
 import ExportIcon from 'web/components/icon/exporticon';
@@ -51,7 +52,12 @@ import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
 
-import {useGetAlert, useCloneAlert, useDeleteAlert} from 'web/graphql/alerts';
+import {
+  useGetAlert,
+  useCloneAlert,
+  useDeleteAlert,
+  useExportAlertsByIds,
+} from 'web/graphql/alerts';
 
 import {selector, loadEntity} from 'web/store/entities/alerts';
 
@@ -128,8 +134,11 @@ const Page = ({
   const gmpSettings = useGmpSettings();
   const {alert, refetch, loading} = useGetAlert(id);
 
+  const exportEntity = useExportEntity();
+
   const [cloneAlert] = useCloneAlert();
   const [deleteAlert] = useDeleteAlert();
+  const exportAlert = useExportAlertsByIds();
 
   // Alert methods
 
@@ -143,6 +152,16 @@ const Page = ({
     return deleteAlert(deletedAlert.id)
       .then(goto_list('alerts', {history}))
       .catch(onError);
+  };
+
+  const handleDownloadAlert = exportedAlert => {
+    exportEntity({
+      entity: exportedAlert,
+      exportFunc: exportAlert,
+      resourceType: 'alerts',
+      onDownload: onDownloaded,
+      onError,
+    });
   };
 
   const timeoutFunc = useCallback(
@@ -196,7 +215,7 @@ const Page = ({
           onAlertCloneClick={handleCloneAlert}
           onAlertCreateClick={create}
           onAlertDeleteClick={handleDeleteAlert}
-          onAlertDownloadClick={download}
+          onAlertDownloadClick={handleDownloadAlert}
           onAlertEditClick={edit}
           onAlertSaveClick={save}
           onInteraction={onInteraction}


### PR DESCRIPTION
**What**:

This PR refactors the detailspage to use graphQL related commands such as adding clone/delete/export handlers. It also adds a custom hook to handle exporting entities via graphQL in the same vein as the new bulk action custom hooks.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Manual and unit testing. 
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
