### PR TITLE
Use params_value instead of params_value_bool for allow_simultaneous_ips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Added CVSS date to NVT details [#2802](https://github.com/greenbone/gsa/pull/2802)
-- Add option to allow to scan simultaneous IPs to targets [#2779](https://github.com/greenbone/gsa/pull/2779)
+- Add option to allow to scan simultaneous IPs to targets
+  [#2779](https://github.com/greenbone/gsa/pull/2779),
+  [#2813](https://github.com/greenbone/gsa/pull/2813)
 - Added CVSS origin to NVT details [#2588](https://github.com/greenbone/gsa/pull/2588)
 - Added the CVSS v3.1 BaseScore calculator to the `/cvsscalculator` page in the Help section. [#2536](https://github.com/greenbone/gsa/pull/2536)
 

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -5313,7 +5313,7 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
   hosts_filter = params_value (params, "hosts_filter");
   file = params_value (params, "file");
   exclude_file = params_value (params, "exclude_file");
-  allow_simultaneous_ips = params_value_bool (params, "allow_simultaneous_ips");
+  allow_simultaneous_ips = params_value (params, "allow_simultaneous_ips");
 
   CHECK_VARIABLE_INVALID (name, "Create Target");
   CHECK_VARIABLE_INVALID (target_source, "Create Target")
@@ -6284,7 +6284,7 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
   target_smb_credential = params_value (params, "smb_credential_id");
   target_esxi_credential = params_value (params, "esxi_credential_id");
   target_snmp_credential = params_value (params, "snmp_credential_id");
-  allow_simultaneous_ips = params_value_bool (params, "allow_simultaneous_ips");
+  allow_simultaneous_ips = params_value (params, "allow_simultaneous_ips");
 
   CHECK_VARIABLE_INVALID (target_source, "Save Target");
   CHECK_VARIABLE_INVALID (target_exclude_source, "Save Target");


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Use `params_value()` instead of `params_value_bool()` for getting `allow_simultaneous_ips`.

**Why**:
<!-- Why are these changes necessary? -->

Although the underlying value is bool we should not use params_value_bool for retrieving the value of reverse_lookup_only because it would break the mechanism of setting a default value for the setting.

params_value() returns a string ("0" or "1") if there is an value and NULL if not. params_value_bool() return 0 if the value is "0"
OR there is no value. This means that if we want to be able to set a default if there is no value (NULL) we need to use params_value() else the information is lost.

Fix crash.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Created target with and without PR. Without PR gsad crashes. 

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
