### PR TITLE
Allow umlauts and ß in object names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added option for "Start Task" event upon "New SecInfo arrived" condition in alerts dialog [#2418](https://github.com/greenbone/gsa/pull/2418)
 
 ### Changed
+- Allow äüöÄÜÖß in form validation rule for "name" [#2586](https://github.com/greenbone/gsa/pull/2586)
 - Show "Filter x matches at least y results" condition to task events in alert dialog [#2580](https://github.com/greenbone/gsa/pull/2580)
 - Always send sort=name with delta report request filters [#2570](https://github.com/greenbone/gsa/pull/2570)
 - Changed trash icon to delete icon on host detailspage [#2565](https://github.com/greenbone/gsa/pull/2565)

--- a/gsa/src/web/components/form/useFormValidation.js
+++ b/gsa/src/web/components/form/useFormValidation.js
@@ -124,8 +124,9 @@ const useFormValidation = (
 export const shouldBeNonEmpty = (string = '') => string.trim().length > 0;
 export const shouldBeValidPassword = (password = '') => password.length > 5;
 export const shouldBeValidName = (string = '') =>
-  string.match(/^[.#\-_ ,/a-z0-9]+$/i) !== null; // this is analogue to the
-// regex in gsad.c for 'name'
+  string.match(/^[.#\-_ ,/a-z0-9äüöÄÜÖß]+$/i) !== null; // this is analogue to the
+// regex in gsad.c for 'name' - it needs to be checked, whether :alnum: cotains
+// more than the characters above
 export const VALID_NAME_ERROR_MESSAGE = _l(
   'The name must include at least one alphanumeric character or one of .,-/_# and space.',
 );


### PR DESCRIPTION
**What**:
While converting the regexp :alnum: to JS (that doesn't have a 1:1 equivalent) äüöÄÜÖß where dropped from the list of allowed characters. This PR reintroduces them to the regexp that is used for checking the "name" fields in forms.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:
Created a process with äüöÄÜÖß in the name. There was no error message any more.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
