### PR TITLE
Fix display of severity level change alert condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use <predefined> to disable feed object editing and filter creation on feed status page [#2398](https://github.com/greenbone/gsa/pull/2398)
 
 ### Fixed
+- Fixed display of alert condition "Severity changed" [#2623](https://github.com/greenbone/gsa/pull/2623)
 - Fixed sanity check for port ranges [#2566](https://github.com/greenbone/gsa/pull/2566)
 - Allow to delete processes without having had edges in BPM [#2507](https://github.com/greenbone/gsa/pull/2507)
 - Fixed TLS certificate download for users with permissions [#2496](https://github.com/greenbone/gsa/pull/2496)

--- a/gsa/src/web/pages/alerts/condition.js
+++ b/gsa/src/web/pages/alerts/condition.js
@@ -28,6 +28,7 @@ import {
   CONDITION_TYPE_FILTER_COUNT_CHANGED,
   CONDITION_TYPE_SEVERITY_AT_LEAST,
   CONDITION_DIRECTION_DECREASED,
+  CONDITION_DIRECTION_INCREASED,
 } from 'gmp/models/alert';
 
 const Condition = ({condition = {}, event}) => {
@@ -85,10 +86,11 @@ const Condition = ({condition = {}, event}) => {
   }
 
   if (condition.type === 'Severity changed') {
-    if (isDefined(condition.data.direction)) {
-      if (condition.data.direction.value === CONDITION_DIRECTION_DECREASED) {
-        return _('Severity level decreased');
-      }
+    if (condition?.data?.direction?.value === CONDITION_DIRECTION_DECREASED) {
+      return _('Severity level decreased');
+    } else if (
+      condition?.data?.direction?.value === CONDITION_DIRECTION_INCREASED
+    ) {
       return _('Severity level increased');
     }
     return _('Severity level changed');


### PR DESCRIPTION
**What**:
Show the correct direction of severity change in the condition column of alerts.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The logic behind selecting the correct value was incorrect. It was impossible to get "Severity level changed" and instead we always got "Severity level increased"
<!-- Why are these changes necessary? -->

**How**:
I created 3 alerts, one for each condition, and visually checked whether the correct value was displayed. After editing those alerts the conditions were correctly updated. The alerts were created by sending the correct parameters to gvmd, so it was really just a displaying error.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
