### PR TITLE
Implement get_report_formats and get_permissions via graphQL on alert detailspage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [21.04] - unreleased
 
 ### Added
+- Implement get_report_formats and get_permissions via graphQL on alert detailspage [#2585](https://github.com/greenbone/gsa/pull/2585)
 - Implemented parseObject for alert model implement [#2552](https://github.com/greenbone/gsa/pull/2552)
 - Added getNotes query [#2485](https://github.com/greenbone/gsa/pull/2485)
 - Create and modify schedule from graphql [#2477](https://github.com/greenbone/gsa/pull/2477)

--- a/gsa/src/gmp/__tests__/model.js
+++ b/gsa/src/gmp/__tests__/model.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Model, {parseModelFromElement} from 'gmp/model';
+import Model, {parseModelFromElement, parseModelFromObject} from 'gmp/model';
 import {testModel} from 'gmp/models/testing';
 
 describe('Model tests', () => {
@@ -40,6 +40,30 @@ describe('parseModelFromElement tests', () => {
       _id: '1',
     };
     const model = parseModelFromElement(element, 'foo');
+
+    expect(model.id).toEqual('1');
+    expect(model).toBeInstanceOf(Model);
+    expect(model.entityType).toEqual('foo');
+  });
+});
+
+describe('parseModelFromObject tests', () => {
+  test('should parse model', () => {
+    const obj = {
+      id: '1',
+    };
+    const model = parseModelFromObject(obj);
+
+    expect(model.id).toEqual('1');
+    expect(model).toBeInstanceOf(Model);
+    expect(model.entityType).toEqual('unknown');
+  });
+
+  test('should parse model and set entity type', () => {
+    const obj = {
+      id: '1',
+    };
+    const model = parseModelFromObject(obj, 'foo');
 
     expect(model.id).toEqual('1');
     expect(model).toBeInstanceOf(Model);

--- a/gsa/src/gmp/model.js
+++ b/gsa/src/gmp/model.js
@@ -125,7 +125,6 @@ class Model {
   static fromObject(object = {}) {
     const f = new this();
     f.setProperties(this.parseObject(object));
-    console.log(f, object);
     return f;
   }
 

--- a/gsa/src/gmp/model.js
+++ b/gsa/src/gmp/model.js
@@ -39,6 +39,13 @@ export const parseModelFromElement = (element, entityType) => {
   return m;
 };
 
+export const parseModelFromObject = (object, entityType) => {
+  const m = new Model(entityType);
+  const props = Model.parseObject(object);
+  m.setProperties(props);
+  return m;
+};
+
 class Model {
   static entityType = 'unknown';
 

--- a/gsa/src/gmp/model.js
+++ b/gsa/src/gmp/model.js
@@ -125,12 +125,12 @@ class Model {
   static fromObject(object = {}) {
     const f = new this();
     f.setProperties(this.parseObject(object));
+    console.log(f, object);
     return f;
   }
 
   static parseObject(object = {}) {
     const copy = parseDefaultProperties(object);
-
     // use hasValue instead of isDefined for all things graphql related, since no value is null in Django.
 
     if (hasValue(object.end_time)) {

--- a/gsa/src/gmp/models/__tests__/permission.js
+++ b/gsa/src/gmp/models/__tests__/permission.js
@@ -24,7 +24,59 @@ import {testModel} from 'gmp/models/testing';
 
 testModel(Permission, 'permission');
 
-describe('Permission model tests', () => {
+describe('Permission model parseObject tests', () => {
+  test('should parse resource as model of their type', () => {
+    const obj = {
+      resource: {
+        id: '123',
+        type: 'alert',
+      },
+    };
+    const permission = Permission.fromObject(obj);
+
+    expect(permission.resource).toBeInstanceOf(Model);
+    expect(permission.resource.entityType).toEqual('alert');
+    expect(permission.resource.id).toEqual('123');
+  });
+
+  test('should not parse resource if no id is given', () => {
+    const obj = {
+      resource: {
+        type: 'alert',
+      },
+    };
+    const permission = Permission.fromObject(obj);
+
+    expect(permission.resource).toBeUndefined();
+  });
+
+  test('should parse subject as model of their type', () => {
+    const obj = {
+      subject: {
+        id: '123',
+        type: 'alert',
+      },
+    };
+    const permission = Permission.fromObject(obj);
+
+    expect(permission.subject).toBeInstanceOf(Model);
+    expect(permission.subject.id).toEqual('123');
+    expect(permission.subject.entityType).toEqual('alert');
+  });
+
+  test('should not parse subject if no id is given', () => {
+    const obj = {
+      subject: {
+        type: 'alert',
+      },
+    };
+    const permission = Permission.fromObject(obj);
+
+    expect(permission.subject).toBeUndefined();
+  });
+});
+
+describe('Permission model parseElement tests', () => {
   test('should parse resource as model of their type', () => {
     const elem = {
       resource: {

--- a/gsa/src/gmp/models/__tests__/reportformat.js
+++ b/gsa/src/gmp/models/__tests__/reportformat.js
@@ -28,7 +28,7 @@ import {NO_VALUE, YES_VALUE} from 'gmp/parser';
 
 testModel(ReportFormat, 'reportformat', {testIsActive: false});
 
-describe('ReportFormat model tests', () => {
+describe('ReportFormat model parseElement tests', () => {
   test('should parse trust', () => {
     const elem = {
       trust: {
@@ -89,6 +89,49 @@ describe('ReportFormat model tests', () => {
     const reportFormat = ReportFormat.fromElement({});
 
     expect(reportFormat.alerts).toEqual([]);
+  });
+
+  describe('ReportFormat model parseObject tests', () => {
+    test('should parse trust', () => {
+      const obj = {
+        trust: 'foo',
+        trustTime: '2018-10-10T13:30:00+01:00',
+      };
+      const obj2 = {
+        trust: 'bar',
+      };
+      const reportFormat = ReportFormat.fromObject(obj);
+      const reportFormat2 = ReportFormat.fromObject(obj2);
+
+      expect(reportFormat.trust.value).toEqual('foo');
+      expect(isDate(reportFormat.trust.time)).toEqual(true);
+      expect(reportFormat2.trust.value).toEqual('bar');
+      expect(reportFormat2.trust.time).toBeUndefined();
+    });
+
+    test('should return empty object if no trust is given', () => {
+      const reportFormat = ReportFormat.fromObject({});
+
+      expect(reportFormat.trust).toEqual({});
+    });
+
+    test('should parse active as yes/no correctly', () => {
+      const reportFormat = ReportFormat.fromObject({active: false});
+      const reportFormat2 = ReportFormat.fromObject({active: true});
+
+      expect(reportFormat.active).toEqual(NO_VALUE);
+      expect(reportFormat2.active).toEqual(YES_VALUE);
+    });
+
+    test('should parse predefined as boolean correctly', () => {
+      const reportFormat = ReportFormat.fromObject({predefined: false});
+      const reportFormat2 = ReportFormat.fromObject({predefined: true});
+
+      expect(reportFormat.predefined).toEqual(false);
+      expect(reportFormat2.predefined).toEqual(true);
+    });
+
+    // Hyperion report formats have no alert field
   });
 
   describe('params tests', () => {
@@ -225,13 +268,20 @@ describe('ReportFormat model tests', () => {
     });
   });
 
+  // hyperion report formats have no params attribute
+
   describe('ReportFormat model method tests', () => {
     test('isActive() returns correct true/false', () => {
       const reportFormat = ReportFormat.fromElement({active: '0'});
       const reportFormat2 = ReportFormat.fromElement({active: '1'});
 
+      const reportFormat3 = ReportFormat.fromObject({active: false});
+      const reportFormat4 = ReportFormat.fromObject({active: true});
+
       expect(reportFormat.isActive()).toBe(false);
       expect(reportFormat2.isActive()).toBe(true);
+      expect(reportFormat3.isActive()).toBe(false);
+      expect(reportFormat4.isActive()).toBe(true);
     });
 
     test('isTrusted() returns correct true/false', () => {
@@ -245,11 +295,24 @@ describe('ReportFormat model tests', () => {
           __text: 'yes',
         },
       };
+
+      const obj = {
+        trust: 'no',
+      };
+
+      const obj2 = {
+        trust: 'yes',
+      };
+
       const reportFormat = ReportFormat.fromElement(elem);
       const reportFormat2 = ReportFormat.fromElement(elem2);
+      const reportFormat3 = ReportFormat.fromObject(obj);
+      const reportFormat4 = ReportFormat.fromObject(obj2);
 
       expect(reportFormat.isTrusted()).toBe(false);
       expect(reportFormat2.isTrusted()).toBe(true);
+      expect(reportFormat3.isTrusted()).toBe(false);
+      expect(reportFormat4.isTrusted()).toBe(true);
     });
   });
 });

--- a/gsa/src/gmp/models/permission.js
+++ b/gsa/src/gmp/models/permission.js
@@ -16,13 +16,34 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {isDefined} from '../utils/identity';
+import {hasValue, isDefined} from '../utils/identity';
 import {isEmpty} from '../utils/string';
 
-import Model, {parseModelFromElement} from '../model';
+import Model, {parseModelFromElement, parseModelFromObject} from '../model';
 
 class Permission extends Model {
   static entityType = 'permission';
+
+  static parseObject(object) {
+    const ret = super.parseObject(object);
+
+    if (hasValue(object.resource) && !isEmpty(object.resource.id)) {
+      ret.resource = parseModelFromObject(
+        object.resource,
+        object.resource.type,
+      );
+    } else {
+      delete ret.resource;
+    }
+
+    if (hasValue(object.subject) && !isEmpty(object.subject.id)) {
+      ret.subject = parseModelFromObject(object.subject, object.subject.type);
+    } else {
+      delete ret.subject;
+    }
+
+    return ret;
+  }
 
   static parseElement(element) {
     const ret = super.parseElement(element);

--- a/gsa/src/gmp/models/reportformat.js
+++ b/gsa/src/gmp/models/reportformat.js
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import {isDefined, isObject} from '../utils/identity';
+import {hasValue, isDefined, isObject} from '../utils/identity';
 import {map} from '../utils/array';
 import {isEmpty} from '../utils/string';
 
@@ -56,6 +56,27 @@ class Param {
 
 class ReportFormat extends Model {
   static entityType = 'reportformat';
+
+  static parseObject(object) {
+    const ret = super.parseObject(object);
+
+    if (hasValue(ret.trust)) {
+      ret.trust = {
+        value: ret.trust,
+        time: isEmpty(object.trustTime)
+          ? undefined
+          : parseDate(object.trustTime),
+      };
+    } else {
+      ret.trust = {};
+    }
+
+    // object has no params
+    // Has no alert field
+    // active and predefined are already boolean
+
+    return ret;
+  }
 
   static parseElement(element) {
     const ret = super.parseElement(element);

--- a/gsa/src/gmp/utils/entitytype.js
+++ b/gsa/src/gmp/utils/entitytype.js
@@ -142,4 +142,7 @@ export const apiType = type => {
   return isDefined(name) ? name : type;
 };
 
+// An array of hyperion entity types that might need special parsing in components
+export const hyperionEntityTypes = ['task', 'alert'];
+
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/entity/__tests__/link.js
+++ b/gsa/src/web/entity/__tests__/link.js
@@ -117,6 +117,25 @@ describe('EntityLink component tests', () => {
     expect(a).toBe(null);
     expect(element).toHaveTextContent('Orphan');
   });
+  test('should indicate orphaned status for hyperion entities', () => {
+    const entity = Model.fromObject({
+      id: '123',
+      entityType: 'alert',
+      name: 'bar',
+      deleted: true,
+    });
+
+    const {render} = rendererWith({
+      capabilities: caps,
+      router: true,
+    });
+    const {element} = render(<EntityLink entity={entity} />);
+
+    const a = element.querySelector('a');
+
+    expect(a).toBe(null);
+    expect(element).toHaveTextContent('Orphan');
+  });
 });
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/entity/icon/observericon.js
+++ b/gsa/src/web/entity/icon/observericon.js
@@ -26,7 +26,7 @@ import PropTypes from 'web/utils/proptypes';
 
 import ViewOtherIcon from 'web/components/icon/viewothericon';
 
-const hyperionEntityTypes = ['task', 'alert'];
+export const hyperionEntityTypes = ['task', 'alert'];
 
 const ObserverIcon = ({entity, userName, displayName = _('Entity')}) => {
   let owner;

--- a/gsa/src/web/entity/icon/observericon.js
+++ b/gsa/src/web/entity/icon/observericon.js
@@ -19,14 +19,13 @@
 import React from 'react';
 
 import _ from 'gmp/locale';
+import {hyperionEntityTypes} from 'gmp/utils/entitytype';
 
 import {isDefined, hasValue} from 'gmp/utils/identity';
 
 import PropTypes from 'web/utils/proptypes';
 
 import ViewOtherIcon from 'web/components/icon/viewothericon';
-
-export const hyperionEntityTypes = ['task', 'alert'];
 
 const ObserverIcon = ({entity, userName, displayName = _('Entity')}) => {
   let owner;

--- a/gsa/src/web/entity/link.js
+++ b/gsa/src/web/entity/link.js
@@ -49,7 +49,7 @@ const EntityLink = ({capabilities, entity, textOnly, ...props}) => {
     // FIXME is this still used?
     if (hyperionEntityTypes.includes(type) && deleted === true) {
       return <b>{_('Orphan')}</b>;
-    } else if (deleted !== 0) {
+    } else if (deleted === 1) {
       return <b>{_('Orphan')}</b>;
     }
   }

--- a/gsa/src/web/entity/link.js
+++ b/gsa/src/web/entity/link.js
@@ -50,6 +50,7 @@ const EntityLink = ({capabilities, entity, textOnly, ...props}) => {
     if (hyperionEntityTypes.includes(type) && deleted === true) {
       return <b>{_('Orphan')}</b>;
     } else if (deleted === 1) {
+      // explicitly use deleted === 1. If we use deleted !== 0, and the entityType is not from hyperion and deleted === false, this can cause Orphan to be returned
       return <b>{_('Orphan')}</b>;
     }
   }

--- a/gsa/src/web/entity/link.js
+++ b/gsa/src/web/entity/link.js
@@ -19,7 +19,7 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
+import {hasValue} from 'gmp/utils/identity';
 
 import PropTypes from '../utils/proptypes.js';
 import withCapabilities from '../utils/withCapabilities.js';
@@ -45,11 +45,11 @@ const EntityLink = ({capabilities, entity, textOnly, ...props}) => {
     );
   }
 
-  if (isDefined(deleted)) {
+  if (hasValue(deleted)) {
     // FIXME is this still used?
     if (hyperionEntityTypes.includes(type) && deleted === true) {
       return <b>{_('Orphan')}</b>;
-    } else if (deleted === 1) {
+    } else if (deleted !== 0) {
       return <b>{_('Orphan')}</b>;
     }
   }

--- a/gsa/src/web/entity/link.js
+++ b/gsa/src/web/entity/link.js
@@ -24,6 +24,7 @@ import {isDefined} from 'gmp/utils/identity';
 import PropTypes from '../utils/proptypes.js';
 import withCapabilities from '../utils/withCapabilities.js';
 
+import {hyperionEntityTypes} from 'web/entity/icon/observericon';
 import DetailsLink from '../components/link/detailslink.js';
 import Link from '../components/link/link.js';
 import {getEntityType, normalizeType} from 'gmp/utils/entitytype.js';
@@ -44,9 +45,13 @@ const EntityLink = ({capabilities, entity, textOnly, ...props}) => {
     );
   }
 
-  if (isDefined(deleted) && deleted !== 0) {
+  if (isDefined(deleted)) {
     // FIXME is this still used?
-    return <b>{_('Orphan')}</b>;
+    if (hyperionEntityTypes.includes(type) && deleted === true) {
+      return <b>{_('Orphan')}</b>;
+    } else if (deleted === 1) {
+      return <b>{_('Orphan')}</b>;
+    }
   }
 
   if (

--- a/gsa/src/web/entity/link.js
+++ b/gsa/src/web/entity/link.js
@@ -19,12 +19,12 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
+import {hyperionEntityTypes} from 'gmp/utils/entitytype';
 import {hasValue} from 'gmp/utils/identity';
 
-import PropTypes from '../utils/proptypes.js';
+import PropTypes from 'web/utils/proptypes.js';
 import withCapabilities from '../utils/withCapabilities.js';
 
-import {hyperionEntityTypes} from 'web/entity/icon/observericon';
 import DetailsLink from '../components/link/detailslink.js';
 import Link from '../components/link/link.js';
 import {getEntityType, normalizeType} from 'gmp/utils/entitytype.js';

--- a/gsa/src/web/graphql/__mocks__/alerts.js
+++ b/gsa/src/web/graphql/__mocks__/alerts.js
@@ -91,9 +91,9 @@ export const alert1 = deepFreeze({
 export const alert2 = deepFreeze({
   id: '2',
   name: 'alert 2',
-  inUse: true,
-  writable: false,
-  active: true,
+  inUse: false,
+  writable: true,
+  active: false,
   comment: 'lorem',
   creationTime: '2020-08-06T11:30:41+00:00',
   modificationTime: '2020-08-07T09:26:05+00:00',
@@ -119,6 +119,38 @@ export const alert2 = deepFreeze({
   condition: {
     type: 'Filter count at least',
     data: [{name: 'count', value: '3'}],
+  },
+  permissions: [{name: 'get_alerts'}],
+  tasks: null,
+});
+
+export const alert3 = deepFreeze({
+  id: '3',
+  name: 'alert 3',
+  inUse: true,
+  writable: true,
+  active: false,
+  comment: 'ipsum',
+  creationTime: '2020-11-11T15:44:20+00:00',
+  modificationTime: '2020-11-11T15:44:20+00:00',
+  owner: 'admin',
+  filter: null,
+  userTags: null,
+  method: {
+    type: 'HTTP Get',
+    data: [
+      {name: 'URL', value: '127.0.0.1'},
+      {name: 'delta_type', value: 'None'},
+      {name: 'details_url', value: '"https://secinfo.greenbone.net/'},
+    ],
+  },
+  event: {
+    type: 'Task run status changed',
+    data: [{name: 'status', value: 'Done'}],
+  },
+  condition: {
+    type: 'Always',
+    data: [],
   },
   permissions: [{name: 'Everything'}],
   tasks: null,

--- a/gsa/src/web/graphql/__mocks__/permissions.js
+++ b/gsa/src/web/graphql/__mocks__/permissions.js
@@ -69,17 +69,17 @@ export const perm2 = deepFreeze({
   permissions: [{name: 'Everything'}],
   resource: {
     deleted: false,
-    name: 'alert 2',
+    name: 'alert 1',
     permissions: [{name: 'get_alerts'}],
     trash: false,
-    id: '2',
+    id: '1',
     type: 'alert',
   },
   subject: {
-    id: '234',
-    name: 'admin',
+    id: '344',
+    name: 'stormtroopers',
     trash: false,
-    type: 'user',
+    type: 'role',
   },
   userTags: {
     count: 1,

--- a/gsa/src/web/graphql/__mocks__/permissions.js
+++ b/gsa/src/web/graphql/__mocks__/permissions.js
@@ -1,0 +1,127 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {deepFreeze, createGenericQueryMock} from 'web/utils/testing';
+
+import {GET_PERMISSIONS} from '../permissions';
+
+export const perm1 = deepFreeze({
+  id: '132',
+  comment: 'olympics',
+  name: 'get_foo',
+  writable: true,
+  inUse: false,
+  creationTime: '2020-11-17T14:43:35+00:00',
+  modificationTime: '2020-11-17T14:43:35+00:00',
+  owner: 'admin',
+  permissions: [{name: 'Everything'}],
+  resource: {
+    deleted: false,
+    name: 'alert 1',
+    permissions: [{name: 'get_alerts'}],
+    trash: false,
+    id: '1',
+    type: 'alert',
+  },
+  subject: {
+    id: '234',
+    name: 'admin',
+    trash: false,
+    type: 'user',
+  },
+  userTags: {
+    count: 1,
+    tags: [
+      {
+        name: 'alert:unnamed',
+        id: '12343',
+        value: null,
+        comment: 'real',
+      },
+    ],
+  },
+});
+
+export const perm2 = deepFreeze({
+  id: '434',
+  comment: null,
+  name: 'get_bar',
+  writable: false,
+  inUse: true,
+  creationTime: '2020-11-17T14:43:42+00:00',
+  modificationTime: '2020-11-17T14:43:42+00:00',
+  owner: 'admin',
+  permissions: [{name: 'Everything'}],
+  resource: {
+    deleted: false,
+    name: 'alert 2',
+    permissions: [{name: 'get_alerts'}],
+    trash: false,
+    id: '2',
+    type: 'alert',
+  },
+  subject: {
+    id: '234',
+    name: 'admin',
+    trash: false,
+    type: 'user',
+  },
+  userTags: {
+    count: 1,
+    tags: [
+      {
+        name: 'somedummyname',
+        id: '4346',
+        value: null,
+        comment: 'fake',
+      },
+    ],
+  },
+});
+
+const mockPermissions = {
+  edges: [
+    {
+      node: perm1,
+    },
+    {
+      node: perm2,
+    },
+  ],
+  counts: {
+    total: 2,
+    filtered: 2,
+    offset: 0,
+    limit: 10,
+    length: 2,
+  },
+  pageInfo: {
+    hasNextPage: false,
+    hasPreviousPage: false,
+    startCursor: 'YWxlcnQ6MA==',
+    endCursor: 'YWxlcnQ6OQ==',
+    lastPageCursor: 'YWxlcnQ6MA==',
+  },
+};
+
+export const createGetPermissionsQueryMock = variables =>
+  createGenericQueryMock(
+    GET_PERMISSIONS,
+    {permissions: mockPermissions},
+    variables,
+  );

--- a/gsa/src/web/graphql/__mocks__/report_formats.js
+++ b/gsa/src/web/graphql/__mocks__/report_formats.js
@@ -1,0 +1,93 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {deepFreeze, createGenericQueryMock} from 'web/utils/testing';
+
+import {GET_REPORT_FORMATS} from '../report_formats';
+
+export const reportFormat1 = deepFreeze({
+  id: '4983',
+  name: 'blah',
+  owner: 'admin',
+  predefined: true,
+  comment: 'not good enough',
+  writable: false,
+  inUse: true,
+  creationTime: '2020-08-17T12:07:28+00:00',
+  modificationTime: '2020-09-29T12:16:51+00:00',
+  permisssions: [{name: 'get_alerts'}],
+  userTags: null,
+  summary: 'once upon a time',
+  description: 'A very generic fairytale',
+  trust: 'yes',
+  trustTime: '2020-08-17T14:07:27+02:00',
+  active: false,
+  extension: 'bleh',
+});
+
+export const reportFormat2 = deepFreeze({
+  id: '46789',
+  name: 'interrupted',
+  owner: 'admin',
+  predefined: true,
+  comment: null,
+  writable: true,
+  inUse: false,
+  creationTime: '2020-08-17T12:07:28+00:00',
+  modificationTime: '2020-09-29T12:16:51+00:00',
+  permisssions: [{name: 'no'}],
+  userTags: null,
+  summary: 'and they lived happily ever after',
+  description: 'A very generic ending',
+  trust: 'yes',
+  trustTime: '2020-08-17T14:07:27+02:00',
+  active: true,
+  extension: 'lol.no',
+});
+
+const mockReportFormats = {
+  edges: [
+    {
+      node: reportFormat1,
+    },
+    {
+      node: reportFormat2,
+    },
+  ],
+  counts: {
+    total: 2,
+    filtered: 2,
+    offset: 0,
+    limit: 10,
+    length: 2,
+  },
+  pageInfo: {
+    hasNextPage: false,
+    hasPreviousPage: false,
+    startCursor: 'YWxlcnQ6MA==',
+    endCursor: 'YWxlcnQ6OQ==',
+    lastPageCursor: 'YWxlcnQ6MA==',
+  },
+};
+
+export const createGetReportFormatsQueryMock = variables =>
+  createGenericQueryMock(
+    GET_REPORT_FORMATS,
+    {reportFormats: mockReportFormats},
+    variables,
+  );

--- a/gsa/src/web/graphql/__mocks__/report_formats.js
+++ b/gsa/src/web/graphql/__mocks__/report_formats.js
@@ -20,26 +20,6 @@ import {deepFreeze, createGenericQueryMock} from 'web/utils/testing';
 
 import {GET_REPORT_FORMATS} from '../report_formats';
 
-/* export const reportFormat1 = deepFreeze({
-  id: '4983',
-  name: 'blah',
-  owner: 'admin',
-  predefined: true,
-  comment: 'not good enough',
-  writable: false,
-  inUse: true,
-  creationTime: '2020-08-17T12:07:28+00:00',
-  modificationTime: '2020-09-29T12:16:51+00:00',
-  permisssions: [{name: 'get_alerts'}],
-  userTags: null,
-  summary: 'once upon a time',
-  description: 'A very generic fairytale',
-  trust: 'yes',
-  trustTime: '2020-08-17T14:07:27+02:00',
-  active: false,
-  extension: 'bleh',
-}); */
-
 export const reportFormat1 = deepFreeze({
   id: '665',
   name: 'foo',

--- a/gsa/src/web/graphql/__mocks__/report_formats.js
+++ b/gsa/src/web/graphql/__mocks__/report_formats.js
@@ -20,7 +20,7 @@ import {deepFreeze, createGenericQueryMock} from 'web/utils/testing';
 
 import {GET_REPORT_FORMATS} from '../report_formats';
 
-export const reportFormat1 = deepFreeze({
+/* export const reportFormat1 = deepFreeze({
   id: '4983',
   name: 'blah',
   owner: 'admin',
@@ -38,26 +38,56 @@ export const reportFormat1 = deepFreeze({
   trustTime: '2020-08-17T14:07:27+02:00',
   active: false,
   extension: 'bleh',
+}); */
+
+export const reportFormat1 = deepFreeze({
+  id: '665',
+  name: 'foo',
+  owner: 'admin',
+  comment: 'comm',
+  writable: true,
+  inUse: true,
+  creationTime: '2020-08-17T12:07:28+00:00',
+  modificationTime: '2020-09-29T12:16:51+00:00',
+  permissions: [{name: 'get_alerts'}],
+  userTags: {
+    count: 1,
+    tags: [
+      {
+        name: 'sometag',
+        id: '235',
+        value: 'november',
+        comment: 'nocomment',
+      },
+    ],
+  },
+  summary: 'source',
+  description: 'desc',
+  predefined: true,
+  trust: 'yes',
+  trustTime: '2020-08-17T14:07:27+02:00',
+  active: false,
+  extension: 'xml',
 });
 
 export const reportFormat2 = deepFreeze({
-  id: '46789',
-  name: 'interrupted',
+  id: '789',
+  name: 'bar',
   owner: 'admin',
-  predefined: true,
-  comment: null,
+  comment: 'lorem ipsum',
   writable: true,
-  inUse: false,
+  inUse: true,
   creationTime: '2020-08-17T12:07:28+00:00',
   modificationTime: '2020-09-29T12:16:51+00:00',
-  permisssions: [{name: 'no'}],
+  permissions: [{name: 'Everything'}],
   userTags: null,
-  summary: 'and they lived happily ever after',
-  description: 'A very generic ending',
+  summary: 'something happened',
+  description: 'desc',
+  predefined: true,
   trust: 'yes',
   trustTime: '2020-08-17T14:07:27+02:00',
-  active: true,
-  extension: 'lol.no',
+  active: false,
+  extension: 'xml',
 });
 
 const mockReportFormats = {

--- a/gsa/src/web/graphql/__tests__/permissions.js
+++ b/gsa/src/web/graphql/__tests__/permissions.js
@@ -1,0 +1,82 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+/* eslint-disable react/prop-types */
+import React, {useState} from 'react';
+
+import {isDefined} from 'gmp/utils/identity';
+
+import {rendererWith, screen, wait, fireEvent} from 'web/utils/testing';
+import {useGetPermissions} from '../permissions';
+import {createGetPermissionsQueryMock} from '../__mocks__/permissions';
+
+const GetPermissionsComponent = () => {
+  const {counts, permissions} = useGetPermissions();
+  return (
+    <div>
+      {isDefined(counts) ? (
+        <div data-testid="counts">
+          <span data-testid="total">{counts.all}</span>
+          <span data-testid="filtered">{counts.filtered}</span>
+          <span data-testid="first">{counts.first}</span>
+          <span data-testid="limit">{counts.rows}</span>
+          <span data-testid="length">{counts.length}</span>
+        </div>
+      ) : (
+        <div data-testid="no-counts" />
+      )}
+      {isDefined(permissions) ? (
+        permissions.map(permission => {
+          return (
+            <div key={permission.id} data-testid="permission">
+              {permission.name}
+            </div>
+          );
+        })
+      ) : (
+        <div data-testid="no-permission" />
+      )}
+    </div>
+  );
+};
+
+describe('useLazyGetPermission tests', () => {
+  test('should query permissions', async () => {
+    const [mock, resultFunc] = createGetPermissionsQueryMock();
+    const {render} = rendererWith({queryMocks: [mock]});
+
+    render(<GetPermissionsComponent />);
+    await wait();
+
+    const permissionElements = screen.queryAllByTestId('permission');
+    expect(permissionElements).toHaveLength(2);
+
+    expect(resultFunc).toHaveBeenCalled();
+
+    expect(permissionElements[0]).toHaveTextContent('get_foo');
+    expect(permissionElements[1]).toHaveTextContent('get_bar');
+
+    const noPermissions = screen.queryByTestId('no-permission');
+    expect(noPermissions).not.toBeInTheDocument();
+
+    expect(screen.getByTestId('total')).toHaveTextContent(2);
+    expect(screen.getByTestId('filtered')).toHaveTextContent(2);
+    expect(screen.getByTestId('first')).toHaveTextContent(1);
+    expect(screen.getByTestId('limit')).toHaveTextContent(10);
+    expect(screen.getByTestId('length')).toHaveTextContent(2);
+  });
+});

--- a/gsa/src/web/graphql/__tests__/permissions.js
+++ b/gsa/src/web/graphql/__tests__/permissions.js
@@ -16,11 +16,11 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 /* eslint-disable react/prop-types */
-import React, {useState} from 'react';
+import React from 'react';
 
 import {isDefined} from 'gmp/utils/identity';
 
-import {rendererWith, screen, wait, fireEvent} from 'web/utils/testing';
+import {rendererWith, screen, wait} from 'web/utils/testing';
 import {useGetPermissions} from '../permissions';
 import {createGetPermissionsQueryMock} from '../__mocks__/permissions';
 

--- a/gsa/src/web/graphql/__tests__/permissions.js
+++ b/gsa/src/web/graphql/__tests__/permissions.js
@@ -54,7 +54,7 @@ const GetPermissionsComponent = () => {
   );
 };
 
-describe('useLazyGetPermission tests', () => {
+describe('useGetPermission tests', () => {
   test('should query permissions', async () => {
     const [mock, resultFunc] = createGetPermissionsQueryMock();
     const {render} = rendererWith({queryMocks: [mock]});

--- a/gsa/src/web/graphql/__tests__/report_formats.js
+++ b/gsa/src/web/graphql/__tests__/report_formats.js
@@ -1,0 +1,75 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+/* eslint-disable react/prop-types */
+import React from 'react';
+
+import {rendererWith, screen, wait} from 'web/utils/testing';
+import {useGetReportFormats} from '../report_formats';
+import {createGetReportFormatsQueryMock} from '../__mocks__/report_formats';
+
+const GetReportFormatsComponent = () => {
+  const {counts, loading, reportFormats} = useGetReportFormats();
+  if (loading) {
+    return <span data-testid="loading">Loading</span>;
+  }
+  return (
+    <div>
+      <div data-testid="counts">
+        <span data-testid="total">{counts.all}</span>
+        <span data-testid="filtered">{counts.filtered}</span>
+        <span data-testid="offset">{counts.first}</span>
+        <span data-testid="limit">{counts.rows}</span>
+        <span data-testid="length">{counts.length}</span>
+      </div>
+      {reportFormats.map(format => {
+        return (
+          <div key={format.id} data-testid="reportformat">
+            {format.name}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+describe('useGetTasks tests', () => {
+  test('should query useGetReportFormats', async () => {
+    const [mock, resultFunc] = createGetReportFormatsQueryMock();
+    const {render} = rendererWith({queryMocks: [mock]});
+
+    render(<GetReportFormatsComponent />);
+
+    expect(screen.getByTestId('loading')).toHaveTextContent('Loading');
+
+    await wait();
+
+    expect(resultFunc).toHaveBeenCalled();
+
+    const reportFormatElements = screen.getAllByTestId('reportformat');
+    expect(reportFormatElements).toHaveLength(2);
+
+    expect(reportFormatElements[0]).toHaveTextContent('foo');
+    expect(reportFormatElements[1]).toHaveTextContent('bar');
+
+    expect(screen.getByTestId('total')).toHaveTextContent(2);
+    expect(screen.getByTestId('filtered')).toHaveTextContent(2);
+    expect(screen.getByTestId('offset')).toHaveTextContent(1);
+    expect(screen.getByTestId('limit')).toHaveTextContent(10);
+    expect(screen.getByTestId('length')).toHaveTextContent(2);
+  });
+});

--- a/gsa/src/web/graphql/__tests__/report_formats.js
+++ b/gsa/src/web/graphql/__tests__/report_formats.js
@@ -47,7 +47,7 @@ const GetReportFormatsComponent = () => {
   );
 };
 
-describe('useGetTasks tests', () => {
+describe('useGetReportFormats tests', () => {
   test('should query useGetReportFormats', async () => {
     const [mock, resultFunc] = createGetReportFormatsQueryMock();
     const {render} = rendererWith({queryMocks: [mock]});

--- a/gsa/src/web/graphql/permissions.js
+++ b/gsa/src/web/graphql/permissions.js
@@ -20,6 +20,7 @@
 import {gql, useQuery} from '@apollo/client';
 import {isDefined} from 'gmp/utils/identity';
 import Permission from 'gmp/models/permission';
+import CollectionCounts from 'gmp/collection/collectioncounts';
 
 export const GET_PERMISSIONS = gql`
   query Permission($filterString: FilterString) {
@@ -90,5 +91,18 @@ export const useGetPermissions = (variables, options) => {
   const permissions = isDefined(data?.permissions)
     ? data.permissions.edges.map(entity => Permission.fromObject(entity.node))
     : undefined;
-  return {...other, permissions};
+
+  const {total, filtered, offset = -1, limit, length} =
+    data?.permissions?.counts || {};
+  const counts = isDefined(data?.permissions?.counts)
+    ? new CollectionCounts({
+        all: total,
+        filtered: filtered,
+        first: offset + 1,
+        length: length,
+        rows: limit,
+      })
+    : undefined;
+  const pageInfo = data?.permissions?.pageInfo;
+  return {...other, counts, permissions, pageInfo};
 };

--- a/gsa/src/web/graphql/permissions.js
+++ b/gsa/src/web/graphql/permissions.js
@@ -22,10 +22,62 @@ import {isDefined} from 'gmp/utils/identity';
 import Permission from 'gmp/models/permission';
 
 export const GET_PERMISSIONS = gql`
-  query Permission($filterString: String) {
+  query Permission($filterString: FilterString) {
     permissions(filterString: $filterString) {
-      name
-      id
+      edges {
+        node {
+          name
+          id
+          owner
+          comment
+          writable
+          inUse
+          creationTime
+          modificationTime
+          permissions {
+            name
+          }
+          resource {
+            name
+            id
+            type
+            trash
+            deleted
+            permissions {
+              name
+            }
+          }
+          subject {
+            name
+            id
+            type
+            trash
+          }
+          userTags {
+            count
+            tags {
+              name
+              id
+              value
+              comment
+            }
+          }
+        }
+      }
+      counts {
+        total
+        filtered
+        offset
+        limit
+        length
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+        lastPageCursor
+      }
     }
   }
 `;
@@ -36,7 +88,7 @@ export const useGetPermissions = (variables, options) => {
     variables,
   });
   const permissions = isDefined(data?.permissions)
-    ? data.permissions.map(entity => Permission.fromObject(entity))
+    ? data.permissions.edges.map(entity => Permission.fromObject(entity.node))
     : undefined;
   return {...other, permissions};
 };

--- a/gsa/src/web/graphql/permissions.js
+++ b/gsa/src/web/graphql/permissions.js
@@ -18,43 +18,14 @@
  */
 
 import {gql, useQuery} from '@apollo/client';
+import {isDefined} from 'gmp/utils/identity';
 import Permission from 'gmp/models/permission';
 
 export const GET_PERMISSIONS = gql`
-  query Permission(
-    $filterString: FilterString
-    $after: String
-    $before: String
-    $first: Int
-    $last: Int
-  ) {
-    permissions(
-      filterString: $filterString
-      after: $after
-      before: $before
-      first: $first
-      last: $last
-    ) {
-      edges {
-        node {
-          name
-          id
-        }
-      }
-      counts {
-        total
-        filtered
-        offset
-        limit
-        length
-      }
-      pageInfo {
-        hasNextPage
-        hasPreviousPage
-        startCursor
-        endCursor
-        lastPageCursor
-      }
+  query Permission($filterString: String) {
+    permissions(filterString: $filterString) {
+      name
+      id
     }
   }
 `;
@@ -65,20 +36,7 @@ export const useGetPermissions = (variables, options) => {
     variables,
   });
   const permissions = isDefined(data?.permissions)
-    ? data.permissions.edges.map(entity => Permission.fromObject(entity.node))
+    ? data.permissions.map(entity => Permission.fromObject(entity))
     : undefined;
-
-  const {total, filtered, offset = -1, limit, length} =
-    data?.permissions?.counts || {};
-  const counts = isDefined(data?.permissions?.counts)
-    ? new CollectionCounts({
-        all: total,
-        filtered: filtered,
-        first: offset + 1,
-        length: length,
-        rows: limit,
-      })
-    : undefined;
-  const pageInfo = data?.permissions?.pageInfo;
-  return {...other, counts, permissions, pageInfo};
+  return {...other, permissions};
 };

--- a/gsa/src/web/graphql/report_formats.js
+++ b/gsa/src/web/graphql/report_formats.js
@@ -18,7 +18,9 @@
  */
 
 import {gql, useQuery} from '@apollo/client';
+import CollectionCounts from 'gmp/collection/collectioncounts';
 import ReportFormat from 'gmp/models/reportformat';
+import {isDefined} from 'gmp/utils/identity';
 
 export const GET_REPORT_FORMATS = gql`
   query ReportFormat(

--- a/gsa/src/web/graphql/report_formats.js
+++ b/gsa/src/web/graphql/report_formats.js
@@ -41,6 +41,24 @@ export const GET_REPORT_FORMATS = gql`
         node {
           id
           name
+          owner
+          comment
+          writable
+          inUse
+          creationTime
+          modificationTime
+          permissions {
+            name
+          }
+          userTags {
+            count
+            tags {
+              name
+              id
+              value
+              comment
+            }
+          }
           summary
           description
           predefined

--- a/gsa/src/web/graphql/report_formats.js
+++ b/gsa/src/web/graphql/report_formats.js
@@ -39,6 +39,8 @@ export const GET_REPORT_FORMATS = gql`
     ) {
       edges {
         node {
+          id
+          name
           summary
           description
           predefined

--- a/gsa/src/web/graphql/report_formats.js
+++ b/gsa/src/web/graphql/report_formats.js
@@ -1,0 +1,91 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+import {gql, useQuery} from '@apollo/client';
+import ReportFormat from 'gmp/models/reportformat';
+
+export const GET_REPORT_FORMATS = gql`
+  query ReportFormat(
+    $filterString: FilterString
+    $after: String
+    $before: String
+    $first: Int
+    $last: Int
+  ) {
+    reportFormats(
+      filterString: $filterString
+      after: $after
+      before: $before
+      first: $first
+      last: $last
+    ) {
+      edges {
+        node {
+          summary
+          description
+          predefined
+          trust
+          trustTime
+          active
+          extension
+        }
+      }
+      counts {
+        total
+        filtered
+        offset
+        limit
+        length
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+        lastPageCursor
+      }
+    }
+  }
+`;
+
+export const useGetReportFormats = (variables, options) => {
+  const {data, ...other} = useQuery(GET_REPORT_FORMATS, {
+    ...options,
+    variables,
+  });
+  const reportFormats = isDefined(data?.reportFormats)
+    ? data.reportFormats.edges.map(entity =>
+        ReportFormat.fromObject(entity.node),
+      )
+    : undefined;
+
+  const {total, filtered, offset = -1, limit, length} =
+    data?.reportFormats?.counts || {};
+  const counts = isDefined(data?.reportFormats?.counts)
+    ? new CollectionCounts({
+        all: total,
+        filtered: filtered,
+        first: offset + 1,
+        length: length,
+        rows: limit,
+      })
+    : undefined;
+  const pageInfo = data?.reportFormats?.pageInfo;
+  return {...other, counts, reportFormats, pageInfo};
+};

--- a/gsa/src/web/pages/alerts/__tests__/detailspage.js
+++ b/gsa/src/web/pages/alerts/__tests__/detailspage.js
@@ -40,6 +40,10 @@ import {
   alert1,
 } from 'web/graphql/__mocks__/alerts';
 
+import {createGetReportFormatsQueryMock} from 'web/graphql/__mocks__/report_formats';
+
+import {createGetPermissionsQueryMock} from 'web/graphql/__mocks__/permissions';
+
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import Detailspage, {ToolBarIcons} from '../detailspage';
@@ -146,13 +150,20 @@ describe('Alert Detailspage tests', () => {
     };
 
     const [mock, resultFunc] = createGetAlertQueryMock('1', alert1);
+    const [permissionMock, permissionResult] = createGetPermissionsQueryMock({
+      filterString: 'resource_uuid=1 first=1 rows=-1',
+    });
+    const [
+      reportFormatsMock,
+      reportFormatsResult,
+    ] = createGetReportFormatsQueryMock();
 
     const {render, store} = rendererWith({
       capabilities: caps,
       gmp,
       router: true,
       store: true,
-      queryMocks: [mock],
+      queryMocks: [mock, permissionMock, reportFormatsMock],
     });
 
     store.dispatch(setTimezone('CET'));
@@ -165,6 +176,8 @@ describe('Alert Detailspage tests', () => {
     await wait();
 
     expect(resultFunc).toHaveBeenCalled();
+    expect(permissionResult).toHaveBeenCalled();
+    expect(reportFormatsResult).toHaveBeenCalled();
 
     expect(element).toHaveTextContent('Alert: alert 1');
 
@@ -240,13 +253,20 @@ describe('Alert Detailspage tests', () => {
     };
 
     const [mock, resultFunc] = createGetAlertQueryMock('1', alert1);
+    const [permissionMock, permissionResult] = createGetPermissionsQueryMock({
+      filterString: 'resource_uuid=1 first=1 rows=-1',
+    });
+    const [
+      reportFormatsMock,
+      reportFormatsResult,
+    ] = createGetReportFormatsQueryMock();
 
     const {render, store} = rendererWith({
       capabilities: caps,
       gmp,
       router: true,
       store: true,
-      queryMocks: [mock],
+      queryMocks: [mock, permissionMock, reportFormatsMock],
     });
 
     store.dispatch(setTimezone('CET'));
@@ -259,7 +279,8 @@ describe('Alert Detailspage tests', () => {
     await wait();
 
     expect(resultFunc).toHaveBeenCalled();
-
+    expect(permissionResult).toHaveBeenCalled();
+    expect(reportFormatsResult).toHaveBeenCalled();
     const tabs = screen.getAllByTestId('entities-tab-title');
 
     expect(baseElement).toHaveTextContent('User Tags(1)');
@@ -287,13 +308,20 @@ describe('Alert Detailspage tests', () => {
     };
 
     const [mock, resultFunc] = createGetAlertQueryMock('1', alert1);
+    const [permissionMock, permissionResult] = createGetPermissionsQueryMock({
+      filterString: 'resource_uuid=1 first=1 rows=-1',
+    });
+    const [
+      reportFormatsMock,
+      reportFormatsResult,
+    ] = createGetReportFormatsQueryMock();
 
     const {render, store} = rendererWith({
       capabilities: caps,
       gmp,
       router: true,
       store: true,
-      queryMocks: [mock],
+      queryMocks: [mock, permissionMock, reportFormatsMock],
     });
 
     store.dispatch(setTimezone('CET'));
@@ -306,13 +334,62 @@ describe('Alert Detailspage tests', () => {
     await wait();
 
     expect(resultFunc).toHaveBeenCalled();
+    expect(permissionResult).toHaveBeenCalled();
+    expect(reportFormatsResult).toHaveBeenCalled();
 
     const tabs = screen.getAllByTestId('entities-tab-title');
 
     expect(tabs[1]).toHaveTextContent('Permissions');
     fireEvent.click(tabs[1]);
 
-    expect(baseElement).toHaveTextContent('No permissions available');
+    // permission 1
+    expect(baseElement).toHaveTextContent('Name');
+    expect(baseElement).toHaveTextContent('get_foo');
+
+    expect(baseElement).toHaveTextContent('Description');
+    expect(baseElement).toHaveTextContent(
+      'User admin has read access to Alert alert 1',
+    );
+
+    expect(baseElement).toHaveTextContent('Resource Type');
+    expect(baseElement).toHaveTextContent('Alert');
+
+    expect(baseElement).toHaveTextContent('Resource');
+    expect(baseElement).toHaveTextContent('alert 1');
+
+    expect(baseElement).toHaveTextContent('Subject Type');
+    expect(baseElement).toHaveTextContent('User');
+
+    expect(baseElement).toHaveTextContent('Subject');
+    expect(baseElement).toHaveTextContent('admin');
+
+    // permission 2
+    expect(baseElement).toHaveTextContent('Name');
+    expect(baseElement).toHaveTextContent('get_bar');
+
+    expect(baseElement).toHaveTextContent('Description');
+    expect(baseElement).toHaveTextContent(
+      'Role stormtroopers has read access to Alert alert 1',
+    );
+
+    expect(baseElement).toHaveTextContent('Resource Type');
+    expect(baseElement).toHaveTextContent('Alert');
+
+    expect(baseElement).toHaveTextContent('Resource');
+    expect(baseElement).toHaveTextContent('alert 1');
+
+    expect(baseElement).toHaveTextContent('Subject Type');
+    expect(baseElement).toHaveTextContent('Role');
+
+    expect(baseElement).toHaveTextContent('Subject');
+    expect(baseElement).toHaveTextContent('admin');
+
+    const detailsLinks = screen.getAllByTestId('details-link');
+
+    expect(detailsLinks[0]).toHaveAttribute('href', '/alert/1');
+    expect(detailsLinks[1]).toHaveAttribute('href', '/user/234');
+    expect(detailsLinks[2]).toHaveAttribute('href', '/alert/1');
+    expect(detailsLinks[3]).toHaveAttribute('href', '/role/344');
   });
 
   test('should call commands', async () => {
@@ -337,13 +414,28 @@ describe('Alert Detailspage tests', () => {
     const [cloneMock, cloneResult] = createCloneAlertQueryMock();
     const [deleteMock, deleteResult] = createDeleteAlertQueryMock();
     const [exportMock, exportResult] = createExportAlertsByIdsQueryMock(['1']);
+    const [permissionMock, permissionResult] = createGetPermissionsQueryMock({
+      filterString: 'resource_uuid=1 first=1 rows=-1',
+    });
+    const [
+      reportFormatsMock,
+      reportFormatsResult,
+    ] = createGetReportFormatsQueryMock();
 
     const {render, store} = rendererWith({
       capabilities: caps,
       gmp,
       router: true,
       store: true,
-      queryMocks: [renewQueryMock, mock, cloneMock, deleteMock, exportMock],
+      queryMocks: [
+        renewQueryMock,
+        mock,
+        cloneMock,
+        deleteMock,
+        exportMock,
+        permissionMock,
+        reportFormatsMock,
+      ],
     });
 
     store.dispatch(setTimezone('CET'));
@@ -356,6 +448,8 @@ describe('Alert Detailspage tests', () => {
     await wait();
 
     expect(resultFunc).toHaveBeenCalled();
+    expect(permissionResult).toHaveBeenCalled();
+    expect(reportFormatsResult).toHaveBeenCalled();
 
     const icons = screen.getAllByTestId('svg-icon');
 

--- a/gsa/src/web/pages/alerts/__tests__/detailspage.js
+++ b/gsa/src/web/pages/alerts/__tests__/detailspage.js
@@ -22,10 +22,8 @@ import {setLocale} from 'gmp/locale/lang';
 import {isDefined} from 'gmp/utils/identity';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import CollectionCounts from 'gmp/collection/collectioncounts';
 
 import Alert from 'gmp/models/alert';
-import Filter from 'gmp/models/filter';
 
 import {createRenewSessionQueryMock} from 'web/graphql/__mocks__/session';
 
@@ -38,6 +36,8 @@ import {
   createDeleteAlertQueryMock,
   createExportAlertsByIdsQueryMock,
   alert1,
+  alert2,
+  alert3,
 } from 'web/graphql/__mocks__/alerts';
 
 import {createGetReportFormatsQueryMock} from 'web/graphql/__mocks__/report_formats';
@@ -93,35 +93,9 @@ const alert = Alert.fromElement({
   },
 });
 
-const observedAlert = Alert.fromElement({
-  _id: '1234',
-  owner: {name: 'admin'},
-  name: 'foo',
-  comment: 'bar',
-  permissions: {permission: [{name: 'get_alerts'}]},
-});
-
-const alertInUse = Alert.fromElement({
-  _id: '1234',
-  owner: {name: 'admin'},
-  name: 'foo',
-  comment: 'bar',
-  permissions: {permission: [{name: 'everything'}]},
-  inUse: true,
-});
-
 const parsedAlert = Alert.fromObject(alert1);
-const getAlert = jest.fn().mockResolvedValue({
-  data: parsedAlert,
-});
-
-const getEntities = jest.fn().mockResolvedValue({
-  data: [],
-  meta: {
-    filter: Filter.fromString(),
-    counts: new CollectionCounts(),
-  },
-});
+const parsedAlert2 = Alert.fromObject(alert2);
+const parsedAlert3 = Alert.fromObject(alert3);
 
 const currentSettings = jest.fn().mockResolvedValue({
   foo: 'bar',
@@ -134,15 +108,6 @@ const renewSession = jest.fn().mockResolvedValue({
 describe('Alert Detailspage tests', () => {
   test('should render full Detailspage', async () => {
     const gmp = {
-      alert: {
-        get: getAlert,
-      },
-      permissions: {
-        get: getEntities,
-      },
-      reportformats: {
-        get: getEntities,
-      },
       settings: {manualUrl, reloadInterval},
       user: {
         currentSettings,
@@ -236,15 +201,6 @@ describe('Alert Detailspage tests', () => {
 
   test('should render user tags tab', async () => {
     const gmp = {
-      alert: {
-        get: getAlert,
-      },
-      permissions: {
-        get: getEntities,
-      },
-      reportformats: {
-        get: getEntities,
-      },
       settings: {manualUrl, reloadInterval},
       user: {
         currentSettings,
@@ -291,15 +247,6 @@ describe('Alert Detailspage tests', () => {
 
   test('should render permissions tab', async () => {
     const gmp = {
-      alert: {
-        get: getAlert,
-      },
-      permissions: {
-        get: getEntities,
-      },
-      reportformats: {
-        get: getEntities,
-      },
       settings: {manualUrl, reloadInterval},
       user: {
         currentSettings,
@@ -394,15 +341,6 @@ describe('Alert Detailspage tests', () => {
 
   test('should call commands', async () => {
     const gmp = {
-      alert: {
-        get: getAlert,
-      },
-      permissions: {
-        get: getEntities,
-      },
-      reportformats: {
-        get: getEntities,
-      },
       settings: {manualUrl, reloadInterval},
       user: {
         currentSettings,
@@ -494,7 +432,7 @@ describe('Alert ToolBarIcons tests', () => {
 
     const {element} = render(
       <ToolBarIcons
-        entity={alert}
+        entity={parsedAlert}
         onAlertCloneClick={handleAlertCloneClick}
         onAlertDeleteClick={handleAlertDeleteClick}
         onAlertDownloadClick={handleAlertDownloadClick}
@@ -533,7 +471,7 @@ describe('Alert ToolBarIcons tests', () => {
 
     render(
       <ToolBarIcons
-        entity={alert}
+        entity={parsedAlert}
         onAlertCloneClick={handleAlertCloneClick}
         onAlertDeleteClick={handleAlertDeleteClick}
         onAlertDownloadClick={handleAlertDownloadClick}
@@ -545,19 +483,19 @@ describe('Alert ToolBarIcons tests', () => {
     const icons = screen.getAllByTestId('svg-icon');
 
     fireEvent.click(icons[3]);
-    expect(handleAlertCloneClick).toHaveBeenCalledWith(alert);
+    expect(handleAlertCloneClick).toHaveBeenCalledWith(parsedAlert);
     expect(icons[3]).toHaveAttribute('title', 'Clone Alert');
 
     fireEvent.click(icons[4]);
-    expect(handleAlertEditClick).toHaveBeenCalledWith(alert);
+    expect(handleAlertEditClick).toHaveBeenCalledWith(parsedAlert);
     expect(icons[4]).toHaveAttribute('title', 'Edit Alert');
 
     fireEvent.click(icons[5]);
-    expect(handleAlertDeleteClick).toHaveBeenCalledWith(alert);
+    expect(handleAlertDeleteClick).toHaveBeenCalledWith(parsedAlert);
     expect(icons[5]).toHaveAttribute('title', 'Move Alert to trashcan');
 
     fireEvent.click(icons[6]);
-    expect(handleAlertDownloadClick).toHaveBeenCalledWith(alert);
+    expect(handleAlertDownloadClick).toHaveBeenCalledWith(parsedAlert);
     expect(icons[6]).toHaveAttribute('title', 'Export Alert as XML');
   });
 
@@ -578,7 +516,7 @@ describe('Alert ToolBarIcons tests', () => {
 
     render(
       <ToolBarIcons
-        entity={observedAlert}
+        entity={parsedAlert2}
         onAlertCloneClick={handleAlertCloneClick}
         onAlertDeleteClick={handleAlertDeleteClick}
         onAlertDownloadClick={handleAlertDownloadClick}
@@ -591,7 +529,7 @@ describe('Alert ToolBarIcons tests', () => {
 
     expect(icons[3]).toHaveAttribute('title', 'Clone Alert');
     fireEvent.click(icons[3]);
-    expect(handleAlertCloneClick).toHaveBeenCalledWith(observedAlert);
+    expect(handleAlertCloneClick).toHaveBeenCalledWith(parsedAlert2);
     expect(icons[3]).toHaveAttribute('title', 'Clone Alert');
 
     expect(icons[4]).toHaveAttribute(
@@ -609,7 +547,7 @@ describe('Alert ToolBarIcons tests', () => {
     );
 
     fireEvent.click(icons[6]);
-    expect(handleAlertDownloadClick).toHaveBeenCalledWith(observedAlert);
+    expect(handleAlertDownloadClick).toHaveBeenCalledWith(parsedAlert2);
     expect(icons[6]).toHaveAttribute('title', 'Export Alert as XML');
   });
 
@@ -630,7 +568,7 @@ describe('Alert ToolBarIcons tests', () => {
 
     render(
       <ToolBarIcons
-        entity={alertInUse}
+        entity={parsedAlert3}
         onAlertCloneClick={handleAlertCloneClick}
         onAlertDeleteClick={handleAlertDeleteClick}
         onAlertDownloadClick={handleAlertDownloadClick}
@@ -643,7 +581,7 @@ describe('Alert ToolBarIcons tests', () => {
 
     expect(icons[3]).toHaveAttribute('title', 'Clone Alert');
     fireEvent.click(icons[3]);
-    expect(handleAlertCloneClick).toHaveBeenCalledWith(alertInUse);
+    expect(handleAlertCloneClick).toHaveBeenCalledWith(parsedAlert3);
     expect(icons[3]).toHaveAttribute('title', 'Clone Alert');
 
     expect(icons[4]).toHaveAttribute('title', 'Edit Alert');
@@ -655,7 +593,7 @@ describe('Alert ToolBarIcons tests', () => {
     expect(icons[5]).toHaveAttribute('title', 'Alert is still in use');
 
     fireEvent.click(icons[6]);
-    expect(handleAlertDownloadClick).toHaveBeenCalledWith(alertInUse);
+    expect(handleAlertDownloadClick).toHaveBeenCalledWith(parsedAlert3);
     expect(icons[6]).toHaveAttribute('title', 'Export Alert as XML');
   });
 });

--- a/gsa/src/web/pages/alerts/__tests__/detailspage.js
+++ b/gsa/src/web/pages/alerts/__tests__/detailspage.js
@@ -67,32 +67,6 @@ const caps = new Capabilities(['everything']);
 const reloadInterval = -1;
 const manualUrl = 'test/';
 
-const alert = Alert.fromElement({
-  _id: '1234',
-  owner: {name: 'admin'},
-  name: 'foo',
-  comment: 'bar',
-  permissions: {permission: [{name: 'everything'}]},
-  creation_time: '2019-07-16T06:31:29Z',
-  modification_time: '2019-07-16T06:44:55Z',
-  active: 1,
-  condition: 'Always',
-  event: {
-    data: {
-      name: 'status',
-      __text: 'Done',
-    },
-    __text: 'Task run status changed',
-  },
-  filter: {
-    _id: 'filter id',
-    name: 'report results filter',
-  },
-  method: {
-    __text: 'SMB',
-  },
-});
-
 const parsedAlert = Alert.fromObject(alert1);
 const parsedAlert2 = Alert.fromObject(alert2);
 const parsedAlert3 = Alert.fromObject(alert3);
@@ -332,6 +306,7 @@ describe('Alert Detailspage tests', () => {
     expect(baseElement).toHaveTextContent('admin');
 
     const detailsLinks = screen.getAllByTestId('details-link');
+    expect(detailsLinks).toHaveLength(4);
 
     expect(detailsLinks[0]).toHaveAttribute('href', '/alert/1');
     expect(detailsLinks[1]).toHaveAttribute('href', '/user/234');

--- a/gsa/src/web/pages/alerts/__tests__/listpage.js
+++ b/gsa/src/web/pages/alerts/__tests__/listpage.js
@@ -185,7 +185,7 @@ describe('Alert listpage tests', () => {
     expect(row[2]).toHaveTextContent('Filter matches at least 3 NVTs');
     expect(row[2]).toHaveTextContent('Email to foo@bar.com');
 
-    expect(row[2]).toHaveTextContent('Yes');
+    expect(row[2]).toHaveTextContent('No');
 
     expect(icons[13]).toHaveAttribute('title', 'Move Alert to trashcan');
     expect(icons[14]).toHaveAttribute('title', 'Edit Alert');

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -170,7 +170,7 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
   );
 
   const [startReload, stopReload, hasRunningTimer] = useReload(
-    () => refetchAlerts(),
+    refetchAlerts,
     timeoutFunc,
   );
 

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -170,7 +170,7 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
   );
 
   const [startReload, stopReload, hasRunningTimer] = useReload(
-    refetchAlerts,
+    () => refetchAlerts(),
     timeoutFunc,
   );
 
@@ -242,7 +242,7 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
                       <TabPanel>
                         <EntityTags
                           entity={alert}
-                          onChanged={onChanged}
+                          onChanged={() => refetchAlerts()}
                           onError={onError}
                           onInteraction={onInteraction}
                         />
@@ -251,7 +251,7 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
                         <EntityPermissions
                           entity={alert}
                           permissions={permissions}
-                          onChanged={refetchPermissions}
+                          onChanged={() => refetchPermissions()}
                           onDownloaded={handleDownload}
                           onError={onError}
                           onInteraction={onInteraction}

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -119,8 +119,8 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
   const {id} = useParams();
   const gmpSettings = useGmpSettings();
   const [downloadRef, handleDownload] = useDownload();
-  const {alert, refetch, loading} = useGetAlert(id);
-  const {permissions} = useGetPermissions({
+  const {alert, refetch: refetchAlerts, loading} = useGetAlert(id);
+  const {permissions, refetch: refetchPermissions} = useGetPermissions({
     filterString: permissionsResourceFilter(id).toFilterString(),
   });
   const {reportFormats} = useGetReportFormats();
@@ -170,7 +170,7 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
   );
 
   const [startReload, stopReload, hasRunningTimer] = useReload(
-    refetch,
+    refetchAlerts,
     timeoutFunc,
   );
 
@@ -251,7 +251,7 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
                         <EntityPermissions
                           entity={alert}
                           permissions={permissions}
-                          onChanged={onChanged}
+                          onChanged={refetchPermissions}
                           onDownloaded={handleDownload}
                           onError={onError}
                           onInteraction={onInteraction}

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -302,19 +302,10 @@ const load = gmp => {
     ]);
 };
 
-const mapStateToProps = (rootState, {id}) => {
-  const permissionsSel = permissionsSelector(rootState);
-  const reportFormatsSel = reportFormatsSelector(rootState);
-  return {
-    permissions: permissionsSel.getEntities(permissionsResourceFilter(id)),
-    reportFormats: reportFormatsSel.getAllEntities(),
-  };
-};
-
 export default withEntityContainer('alert', {
   entitySelector: selector,
   load,
-  mapStateToProps,
+  undefined,
 })(Page);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -125,6 +125,10 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
   });
   const {reportFormats} = useGetReportFormats();
 
+  if (hasValue(reportFormats)) {
+    console.log(reportFormats[0]);
+  }
+
   // Alert related mutations
   const exportEntity = useExportEntity();
 

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -118,12 +118,13 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
   // Page methods
   const {id} = useParams();
   const gmpSettings = useGmpSettings();
+
   const [downloadRef, handleDownload] = useDownload();
   const {alert, refetch: refetchAlerts, loading} = useGetAlert(id);
   const {permissions, refetch: refetchPermissions} = useGetPermissions({
     filterString: permissionsResourceFilter(id).toFilterString(),
   });
-  const {reportFormats} = useGetReportFormats();
+  const {reportFormats = []} = useGetReportFormats();
 
   // Alert related mutations
   const exportEntity = useExportEntity();

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -81,6 +81,8 @@ import AlertComponent from './component';
 import AlertDetails from './details';
 import useGmpSettings from 'web/utils/useGmpSettings';
 import useReload from 'web/components/loading/useReload';
+import {useGetPermissions} from 'web/graphql/permissions';
+import {useGetReportFormats} from 'web/graphql/report_formats';
 
 export const ToolBarIcons = ({
   entity,
@@ -122,19 +124,16 @@ ToolBarIcons.propTypes = {
   onAlertEditClick: PropTypes.func.isRequired,
 };
 
-const Page = ({
-  permissions = [],
-  reportFormats,
-  onChanged,
-  onError,
-  onInteraction,
-  ...props
-}) => {
+const Page = ({onChanged, onError, onInteraction, ...props}) => {
   // Page methods
   const {id} = useParams();
   const gmpSettings = useGmpSettings();
   const [downloadRef, handleDownload] = useDownload();
   const {alert, refetch, loading} = useGetAlert(id);
+  const {permissions} = useGetPermissions({
+    filterString: permissionsResourceFilter(id).toFilterString(),
+  });
+  const {reportFormats} = useGetReportFormats();
 
   // Alert related mutations
   const exportEntity = useExportEntity();

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -125,10 +125,6 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
   });
   const {reportFormats} = useGetReportFormats();
 
-  if (hasValue(reportFormats)) {
-    console.log(reportFormats[0]);
-  }
-
   // Alert related mutations
   const exportEntity = useExportEntity();
 

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -62,17 +62,7 @@ import {
   useExportAlertsByIds,
 } from 'web/graphql/alerts';
 
-import {selector, loadEntity} from 'web/store/entities/alerts';
-
-import {
-  selector as permissionsSelector,
-  loadEntities as loadPermissions,
-} from 'web/store/entities/permissions';
-
-import {
-  loadAllEntities as loadAllReportFormats,
-  selector as reportFormatsSelector,
-} from 'web/store/entities/reportformats';
+import {selector} from 'web/store/entities/alerts';
 
 import PropTypes from 'web/utils/proptypes';
 import {goto_entity_details} from 'web/utils/graphql';
@@ -193,7 +183,6 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
 
   // stop reload on unmount
   useEffect(() => stopReload, [stopReload]);
-
   return (
     <AlertComponent
       onCloned={goto_details('alert', props)}
@@ -283,24 +272,12 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
 
 Page.propTypes = {
   entity: PropTypes.model,
-  permissions: PropTypes.array,
-  reportFormats: PropTypes.array,
   onChanged: PropTypes.func.isRequired,
   onError: PropTypes.func.isRequired,
   onInteraction: PropTypes.func.isRequired,
 };
 
-const load = gmp => {
-  const loadEntityFunc = loadEntity(gmp);
-  const loadPermissionsFunc = loadPermissions(gmp);
-  const loadAllReportFormatsFunc = loadAllReportFormats(gmp);
-  return id => dispatch =>
-    Promise.all([
-      dispatch(loadEntityFunc(id)),
-      dispatch(loadPermissionsFunc(permissionsResourceFilter(id))),
-      dispatch(loadAllReportFormatsFunc()),
-    ]);
-};
+const load = gmp => id => dispatch => Promise.resolve();
 
 export default withEntityContainer('alert', {
   entitySelector: selector,

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -37,6 +37,7 @@ import TabPanels from 'web/components/tab/tabpanels';
 import Tabs from 'web/components/tab/tabs';
 import Download from 'web/components/form/download';
 import useDownload from 'web/components/form/useDownload';
+import useReload from 'web/components/loading/useReload';
 
 import EntityPage from 'web/entity/page';
 import {goto_details, goto_list} from 'web/entity/component';
@@ -61,18 +62,17 @@ import {
   useDeleteAlert,
   useExportAlertsByIds,
 } from 'web/graphql/alerts';
+import {useGetPermissions} from 'web/graphql/permissions';
+import {useGetReportFormats} from 'web/graphql/report_formats';
 
 import {selector} from 'web/store/entities/alerts';
 
 import PropTypes from 'web/utils/proptypes';
 import {goto_entity_details} from 'web/utils/graphql';
+import useGmpSettings from 'web/utils/useGmpSettings';
 
 import AlertComponent from './component';
 import AlertDetails from './details';
-import useGmpSettings from 'web/utils/useGmpSettings';
-import useReload from 'web/components/loading/useReload';
-import {useGetPermissions} from 'web/graphql/permissions';
-import {useGetReportFormats} from 'web/graphql/report_formats';
 
 export const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -243,7 +243,7 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
                       <TabPanel>
                         <EntityTags
                           entity={alert}
-                          onChanged={() => refetchAlerts()}
+                          onChanged={() => refetchAlerts()} // Must be called like this instead of simply onChanged={refetchAlerts} because we don't want this query to be called with new arguments on tag related actions
                           onError={onError}
                           onInteraction={onInteraction}
                         />
@@ -252,7 +252,7 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
                         <EntityPermissions
                           entity={alert}
                           permissions={permissions}
-                          onChanged={() => refetchPermissions()}
+                          onChanged={() => refetchPermissions()} // Same here, for permissions. We want same query variables.
                           onDownloaded={handleDownload}
                           onError={onError}
                           onInteraction={onInteraction}
@@ -278,7 +278,7 @@ Page.propTypes = {
   onInteraction: PropTypes.func.isRequired,
 };
 
-const load = gmp => id => dispatch => Promise.resolve();
+const load = gmp => id => dispatch => Promise.resolve(); // Must keep this for now before we can get rid of withEntityContainer
 
 export default withEntityContainer('alert', {
   entitySelector: selector,


### PR DESCRIPTION
**What**:

Do not use gmp to load the permissions and report formats required for the alert detailspage. Use as little gmp and HOC as possible. Eventually we'll get rid of withEntityContainer.

- Implemented parseObject for report formats and permissions and tested those
- implemented parseModelFromObject and tested this
- Implemented get_alerts and get_report_formats query tests
- Adjusted detailslink to be able to distinguish between hyperion and gmp entities (to parse them differently)
- Adjusted detailspage tests and mocks to accept the new command mocks
- Use refetchAlert() and refetchPermissions() for onChanged

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

Manual and unit testing.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
