### PR TITLE
Fix default port value for scanner dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use <predefined> to disable feed object editing and filter creation on feed status page [#2398](https://github.com/greenbone/gsa/pull/2398)
 
 ### Fixed
+- Fix default port value for scanner dialog [#2773](https://github.com/greenbone/gsa/pull/2773)
 - Stop growing of toolbars which only have the help icon [#2641](https://github.com/greenbone/gsa/pull/2641)
 - Fixed initial value of dropdown for including related resources for permissions [#2632](https://github.com/greenbone/gsa/pull/2632)
 - Fixed compiling gsad with libmicrohttp 0.9.71 and later [#2625](https://github.com/greenbone/gsa/pull/2625)

--- a/gsa/src/web/pages/scanners/__tests__/__snapshots__/dialog.js.snap
+++ b/gsa/src/web/pages/scanners/__tests__/__snapshots__/dialog.js.snap
@@ -899,7 +899,7 @@ exports[`ScannerDialog component tests should render 1`] = `
                         class="c12 c13"
                         name="port"
                         type="text"
-                        value="9391"
+                        value="22"
                       />
                       <div
                         class="c14"

--- a/gsa/src/web/pages/scanners/__tests__/dialog.js
+++ b/gsa/src/web/pages/scanners/__tests__/dialog.js
@@ -139,7 +139,7 @@ describe('ScannerDialog component tests', () => {
     expect(inputs[2]).toHaveAttribute('value', 'localhost');
 
     expect(inputs[3]).toHaveAttribute('name', 'port');
-    expect(inputs[3]).toHaveAttribute('value', '9391');
+    expect(inputs[3]).toHaveAttribute('value', '22');
 
     const selectedValues = getAllByTestId('select-selected-value');
 
@@ -233,7 +233,7 @@ describe('ScannerDialog component tests', () => {
       credential_id: '2345',
       type: 4,
       id: '1234',
-      port: '9391',
+      port: '22',
       which_cert: undefined,
     });
   });
@@ -287,7 +287,7 @@ describe('ScannerDialog component tests', () => {
       credential_id: '2345',
       type: 4,
       id: '1234',
-      port: '9391',
+      port: '22',
       which_cert: undefined,
     });
   });

--- a/gsa/src/web/pages/scanners/dialog.js
+++ b/gsa/src/web/pages/scanners/dialog.js
@@ -133,7 +133,7 @@ const ScannerDialog = ({
   host = 'localhost',
   id,
   name = _('Unnamed'),
-  port = '9391',
+  port = '22',
   title = _('New Scanner'),
   type = OSP_SCANNER_TYPE,
   which_cert,


### PR DESCRIPTION
**What**:

Change default port value to 22.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Because 9391 is incorrect for certain scanner types.

<!-- Why are these changes necessary? -->

**How**:

Adjusted tests and manual confirmation.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
