### PR TITLE
Stop toolbars from growing if they have only the help icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use <predefined> to disable feed object editing and filter creation on feed status page [#2398](https://github.com/greenbone/gsa/pull/2398)
 
 ### Fixed
+- Stop growing of toolbars which only have the help icon [#2641](https://github.com/greenbone/gsa/pull/2641)
 - Fixed initial value of dropdown for including related resources for permissions [#2632](https://github.com/greenbone/gsa/pull/2632)
 - Fixed compiling gsad with libmicrohttp 0.9.71 and later [#2625](https://github.com/greenbone/gsa/pull/2625)
 - Fixed display of alert condition "Severity changed" [#2623](https://github.com/greenbone/gsa/pull/2623)

--- a/gsa/src/web/pages/extras/cvsscalculatorpage.js
+++ b/gsa/src/web/pages/extras/cvsscalculatorpage.js
@@ -198,7 +198,11 @@ const CvssCalculator = ({gmp, onInteraction, ...props}) => {
 
   return (
     <Layout flex="column">
-      <ToolBarIcons />
+      <span>
+        {' '}
+        {/* span prevents Toolbar from growing */}
+        <ToolBarIcons />
+      </span>
       <Section
         img={<CvssIcon size="large" />}
         title={_('CVSSv2 Base Score Calculator')}
@@ -370,10 +374,7 @@ const mapDispatchToProps = (dispatch, {gmp}) => ({
 
 export default compose(
   withGmp,
-  connect(
-    undefined,
-    mapDispatchToProps,
-  ),
+  connect(undefined, mapDispatchToProps),
 )(CvssCalculator);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/extras/feedstatuspage.js
+++ b/gsa/src/web/pages/extras/feedstatuspage.js
@@ -105,7 +105,11 @@ const FeedStatus = ({feeds}) => {
     <React.Fragment>
       <PageTitle title={_('Feed Status')} />
       <Layout flex="column">
-        <ToolBarIcons />
+        <span>
+          {' '}
+          {/* span prevents Toolbar from growing */}
+          <ToolBarIcons />
+        </span>
         <Section img={<FeedIcon size="large" />} title={_('Feed Status')} />
         <Table>
           <TableBody>

--- a/gsa/src/web/pages/extras/trashcanpage.js
+++ b/gsa/src/web/pages/extras/trashcanpage.js
@@ -372,7 +372,11 @@ class Trashcan extends React.Component {
       <React.Fragment>
         <PageTitle title={_('Trashcan')} />
         <Layout flex="column">
-          <ToolBarIcons />
+          <span>
+            {' '}
+            {/* span prevents Toolbar from growing */}
+            <ToolBarIcons />
+          </span>
           {error && (
             <ErrorDialog
               text={error.message}
@@ -560,10 +564,7 @@ const mapDispatchToProps = (dispatch, {gmp}) => ({
 
 export default compose(
   withGmp,
-  connect(
-    undefined,
-    mapDispatchToProps,
-  ),
+  connect(undefined, mapDispatchToProps),
 )(Trashcan);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/gsa/src/web/pages/start/__tests__/page.js
+++ b/gsa/src/web/pages/start/__tests__/page.js
@@ -110,7 +110,7 @@ describe('StartPage tests', () => {
     expect(icons[0]).toHaveAttribute('title', 'Help: Dashboards');
 
     // Tabs
-    expect(spans[2]).toHaveTextContent('Overview');
+    expect(spans[3]).toHaveTextContent('Overview');
     expect(icons[2]).toHaveAttribute('title', 'Add new Dashboard');
 
     // Dashboard Controls

--- a/gsa/src/web/pages/start/page.js
+++ b/gsa/src/web/pages/start/page.js
@@ -401,7 +401,11 @@ class StartPage extends React.Component {
     return (
       <React.Fragment>
         <PageTitle title={_('Dashboards')} />
-        <ToolBarIcons />
+        <span>
+          {' '}
+          {/* span prevents Toolbar from growing */}
+          <ToolBarIcons />
+        </span>
         <Section title={_('Dashboards')} img={<DashboardIcon size="large" />}>
           {isLoading ? (
             <Loading />
@@ -557,10 +561,7 @@ const mapDispatchToProps = (dispatch, {gmp}) => ({
 
 export default compose(
   withGmp,
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  ),
+  connect(mapStateToProps, mapDispatchToProps),
 )(StartPage);
 
 // vim: set ts=2 sw=2 tw=80:


### PR DESCRIPTION
**What**:
Don't grow the toolbar on pages where there is only the help icon. This is achieved by simply wrapping it into a span.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The clickable area to link to the manual spread to 100% width of the screen. Other pages (e.g. tickets) already had a reduced click area, because their toolbar is wrapped already.
<!-- Why are these changes necessary? -->

**How**:
Manually check whether the clickable areas are reduced to the icon on the 4 pages in question and if the links still work. Also updated the startpage test.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
