### PR TITLE
Fix dynamic severity checkbox not being checked upon clicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ### Fixed
+- Fix dynamic severity checkbox not being checked upon clicking [#2882](https://github.com/greenbone/gsa/pull/2882)
 - Fixed result CVE parsing for result listpage and CVE reports [#2869](https://github.com/greenbone/gsa/pull/2869)
 - Fixed setting comments of business process nodes [#2781](https://github.com/greenbone/gsa/pull/2781)
 - Added the deprecatedBy field to CPEs [#2751](https://github.com/greenbone/gsa/pull/2751)

--- a/gsa/src/web/pages/usersettings/dialog.js
+++ b/gsa/src/web/pages/usersettings/dialog.js
@@ -224,6 +224,7 @@ let UserSettingsDialog = ({
           <Section title={_('Severity Settings')} foldable>
             <FormGroupSizer>
               <SeverityPart
+                dynamicSeverity={values.dynamicSeverity}
                 defaultSeverity={values.defaultSeverity}
                 severityClass={values.severityClass}
                 onChange={handleValueChange}


### PR DESCRIPTION
**What**:
The dynamic severity checkbox can be clicked now. It reliably sends the right information.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
It was broken before.
<!-- Why are these changes necessary? -->

**How**:
Manual verification.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
