### PR TITLE
Implement loadScanConfigPromise for scan config component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [21.04] - unreleased
 
 ### Added
+- Implement loadScanConfigPromise for scan config component [#2612](https://github.com/greenbone/gsa/pull/2612)
 - Implement scan config detailspage queries and mutations [#2610](https://github.com/greenbone/gsa/pull/2610)
 - Implement create_scan_config, import_scan_config via graphql [#2604](https://github.com/greenbone/gsa/pull/2604)
 - Added CVSS origin to NVT details [#2588](https://github.com/greenbone/gsa/pull/2588)

--- a/gsa/src/web/graphql/__tests__/scanconfigs.js
+++ b/gsa/src/web/graphql/__tests__/scanconfigs.js
@@ -42,7 +42,6 @@ import {
   createDeleteScanConfigsByIdsQueryMock,
   createCloneScanConfigQueryMock,
 } from '../__mocks__/scanconfigs';
-import ScanConfig from 'gmp/models/scanconfig';
 
 const GetLazyScanConfigsComponent = () => {
   const [

--- a/gsa/src/web/graphql/__tests__/scanconfigs.js
+++ b/gsa/src/web/graphql/__tests__/scanconfigs.js
@@ -380,11 +380,11 @@ describe('useCloneScanConfig tests', () => {
 });
 
 const GetPromisedScanConfigComponent = () => {
-  const loadConfigPromise = useLoadScanConfigPromise();
+  const loadScanConfigPromise = useLoadScanConfigPromise();
   const [scanConfig, setScanConfig] = useState();
 
   const handleLoadScanConfig = configId => {
-    return loadConfigPromise(configId).then(response =>
+    return loadScanConfigPromise(configId).then(response =>
       setScanConfig(response),
     );
   };

--- a/gsa/src/web/graphql/__tests__/scanconfigs.js
+++ b/gsa/src/web/graphql/__tests__/scanconfigs.js
@@ -30,6 +30,7 @@ import {
   useExportScanConfigsByIds,
   useDeleteScanConfig,
   useCloneScanConfig,
+  useLoadScanConfigPromise,
 } from '../scanconfigs';
 import {
   createGetScanConfigsQueryMock,
@@ -374,5 +375,54 @@ describe('useCloneScanConfig tests', () => {
     expect(resultFunc).toHaveBeenCalled();
 
     expect(screen.getByTestId('cloned-scanConfig')).toHaveTextContent('354');
+  });
+});
+
+const GetPromisedScanConfigComponent = () => {
+  const loadConfigPromise = useLoadScanConfigPromise();
+
+  if (loading) {
+    return <span data-testid="loading">Loading</span>;
+  }
+  return (
+    <div>
+      <button data-testid="load" onClick={() => getScanConfig('314')} />
+      {isDefined(scanConfig) ? (
+        <div key={scanConfig.id} data-testid="scanConfig">
+          {scanConfig.id}
+        </div>
+      ) : (
+        <div data-testid="no-scanConfig" />
+      )}
+    </div>
+  );
+};
+
+describe('useLazyGetScanConfig tests', () => {
+  test('should query scanConfig after user interaction', async () => {
+    const [mock, resultFunc] = createGetScanConfigQueryMock();
+    const {render} = rendererWith({queryMocks: [mock]});
+    render(<GetLazyScanConfigComponent />);
+
+    let scanConfigElement = screen.queryAllByTestId('scanConfig');
+    expect(scanConfigElement).toHaveLength(0);
+
+    expect(screen.queryByTestId('no-scanConfig')).toBeInTheDocument();
+
+    const button = screen.getByTestId('load');
+    fireEvent.click(button);
+
+    const loading = await screen.findByTestId('loading');
+    expect(loading).toHaveTextContent('Loading');
+
+    await wait();
+
+    expect(resultFunc).toHaveBeenCalled();
+
+    scanConfigElement = screen.getByTestId('scanConfig');
+
+    expect(scanConfigElement).toHaveTextContent('314');
+
+    expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
   });
 });

--- a/gsa/src/web/graphql/scanconfigs.js
+++ b/gsa/src/web/graphql/scanconfigs.js
@@ -365,7 +365,7 @@ export const useLoadScanConfigPromise = () => {
     client.query({
       query: GET_SCAN_CONFIG,
       variables: {id: configId},
-      fetchPolicy: 'network-only', // do not cache, since this is used when a change is saved
+      fetchPolicy: 'no-cache', // do not cache, since this is used when a change is saved
     });
 
   return loadScanConfig;

--- a/gsa/src/web/graphql/scanconfigs.js
+++ b/gsa/src/web/graphql/scanconfigs.js
@@ -18,7 +18,13 @@
  */
 import {useCallback} from 'react';
 
-import {gql, useLazyQuery, useMutation, useQuery} from '@apollo/client';
+import {
+  gql,
+  useApolloClient,
+  useLazyQuery,
+  useMutation,
+  useQuery,
+} from '@apollo/client';
 import ScanConfig from 'gmp/models/scanconfig';
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
@@ -350,4 +356,17 @@ export const useCloneScanConfig = options => {
   );
   const scanConfigId = data?.cloneScanConfig?.id;
   return [cloneScanConfig, {...other, id: scanConfigId}];
+};
+
+export const useLoadScanConfigPromise = () => {
+  const client = useApolloClient();
+
+  const loadScanConfig = configId =>
+    client.query({
+      query: GET_SCAN_CONFIG,
+      variables: {id: configId},
+      fetchPolicy: 'network-only', // do not cache, since this is used when a change is saved
+    });
+
+  return loadScanConfig;
 };

--- a/gsa/src/web/graphql/scanconfigs.js
+++ b/gsa/src/web/graphql/scanconfigs.js
@@ -362,11 +362,17 @@ export const useLoadScanConfigPromise = () => {
   const client = useApolloClient();
 
   const loadScanConfig = configId =>
-    client.query({
-      query: GET_SCAN_CONFIG,
-      variables: {id: configId},
-      fetchPolicy: 'no-cache', // do not cache, since this is used when a change is saved
-    });
+    client
+      .query({
+        query: GET_SCAN_CONFIG,
+        variables: {id: configId},
+        fetchPolicy: 'no-cache', // do not cache, since this is used when a change is saved
+      })
+      .then(response => {
+        const scanConfig = ScanConfig.fromObject(response?.data?.scanConfig);
+
+        return scanConfig;
+      });
 
   return loadScanConfig;
 };

--- a/gsa/src/web/pages/scanconfigs/__tests__/editdialog.js
+++ b/gsa/src/web/pages/scanconfigs/__tests__/editdialog.js
@@ -26,7 +26,7 @@ import {
   SCANCONFIG_TREND_DYNAMIC,
 } from 'gmp/models/scanconfig';
 
-import {rendererWith, fireEvent, getAllByTestId, wait} from 'web/utils/testing';
+import {rendererWith, fireEvent, getAllByTestId} from 'web/utils/testing';
 
 import EditScanConfigDialog from '../editdialog';
 
@@ -292,7 +292,7 @@ describe('EditScanConfigDialog component tests', () => {
     );
   });
 
-  test('should render dialog for osp config', async () => {
+  test('should render dialog for osp config', () => {
     const handleClose = jest.fn();
     const handleSave = jest.fn();
     const handleOpenEditConfigFamilyDialog = jest.fn();
@@ -324,8 +324,6 @@ describe('EditScanConfigDialog component tests', () => {
         onSave={handleSave}
       />,
     );
-
-    await wait();
 
     expect(baseElement).toMatchSnapshot();
 

--- a/gsa/src/web/pages/scanconfigs/__tests__/editdialog.js
+++ b/gsa/src/web/pages/scanconfigs/__tests__/editdialog.js
@@ -26,7 +26,7 @@ import {
   SCANCONFIG_TREND_DYNAMIC,
 } from 'gmp/models/scanconfig';
 
-import {rendererWith, fireEvent, getAllByTestId} from 'web/utils/testing';
+import {rendererWith, fireEvent, getAllByTestId, wait} from 'web/utils/testing';
 
 import EditScanConfigDialog from '../editdialog';
 
@@ -129,7 +129,7 @@ const trend = {
 const scannerPreferences = [
   {
     name: 'scannerpref0',
-    hr_name: 'Scanner Preference 1',
+    hrName: 'Scanner Preference 1',
     value: 0,
   },
 ];
@@ -292,7 +292,7 @@ describe('EditScanConfigDialog component tests', () => {
     );
   });
 
-  test('should render dialog for osp config', () => {
+  test('should render dialog for osp config', async () => {
     const handleClose = jest.fn();
     const handleSave = jest.fn();
     const handleOpenEditConfigFamilyDialog = jest.fn();
@@ -324,6 +324,8 @@ describe('EditScanConfigDialog component tests', () => {
         onSave={handleSave}
       />,
     );
+
+    await wait();
 
     expect(baseElement).toMatchSnapshot();
 

--- a/gsa/src/web/pages/scanconfigs/component.js
+++ b/gsa/src/web/pages/scanconfigs/component.js
@@ -48,7 +48,6 @@ import EditScanConfigDialog from './editdialog';
 import EditNvtDetailsDialog from './editnvtdetailsdialog';
 import ImportDialog from './importdialog';
 import ScanConfigDialog from './dialog';
-import ScanConfig from 'gmp/models/scanconfig';
 
 export const createSelectedNvts = (configFamily, nvts) => {
   const selected = {};
@@ -392,9 +391,7 @@ const ScanConfigComponent = ({
     );
 
     return loadConfigPromise(configId)
-      .then(response => {
-        const scanConfig = ScanConfig.fromObject(response?.data?.scanConfig);
-        console.log(scanConfig);
+      .then(scanConfig => {
         dispatchState(
           updateState({
             config: scanConfig,

--- a/gsa/src/web/pages/scanconfigs/component.js
+++ b/gsa/src/web/pages/scanconfigs/component.js
@@ -91,7 +91,7 @@ const ScanConfigComponent = ({
     importDialogVisible: false,
   });
 
-  const loadConfigPromise = useLoadScanConfigPromise();
+  const loadScanConfigPromise = useLoadScanConfigPromise();
   const [importScanConfig] = useImportScanConfig();
   const [createScanConfig] = useCreateScanConfig();
   const [
@@ -390,7 +390,7 @@ const ScanConfigComponent = ({
       }),
     );
 
-    return loadConfigPromise(configId)
+    return loadScanConfigPromise(configId)
       .then(scanConfig => {
         dispatchState(
           updateState({

--- a/gsa/src/web/pages/scanconfigs/component.js
+++ b/gsa/src/web/pages/scanconfigs/component.js
@@ -32,6 +32,7 @@ import {YES_VALUE} from 'gmp/parser';
 import {
   useImportScanConfig,
   useCreateScanConfig,
+  useLoadScanConfigPromise,
 } from 'web/graphql/scanconfigs';
 import {useLazyGetScanners} from 'web/graphql/scanners';
 
@@ -47,6 +48,7 @@ import EditScanConfigDialog from './editdialog';
 import EditNvtDetailsDialog from './editnvtdetailsdialog';
 import ImportDialog from './importdialog';
 import ScanConfigDialog from './dialog';
+import ScanConfig from 'gmp/models/scanconfig';
 
 export const createSelectedNvts = (configFamily, nvts) => {
   const selected = {};
@@ -90,6 +92,7 @@ const ScanConfigComponent = ({
     importDialogVisible: false,
   });
 
+  const loadConfigPromise = useLoadScanConfigPromise();
   const [importScanConfig] = useImportScanConfig();
   const [createScanConfig] = useCreateScanConfig();
   const [
@@ -388,12 +391,13 @@ const ScanConfigComponent = ({
       }),
     );
 
-    return gmp.scanconfig
-      .get({id: configId})
+    return loadConfigPromise(configId)
       .then(response => {
+        const scanConfig = ScanConfig.fromObject(response?.data?.scanConfig);
+        console.log(scanConfig);
         dispatchState(
           updateState({
-            config: response.data,
+            config: scanConfig,
           }),
         );
       })

--- a/gsa/src/web/pages/scanconfigs/detailspage.js
+++ b/gsa/src/web/pages/scanconfigs/detailspage.js
@@ -323,7 +323,7 @@ const Page = () => {
     refetch: refetchScanConfig,
     loading,
     error: entityError,
-  } = useGetScanConfig(id);
+  } = useGetScanConfig(id, {fetchPolicy: 'no-cache'}); // if we allow caching, all scanner preferences will be parsed as auto_enable_dependencies
   const {permissions = [], refetch: refetchPermissions} = useGetPermissions({
     filterString: permissionsResourceFilter(id).toFilterString(),
   });

--- a/gsa/src/web/pages/scanconfigs/scannerpreferences.js
+++ b/gsa/src/web/pages/scanconfigs/scannerpreferences.js
@@ -129,7 +129,7 @@ const ScannerPreferences = ({
             <ScannerPreference
               key={pref.name}
               defaultValue={pref.default}
-              displayName={pref.hr_name}
+              displayName={pref.hrName}
               name={pref.name}
               value={values[pref.name]}
               onPreferenceChange={(value, name) =>
@@ -145,7 +145,7 @@ const ScannerPreferences = ({
 
 export const ScannerPreferencePropType = PropTypes.shape({
   default: PropTypes.any,
-  hr_name: PropTypes.string.isRequired,
+  hrName: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   value: PropTypes.any,
 });

--- a/gsa/src/web/pages/scanconfigs/scannerpreferences.js
+++ b/gsa/src/web/pages/scanconfigs/scannerpreferences.js
@@ -81,7 +81,7 @@ const ScannerPreference = ({
               yesValue={1}
               noValue={0}
               name={name}
-              value={value}
+              value={parseInt(value)} // scanner preferences are "1" and "0" and should be preconverted for the right radio button to be checked.
               convert={parseInt}
               onChange={onPreferenceChange}
             />


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Currently, getLazyQuery does not return a promise. Implement a custom hook that invokes the Apollo client directly that returns such a promise. Also, some minor adjustments to support using hyperion scan configs in the edit dialog.

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
