### PR TITLE
Don't mutate the filter in the filter provider

### DIFF
--- a/gsa/src/web/entities/filterprovider.js
+++ b/gsa/src/web/entities/filterprovider.js
@@ -127,7 +127,7 @@ const FilterProvider = ({
   }
 
   if (!returnedFilter.has('rows') && isDefined(rowsPerPage)) {
-    returnedFilter.set('rows', rowsPerPage);
+    returnedFilter = returnedFilter.copy().set('rows', rowsPerPage);
   }
 
   const showChildren =


### PR DESCRIPTION
**What**:

Don't mutate the filter in the filter provider

**Why**:

A filter instance should not be mutated if you are not creating a new
filter or if you are not working on a copy of the original filter.
Changing an existing filter in place might have serious impact on other
places where it is used. For example if the filter is put into the redux
store the stored filter is changed too! to avoid that always use a copy
of the original filter before changing it.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to yochanges -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- n/a Tests
- n/a [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
