### PR TITLE
Fix reload inteval calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added missing fields for getScanners query and parseObject() for scanner model [#2301](https://github.com/greenbone/gsa/pull/2301)
 
 ### Fixed
+- Fixed reload interval for pages using useEntityReloadInterval and useEntitiesReloadInterval hooks [#2716](https://github.com/greenbone/gsa/pull/2716)
 
 ### Removed
 - Removed unused task.js [#2714](https://github.com/greenbone/gsa/pull/2714)

--- a/gsa/src/web/pages/alerts/detailspage.js
+++ b/gsa/src/web/pages/alerts/detailspage.js
@@ -57,7 +57,6 @@ import EntityPage from 'web/entity/page';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
-import useEntityReloadInterval from 'web/entity/useEntityReloadInterval';
 import useExportEntity from 'web/entity/useExportEntity';
 import {permissionsResourceFilter} from 'web/entity/withEntityContainer';
 
@@ -76,6 +75,7 @@ import useUserSessionTimeout from 'web/utils/useUserSessionTimeout';
 
 import AlertComponent from './component';
 import AlertDetails from './details';
+import useDefaultReloadInterval from 'web/utils/useDefaultReloadInterval';
 
 export const ToolBarIcons = ({
   entity,
@@ -172,7 +172,7 @@ const Page = () => {
   };
 
   // Timeout and reload
-  const timeoutFunc = useEntityReloadInterval(alert);
+  const timeoutFunc = useDefaultReloadInterval();
 
   const [startReload, stopReload, hasRunningTimer] = useReload(
     refetchAlert,

--- a/gsa/src/web/pages/alerts/listpage.js
+++ b/gsa/src/web/pages/alerts/listpage.js
@@ -48,7 +48,6 @@ import {
   useBulkExportEntities,
 } from 'web/entities/bulkactions';
 import usePagination from 'web/entities/usePagination';
-import useEntitiesReloadInterval from 'web/entities/useEntitiesReloadInterval';
 
 import {
   useLazyGetAlerts,
@@ -65,6 +64,7 @@ import PropTypes from 'web/utils/proptypes';
 
 import useCapabilities from 'web/utils/useCapabilities';
 import useChangeFilter from 'web/utils/useChangeFilter';
+import useDefaultReloadInterval from 'web/utils/useDefaultReloadInterval';
 import useFilterSortBy from 'web/utils/useFilterSortby';
 import usePageFilter from 'web/utils/usePageFilter';
 import usePrevious from 'web/utils/usePrevious';
@@ -148,7 +148,7 @@ const AlertsPage = ({onChanged, onDownloaded, onError, ...props}) => {
 
   const bulkDeleteAlerts = useBulkDeleteEntities();
 
-  const timeoutFunc = useEntitiesReloadInterval(alerts);
+  const timeoutFunc = useDefaultReloadInterval();
 
   const [startReload, stopReload, hasRunningTimer] = useReload(
     refetch,

--- a/gsa/src/web/pages/hosts/detailspage.js
+++ b/gsa/src/web/pages/hosts/detailspage.js
@@ -68,7 +68,6 @@ import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 import {permissionsResourceFilter} from 'web/entity/withEntityContainer';
-import useEntityReloadInterval from 'web/entity/useEntityReloadInterval';
 
 import CreateIcon from 'web/entity/icon/createicon';
 import DeleteIcon from 'web/entity/icon/deleteicon';
@@ -85,6 +84,7 @@ import {useGetPermissions} from 'web/graphql/permissions';
 
 import PropTypes from 'web/utils/proptypes';
 import {goto_entity_details} from 'web/utils/graphql';
+import useDefaultReloadInterval from 'web/utils/useDefaultReloadInterval';
 import useUserSessionTimeout from 'web/utils/useUserSessionTimeout';
 
 import HostDetails from './details';
@@ -318,7 +318,7 @@ const Page = () => {
   };
 
   // Timeout and reload
-  const timeoutFunc = useEntityReloadInterval(host);
+  const timeoutFunc = useDefaultReloadInterval();
 
   const [startReload, stopReload, hasRunningTimer] = useReload(
     refetchHost,

--- a/gsa/src/web/pages/hosts/listpage.js
+++ b/gsa/src/web/pages/hosts/listpage.js
@@ -47,7 +47,6 @@ import {
 } from 'web/entities/bulkactions';
 import EntitiesPage from 'web/entities/page';
 import withEntitiesContainer from 'web/entities/withEntitiesContainer';
-import useEntitiesReloadInterval from 'web/entities/useEntitiesReloadInterval';
 
 import useExportEntity from 'web/entity/useExportEntity';
 
@@ -70,6 +69,7 @@ import PropTypes from 'web/utils/proptypes';
 
 import useCapabilities from 'web/utils/useCapabilities';
 import useChangeFilter from 'web/utils/useChangeFilter';
+import useDefaultReloadInterval from 'web/utils/useDefaultReloadInterval';
 import useFilterSortBy from 'web/utils/useFilterSortby';
 import usePageFilter from 'web/utils/usePageFilter';
 import usePrevious from 'web/utils/usePrevious';
@@ -151,7 +151,7 @@ const Page = props => {
 
   const bulkDeleteHosts = useBulkDeleteEntities();
 
-  const timeoutFunc = useEntitiesReloadInterval(hosts);
+  const timeoutFunc = useDefaultReloadInterval();
 
   const [startReload, stopReload, hasRunningTimer] = useReload(
     refetch,

--- a/gsa/src/web/pages/policies/detailspage.js
+++ b/gsa/src/web/pages/policies/detailspage.js
@@ -52,7 +52,6 @@ import EntityPage from 'web/entity/page';
 import {goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
-import useEntityReloadInterval from 'web/entity/useEntityReloadInterval';
 import {permissionsResourceFilter} from 'web/entity/withEntityContainer';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
@@ -77,6 +76,7 @@ import {
 import {goto_entity_details} from 'web/utils/graphql';
 
 import PropTypes from 'web/utils/proptypes';
+import useDefaultReloadInterval from 'web/utils/useDefaultReloadInterval';
 import useUserSessionTimeout from 'web/utils/useUserSessionTimeout';
 import withCapabilities from 'web/utils/withCapabilities';
 
@@ -202,7 +202,7 @@ const Page = () => {
   };
 
   // Timeout and reload
-  const timeoutFunc = useEntityReloadInterval(policy);
+  const timeoutFunc = useDefaultReloadInterval();
 
   const [startReload, stopReload, hasRunningTimer] = useReload(
     refetchPolicy,

--- a/gsa/src/web/pages/policies/listpage.js
+++ b/gsa/src/web/pages/policies/listpage.js
@@ -42,7 +42,6 @@ import {
   useBulkExportEntities,
 } from 'web/entities/bulkactions';
 import EntitiesPage from 'web/entities/page';
-import useEntitiesReloadInterval from 'web/entities/useEntitiesReloadInterval';
 import withEntitiesContainer from 'web/entities/withEntitiesContainer';
 
 import {
@@ -64,6 +63,7 @@ import {
 
 import PropTypes from 'web/utils/proptypes';
 import withCapabilities from 'web/utils/withCapabilities';
+import useDefaultReloadInterval from 'web/utils/useDefaultReloadInterval';
 import useFilterSortBy from 'web/utils/useFilterSortby';
 import usePageFilter from 'web/utils/usePageFilter';
 import useChangeFilter from 'web/utils/useChangeFilter';
@@ -147,7 +147,7 @@ const PoliciesPage = props => {
 
   const bulkDeletePolicies = useBulkDeleteEntities();
 
-  const timeoutFunc = useEntitiesReloadInterval(policies);
+  const timeoutFunc = useDefaultReloadInterval();
 
   const [startReload, stopReload, hasRunningTimer] = useReload(
     refetch,

--- a/gsa/src/web/pages/scanconfigs/detailspage.js
+++ b/gsa/src/web/pages/scanconfigs/detailspage.js
@@ -72,7 +72,6 @@ import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
 import {permissionsResourceFilter} from 'web/entity/withEntityContainer';
-import useEntityReloadInterval from 'web/entity/useEntityReloadInterval';
 
 import CloneIcon from 'web/entity/icon/cloneicon';
 import CreateIcon from 'web/entity/icon/createicon';
@@ -82,6 +81,7 @@ import useExportEntity from 'web/entity/useExportEntity';
 
 import PropTypes from 'web/utils/proptypes';
 import useCapabilities from 'web/utils/useCapabilities';
+import useDefaultReloadInterval from 'web/utils/useDefaultReloadInterval';
 import useUserSessionTimeout from 'web/utils/useUserSessionTimeout';
 import {goto_entity_details} from 'web/utils/graphql';
 
@@ -361,7 +361,7 @@ const Page = () => {
   };
 
   // Timeout and reload
-  const timeoutFunc = useEntityReloadInterval(scanConfig);
+  const timeoutFunc = useDefaultReloadInterval();
 
   const [startReload, stopReload, hasRunningTimer] = useReload(
     refetchScanConfig,

--- a/gsa/src/web/pages/schedules/detailspage.js
+++ b/gsa/src/web/pages/schedules/detailspage.js
@@ -57,7 +57,6 @@ import {goto_details, goto_list} from 'web/entity/component';
 import EntityPermissions from 'web/entity/permissions';
 import EntitiesTab from 'web/entity/tab';
 import EntityTags from 'web/entity/tags';
-import useEntityReloadInterval from 'web/entity/useEntityReloadInterval';
 import useExportEntity from 'web/entity/useExportEntity';
 import {permissionsResourceFilter} from 'web/entity/withEntityContainer';
 
@@ -71,6 +70,7 @@ import {
 
 import {goto_entity_details} from 'web/utils/graphql';
 import PropTypes from 'web/utils/proptypes';
+import useDefaultReloadInterval from 'web/utils/useDefaultReloadInterval';
 import useUserSessionTimeout from 'web/utils/useUserSessionTimeout';
 
 import ScheduleComponent from './component';
@@ -172,7 +172,7 @@ const Page = () => {
   };
 
   // Timeout and reload
-  const timeoutFunc = useEntityReloadInterval(schedule);
+  const timeoutFunc = useDefaultReloadInterval();
 
   const [startReload, stopReload, hasRunningTimer] = useReload(
     refetchSchedule,

--- a/gsa/src/web/pages/schedules/listpage.js
+++ b/gsa/src/web/pages/schedules/listpage.js
@@ -45,7 +45,6 @@ import {
   useBulkExportEntities,
 } from 'web/entities/bulkactions';
 import EntitiesPage from 'web/entities/page';
-import useEntitiesReloadInterval from 'web/entities/useEntitiesReloadInterval';
 import usePagination from 'web/entities/usePagination';
 
 import {
@@ -61,6 +60,8 @@ import {
 import PropTypes from 'web/utils/proptypes';
 import useCapabilities from 'web/utils/useCapabilities';
 import useChangeFilter from 'web/utils/useChangeFilter';
+import useDefaultReloadInterval from 'web/utils/useDefaultReloadInterval';
+import useExportEntity from 'web/entity/useExportEntity';
 import useFilterSortBy from 'web/utils/useFilterSortby';
 import usePageFilter from 'web/utils/usePageFilter';
 import usePrevious from 'web/utils/usePrevious';
@@ -69,7 +70,6 @@ import useUserSessionTimeout from 'web/utils/useUserSessionTimeout';
 
 import ScheduleComponent from './component';
 import SchedulesTable, {SORT_FIELDS} from './table';
-import useExportEntity from 'web/entity/useExportEntity';
 
 export const ToolBarIcons = ({onScheduleCreateClick}) => {
   const capabilities = useCapabilities();
@@ -136,7 +136,7 @@ const SchedulesPage = () => {
   const [deleteSchedule] = useDeleteSchedule();
   const exportSchedule = useExportSchedulesByIds();
 
-  const timeoutFunc = useEntitiesReloadInterval(schedules);
+  const timeoutFunc = useDefaultReloadInterval();
 
   const exportSchedulesByFilter = useExportSchedulesByFilter();
   const exportSchedulesByIds = useExportSchedulesByIds();

--- a/gsa/src/web/pages/tasks/listpage.js
+++ b/gsa/src/web/pages/tasks/listpage.js
@@ -50,6 +50,7 @@ import {
   useBulkExportEntities,
   useBulkDeleteEntities,
 } from 'web/entities/bulkactions';
+import useEntitiesReloadInterval from 'web/entities/useEntitiesReloadInterval';
 import usePagination from 'web/entities/usePagination';
 
 import {
@@ -65,7 +66,6 @@ import {
 import PropTypes from 'web/utils/proptypes';
 import useCapabilities from 'web/utils/useCapabilities';
 import useChangeFilter from 'web/utils/useChangeFilter';
-import useGmpSettings from 'web/utils/useGmpSettings';
 import useFilterSortBy from 'web/utils/useFilterSortby';
 import usePageFilter from 'web/utils/usePageFilter';
 import useSelection from 'web/utils/useSelection';
@@ -132,7 +132,6 @@ ToolBarIcons.propTypes = {
 
 const TasksListPage = () => {
   // Page methods and hooks
-  const gmpSettings = useGmpSettings();
   const [downloadRef, handleDownload] = useDownload();
   const [, renewSession] = useUserSessionTimeout();
   const [filter, isLoadingFilter] = usePageFilter('task');
@@ -177,19 +176,7 @@ const TasksListPage = () => {
   const bulkDeleteTasks = useBulkDeleteEntities();
   const [cloneTask] = useCloneTask();
 
-  const timeoutFunc = useCallback(
-    ({isVisible}) => {
-      if (!isVisible) {
-        return gmpSettings.reloadIntervalInactive;
-      }
-      if (hasValue(tasks) && tasks.some(task => task.isActive())) {
-        return gmpSettings.reloadIntervalActive;
-      }
-      return gmpSettings.reloadInterval;
-    },
-    [tasks, gmpSettings],
-  );
-
+  const timeoutFunc = useEntitiesReloadInterval(tasks);
   const [startReload, stopReload, hasRunningTimer] = useReload(
     refetch,
     timeoutFunc,

--- a/gsa/src/web/utils/__tests__/useDefaultReloadInterval.js
+++ b/gsa/src/web/utils/__tests__/useDefaultReloadInterval.js
@@ -1,0 +1,62 @@
+/* Copyright (C) 2020-2021 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+/* eslint-disable react/prop-types */
+
+import React from 'react';
+
+import {
+  DEFAULT_RELOAD_INTERVAL_INACTIVE,
+  DEFAULT_RELOAD_INTERVAL,
+} from 'gmp/gmpsettings';
+
+import {rendererWith, screen} from 'web/utils/testing';
+
+import useDefaultReloadInterval from '../useDefaultReloadInterval';
+
+const gmp = {
+  settings: {
+    reloadIntervalInactive: DEFAULT_RELOAD_INTERVAL_INACTIVE,
+    reloadInterval: DEFAULT_RELOAD_INTERVAL,
+  },
+};
+
+const TestComponent = ({isVisible}) => {
+  const timeoutFunc = useDefaultReloadInterval();
+
+  return <span data-testid="reload-interval">{timeoutFunc({isVisible})}</span>;
+};
+
+describe('useDefaultReloadInterval tests', () => {
+  test('Should return inactive interval when the page is invisible', () => {
+    const {render} = rendererWith({gmp});
+    render(<TestComponent isVisible={false} />);
+
+    const reloadInterval = screen.getByTestId('reload-interval');
+
+    expect(reloadInterval).toHaveTextContent(DEFAULT_RELOAD_INTERVAL_INACTIVE);
+  });
+
+  test('Should return default interval when the page is visible', () => {
+    const {render} = rendererWith({gmp});
+    render(<TestComponent isVisible={true} />);
+
+    const reloadInterval = screen.getByTestId('reload-interval');
+
+    expect(reloadInterval).toHaveTextContent(DEFAULT_RELOAD_INTERVAL);
+  });
+});

--- a/gsa/src/web/utils/useDefaultReloadInterval.js
+++ b/gsa/src/web/utils/useDefaultReloadInterval.js
@@ -1,0 +1,36 @@
+/* Copyright (C) 2020-2021 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {useCallback} from 'react';
+
+import useGmpSettings from 'web/utils/useGmpSettings';
+
+const useDefaultReloadInterval = () => {
+  const gmpSettings = useGmpSettings();
+  const timeoutFunc = useCallback(
+    ({isVisible}) =>
+      isVisible
+        ? gmpSettings.reloadInterval
+        : gmpSettings.reloadIntervalInactive,
+    [gmpSettings],
+  );
+
+  return timeoutFunc;
+};
+
+export default useDefaultReloadInterval;


### PR DESCRIPTION
**What**:

Fix setting reload interval calculation for all pages using useEntityReloadInterval and useEntitiesReloadInterval hooks.

**Why**:

These two hooks are considering the active status of the entity. The activate status has only a meaning for the reload interval for the task (audit) and report entities where activate depends on the scan status. Therefore if an entity has been active the reload interval has been set to three seconds which is way to often for not changing entities.

**How**:

Added new unittest and run all tests

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
