### PR TITLE
Pre-select greenbone sensor as default scanner type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unrelased]
+
+### Added
+### Changed
+- Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
+
+### Fixed
+### Removed
+
+[Unreleased]: https://github.com/greenbone/gsa/compare/v21.4.0...gsa-21.04
+
 ## [21.04] - 2021-04-16
 
 ### Added

--- a/gsa/src/web/pages/scanners/dialog.js
+++ b/gsa/src/web/pages/scanners/dialog.js
@@ -118,7 +118,7 @@ const ScannerDialog = ({
   name = _('Unnamed'),
   port = '22',
   title = _('New Scanner'),
-  type = OSP_SCANNER_TYPE,
+  type,
   which_cert,
   onClose,
   onCredentialChange,
@@ -159,8 +159,10 @@ const ScannerDialog = ({
   const {gmp} = props;
 
   if (gmp.settings.enableGreenboneSensor) {
-    SCANNER_TYPES = [OSP_SCANNER_TYPE, GREENBONE_SENSOR_SCANNER_TYPE];
+    type = GREENBONE_SENSOR_SCANNER_TYPE;
+    SCANNER_TYPES = [GREENBONE_SENSOR_SCANNER_TYPE, OSP_SCANNER_TYPE];
   } else {
+    type = OSP_SCANNER_TYPE;
     SCANNER_TYPES = [OSP_SCANNER_TYPE];
   }
 

--- a/gsa/src/web/pages/scanners/dialog.js
+++ b/gsa/src/web/pages/scanners/dialog.js
@@ -24,7 +24,7 @@ import _ from 'gmp/locale';
 import {longDate} from 'gmp/locale/date';
 
 import {filter, map} from 'gmp/utils/array';
-import {isDefined} from 'gmp/utils/identity';
+import {hasValue, isDefined} from 'gmp/utils/identity';
 import {selectSaveId} from 'gmp/utils/id';
 
 import {parseInt} from 'gmp/parser';
@@ -159,10 +159,10 @@ const ScannerDialog = ({
   const {gmp} = props;
 
   if (gmp.settings.enableGreenboneSensor) {
-    type = GREENBONE_SENSOR_SCANNER_TYPE;
+    type = hasValue(type) ? type : GREENBONE_SENSOR_SCANNER_TYPE;
     SCANNER_TYPES = [GREENBONE_SENSOR_SCANNER_TYPE, OSP_SCANNER_TYPE];
   } else {
-    type = OSP_SCANNER_TYPE;
+    type = hasValue(type) ? type : OSP_SCANNER_TYPE;
     SCANNER_TYPES = [OSP_SCANNER_TYPE];
   }
 


### PR DESCRIPTION
**What**:

For creating a scanner use the greenbone sensor as default scanner type
when opening the dialog.


**Why**:

Customers may be confused by adding a OSP scanner because current sensors are based on OSP too.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [x] Labels for ports to other branches
