### PR TITLE
Fix changing Trend and Select for NVT-families and whole selection only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
 
 ### Fixed
+- Fixed changing Trend and Select for NVT-families and whole selection only [#2905](https://github.com/greenbone/gsa/pull/2905)
 - Fixed missing name for CVE results on result detailspage [#2892](https://github.com/greenbone/gsa/pull/2892)
 - Fixed setting secret key in RADIUS dialog [#2891](https://github.com/greenbone/gsa/pull/2891)
 - Fixed setting result UUID in notes dialog [#2889](https://github.com/greenbone/gsa/pull/2889)

--- a/gsa/src/web/pages/scanconfigs/nvtfamilies.js
+++ b/gsa/src/web/pages/scanconfigs/nvtfamilies.js
@@ -89,14 +89,18 @@ const NvtFamily = ({
             name={familyName}
             checked={isToSelectWhole || trend === SCANCONFIG_TREND_DYNAMIC}
             convert={parseTrend}
+            disabled={isToSelectWhole}
             value={SCANCONFIG_TREND_DYNAMIC}
             onChange={onTrendChange}
           />
-          <Trend trend={SCANCONFIG_TREND_DYNAMIC} />
+          <Trend active={!isToSelectWhole} trend={SCANCONFIG_TREND_DYNAMIC} />
           <Radio
             flex
             name={familyName}
-            checked={!isToSelectWhole && trend === SCANCONFIG_TREND_STATIC}
+            checked={
+              (!isToSelectWhole && trend === SCANCONFIG_TREND_STATIC) ||
+              (isToSelectWhole && select === NO_VALUE)
+            }
             disabled={isToSelectWhole}
             convert={parseTrend}
             value={SCANCONFIG_TREND_STATIC}
@@ -155,8 +159,11 @@ const NvtFamilies = ({
     onValueChange(trend, 'trend');
   };
   const onSelectChange = (value, name) => {
+    const isToSelectWhole = WHOLE_SELECTION_FAMILIES.includes(name);
     select[name] = value;
-
+    if (isToSelectWhole) {
+      onTrendChange(value, name);
+    }
     onValueChange(select, 'select');
   };
   return (


### PR DESCRIPTION
**What**:
Automatically send trend:0 (static) when a whole-selection only family is unselected.

Needs https://github.com/greenbone/gvmd/pull/1517
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
gvmd needs an explicit trend:0 with an unselected whole-selection family
<!-- Why are these changes necessary? -->

**How**:
Observe automatic radio button changes when selecting/unselecting a whole-selection family, verify that the old behavior still works for all other families (no automatic changes), and check parameters in network request.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [X] Labels for ports to other branches
