### PR TITLE
Show StartIcon for scheduled tasks on task listpage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added the CVSS v3.1 BaseScore calculator to the `/cvsscalculator` page in the Help section. [#2536](https://github.com/greenbone/gsa/pull/2536)
 
 ### Changed
+- Show StartIcon for scheduled tasks [#2840](https://github.com/greenbone/gsa/pull/2840)
 - Move error message and adjust design on login page [#2780](https://github.com/greenbone/gsa/pull/2780)
 - Refactored useFormValidation hook [#2704](https://github.com/greenbone/gsa/pull/2704)
 - Updated copyright and footer layout [#2687](https://github.com/greenbone/gsa/pull/2687)

--- a/gsa/src/web/pages/tasks/__tests__/actions.js
+++ b/gsa/src/web/pages/tasks/__tests__/actions.js
@@ -518,9 +518,10 @@ describe('Task Actions tests', () => {
       'View Details of Schedule schedule1 (Next due: over)',
     );
 
-    fireEvent.click(icons[1]);
+    fireEvent.click(icons[2]);
     expect(handleTaskResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Task is scheduled');
+    expect(icons[1]).toHaveAttribute('title', 'Start');
+    expect(icons[2]).toHaveAttribute('title', 'Task is scheduled');
   });
 
   test('should call click handlers for container task', () => {

--- a/gsa/src/web/pages/tasks/actions.js
+++ b/gsa/src/web/pages/tasks/actions.js
@@ -52,11 +52,10 @@ const Actions = ({
   onTaskStopClick,
 }) => (
   <IconDivider align={['center', 'center']} grow>
-    {isDefined(entity.schedule) ? (
+    {isDefined(entity.schedule) && (
       <ScheduleIcon schedule={entity.schedule} links={links} />
-    ) : (
-      <StartIcon task={entity} onClick={onTaskStartClick} />
     )}
+    <StartIcon task={entity} onClick={onTaskStartClick} />
 
     <ImportReportIcon task={entity} onClick={onReportImportClick} />
 


### PR DESCRIPTION
**What**:
Show the start icon for scheduled tasks at the actions column the task listpage.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
There is a discrepancy between task detailspage and listpage. The listpage didn't allow to manually start a task. The detailspage, however, offered this functionality. In order to avoid cumbersome searching for functions, the actions on the listpage and detailspage are nowequalized.
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [x] Labels for ports to other branches
