### PR TITLE
Don't show word cloud as default in result dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added the CVSS v3.1 BaseScore calculator to the `/cvsscalculator` page in the Help section. [#2536](https://github.com/greenbone/gsa/pull/2536)
 
 ### Changed
+- Don't show word cloud as default in result dashboard [#2883](https://github.com/greenbone/gsa/pull/2883)
 - Sort host, os and vulns listpage by descending severity [#2880](https://github.com/greenbone/gsa/pull/2880)
 - Revert the changes from integer `score` to a float `severity` [#2854](https://github.com/greenbone/gsa/pull/2854)
 - Show StartIcon for scheduled tasks [#2840](https://github.com/greenbone/gsa/pull/2840)

--- a/gsa/src/web/pages/results/dashboard/index.js
+++ b/gsa/src/web/pages/results/dashboard/index.js
@@ -53,11 +53,7 @@ const ResultsDashboard = props => (
     id={RESULTS_DASHBOARD_ID}
     permittedDisplays={RESULTS_DISPLAYS}
     defaultDisplays={[
-      [
-        ResultsSeverityDisplay.displayId,
-        ResultsWordCloudDisplay.displayId,
-        ResultsCvssDisplay.displayId,
-      ],
+      [ResultsSeverityDisplay.displayId, ResultsCvssDisplay.displayId],
     ]}
   />
 );


### PR DESCRIPTION
**What**:
Don't show word cloud as default in result dashboard.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
It should not be shown by default
<!-- Why are these changes necessary? -->

**How**:
Load default dashboard and verify that said display is not visible.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [X] Labels for ports to other branches
