### PR TITLE
Set result UUID in note dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
 
 ### Fixed
+- Fix setting result UUID in notes dialog [#2889](https://github.com/greenbone/gsa/pull/2889)
+
 ### Removed
 
 [Unreleased]: https://github.com/greenbone/gsa/compare/v21.4.0...gsa-21.04

--- a/gsa/src/web/pages/notes/dialog.js
+++ b/gsa/src/web/pages/notes/dialog.js
@@ -36,6 +36,7 @@ import {
   ACTIVE_YES_FOR_NEXT_VALUE,
   ACTIVE_NO_VALUE,
   RESULT_ANY,
+  RESULT_UUID,
 } from 'gmp/models/override';
 
 import DateTime from 'web/components/date/datetime';
@@ -345,8 +346,8 @@ const NoteDialog = ({
               <Radio
                 name="result_id"
                 title={_('Any')}
-                checked={state.result_id === ''}
-                value=""
+                checked={state.result_id === RESULT_ANY}
+                value={RESULT_ANY}
                 onChange={onValueChange}
               />
               <Divider>
@@ -359,16 +360,16 @@ const NoteDialog = ({
                         })
                       : _('UUID')
                   }
-                  checked={state.result_id === '0'}
-                  value="0"
+                  checked={state.result_id === RESULT_UUID}
+                  value={RESULT_UUID}
                   onChange={onValueChange}
                 />
                 {!fixed && (
                   <TextField
                     name="result_uuid"
                     size="34"
-                    disabled={state.result_id !== '0'}
-                    value={state.result_id}
+                    disabled={state.result_id !== RESULT_UUID}
+                    value={state.result_uuid}
                     onChange={onValueChange}
                   />
                 )}


### PR DESCRIPTION
**What**:
Set the correct value in the result uuid textfield in the notes dialog.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This allows to change the result UUID in the notes dialog. If it hasn't been set while creating a new note, the id was unchangeable, or at least not changeable to a valid UUID. It was rather taking the value of the _choice_ whether to use a UUID or not.
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
