### PR TITLE
Refactor alerts detailspage to not use withEntityContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added the CVSS v3.1 BaseScore calculator to the `/cvsscalculator` page in the Help section. [#2536](https://github.com/greenbone/gsa/pull/2536)
 
 ### Changed
-- Final refactor alerts detailspage, get rid of withEntityContainer [#2587](https://github.com/greenbone/gsa/pull/2587)
+- Refactor alerts detailspage to not use withEntityContainer [#2587](https://github.com/greenbone/gsa/pull/2587)
 -Implement get_alert via graphql and preliminary refactor of alert detailspage [#2571](https://github.com/greenbone/gsa/pull/2571)
 - Implement bulk actions for alerts via graphQL [#2569](https://github.com/greenbone/gsa/pull/2569)
 - Implement clone, delete and test alert via graphql [#2567](https://github.com/greenbone/gsa/pull/2567)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added the CVSS v3.1 BaseScore calculator to the `/cvsscalculator` page in the Help section. [#2536](https://github.com/greenbone/gsa/pull/2536)
 
 ### Changed
+- Final refactor alerts detailspage, get rid of withEntityContainer [#2587](https://github.com/greenbone/gsa/pull/2587)
 -Implement get_alert via graphql and preliminary refactor of alert detailspage [#2571](https://github.com/greenbone/gsa/pull/2571)
 - Implement bulk actions for alerts via graphQL [#2569](https://github.com/greenbone/gsa/pull/2569)
 - Implement clone, delete and test alert via graphql [#2567](https://github.com/greenbone/gsa/pull/2567)

--- a/gsa/src/web/entities/__tests__/useEntitiesTimeout.js
+++ b/gsa/src/web/entities/__tests__/useEntitiesTimeout.js
@@ -15,6 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+
+/* eslint-disable react/prop-types */
+
 import React from 'react';
 
 import {

--- a/gsa/src/web/entities/__tests__/useEntitiesTimeout.js
+++ b/gsa/src/web/entities/__tests__/useEntitiesTimeout.js
@@ -1,0 +1,90 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+
+import {parseModelFromObject} from 'gmp/model';
+
+import {
+  DEFAULT_RELOAD_INTERVAL_INACTIVE,
+  DEFAULT_RELOAD_INTERVAL_ACTIVE,
+  DEFAULT_RELOAD_INTERVAL,
+} from 'gmp/gmpsettings';
+import useGmpSettings from 'web/utils/useGmpSettings';
+import {rendererWith, screen} from 'web/utils/testing';
+
+import useEntitiesTimeout from '../useEntitiesTimeout';
+
+const gmp = {
+  settings: {
+    reloadIntervalInactive: DEFAULT_RELOAD_INTERVAL_INACTIVE,
+    reloadIntervalActive: DEFAULT_RELOAD_INTERVAL_ACTIVE,
+    reloadInterval: DEFAULT_RELOAD_INTERVAL,
+  },
+};
+
+const TestComponent = ({isVisible, entities}) => {
+  const gmpSettings = useGmpSettings();
+  const timeoutFunc = useEntitiesTimeout({
+    entities,
+    gmpSettings,
+  });
+
+  return <span data-testid="reload-interval">{timeoutFunc({isVisible})}</span>;
+};
+
+const activeEntity = parseModelFromObject({active: true});
+const inactiveEntity = parseModelFromObject({active: false});
+
+const entities = [activeEntity, inactiveEntity];
+
+describe('useEntitiesTimeout tests', () => {
+  test('Should return correct interval when isVisible is false', () => {
+    const {render} = rendererWith({gmp});
+    render(<TestComponent isVisible={false} entities={entities} />);
+
+    const reloadInterval = screen.getByTestId('reload-interval');
+
+    expect(reloadInterval).toHaveTextContent(DEFAULT_RELOAD_INTERVAL_INACTIVE);
+  });
+
+  test('Should return correct interval when there is an active entity', () => {
+    const {render} = rendererWith({gmp});
+    render(<TestComponent isVisible={true} entities={entities} />);
+
+    const reloadInterval = screen.getByTestId('reload-interval');
+
+    expect(reloadInterval).toHaveTextContent(DEFAULT_RELOAD_INTERVAL_ACTIVE);
+  });
+  test('Should return correct interval when there is no active entity', () => {
+    const {render} = rendererWith({gmp});
+    render(<TestComponent isVisible={true} entities={[inactiveEntity]} />);
+
+    const reloadInterval = screen.getByTestId('reload-interval');
+
+    expect(reloadInterval).toHaveTextContent(DEFAULT_RELOAD_INTERVAL);
+  });
+
+  test('Should not crash when entities are undefined', () => {
+    const {render} = rendererWith({gmp});
+    render(<TestComponent isVisible={true} />);
+
+    const reloadInterval = screen.getByTestId('reload-interval');
+
+    expect(reloadInterval).toHaveTextContent(DEFAULT_RELOAD_INTERVAL);
+  });
+});

--- a/gsa/src/web/entities/__tests__/useEntitiesTimeout.js
+++ b/gsa/src/web/entities/__tests__/useEntitiesTimeout.js
@@ -17,15 +17,16 @@
  */
 import React from 'react';
 
-import {parseModelFromObject} from 'gmp/model';
-
 import {
   DEFAULT_RELOAD_INTERVAL_INACTIVE,
   DEFAULT_RELOAD_INTERVAL_ACTIVE,
   DEFAULT_RELOAD_INTERVAL,
 } from 'gmp/gmpsettings';
-import useGmpSettings from 'web/utils/useGmpSettings';
+
+import {parseModelFromObject} from 'gmp/model';
+
 import {rendererWith, screen} from 'web/utils/testing';
+import useGmpSettings from 'web/utils/useGmpSettings';
 
 import useEntitiesTimeout from '../useEntitiesTimeout';
 
@@ -80,6 +81,7 @@ describe('useEntitiesTimeout tests', () => {
   });
 
   test('Should not crash when entities are undefined', () => {
+    // because entities can be undefined before they're loaded
     const {render} = rendererWith({gmp});
     render(<TestComponent isVisible={true} />);
 

--- a/gsa/src/web/entities/useEntitiesTimeout.js
+++ b/gsa/src/web/entities/useEntitiesTimeout.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+/* eslint-disable react/prop-types */
+
 import {useCallback} from 'react';
 import {isDefined} from 'gmp/utils/identity';
 

--- a/gsa/src/web/entities/useEntitiesTimeout.js
+++ b/gsa/src/web/entities/useEntitiesTimeout.js
@@ -1,0 +1,38 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+import {useCallback} from 'react';
+import {hasValue} from 'gmp/utils/identity';
+
+const useEntitiesTimeout = ({entities, gmpSettings}) => {
+  const timeoutFunc = useCallback(
+    ({isVisible}) => {
+      if (!isVisible) {
+        return gmpSettings.reloadIntervalInactive;
+      }
+      if (hasValue(entities) && entities.some(entity => entity.isActive())) {
+        return gmpSettings.reloadIntervalActive;
+      }
+      return gmpSettings.reloadInterval;
+    },
+    [entities, gmpSettings],
+  );
+
+  return timeoutFunc;
+};
+
+export default useEntitiesTimeout;

--- a/gsa/src/web/entities/useEntitiesTimeout.js
+++ b/gsa/src/web/entities/useEntitiesTimeout.js
@@ -15,7 +15,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-/* eslint-disable react/prop-types */
 
 import {useCallback} from 'react';
 import {isDefined} from 'gmp/utils/identity';

--- a/gsa/src/web/entities/useEntitiesTimeout.js
+++ b/gsa/src/web/entities/useEntitiesTimeout.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 import {useCallback} from 'react';
-import {hasValue} from 'gmp/utils/identity';
+import {isDefined} from 'gmp/utils/identity';
 
 const useEntitiesTimeout = ({entities, gmpSettings}) => {
   const timeoutFunc = useCallback(
@@ -24,7 +24,7 @@ const useEntitiesTimeout = ({entities, gmpSettings}) => {
       if (!isVisible) {
         return gmpSettings.reloadIntervalInactive;
       }
-      if (hasValue(entities) && entities.some(entity => entity.isActive())) {
+      if (isDefined(entities) && entities.some(entity => entity.isActive())) {
         return gmpSettings.reloadIntervalActive;
       }
       return gmpSettings.reloadInterval;

--- a/gsa/src/web/entity/__tests__/useEntityTimeout.js
+++ b/gsa/src/web/entity/__tests__/useEntityTimeout.js
@@ -27,7 +27,7 @@ import {
 import useGmpSettings from 'web/utils/useGmpSettings';
 import {rendererWith, screen} from 'web/utils/testing';
 
-import useEntitiesTimeout from '../useEntitiesTimeout';
+import useEntityTimeout from '../useEntityTimeout';
 
 const gmp = {
   settings: {
@@ -37,10 +37,10 @@ const gmp = {
   },
 };
 
-const TestComponent = ({isVisible, entities}) => {
+const TestComponent = ({isVisible, entity}) => {
   const gmpSettings = useGmpSettings();
-  const timeoutFunc = useEntitiesTimeout({
-    entities,
+  const timeoutFunc = useEntityTimeout({
+    entity,
     gmpSettings,
   });
 
@@ -50,36 +50,34 @@ const TestComponent = ({isVisible, entities}) => {
 const activeEntity = parseModelFromObject({active: true});
 const inactiveEntity = parseModelFromObject({active: false});
 
-const entities = [activeEntity, inactiveEntity];
-
-describe('useEntitiesTimeout tests', () => {
+describe('useEntityTimeout tests', () => {
   test('Should return correct interval when isVisible is false', () => {
     const {render} = rendererWith({gmp});
-    render(<TestComponent isVisible={false} entities={entities} />);
+    render(<TestComponent isVisible={false} entity={activeEntity} />);
 
     const reloadInterval = screen.getByTestId('reload-interval');
 
     expect(reloadInterval).toHaveTextContent(DEFAULT_RELOAD_INTERVAL_INACTIVE);
   });
 
-  test('Should return correct interval when there is an active entity', () => {
+  test('Should return correct interval when entity is active', () => {
     const {render} = rendererWith({gmp});
-    render(<TestComponent isVisible={true} entities={entities} />);
+    render(<TestComponent isVisible={true} entity={activeEntity} />);
 
     const reloadInterval = screen.getByTestId('reload-interval');
 
     expect(reloadInterval).toHaveTextContent(DEFAULT_RELOAD_INTERVAL_ACTIVE);
   });
-  test('Should return correct interval when there is no active entity', () => {
+  test('Should return correct interval when entity is inactive', () => {
     const {render} = rendererWith({gmp});
-    render(<TestComponent isVisible={true} entities={[inactiveEntity]} />);
+    render(<TestComponent isVisible={true} entity={inactiveEntity} />);
 
     const reloadInterval = screen.getByTestId('reload-interval');
 
     expect(reloadInterval).toHaveTextContent(DEFAULT_RELOAD_INTERVAL);
   });
 
-  test('Should not crash when entities are undefined', () => {
+  test('Should not crash when entity is undefined', () => {
     const {render} = rendererWith({gmp});
     render(<TestComponent isVisible={true} />);
 

--- a/gsa/src/web/entity/__tests__/useEntityTimeout.js
+++ b/gsa/src/web/entity/__tests__/useEntityTimeout.js
@@ -17,15 +17,16 @@
  */
 import React from 'react';
 
-import {parseModelFromObject} from 'gmp/model';
-
 import {
   DEFAULT_RELOAD_INTERVAL_INACTIVE,
   DEFAULT_RELOAD_INTERVAL_ACTIVE,
   DEFAULT_RELOAD_INTERVAL,
 } from 'gmp/gmpsettings';
-import useGmpSettings from 'web/utils/useGmpSettings';
+
+import {parseModelFromObject} from 'gmp/model';
+
 import {rendererWith, screen} from 'web/utils/testing';
+import useGmpSettings from 'web/utils/useGmpSettings';
 
 import useEntityTimeout from '../useEntityTimeout';
 
@@ -78,6 +79,7 @@ describe('useEntityTimeout tests', () => {
   });
 
   test('Should not crash when entity is undefined', () => {
+    // because entity can be undefined before it's loaded
     const {render} = rendererWith({gmp});
     render(<TestComponent isVisible={true} />);
 

--- a/gsa/src/web/entity/__tests__/useEntityTimeout.js
+++ b/gsa/src/web/entity/__tests__/useEntityTimeout.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+/* eslint-disable react/prop-types */
+
 import React from 'react';
 
 import {

--- a/gsa/src/web/entity/useEntityTimeout.js
+++ b/gsa/src/web/entity/useEntityTimeout.js
@@ -1,0 +1,37 @@
+/* Copyright (C) 2020 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+import {useCallback} from 'react';
+
+const useEntityTimeout = ({entity, gmpSettings}) => {
+  const timeoutFunc = useCallback(
+    ({isVisible}) => {
+      if (!isVisible) {
+        return gmpSettings.reloadIntervalInactive;
+      }
+      if (entity.isActive()) {
+        return gmpSettings.reloadIntervalActive;
+      }
+      return gmpSettings.reloadInterval;
+    },
+    [entity, gmpSettings],
+  );
+
+  return timeoutFunc;
+};
+
+export default useEntityTimeout;

--- a/gsa/src/web/entity/useEntityTimeout.js
+++ b/gsa/src/web/entity/useEntityTimeout.js
@@ -16,6 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 import {useCallback} from 'react';
+import {isDefined} from 'gmp/utils/identity';
 
 const useEntityTimeout = ({entity, gmpSettings}) => {
   const timeoutFunc = useCallback(
@@ -23,7 +24,7 @@ const useEntityTimeout = ({entity, gmpSettings}) => {
       if (!isVisible) {
         return gmpSettings.reloadIntervalInactive;
       }
-      if (entity.isActive()) {
+      if (isDefined(entity) && entity.isActive()) {
         return gmpSettings.reloadIntervalActive;
       }
       return gmpSettings.reloadInterval;

--- a/gsa/src/web/entity/useEntityTimeout.js
+++ b/gsa/src/web/entity/useEntityTimeout.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+/* eslint-disable react/prop-types */
+
 import {useCallback} from 'react';
 import {isDefined} from 'gmp/utils/identity';
 

--- a/gsa/src/web/entity/useEntityTimeout.js
+++ b/gsa/src/web/entity/useEntityTimeout.js
@@ -15,7 +15,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-/* eslint-disable react/prop-types */
 
 import {useCallback} from 'react';
 import {isDefined} from 'gmp/utils/identity';

--- a/gsa/src/web/pages/alerts/__tests__/detailspage.js
+++ b/gsa/src/web/pages/alerts/__tests__/detailspage.js
@@ -98,17 +98,14 @@ describe('Alert Detailspage tests', () => {
     ] = createGetReportFormatsQueryMock();
 
     const {render, store} = rendererWith({
-      capabilities: caps,
       gmp,
+      capabilities: caps,
       router: true,
       store: true,
       queryMocks: [mock, permissionMock, reportFormatsMock],
     });
 
     store.dispatch(setTimezone('CET'));
-    store.dispatch(setUsername('admin'));
-
-    store.dispatch(entityLoadingActions.success('1', alert1));
 
     const {baseElement, element} = render(<Detailspage />);
 
@@ -201,9 +198,6 @@ describe('Alert Detailspage tests', () => {
     });
 
     store.dispatch(setTimezone('CET'));
-    store.dispatch(setUsername('admin'));
-
-    store.dispatch(entityLoadingActions.success('1', alert1));
 
     const {baseElement} = render(<Detailspage />);
 
@@ -249,9 +243,6 @@ describe('Alert Detailspage tests', () => {
     });
 
     store.dispatch(setTimezone('CET'));
-    store.dispatch(setUsername('admin'));
-
-    store.dispatch(entityLoadingActions.success('1', alert1));
 
     const {baseElement} = render(<Detailspage />);
 
@@ -357,9 +348,6 @@ describe('Alert Detailspage tests', () => {
     });
 
     store.dispatch(setTimezone('CET'));
-    store.dispatch(setUsername('admin'));
-
-    store.dispatch(entityLoadingActions.success('1', alert1));
 
     render(<Detailspage />);
 

--- a/gsa/src/web/pages/alerts/__tests__/detailspage.js
+++ b/gsa/src/web/pages/alerts/__tests__/detailspage.js
@@ -110,7 +110,7 @@ describe('Alert Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('1', alert1));
 
-    const {baseElement, element} = render(<Detailspage id="1" />);
+    const {baseElement, element} = render(<Detailspage />);
 
     await wait();
 
@@ -205,7 +205,7 @@ describe('Alert Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('1', alert1));
 
-    const {baseElement} = render(<Detailspage id="1" />);
+    const {baseElement} = render(<Detailspage />);
 
     await wait();
 
@@ -253,7 +253,7 @@ describe('Alert Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('1', alert1));
 
-    const {baseElement} = render(<Detailspage id="1" />);
+    const {baseElement} = render(<Detailspage />);
 
     await wait();
 
@@ -361,7 +361,7 @@ describe('Alert Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('1', alert1));
 
-    render(<Detailspage id="1" />);
+    render(<Detailspage />);
 
     await wait();
 

--- a/gsa/src/web/pages/alerts/__tests__/detailspage.js
+++ b/gsa/src/web/pages/alerts/__tests__/detailspage.js
@@ -27,8 +27,7 @@ import Alert from 'gmp/models/alert';
 
 import {createRenewSessionQueryMock} from 'web/graphql/__mocks__/session';
 
-import {entityLoadingActions} from 'web/store/entities/alerts';
-import {setTimezone, setUsername} from 'web/store/usersettings/actions';
+import {setTimezone} from 'web/store/usersettings/actions';
 
 import {
   createGetAlertQueryMock,

--- a/gsa/src/web/pages/alerts/__tests__/detailspage.js
+++ b/gsa/src/web/pages/alerts/__tests__/detailspage.js
@@ -190,13 +190,14 @@ describe('Alert Detailspage tests', () => {
       reportFormatsMock,
       reportFormatsResult,
     ] = createGetReportFormatsQueryMock();
+    const [renewQueryMock, renewQueryResult] = createRenewSessionQueryMock();
 
     const {render, store} = rendererWith({
       capabilities: caps,
       gmp,
       router: true,
       store: true,
-      queryMocks: [mock, permissionMock, reportFormatsMock],
+      queryMocks: [mock, permissionMock, reportFormatsMock, renewQueryMock],
     });
 
     store.dispatch(setTimezone('CET'));
@@ -217,6 +218,7 @@ describe('Alert Detailspage tests', () => {
     fireEvent.click(tabs[0]);
 
     expect(baseElement).toHaveTextContent('alert:unnamed');
+    expect(renewQueryResult).toHaveBeenCalled();
   });
 
   test('should render permissions tab', async () => {
@@ -236,13 +238,14 @@ describe('Alert Detailspage tests', () => {
       reportFormatsMock,
       reportFormatsResult,
     ] = createGetReportFormatsQueryMock();
+    const [renewQueryMock, renewQueryResult] = createRenewSessionQueryMock();
 
     const {render, store} = rendererWith({
       capabilities: caps,
       gmp,
       router: true,
       store: true,
-      queryMocks: [mock, permissionMock, reportFormatsMock],
+      queryMocks: [mock, permissionMock, reportFormatsMock, renewQueryMock],
     });
 
     store.dispatch(setTimezone('CET'));
@@ -262,6 +265,8 @@ describe('Alert Detailspage tests', () => {
 
     expect(tabs[1]).toHaveTextContent('Permissions');
     fireEvent.click(tabs[1]);
+
+    expect(renewQueryResult).toHaveBeenCalled();
 
     // permission 1
     expect(baseElement).toHaveTextContent('Name');

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 import React, {useCallback, useEffect} from 'react';
-import {useParams} from 'react-router-dom';
+import {useHistory, useParams} from 'react-router-dom';
 
 import _ from 'gmp/locale';
 import {hasValue} from 'gmp/utils/identity';
@@ -121,6 +121,7 @@ const Page = props => {
   // Page methods
   const {id} = useParams();
   const gmpSettings = useGmpSettings();
+  const history = useHistory();
   const [, renewSessionTimeout] = useUserSessionTimeout();
   const [downloadRef, handleDownload] = useDownload();
   const {
@@ -151,13 +152,13 @@ const Page = props => {
   // Alert methods
   const handleCloneAlert = clonedAlert => {
     return cloneAlert(clonedAlert.id)
-      .then(alertId => goto_entity_details('alert', props)(alertId))
+      .then(alertId => goto_entity_details('alert', {history})(alertId))
       .catch(showError);
   };
 
   const handleDeleteAlert = deletedAlert => {
     return deleteAlert(deletedAlert.id)
-      .then(goto_list('alerts', props))
+      .then(goto_list('alerts', {history}))
       .catch(showError);
   };
 
@@ -199,12 +200,13 @@ const Page = props => {
 
   // stop reload on unmount
   useEffect(() => stopReload, [stopReload]);
+  console.log(props);
   return (
     <AlertComponent
-      onCloned={goto_details('alert', props)}
+      onCloned={goto_details('alert', {history})}
       onCloneError={showError}
-      onCreated={goto_entity_details('alert', props)}
-      onDeleted={goto_list('alerts', props)}
+      onCreated={goto_entity_details('alert', {history})}
+      onDeleted={goto_list('alerts', {history})}
       onDeleteError={showError}
       onDownloaded={handleDownload}
       onDownloadError={showError}
@@ -216,6 +218,7 @@ const Page = props => {
           {...props}
           entity={alert}
           entityError={entityError}
+          entityType={'alert'}
           isLoading={loading}
           sectionIcon={<AlertIcon size="large" />}
           title={_('Alert')}

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -291,13 +291,6 @@ const Page = props => {
   );
 };
 
-Page.propTypes = {
-  entity: PropTypes.model,
-  onChanged: PropTypes.func.isRequired,
-  onError: PropTypes.func.isRequired,
-  onInteraction: PropTypes.func.isRequired,
-};
-
 const load = gmp => id => dispatch => Promise.resolve(); // Must keep this for now before we can get rid of withEntityContainer
 
 export default withEntityContainer('alert', {

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -121,7 +121,12 @@ const Page = ({onError, ...props}) => {
   const gmpSettings = useGmpSettings();
   const [, renewSessionTimeout] = useUserSessionTimeout();
   const [downloadRef, handleDownload] = useDownload();
-  const {alert, refetch: refetchAlert, loading} = useGetAlert(id);
+  const {
+    alert,
+    refetch: refetchAlert,
+    loading,
+    error: entityError,
+  } = useGetAlert(id);
   const {permissions, refetch: refetchPermissions} = useGetPermissions({
     filterString: permissionsResourceFilter(id).toFilterString(),
   });
@@ -201,6 +206,7 @@ const Page = ({onError, ...props}) => {
         <EntityPage
           {...props}
           entity={alert}
+          entityError={entityError}
           isLoading={loading}
           sectionIcon={<AlertIcon size="large" />}
           title={_('Alert')}

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -70,10 +70,10 @@ import {selector} from 'web/store/entities/alerts';
 import PropTypes from 'web/utils/proptypes';
 import {goto_entity_details} from 'web/utils/graphql';
 import useGmpSettings from 'web/utils/useGmpSettings';
+import useUserSessionTimeout from 'web/utils/useUserSessionTimeout';
 
 import AlertComponent from './component';
 import AlertDetails from './details';
-import useUserSessionTimeout from 'web/utils/useUserSessionTimeout';
 
 export const ToolBarIcons = ({
   entity,

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React, {useCallback, useEffect} from 'react';
+import React, {useEffect} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
 import _ from 'gmp/locale';
@@ -55,6 +55,7 @@ import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
 import EditIcon from 'web/entity/icon/editicon';
 import TrashIcon from 'web/entity/icon/trashicon';
+import useEntityTimeout from 'web/entity/useEntityTimeout';
 
 import {
   useGetAlert,
@@ -169,18 +170,7 @@ const Page = () => {
   };
 
   // Timeout and reload
-  const timeoutFunc = useCallback(
-    ({isVisible}) => {
-      if (!isVisible) {
-        return gmpSettings.reloadIntervalInactive;
-      }
-      if (alert.isActive()) {
-        return gmpSettings.reloadIntervalActive;
-      }
-      return gmpSettings.reloadInterval;
-    },
-    [alert, gmpSettings],
-  );
+  const timeoutFunc = useEntityTimeout({entity: alert, gmpSettings});
 
   const [startReload, stopReload, hasRunningTimer] = useReload(
     refetchAlert,

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -46,9 +46,7 @@ import {goto_details, goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
-import withEntityContainer, {
-  permissionsResourceFilter,
-} from 'web/entity/withEntityContainer';
+import {permissionsResourceFilter} from 'web/entity/withEntityContainer';
 import useExportEntity from 'web/entity/useExportEntity';
 
 import AlertIcon from 'web/components/icon/alerticon';
@@ -66,8 +64,6 @@ import {
 } from 'web/graphql/alerts';
 import {useGetPermissions} from 'web/graphql/permissions';
 import {useGetReportFormats} from 'web/graphql/report_formats';
-
-import {selector} from 'web/store/entities/alerts';
 
 import PropTypes from 'web/utils/proptypes';
 import {goto_entity_details} from 'web/utils/graphql';
@@ -117,7 +113,7 @@ ToolBarIcons.propTypes = {
   onAlertEditClick: PropTypes.func.isRequired,
 };
 
-const Page = props => {
+const Page = () => {
   // Page methods
   const {id} = useParams();
   const gmpSettings = useGmpSettings();
@@ -200,7 +196,6 @@ const Page = props => {
 
   // stop reload on unmount
   useEffect(() => stopReload, [stopReload]);
-  console.log(props);
   return (
     <AlertComponent
       onCloned={goto_details('alert', {history})}
@@ -215,7 +210,6 @@ const Page = props => {
     >
       {({create, edit, save}) => (
         <EntityPage
-          {...props}
           entity={alert}
           entityError={entityError}
           entityType={'alert'}
@@ -294,12 +288,6 @@ const Page = props => {
   );
 };
 
-const load = gmp => id => dispatch => Promise.resolve(); // Must keep this for now before we can get rid of withEntityContainer
-
-export default withEntityContainer('alert', {
-  entitySelector: selector,
-  load,
-  undefined,
-})(Page);
+export default Page;
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -73,6 +73,7 @@ import useGmpSettings from 'web/utils/useGmpSettings';
 
 import AlertComponent from './component';
 import AlertDetails from './details';
+import useUserSessionTimeout from 'web/utils/useUserSessionTimeout';
 
 export const ToolBarIcons = ({
   entity,
@@ -114,11 +115,11 @@ ToolBarIcons.propTypes = {
   onAlertEditClick: PropTypes.func.isRequired,
 };
 
-const Page = ({onError, onInteraction, ...props}) => {
+const Page = ({onError, ...props}) => {
   // Page methods
   const {id} = useParams();
   const gmpSettings = useGmpSettings();
-
+  const [, renewSessionTimeout] = useUserSessionTimeout();
   const [downloadRef, handleDownload] = useDownload();
   const {alert, refetch: refetchAlert, loading} = useGetAlert(id);
   const {permissions, refetch: refetchPermissions} = useGetPermissions({
@@ -193,7 +194,7 @@ const Page = ({onError, onInteraction, ...props}) => {
       onDeleteError={onError}
       onDownloaded={handleDownload}
       onDownloadError={onError}
-      onInteraction={onInteraction}
+      onInteraction={renewSessionTimeout}
       onSaved={() => refetchAlert()}
     >
       {({create, edit, save}) => (
@@ -210,7 +211,7 @@ const Page = ({onError, onInteraction, ...props}) => {
           onAlertDownloadClick={handleDownloadAlert}
           onAlertEditClick={edit}
           onAlertSaveClick={save}
-          onInteraction={onInteraction}
+          onInteraction={renewSessionTimeout}
         >
           {({activeTab = 0, onActivateTab}) => {
             return (
@@ -245,7 +246,7 @@ const Page = ({onError, onInteraction, ...props}) => {
                           entity={alert}
                           onChanged={() => refetchAlert()} // Must be called like this instead of simply onChanged={refetchAlert} because we don't want this query to be called with new arguments on tag related actions
                           onError={onError}
-                          onInteraction={onInteraction}
+                          onInteraction={renewSessionTimeout}
                         />
                       </TabPanel>
                       <TabPanel>
@@ -255,7 +256,7 @@ const Page = ({onError, onInteraction, ...props}) => {
                           onChanged={() => refetchPermissions()} // Same here, for permissions. We want same query variables.
                           onDownloaded={handleDownload}
                           onError={onError}
-                          onInteraction={onInteraction}
+                          onInteraction={renewSessionTimeout}
                         />
                       </TabPanel>
                     </TabPanels>

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -114,13 +114,13 @@ ToolBarIcons.propTypes = {
   onAlertEditClick: PropTypes.func.isRequired,
 };
 
-const Page = ({onChanged, onError, onInteraction, ...props}) => {
+const Page = ({onError, onInteraction, ...props}) => {
   // Page methods
   const {id} = useParams();
   const gmpSettings = useGmpSettings();
 
   const [downloadRef, handleDownload] = useDownload();
-  const {alert, refetch: refetchAlerts, loading} = useGetAlert(id);
+  const {alert, refetch: refetchAlert, loading} = useGetAlert(id);
   const {permissions, refetch: refetchPermissions} = useGetPermissions({
     filterString: permissionsResourceFilter(id).toFilterString(),
   });
@@ -171,7 +171,7 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
   );
 
   const [startReload, stopReload, hasRunningTimer] = useReload(
-    refetchAlerts,
+    refetchAlert,
     timeoutFunc,
   );
 
@@ -194,7 +194,7 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
       onDownloaded={handleDownload}
       onDownloadError={onError}
       onInteraction={onInteraction}
-      onSaved={onChanged}
+      onSaved={() => refetchAlert()}
     >
       {({create, edit, save}) => (
         <EntityPage
@@ -243,7 +243,7 @@ const Page = ({onChanged, onError, onInteraction, ...props}) => {
                       <TabPanel>
                         <EntityTags
                           entity={alert}
-                          onChanged={() => refetchAlerts()} // Must be called like this instead of simply onChanged={refetchAlerts} because we don't want this query to be called with new arguments on tag related actions
+                          onChanged={() => refetchAlert()} // Must be called like this instead of simply onChanged={refetchAlert} because we don't want this query to be called with new arguments on tag related actions
                           onError={onError}
                           onInteraction={onInteraction}
                         />

--- a/gsa/src/web/pages/alerts/listpage.js
+++ b/gsa/src/web/pages/alerts/listpage.js
@@ -62,6 +62,7 @@ import {
   useBulkExportEntities,
 } from 'web/entities/bulkactions.js';
 import usePagination from 'web/entities/usePagination.js';
+import useEntitiesTimeout from 'web/entities/useEntitiesTimeout.js';
 
 import usePageFilter from 'web/utils/usePageFilter.js';
 import useUserSessionTimeout from 'web/utils/useUserSessionTimeout.js';
@@ -149,18 +150,10 @@ const AlertsPage = ({onChanged, onDownloaded, onError, ...props}) => {
 
   const bulkDeleteAlerts = useBulkDeleteEntities();
 
-  const timeoutFunc = useCallback(
-    ({isVisible}) => {
-      if (!isVisible) {
-        return gmpSettings.reloadIntervalInactive;
-      }
-      if (hasValue(alerts) && alerts.some(alert => alert.isActive())) {
-        return gmpSettings.reloadIntervalActive;
-      }
-      return gmpSettings.reloadInterval;
-    },
-    [alerts, gmpSettings],
-  );
+  const timeoutFunc = useEntitiesTimeout({
+    entities: alerts,
+    gmpSettings,
+  });
 
   const [startReload, stopReload, hasRunningTimer] = useReload(
     refetch,


### PR DESCRIPTION
**What**:

Refactor detailspage to get rid of `withEntityContainer`. Implemented `useEntitiesTimeout` and `useEntityTimeout` for alert listpage and detailspage

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
