### PR TITLE
Fix edit scan config family dialog

### DIFF
--- a/gsa/src/web/pages/scanconfigs/editconfigfamilydialog.js
+++ b/gsa/src/web/pages/scanconfigs/editconfigfamilydialog.js
@@ -68,7 +68,7 @@ class Nvt extends React.Component {
       pref_count = '';
     }
 
-    const {name, id: nvtId, severity, timeout, defaultTimeout} = nvt;
+    const {name, oid: nvtId, severity, timeout, defaultTimeout} = nvt; // change oid to id once hyperion is fully implemented
     return (
       <TableRow>
         <TableData>{name}</TableData>
@@ -114,7 +114,7 @@ Nvt.propTypes = {
 
 const sortFunctions = {
   name: makeCompareString('name'),
-  id: makeCompareString('id'),
+  oid: makeCompareString('oid'),
   severity: makeCompareSeverity(),
   timeout: makeCompareString('timeout'),
 };
@@ -122,10 +122,10 @@ const sortFunctions = {
 const sortNvts = (nvts = [], sortBy, sortReverse, selected = {}) => {
   if (sortBy === 'selected') {
     return [...nvts].sort((a, b) => {
-      if (selected[a.id] && !selected[b.id]) {
+      if (selected[a.oid] && !selected[b.oid]) {
         return sortReverse ? 1 : -1;
       }
-      if (selected[b.id] && !selected[a.id]) {
+      if (selected[b.oid] && !selected[a.oid]) {
         return sortReverse ? -1 : 1;
       }
 
@@ -231,7 +231,7 @@ const EditScanConfigFamilyDialog = ({
                     <TableHead
                       currentSortBy={sortBy}
                       currentSortDir={sortDir}
-                      sortBy="id"
+                      sortBy="oid"
                       onSortChange={handleSortChange}
                       title={_('OID')}
                     />
@@ -263,7 +263,7 @@ const EditScanConfigFamilyDialog = ({
                 </TableHeader>
                 <TableBody>
                   {sortedNvts.map(nvt => {
-                    const {id: nvtId} = nvt;
+                    const {oid: nvtId} = nvt; // change oid to id once hyperion is fully implemented
                     return (
                       <Nvt
                         key={nvtId}


### PR DESCRIPTION
**What**:

The edit scan config dialog still relies on the NVT oid prop being `oid` instead of `id` because it still does not support hyperion. This will fix selecting nvts, sorting and fix selected nvts not being checked by reverting some changes to the dialog. The changes should be made again when hyperion is fully supported.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

If we work on scan config further it would be inconvenient if we cannot interact with the dialog properly.

<!-- Why are these changes necessary? -->

**How**:

Tests are still passing and the dialog works as expected.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
