### PR TITLE
Remove simple filter from list pages

### DIFF
--- a/gsa/src/web/entities/usePagination.js
+++ b/gsa/src/web/entities/usePagination.js
@@ -18,7 +18,26 @@
 
 import {useCallback} from 'react';
 
-const usePagination = ({simpleFilter, filter, pageInfo, refetch}) => {
+import {isDefined} from 'gmp/utils/identity';
+
+/**
+ * Hook to to fetch the next, previous, last and first page for a list of
+ * entities gathered from a GraphQL query.
+ *
+ * @param {Filter} filter Current applied filter
+ * @param {Object} pageInfo Current information about the page with cursors (keyword relay)
+ * @param {Function} refetch Function to refetch the current data. Will be
+ *                           called with to fetch next, previous, last or first page.
+ * @param {Filter} simpleFilter Simplified filter without rows and first (Optional)
+ *
+ * @returns {Array} Tuple of functions to query data for the first, last, next
+ *                  and page.
+ */
+const usePagination = ({filter, pageInfo, refetch, simpleFilter}) => {
+  if (!isDefined(simpleFilter)) {
+    simpleFilter = filter.withoutView();
+  }
+
   const getNext = useCallback(() => {
     refetch({
       filterString: simpleFilter.toFilterString(),

--- a/gsa/src/web/pages/alerts/listpage.js
+++ b/gsa/src/web/pages/alerts/listpage.js
@@ -104,7 +104,6 @@ const AlertsPage = ({onChanged, onDownloaded, onError, ...props}) => {
   const [, renewSession] = useUserSessionTimeout();
   const [filter, isLoadingFilter] = usePageFilter('alert');
   const prevFilter = usePrevious(filter);
-  const simpleFilter = filter.withoutView();
   const {
     change: changeFilter,
     remove: removeFilter,
@@ -157,7 +156,6 @@ const AlertsPage = ({onChanged, onDownloaded, onError, ...props}) => {
 
   // Pagination methods
   const [getFirst, getLast, getNext, getPrevious] = usePagination({
-    simpleFilter,
     filter,
     pageInfo,
     refetch,
@@ -234,7 +232,7 @@ const AlertsPage = ({onChanged, onDownloaded, onError, ...props}) => {
         last: undefined,
       });
     }
-  }, [filter, prevFilter, simpleFilter, refetch]);
+  }, [filter, prevFilter, refetch]);
 
   useEffect(() => {
     // start reloading if alerts are available and no timer is running yet

--- a/gsa/src/web/pages/audits/listpage.js
+++ b/gsa/src/web/pages/audits/listpage.js
@@ -96,7 +96,6 @@ const Page = () => {
   const [, renewSession] = useUserSessionTimeout();
   const [filter, isLoadingFilter] = usePageFilter('audit');
   const prevFilter = usePrevious(filter);
-  const simpleFilter = filter.withoutView();
   const {
     change: changeFilter,
     remove: removeFilter,
@@ -145,7 +144,6 @@ const Page = () => {
 
   // Pagination methods
   const [getFirst, getLast, getNext, getPrevious] = usePagination({
-    simpleFilter,
     filter,
     pageInfo,
     refetch,
@@ -219,7 +217,7 @@ const Page = () => {
         last: undefined,
       });
     }
-  }, [filter, prevFilter, simpleFilter, refetch]);
+  }, [filter, prevFilter, refetch]);
 
   useEffect(() => {
     // start reloading if audits are available and no timer is running yet

--- a/gsa/src/web/pages/cves/listpage.js
+++ b/gsa/src/web/pages/cves/listpage.js
@@ -75,7 +75,6 @@ const CvesPage = () => {
   const fallbackFilter = Filter.fromString('sort-reverse=name');
   const [filter, isLoadingFilter] = usePageFilter('cve', {fallbackFilter});
   const prevFilter = usePrevious(filter);
-  const simpleFilter = filter.withoutView();
   const {
     change: changeFilter,
     remove: removeFilter,
@@ -118,7 +117,6 @@ const CvesPage = () => {
 
   // Pagination methods
   const [getFirst, getLast, getNext, getPrevious] = usePagination({
-    simpleFilter,
     filter,
     pageInfo,
     refetch,
@@ -171,7 +169,7 @@ const CvesPage = () => {
         last: undefined,
       });
     }
-  }, [filter, prevFilter, simpleFilter, refetch]);
+  }, [filter, prevFilter, refetch]);
 
   useEffect(() => {
     // start reloading if cves are available and no timer is running yet

--- a/gsa/src/web/pages/notes/listpage.js
+++ b/gsa/src/web/pages/notes/listpage.js
@@ -100,7 +100,6 @@ const Page = () => {
   const [, renewSessionTimeout] = useUserSessionTimeout();
   const [filter, isLoadingFilter] = usePageFilter('note');
   const prevFilter = usePrevious(filter);
-  const simpleFilter = filter.withoutView();
   const {
     change: changeFilter,
     remove: removeFilter,
@@ -154,7 +153,6 @@ const Page = () => {
 
   // Pagination methods
   const [getFirst, getLast, getNext, getPrevious] = usePagination({
-    simpleFilter,
     filter,
     pageInfo,
     refetch,
@@ -237,7 +235,7 @@ const Page = () => {
         last: undefined,
       });
     }
-  }, [filter, prevFilter, simpleFilter, refetch]);
+  }, [filter, prevFilter, refetch]);
 
   useEffect(() => {
     // start reloading if notes are available and no timer is running yet

--- a/gsa/src/web/pages/policies/listpage.js
+++ b/gsa/src/web/pages/policies/listpage.js
@@ -98,7 +98,6 @@ const PoliciesPage = props => {
   const [, renewSessionTimeout] = useUserSessionTimeout();
   const [filter, isLoadingFilter] = usePageFilter('policy');
   const prevFilter = usePrevious(filter);
-  const simpleFilter = filter.withoutView();
   const {
     change: changeFilter,
     remove: removeFilter,
@@ -150,7 +149,6 @@ const PoliciesPage = props => {
   );
 
   const [getFirst, getLast, getNext, getPrevious] = usePagination({
-    simpleFilter,
     filter,
     pageInfo,
     refetch,
@@ -223,7 +221,7 @@ const PoliciesPage = props => {
         last: undefined,
       });
     }
-  }, [filter, prevFilter, simpleFilter, refetch]);
+  }, [filter, prevFilter, refetch]);
 
   useEffect(() => {
     // start reloading if policies are available and no timer is running yet

--- a/gsa/src/web/pages/scanconfigs/listpage.js
+++ b/gsa/src/web/pages/scanconfigs/listpage.js
@@ -110,7 +110,6 @@ const ScanConfigsPage = props => {
   const [, renewSession] = useUserSessionTimeout();
   const [filter, isLoadingFilter] = usePageFilter('scanconfig');
   const prevFilter = usePrevious(filter);
-  const simpleFilter = filter.withoutView();
   const {
     change: changeFilter,
     remove: removeFilter,
@@ -141,7 +140,6 @@ const ScanConfigsPage = props => {
   ] = useLazyGetScanConfigs();
 
   const [getFirst, getLast, getNext, getPrevious] = usePagination({
-    simpleFilter,
     filter,
     pageInfo,
     refetch,
@@ -243,7 +241,7 @@ const ScanConfigsPage = props => {
         last: undefined,
       });
     }
-  }, [filter, prevFilter, simpleFilter, refetch]);
+  }, [filter, prevFilter, refetch]);
 
   useEffect(() => {
     // start reloading if scanConfigs are available and no timer is running yet

--- a/gsa/src/web/pages/schedules/listpage.js
+++ b/gsa/src/web/pages/schedules/listpage.js
@@ -100,7 +100,6 @@ const SchedulesPage = () => {
   const [, renewSessionTimeout] = useUserSessionTimeout();
   const [filter, isLoadingFilter] = usePageFilter('schedule');
   const prevFilter = usePrevious(filter);
-  const simpleFilter = filter.withoutView();
   const {
     change: changeFilter,
     remove: removeFilter,
@@ -154,7 +153,6 @@ const SchedulesPage = () => {
 
   // Pagination methods
   const [getFirst, getLast, getNext, getPrevious] = usePagination({
-    simpleFilter,
     filter,
     pageInfo,
     refetch,
@@ -237,7 +235,7 @@ const SchedulesPage = () => {
         last: undefined,
       });
     }
-  }, [filter, prevFilter, simpleFilter, refetch]);
+  }, [filter, prevFilter, refetch]);
 
   useEffect(() => {
     // start reloading if schedules are available and no timer is running yet

--- a/gsa/src/web/pages/tasks/listpage.js
+++ b/gsa/src/web/pages/tasks/listpage.js
@@ -136,7 +136,6 @@ const TasksListPage = () => {
   const [, renewSession] = useUserSessionTimeout();
   const [filter, isLoadingFilter] = usePageFilter('task');
   const prevFilter = usePrevious(filter);
-  const simpleFilter = filter.withoutView();
   const {
     change: changeFilter,
     remove: removeFilter,
@@ -184,7 +183,6 @@ const TasksListPage = () => {
 
   // Pagination methods
   const [getFirst, getLast, getNext, getPrevious] = usePagination({
-    simpleFilter,
     filter,
     pageInfo,
     refetch,
@@ -258,7 +256,7 @@ const TasksListPage = () => {
         last: undefined,
       });
     }
-  }, [filter, prevFilter, simpleFilter, refetch]);
+  }, [filter, prevFilter, refetch]);
 
   useEffect(() => {
     // start reloading if tasks are available and no timer is running yet


### PR DESCRIPTION
**What**:

Remove simpleFilter from list pages.

**Why**:

The simpleFilter is always created the same. Therefore it is duplicated code spread across several list pages.

**How**:

Run all testcase to check if something did break.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
