### PR TITLE
Fix a typo.

### DIFF
--- a/gsa/src/gmp/parser/cvss.js
+++ b/gsa/src/gmp/parser/cvss.js
@@ -22,7 +22,7 @@ import {isDefined} from 'gmp/utils/identity';
 
 /**
  * (from https://nvd.nist.gov/site-media/js/nvdApp/cvssV2/cvssV2.service.js)
- * Handles percision and rounding of numbers to one decimal place
+ * Handles precision and rounding of numbers to one decimal place
  * @param value
  * @returns {number}
  */


### PR DESCRIPTION
From codespell:

```
./gsa/src/gmp/parser/cvss.js:25: percision ==> precision
```

Seems the typo already existed in the original / linked .js file. That typo doesn't exist in the gsa-20.08 branch so i have created the PR against master.