### PR TITLE
[gsad] Change socket_mode that it will not run besides the main process

### DIFF
--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -3045,36 +3045,6 @@ main (int argc, char **argv)
   if (http_only)
     no_redirect = TRUE;
 
-  if (unix_socket_path)
-    {
-      /* Fork for the unix socket server. */
-      g_debug ("Forking for unix socket...\n");
-      pid_t pid = fork ();
-      switch (pid)
-        {
-        case 0:
-          /* Child. */
-#if __linux
-          if (prctl (PR_SET_PDEATHSIG, SIGKILL))
-            g_warning ("%s: Failed to change parent death signal;"
-                       " unix socket process will remain if parent is killed:"
-                       " %s\n",
-                       __func__, strerror (errno));
-#endif
-          break;
-        case -1:
-          /* Parent when error. */
-          g_warning ("%s: Failed to fork for unix socket!\n", __func__);
-          exit (EXIT_FAILURE);
-          break;
-        default:
-          /* Parent. */
-          unix_pid = pid;
-          no_redirect = TRUE;
-          break;
-        }
-    }
-
   if (!no_redirect)
     {
       /* Fork for the redirect server. */


### PR DESCRIPTION
With 21.04 GSAD will not be executed in http but in socket_mode behind a
nginx. Therefore it doesn't make sense to start socket_mode as an
subprocess of gsad and start gsad in http mode afterwards.

This removes only the bg start so that gsad.c can pick it up and start in fg:
https://github.com/greenbone/gsa/blob/master/gsad/src/gsad.c#L3160

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
