### PR TITLE
fix missing name for cve results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
 
 ### Fixed
+- Fixed missing name for CVE results on result detailspage [#2892](https://github.com/greenbone/gsa/pull/2892)
 - Fix setting result UUID in notes dialog [#2889](https://github.com/greenbone/gsa/pull/2889)
 
 ### Removed

--- a/gsa/src/gmp/models/__tests__/result.js
+++ b/gsa/src/gmp/models/__tests__/result.js
@@ -105,6 +105,7 @@ describe('Result model tests', () => {
 
     expect(result.information.id).toEqual('CVE-1234');
     expect(result.information.name).toEqual('CVE-1234');
+    expect(result.name).toEqual('CVE-1234');
   });
 
   test('should parse severity', () => {

--- a/gsa/src/gmp/models/result.js
+++ b/gsa/src/gmp/models/result.js
@@ -91,6 +91,7 @@ class Result extends Model {
       copy.information = Nvt.fromElement(information);
     } else {
       copy.information = Cve.fromResultElement(information);
+      copy.name = isDefined(copy.name) ? copy.name : information.name;
     }
 
     delete copy.nvt;


### PR DESCRIPTION
**What**:
CVE results do not have a name. Use the name of the information sub element instead so it can be displayed on the detailspage.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
For CVE results the name was missing on the detailspage.
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
