### PR TITLE
Improve wording of label for allowSimultaneousIPs

### DIFF
--- a/gsa/src/web/pages/targets/dialog.js
+++ b/gsa/src/web/pages/targets/dialog.js
@@ -296,7 +296,7 @@ const TargetDialog = ({
             </FormGroup>
 
             <FormGroup
-              title={_('Allow scan of simultaneous IPs')}
+              title={_('Allow simultaneous scanning via multiple IPs')}
               flex="column"
             >
               <YesNoRadio


### PR DESCRIPTION
**What**:

Improve the wording for the allowSimultaneousIPs option in the target dialog

**Why**:

The wording of the label might be a bit inaccurate. Therefore improve the label.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
