### PR TITLE
Don't show word cloud as default in result dashboard (manual backport #2883)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [21.04] - unreleased
 
 ### Added
-
+- Don't show word cloud as default in result dashboard [#2883](https://github.com/greenbone/gsa/pull/2883)
 - Allow to set unix socket permissions for gsad [#2816](https://github.com/greenbone/gsa/pull/2816)
 - Added CVSS date to NVT details [#2802](https://github.com/greenbone/gsa/pull/2802)
 - Add option to allow to scan simultaneous IPs to targets

--- a/gsa/src/web/pages/results/__tests__/listpage.js
+++ b/gsa/src/web/pages/results/__tests__/listpage.js
@@ -249,8 +249,7 @@ describe('Results listpage tests', () => {
     expect(display[0]).toHaveTextContent(
       'Results by Severity Class (Total: 0)',
     );
-    expect(display[1]).toHaveTextContent('Results Vulnerability Word Cloud');
-    expect(display[2]).toHaveTextContent('Results by CVSS (Total: 0)');
+    expect(display[1]).toHaveTextContent('Results by CVSS (Total: 0)');
 
     // Headings
     const header = baseElement.querySelectorAll('th');

--- a/gsa/src/web/pages/results/dashboard/index.js
+++ b/gsa/src/web/pages/results/dashboard/index.js
@@ -53,11 +53,7 @@ const ResultsDashboard = props => (
     id={RESULTS_DASHBOARD_ID}
     permittedDisplays={RESULTS_DISPLAYS}
     defaultDisplays={[
-      [
-        ResultsSeverityDisplay.displayId,
-        ResultsWordCloudDisplay.displayId,
-        ResultsCvssDisplay.displayId,
-      ],
+      [ResultsSeverityDisplay.displayId, ResultsCvssDisplay.displayId],
     ]}
   />
 );


### PR DESCRIPTION
**What**:
backport to master: https://github.com/greenbone/gsa/pull/2883
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:
Adjust automatic test, visually inspect results dashboard
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [N/A] Labels for ports to other branches
