### PR TITLE
Fix selection for including related resources in permission dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use <predefined> to disable feed object editing and filter creation on feed status page [#2398](https://github.com/greenbone/gsa/pull/2398)
 
 ### Fixed
+- Fixed initial value of dropdown for including related resources for permissions [#2632](https://github.com/greenbone/gsa/pull/2632)
 - Fixed compiling gsad with libmicrohttp 0.9.71 and later [#2625](https://github.com/greenbone/gsa/pull/2625)
 - Fixed display of alert condition "Severity changed" [#2623](https://github.com/greenbone/gsa/pull/2623)
 - Fixed sanity check for port ranges [#2566](https://github.com/greenbone/gsa/pull/2566)

--- a/gsa/src/web/pages/permissions/multipledialog.js
+++ b/gsa/src/web/pages/permissions/multipledialog.js
@@ -70,12 +70,12 @@ const MultiplePermissionDialog = withCapabilities(
     const hasRelated = related.length > 0;
 
     const defaultValues = {
-      includeRelated,
       permission,
       subjectType,
     };
 
     const values = {
+      includeRelated,
       groupId,
       id,
       entityType,


### PR DESCRIPTION
**What**:
Fix initial value of dropdown for including related resources for permissions in MultiplePermissionsDialog
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
When the dropdown is initialized with "include related resources", but later there aren't any, the Select component will show a label- and useless value "1". Now we have "for current resource only" as standard if there are no related resources, and a "include related resources" if there are.

<!-- Why are these changes necessary? -->

**How**:
Visual inspection of the options in the dropdown for entities with and without resources. Also the console doesn't throw a prop warning for Downshift anymore.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
