### PR TITLE
Link from Hosts to TLS Certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [20.8.1] - unreleased
 
 ### Added
+- Added icon to host detailspage to link to TLS certificates [#2624](https://github.com/greenbone/gsa/pull/2624)
 - Added form validation for user setting "rows per page"
   [#2478](https://github.com/greenbone/gsa/pull/2478), [#2505](https://github.com/greenbone/gsa/pull/2505)
 - Added option for "Start Task" event upon "New SecInfo arrived" condition in alerts dialog [#2418](https://github.com/greenbone/gsa/pull/2418)

--- a/gsa/public/locales/gsa-de.json
+++ b/gsa/public/locales/gsa-de.json
@@ -1530,6 +1530,7 @@
   "TLS Certificates are always included for now": "TLS-Zertifikate werden bis auf Weiteres immer hinzugefügt",
   "TLS Certificates by Modification Time (Total: {{count}})": "TLS-Zertifikate nach Änderungszeit (Gesamt: {{count}})",
   "TLS Certificates by Status (Total: {{count}})": "TLS-Zertifikate nach Status (Gesamt: {{count}})",
+  "TLS Certificates for this Host": "TLS-Zertifikate für diesen Host",
   "Table: CERT-Bund Advisories by CVSS": "Tabelle: CERT-Bund-Advisories nach CVSS",
   "Table: CERT-Bund Advisories by Creation Time": "Tabelle: CERT-Bund-Advisories nach Erstellungszeit",
   "Table: CERT-Bund Advisories by Severity Class": "Tabelle: CERT-Bund-Advisories nach Schweregradklasse",

--- a/gsa/src/web/pages/hosts/detailspage.js
+++ b/gsa/src/web/pages/hosts/detailspage.js
@@ -34,6 +34,7 @@ import ListIcon from 'web/components/icon/listicon';
 import ManualIcon from 'web/components/icon/manualicon';
 import OsIcon from 'web/components/icon/osicon';
 import ResultIcon from 'web/components/icon/resulticon';
+import TlsCertificateIcon from 'web/components/icon/tlscertificateicon';
 
 import Divider from 'web/components/layout/divider';
 import IconDivider from 'web/components/layout/icondivider';
@@ -125,6 +126,13 @@ const ToolBarIcons = ({
           title={_('Results for this Host')}
         >
           <ResultIcon />
+        </Link>
+        <Link
+          to="tlsCertificates"
+          filter={'host_id=' + entity.id}
+          title={_('TLS Certificates for this Host')}
+        >
+          <TlsCertificateIcon />
         </Link>
       </IconDivider>
     </Divider>


### PR DESCRIPTION
**What**:
Add an icon and filtered link from the host detailspage to a TLS certificates list with certs that have been found on this host. Use the "new" `host_id=` filter.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This was specified in the feature request for TLS Certificates as assets but was not implemented, yet, because the `host_id=` filter term didn't exist back then.
<!-- Why are these changes necessary? -->

**How**:
Go to host detailspage, find new icon, click it and find yourself on a filtered TLS Certificate listpage.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
