### PR TITLE
Added the deprecated_by field to CPEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The CVSS v2 BaseScore calculator calculates the score on the client side now. [#2536](https://github.com/greenbone/gsa/pull/2536)
 
 ### Fixed
+- Added the deprecatedBy field to CPEs [#2751](https://github.com/greenbone/gsa/pull/2751)
 - Fixed the severity for different advisories [#2611](https://github.com/greenbone/gsa/pull/2611)
-- Added the deprecated_by field to CPEs [#2751](https://github.com/greenbone/gsa/pull/2751)
 
 ### Removed
 - Removed Edge <= 18 support [#2691](https://github.com/greenbone/gsa/pull/2691)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fixed the severity for different advisories [#2611](https://github.com/greenbone/gsa/pull/2611)
+- Added the deprecated_by field to CPEs [#2751](https://github.com/greenbone/gsa/pull/2751)
 
 ### Removed
 - Removed Edge <= 18 support [#2691](https://github.com/greenbone/gsa/pull/2691)

--- a/gsa/src/gmp/models/__tests__/cpe.js
+++ b/gsa/src/gmp/models/__tests__/cpe.js
@@ -100,4 +100,18 @@ describe('CPE model tests', () => {
     expect(cpe.update_time).toBeUndefined();
     expect(isDate(cpe.updateTime)).toBe(true);
   });
+
+  test('should parse deprecated_by', () => {
+    const cpe = Cpe.fromElement({
+      raw_data: {'cpe-item': {_deprecated_by: 'foo:/bar'}},
+    });
+
+    expect(cpe.deprecated_by).toEqual('foo:/bar');
+  });
+
+  test('should not parse deprecated_by', () => {
+    const cpe = Cpe.fromElement({raw_data: {'cpe-item': {}}});
+
+    expect(cpe.deprecated_by).toBeUndefined();
+  });
 });

--- a/gsa/src/gmp/models/__tests__/cpe.js
+++ b/gsa/src/gmp/models/__tests__/cpe.js
@@ -101,17 +101,17 @@ describe('CPE model tests', () => {
     expect(isDate(cpe.updateTime)).toBe(true);
   });
 
-  test('should parse deprecated_by', () => {
+  test('should parse deprecatedBy', () => {
     const cpe = Cpe.fromElement({
       raw_data: {'cpe-item': {_deprecated_by: 'foo:/bar'}},
     });
 
-    expect(cpe.deprecated_by).toEqual('foo:/bar');
+    expect(cpe.deprecatedBy).toEqual('foo:/bar');
   });
 
-  test('should not parse deprecated_by', () => {
+  test('should not parse deprecatedBy', () => {
     const cpe = Cpe.fromElement({raw_data: {'cpe-item': {}}});
 
-    expect(cpe.deprecated_by).toBeUndefined();
+    expect(cpe.deprecatedBy).toBeUndefined();
   });
 });

--- a/gsa/src/gmp/models/cpe.js
+++ b/gsa/src/gmp/models/cpe.js
@@ -51,6 +51,12 @@ class Cpe extends Info {
       delete ret.update_time;
     }
 
+    if (isDefined(ret.raw_data) && isDefined(ret.raw_data['cpe-item'])) {
+      const cpeItem = ret.raw_data['cpe-item'];
+      if (isDefined(cpeItem._deprecated_by)) {
+        ret.deprecated_by = cpeItem._deprecated_by;
+      }
+    }
     return ret;
   }
 }

--- a/gsa/src/gmp/models/cpe.js
+++ b/gsa/src/gmp/models/cpe.js
@@ -46,6 +46,10 @@ class Cpe extends Info {
       delete ret.status;
     }
 
+    if (isDefined(ret.nvd_id)) {
+      ret.nvdId = ret.nvd_id;
+    }
+
     if (isDefined(ret.update_time)) {
       ret.updateTime = parseDate(ret.update_time);
       delete ret.update_time;
@@ -54,7 +58,7 @@ class Cpe extends Info {
     if (isDefined(ret.raw_data) && isDefined(ret.raw_data['cpe-item'])) {
       const cpeItem = ret.raw_data['cpe-item'];
       if (isDefined(cpeItem._deprecated_by)) {
-        ret.deprecated_by = cpeItem._deprecated_by;
+        ret.deprecatedBy = cpeItem._deprecated_by;
       }
     }
     return ret;

--- a/gsa/src/web/pages/cpes/details.js
+++ b/gsa/src/web/pages/cpes/details.js
@@ -27,6 +27,8 @@ import SeverityBar from 'web/components/bar/severitybar.js';
 
 import DateTime from 'web/components/date/datetime';
 
+import DetailsLink from 'web/components/link/detailslink';
+
 import Layout from 'web/components/layout/layout.js';
 
 import InfoTable from 'web/components/table/infotable.js';
@@ -36,7 +38,7 @@ import TableRow from 'web/components/table/row.js';
 
 import {Col} from 'web/entity/page';
 
-const CpeDetails = ({entity}) => {
+const CpeDetails = ({entity, links = true}) => {
   const {title, nvd_id, deprecated_by, updateTime, status, severity} = entity;
   return (
     <Layout flex="column" grow="1">
@@ -70,7 +72,11 @@ const CpeDetails = ({entity}) => {
           {isDefined(deprecated_by) && (
             <TableRow>
               <TableData>{_('Deprecated By')}</TableData>
-              <TableData>{deprecated_by}</TableData>
+              <TableData>
+                <DetailsLink id={deprecated_by} type="cpe" textOnly={!links}>
+                  {deprecated_by}
+                </DetailsLink>
+              </TableData>
             </TableRow>
           )}
           {isDefined(updateTime) && (
@@ -103,6 +109,7 @@ const CpeDetails = ({entity}) => {
 
 CpeDetails.propTypes = {
   entity: PropTypes.model.isRequired,
+  links: PropTypes.bool,
 };
 
 export default CpeDetails;

--- a/gsa/src/web/pages/cpes/details.js
+++ b/gsa/src/web/pages/cpes/details.js
@@ -39,7 +39,7 @@ import TableRow from 'web/components/table/row.js';
 import {Col} from 'web/entity/page';
 
 const CpeDetails = ({entity, links = true}) => {
-  const {title, nvd_id, deprecated_by, updateTime, status, severity} = entity;
+  const {title, nvdId, deprecatedBy, updateTime, status, severity} = entity;
   return (
     <Layout flex="column" grow="1">
       {!isDefined(title) && (
@@ -63,18 +63,18 @@ const CpeDetails = ({entity, links = true}) => {
               <TableData>{title}</TableData>
             </TableRow>
           )}
-          {isDefined(nvd_id) && (
+          {isDefined(nvdId) && (
             <TableRow>
               <TableData>{_('NVD ID')}</TableData>
-              <TableData>{nvd_id}</TableData>
+              <TableData>{nvdId}</TableData>
             </TableRow>
           )}
-          {isDefined(deprecated_by) && (
+          {isDefined(deprecatedBy) && (
             <TableRow>
               <TableData>{_('Deprecated By')}</TableData>
               <TableData>
-                <DetailsLink id={deprecated_by} type="cpe" textOnly={!links}>
-                  {deprecated_by}
+                <DetailsLink id={deprecatedBy} type="cpe" textOnly={!links}>
+                  {deprecatedBy}
                 </DetailsLink>
               </TableData>
             </TableRow>


### PR DESCRIPTION
**What**:

* Added the deprecated_by field to CPEs (again?)

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

* This field was missing. While refactoring CPEs for GraphQL I came across this field in the `details.js`. So I parsed the field in the model:
![image](https://user-images.githubusercontent.com/15268273/108838528-09a11400-75d4-11eb-8f75-7967eed654c0.png)


<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
