### PR TITLE
Ensure superadmins can edit themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added option for "Start Task" event upon "New SecInfo arrived" condition in alerts dialog [#2418](https://github.com/greenbone/gsa/pull/2418)
 
 ### Changed
+- Ensure superadmins can edit themselves [#2633](https://github.com/greenbone/gsa/pull/2633)
 - Allow äüöÄÜÖß in form validation rule for "name" [#2586](https://github.com/greenbone/gsa/pull/2586)
 - Show "Filter x matches at least y results" condition to task events in alert dialog [#2580](https://github.com/greenbone/gsa/pull/2580)
 - Always send sort=name with delta report request filters [#2570](https://github.com/greenbone/gsa/pull/2570)

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -14410,6 +14410,7 @@ save_user_gmp (gvm_connection_t *connection, credentials_t *credentials,
   entity_t entity;
   GString *command, *group_elements, *role_elements;
   params_t *groups, *roles;
+  user_t *current_user;
 
   /* List of hosts user has/lacks access rights. */
   hosts = params_value (params, "access_hosts");
@@ -14456,7 +14457,11 @@ save_user_gmp (gvm_connection_t *connection, credentials_t *credentials,
   g_string_append (command, buf);
   g_free (buf);
 
-  if (login)
+  current_user = credentials_get_user (credentials);
+
+  if (login
+      /* gvmd forbids users from modifying their own names. */
+      && strcmp (login, user_get_username (current_user)))
     {
       buf = g_markup_printf_escaped ("<new_name>%s</new_name>", login);
       g_string_append (command, buf);
@@ -14540,8 +14545,6 @@ save_user_gmp (gvm_connection_t *connection, credentials_t *credentials,
   ret = gmp (connection, credentials, &response, &entity, response_data,
              command->str);
   g_string_free (command, TRUE);
-
-  user_t *current_user = credentials_get_user (credentials);
 
   switch (ret)
     {

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -14522,7 +14522,9 @@ save_user_gmp (gvm_connection_t *connection, credentials_t *credentials,
       params_iterator_init (&iter, roles);
       while (params_iterator_next (&iter, &name, &param))
         {
-          if (param->value && strcmp (param->value, "--"))
+          if (param->value && strcmp (param->value, "--")
+              /* Skip "Super Admin" which may not be added to a user. */
+              && strcmp (param->value, "9c5a6ec6-6fe2-11e4-8cb6-406186ea4fc5"))
             g_string_append_printf (role_elements, "<role id=\"%s\"/>",
                                     param->value ? param->value : "");
         }


### PR DESCRIPTION
**What**:

Skip elements in MODIFY_USER that would prevent a superadmin from saving themself.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Superadmins should be able to edit themselves.

<!-- Why are these changes necessary? -->

**How**:

Login as superadmin s.   Menu > Users.  Click edit icon for user s.  Edit comment.  Click Save.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
