### PR TITLE
Refactor results detailspage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+
+- Implement result detailspage queries [#2823](https://github.com/greenbone/gsa/pull/2823)
 - Implement target detailspage queries and mutations [#2822](https://github.com/greenbone/gsa/pull/2822)
 - Refactor target component to use useReducer [#2812](https://github.com/greenbone/gsa/pull/2812)
 - Implement nvt listpage queries and mutations [#2798](https://github.com/greenbone/gsa/pull/2798)
@@ -63,11 +65,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added missing fields for getScanners query and parseObject() for scanner model [#2301](https://github.com/greenbone/gsa/pull/2301)
 
 ### Fixed
+
 - Fixed redirection of createNote on Note detailspage [#2777](https://github.com/greenbone/gsa/pull/2777)
 - Fixed ScanConfigs and Policies page after changes in [Hyperion](https://github.com/greenbone/hyperion/pull/15) [#2733](https://github.com/greenbone/gsa/pull/2733)
 - Fixed reload interval for pages using useEntityReloadInterval and useEntitiesReloadInterval hooks [#2716](https://github.com/greenbone/gsa/pull/2716)
 
 ### Removed
+
 - Removed unused task.js [#2714](https://github.com/greenbone/gsa/pull/2714)
 - Removed unused task wizard commands for runQuickTask, runQuickFirstScan and runModifyTask [#2514](https://github.com/greenbone/gsa/pull/2514) [#2523](https://github.com/greenbone/gsa/pull/2523)
 - Removed Edge <= 18 support [#2408](https://github.com/greenbone/gsa/pull/2408)
@@ -77,10 +81,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 [21.04]: https://github.com/greenbone/gsa/compare/gsa-21.04...master
 
-
 ## [21.04] - unreleased
 
 ### Added
+
 - Allow to set unix socket permissions for gsad [#2816](https://github.com/greenbone/gsa/pull/2816)
 - Added CVSS date to NVT details [#2802](https://github.com/greenbone/gsa/pull/2802)
 - Add option to allow to scan simultaneous IPs to targets
@@ -90,6 +94,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added the CVSS v3.1 BaseScore calculator to the `/cvsscalculator` page in the Help section. [#2536](https://github.com/greenbone/gsa/pull/2536)
 
 ### Changed
+
 - Move error message and adjust design on login page [#2780](https://github.com/greenbone/gsa/pull/2780)
 - Refactored useFormValidation hook [#2704](https://github.com/greenbone/gsa/pull/2704)
 - Updated copyright and footer layout [#2687](https://github.com/greenbone/gsa/pull/2687)
@@ -101,11 +106,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - The CVSS v2 BaseScore calculator calculates the score on the client side now. [#2536](https://github.com/greenbone/gsa/pull/2536)
 
 ### Fixed
+
 - Fixed setting comments of business process nodes [#2781](https://github.com/greenbone/gsa/pull/2781)
 - Added the deprecatedBy field to CPEs [#2751](https://github.com/greenbone/gsa/pull/2751)
 - Fixed the severity for different advisories [#2611](https://github.com/greenbone/gsa/pull/2611)
 
 ### Removed
+
 - Removed Edge <= 18 support [#2691](https://github.com/greenbone/gsa/pull/2691)
 - Removed Internet Explorer 11 support [#2689](https://github.com/greenbone/gsa/pull/2689)
 - Removed support for uncontrolled form fields [#2520](https://github.com/greenbone/gsa/pull/2520)
@@ -118,12 +125,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [20.8.1] - 2021-02-02
 
 ### Added
+
 - Added icon to host detailspage to link to TLS certificates [#2624](https://github.com/greenbone/gsa/pull/2624)
 - Added form validation for user setting "rows per page"
   [#2478](https://github.com/greenbone/gsa/pull/2478), [#2505](https://github.com/greenbone/gsa/pull/2505)
 - Added option for "Start Task" event upon "New SecInfo arrived" condition in alerts dialog [#2418](https://github.com/greenbone/gsa/pull/2418)
 
 ### Changed
+
 - Ensure superadmins can edit themselves [#2633](https://github.com/greenbone/gsa/pull/2633)
 - Disable clone icon for superadmins [#2634](https://github.com/greenbone/gsa/pull/2634)
 - Allow äüöÄÜÖß in form validation rule for "name" [#2586](https://github.com/greenbone/gsa/pull/2586)
@@ -137,6 +146,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use <predefined> to disable feed object editing and filter creation on feed status page [#2398](https://github.com/greenbone/gsa/pull/2398)
 
 ### Fixed
+
 - Fix default port value for scanner dialog [#2773](https://github.com/greenbone/gsa/pull/2773)
 - Stop growing of toolbars which only have the help icon [#2641](https://github.com/greenbone/gsa/pull/2641)
 - Fixed initial value of dropdown for including related resources for permissions [#2632](https://github.com/greenbone/gsa/pull/2632)
@@ -150,6 +160,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Only show schedule options in advanced and modify task wizard if user has correct permissions [#2472](https://github.com/greenbone/gsa/pull/2472)
 
 ### Removed
+
 - Remove secinfo filter from user settings dialog and elsewhere [#2495](https://github.com/greenbone/gsa/pull/2495)
 - Removed export/download for report formats [#2427](https://github.com/greenbone/gsa/pull/2427)
 
@@ -158,13 +169,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [20.8.0] - 2020-08-11
 
 ### Added
+
 - Added reload timer to feedstatuspage and displaying when updating is in progress [#2350](https://github.com/greenbone/gsa/pull/2350)
 - Added filtered links to GVMD_DATA row in feed status page [#2339](https://github.com/greenbone/gsa/pull/2339)
 - Added loading indicator for CVEs on CPE detailspage [#2248](https://github.com/greenbone/gsa/pull/2248)
 - Added new form validation feature, implemented on create and edit ticket dialog [#1782](https://github.com/greenbone/gsa/pull/1782)
 - Added German translation for About page [#1998](https://github.com/greenbone/gsa/pull/1998)
 - Added a renew session timeout icon to usermenu [#1966](https://github.com/greenbone/gsa/pull/1966)
-- Added new BPM feature [#1931](https://github.com/greenbone/gsa/pull/1931) [#2018](https://github.com/greenbone/gsa/pull/2018) [#2025](https://github.com/greenbone/gsa/pull/2025) [#2099](https://github.com/greenbone/gsa/pull/2099)  [#2129](https://github.com/greenbone/gsa/pull/2129) [#2196](https://github.com/greenbone/gsa/pull/2196)
+- Added new BPM feature [#1931](https://github.com/greenbone/gsa/pull/1931) [#2018](https://github.com/greenbone/gsa/pull/2018) [#2025](https://github.com/greenbone/gsa/pull/2025) [#2099](https://github.com/greenbone/gsa/pull/2099) [#2129](https://github.com/greenbone/gsa/pull/2129) [#2196](https://github.com/greenbone/gsa/pull/2196)
 - Added clean-up-translations script [#1948](https://github.com/greenbone/gsa/pull/1948)
 - Added handling possible undefined trash in case of an error on the trashcanpage [#1908](https://github.com/greenbone/gsa/pull/1908)
 - Added translation using babel-plugin-i18next-extract [#1808](https://github.com/greenbone/gsa/pull/1808)
@@ -172,6 +184,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added handling of queued task status [#2208](https://github.com/greenbone/gsa/pull/2208)
 
 ### Changed
+
 - Increase age for feed being too old [#2394](https://github.com/greenbone/gsa/pull/2394)
 - Do not use result filter from store on report detailspage by default [#2358](https://github.com/greenbone/gsa/pull/2358)
 - Improve performance of form fields in edit scan config dialog [#2354](https://github.com/greenbone/gsa/pull/2354)
@@ -194,6 +207,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Deleting a single entity now removes its ID from store [#1839](https://github.com/greenbone/gsa/pull/1839)
 
 ### Fixed
+
 - Fixed empty subsections on oval def details page [#2396](https://github.com/greenbone/gsa/pull/2396)
 - Fixed missing NVT solution [#2388](https://github.com/greenbone/gsa/pull/2388)
 - EmptyResultsReport uses the same counts as the results tab title in normal reports, when filtering for nonexistent results
@@ -222,6 +236,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed credential_login in gsad request handlers [#2347](https://github.com/greenbone/gsa/pull/2347)
 
 ### Removed
+
 - Remove multistep feature from scanner dialog [#2337](https://github.com/greenbone/gsa/pull/2337)
 - Removed predefined status for report formats [#2111](https://github.com/greenbone/gsa/pull/2111)
 - Removed old translation mechanism [#1952](https://github.com/greenbone/gsa/pull/1952)
@@ -234,6 +249,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [9.0.1] - 2020-05-13
 
 ### Added
+
 - Added scanner selection to audit dialog
   [#2031](https://github.com/greenbone/gsa/pull/2031)
   [#2105](https://github.com/greenbone/gsa/pull/2105)
@@ -241,10 +257,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Display timezone for session timeout in user menu [#1764](https://github.com/greenbone/gsa/pull/1764)
 
 ### Changed
+
 - Adjusted parsing of cve model and removed cwe id as it seems not to be needed anymore [#2294](https://github.com/greenbone/gsa/pull/2294)
 - Adjusted parsing of filter strings to deal with strings with double quotes [#2051](https://github.com/greenbone/gsa/pull/2051)
 - Changed report TlsCertificate table headers to match TlsCertificate assets
-table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
+  table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
 - Unify source reports and hosts in TlsCertficateModel [#2040](https://github.com/greenbone/gsa/pull/2040)
 - Set filter rows in hostsTopologyLoader to not use rows=-1 [#2026](https://github.com/greenbone/gsa/pull/2026)
 - Updated copyright header dates to 2020 [#2019](https://github.com/greenbone/gsa/pull/2020)
@@ -263,6 +280,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
 - Lowered memory usage when getting a report [#1857](https://github.com/greenbone/gvmd/pull/1857)
 
 ### Fixed
+
 - Fixed broken radio buttons and wrong date for schedule in Modify Task Wizard [#2340](https://github.com/greenbone/gsa/pull/2340)
 - Fixed missing nextDate for schedules with recurrence "once" [#2336](https://github.com/greenbone/gsa/pull/2336)
 - Don't crash if dashboard getSetting returns duplicate setting [#2290](https://github.com/greenbone/gsa/pull/2290)
@@ -300,6 +318,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
 - Add usage_type param to get_aggregate [#1872](https://github.com/greenbone/gsa/pull/1872)
 
 ### Removed
+
 - Removed auto delete field from container task dialog [#1784](https://github.com/greenbone/gsa/pull/1784)
 - Removed obsolete DefaultFilter component and withDefaultFilter HOC [#1709](https://github.com/greenbone/gsa/pull/1709)
 
@@ -308,6 +327,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
 ## [9.0.0] - 2019-10-14
 
 ### Added
+
 - Added statereducer function to Select component: Scrolls to last selected item [#1715](https://github.com/greenbone/gsa/pull/1715)
 - Added loading indicator to select [#1716](https://github.com/greenbone/gsa/pull/1716)
 - Added loading indicator to svg icon [#1701](https://github.com/greenbone/gsa/pull/1701)
@@ -340,6 +360,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
   [#1466](https://github.com/greenbone/gsa/pull/1466) [#1467](https://github.com/greenbone/gsa/pull/1467)
 
 ### Changed
+
 - Tweaked LDAP and RADIUS pages to be more consistent [#1718](https://github.com/greenbone/gsa/pull/1718)
 - Decide whether to default to full and fast scan config (task dialog)[#1671](https://github.com/greenbone/gsa/pull/1671)
 - Determine the to be applied filter of a list page in GSA and don't rely on the
@@ -379,6 +400,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
   requests in gsad [#1355](https://github.com/greenbone/gsa/pull/1355)
 
 ### Fixed
+
 - Fixed displaying negative days on the override and note active dashboard [#1727](https://github.com/greenbone/gsa/pull/1727) [#1728](https://github.com/greenbone/gsa/pull/1728)
 - Fixed inability to change to/from LDAP and RADIUS settings [#1723](https://github.com/greenbone/gsa/pull/1723)
 - Fixed filter dialog duplicating filter terms [#1705] (https://github.com/greenbone/gsa/pull/1705)
@@ -390,6 +412,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
   [#1504](https://github.com/greenbone/gsa/pull/1504)
 
 ### Removed
+
 - Removed UserLink component [#1481](https://github.com/greenbone/gsa/pull/1481)
 - Remove edit_config command from gsad [#1439](https://github.com/greenbone/gsa/pull/1439)
 - Remove copyright from gsad version output [#1379](https://github.com/greenbone/gsa/pull/1379)
@@ -399,6 +422,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
 ## [8.0.2] - 2020-05-13
 
 ### Added
+
 - Show passphrase field in credential dialog for cc type [#2006](https://github.com/greenbone/gsa/pull/2006)
 - Display error details at report details page [#1862](https://github.com/greenbone/gsa/pull/1862)
 - Added warnings to content composer if reportResultThreshold is exceeded [#1852](https://github.com/greenbone/gsa/pull/1852)
@@ -417,6 +441,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
   [#1507](https://github.com/greenbone/gsa/pull/1507)
 
 ### Changed
+
 - Use IP Address instead of Name in host dialog form field title [#2311](https://github.com/greenbone/gsa/pull/2311)
 - Use = instead of ~ in filter of link in OS row [#2086](https://github.com/greenbone/gsa/pull/2086)
 - Update copyright header dates to 2020 [#2019](https://github.com/greenbone/gsa/pull/2019)
@@ -460,6 +485,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
 - Lower memory usage when getting a report [#1858](https://github.com/greenbone/gvmd/pull/1858)
 
 ### Fixed
+
 - Fixed missing CVEs on CPE detailspage [#2220](https://github.com/greenbone/gsa/pull/2220)
 - Fixed nvt family links not changing the filter [#1997](https://github.com/greenbone/gsa/pull/1997)
 - Use correct capabilities for task icons [#1973](https://github.com/greenbone/gsa/pull/1973)
@@ -513,6 +539,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
 ## [8.0.1] - 2019-07-17
 
 ### Added
+
 - Added systemd service file and logrotate config to gsad [#1486](https://github.com/greenbone/gsa/pull/1486)
 - Additional report-host information [#1468](https://github.com/greenbone/gsa/pull/1468)
 - New VerifyNoIcon [#1468](https://github.com/greenbone/gsa/pull/1468)
@@ -539,6 +566,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
 - Add tooltips to deactivated text fields in AlertDialog [#1269](https://github.com/greenbone/gsa/pull/1269)
 
 ### Changed
+
 - Brand the Loading indicator [#1469](https://github.com/greenbone/gsa/pull/1469)
 - Always load notes and overrides when getting results [#1446](https://github.com/greenbone/gsa/pull/1446)
 - Disable some FileFields when RadioButton is not checked [#1430](https://github.com/greenbone/gsa/pull/1430)
@@ -598,9 +626,9 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
 - Fix race condition in EditUserSettingsDialog and loading all default filters [#1383](https://github.com/greenbone/gsa/pull/1383)
 - Fix scheduled task tooltip time format [#1382](https://github.com/greenbone/gsa/pull/1382)
 - Fix updating Titlebar after session timeout [#1377](https://github.com/greenbone/gsa/pull/1377)
-- Use German manual for *DE* locale [#1372](https://github.com/greenbone/gsa/pull/1372)
+- Use German manual for _DE_ locale [#1372](https://github.com/greenbone/gsa/pull/1372)
 - Load all container tasks for report import dialog from redux store [#1370](https://github.com/greenbone/gsa/pull/1370)
-- Don't render *Invalid Date* [#1368](https://github.com/greenbone/gsa/pull/1368)
+- Don't render _Invalid Date_ [#1368](https://github.com/greenbone/gsa/pull/1368)
 - Don't show error message after re-login [#1366](https://github.com/greenbone/gsa/pull/1366)
 - Fix creating permissions in Roles dialog [#1365](https://github.com/greenbone/gsa/pull/1365)
 - Fix cloning permission for Roles [#1361](https://github.com/greenbone/gsa/pull/1361)
@@ -649,6 +677,7 @@ table headers [#2044](https://github.com/greenbone/gsa/pull/2044)
 - Fix release build [#1259](https://github.com/greenbone/gsa/pull/1259), [#1265](https://github.com/greenbone/gsa/pull/1265)
 
 ### Removed
+
 - Remove old tool tips from credential download icons because they are not visible and update new tool tips [#1338](https://github.com/greenbone/gsa/pull/1338)
 - Remove sort by credential from Target view [1300](https://github.com/greenbone/gsa/pull/1300)
 - Remove fifth from schedule [#1279](https://github.com/greenbone/gsa/pull/1279)
@@ -681,6 +710,7 @@ Apart from this, the module covers a number of significant advances
 and clean-ups compared to the previous gsa module.
 
 ### Added
+
 - Display error message if an entity couldn't be loaded [#1252](https://github.com/greenbone/gsa/pull/1252)
 - Support old secinfo URLs and redirect to replacement pages [#1247](https://github.com/greenbone/gsa/pull/1247)
 - Add guest user login support [#1246](https://github.com/greenbone/gsa/pull/1246)
@@ -702,6 +732,7 @@ and clean-ups compared to the previous gsa module.
 - Add Sourcefire PKCS12 password support [#1150](https://github.com/greenbone/gsa/pull/1150)
 
 ### Changed
+
 - Change order of options in target dialog [#1233](https://github.com/greenbone/gsa/pull/1233)
 - Don't limit the input field lengths anymore [#1232](https://github.com/greenbone/gsa/pull/1232)
 - Renamed "PGP Key" credential to "PGP Encryption Key" [#1208](https://github.com/greenbone/gsa/pull/1208)
@@ -712,6 +743,7 @@ and clean-ups compared to the previous gsa module.
   [#1220](https://github.com/greenbone/gsa/pull/1220)
 
 ### Fixed
+
 - Don't crash if start or end date for performance page are invalid [#1237](https://github.com/greenbone/gsa/pull/1237)
 - Convert first filter keyword values less then one to one [#1228](https://github.com/greenbone/gsa/pull/1228)
 - Always use equal relation for first and rows filter keywords [#1228](https://github.com/greenbone/gsa/pull/1228)
@@ -734,6 +766,7 @@ and clean-ups compared to the previous gsa module.
 ## [8.0+beta2] - 2018-12-04
 
 ### Added
+
 - Allow rename main dashboards [#1076](https://github.com/greenbone/gsa/pull/1076)
 - Allow to encrypt alert emails via S/MIME and PGP [#1070](https://github.com/greenbone/gsa/pull/1070)
 - New credential types S/MIME and PGP for alert email encryption [#1070](https://github.com/greenbone/gsa/pull/1070)
@@ -769,6 +802,7 @@ and clean-ups compared to the previous gsa module.
 - Allow to add Tags to scanners [#702](https://github.com/greenbone/gsa/pull/702)
 
 ### Changed
+
 - Refined appearance of the GUI
   [#987](https://github.com/greenbone/gsa/pull/987), [#991](https://github.com/greenbone/gsa/pull/991),
   [#995](https://github.com/greenbone/gsa/pull/995), [#998](https://github.com/greenbone/gsa/pull/998),
@@ -817,6 +851,7 @@ and clean-ups compared to the previous gsa module.
   [#719](https://github.com/greenbone/gsa/pull/719)
 
 ### Fixed
+
 - Fixed displaying the Observer icon [#1053](https://github.com/greenbone/gsa/pull/1053)
 - Don't crash GSA completely if an unexpected error did occur [#1046](https://github.com/greenbone/gsa/pull/1046)
 - Fix saving nvt preferences in gsad [#1045](https://github.com/greenbone/gsa/pull/1045)
@@ -831,6 +866,7 @@ and clean-ups compared to the previous gsa module.
 - Don't show default dashboard if settings haven't been loaded yet [#714](https://github.com/greenbone/gsa/pull/714)
 
 ### Removed
+
 - Remove max length of hosts for notes and overrides [#1033](https://github.com/greenbone/gsa/pull/1033)
 - Removed Scan, Asset, SecInfo Dashboards and added Dashboard "templates" to
   the main dashboard [#974](https://github.com/greenbone/gsa/pull/974)
@@ -861,12 +897,14 @@ Apart from this, the module covers a number of significant advances
 and clean-ups compared to the previous gsa module.
 
 ### Added
+
 - The 'excluded' list option when a New Target is created has been added.
 - New view on scan results by vulnerability has been added.
 - A link to Scanconfigs from scanner details has been added.
 - Multiple dashboards can be defined by the user at the main entry page.
 
 ### Changed
+
 - The web user interface has been transformed into a single page application
   which is loaded once and then only updates the in-browser data from the
   server.
@@ -884,6 +922,7 @@ and clean-ups compared to the previous gsa module.
 - Minimum required version of cmake has been raised to 3.0.
 
 ### Removed
+
 - The its "face" has been removed.
 - The 'classic hosts' asset has been removed.
 - The edit mode of the dashboards has been removed. Dashboards are always

--- a/gsa/src/gmp/models/__tests__/result.js
+++ b/gsa/src/gmp/models/__tests__/result.js
@@ -25,7 +25,162 @@ import {testModel} from 'gmp/models/testing';
 
 testModel(Result, 'result');
 
-describe('Result model tests', () => {
+describe('Result model parseObject tests', () => {
+  test('should parse host object', () => {
+    const obj = {
+      host: {
+        ip: '123.456.789.10',
+        id: '123',
+        hostname: 'foo',
+      },
+    };
+    const obj2 = {
+      host: {
+        ip: '123.456.789.10',
+      },
+    };
+    const result = Result.fromObject(obj);
+    const result2 = Result.fromObject(obj2);
+    const res = {
+      name: '123.456.789.10',
+      id: '123',
+      hostname: 'foo',
+    };
+    const res2 = {
+      name: '123.456.789.10',
+      hostname: '',
+    };
+    expect(result.host).toEqual(res);
+    expect(result2.host).toEqual(res2);
+  });
+
+  test('should remove empty host id', () => {
+    const host = {
+      id: '',
+      ip: 'foo',
+      hostname: 'bar',
+    };
+    const result = Result.fromObject({host});
+
+    expect(result.host).toEqual({
+      name: 'foo',
+      hostname: 'bar',
+    });
+  });
+
+  test('should parse NVTs', () => {
+    const obj = {
+      nvt: {
+        id: 'bar',
+      },
+    };
+    const result = Result.fromObject(obj);
+
+    expect(result.nvt).toBeInstanceOf(Nvt);
+    expect(result.nvt.id).toEqual('bar');
+  });
+
+  test('should parse severity', () => {
+    const result = Result.fromObject({severity: '4.2'});
+    const result2 = Result.fromObject({});
+
+    expect(result.severity).toEqual(4.2);
+    expect(result2.severity).toBeUndefined();
+  });
+
+  test('should parse name/id to vulnerability', () => {
+    const obj = {
+      nvt: {
+        id: '42',
+      },
+    };
+    const result = Result.fromObject({name: 'foo'});
+    const result2 = Result.fromObject(obj);
+
+    expect(result.vulnerability).toEqual('foo');
+    expect(result2.vulnerability).toEqual('42');
+  });
+
+  test('should parse task', () => {
+    const result = Result.fromObject({task: {name: 'foo'}});
+
+    expect(result.task).toBeInstanceOf(Model);
+    expect(result.task.entityType).toEqual('task');
+  });
+
+  test('should parse detection', () => {
+    const obj = {
+      detectionResult: {
+        id: '1337',
+        details: [
+          {
+            name: 'foo',
+            value: 'bar',
+          },
+          {
+            name: 'lorem',
+            value: 'ipsum',
+          },
+        ],
+      },
+    };
+    const res = {
+      id: '1337',
+      details: {
+        foo: 'bar',
+        lorem: 'ipsum',
+      },
+    };
+    const result = Result.fromObject(obj);
+
+    expect(result.detectionResult).toEqual(res);
+  });
+
+  test('should parse original severity', () => {
+    const result = Result.fromObject({originalSeverity: '4.2'});
+
+    expect(result.originalSeverity).toEqual(4.2);
+  });
+
+  test('should parse QoD', () => {
+    const obj = {
+      qod: {
+        type: 'foo',
+        value: '42.5',
+      },
+    };
+    const res = {
+      type: 'foo',
+      value: 42.5,
+    };
+    const result = Result.fromObject(obj);
+
+    expect(result.qod).toEqual(res);
+  });
+
+  test('should parse notes', () => {
+    const obj = {
+      notes: [{id: 'foo'}, {id: 'bar'}],
+    };
+    const result = Result.fromObject(obj);
+
+    expect(result.notes[0]).toBeInstanceOf(Note);
+    expect(result.notes[0].entityType).toEqual('note');
+    expect(result.notes[1]).toBeInstanceOf(Note);
+    expect(result.notes[1].entityType).toEqual('note');
+  });
+
+  test('should return empty array if no notes are given', () => {
+    const result = Result.fromObject({});
+
+    expect(result.notes).toEqual([]);
+  });
+
+  // ToDo: Overrides
+  // ToDo: delta result
+});
+
+describe('Result model parseElement tests', () => {
   test('should parse host object', () => {
     const elem = {
       host: {

--- a/gsa/src/gmp/models/result.js
+++ b/gsa/src/gmp/models/result.js
@@ -54,32 +54,35 @@ class Result extends Model {
 
     const {
       detectionResult,
+      host = {},
       name,
       notes,
       nvt = {},
       overrides,
-      report,
+      originalSeverity,
+      qod = {},
+      severity,
       task,
       tickets,
     } = object;
 
+    copy.host = {
+      name: host.ip,
+      id: isDefined(host.id) && !isEmpty(host.id) ? host.id : undefined,
+      hostname: isDefined(host.hostname) ? host.hostname : '',
+    };
+
     copy.nvt = Nvt.fromObject(nvt);
 
-    copy.vulnerability = hasValue(name) ? name : nvt?.id;
-
-    if (hasValue(report)) {
-      copy.report = parseModelFromObject(report, 'report');
-    }
-
     if (hasValue(task)) {
-      copy.report = parseModelFromObject(task, 'task');
+      copy.task = parseModelFromObject(task, 'task');
     }
 
     if (hasValue(detectionResult)) {
       const details = {};
 
       if (hasValue(detectionResult.details)) {
-        forEach(detectionResult.details.detail, detail => {
+        forEach(detectionResult.details, detail => {
           details[detail.name] = detail.value;
         });
       }
@@ -101,6 +104,18 @@ class Result extends Model {
     copy.tickets = hasValue(tickets)
       ? map(tickets, ticket => parseModelFromObject(ticket, 'ticket'))
       : [];
+
+    copy.qod = parseQod(qod);
+
+    if (isDefined(severity)) {
+      copy.severity = parseSeverity(severity);
+    }
+
+    if (isDefined(originalSeverity)) {
+      copy.originalSeverity = parseSeverity(originalSeverity);
+    }
+
+    copy.vulnerability = hasValue(name) ? name : nvt?.id;
 
     // ToDo: Delta
 

--- a/gsa/src/gmp/models/result.js
+++ b/gsa/src/gmp/models/result.js
@@ -68,8 +68,8 @@ class Result extends Model {
 
     copy.host = {
       name: host.ip,
-      id: isDefined(host.id) && !isEmpty(host.id) ? host.id : undefined,
-      hostname: isDefined(host.hostname) ? host.hostname : '',
+      id: hasValue(host.id) && !isEmpty(host.id) ? host.id : undefined,
+      hostname: hasValue(host.hostname) ? host.hostname : '',
     };
 
     copy.nvt = Nvt.fromObject(nvt);
@@ -107,11 +107,11 @@ class Result extends Model {
 
     copy.qod = parseQod(qod);
 
-    if (isDefined(severity)) {
+    if (hasValue(severity)) {
       copy.severity = parseSeverity(severity);
     }
 
-    if (isDefined(originalSeverity)) {
+    if (hasValue(originalSeverity)) {
       copy.originalSeverity = parseSeverity(originalSeverity);
     }
 

--- a/gsa/src/web/graphql/__mocks__/results.js
+++ b/gsa/src/web/graphql/__mocks__/results.js
@@ -1,0 +1,107 @@
+/* Copyright (C) 2021 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {createGenericQueryMock, deepFreeze} from 'web/utils/testing';
+import {GET_RESULT} from '../results';
+
+export const mockResult = deepFreeze({
+  id: '12345',
+  name: 'foo',
+  comment: null,
+  owner: 'admin',
+  creationTime: '2019-06-02T12:00:00Z',
+  modificationTime: '2019-06-03T11:00:00Z',
+  detectionResult: {
+    id: '12345',
+    details: [
+      {
+        name: 'product',
+        value: 'cpe:/a:python:python:2.7.16',
+      },
+      {
+        name: 'location',
+        value: '/usr/bin/python, /usr/bin/python2.7',
+      },
+      {
+        name: 'source_oid',
+        value: 'CVE-2019-13404',
+      },
+      {
+        name: 'source_name',
+        value: 'CVE-2019-13404',
+      },
+    ],
+  },
+  reportId: '314',
+  task: {
+    id: '159',
+    name: 'task 1',
+  },
+  host: {
+    id: '265',
+    ip: '109.876.54.321',
+    hostname: 'lorem',
+  },
+  port: '80/tcp',
+  nvt: {
+    id: '1.3.6.1.4.1.25623.1.12345',
+    score: 50,
+    severities: {
+      type: null,
+      score: 50,
+      vector: 'AV:N/AC:M/Au:N/C:P/I:N/A:N',
+    },
+    tags: {
+      cvssBaseVector: 'AV:N/AC:M/Au:S/C:P/I:N/A:P',
+      summary: 'This is a description',
+      solutionType: 'VendorFix',
+      insight: 'Foo',
+      impact: 'Bar',
+      detectionMethod: 'Baz',
+      affected: 'foo',
+    },
+    solution: {
+      type: 'VendorFix',
+      method: null,
+      description: 'This is a description',
+    },
+  },
+  description: 'This is a description',
+  originalSeverity: 5.0,
+  originalThreat: 'Medium',
+  qod: {value: 80, type: 'registry'},
+  scanNvtVersion: '2019-02-14T07:33:50Z',
+  severity: 5.0,
+  threat: 'Medium',
+  notes: [
+    {
+      id: '358',
+      creationTime: '2019-06-02T12:05:00Z',
+      modificationTime: '2019-06-03T11:05:00Z',
+      active: true,
+      text: 'Very important note',
+    },
+  ],
+  tickets: [{id: '979'}],
+  userTags: null,
+});
+
+export const createGetResultQueryMock = (
+  resultId = '12345',
+  result = mockResult,
+) => createGenericQueryMock(GET_RESULT, {result}, {id: resultId});

--- a/gsa/src/web/graphql/__mocks__/results.js
+++ b/gsa/src/web/graphql/__mocks__/results.js
@@ -60,6 +60,7 @@ export const mockResult = deepFreeze({
   port: '80/tcp',
   nvt: {
     id: '1.3.6.1.4.1.25623.1.12345',
+    name: 'nvt1',
     score: 50,
     severities: {
       type: null,
@@ -68,17 +69,27 @@ export const mockResult = deepFreeze({
     },
     tags: {
       cvssBaseVector: 'AV:N/AC:M/Au:S/C:P/I:N/A:P',
-      summary: 'This is a description',
+      summary: 'This is a mock result',
       solutionType: 'VendorFix',
-      insight: 'Foo',
-      impact: 'Bar',
-      detectionMethod: 'Baz',
-      affected: 'foo',
+      insight: 'This is just a test',
+      impact: 'No real impact',
+      detectionMethod: 'This is the detection method',
+      affected: 'Affects test cases only',
     },
+    cveReferences: [{type: 'cve', id: 'CVE-2019-1234'}],
+    certReferences: [
+      {type: 'cert-bund', id: 'CB-K12/3456'},
+      {type: 'dfn-cert', id: 'DFN-CERT-2019-1234'},
+    ],
+    bidReferences: [
+      {type: 'bid', id: '75750'},
+      {type: 'bugtraq_id', id: '75751'},
+    ],
+    otherReferences: [{type: 'url', id: 'https://www.foo.bar'}],
     solution: {
       type: 'VendorFix',
       method: null,
-      description: 'This is a description',
+      description: 'Keep writing tests',
     },
   },
   description: 'This is a description',

--- a/gsa/src/web/graphql/__tests__/results.js
+++ b/gsa/src/web/graphql/__tests__/results.js
@@ -1,0 +1,64 @@
+/* Copyright (C) 2021 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+/* eslint-disable react/prop-types */
+import {rendererWith, screen, wait} from 'web/utils/testing';
+
+import {createGetResultQueryMock} from '../__mocks__/results';
+import {useGetResult} from '../results';
+
+const GetResultComponent = ({id}) => {
+  const {loading, result, error} = useGetResult(id);
+  if (loading) {
+    return <span data-testid="loading">Loading</span>;
+  }
+  return (
+    <div>
+      {error && <div data-testid="error">{error.message}</div>}
+      {result && (
+        <div data-testid="result">
+          <span data-testid="id">{result.id}</span>
+          <span data-testid="name">{result.name}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+describe('useGetResult tests', () => {
+  test('should load result', async () => {
+    const [queryMock, resultFunc] = createGetResultQueryMock();
+
+    const {render} = rendererWith({queryMocks: [queryMock]});
+
+    render(<GetResultComponent id="12345" />);
+
+    expect(screen.queryByTestId('loading')).toBeInTheDocument();
+
+    await wait();
+
+    expect(resultFunc).toHaveBeenCalled();
+
+    expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('error')).not.toBeInTheDocument();
+
+    expect(screen.getByTestId('result')).toBeInTheDocument();
+
+    expect(screen.getByTestId('id')).toHaveTextContent('12345');
+    expect(screen.getByTestId('name')).toHaveTextContent('foo');
+  });
+});

--- a/gsa/src/web/graphql/results.js
+++ b/gsa/src/web/graphql/results.js
@@ -49,11 +49,28 @@ export const GET_RESULT = gql`
       port
       nvt {
         id
+        name
         score
         severities {
           type
           score
           vector
+        }
+        cveReferences {
+          id
+          type
+        }
+        bidReferences {
+          id
+          type
+        }
+        certReferences {
+          id
+          type
+        }
+        otherReferences {
+          id
+          type
         }
         tags {
           cvssBaseVector

--- a/gsa/src/web/graphql/results.js
+++ b/gsa/src/web/graphql/results.js
@@ -1,0 +1,109 @@
+/* Copyright (C) 2021 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+import {gql, useQuery} from '@apollo/client';
+
+import {isDefined} from 'gmp/utils/identity';
+import Result from 'gmp/models/result';
+
+export const GET_RESULT = gql`
+  query Result($id: UUID!) {
+    result(id: $id) {
+      id
+      name
+      comment
+      owner
+      creationTime
+      modificationTime
+      detectionResult {
+        id
+        details {
+          name
+          value
+        }
+      }
+      reportId
+      task {
+        id
+        name
+      }
+      host {
+        ip
+        id
+        hostname
+      }
+      port
+      nvt {
+        id
+        score
+        severities {
+          type
+          score
+          vector
+        }
+        tags {
+          cvssBaseVector
+          summary
+          insight
+          impact
+          detectionMethod
+          affected
+        }
+        solution {
+          type
+          method
+          description
+        }
+      }
+      scanNvtVersion
+      originalThreat
+      originalSeverity
+      threat
+      severity
+      qod {
+        value
+        type
+      }
+      description
+      notes {
+        id
+        creationTime
+        modificationTime
+        active
+        text
+      }
+      tickets {
+        id
+      }
+      userTags {
+        count
+        tags {
+          id
+          name
+        }
+      }
+    }
+  }
+`;
+
+export const useGetResult = (id, options) => {
+  const {data, ...other} = useQuery(GET_RESULT, {...options, variables: {id}});
+  const result = isDefined(data?.result)
+    ? Result.fromObject(data.result)
+    : undefined;
+  return {result, ...other};
+};

--- a/gsa/src/web/pages/nvts/references.js
+++ b/gsa/src/web/pages/nvts/references.js
@@ -58,7 +58,7 @@ const References = ({nvt, links = true}) => {
                 {cveReferences.map(cve => (
                   <span key={cve.id}>
                     <CveLink
-                      title={_('View Details of {{cve_id}}', cve.id)}
+                      title={_('View Details of {{id}}', {id: cve.id})}
                       id={cve.id}
                       textOnly={!links}
                     />

--- a/gsa/src/web/pages/results/details.js
+++ b/gsa/src/web/pages/results/details.js
@@ -22,7 +22,7 @@ import styled from 'styled-components';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
+import {hasValue, isDefined} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
 
 import {TAG_NA} from 'gmp/models/nvt';
@@ -105,12 +105,11 @@ const ResultDetails = ({className, links = true, entity}) => {
   const {nvt} = result;
   const {id: nvtId, tags, solution} = nvt;
 
-  const is_oval = isDefined(nvtId) && nvtId.startsWith('oval:');
-  const has_detection =
-    isDefined(result.detection) && isDefined(result.detection.result);
+  const is_oval = hasValue(nvtId) && nvtId.startsWith('oval:');
+  const hasDetection = hasValue(result.detectionResult);
 
-  const detection_details = has_detection
-    ? result.detection.result.details
+  const detectionDetails = hasDetection
+    ? result.detectionResult.details
     : undefined;
 
   const result2 = isDefined(result.delta) ? result.delta.result : undefined;
@@ -211,7 +210,7 @@ const ResultDetails = ({className, links = true, entity}) => {
         </DetailsBlock>
       )}
 
-      {has_detection && (
+      {hasDetection && (
         <DetailsBlock title={_('Product Detection Result')}>
           <InfoTable>
             <TableBody>
@@ -221,10 +220,10 @@ const ResultDetails = ({className, links = true, entity}) => {
                   <span>
                     <DetailsLink
                       type="cpe"
-                      id={detection_details.product}
+                      id={detectionDetails.product}
                       textOnly={!links}
                     >
-                      {detection_details.product}
+                      {detectionDetails.product}
                     </DetailsLink>
                   </span>
                 </TableData>
@@ -234,17 +233,17 @@ const ResultDetails = ({className, links = true, entity}) => {
                 <TableData>
                   <span>
                     <DetailsLink
-                      id={detection_details.source_oid}
+                      id={detectionDetails.source_oid}
                       type={
-                        detection_details.source_oid.startsWith('CVE-')
+                        detectionDetails.source_oid.startsWith('CVE-')
                           ? 'cve'
                           : 'nvt'
                       }
                       textOnly={!links}
                     >
-                      {detection_details.source_name +
+                      {detectionDetails.source_name +
                         ' (OID: ' +
-                        detection_details.source_oid +
+                        detectionDetails.source_oid +
                         ')'}
                     </DetailsLink>
                   </span>
@@ -256,7 +255,7 @@ const ResultDetails = ({className, links = true, entity}) => {
                   <span>
                     <DetailsLink
                       type="result"
-                      id={result.detection.result.id}
+                      id={result.detectionResult.id}
                       textOnly={!links}
                     >
                       {_('View details of product detection')}
@@ -299,7 +298,7 @@ const ResultDetails = ({className, links = true, entity}) => {
                       {nvtId}
                     </DetailsLink>
                   )}
-                  {isDefined(nvtId) && nvtId.startsWith(DEFAULT_OID_VALUE) && (
+                  {hasValue(nvtId) && nvtId.startsWith(DEFAULT_OID_VALUE) && (
                     <span>
                       <DetailsLink type="nvt" id={nvtId} textOnly={!links}>
                         {renderNvtName(nvtId, nvt.name)}
@@ -307,14 +306,14 @@ const ResultDetails = ({className, links = true, entity}) => {
                       </DetailsLink>
                     </span>
                   )}
-                  {!isDefined(nvtId) &&
+                  {!hasValue(nvtId) &&
                     _('No details available for this method.')}
                 </TableData>
               </TableRow>
-              {!isEmpty(result.scan_nvt_version) && (
+              {!isEmpty(result.scanNvtVersion) && (
                 <TableRow>
                   <TableData>{_('Version used: ')}</TableData>
-                  <TableData>{result.scan_nvt_version}</TableData>
+                  <TableData>{result.scanNvtVersion}</TableData>
                 </TableRow>
               )}
             </TableBody>

--- a/gsa/src/web/pages/results/detailspage.js
+++ b/gsa/src/web/pages/results/detailspage.js
@@ -363,22 +363,20 @@ const Page = ({onDownloaded}) => {
     const {nvt = {}, task = {}, host = {}} = resultEntity;
     createfunc({
       fixed: true,
-      oid: nvt.oid,
-      nvt_name: nvt.name,
-      task_id: TASK_SELECTED,
-      task_name: task.name,
-      result_id: RESULT_ANY,
-      task_uuid: task.id,
-      result_uuid: resultEntity.id,
-      result_name: resultEntity.name,
+      nvtId: nvt.id,
+      nvtName: nvt.name,
+      taskId: TASK_SELECTED,
+      taskName: task.name,
+      resultId: RESULT_ANY,
+      taskUuid: task.id,
+      resultUuid: resultEntity.id,
+      resultName: resultEntity.name,
       severity:
-        resultEntity.original_severity > 0
-          ? 0.1
-          : resultEntity.original_severity,
+        resultEntity.originalSeverity > 0 ? 0.1 : resultEntity.originalSeverity,
       hosts: MANUAL,
-      hosts_manual: host.name,
+      hostsManual: host.name,
       port: MANUAL,
-      port_manual: resultEntity.port,
+      portManual: resultEntity.port,
     });
   };
 

--- a/gsa/src/web/pages/results/detailspage.js
+++ b/gsa/src/web/pages/results/detailspage.js
@@ -151,8 +151,8 @@ export const ToolBarIcons = ({
             <TaskIcon title={_('Corresponding Task ({{name}})', entity.task)} />
           </DetailsLink>
         )}
-        {capabilities.mayAccess('reports') && isDefined(entity.report) && (
-          <DetailsLink type="report" id={entity.report.id}>
+        {capabilities.mayAccess('reports') && isDefined(entity.reportId) && (
+          <DetailsLink type="report" id={entity.reportId}>
             <ReportIcon title={_('Corresponding Report')} />
           </DetailsLink>
         )}
@@ -289,7 +289,7 @@ Details.propTypes = {
   entity: PropTypes.model.isRequired,
 };
 
-const Page = ({onDownloaded, ...props}) => {
+const Page = ({onDownloaded}) => {
   // Page methods
   const {id} = useParams();
   const history = useHistory();


### PR DESCRIPTION
**What**:
Refactor results detailspage to use graphql queries instead of gmp commands.
The overrides and delta results section of the detailspage have not been refactored yet and will follow in later PRs.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The results detailspage is still using gmp commands.
Overrides will be added once they are working correctly again and the behaviour can be tested properly. Delta results will be added in another separate PR together with the deltareportspage.
WithEntityContainer is still used for the export until useEntityExport has been adjusted for single entity exports. 
CVE results might still cause problems and will be adjusted after changes to the NVTs.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
