### PR TITLE
Fix schedule tests

### DIFF
--- a/gsa/src/web/graphql/__mocks__/schedules.js
+++ b/gsa/src/web/graphql/__mocks__/schedules.js
@@ -34,7 +34,7 @@ const schedule1 = deepFreeze({
   id: 'foo',
   name: 'schedule 1',
   icalendar:
-    'BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Greenbone.net//NONSGML Greenbone Security Manager \n 21.04+alpha~git-bb97c86-master//EN\nBEGIN:VEVENT\nDTSTART:20210104T115400Z\nDURATION:PT0S\nRRULE:FREQ=WEEKLY\nUID:3dfd6e6f-4e79-4f18-a5c2-adb3fca56bd3\nDTSTAMP:20210104T115412Z\nEND:VEVENT\nEND:VCALENDAR\n',
+    'BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Greenbone.net//NONSGML Greenbone Security Manager \n 21.4.0~dev1~git-5f8b6cf-master//EN\nBEGIN:VEVENT\nDTSTART:20210104T115400Z\nDURATION:PT0S\nUID:foo\nDTSTAMP:20210111T134141Z\nEND:VEVENT\nEND:VCALENDAR',
   timezone: 'UTC',
   userTags: {
     count: 1,

--- a/gsa/src/web/pages/schedules/__tests__/detailspage.js
+++ b/gsa/src/web/pages/schedules/__tests__/detailspage.js
@@ -52,7 +52,7 @@ const schedule = Schedule.fromElement({
   comment: 'hello world',
   creation_time: '2020-12-23T14:14:11Z',
   icalendar:
-    'BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Greenbone.net//NONSGML Greenbone Security Manager \n 21.04+alpha~git-bb97c86-master//EN\nBEGIN:VEVENT\nDTSTART:20210104T115400Z\nDURATION:PT0S\nRRULE:FREQ=WEEKLY\nUID:3dfd6e6f-4e79-4f18-a5c2-adb3fca56bd3\nDTSTAMP:20210104T115412Z\nEND:VEVENT\nEND:VCALENDAR\n',
+    'BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//Greenbone.net//NONSGML Greenbone Security Manager \n 21.4.0~dev1~git-5f8b6cf-master//EN\nBEGIN:VEVENT\nDTSTART:20210104T115400Z\nDURATION:PT0S\nUID:84198224-d124-4194-a9e8-6f99ded72482\nDTSTAMP:20210111T134141Z\nEND:VEVENT\nEND:VCALENDAR',
   in_use: 0,
   modification_time: '2021-01-04T11:54:12Z',
   name: 'schedule 1',
@@ -171,13 +171,13 @@ describe('Schedule Detailspage tests', () => {
     expect(element).toHaveTextContent('Mon, Jan 4, 2021 11:54 AM UTC');
 
     expect(element).toHaveTextContent('Next Run');
-    expect(element).toHaveTextContent('Mon, Jan 11, 2021 11:54 AM UTC');
+    expect(element).toHaveTextContent('-');
 
     expect(element).toHaveTextContent('Timezone');
     expect(element).toHaveTextContent('UTC');
 
     expect(element).toHaveTextContent('Recurrence');
-    expect(element).toHaveTextContent('Every week');
+    expect(element).toHaveTextContent('Once');
 
     expect(element).toHaveTextContent('Duration');
     expect(element).toHaveTextContent('Entire Operation');

--- a/gsa/src/web/pages/schedules/__tests__/listpage.js
+++ b/gsa/src/web/pages/schedules/__tests__/listpage.js
@@ -144,7 +144,7 @@ describe('SchedulePage tests', () => {
     expect(row[1]).toHaveTextContent('schedule 1');
     expect(row[1]).toHaveTextContent('(hello world)');
     expect(row[1]).toHaveTextContent('Mon, Jan 4, 2021 11:54 AM UTC');
-    expect(row[1]).toHaveTextContent('Mon, Jan 11, 2021 11:54 AM UTC');
+    expect(row[1]).toHaveTextContent('-');
     expect(row[1]).toHaveTextContent('Entire Operation');
 
     expect(


### PR DESCRIPTION
**What**:

Old schedule tests uses a mock schedule that recurs weekly. The problem with that is, if system time changes, so will the Next Run dates. In lieu of setting a mock date, I modify the mock schedule to run once.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
