### PR TITLE
Allow underscores and hyphens in host parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Changed visual appearance of compliance status bar [#2457](https://github.com/greenbone/gsa/pull/2457)
 - Changed delete icons on report format detailspage and schedule detailspage to trashcan icons [#2459](https://github.com/greenbone/gsa/pull/2459)
 - Use <predefined> to disable feed object editing and filter creation on feed status page [#2398](https://github.com/greenbone/gsa/pull/2398)
+- Allow underscores and hyphens in host parameters [#2846](https://github.com/greenbone/gsa/pull/#2846)
 
 ### Fixed
 - Fix default port value for scanner dialog [#2773](https://github.com/greenbone/gsa/pull/2773)

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -558,12 +558,12 @@ init_validator ()
   gvm_validator_add (validator, "max", "^(-?[0-9]+|)$");
   gvm_validator_add (validator, "max_results", "^[0-9]+$");
   gvm_validator_add (validator, "format", "^[-[:alnum:]]+$");
-  gvm_validator_add (validator, "host", "^[[:alnum:]:\\.]+$");
-  gvm_validator_add (validator, "hostport", "^[-[:alnum:]\\. :]+$");
-  gvm_validator_add (validator, "hostpath", "^[-[:alnum:]\\. :/]+$");
-  gvm_validator_add (validator, "hosts", "^[-[:alnum:],: \\./]+$");
+  gvm_validator_add (validator, "host", "^[-_[:alnum:]:\\.]+$");
+  gvm_validator_add (validator, "hostport", "^[-_[:alnum:]\\. :]+$");
+  gvm_validator_add (validator, "hostpath", "^[-_[:alnum:]\\. :/]+$");
+  gvm_validator_add (validator, "hosts", "^[-_[:alnum:],: \\./]+$");
   gvm_validator_add (validator, "hosts_allow", "^(0|1)$");
-  gvm_validator_add (validator, "hosts_opt", "^[-[:alnum:],: \\./]*$");
+  gvm_validator_add (validator, "hosts_opt", "^[-_[:alnum:],: \\./]*$");
   gvm_validator_add (validator, "hosts_ordering",
                      "^(sequential|random|reverse)$");
   gvm_validator_add (validator, "hour", "^([01]?[0-9]|2[0-3])$");


### PR DESCRIPTION
**What**:
The request parameters host, hostport, hostpath, hosts and hosts_opt and
their aliases can now all contain underscores and hyphens.

**Why**:
To allow uses to specify hosts with these characters, for example as scan targets.

**How**:
By trying to create a target that contains an underscore.

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [x] Labels for ports to other branches
