### PR TITLE
Add "Filter x matches at least y results" condition to task events in alert dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added option for "Start Task" event upon "New SecInfo arrived" condition in alerts dialog [#2418](https://github.com/greenbone/gsa/pull/2418)
 
 ### Changed
+- Show "Filter x matches at least y results" condition to task events in alert dialog [#2580](https://github.com/greenbone/gsa/pull/2580)
 - Always send sort=name with delta report request filters [#2570](https://github.com/greenbone/gsa/pull/2570)
 - Changed trash icon to delete icon on host detailspage [#2565](https://github.com/greenbone/gsa/pull/2565)
 - Change tooltip of override icon in result details [#2467](https://github.com/greenbone/gsa/pull/2467)

--- a/gsa/src/web/pages/alerts/dialog.js
+++ b/gsa/src/web/pages/alerts/dialog.js
@@ -585,7 +585,7 @@ class AlertDialog extends React.Component {
                     />
                   )}
 
-                  {secinfoEvent && (
+                  {(secinfoEvent || taskEvent) && (
                     <FilterCountLeastConditionPart
                       prefix="condition_data"
                       condition={values.condition}

--- a/gsa/src/web/pages/alerts/filtercountleastconditionpart.js
+++ b/gsa/src/web/pages/alerts/filtercountleastconditionpart.js
@@ -19,16 +19,16 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import Divider from '../../components/layout/divider.js';
-import Layout from '../../components/layout/layout.js';
+import Divider from 'web/components/layout/divider';
+import Layout from 'web/components/layout/layout';
 
-import PropTypes from '../../utils/proptypes.js';
-import {renderSelectItems} from '../../utils/render.js';
-import withPrefix from '../../utils/withPrefix.js';
+import PropTypes from 'web/utils/proptypes';
+import {renderSelectItems} from 'web/utils/render';
+import withPrefix from 'web/utils/withPrefix';
 
-import Select from '../../components/form/select.js';
-import Spinner from '../../components/form/spinner.js';
-import Radio from '../../components/form/radio.js';
+import Select from 'web/components/form/select';
+import Spinner from 'web/components/form/spinner';
+import Radio from 'web/components/form/radio';
 
 const VALUE = 'Filter count at least';
 


### PR DESCRIPTION
**What**:
Add "Filter x matches at least y results" condition to task events in alert dialog
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This option was present in older versions
<!-- Why are these changes necessary? -->

**How**:
Created an alert and a filter that would match at least 1 result. After the task status changed to 'Done' the event 'Start task' was called, showing that the new option works with task events.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
