### PR TITLE
Fix compiling gsad with libmicrohttp >= 0.9.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use <predefined> to disable feed object editing and filter creation on feed status page [#2398](https://github.com/greenbone/gsa/pull/2398)
 
 ### Fixed
+- Fixed compiling gsad with libmicrohttp 0.9.71 and later [#2625](https://github.com/greenbone/gsa/pull/2625)
 - Fixed sanity check for port ranges [#2566](https://github.com/greenbone/gsa/pull/2566)
 - Allow to delete processes without having had edges in BPM [#2507](https://github.com/greenbone/gsa/pull/2507)
 - Fixed TLS certificate download for users with permissions [#2496](https://github.com/greenbone/gsa/pull/2496)

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -1591,7 +1591,11 @@ exec_gmp_post (http_connection_t *con, gsad_connection_info_t *con_info,
  * @param[in]  name    Name.
  * @param[in]  value   Value.
  */
+#if MHD_VERSION < 0x00097002
 int
+#else
+enum MHD_Result
+#endif
 params_mhd_add (void *params, enum MHD_ValueKind kind, const char *name,
                 const char *value)
 {
@@ -2180,7 +2184,11 @@ exec_gmp_get (http_connection_t *con, gsad_connection_info_t *con_info,
  *
  * @return MHD_NO in case of problems. MHD_YES if all is OK.
  */
-int
+#if MHD_VERSION < 0x00097002
+static int
+#else
+static enum MHD_Result
+#endif
 redirect_handler (void *cls, struct MHD_Connection *connection, const char *url,
                   const char *method, const char *version,
                   const char *upload_data, size_t *upload_data_size,
@@ -2516,9 +2524,17 @@ mhd_logger (void *arg, const char *fmt, va_list ap)
 
 static struct MHD_Daemon *
 start_unix_http_daemon (const char *unix_socket_path,
+#if MHD_VERSION < 0x00097002
                         int handler (void *, struct MHD_Connection *,
                                      const char *, const char *, const char *,
                                      const char *, size_t *, void **),
+#else
+                        enum MHD_Result handler (void *,
+                                                 struct MHD_Connection *,
+                                                 const char *, const char *,
+                                                 const char *, const char *,
+                                                 size_t *, void **),
+#endif
                         http_handler_t *http_handlers)
 {
   struct sockaddr_un addr;
@@ -2572,9 +2588,16 @@ start_unix_http_daemon (const char *unix_socket_path,
 
 static struct MHD_Daemon *
 start_http_daemon (int port,
+#if MHD_VERSION < 0x00097002
                    int handler (void *, struct MHD_Connection *, const char *,
                                 const char *, const char *, const char *,
                                 size_t *, void **),
+#else
+                   enum MHD_Result handler (void *, struct MHD_Connection *,
+                                            const char *, const char *,
+                                            const char *, const char *,
+                                            size_t *, void **),
+#endif
                    http_handler_t *http_handlers,
                    struct sockaddr_storage *address)
 {

--- a/gsad/src/gsad_http.c
+++ b/gsad/src/gsad_http.c
@@ -749,7 +749,11 @@ file_content_response (http_connection_t *connection, const char *url,
  *
  * @return MHD_YES.
  */
+#if MHD_VERSION < 0x00097002
 static int
+#else
+static enum MHD_Result
+#endif
 append_param (void *string, enum MHD_ValueKind kind, const char *key,
               const char *value)
 {
@@ -922,7 +926,11 @@ get_client_address (http_connection_t *conn, char *client_address)
  *
  * @return MHD_YES to continue iterating over post data, MHD_NO to stop.
  */
+#if MHD_VERSION < 0x00097002
 int
+#else
+enum MHD_Result
+#endif
 serve_post (void *coninfo_cls, enum MHD_ValueKind kind, const char *key,
             const char *filename, const char *content_type,
             const char *transfer_encoding, const char *data, uint64_t off,

--- a/gsad/src/gsad_http.h
+++ b/gsad/src/gsad_http.h
@@ -204,7 +204,11 @@ reconstruct_url (http_connection_t *connection, const char *url);
 int
 get_client_address (http_connection_t *conn, char *client_address);
 
+#if MHD_VERSION < 0x00097002
 int
+#else
+enum MHD_Result
+#endif
 serve_post (void *coninfo_cls, enum MHD_ValueKind kind, const char *key,
             const char *filename, const char *content_type,
             const char *transfer_encoding, const char *data, uint64_t off,

--- a/gsad/src/gsad_http_handler.c
+++ b/gsad/src/gsad_http_handler.c
@@ -841,7 +841,11 @@ cleanup_http_handlers ()
  *
  * @return MHD_NO in case of problems. MHD_YES if all is OK.
  */
+#if MHD_VERSION < 0x00097002
 int
+#else
+enum MHD_Result
+#endif
 handle_request (void *cls, http_connection_t *connection, const char *url,
                 const char *method, const char *version,
                 const char *upload_data, size_t *upload_data_size,

--- a/gsad/src/gsad_http_handler.h
+++ b/gsad/src/gsad_http_handler.h
@@ -76,7 +76,11 @@ void
 method_router_set_post_handler (http_handler_t *router,
                                 http_handler_t *handler);
 
+#if MHD_VERSION < 0x00097002
 int
+#else
+enum MHD_Result
+#endif
 handle_request (void *cls, http_connection_t *connection, const char *url,
                 const char *method, const char *version,
                 const char *upload_data, size_t *upload_data_size,

--- a/gsad/src/gsad_params.h
+++ b/gsad/src/gsad_params.h
@@ -100,7 +100,11 @@ params_append_bin (params_t *, const char *, const char *, int, int);
 gboolean
 params_iterator_next (params_iterator_t *, char **, param_t **);
 
+#if MHD_VERSION < 0x00097002
 int
+#else
+enum MHD_Result
+#endif
 params_mhd_add (void *params, enum MHD_ValueKind kind, const char *name,
                 const char *value);
 


### PR DESCRIPTION
**What**:

Fix compiling gsad with libmicrohttp 0.9.71 and later

**Why**:

ibmicrohttp 0.9.71 changed the return value of the request handler callback functions. This causes a compiler warning with newer distributions like Ubuntu 20.10. Because we treat warnings as errors (`-Wall`) the compilation fails on such systems.

**How**:

Build gsad on Ubuntu 20.10 successfully.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
