### PR TITLE
Fixed result CVE parsing for result listpage and CVE reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ### Fixed
+- Fixed result CVE parsing for result listpage and CVE reports [#2869](https://github.com/greenbone/gsa/pull/2869)
 - Fixed setting comments of business process nodes [#2781](https://github.com/greenbone/gsa/pull/2781)
 - Added the deprecatedBy field to CPEs [#2751](https://github.com/greenbone/gsa/pull/2751)
 - Fixed the severity for different advisories [#2611](https://github.com/greenbone/gsa/pull/2611)

--- a/gsa/src/gmp/models/__tests__/cve.js
+++ b/gsa/src/gmp/models/__tests__/cve.js
@@ -289,6 +289,6 @@ describe('CVE model tests', () => {
     const cve = Cve.fromResultElement(elem);
 
     expect(cve.name).toBe('CVE-1234');
-    expect(cve.oid).toBe('CVE-1234');
+    expect(cve.id).toBe('CVE-1234');
   });
 });

--- a/gsa/src/gmp/models/__tests__/cve.js
+++ b/gsa/src/gmp/models/__tests__/cve.js
@@ -280,4 +280,17 @@ describe('CVE model tests', () => {
 
     expect(cve.references).toEqual([]);
   });
+
+  test('should parse result cve', () => {
+    const elem = {
+      cvss_base: 6.4,
+      name: 'CVE-1234',
+    };
+
+    const cve = Cve.fromResultElement(elem);
+
+    expect(cve.name).toBe('CVE-1234');
+    expect(cve.oid).toBe('CVE-1234');
+    expect(cve.severity).toBe(6.4);
+  });
 });

--- a/gsa/src/gmp/models/__tests__/cve.js
+++ b/gsa/src/gmp/models/__tests__/cve.js
@@ -283,7 +283,6 @@ describe('CVE model tests', () => {
 
   test('should parse result cve', () => {
     const elem = {
-      cvss_base: 6.4,
       name: 'CVE-1234',
     };
 
@@ -291,6 +290,5 @@ describe('CVE model tests', () => {
 
     expect(cve.name).toBe('CVE-1234');
     expect(cve.oid).toBe('CVE-1234');
-    expect(cve.severity).toBe(6.4);
   });
 });

--- a/gsa/src/gmp/models/__tests__/result.js
+++ b/gsa/src/gmp/models/__tests__/result.js
@@ -90,19 +90,20 @@ describe('Result model tests', () => {
     const result = Result.fromElement(elem);
 
     expect(result.information).toBeInstanceOf(Nvt);
-    expect(result.information.oid).toEqual('bar');
+    expect(result.information.id).toEqual('bar');
   });
 
   test('should parse CVEs', () => {
     const elem = {
       nvt: {
         name: 'CVE-1234',
+        type: 'cve',
       },
     };
 
     const result = Result.fromElement(elem);
 
-    expect(result.information.oid).toEqual('CVE-1234');
+    expect(result.information.id).toEqual('CVE-1234');
     expect(result.information.name).toEqual('CVE-1234');
   });
 

--- a/gsa/src/gmp/models/__tests__/result.js
+++ b/gsa/src/gmp/models/__tests__/result.js
@@ -84,12 +84,28 @@ describe('Result model tests', () => {
     const elem = {
       nvt: {
         _oid: 'bar',
+        type: 'nvt',
       },
     };
     const result = Result.fromElement(elem);
 
-    expect(result.nvt).toBeInstanceOf(Nvt);
-    expect(result.nvt.oid).toEqual('bar');
+    expect(result.information).toBeInstanceOf(Nvt);
+    expect(result.information.oid).toEqual('bar');
+  });
+
+  test('should parse CVEs', () => {
+    const elem = {
+      nvt: {
+        cvss_base: 4.9,
+        name: 'CVE-1234',
+        _oid: 'CVE-1234',
+      },
+    };
+
+    const result = Result.fromElement(elem);
+
+    expect(result.information.oid).toEqual('CVE-1234');
+    expect(result.information.severity).toEqual(4.9);
   });
 
   test('should parse severity', () => {

--- a/gsa/src/gmp/models/__tests__/result.js
+++ b/gsa/src/gmp/models/__tests__/result.js
@@ -96,16 +96,14 @@ describe('Result model tests', () => {
   test('should parse CVEs', () => {
     const elem = {
       nvt: {
-        cvss_base: 4.9,
         name: 'CVE-1234',
-        _oid: 'CVE-1234',
       },
     };
 
     const result = Result.fromElement(elem);
 
     expect(result.information.oid).toEqual('CVE-1234');
-    expect(result.information.severity).toEqual(4.9);
+    expect(result.information.name).toEqual('CVE-1234');
   });
 
   test('should parse severity', () => {

--- a/gsa/src/gmp/models/cve.js
+++ b/gsa/src/gmp/models/cve.js
@@ -35,7 +35,6 @@ class Cve extends Info {
     const ret = {};
 
     ret.name = element.name;
-    ret.severity = element.cvss_base;
     ret.oid = element.name;
 
     return ret;

--- a/gsa/src/gmp/models/cve.js
+++ b/gsa/src/gmp/models/cve.js
@@ -35,7 +35,7 @@ class Cve extends Info {
     const ret = {};
 
     ret.name = element.name;
-    ret.oid = element.name;
+    ret.id = element.name;
 
     return ret;
   }

--- a/gsa/src/gmp/models/cve.js
+++ b/gsa/src/gmp/models/cve.js
@@ -31,6 +31,16 @@ import Info from './info';
 class Cve extends Info {
   static entityType = 'cve';
 
+  static fromResultElement(element) {
+    const ret = {};
+
+    ret.name = element.name;
+    ret.severity = element.cvss_base;
+    ret.oid = element.name;
+
+    return ret;
+  }
+
   static parseElement(element) {
     const ret = super.parseElement(element, 'cve');
 

--- a/gsa/src/gmp/models/result.js
+++ b/gsa/src/gmp/models/result.js
@@ -59,7 +59,7 @@ class Result extends Model {
       host = {},
       name,
       notes,
-      nvt = {},
+      nvt: information = {},
       original_severity,
       overrides,
       report,
@@ -87,11 +87,13 @@ class Result extends Model {
       };
     }
 
-    if (nvt.type === 'nvt') {
-      copy.nvt = Nvt.fromElement(nvt);
+    if (information.type === 'nvt') {
+      copy.information = Nvt.fromElement(information);
     } else {
-      copy.nvt = Cve.fromResultElement(nvt);
+      copy.information = Cve.fromResultElement(information);
     }
+
+    delete copy.nvt;
 
     if (isDefined(description)) {
       copy.description = description;
@@ -101,7 +103,7 @@ class Result extends Model {
       copy.severity = parseSeverity(severity);
     }
 
-    copy.vulnerability = isDefined(name) ? name : nvt._oid;
+    copy.vulnerability = isDefined(name) ? name : information._oid;
 
     if (isDefined(report)) {
       copy.report = parseModelFromElement(report, 'report');

--- a/gsa/src/gmp/models/result.js
+++ b/gsa/src/gmp/models/result.js
@@ -28,6 +28,7 @@ import Nvt from './nvt';
 import Note from './note';
 
 import Override from './override';
+import Cve from './cve';
 
 export class Delta {
   static TYPE_NEW = 'new';
@@ -89,9 +90,7 @@ class Result extends Model {
     if (nvt.type === 'nvt') {
       copy.nvt = Nvt.fromElement(nvt);
     } else {
-      copy.nvt = {};
-      copy.nvt.name = nvt.name;
-      copy.nvt.oid = nvt.name;
+      copy.nvt = Cve.fromResultElement(nvt);
     }
 
     if (isDefined(description)) {

--- a/gsa/src/gmp/models/result.js
+++ b/gsa/src/gmp/models/result.js
@@ -86,7 +86,13 @@ class Result extends Model {
       };
     }
 
-    copy.nvt = Nvt.fromElement(nvt);
+    if (nvt.type === 'nvt') {
+      copy.nvt = Nvt.fromElement(nvt);
+    } else {
+      copy.nvt = {};
+      copy.nvt.name = nvt.name;
+      copy.nvt.oid = nvt.name;
+    }
 
     if (isDefined(description)) {
       copy.description = description;

--- a/gsa/src/web/pages/results/details.js
+++ b/gsa/src/web/pages/results/details.js
@@ -102,10 +102,10 @@ DerivedDiff.propTypes = {
 const ResultDetails = ({className, links = true, entity}) => {
   const result = entity;
 
-  const {nvt} = result;
-  const {oid, tags = {}, solution} = nvt;
+  const {information} = result;
+  const {oid: infoId, tags = {}, solution} = information;
 
-  const is_oval = isDefined(oid) && oid.startsWith('oval:');
+  const is_oval = isDefined(infoId) && infoId.startsWith('oval:');
   const has_detection =
     isDefined(result.detection) && isDefined(result.detection.result);
 
@@ -292,24 +292,24 @@ const ResultDetails = ({className, links = true, entity}) => {
                   {is_oval && (
                     <DetailsLink
                       type="ovaldef"
-                      id={oid}
+                      id={infoId}
                       title={_('View Details of OVAL Definition {{oid}}', {
-                        oid,
+                        infoId,
                       })}
                       textOnly={!links}
                     >
-                      {oid}
+                      {infoId}
                     </DetailsLink>
                   )}
-                  {isDefined(oid) && oid.startsWith(DEFAULT_OID_VALUE) && (
+                  {isDefined(infoId) && infoId.startsWith(DEFAULT_OID_VALUE) && (
                     <span>
-                      <DetailsLink type="nvt" id={oid} textOnly={!links}>
-                        {renderNvtName(oid, nvt.name)}
-                        {' OID: ' + oid}
+                      <DetailsLink type="nvt" id={infoId} textOnly={!links}>
+                        {renderNvtName(infoId, information.name)}
+                        {' OID: ' + infoId}
                       </DetailsLink>
                     </span>
                   )}
-                  {!isDefined(oid) &&
+                  {!isDefined(infoId) &&
                     _('No details available for this method.')}
                 </TableData>
               </TableRow>
@@ -341,7 +341,7 @@ const ResultDetails = ({className, links = true, entity}) => {
         solutionType={solution?.type}
       />
 
-      <References links={links} nvt={nvt} />
+      <References links={links} nvt={information} />
     </Layout>
   );
 };

--- a/gsa/src/web/pages/results/details.js
+++ b/gsa/src/web/pages/results/details.js
@@ -103,7 +103,7 @@ const ResultDetails = ({className, links = true, entity}) => {
   const result = entity;
 
   const {information} = result;
-  const {oid: infoId, tags = {}, solution} = information;
+  const {id: infoId, tags = {}, solution} = information;
 
   const is_oval = isDefined(infoId) && infoId.startsWith('oval:');
   const has_detection =

--- a/gsa/src/web/pages/results/details.js
+++ b/gsa/src/web/pages/results/details.js
@@ -103,7 +103,7 @@ const ResultDetails = ({className, links = true, entity}) => {
   const result = entity;
 
   const {nvt} = result;
-  const {oid, tags, solution} = nvt;
+  const {oid, tags = {}, solution} = nvt;
 
   const is_oval = isDefined(oid) && oid.startsWith('oval:');
   const has_detection =
@@ -149,9 +149,11 @@ const ResultDetails = ({className, links = true, entity}) => {
 
   return (
     <Layout flex="column" grow="1" className={className}>
-      <DetailsBlock title={_('Summary')}>
-        <P>{tags.summary}</P>
-      </DetailsBlock>
+      {isDefined(tags.summary) && (
+        <DetailsBlock title={_('Summary')}>
+          <P>{tags.summary}</P>
+        </DetailsBlock>
+      )}
 
       {result.hasDelta() ? (
         <DetailsBlock title={_('Detection Results')}>

--- a/gsa/src/web/pages/results/row.js
+++ b/gsa/src/web/pages/results/row.js
@@ -59,7 +59,7 @@ const Row = ({
   ...props
 }) => {
   const {host} = entity;
-  let shownName = isDefined(entity.name) ? entity.name : entity.information.oid;
+  let shownName = isDefined(entity.name) ? entity.name : entity.information.id;
   if (!isDefined(shownName)) {
     shownName = entity.id;
   }

--- a/gsa/src/web/pages/results/row.js
+++ b/gsa/src/web/pages/results/row.js
@@ -59,7 +59,7 @@ const Row = ({
   ...props
 }) => {
   const {host} = entity;
-  let shownName = isDefined(entity.name) ? entity.name : entity.nvt.oid;
+  let shownName = isDefined(entity.name) ? entity.name : entity.information.oid;
   if (!isDefined(shownName)) {
     shownName = entity.id;
   }
@@ -94,8 +94,8 @@ const Row = ({
         </Layout>
       </TableData>
       <TableData>
-        {isDefined(entity?.nvt?.solution) && (
-          <SolutionTypeIcon type={entity.nvt.solution.type} />
+        {isDefined(entity?.information?.solution) && (
+          <SolutionTypeIcon type={entity.information.solution.type} />
         )}
       </TableData>
       <TableData>


### PR DESCRIPTION
**What**:

Introduced a new method for the Cve model `fromResultElement` to parse CVE type results to avoid unnecessary changes to `Cve.fromElement` (using the latter won't work correctly for the result rows) Also changed `result.nvt` to be `result.information` for clarity, wherever changing it does not alter too much of the code base.

This should not be forward ported, as result entity is very different there.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
CVE reports are currently broken because the cve type results are being parsed as NVTs which leads to missing and undefined fields.
<!-- Why are these changes necessary? -->

**How**:

Unit tests on the models. Also manually confirmed that CVE reports now do not show errors and the results listpage filtered for a CVE report does not show errors.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
