### PR TITLE
Disable clone icon for superadmin users on listpages and detailspages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added option for "Start Task" event upon "New SecInfo arrived" condition in alerts dialog [#2418](https://github.com/greenbone/gsa/pull/2418)
 
 ### Changed
+- Disable clone icon for superadmins [#2633](https://github.com/greenbone/gsa/pull/2633)
 - Allow äüöÄÜÖß in form validation rule for "name" [#2586](https://github.com/greenbone/gsa/pull/2586)
 - Show "Filter x matches at least y results" condition to task events in alert dialog [#2580](https://github.com/greenbone/gsa/pull/2580)
 - Always send sort=name with delta report request filters [#2570](https://github.com/greenbone/gsa/pull/2570)

--- a/gsa/src/gmp/models/__tests__/user.js
+++ b/gsa/src/gmp/models/__tests__/user.js
@@ -122,6 +122,37 @@ describe('User model tests', () => {
     expect(user1.sources).toBeUndefined();
     expect(user3.authMethod).toEqual(AUTH_METHOD_PASSWORD);
   });
+
+  test('isSuperAdmin() should return correct true/false', () => {
+    const user1 = User.fromElement({
+      role: [
+        {
+          _id: '9c5a6ec6-6fe2-11e4-8cb6-406186ea4fc5', // ID for Superadmin
+        },
+      ],
+    });
+    const user2 = User.fromElement({
+      role: [
+        {
+          _id: '42',
+        },
+      ],
+    });
+    const user3 = User.fromElement({
+      role: [
+        {
+          _id: '9c5a6ec6-6fe2-11e4-8cb6-406186ea4fc5', // ID for Superadmin
+        },
+        {
+          _id: '42',
+        },
+      ],
+    });
+
+    expect(user1.isSuperAdmin()).toEqual(true);
+    expect(user2.isSuperAdmin()).toEqual(false);
+    expect(user3.isSuperAdmin()).toEqual(true);
+  });
 });
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/gmp/models/user.js
+++ b/gsa/src/gmp/models/user.js
@@ -31,6 +31,8 @@ export const AUTH_METHOD_RADIUS = 'radius';
 export const ACCESS_ALLOW_ALL = '0';
 export const ACCESS_DENY_ALL = '1';
 
+const SUPERADMIN_ROLE_ID = '9c5a6ec6-6fe2-11e4-8cb6-406186ea4fc5';
+
 class User extends Model {
   static entityType = 'user';
 
@@ -84,6 +86,12 @@ class User extends Model {
     }
 
     return ret;
+  }
+
+  isSuperAdmin() {
+    return isDefined(
+      this.roles.find(element => element.id === SUPERADMIN_ROLE_ID),
+    );
   }
 }
 

--- a/gsa/src/web/pages/users/detailspage.js
+++ b/gsa/src/web/pages/users/detailspage.js
@@ -81,7 +81,11 @@ const ToolBarIcons = ({
     </IconDivider>
     <IconDivider>
       <CreateIcon entity={entity} onClick={onUserCreateClick} />
-      <CloneIcon entity={entity} onClick={onUserCloneClick} />
+      <CloneIcon
+        entity={entity}
+        mayClone={!entity.isSuperAdmin()}
+        onClick={onUserCloneClick}
+      />
       <EditIcon entity={entity} onClick={onUserEditClick} />
       <DeleteIcon entity={entity} onClick={onUserDeleteClick} />
       <ExportIcon

--- a/gsa/src/web/pages/users/row.js
+++ b/gsa/src/web/pages/users/row.js
@@ -66,6 +66,7 @@ const Actions = withEntitiesActions(
       />
       <CloneIcon
         displayName={_('User')}
+        mayClone={!entity.isSuperAdmin()}
         name="user"
         entity={entity}
         title={_('Clone User')}


### PR DESCRIPTION
**What**:
Disable the clone icon for superadmin users.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Superadmins can't be cloned, it doesn't make sense to offer the option just to throw an error.
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
