### PR TITLE
Adjust tasks and audits to display correct information on listpage and detailspage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
-
+- Adjust tasks and audits to display correct information on listpage and detailspage [#2906](https://github.com/greenbone/gsa/pull/2906)
 - Adjust target credentials to reflect changes in Hyperion [#2898](https://github.com/greenbone/gsa/pull/2898)
 - Use graphql on override listpage [#2887](https://github.com/greenbone/gsa/pull/2887)
 - Adjust port list mutations to reflect changes in Hyperion [#2886](https://github.com/greenbone/gsa/pull/2886)

--- a/gsa/src/gmp/models/__tests__/audit.js
+++ b/gsa/src/gmp/models/__tests__/audit.js
@@ -31,107 +31,35 @@ import {testModel} from 'gmp/models/testing';
 describe.only('Audit model parseObject tests', () => {
   testModel(Audit, 'audit', {testIsActive: false});
 
-  test('should parse undefined hosts_ordering', () => {
-    const obj = {hostsOrdering: null};
-    const audit = Audit.fromObject(obj);
-    expect(audit.hostsOrdering).toBeUndefined();
-  });
-
-  test('should parse unknown hosts_ordering as undefined', () => {
-    const obj = {hostsOrdering: 'FOO'};
-    const audit = Audit.fromObject(obj);
-    expect(audit.hostsOrdering).toBeUndefined();
-  });
-
-  test('should parse known hosts_ordering', () => {
-    let obj = {hostsOrdering: 'RANDOM'};
-    let audit = Audit.fromObject(obj);
-    expect(audit.hostsOrdering).toEqual(HOSTS_ORDERING_RANDOM);
-
-    obj = {hostsOrdering: 'REVERSE'};
-    audit = Audit.fromObject(obj);
-    expect(audit.hostsOrdering).toEqual(HOSTS_ORDERING_REVERSE);
-
-    obj = {hostsOrdering: 'SEQUENTIAL'};
-    audit = Audit.fromObject(obj);
-    expect(audit.hostsOrdering).toEqual(HOSTS_ORDERING_SEQUENTIAL);
-  });
-
   test('should parse preferences', () => {
     const audit1 = Audit.fromObject({
       id: 'a1',
-      preferences: [
-        {
-          name: 'in_assets',
-          value: 'yes',
-        },
-        {
-          name: 'assets_apply_overrides',
-          value: 'yes',
-        },
-        {
-          name: 'assets_min_qod',
-          value: '70',
-        },
-        {
-          name: 'auto_delete',
-          value: 'keep',
-        },
-        {
-          name: 'auto_delete_data',
-          value: '0',
-        },
-        {
-          name: 'max_hosts',
-          value: '20',
-        },
-        {
-          name: 'max_checks',
-          value: '4',
-        },
-        {
-          name: 'source_iface',
-          value: 'eth0',
-        },
-        {
-          name: 'foo',
-          value: 'bar',
-        },
-      ],
+      preferences: {
+        createAssets: true,
+        createAssetsApplyOverrides: true,
+        createAssetsMinQod: 70,
+        autoDeleteReports: 0,
+        maxConcurrentHosts: 20,
+        maxConcurrentNvts: 4,
+      },
     });
     const audit2 = Audit.fromObject({
       id: 'a1',
-      preferences: [
-        {
-          name: 'in_assets',
-          value: 'no',
-        },
-        {
-          name: 'assets_apply_overrides',
-          value: 'no',
-        },
-        {
-          name: 'auto_delete',
-          value: 'no',
-        },
-        {
-          name: 'auto_delete_data',
-          value: '3',
-        },
-      ],
+      preferences: {
+        createAssets: false,
+        createAssetsApplyOverrides: false,
+        autoDeleteReports: 3,
+      },
     });
 
-    expect(audit1.inAssets).toEqual(1);
-    expect(audit1.applyOverrides).toEqual(1);
-    expect(audit1.minQod).toEqual(70);
-    expect(audit1.autoDelete).toEqual('keep');
-    expect(audit1.maxHosts).toEqual(20);
-    expect(audit1.maxChecks).toEqual(4);
-    expect(audit1.sourceIface).toEqual('eth0');
-    expect(audit2.inAssets).toEqual(0);
-    expect(audit2.applyOverrides).toEqual(0);
-    expect(audit2.autoDelete).toEqual('no');
-    expect(audit2.autoDeleteData).toEqual(3);
+    expect(audit1.preferences.createAssets).toEqual(true);
+    expect(audit1.preferences.createAssetsApplyOverrides).toEqual(true);
+    expect(audit1.preferences.createAssetsMinQod).toEqual(70);
+    expect(audit1.preferences.maxConcurrentHosts).toEqual(20);
+    expect(audit1.preferences.maxConcurrentNvts).toEqual(4);
+    expect(audit2.preferences.createAssets).toEqual(false);
+    expect(audit2.preferences.createAssetsApplyOverrides).toEqual(false);
+    expect(audit2.preferences.autoDeleteReports).toEqual(3);
   });
 
   test('should parse audit progress', () => {

--- a/gsa/src/gmp/models/__tests__/audit.js
+++ b/gsa/src/gmp/models/__tests__/audit.js
@@ -17,18 +17,13 @@
  */
 
 import Model from 'gmp/model';
-import Audit, {
-  HOSTS_ORDERING_RANDOM,
-  HOSTS_ORDERING_REVERSE,
-  HOSTS_ORDERING_SEQUENTIAL,
-  AUDIT_STATUS,
-} from 'gmp/models/audit';
+import Audit, {AUDIT_STATUS, HYPERION_AUDIT_STATUS} from 'gmp/models/audit';
 import Policy from 'gmp/models/policy';
 import Scanner from 'gmp/models/scanner';
 import Schedule from 'gmp/models/schedule';
 import {testModel} from 'gmp/models/testing';
 
-describe.only('Audit model parseObject tests', () => {
+describe('Audit model parseObject tests', () => {
   testModel(Audit, 'audit', {testIsActive: false});
 
   test('should parse preferences', () => {
@@ -213,32 +208,6 @@ describe.only('Audit model parseObject tests', () => {
 describe('Audit model parseElement tests', () => {
   testModel(Audit, 'audit', {testIsActive: false});
 
-  test('should parse undefined hosts_ordering', () => {
-    const obj = {hosts_ordering: undefined};
-    const audit = Audit.fromElement(obj);
-    expect(audit.hosts_ordering).toBeUndefined();
-  });
-
-  test('should parse unknown hosts_ordering as undefined', () => {
-    const obj = {hosts_ordering: 'foo'};
-    const audit = Audit.fromElement(obj);
-    expect(audit.hosts_ordering).toBeUndefined();
-  });
-
-  test('should parse known hosts_ordering', () => {
-    let obj = {hosts_ordering: HOSTS_ORDERING_RANDOM};
-    let audit = Audit.fromElement(obj);
-    expect(audit.hosts_ordering).toEqual(HOSTS_ORDERING_RANDOM);
-
-    obj = {hosts_ordering: HOSTS_ORDERING_REVERSE};
-    audit = Audit.fromElement(obj);
-    expect(audit.hosts_ordering).toEqual(HOSTS_ORDERING_REVERSE);
-
-    obj = {hosts_ordering: HOSTS_ORDERING_SEQUENTIAL};
-    audit = Audit.fromElement(obj);
-    expect(audit.hosts_ordering).toEqual(HOSTS_ORDERING_SEQUENTIAL);
-  });
-
   test('should parse preferences', () => {
     const audit1 = Audit.fromElement({
       _id: 't1',
@@ -271,10 +240,6 @@ describe('Audit model parseElement tests', () => {
           {
             scanner_name: 'max_checks',
             value: '4',
-          },
-          {
-            scanner_name: 'source_iface',
-            value: 'eth0',
           },
           {
             scanner_name: 'foo',
@@ -314,16 +279,173 @@ describe('Audit model parseElement tests', () => {
     expect(audit1.auto_delete).toEqual('keep');
     expect(audit1.max_hosts).toEqual(20);
     expect(audit1.max_checks).toEqual(4);
-    expect(audit1.source_iface).toEqual('eth0');
     expect(audit1.preferences).toEqual({foo: {value: 'bar', name: 'lorem'}});
     expect(audit2.in_assets).toEqual(0);
     expect(audit2.apply_overrides).toEqual(0);
     expect(audit2.auto_delete).toEqual('no');
     expect(audit2.auto_delete_data).toEqual(3);
   });
+
+  test('should parse observer strings', () => {
+    const audit = Audit.fromElement({
+      observers: 'foo bar',
+    });
+
+    const {observers} = audit;
+    expect(observers.user).toEqual(['foo', 'bar']);
+  });
+  test('should parse all observers types', () => {
+    const audit = Audit.fromElement({
+      observers: {
+        __text: 'anon nymous',
+        role: [{name: 'lorem'}],
+        group: [{name: 'ipsum'}, {name: 'dolor'}],
+      },
+    });
+
+    const {observers} = audit;
+
+    expect(observers.user).toEqual(['anon', 'nymous']);
+    expect(observers.role).toEqual([{name: 'lorem'}]);
+    expect(observers.group).toEqual([{name: 'ipsum'}, {name: 'dolor'}]);
+  });
 });
 
-describe(`Audit Model methods tests`, () => {
+describe(`Audit Model methods parseObject tests`, () => {
+  test('should be a container if targetid is not set', () => {
+    const audit1 = Audit.fromObject({});
+    const audit2 = Audit.fromObject({target: {id: 'foo'}});
+
+    expect(audit1.isContainer()).toEqual(true);
+    expect(audit2.isContainer()).toEqual(false);
+  });
+
+  test('should use status for isActive', () => {
+    const statusList = {
+      [HYPERION_AUDIT_STATUS.running]: true,
+      [HYPERION_AUDIT_STATUS.stoprequested]: true,
+      [HYPERION_AUDIT_STATUS.deleterequested]: true,
+      [HYPERION_AUDIT_STATUS.ultimatedeleterequested]: true,
+      [HYPERION_AUDIT_STATUS.resumerequested]: true,
+      [HYPERION_AUDIT_STATUS.requested]: true,
+      [HYPERION_AUDIT_STATUS.stopped]: false,
+      [HYPERION_AUDIT_STATUS.new]: false,
+      [HYPERION_AUDIT_STATUS.interrupted]: false,
+      [HYPERION_AUDIT_STATUS.container]: false,
+      [HYPERION_AUDIT_STATUS.uploading]: false,
+      [HYPERION_AUDIT_STATUS.done]: false,
+    };
+
+    for (const [status, exp] of Object.entries(statusList)) {
+      const audit = Audit.fromObject({status});
+      expect(audit.isActive()).toEqual(exp);
+    }
+  });
+
+  test('should use status for isRunning', () => {
+    const statusList = {
+      [HYPERION_AUDIT_STATUS.running]: true,
+      [HYPERION_AUDIT_STATUS.stoprequested]: false,
+      [HYPERION_AUDIT_STATUS.deleterequested]: false,
+      [HYPERION_AUDIT_STATUS.ultimatedeleterequested]: false,
+      [HYPERION_AUDIT_STATUS.resumerequested]: false,
+      [HYPERION_AUDIT_STATUS.requested]: false,
+      [HYPERION_AUDIT_STATUS.stopped]: false,
+      [HYPERION_AUDIT_STATUS.new]: false,
+      [HYPERION_AUDIT_STATUS.interrupted]: false,
+      [HYPERION_AUDIT_STATUS.container]: false,
+      [HYPERION_AUDIT_STATUS.uploading]: false,
+      [HYPERION_AUDIT_STATUS.done]: false,
+    };
+
+    for (const [status, exp] of Object.entries(statusList)) {
+      const audit = Audit.fromObject({status});
+      expect(audit.isRunning()).toEqual(exp);
+    }
+  });
+
+  test('should use status for isStopped', () => {
+    const statusList = {
+      [HYPERION_AUDIT_STATUS.running]: false,
+      [HYPERION_AUDIT_STATUS.stoprequested]: false,
+      [HYPERION_AUDIT_STATUS.deleterequested]: false,
+      [HYPERION_AUDIT_STATUS.ultimatedeleterequested]: false,
+      [HYPERION_AUDIT_STATUS.resumerequested]: false,
+      [HYPERION_AUDIT_STATUS.requested]: false,
+      [HYPERION_AUDIT_STATUS.stopped]: true,
+      [HYPERION_AUDIT_STATUS.new]: false,
+      [HYPERION_AUDIT_STATUS.interrupted]: false,
+      [HYPERION_AUDIT_STATUS.container]: false,
+      [HYPERION_AUDIT_STATUS.uploading]: false,
+      [HYPERION_AUDIT_STATUS.done]: false,
+    };
+
+    for (const [status, exp] of Object.entries(statusList)) {
+      const audit = Audit.fromObject({status});
+      expect(audit.isStopped()).toEqual(exp);
+    }
+  });
+
+  test('should use status for isInterrupted', () => {
+    const statusList = {
+      [HYPERION_AUDIT_STATUS.running]: false,
+      [HYPERION_AUDIT_STATUS.stoprequested]: false,
+      [HYPERION_AUDIT_STATUS.deleterequested]: false,
+      [HYPERION_AUDIT_STATUS.ultimatedeleterequested]: false,
+      [HYPERION_AUDIT_STATUS.resumerequested]: false,
+      [HYPERION_AUDIT_STATUS.requested]: false,
+      [HYPERION_AUDIT_STATUS.stopped]: false,
+      [HYPERION_AUDIT_STATUS.new]: false,
+      [HYPERION_AUDIT_STATUS.interrupted]: true,
+      [HYPERION_AUDIT_STATUS.container]: false,
+      [HYPERION_AUDIT_STATUS.uploading]: false,
+      [HYPERION_AUDIT_STATUS.done]: false,
+    };
+
+    for (const [status, exp] of Object.entries(statusList)) {
+      const audit = Audit.fromObject({status});
+      expect(audit.isInterrupted()).toEqual(exp);
+    }
+  });
+
+  test('should use status for isNew', () => {
+    const statusList = {
+      [HYPERION_AUDIT_STATUS.running]: false,
+      [HYPERION_AUDIT_STATUS.stoprequested]: false,
+      [HYPERION_AUDIT_STATUS.deleterequested]: false,
+      [HYPERION_AUDIT_STATUS.ultimatedeleterequested]: false,
+      [HYPERION_AUDIT_STATUS.resumerequested]: false,
+      [HYPERION_AUDIT_STATUS.requested]: false,
+      [HYPERION_AUDIT_STATUS.stopped]: false,
+      [HYPERION_AUDIT_STATUS.new]: true,
+      [HYPERION_AUDIT_STATUS.interrupted]: false,
+      [HYPERION_AUDIT_STATUS.container]: false,
+      [HYPERION_AUDIT_STATUS.uploading]: false,
+      [HYPERION_AUDIT_STATUS.done]: false,
+    };
+
+    for (const [status, exp] of Object.entries(statusList)) {
+      const audit = Audit.fromObject({status});
+      expect(audit.isNew()).toEqual(exp);
+    }
+  });
+
+  test('should be changeable if alterable or new', () => {
+    let audit = Audit.fromObject({
+      status: HYPERION_AUDIT_STATUS.new,
+      alterable: '0',
+    });
+    expect(audit.isChangeable()).toEqual(true);
+
+    audit = Audit.fromObject({
+      status: HYPERION_AUDIT_STATUS.done,
+      alterable: '1',
+    });
+    expect(audit.isChangeable()).toEqual(true);
+  });
+});
+
+describe(`Audit Model methods parseElement tests`, () => {
   test('should use status for isActive', () => {
     const statusList = {
       [AUDIT_STATUS.running]: true,
@@ -440,29 +562,5 @@ describe(`Audit Model methods tests`, () => {
 
     audit = Audit.fromElement({status: AUDIT_STATUS.done, alterable: '1'});
     expect(audit.isChangeable()).toEqual(true);
-  });
-
-  test('should parse observer strings', () => {
-    const audit = Audit.fromElement({
-      observers: 'foo bar',
-    });
-
-    const {observers} = audit;
-    expect(observers.user).toEqual(['foo', 'bar']);
-  });
-  test('should parse all observers types', () => {
-    const audit = Audit.fromElement({
-      observers: {
-        __text: 'anon nymous',
-        role: [{name: 'lorem'}],
-        group: [{name: 'ipsum'}, {name: 'dolor'}],
-      },
-    });
-
-    const {observers} = audit;
-
-    expect(observers.user).toEqual(['anon', 'nymous']);
-    expect(observers.role).toEqual([{name: 'lorem'}]);
-    expect(observers.group).toEqual([{name: 'ipsum'}, {name: 'dolor'}]);
   });
 });

--- a/gsa/src/gmp/models/__tests__/task.js
+++ b/gsa/src/gmp/models/__tests__/task.js
@@ -18,12 +18,7 @@
 
 import Model from 'gmp/model';
 
-import Task, {
-  HOSTS_ORDERING_RANDOM,
-  HOSTS_ORDERING_REVERSE,
-  HOSTS_ORDERING_SEQUENTIAL,
-  TASK_STATUS,
-} from 'gmp/models/task';
+import Task, {HYPERION_TASK_STATUS} from 'gmp/models/task';
 
 import Report from '../report';
 import Scanner from '../scanner';
@@ -34,35 +29,9 @@ import {testModel} from '../testing';
 describe('Task Model parse tests', () => {
   testModel(Task, 'task', {testIsActive: false});
 
-  test('should parse undefined hostsOrdering', () => {
-    const obj = {hostsOrdering: undefined};
-    const task = Task.fromObject(obj);
-    expect(task.hostsOrdering).toBeUndefined();
-  });
-
-  test('should parse unknown hostsOrdering as undefined', () => {
-    const obj = {hostsOrdering: 'foo'};
-    const task = Task.fromObject(obj);
-    expect(task.hostsOrdering).toBeUndefined();
-  });
-
-  test('should parse known hostsOrdering', () => {
-    let obj = {hostsOrdering: HOSTS_ORDERING_RANDOM};
-    let task = Task.fromObject(obj);
-    expect(task.hostsOrdering).toEqual(HOSTS_ORDERING_RANDOM);
-
-    obj = {hostsOrdering: HOSTS_ORDERING_REVERSE};
-    task = Task.fromObject(obj);
-    expect(task.hostsOrdering).toEqual(HOSTS_ORDERING_REVERSE);
-
-    obj = {hostsOrdering: HOSTS_ORDERING_SEQUENTIAL};
-    task = Task.fromObject(obj);
-    expect(task.hostsOrdering).toEqual(HOSTS_ORDERING_SEQUENTIAL);
-  });
-
   test('should parse lastReport', () => {
-    const element = {
-      _id: 't1',
+    const object = {
+      id: 't1',
       reports: {
         lastReport: {
           id: 'r1',
@@ -70,7 +39,7 @@ describe('Task Model parse tests', () => {
       },
     };
 
-    const task = Task.fromObject(element);
+    const task = Task.fromObject(object);
 
     expect(task.id).toEqual('t1');
 
@@ -80,8 +49,8 @@ describe('Task Model parse tests', () => {
   });
 
   test('should parse current_report', () => {
-    const element = {
-      _id: 't1',
+    const object = {
+      id: 't1',
       reports: {
         currentReport: {
           id: 'r1',
@@ -89,7 +58,7 @@ describe('Task Model parse tests', () => {
       },
     };
 
-    const task = Task.fromObject(element);
+    const task = Task.fromObject(object);
 
     expect(task.id).toEqual('t1');
 
@@ -99,14 +68,14 @@ describe('Task Model parse tests', () => {
   });
 
   test('should parse config', () => {
-    const element = {
-      _id: 't1',
+    const object = {
+      id: 't1',
       scanConfig: {
-        _id: 'c1',
+        id: 'c1',
       },
     };
 
-    const task = Task.fromObject(element);
+    const task = Task.fromObject(object);
 
     expect(task.id).toEqual('t1');
 
@@ -115,32 +84,15 @@ describe('Task Model parse tests', () => {
     expect(task.config.entityType).toEqual('scanconfig');
   });
 
-  test('should parse slave', () => {
-    const element = {
-      _id: 't1',
-      slave: {
-        _id: 's1',
-      },
-    };
-
-    const task = Task.fromObject(element);
-
-    expect(task.id).toEqual('t1');
-
-    expect(task.slave).toBeInstanceOf(Model);
-    expect(task.slave.id).toEqual('s1');
-    expect(task.slave.entityType).toEqual('slave');
-  });
-
   test('should parse target', () => {
-    const element = {
-      _id: 't1',
+    const object = {
+      id: 't1',
       target: {
-        _id: 't1',
+        id: 't1',
       },
     };
 
-    const task = Task.fromObject(element);
+    const task = Task.fromObject(object);
 
     expect(task.id).toEqual('t1');
 
@@ -150,19 +102,19 @@ describe('Task Model parse tests', () => {
   });
 
   test('should parse alerts', () => {
-    const element = {
-      _id: 't1',
+    const object = {
+      id: 't1',
       alerts: [
         {
-          _id: 'a1',
+          id: 'a1',
         },
         {
-          _id: 'a2',
+          id: 'a2',
         },
       ],
     };
 
-    const task = Task.fromObject(element);
+    const task = Task.fromObject(object);
 
     expect(task.id).toEqual('t1');
 
@@ -175,14 +127,14 @@ describe('Task Model parse tests', () => {
   });
 
   test('should parse scanner', () => {
-    const element = {
-      _id: 't1',
+    const object = {
+      id: 't1',
       scanner: {
         id: 's1',
       },
     };
 
-    const task = Task.fromObject(element);
+    const task = Task.fromObject(object);
 
     expect(task.id).toEqual('t1');
 
@@ -192,14 +144,14 @@ describe('Task Model parse tests', () => {
   });
 
   test('should parse schedule', () => {
-    const element = {
-      _id: 't1',
+    const object = {
+      id: 't1',
       schedule: {
         id: 's1',
       },
     };
 
-    const task = Task.fromObject(element);
+    const task = Task.fromObject(object);
 
     expect(task.id).toEqual('t1');
 
@@ -209,7 +161,7 @@ describe('Task Model parse tests', () => {
   });
 
   test('should parse report counts', () => {
-    const element = {
+    const object = {
       id: 't1',
       reports: {
         counts: {
@@ -219,7 +171,7 @@ describe('Task Model parse tests', () => {
       },
     };
 
-    const task = Task.fromObject(element);
+    const task = Task.fromObject(object);
 
     expect(task.id).toEqual('t1');
 
@@ -228,8 +180,8 @@ describe('Task Model parse tests', () => {
   });
 
   test('should parse result counts', () => {
-    const element = {
-      _id: 't1',
+    const object = {
+      id: 't1',
       results: {
         counts: {
           current: 666,
@@ -237,7 +189,7 @@ describe('Task Model parse tests', () => {
       },
     };
 
-    const task = Task.fromObject(element);
+    const task = Task.fromObject(object);
 
     expect(task.id).toEqual('t1');
 
@@ -246,19 +198,19 @@ describe('Task Model parse tests', () => {
 
   test('should parse progress', () => {
     const task1 = Task.fromObject({
-      _id: 't1',
+      id: 't1',
     });
 
     expect(task1.progress).toEqual(0);
 
     const task2 = Task.fromObject({
-      _id: 't1',
+      id: 't1',
       progress: {},
     });
     expect(task2.progress).toEqual(0);
 
     const task3 = Task.fromObject({
-      _id: 't1',
+      id: 't1',
       progress: {
         __text: '66',
       },
@@ -266,7 +218,7 @@ describe('Task Model parse tests', () => {
     expect(task3.progress).toEqual(66);
 
     const task4 = Task.fromObject({
-      _id: 't1',
+      id: 't1',
       progress: '66',
     });
     expect(task4.progress).toEqual(66);
@@ -274,94 +226,41 @@ describe('Task Model parse tests', () => {
 
   test('should parse preferences', () => {
     const task1 = Task.fromObject({
-      _id: 't1',
-      preferences: [
-        {
-          name: 'in_assets',
-          value: 'yes',
-        },
-        {
-          name: 'assets_apply_overrides',
-          value: 'yes',
-        },
-        {
-          name: 'assets_min_qod',
-          value: '70',
-        },
-        {
-          name: 'auto_delete',
-          value: 'keep',
-        },
-        {
-          name: 'auto_delete_data',
-          value: 0,
-        },
-        {
-          name: 'max_hosts',
-          value: '20',
-        },
-        {
-          name: 'max_checks',
-          value: '4',
-        },
-        {
-          name: 'source_iface',
-          value: 'eth0',
-        },
-        {
-          value: 'bar',
-          name: 'foo',
-        },
-        {
-          value: 'ipsum',
-          name: 'lorem',
-        },
-      ],
+      id: 't1',
+      preferences: {
+        createAssets: true,
+        createAssetsApplyOverrides: true,
+        createAssetsMinQod: 70,
+        autoDeleteReports: 0,
+        maxConcurrentHosts: 20,
+        maxConcurrentNvts: 4,
+      },
     });
     const task2 = Task.fromObject({
-      _id: 't1',
-      preferences: [
-        {
-          name: 'in_assets',
-          value: 'no',
-        },
-        {
-          name: 'assets_apply_overrides',
-          value: 'no',
-        },
-        {
-          name: 'auto_delete',
-          value: 'no',
-        },
-        {
-          name: 'auto_delete_data',
-          value: 3,
-        },
-      ],
+      id: 't1',
+      preferences: {
+        createAssets: false,
+        createAssetsApplyOverrides: false,
+        autoDeleteReports: 3,
+      },
     });
 
-    expect(task1.inAssets).toEqual(1);
-    expect(task1.applyOverrides).toEqual(1);
-    expect(task1.minQod).toEqual(70);
-    expect(task1.autoDelete).toEqual('keep');
-    expect(task1.maxHosts).toEqual(20);
-    expect(task1.maxChecks).toEqual(4);
-    expect(task1.sourceIface).toEqual('eth0');
-    expect(task1.preferences).toEqual({
-      foo: {value: 'bar', name: 'foo'},
-      lorem: {value: 'ipsum', name: 'lorem'},
-    });
-    expect(task2.inAssets).toEqual(0);
-    expect(task2.applyOverrides).toEqual(0);
-    expect(task2.autoDelete).toEqual('no');
-    expect(task2.autoDeleteData).toEqual(3);
+    expect(task1.preferences.createAssets).toEqual(true);
+    expect(task1.preferences.createAssetsApplyOverrides).toEqual(true);
+    expect(task1.preferences.createAssetsMinQod).toEqual(70);
+    expect(task1.preferences.maxConcurrentHosts).toEqual(20);
+    expect(task1.preferences.maxConcurrentNvts).toEqual(4);
+    expect(task1.preferences.autoDeleteReports).toBe(0);
+    expect(task2.preferences.createAssets).toEqual(false);
+    expect(task2.preferences.createAssetsApplyOverrides).toEqual(false);
+    expect(task2.preferences.autoDeleteReports).toEqual(3);
   });
 });
 
 describe(`Task Model methods tests`, () => {
-  test('should be a container if target_id is not set', () => {
+  test('should be a container if targetid is not set', () => {
     const task1 = Task.fromObject({});
-    const task2 = Task.fromObject({target: {_id: 'foo'}});
+    const task2 = Task.fromObject({target: {id: 'foo'}});
 
     expect(task1.isContainer()).toEqual(true);
     expect(task2.isContainer()).toEqual(false);
@@ -369,18 +268,18 @@ describe(`Task Model methods tests`, () => {
 
   test('should use status for isActive', () => {
     const statusList = {
-      [TASK_STATUS.running]: true,
-      [TASK_STATUS.stoprequested]: true,
-      [TASK_STATUS.deleterequested]: true,
-      [TASK_STATUS.ultimatedeleterequested]: true,
-      [TASK_STATUS.resumerequested]: true,
-      [TASK_STATUS.requested]: true,
-      [TASK_STATUS.stopped]: false,
-      [TASK_STATUS.new]: false,
-      [TASK_STATUS.interrupted]: false,
-      [TASK_STATUS.container]: false,
-      [TASK_STATUS.uploading]: false,
-      [TASK_STATUS.done]: false,
+      [HYPERION_TASK_STATUS.running]: true,
+      [HYPERION_TASK_STATUS.stoprequested]: true,
+      [HYPERION_TASK_STATUS.deleterequested]: true,
+      [HYPERION_TASK_STATUS.ultimatedeleterequested]: true,
+      [HYPERION_TASK_STATUS.resumerequested]: true,
+      [HYPERION_TASK_STATUS.requested]: true,
+      [HYPERION_TASK_STATUS.stopped]: false,
+      [HYPERION_TASK_STATUS.new]: false,
+      [HYPERION_TASK_STATUS.interrupted]: false,
+      [HYPERION_TASK_STATUS.container]: false,
+      [HYPERION_TASK_STATUS.uploading]: false,
+      [HYPERION_TASK_STATUS.done]: false,
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
@@ -391,18 +290,18 @@ describe(`Task Model methods tests`, () => {
 
   test('should use status for isRunning', () => {
     const statusList = {
-      [TASK_STATUS.running]: true,
-      [TASK_STATUS.stoprequested]: false,
-      [TASK_STATUS.deleterequested]: false,
-      [TASK_STATUS.ultimatedeleterequested]: false,
-      [TASK_STATUS.resumerequested]: false,
-      [TASK_STATUS.requested]: false,
-      [TASK_STATUS.stopped]: false,
-      [TASK_STATUS.new]: false,
-      [TASK_STATUS.interrupted]: false,
-      [TASK_STATUS.container]: false,
-      [TASK_STATUS.uploading]: false,
-      [TASK_STATUS.done]: false,
+      [HYPERION_TASK_STATUS.running]: true,
+      [HYPERION_TASK_STATUS.stoprequested]: false,
+      [HYPERION_TASK_STATUS.deleterequested]: false,
+      [HYPERION_TASK_STATUS.ultimatedeleterequested]: false,
+      [HYPERION_TASK_STATUS.resumerequested]: false,
+      [HYPERION_TASK_STATUS.requested]: false,
+      [HYPERION_TASK_STATUS.stopped]: false,
+      [HYPERION_TASK_STATUS.new]: false,
+      [HYPERION_TASK_STATUS.interrupted]: false,
+      [HYPERION_TASK_STATUS.container]: false,
+      [HYPERION_TASK_STATUS.uploading]: false,
+      [HYPERION_TASK_STATUS.done]: false,
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
@@ -413,18 +312,18 @@ describe(`Task Model methods tests`, () => {
 
   test('should use status for isStopped', () => {
     const statusList = {
-      [TASK_STATUS.running]: false,
-      [TASK_STATUS.stoprequested]: false,
-      [TASK_STATUS.deleterequested]: false,
-      [TASK_STATUS.ultimatedeleterequested]: false,
-      [TASK_STATUS.resumerequested]: false,
-      [TASK_STATUS.requested]: false,
-      [TASK_STATUS.stopped]: true,
-      [TASK_STATUS.new]: false,
-      [TASK_STATUS.interrupted]: false,
-      [TASK_STATUS.container]: false,
-      [TASK_STATUS.uploading]: false,
-      [TASK_STATUS.done]: false,
+      [HYPERION_TASK_STATUS.running]: false,
+      [HYPERION_TASK_STATUS.stoprequested]: false,
+      [HYPERION_TASK_STATUS.deleterequested]: false,
+      [HYPERION_TASK_STATUS.ultimatedeleterequested]: false,
+      [HYPERION_TASK_STATUS.resumerequested]: false,
+      [HYPERION_TASK_STATUS.requested]: false,
+      [HYPERION_TASK_STATUS.stopped]: true,
+      [HYPERION_TASK_STATUS.new]: false,
+      [HYPERION_TASK_STATUS.interrupted]: false,
+      [HYPERION_TASK_STATUS.container]: false,
+      [HYPERION_TASK_STATUS.uploading]: false,
+      [HYPERION_TASK_STATUS.done]: false,
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
@@ -435,18 +334,18 @@ describe(`Task Model methods tests`, () => {
 
   test('should use status for isInterrupted', () => {
     const statusList = {
-      [TASK_STATUS.running]: false,
-      [TASK_STATUS.stoprequested]: false,
-      [TASK_STATUS.deleterequested]: false,
-      [TASK_STATUS.ultimatedeleterequested]: false,
-      [TASK_STATUS.resumerequested]: false,
-      [TASK_STATUS.requested]: false,
-      [TASK_STATUS.stopped]: false,
-      [TASK_STATUS.new]: false,
-      [TASK_STATUS.interrupted]: true,
-      [TASK_STATUS.container]: false,
-      [TASK_STATUS.uploading]: false,
-      [TASK_STATUS.done]: false,
+      [HYPERION_TASK_STATUS.running]: false,
+      [HYPERION_TASK_STATUS.stoprequested]: false,
+      [HYPERION_TASK_STATUS.deleterequested]: false,
+      [HYPERION_TASK_STATUS.ultimatedeleterequested]: false,
+      [HYPERION_TASK_STATUS.resumerequested]: false,
+      [HYPERION_TASK_STATUS.requested]: false,
+      [HYPERION_TASK_STATUS.stopped]: false,
+      [HYPERION_TASK_STATUS.new]: false,
+      [HYPERION_TASK_STATUS.interrupted]: true,
+      [HYPERION_TASK_STATUS.container]: false,
+      [HYPERION_TASK_STATUS.uploading]: false,
+      [HYPERION_TASK_STATUS.done]: false,
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
@@ -457,18 +356,18 @@ describe(`Task Model methods tests`, () => {
 
   test('should use status for isNew', () => {
     const statusList = {
-      [TASK_STATUS.running]: false,
-      [TASK_STATUS.stoprequested]: false,
-      [TASK_STATUS.deleterequested]: false,
-      [TASK_STATUS.ultimatedeleterequested]: false,
-      [TASK_STATUS.resumerequested]: false,
-      [TASK_STATUS.requested]: false,
-      [TASK_STATUS.stopped]: false,
-      [TASK_STATUS.new]: true,
-      [TASK_STATUS.interrupted]: false,
-      [TASK_STATUS.container]: false,
-      [TASK_STATUS.uploading]: false,
-      [TASK_STATUS.done]: false,
+      [HYPERION_TASK_STATUS.running]: false,
+      [HYPERION_TASK_STATUS.stoprequested]: false,
+      [HYPERION_TASK_STATUS.deleterequested]: false,
+      [HYPERION_TASK_STATUS.ultimatedeleterequested]: false,
+      [HYPERION_TASK_STATUS.resumerequested]: false,
+      [HYPERION_TASK_STATUS.requested]: false,
+      [HYPERION_TASK_STATUS.stopped]: false,
+      [HYPERION_TASK_STATUS.new]: true,
+      [HYPERION_TASK_STATUS.interrupted]: false,
+      [HYPERION_TASK_STATUS.container]: false,
+      [HYPERION_TASK_STATUS.uploading]: false,
+      [HYPERION_TASK_STATUS.done]: false,
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
@@ -478,10 +377,13 @@ describe(`Task Model methods tests`, () => {
   });
 
   test('should be changeable if alterable or new', () => {
-    let task = Task.fromObject({status: TASK_STATUS.new, alterable: '0'});
+    let task = Task.fromObject({
+      status: HYPERION_TASK_STATUS.new,
+      alterable: '0',
+    });
     expect(task.isChangeable()).toEqual(true);
 
-    task = Task.fromObject({status: TASK_STATUS.done, alterable: '1'});
+    task = Task.fromObject({status: HYPERION_TASK_STATUS.done, alterable: '1'});
     expect(task.isChangeable()).toEqual(true);
   });
 

--- a/gsa/src/gmp/models/audit.js
+++ b/gsa/src/gmp/models/audit.js
@@ -296,10 +296,7 @@ class Audit extends Model {
           case 'max_hosts':
           case 'max_checks':
             copy[pref.scanner_name] = parseInt(pref.value);
-            break;
-          case 'source_iface':
-            copy.source_iface = pref.value;
-            break;
+            break; // no more source_iface
           default:
             prefs[pref.scanner_name] = {value: pref.value, name: pref.name};
             break;
@@ -313,13 +310,7 @@ class Audit extends Model {
       copy.average_duration = parseDuration(element.average_duration);
     }
 
-    if (
-      copy.hosts_ordering !== HOSTS_ORDERING_RANDOM &&
-      copy.hosts_ordering !== HOSTS_ORDERING_REVERSE &&
-      copy.hosts_ordering !== HOSTS_ORDERING_SEQUENTIAL
-    ) {
-      delete copy.hosts_ordering;
-    }
+    // no more hosts_ordering
 
     return copy;
   }

--- a/gsa/src/gmp/models/audit.js
+++ b/gsa/src/gmp/models/audit.js
@@ -49,6 +49,7 @@ import {
   DEFAULT_MIN_QOD,
   TASK_STATUS as AUDIT_STATUS,
   getTranslatableTaskStatus as getTranslatableAuditStatus,
+  getTranslatableHyperionTaskStatus as getTranslatableHyperionAuditStatus,
   isActive,
 } from './task';
 import Policy from './policy';
@@ -170,66 +171,14 @@ class Audit extends Model {
       copy.progress = 0;
     }
 
-    const prefs = {};
-
-    if (copy.preferences && isArray(object.preferences)) {
-      for (const pref of object.preferences) {
-        switch (pref.name) {
-          case 'in_assets':
-            copy.inAssets = parseYes(pref.value);
-            break;
-          case 'assets_apply_overrides':
-            copy.applyOverrides = parseYes(pref.value);
-            break;
-          case 'assets_min_qod':
-            copy.minQod = parseInt(pref.value);
-            break;
-          case 'auto_delete':
-            copy.autoDelete =
-              pref.value === AUTO_DELETE_KEEP
-                ? AUTO_DELETE_KEEP
-                : AUTO_DELETE_NO;
-            break;
-          case 'auto_delete_data':
-            copy.autoDeleteData =
-              pref.value === '0'
-                ? AUTO_DELETE_KEEP_DEFAULT_VALUE
-                : parseInt(pref.value);
-            break;
-          case 'max_hosts':
-            copy.maxHosts = parseInt(pref.value);
-            delete copy.max_hosts;
-            break;
-          case 'max_checks':
-            copy.maxChecks = parseInt(pref.value);
-            delete copy.max_checks;
-            break;
-          case 'source_iface':
-            copy.sourceIface = pref.value; // is this defined in selene?
-            delete copy.source_iface;
-            break;
-          default:
-            prefs[pref.name] = {value: pref.value, name: pref.name};
-            break;
-        }
-      }
-    }
-
-    copy.preferences = prefs;
-
     if (hasValue(object.averageDuration)) {
       copy.averageDuration = parseDuration(object.averageDuration);
     }
 
-    if (hasValue(object.hostsOrdering)) {
-      copy.hostsOrdering = object.hostsOrdering.toLowerCase();
-    }
-    if (
-      copy.hostsOrdering !== HOSTS_ORDERING_RANDOM &&
-      copy.hostsOrdering !== HOSTS_ORDERING_REVERSE &&
-      copy.hostsOrdering !== HOSTS_ORDERING_SEQUENTIAL
-    ) {
-      delete copy.hostsOrdering;
+    if (hasValue(object.status)) {
+      copy.status = getTranslatableHyperionAuditStatus(object.status);
+    } else {
+      delete copy.status;
     }
 
     return copy;

--- a/gsa/src/gmp/models/audit.js
+++ b/gsa/src/gmp/models/audit.js
@@ -47,6 +47,7 @@ import {
   DEFAULT_MAX_CHECKS,
   DEFAULT_MAX_HOSTS,
   DEFAULT_MIN_QOD,
+  HYPERION_TASK_STATUS as HYPERION_AUDIT_STATUS,
   TASK_STATUS as AUDIT_STATUS,
   getTranslatableTaskStatus as getTranslatableAuditStatus,
   getTranslatableHyperionTaskStatus as getTranslatableHyperionAuditStatus,
@@ -65,6 +66,7 @@ export {
   DEFAULT_MAX_HOSTS,
   DEFAULT_MIN_QOD,
   AUDIT_STATUS,
+  HYPERION_AUDIT_STATUS,
   getTranslatableAuditStatus,
   isActive,
 };

--- a/gsa/src/gmp/models/scanconfig.js
+++ b/gsa/src/gmp/models/scanconfig.js
@@ -37,6 +37,12 @@ export const OPENVAS_SCAN_CONFIG_TYPE = 0;
 export const SCANCONFIG_TREND_DYNAMIC = 1;
 export const SCANCONFIG_TREND_STATIC = 0;
 
+export const SCAN_CONFIG_TYPE = {
+  // for hyperion enum
+  openvas: 'OPENVAS',
+  osp: 'OSP',
+};
+
 export const getTranslatedType = config => {
   return config.scanConfigType === OSP_SCAN_CONFIG_TYPE
     ? _('OSP')

--- a/gsa/src/gmp/models/task.js
+++ b/gsa/src/gmp/models/task.js
@@ -85,10 +85,28 @@ const TASK_STATUS_TRANSLATIONS = {
   Done: _l('Done'),
   Queued: _l('Queued'),
 };
+const HYPERION_TASK_STATUS_TRANSLATIONS = {
+  RUNNING: _l('Running'),
+  STOP_REQUESTED: _l('Stop Requested'),
+  DELETE_REQUESTED: _l('Delete Requested'),
+  ULTIMATE_DELETE_REQUESTED: _l('Ultimate Delete Requested'),
+  RESUME_REQUESTED: _l('Resume Requested'),
+  REQUESTED: _l('Requested'),
+  STOPPED: _l('Stopped'),
+  NEW: _l('New'),
+  INTERRUPTED: _l('Interrupted'),
+  CONTAINER: _l('Container'),
+  UPLOADING: _l('Uploading'),
+  DONE: _l('Done'),
+  QUEUED: _l('Queued'),
+};
 /* eslint-disable quote-props */
 
 export const getTranslatableTaskStatus = status =>
   `${TASK_STATUS_TRANSLATIONS[status]}`;
+
+export const getTranslatableHyperionTaskStatus = status =>
+  `${HYPERION_TASK_STATUS_TRANSLATIONS[status]}`;
 
 export const isActive = status =>
   status === TASK_STATUS.running ||
@@ -202,66 +220,8 @@ class Task extends Model {
 
     copy.progress = parseProgressElement(object.progress);
 
-    const prefs = {};
-
-    if (copy.preferences && isArray(object.preferences)) {
-      for (const pref of object.preferences) {
-        switch (pref.name) {
-          case 'in_assets':
-            copy.inAssets = parseYes(pref.value);
-            break;
-          case 'assets_apply_overrides':
-            copy.applyOverrides = parseYes(pref.value);
-            break;
-          case 'assets_min_qod':
-            copy.minQod = parseInt(pref.value);
-            break;
-          case 'auto_delete':
-            copy.autoDelete =
-              pref.value === AUTO_DELETE_KEEP
-                ? AUTO_DELETE_KEEP
-                : AUTO_DELETE_NO;
-            break;
-          case 'auto_delete_data':
-            copy.autoDeleteData =
-              pref.value === '0'
-                ? AUTO_DELETE_KEEP_DEFAULT_VALUE
-                : parseInt(pref.value);
-            break;
-          case 'max_hosts':
-            copy.maxHosts = parseInt(pref.value);
-            delete copy.max_hosts;
-            break;
-          case 'max_checks':
-            copy.maxChecks = parseInt(pref.value);
-            delete copy.max_checks;
-            break;
-          case 'source_iface':
-            copy.sourceIface = pref.value; // is this defined in selene?
-            delete copy.source_iface;
-            break;
-          default:
-            prefs[pref.name] = {value: pref.value, name: pref.name};
-            break;
-        }
-      }
-    }
-
-    copy.preferences = prefs;
-
     if (isDefined(object.average_duration)) {
       copy.averageDuration = parseDuration(object.average_duration);
-    }
-
-    if (hasValue(object.hostsOrdering)) {
-      copy.hostsOrdering = object.hostsOrdering.toLowerCase();
-    }
-    if (
-      copy.hostsOrdering !== HOSTS_ORDERING_RANDOM &&
-      copy.hostsOrdering !== HOSTS_ORDERING_REVERSE &&
-      copy.hostsOrdering !== HOSTS_ORDERING_SEQUENTIAL
-    ) {
-      delete copy.hostsOrdering;
     }
 
     if (hasValue(object.userTags)) {
@@ -270,6 +230,12 @@ class Task extends Model {
       });
     } else {
       copy.userTags = [];
+    }
+
+    if (hasValue(object.status)) {
+      copy.status = getTranslatableHyperionTaskStatus(object.status);
+    } else {
+      delete copy.status;
     }
 
     return copy;

--- a/gsa/src/gmp/models/task.js
+++ b/gsa/src/gmp/models/task.js
@@ -69,6 +69,22 @@ export const TASK_STATUS = {
   done: 'Done',
 };
 
+export const HYPERION_TASK_STATUS = {
+  queued: 'QUEUED',
+  running: 'RUNNING',
+  stoprequested: 'STOP_REQUESTED',
+  deleterequested: 'DELETE_REQUESTED',
+  ultimatedeleterequested: 'ULTIMATE_DELETE_REQUESTED',
+  resumerequested: 'RESUME_REQUESTED',
+  requested: 'REQUESTED',
+  stopped: 'STOPPED',
+  new: 'NEW',
+  interrupted: 'INTERRUPTED',
+  container: 'CONTAINER',
+  uploading: 'UPLOADING',
+  done: 'DONE',
+};
+
 /* eslint-disable quote-props */
 const TASK_STATUS_TRANSLATIONS = {
   Running: _l('Running'),

--- a/gsa/src/gmp/models/task.js
+++ b/gsa/src/gmp/models/task.js
@@ -53,6 +53,14 @@ export const DEFAULT_MAX_CHECKS = 4;
 export const DEFAULT_MAX_HOSTS = 20;
 export const DEFAULT_MIN_QOD = 70;
 
+export const TASK_TREND = {
+  up: 'UP',
+  down: 'DOWN',
+  more: 'MORE',
+  less: 'LESS',
+  same: 'SAME',
+};
+
 export const TASK_STATUS = {
   queued: 'Queued',
   running: 'Running',

--- a/gsa/src/gmp/models/task.js
+++ b/gsa/src/gmp/models/task.js
@@ -367,10 +367,7 @@ class Task extends Model {
             break;
           case 'max_checks':
             copy.maxChecks = parseInt(pref.value);
-            break;
-          case 'source_iface':
-            copy.sourceIface = pref.value;
-            break;
+            break; // no more source_iface
           default:
             prefs[pref.scanner_name] = {value: pref.value, name: pref.name};
             break;
@@ -381,13 +378,7 @@ class Task extends Model {
     copy.preferences = prefs;
 
     // no average duration in trash
-    if (
-      copy.hostsOrdering !== HOSTS_ORDERING_RANDOM &&
-      copy.hostsOrdering !== HOSTS_ORDERING_REVERSE &&
-      copy.hostsOrdering !== HOSTS_ORDERING_SEQUENTIAL
-    ) {
-      delete copy.hosts_ordering;
-    }
+    // no more hosts_ordering!
 
     copy.usageType = element.usage_type;
 

--- a/gsa/src/web/graphql/__mocks__/audits.js
+++ b/gsa/src/web/graphql/__mocks__/audits.js
@@ -16,7 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 import {
   createGenericQueryMock,
   createGenericMutationResult,

--- a/gsa/src/web/graphql/__mocks__/audits.js
+++ b/gsa/src/web/graphql/__mocks__/audits.js
@@ -16,6 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {HYPERION_AUDIT_STATUS} from 'gmp/models/audit';
+
 import {
   createGenericQueryMock,
   createGenericMutationResult,
@@ -237,7 +239,7 @@ export const auditDetailsAudit = deepFreeze({
     },
   },
   results: null,
-  status: 'DONE',
+  status: HYPERION_AUDIT_STATUS.done,
   progress: null,
   target: auditDetailsTarget,
   trend: null,
@@ -273,7 +275,7 @@ export const detailsMockAudit = deepFreeze({
       current: 20,
     },
   },
-  status: 'DONE',
+  status: HYPERION_AUDIT_STATUS.done,
   progress: 100,
   target,
   trend: null,
@@ -309,7 +311,7 @@ export const unscheduledAudit = deepFreeze({
       current: 20,
     },
   },
-  status: 'STOPPED',
+  status: HYPERION_AUDIT_STATUS.stopped,
   progress: 100,
   target,
   trend: null,

--- a/gsa/src/web/graphql/__mocks__/audits.js
+++ b/gsa/src/web/graphql/__mocks__/audits.js
@@ -16,7 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {AUDIT_STATUS} from 'gmp/models/audit';
 import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 import {
   createGenericQueryMock,
@@ -74,7 +73,6 @@ export const auditPolicy = deepFreeze({
   creationTime: null,
   modificationTime: null,
   permissions: null,
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   trash: null,
   familyCount: null,
   familyGrowing: null,
@@ -101,7 +99,6 @@ export const auditDetailsPolicy = deepFreeze({
   creationTime: null,
   modificationTime: null,
   permissions: null,
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   trash: null,
   familyCount: null,
   familyGrowing: null,
@@ -124,8 +121,7 @@ export const auditDetailsPolicy = deepFreeze({
 // Reports
 const lastReport = deepFreeze({
   id: '1234',
-  severity: '5.0',
-  timestamp: '2019-07-30T13:23:30Z',
+  creationTime: '2019-07-30T13:23:30Z',
   scanStart: '2019-07-30T13:23:34Z',
   scanEnd: '2019-07-30T13:25:43Z',
   complianceCount: {
@@ -146,7 +142,7 @@ const auditDetailsLastReport = deepFreeze({
 
 const currentReport = deepFreeze({
   id: '5678',
-  timestamp: '2019-08-30T13:23:30Z',
+  creationTime: '2019-08-30T13:23:30Z',
   scanStart: '2019-08-30T13:23:34Z',
 });
 
@@ -213,61 +209,18 @@ const observers = deepFreeze({
 });
 
 // Preferences
-const preferences = deepFreeze([
-  {
-    description: 'Add results to Asset Management',
-    name: 'in_assets',
-    value: 'yes',
-  },
-  {
-    description: 'Apply Overrides when adding Assets',
-    name: 'assets_apply_overrides',
-    value: 'yes',
-  },
-  {
-    description: 'Min QOD when adding Assets',
-    name: 'assets_min_qod',
-    value: '70',
-  },
-  {
-    description: 'Auto Delete Reports',
-    name: 'auto_delete',
-    value: 'no',
-  },
-  {
-    description: 'Auto Delete Reports Data',
-    name: 'auto_delete_data',
-    value: '5',
-  },
-  {
-    description: 'Maximum concurrently executed NVTs per host',
-    name: 'max_checks',
-    value: '4',
-  },
-  {
-    description: 'Maximum concurrently scanned hosts',
-    name: 'max_hosts',
-    value: '20',
-  },
-]);
+const preferences = deepFreeze({
+  createAssets: true,
+  createAssetsApplyOverrides: true,
+  createAssetsMinQod: 70,
+  autoDeleteReports: 5,
+  maxConcurrentNvts: 4,
+  maxConcurrentHosts: 20,
+});
 
-const auditDetailsPreferences = deepFreeze([
-  {
-    name: 'Add results to Asset Management',
-    scanner_name: 'in_assets',
-    value: 'yes',
-  },
-  {
-    name: 'Auto Delete Reports',
-    scanner_name: 'auto_delete',
-    value: 'no',
-  },
-  {
-    description: 'Add results to Asset Management',
-    name: 'in_assets',
-    value: 'yes',
-  },
-]);
+const auditDetailsPreferences = deepFreeze({
+  createAssets: true, // if no autoDeleteReports field, then auto_delete is no
+});
 
 export const auditDetailsAudit = deepFreeze({
   name: 'foo',
@@ -285,7 +238,7 @@ export const auditDetailsAudit = deepFreeze({
     },
   },
   results: null,
-  status: AUDIT_STATUS.done,
+  status: 'DONE',
   progress: null,
   target: auditDetailsTarget,
   trend: null,
@@ -298,7 +251,6 @@ export const auditDetailsAudit = deepFreeze({
   policy: auditDetailsPolicy,
   scanner: auditDetailsScanner,
   schedulePeriods: null,
-  hostsOrdering: null,
   observers: null,
 });
 
@@ -322,7 +274,7 @@ export const detailsMockAudit = deepFreeze({
       current: 20,
     },
   },
-  status: AUDIT_STATUS.done,
+  status: 'DONE',
   progress: 100,
   target,
   trend: null,
@@ -335,7 +287,6 @@ export const detailsMockAudit = deepFreeze({
   policy: auditPolicy,
   scanner,
   schedulePeriods: null,
-  hostsOrdering: 'sequential',
   observers,
 });
 
@@ -359,7 +310,7 @@ export const unscheduledAudit = deepFreeze({
       current: 20,
     },
   },
-  status: AUDIT_STATUS.stopped,
+  status: 'STOPPED',
   progress: 100,
   target,
   trend: null,
@@ -372,7 +323,6 @@ export const unscheduledAudit = deepFreeze({
   policy: auditPolicy,
   scanner,
   schedulePeriods: null,
-  hostsOrdering: 'sequential',
   observers,
 });
 

--- a/gsa/src/web/graphql/__mocks__/tasks.js
+++ b/gsa/src/web/graphql/__mocks__/tasks.js
@@ -16,9 +16,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {TASK_STATUS} from 'gmp/models/task';
-import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
-
 import {
   CLONE_TASK,
   CREATE_CONTAINER_TASK,
@@ -56,24 +53,21 @@ const scanner = deepFreeze({
 const scanConfig = deepFreeze({
   id: '314',
   name: 'foo',
-  comment: 'bar',
   trash: false,
-  scanner: scanner,
-  type: OPENVAS_SCAN_CONFIG_TYPE,
+  type: 'OPENVAS',
 });
 
 // Reports
 const lastReport = deepFreeze({
   id: '1234',
-  severity: '5.0',
-  timestamp: '2019-07-30T13:23:30Z',
+  severity: 5.0,
+  creationTime: '2019-07-30T13:23:30Z',
   scanStart: '2019-07-30T13:23:34Z',
   scanEnd: '2019-07-30T13:25:43Z',
 });
 
 const currentReport = deepFreeze({
   id: '5678',
-  timestamp: '2019-08-30T13:23:30Z',
   scanStart: '2019-08-30T13:23:34Z',
 });
 
@@ -129,43 +123,14 @@ const observers = deepFreeze({
 });
 
 // Preferences
-const preferences = deepFreeze([
-  {
-    description: 'Add results to Asset Management',
-    name: 'in_assets',
-    value: 'yes',
-  },
-  {
-    description: 'Apply Overrides when adding Assets',
-    name: 'assets_apply_overrides',
-    value: 'yes',
-  },
-  {
-    description: 'Min QOD when adding Assets',
-    name: 'assets_min_qod',
-    value: '70',
-  },
-  {
-    description: 'Auto Delete Reports',
-    name: 'auto_delete',
-    value: 'no',
-  },
-  {
-    description: 'Auto Delete Reports Data',
-    name: 'auto_delete_data',
-    value: '5',
-  },
-  {
-    description: 'Maximum concurrently executed NVTs per host',
-    name: 'max_checks',
-    value: '4',
-  },
-  {
-    description: 'Maximum concurrently scanned hosts',
-    name: 'max_hosts',
-    value: '20',
-  },
-]);
+const preferences = deepFreeze({
+  createAssets: true,
+  createAssetsApplyOverrides: true,
+  createAssetsMinQod: 70,
+  autoDeleteReports: 5,
+  maxConcurrentNvts: 4,
+  maxConcurrentHosts: 20,
+});
 
 const listMockTask = deepFreeze({
   name: 'foo',
@@ -180,9 +145,9 @@ const listMockTask = deepFreeze({
     },
   },
   progress: 100,
-  status: TASK_STATUS.done,
+  status: 'DONE',
   target,
-  trend: 'up',
+  trend: 'UP',
   alterable: 0,
   comment: 'bar',
   owner: 'admin',
@@ -191,7 +156,6 @@ const listMockTask = deepFreeze({
   alerts: [],
   scanConfig,
   scanner,
-  hostsOrdering: null,
   observers,
 });
 
@@ -232,7 +196,7 @@ const detailsMockTask = deepFreeze({
     },
   },
   progress: 100,
-  status: TASK_STATUS.stopped,
+  status: 'STOPPED',
   target,
   alterable: 0,
   trend: null,
@@ -244,7 +208,6 @@ const detailsMockTask = deepFreeze({
   scanConfig,
   scanner,
   schedulePeriods: null,
-  hostsOrdering: 'sequential',
   userTags: null,
   observers,
   results: {

--- a/gsa/src/web/graphql/__mocks__/tasks.js
+++ b/gsa/src/web/graphql/__mocks__/tasks.js
@@ -16,6 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {HYPERION_TASK_STATUS, TASK_TREND} from 'gmp/models/task';
+
 import {
   CLONE_TASK,
   CREATE_CONTAINER_TASK,
@@ -145,9 +147,9 @@ const listMockTask = deepFreeze({
     },
   },
   progress: 100,
-  status: 'DONE',
+  status: HYPERION_TASK_STATUS.done,
   target,
-  trend: 'UP',
+  trend: TASK_TREND.up,
   alterable: 0,
   comment: 'bar',
   owner: 'admin',
@@ -196,7 +198,7 @@ const detailsMockTask = deepFreeze({
     },
   },
   progress: 100,
-  status: 'STOPPED',
+  status: HYPERION_TASK_STATUS.stopped,
   target,
   alterable: 0,
   trend: null,

--- a/gsa/src/web/graphql/__mocks__/tasks.js
+++ b/gsa/src/web/graphql/__mocks__/tasks.js
@@ -16,6 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 import {HYPERION_TASK_STATUS, TASK_TREND} from 'gmp/models/task';
 
 import {
@@ -56,7 +57,7 @@ const scanConfig = deepFreeze({
   id: '314',
   name: 'foo',
   trash: false,
-  type: 'OPENVAS',
+  type: SCAN_CONFIG_TYPE.openvas,
 });
 
 // Reports

--- a/gsa/src/web/graphql/audits.js
+++ b/gsa/src/web/graphql/audits.js
@@ -106,8 +106,7 @@ export const GET_AUDIT = gql`
       reports {
         lastReport {
           id
-          severity
-          timestamp
+          creationTime
           scanStart
           scanEnd
           complianceCount {
@@ -119,7 +118,7 @@ export const GET_AUDIT = gql`
         currentReport {
           id
           scanStart
-          timestamp
+          creationTime
         }
         counts {
           total
@@ -142,9 +141,12 @@ export const GET_AUDIT = gql`
       comment
       owner
       preferences {
-        name
-        value
-        description
+        autoDeleteReports
+        createAssets
+        createAssetsApplyOverrides
+        createAssetsMinQod
+        maxConcurrentNvts
+        maxConcurrentHosts
       }
       schedule {
         name
@@ -161,7 +163,6 @@ export const GET_AUDIT = gql`
         id
         name
         trash
-        type
       }
       scanner {
         id
@@ -169,7 +170,6 @@ export const GET_AUDIT = gql`
         type
       }
       schedulePeriods
-      hostsOrdering
       observers {
         users
         roles {
@@ -211,8 +211,7 @@ export const GET_AUDITS = gql`
           reports {
             lastReport {
               id
-              severity
-              timestamp
+              creationTime
               scanStart
               scanEnd
               complianceCount {
@@ -224,7 +223,7 @@ export const GET_AUDITS = gql`
             currentReport {
               id
               scanStart
-              timestamp
+              creationTime
             }
             counts {
               total
@@ -247,9 +246,12 @@ export const GET_AUDITS = gql`
           comment
           owner
           preferences {
-            name
-            value
-            description
+            autoDeleteReports
+            createAssets
+            createAssetsApplyOverrides
+            createAssetsMinQod
+            maxConcurrentNvts
+            maxConcurrentHosts
           }
           schedule {
             name
@@ -266,7 +268,6 @@ export const GET_AUDITS = gql`
             id
             name
             trash
-            type
           }
           scanner {
             id
@@ -274,7 +275,6 @@ export const GET_AUDITS = gql`
             type
           }
           schedulePeriods
-          hostsOrdering
           observers {
             users
             roles {

--- a/gsa/src/web/graphql/policies.js
+++ b/gsa/src/web/graphql/policies.js
@@ -45,7 +45,6 @@ export const GET_POLICY = gql`
       permissions {
         name
       }
-      type
       trash
       familyCount
       nvtGrowing

--- a/gsa/src/web/graphql/tasks.js
+++ b/gsa/src/web/graphql/tasks.js
@@ -87,7 +87,7 @@ export const GET_TASK = gql`
         lastReport {
           id
           severity
-          timestamp
+          creationTime
           scanStart
           scanEnd
         }
@@ -116,9 +116,12 @@ export const GET_TASK = gql`
       comment
       owner
       preferences {
-        name
-        value
-        description
+        autoDeleteReports
+        createAssets
+        createAssetsApplyOverrides
+        createAssetsMinQod
+        maxConcurrentNvts
+        maxConcurrentHosts
       }
       schedule {
         name
@@ -143,7 +146,6 @@ export const GET_TASK = gql`
         type
       }
       schedulePeriods
-      hostsOrdering
       userTags {
         count
         tags {
@@ -196,7 +198,8 @@ export const GET_TASKS = gql`
             lastReport {
               id
               severity
-              timestamp
+              creationTime
+              scanStart
             }
             counts {
               total
@@ -214,9 +217,12 @@ export const GET_TASKS = gql`
           comment
           owner
           preferences {
-            name
-            value
-            description
+            autoDeleteReports
+            createAssets
+            createAssetsApplyOverrides
+            createAssetsMinQod
+            maxConcurrentNvts
+            maxConcurrentHosts
           }
           schedule {
             name
@@ -239,7 +245,6 @@ export const GET_TASKS = gql`
             name
             type
           }
-          hostsOrdering
           observers {
             users
             roles {

--- a/gsa/src/web/pages/audits/__tests__/__snapshots__/detailspage.js.snap
+++ b/gsa/src/web/pages/audits/__tests__/__snapshots__/detailspage.js.snap
@@ -1250,36 +1250,6 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                           <div
                             class="c28"
                           >
-                            Order for target hosts
-                          </div>
-                        </td>
-                        <td>
-                          <div
-                            class="c28"
-                          >
-                            sequential
-                          </div>
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>
-                          <div
-                            class="c28"
-                          >
-                            Network Source Interface
-                          </div>
-                        </td>
-                        <td>
-                          <div
-                            class="c28"
-                          />
-                        </td>
-                      </tr>
-                      <tr>
-                        <td>
-                          <div
-                            class="c28"
-                          >
                             Maximum concurrently executed NVTs per host
                           </div>
                         </td>
@@ -1488,7 +1458,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                           <div
                             class="c28"
                           >
-                            Do not automatically delete reports
+                            Automatically delete oldest reports but always keep newest 5 reports
                           </div>
                         </td>
                       </tr>

--- a/gsa/src/web/pages/audits/__tests__/actions.js
+++ b/gsa/src/web/pages/audits/__tests__/actions.js
@@ -26,7 +26,7 @@ import {rendererWith, fireEvent} from 'web/utils/testing';
 import Theme from 'web/utils/theme';
 
 import Actions from '../actions';
-import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
+import Audit from 'gmp/models/audit';
 
 setLocale('en');
 
@@ -41,7 +41,7 @@ describe('Audit Actions tests', () => {
 
   test('should render', () => {
     const audit = Audit.fromObject({
-      status: AUDIT_STATUS.new,
+      status: 'NEW',
       alterable: false,
       reports: {
         lastReport: {id: 'id'},
@@ -82,7 +82,7 @@ describe('Audit Actions tests', () => {
 
   test('should call click handlers', () => {
     const audit = Audit.fromObject({
-      status: AUDIT_STATUS.done,
+      status: 'DONE',
       alterable: false,
       reports: {
         lastReport: {id: 'id'},
@@ -155,7 +155,7 @@ describe('Audit Actions tests', () => {
 
   test('should not call click handlers without permissions', () => {
     const audit = Audit.fromObject({
-      status: AUDIT_STATUS.done,
+      status: 'DONE',
       alterable: false,
       reports: {
         lastReport: {id: 'id'},
@@ -240,7 +240,7 @@ describe('Audit Actions tests', () => {
 
   test('should not call click handlers for stopped audit without permissions', () => {
     const audit = Audit.fromObject({
-      status: AUDIT_STATUS.stopped,
+      status: 'STOPPED',
       alterable: false,
       reports: {
         lastReport: {id: 'id'},
@@ -327,7 +327,7 @@ describe('Audit Actions tests', () => {
 
   test('should not call click handlers for running audit without permissions', () => {
     const audit = Audit.fromObject({
-      status: AUDIT_STATUS.running,
+      status: 'RUNNING',
       alterable: false,
       reports: {
         lastReport: {id: 'id'},
@@ -411,7 +411,7 @@ describe('Audit Actions tests', () => {
 
   test('should call click handlers for running audit', () => {
     const audit = Audit.fromObject({
-      status: AUDIT_STATUS.running,
+      status: 'RUNNING',
       alterable: false,
       inUse: true,
       permissions: [{name: 'everything'}],
@@ -480,7 +480,7 @@ describe('Audit Actions tests', () => {
 
   test('should call click handlers for stopped audit', () => {
     const audit = Audit.fromObject({
-      status: AUDIT_STATUS.stopped,
+      status: 'STOPPED',
       alterable: false,
       reports: {
         lastReport: {id: 'id'},
@@ -553,7 +553,7 @@ describe('Audit Actions tests', () => {
 
   test('should disable report download if grc format is not defined', () => {
     const audit = Audit.fromObject({
-      status: AUDIT_STATUS.stopped,
+      status: 'STOPPED',
       alterable: false,
       reports: {
         lastReport: {id: 'id'},
@@ -602,7 +602,7 @@ describe('Audit Actions tests', () => {
 
   test('should render schedule icon if task is scheduled', () => {
     const audit = Audit.fromObject({
-      status: AUDIT_STATUS.stopped,
+      status: 'STOPPED',
       alterable: false,
       reports: {
         lastReport: {id: 'id'},

--- a/gsa/src/web/pages/audits/__tests__/actions.js
+++ b/gsa/src/web/pages/audits/__tests__/actions.js
@@ -26,7 +26,7 @@ import {rendererWith, fireEvent} from 'web/utils/testing';
 import Theme from 'web/utils/theme';
 
 import Actions from '../actions';
-import Audit from 'gmp/models/audit';
+import Audit, {HYPERION_AUDIT_STATUS} from 'gmp/models/audit';
 
 setLocale('en');
 
@@ -41,7 +41,7 @@ describe('Audit Actions tests', () => {
 
   test('should render', () => {
     const audit = Audit.fromObject({
-      status: 'NEW',
+      status: HYPERION_AUDIT_STATUS.new,
       alterable: false,
       reports: {
         lastReport: {id: 'id'},
@@ -82,7 +82,7 @@ describe('Audit Actions tests', () => {
 
   test('should call click handlers', () => {
     const audit = Audit.fromObject({
-      status: 'DONE',
+      status: HYPERION_AUDIT_STATUS.done,
       alterable: false,
       reports: {
         lastReport: {id: 'id'},
@@ -155,7 +155,7 @@ describe('Audit Actions tests', () => {
 
   test('should not call click handlers without permissions', () => {
     const audit = Audit.fromObject({
-      status: 'DONE',
+      status: HYPERION_AUDIT_STATUS.done,
       alterable: false,
       reports: {
         lastReport: {id: 'id'},
@@ -240,7 +240,7 @@ describe('Audit Actions tests', () => {
 
   test('should not call click handlers for stopped audit without permissions', () => {
     const audit = Audit.fromObject({
-      status: 'STOPPED',
+      status: HYPERION_AUDIT_STATUS.stopped,
       alterable: false,
       reports: {
         lastReport: {id: 'id'},
@@ -327,7 +327,7 @@ describe('Audit Actions tests', () => {
 
   test('should not call click handlers for running audit without permissions', () => {
     const audit = Audit.fromObject({
-      status: 'RUNNING',
+      status: HYPERION_AUDIT_STATUS.running,
       alterable: false,
       reports: {
         lastReport: {id: 'id'},
@@ -411,7 +411,7 @@ describe('Audit Actions tests', () => {
 
   test('should call click handlers for running audit', () => {
     const audit = Audit.fromObject({
-      status: 'RUNNING',
+      status: HYPERION_AUDIT_STATUS.running,
       alterable: false,
       inUse: true,
       permissions: [{name: 'everything'}],
@@ -480,7 +480,7 @@ describe('Audit Actions tests', () => {
 
   test('should call click handlers for stopped audit', () => {
     const audit = Audit.fromObject({
-      status: 'STOPPED',
+      status: HYPERION_AUDIT_STATUS.stopped,
       alterable: false,
       reports: {
         lastReport: {id: 'id'},
@@ -553,7 +553,7 @@ describe('Audit Actions tests', () => {
 
   test('should disable report download if grc format is not defined', () => {
     const audit = Audit.fromObject({
-      status: 'STOPPED',
+      status: HYPERION_AUDIT_STATUS.stopped,
       alterable: false,
       reports: {
         lastReport: {id: 'id'},
@@ -602,7 +602,7 @@ describe('Audit Actions tests', () => {
 
   test('should render schedule icon if task is scheduled', () => {
     const audit = Audit.fromObject({
-      status: 'STOPPED',
+      status: HYPERION_AUDIT_STATUS.stopped,
       alterable: false,
       reports: {
         lastReport: {id: 'id'},

--- a/gsa/src/web/pages/audits/__tests__/detailspage.js
+++ b/gsa/src/web/pages/audits/__tests__/detailspage.js
@@ -23,7 +23,7 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
-import Audit from 'gmp/models/audit';
+import Audit, {HYPERION_AUDIT_STATUS} from 'gmp/models/audit';
 import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 
 import {isDefined} from 'gmp/utils/identity';
@@ -113,7 +113,7 @@ const audit = Audit.fromObject({
   comment: 'bar',
   creationTime: '2019-07-16T06:31:29Z',
   modificationTime: '2019-07-16T06:44:55Z',
-  status: 'DONE',
+  status: HYPERION_AUDIT_STATUS.done,
   alterable: true,
   reports: {
     lastReport,
@@ -143,7 +143,7 @@ const audit2 = Audit.fromObject({
   comment: 'bar',
   creationTime: '2019-07-16T06:31:29Z',
   modificationTime: '2019-07-16T06:44:55Z',
-  status: 'DONE',
+  status: HYPERION_AUDIT_STATUS.done,
   alterable: false,
   reports: {
     lastReport,
@@ -173,7 +173,7 @@ const audit3 = Audit.fromObject({
   comment: 'bar',
   creationTime: '2019-07-16T06:31:29Z',
   modificationTime: '2019-07-16T06:44:55Z',
-  status: 'NEW',
+  status: HYPERION_AUDIT_STATUS.new,
   alterable: false,
   reports: {
     counts: {
@@ -202,7 +202,7 @@ const audit4 = Audit.fromObject({
   inUse: true,
   creationTime: '2019-07-16T06:31:29Z',
   modificationTime: '2019-07-16T06:44:55Z',
-  status: 'RUNNING',
+  status: HYPERION_AUDIT_STATUS.running,
   alterable: false,
   reports: {
     currentReport,
@@ -231,7 +231,7 @@ const audit5 = Audit.fromObject({
   comment: 'bar',
   creationTime: '2019-07-16T06:31:29Z',
   modificationTime: '2019-07-16T06:44:55Z',
-  status: 'STOPPED',
+  status: HYPERION_AUDIT_STATUS.stopped,
   alterable: false,
   reports: {
     currentReport,
@@ -262,7 +262,7 @@ const audit6 = Audit.fromObject({
   comment: 'bar',
   creationTime: '2019-07-16T06:31:29Z',
   modificationTime: '2019-07-16T06:44:55Z',
-  status: 'DONE',
+  status: HYPERION_AUDIT_STATUS.done,
   alterable: false,
   reports: {
     lastReport,
@@ -292,7 +292,7 @@ const audit7 = Audit.fromObject({
   comment: 'bar',
   creationTime: '2019-07-16T06:31:29Z',
   modificationTime: '2019-07-16T06:44:55Z',
-  status: 'DONE',
+  status: HYPERION_AUDIT_STATUS.done,
   alterable: false,
   reports: {
     lastReport,

--- a/gsa/src/web/pages/audits/__tests__/detailspage.js
+++ b/gsa/src/web/pages/audits/__tests__/detailspage.js
@@ -23,7 +23,7 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
-import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
+import Audit from 'gmp/models/audit';
 import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 
 import {isDefined} from 'gmp/utils/identity';
@@ -113,7 +113,7 @@ const audit = Audit.fromObject({
   comment: 'bar',
   creationTime: '2019-07-16T06:31:29Z',
   modificationTime: '2019-07-16T06:44:55Z',
-  status: AUDIT_STATUS.done,
+  status: 'DONE',
   alterable: true,
   reports: {
     lastReport,
@@ -143,7 +143,7 @@ const audit2 = Audit.fromObject({
   comment: 'bar',
   creationTime: '2019-07-16T06:31:29Z',
   modificationTime: '2019-07-16T06:44:55Z',
-  status: AUDIT_STATUS.done,
+  status: 'DONE',
   alterable: false,
   reports: {
     lastReport,
@@ -173,7 +173,7 @@ const audit3 = Audit.fromObject({
   comment: 'bar',
   creationTime: '2019-07-16T06:31:29Z',
   modificationTime: '2019-07-16T06:44:55Z',
-  status: AUDIT_STATUS.new,
+  status: 'NEW',
   alterable: false,
   reports: {
     counts: {
@@ -202,7 +202,7 @@ const audit4 = Audit.fromObject({
   inUse: true,
   creationTime: '2019-07-16T06:31:29Z',
   modificationTime: '2019-07-16T06:44:55Z',
-  status: AUDIT_STATUS.running,
+  status: 'RUNNING',
   alterable: false,
   reports: {
     currentReport,
@@ -231,7 +231,7 @@ const audit5 = Audit.fromObject({
   comment: 'bar',
   creationTime: '2019-07-16T06:31:29Z',
   modificationTime: '2019-07-16T06:44:55Z',
-  status: AUDIT_STATUS.stopped,
+  status: 'STOPPED',
   alterable: false,
   reports: {
     currentReport,
@@ -262,7 +262,7 @@ const audit6 = Audit.fromObject({
   comment: 'bar',
   creationTime: '2019-07-16T06:31:29Z',
   modificationTime: '2019-07-16T06:44:55Z',
-  status: AUDIT_STATUS.done,
+  status: 'DONE',
   alterable: false,
   reports: {
     lastReport,
@@ -292,7 +292,7 @@ const audit7 = Audit.fromObject({
   comment: 'bar',
   creationTime: '2019-07-16T06:31:29Z',
   modificationTime: '2019-07-16T06:44:55Z',
-  status: AUDIT_STATUS.done,
+  status: 'DONE',
   alterable: false,
   reports: {
     lastReport,
@@ -433,9 +433,6 @@ describe('Audit Detailspage tests', () => {
 
     expect(detailslinks[6]).toHaveAttribute('href', '/policy/234');
     expect(baseElement).toHaveTextContent('unnamed policy');
-    expect(baseElement).toHaveTextContent('Order for target hosts');
-    expect(baseElement).toHaveTextContent('sequential');
-    expect(baseElement).toHaveTextContent('Network Source Interface');
     expect(baseElement).toHaveTextContent(
       'Maximum concurrently executed NVTs per host',
     );
@@ -454,7 +451,7 @@ describe('Audit Detailspage tests', () => {
     expect(headings[6]).toHaveTextContent('Scan');
     expect(baseElement).toHaveTextContent('2 minutes');
     expect(baseElement).toHaveTextContent(
-      'Do not automatically delete reports',
+      'Automatically delete oldest reports but always keep newest 5 reports',
     );
   });
 

--- a/gsa/src/web/pages/audits/__tests__/row.js
+++ b/gsa/src/web/pages/audits/__tests__/row.js
@@ -58,13 +58,13 @@ const caps = new Capabilities(['everything']);
 
 const lastReport = {
   id: '1234',
-  timestamp: '2019-07-10T12:51:27Z',
+  creationTime: '2019-07-10T12:51:27Z',
   complianceCount: {yes: 4, no: 3, incomplete: 1},
 };
 
 const currentReport = {
   id: '5678',
-  timestamp: '2019-07-10T12:51:27Z',
+  creationTime: '2019-07-10T12:51:27Z',
 };
 
 describe('Audit Row tests', () => {
@@ -79,7 +79,7 @@ describe('Audit Row tests', () => {
       owner: 'username',
       name: 'foo',
       comment: 'bar',
-      status: AUDIT_STATUS.done,
+      status: 'DONE',
       alterable: false,
       reports: {
         lastReport,
@@ -165,7 +165,7 @@ describe('Audit Row tests', () => {
       owner: 'username',
       name: 'foo',
       comment: 'bar',
-      status: AUDIT_STATUS.new,
+      status: 'NEW',
       alterable: true,
       reports: {
         lastReport,
@@ -231,7 +231,7 @@ describe('Audit Row tests', () => {
       owner: 'username',
       name: 'foo',
       comment: 'bar',
-      status: AUDIT_STATUS.new,
+      status: 'NEW',
       alterable: false,
       permissions: [{name: 'everything'}],
       target: {id: 'id', name: 'target'},
@@ -326,7 +326,7 @@ describe('Audit Row tests', () => {
       name: 'foo',
       comment: 'bar',
       inUse: true,
-      status: AUDIT_STATUS.running,
+      status: 'RUNNING',
       alterable: false,
       reports: {
         currentReport,
@@ -432,7 +432,7 @@ describe('Audit Row tests', () => {
       owner: 'username',
       name: 'foo',
       comment: 'bar',
-      status: AUDIT_STATUS.stopped,
+      status: 'STOPPED',
       alterable: false,
       reports: {
         currentReport,
@@ -539,7 +539,7 @@ describe('Audit Row tests', () => {
       owner: 'username',
       name: 'foo',
       comment: 'bar',
-      status: AUDIT_STATUS.done,
+      status: 'DONE',
       alterable: false,
       reports: {
         lastReport,
@@ -645,7 +645,7 @@ describe('Audit Row tests', () => {
       owner: 'user',
       name: 'foo',
       comment: 'bar',
-      status: AUDIT_STATUS.done,
+      status: 'DONE',
       alterable: false,
       reports: {
         lastReport,

--- a/gsa/src/web/pages/audits/__tests__/row.js
+++ b/gsa/src/web/pages/audits/__tests__/row.js
@@ -21,7 +21,7 @@ import React from 'react';
 import Capabilities from 'gmp/capabilities/capabilities';
 import {setLocale} from 'gmp/locale/lang';
 
-import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
+import Audit, {AUDIT_STATUS, HYPERION_AUDIT_STATUS} from 'gmp/models/audit';
 
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 
@@ -79,7 +79,7 @@ describe('Audit Row tests', () => {
       owner: 'username',
       name: 'foo',
       comment: 'bar',
-      status: 'DONE',
+      status: HYPERION_AUDIT_STATUS.done,
       alterable: false,
       reports: {
         lastReport,
@@ -165,7 +165,7 @@ describe('Audit Row tests', () => {
       owner: 'username',
       name: 'foo',
       comment: 'bar',
-      status: 'NEW',
+      status: HYPERION_AUDIT_STATUS.new,
       alterable: true,
       reports: {
         lastReport,
@@ -231,7 +231,7 @@ describe('Audit Row tests', () => {
       owner: 'username',
       name: 'foo',
       comment: 'bar',
-      status: 'NEW',
+      status: HYPERION_AUDIT_STATUS.new,
       alterable: false,
       permissions: [{name: 'everything'}],
       target: {id: 'id', name: 'target'},
@@ -326,7 +326,7 @@ describe('Audit Row tests', () => {
       name: 'foo',
       comment: 'bar',
       inUse: true,
-      status: 'RUNNING',
+      status: HYPERION_AUDIT_STATUS.running,
       alterable: false,
       reports: {
         currentReport,
@@ -432,7 +432,7 @@ describe('Audit Row tests', () => {
       owner: 'username',
       name: 'foo',
       comment: 'bar',
-      status: 'STOPPED',
+      status: HYPERION_AUDIT_STATUS.stopped,
       alterable: false,
       reports: {
         currentReport,
@@ -539,7 +539,7 @@ describe('Audit Row tests', () => {
       owner: 'username',
       name: 'foo',
       comment: 'bar',
-      status: 'DONE',
+      status: HYPERION_AUDIT_STATUS.done,
       alterable: false,
       reports: {
         lastReport,
@@ -645,7 +645,7 @@ describe('Audit Row tests', () => {
       owner: 'user',
       name: 'foo',
       comment: 'bar',
-      status: 'DONE',
+      status: HYPERION_AUDIT_STATUS.done,
       alterable: false,
       reports: {
         lastReport,

--- a/gsa/src/web/pages/audits/__tests__/table.js
+++ b/gsa/src/web/pages/audits/__tests__/table.js
@@ -22,7 +22,7 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
-import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
+import Audit from 'gmp/models/audit';
 
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 
@@ -36,19 +36,19 @@ const caps = new Capabilities(['everything']);
 
 const lastReport = {
   id: '1234',
-  timestamp: '2019-08-10T12:51:27Z',
+  creationTime: '2019-08-10T12:51:27Z',
   complianceCount: {yes: 4, no: 3, incomplete: 1},
 };
 
 const lastReport2 = {
   id: '1234',
-  timestamp: '2019-07-10T12:51:27Z',
+  creationTime: '2019-07-10T12:51:27Z',
   complianceCount: {yes: 4, no: 3, incomplete: 1},
 };
 
 const currentReport = {
   id: '5678',
-  timestamp: '2019-07-10T12:51:27Z',
+  creationTime: '2019-07-10T12:51:27Z',
 };
 
 const audit = Audit.fromObject({
@@ -56,7 +56,7 @@ const audit = Audit.fromObject({
   owner: 'admin',
   name: 'foo',
   comment: 'bar',
-  status: AUDIT_STATUS.done,
+  status: 'DONE',
   alterable: false,
   reports: {
     lastReport,
@@ -70,7 +70,7 @@ const audit2 = Audit.fromObject({
   owner: 'user',
   name: 'lorem',
   comment: 'ipsum',
-  status: AUDIT_STATUS.new,
+  status: 'NEW',
   alterable: false,
   permissions: [{name: 'everything'}],
   target: {id: 'id2', name: 'target2'},
@@ -81,7 +81,7 @@ const audit3 = Audit.fromObject({
   owner: 'user',
   name: 'hello',
   comment: 'world',
-  status: AUDIT_STATUS.running,
+  status: 'RUNNING',
   alterable: false,
   reports: {
     currentReport,

--- a/gsa/src/web/pages/audits/__tests__/table.js
+++ b/gsa/src/web/pages/audits/__tests__/table.js
@@ -22,7 +22,7 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
-import Audit from 'gmp/models/audit';
+import Audit, {HYPERION_AUDIT_STATUS} from 'gmp/models/audit';
 
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 
@@ -56,7 +56,7 @@ const audit = Audit.fromObject({
   owner: 'admin',
   name: 'foo',
   comment: 'bar',
-  status: 'DONE',
+  status: HYPERION_AUDIT_STATUS.done,
   alterable: false,
   reports: {
     lastReport,
@@ -70,7 +70,7 @@ const audit2 = Audit.fromObject({
   owner: 'user',
   name: 'lorem',
   comment: 'ipsum',
-  status: 'NEW',
+  status: HYPERION_AUDIT_STATUS.new,
   alterable: false,
   permissions: [{name: 'everything'}],
   target: {id: 'id2', name: 'target2'},
@@ -81,7 +81,7 @@ const audit3 = Audit.fromObject({
   owner: 'user',
   name: 'hello',
   comment: 'world',
-  status: 'RUNNING',
+  status: HYPERION_AUDIT_STATUS.running,
   alterable: false,
   reports: {
     currentReport,

--- a/gsa/src/web/pages/audits/details.js
+++ b/gsa/src/web/pages/audits/details.js
@@ -157,26 +157,22 @@ const AuditDetails = ({entity, links = true}) => {
                   </TableData>
                 </TableRow>
               )}
-              {hasValue(policy) &&
-                policy.policyType === 'OPENVAS' &&
-                hasValue(maxConcurrentNvts) && (
-                  <TableRow>
-                    <TableData>
-                      {_('Maximum concurrently executed NVTs per host')}
-                    </TableData>
-                    <TableData>{maxConcurrentNvts}</TableData>
-                  </TableRow>
-                )}
-              {hasValue(policy) &&
-                policy.policyType === 'OPENVAS' &&
-                hasValue(maxConcurrentHosts) && (
-                  <TableRow>
-                    <TableData>
-                      {_('Maximum concurrently scanned hosts')}
-                    </TableData>
-                    <TableData>{maxConcurrentHosts}</TableData>
-                  </TableRow>
-                )}
+              {hasValue(maxConcurrentNvts) && ( // policies do not have types anymore
+                <TableRow>
+                  <TableData>
+                    {_('Maximum concurrently executed NVTs per host')}
+                  </TableData>
+                  <TableData>{maxConcurrentNvts}</TableData>
+                </TableRow>
+              )}
+              {hasValue(maxConcurrentHosts) && (
+                <TableRow>
+                  <TableData>
+                    {_('Maximum concurrently scanned hosts')}
+                  </TableData>
+                  <TableData>{maxConcurrentHosts}</TableData>
+                </TableRow>
+              )}
             </TableBody>
           </DetailsTable>
         </DetailsBlock>

--- a/gsa/src/web/pages/audits/details.js
+++ b/gsa/src/web/pages/audits/details.js
@@ -63,23 +63,24 @@ const AuditDetails = ({entity, links = true}) => {
 
   const {
     alerts,
-    autoDelete,
-    autoDeleteData,
     averageDuration,
-    hostsOrdering,
-    inAssets,
-    preferences,
+    preferences = {},
     scanner,
     schedulePeriods,
     target,
     reports,
-    maxChecks,
-    maxHosts,
   } = entity;
 
   const {lastReport} = reports;
 
-  const {iface = {}} = preferences;
+  const {
+    autoDeleteReports,
+    createAssets,
+    createAssetsApplyOverrides,
+    createAssetsMinQod,
+    maxConcurrentHosts,
+    maxConcurrentNvts,
+  } = preferences;
 
   let dur;
   const hasDuration = hasValue(lastReport) && hasValue(lastReport.scanStart);
@@ -160,37 +161,23 @@ const AuditDetails = ({entity, links = true}) => {
                 </TableRow>
               )}
               {hasValue(policy) &&
-                policy.policyType === OPENVAS_SCAN_CONFIG_TYPE && (
-                  <TableRow>
-                    <TableData>{_('Order for target hosts')}</TableData>
-                    <TableData>{hostsOrdering}</TableData>
-                  </TableRow>
-                )}
-              {hasValue(policy) &&
-                policy.policyType === OPENVAS_SCAN_CONFIG_TYPE && (
-                  <TableRow>
-                    <TableData>{_('Network Source Interface')}</TableData>
-                    <TableData>{iface.value}</TableData>
-                  </TableRow>
-                )}
-              {hasValue(policy) &&
-                policy.policyType === OPENVAS_SCAN_CONFIG_TYPE &&
-                hasValue(maxChecks) && (
+                policy.policyType === 'OPENVAS' &&
+                hasValue(maxConcurrentNvts) && (
                   <TableRow>
                     <TableData>
                       {_('Maximum concurrently executed NVTs per host')}
                     </TableData>
-                    <TableData>{maxChecks}</TableData>
+                    <TableData>{maxConcurrentNvts}</TableData>
                   </TableRow>
                 )}
               {hasValue(policy) &&
-                policy.policyType === OPENVAS_SCAN_CONFIG_TYPE &&
-                hasValue(maxHosts) && (
+                policy.policyType === 'OPENVAS' &&
+                hasValue(maxConcurrentHosts) && (
                   <TableRow>
                     <TableData>
                       {_('Maximum concurrently scanned hosts')}
                     </TableData>
-                    <TableData>{maxHosts}</TableData>
+                    <TableData>{maxConcurrentHosts}</TableData>
                   </TableRow>
                 )}
             </TableBody>
@@ -203,7 +190,7 @@ const AuditDetails = ({entity, links = true}) => {
           <TableBody>
             <TableRow>
               <TableData>{_('Add to Assets')}</TableData>
-              <TableData>{renderYesNo(inAssets)}</TableData>
+              <TableData>{renderYesNo(createAssets)}</TableData>
             </TableRow>
           </TableBody>
         </DetailsTable>
@@ -270,11 +257,11 @@ const AuditDetails = ({entity, links = true}) => {
             <TableRow>
               <TableData>{_('Auto delete Reports')}</TableData>
               <TableData>
-                {autoDelete === 'keep'
+                {hasValue(autoDeleteReports)
                   ? _(
                       'Automatically delete oldest reports but always keep ' +
                         'newest {{nr}} reports',
-                      {nr: autoDeleteData},
+                      {nr: autoDeleteReports},
                     )
                   : _('Do not automatically delete reports')}
               </TableData>

--- a/gsa/src/web/pages/audits/details.js
+++ b/gsa/src/web/pages/audits/details.js
@@ -23,7 +23,6 @@ import DateTime from 'web/components/date/datetime';
 import {hasValue, isDefined} from 'gmp/utils/identity';
 
 import {duration} from 'gmp/models/date';
-import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 import {scannerTypeName} from 'gmp/models/scanner';
 
 import HorizontalSep from 'web/components/layout/horizontalsep';
@@ -76,8 +75,6 @@ const AuditDetails = ({entity, links = true}) => {
   const {
     autoDeleteReports,
     createAssets,
-    createAssetsApplyOverrides,
-    createAssetsMinQod,
     maxConcurrentHosts,
     maxConcurrentNvts,
   } = preferences;

--- a/gsa/src/web/pages/tasks/__mocks__/mocktasks.js
+++ b/gsa/src/web/pages/tasks/__mocks__/mocktasks.js
@@ -17,8 +17,7 @@
  */
 import {setLocale} from 'gmp/locale/lang';
 
-import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
-import Task, {TASK_STATUS} from 'gmp/models/task';
+import Task from 'gmp/models/task';
 
 import {deepFreeze} from 'web/utils/testing';
 
@@ -57,10 +56,8 @@ const greenboneSensor = deepFreeze({
 const scanConfig = deepFreeze({
   id: '314',
   name: 'foo',
-  comment: 'bar',
   trash: false,
-  scanner: scanner,
-  type: OPENVAS_SCAN_CONFIG_TYPE,
+  type: 'OPENVAS',
 });
 
 // Schedule
@@ -76,14 +73,14 @@ const alert = deepFreeze({id: '151617', name: 'alert 1'});
 const lastReport = deepFreeze({
   id: '1234',
   severity: '5.0',
-  timestamp: '2019-07-30T13:23:30Z',
+  creationTime: '2019-07-30T13:23:30Z',
   scanStart: '2019-07-30T13:23:34Z',
   scanEnd: '2019-07-30T13:25:43Z',
 });
 
 const currentReport = deepFreeze({
   id: '5678',
-  timestamp: '2019-08-30T13:23:30Z',
+  creationTime: '2019-08-30T13:23:30Z',
   scanStart: '2019-08-30T13:23:34Z',
 });
 
@@ -118,43 +115,14 @@ const observers = deepFreeze({
 });
 
 // Preferences
-const preferences = deepFreeze([
-  {
-    description: 'Add results to Asset Management',
-    name: 'in_assets',
-    value: 'yes',
-  },
-  {
-    description: 'Apply Overrides when adding Assets',
-    name: 'assets_apply_overrides',
-    value: 'yes',
-  },
-  {
-    description: 'Min QOD when adding Assets',
-    name: 'assets_min_qod',
-    value: '70',
-  },
-  {
-    description: 'Auto Delete Reports',
-    name: 'auto_delete',
-    value: 'no',
-  },
-  {
-    description: 'Auto Delete Reports Data',
-    name: 'auto_delete_data',
-    value: '5',
-  },
-  {
-    description: 'Maximum concurrently executed NVTs per host',
-    name: 'max_checks',
-    value: '4',
-  },
-  {
-    description: 'Maximum concurrently scanned hosts',
-    name: 'max_hosts',
-    value: '20',
-  },
-]);
+const preferences = deepFreeze({
+  createAssets: true,
+  createAssetsApplyOverrides: true,
+  createAssetsMinQod: 70,
+  autoDeleteReports: null,
+  maxConcurrentNvts: 4,
+  maxConcurrentHosts: 20,
+});
 
 // Tasks
 const task = deepFreeze({
@@ -165,7 +133,7 @@ const task = deepFreeze({
   alterable: 1,
   creationTime: '2019-07-30T13:00:00Z',
   modificationTime: '2019-08-30T13:23:30Z',
-  status: TASK_STATUS.stopped,
+  status: 'STOPPED',
   reports: {
     lastReport,
     currentReport,
@@ -181,7 +149,6 @@ const task = deepFreeze({
   scanner: greenboneSensor,
   scanConfig: scanConfig,
   preferences: preferences,
-  hostsOrdering: 'sequential',
   observers: observers,
 });
 
@@ -191,7 +158,7 @@ const newTask = deepFreeze({
   comment: 'bar',
   owner: 'admin',
   alterable: 0,
-  status: TASK_STATUS.new,
+  status: 'NEW',
   reports: {
     counts: {
       total: 0,
@@ -212,7 +179,7 @@ const finishedTask = deepFreeze({
   name: 'foo',
   comment: 'bar',
   owner: 'admin',
-  status: TASK_STATUS.done,
+  status: 'DONE',
   reports: {
     lastReport,
     counts: {
@@ -236,7 +203,7 @@ const runningTask = deepFreeze({
   owner: 'admin',
   alterable: 0,
   inUse: true,
-  status: TASK_STATUS.running,
+  status: 'RUNNING',
   reports: {
     lastReport,
     currentReport,
@@ -260,7 +227,7 @@ const stoppedTask = deepFreeze({
   comment: 'bar',
   owner: 'admin',
   alterable: 0,
-  status: TASK_STATUS.stopped,
+  status: 'STOPPED',
   reports: {
     lastReport,
     currentReport,
@@ -284,7 +251,7 @@ const observedTask = deepFreeze({
   comment: 'bar',
   owner: 'admin',
   alterable: 0,
-  status: TASK_STATUS.done,
+  status: 'DONE',
   reports: {
     lastReport,
     counts: {
@@ -307,7 +274,7 @@ const containerTask = deepFreeze({
   comment: 'bar',
   owner: 'admin',
   alterable: 0,
-  status: TASK_STATUS.done,
+  status: 'DONE',
   reports: {
     lastReport,
     counts: {
@@ -334,9 +301,9 @@ const listMockTask = deepFreeze({
       finished: 1,
     },
   },
-  status: TASK_STATUS.done,
+  status: 'DONE',
   target,
-  trend: 'up',
+  trend: 'UP',
   alterable: 0,
   comment: 'bar',
   owner: 'admin',
@@ -345,7 +312,6 @@ const listMockTask = deepFreeze({
   alerts: [],
   scanConfig,
   scanner,
-  hostsOrdering: null,
   observers,
 });
 
@@ -363,7 +329,7 @@ const detailsMockTask = deepFreeze({
       finished: 1,
     },
   },
-  status: TASK_STATUS.stopped,
+  status: 'STOPPED',
   target,
   alterable: 0,
   trend: null,
@@ -375,7 +341,6 @@ const detailsMockTask = deepFreeze({
   scanConfig,
   scanner,
   schedulePeriods: null,
-  hostsOrdering: 'sequential',
   userTags: null,
   observers,
 });

--- a/gsa/src/web/pages/tasks/__mocks__/mocktasks.js
+++ b/gsa/src/web/pages/tasks/__mocks__/mocktasks.js
@@ -17,7 +17,7 @@
  */
 import {setLocale} from 'gmp/locale/lang';
 
-import Task from 'gmp/models/task';
+import Task, {HYPERION_TASK_STATUS, TASK_TREND} from 'gmp/models/task';
 
 import {deepFreeze} from 'web/utils/testing';
 
@@ -58,6 +58,73 @@ const scanConfig = deepFreeze({
   name: 'foo',
   trash: false,
   type: 'OPENVAS',
+});
+
+export const detailsScanConfig = deepFreeze({
+  id: '314',
+  name: 'Half empty and slow',
+  creationTime: null,
+  comment: "Most NVT's",
+  families: [
+    {name: 'family1', growing: true, maxNvtCount: 10, nvtCount: 7},
+    {name: 'family2', growing: false, maxNvtCount: 5, nvtCount: 0},
+  ],
+  familyCount: 1,
+  familyGrowing: true,
+  nvtGrowing: false,
+  owner: 'admin',
+  inUse: false,
+  knownNvtCount: 99998,
+  maxNvtCount: 99999,
+  modificationTime: '2020-09-29T12:16:50+00:00',
+  nvtCount: 99998,
+  nvtSelectors: [
+    {
+      name: '436',
+      include: true,
+      type: 2,
+      familyOrNvt: '1.3.6.1.4.1.25623.1.0.100315',
+    },
+  ],
+  permissions: [{name: 'Everything'}],
+  predefined: true,
+  nvtPreferences: [
+    {
+      alternativeValues: ['postgres', 'regress'],
+      default: 'postgres',
+      hrName: 'Postgres Username:',
+      id: 1,
+      name: 'Postgres Username:',
+      type: 'entry',
+      value: 'regress',
+      nvt: {
+        id: '1.3.6.1.4.1.25623.1.0.100151',
+        name: 'PostgreSQL Detection',
+      },
+    },
+  ],
+  scannerPreferences: [
+    {
+      alternativeValues: ['foo', 'bar'],
+      default: '1',
+      hrName: 'scanner_pref',
+      id: null,
+      name: 'scanner_pref',
+      type: null,
+      value: '1',
+    },
+  ],
+  tasks: [
+    {
+      name: 'foo',
+      id: '457',
+    },
+  ],
+  trash: false,
+  type: 'OPENVAS',
+  usageType: 'scan',
+  userTags: null,
+  writable: false,
 });
 
 // Schedule
@@ -133,7 +200,7 @@ const task = deepFreeze({
   alterable: 1,
   creationTime: '2019-07-30T13:00:00Z',
   modificationTime: '2019-08-30T13:23:30Z',
-  status: 'STOPPED',
+  status: HYPERION_TASK_STATUS.stopped,
   reports: {
     lastReport,
     currentReport,
@@ -158,7 +225,7 @@ const newTask = deepFreeze({
   comment: 'bar',
   owner: 'admin',
   alterable: 0,
-  status: 'NEW',
+  status: HYPERION_TASK_STATUS.new,
   reports: {
     counts: {
       total: 0,
@@ -179,7 +246,7 @@ const finishedTask = deepFreeze({
   name: 'foo',
   comment: 'bar',
   owner: 'admin',
-  status: 'DONE',
+  status: HYPERION_TASK_STATUS.done,
   reports: {
     lastReport,
     counts: {
@@ -203,7 +270,7 @@ const runningTask = deepFreeze({
   owner: 'admin',
   alterable: 0,
   inUse: true,
-  status: 'RUNNING',
+  status: HYPERION_TASK_STATUS.running,
   reports: {
     lastReport,
     currentReport,
@@ -227,7 +294,7 @@ const stoppedTask = deepFreeze({
   comment: 'bar',
   owner: 'admin',
   alterable: 0,
-  status: 'STOPPED',
+  status: HYPERION_TASK_STATUS.stopped,
   reports: {
     lastReport,
     currentReport,
@@ -251,7 +318,7 @@ const observedTask = deepFreeze({
   comment: 'bar',
   owner: 'admin',
   alterable: 0,
-  status: 'DONE',
+  status: HYPERION_TASK_STATUS.done,
   reports: {
     lastReport,
     counts: {
@@ -274,7 +341,7 @@ const containerTask = deepFreeze({
   comment: 'bar',
   owner: 'admin',
   alterable: 0,
-  status: 'DONE',
+  status: HYPERION_TASK_STATUS.done,
   reports: {
     lastReport,
     counts: {
@@ -301,9 +368,9 @@ const listMockTask = deepFreeze({
       finished: 1,
     },
   },
-  status: 'DONE',
+  status: HYPERION_TASK_STATUS.done,
   target,
-  trend: 'UP',
+  trend: TASK_TREND.up,
   alterable: 0,
   comment: 'bar',
   owner: 'admin',
@@ -329,7 +396,7 @@ const detailsMockTask = deepFreeze({
       finished: 1,
     },
   },
-  status: 'STOPPED',
+  status: HYPERION_TASK_STATUS.stopped,
   target,
   alterable: 0,
   trend: null,

--- a/gsa/src/web/pages/tasks/__mocks__/mocktasks.js
+++ b/gsa/src/web/pages/tasks/__mocks__/mocktasks.js
@@ -16,6 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 import {setLocale} from 'gmp/locale/lang';
+import {SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 
 import Task, {HYPERION_TASK_STATUS, TASK_TREND} from 'gmp/models/task';
 
@@ -57,7 +58,7 @@ const scanConfig = deepFreeze({
   id: '314',
   name: 'foo',
   trash: false,
-  type: 'OPENVAS',
+  type: SCAN_CONFIG_TYPE.openvas,
 });
 
 export const detailsScanConfig = deepFreeze({
@@ -121,7 +122,7 @@ export const detailsScanConfig = deepFreeze({
     },
   ],
   trash: false,
-  type: 'OPENVAS',
+  type: SCAN_CONFIG_TYPE.openvas,
   usageType: 'scan',
   userTags: null,
   writable: false,

--- a/gsa/src/web/pages/tasks/__tests__/details.js
+++ b/gsa/src/web/pages/tasks/__tests__/details.js
@@ -28,11 +28,78 @@ import {setTimezone} from 'web/store/usersettings/actions';
 
 import {getMockTasks} from 'web/pages/tasks/__mocks__/mocktasks';
 
-import {rendererWith, screen, wait} from 'web/utils/testing';
+import {deepFreeze, rendererWith, screen, wait} from 'web/utils/testing';
 
 import Details from '../details';
 
 setLocale('en');
+
+export const taskScanConfig = deepFreeze({
+  id: '314',
+  name: 'Half empty and slow',
+  creationTime: null,
+  comment: "Most NVT's",
+  families: [
+    {name: 'family1', growing: true, maxNvtCount: 10, nvtCount: 7},
+    {name: 'family2', growing: false, maxNvtCount: 5, nvtCount: 0},
+  ],
+  familyCount: 1,
+  familyGrowing: true,
+  nvtGrowing: false,
+  owner: 'admin',
+  inUse: false,
+  knownNvtCount: 99998,
+  maxNvtCount: 99999,
+  modificationTime: '2020-09-29T12:16:50+00:00',
+  nvtCount: 99998,
+  nvtSelectors: [
+    {
+      name: '436',
+      include: true,
+      type: 2,
+      familyOrNvt: '1.3.6.1.4.1.25623.1.0.100315',
+    },
+  ],
+  permissions: [{name: 'Everything'}],
+  predefined: true,
+  nvtPreferences: [
+    {
+      alternativeValues: ['postgres', 'regress'],
+      default: 'postgres',
+      hrName: 'Postgres Username:',
+      id: 1,
+      name: 'Postgres Username:',
+      type: 'entry',
+      value: 'regress',
+      nvt: {
+        id: '1.3.6.1.4.1.25623.1.0.100151',
+        name: 'PostgreSQL Detection',
+      },
+    },
+  ],
+  scannerPreferences: [
+    {
+      alternativeValues: ['foo', 'bar'],
+      default: '1',
+      hrName: 'scanner_pref',
+      id: null,
+      name: 'scanner_pref',
+      type: null,
+      value: '1',
+    },
+  ],
+  tasks: [
+    {
+      name: 'foo',
+      id: '457',
+    },
+  ],
+  trash: false,
+  type: 'OPENVAS',
+  usageType: 'scan',
+  userTags: null,
+  writable: false,
+});
 
 describe('Task Details tests', () => {
   test('should render full task details', async () => {
@@ -40,7 +107,10 @@ describe('Task Details tests', () => {
 
     const caps = new Capabilities(['everything']);
     const [scheduleMock, resultFunc] = createGetScheduleQueryMock('foo');
-    const [scanConfigMock, scanConfigResult] = createGetScanConfigQueryMock();
+    const [scanConfigMock, scanConfigResult] = createGetScanConfigQueryMock(
+      '314',
+      taskScanConfig,
+    );
 
     const {render, store} = rendererWith({
       capabilities: caps,
@@ -74,8 +144,6 @@ describe('Task Details tests', () => {
     expect(element).toHaveTextContent('OpenVAS Scanner');
     expect(element).toHaveTextContent('Scan Config');
     expect(detailslinks[3]).toHaveAttribute('href', '/scanconfig/314');
-    expect(element).toHaveTextContent('Order for target hostssequential');
-    expect(element).toHaveTextContent('Network Source Interface');
     expect(element).toHaveTextContent(
       'Maximum concurrently executed NVTs per host4',
     );

--- a/gsa/src/web/pages/tasks/__tests__/details.js
+++ b/gsa/src/web/pages/tasks/__tests__/details.js
@@ -26,80 +26,16 @@ import {createGetScheduleQueryMock} from 'web/graphql/__mocks__/schedules';
 
 import {setTimezone} from 'web/store/usersettings/actions';
 
-import {getMockTasks} from 'web/pages/tasks/__mocks__/mocktasks';
+import {
+  detailsScanConfig,
+  getMockTasks,
+} from 'web/pages/tasks/__mocks__/mocktasks';
 
-import {deepFreeze, rendererWith, screen, wait} from 'web/utils/testing';
+import {rendererWith, screen, wait} from 'web/utils/testing';
 
 import Details from '../details';
 
 setLocale('en');
-
-export const taskScanConfig = deepFreeze({
-  id: '314',
-  name: 'Half empty and slow',
-  creationTime: null,
-  comment: "Most NVT's",
-  families: [
-    {name: 'family1', growing: true, maxNvtCount: 10, nvtCount: 7},
-    {name: 'family2', growing: false, maxNvtCount: 5, nvtCount: 0},
-  ],
-  familyCount: 1,
-  familyGrowing: true,
-  nvtGrowing: false,
-  owner: 'admin',
-  inUse: false,
-  knownNvtCount: 99998,
-  maxNvtCount: 99999,
-  modificationTime: '2020-09-29T12:16:50+00:00',
-  nvtCount: 99998,
-  nvtSelectors: [
-    {
-      name: '436',
-      include: true,
-      type: 2,
-      familyOrNvt: '1.3.6.1.4.1.25623.1.0.100315',
-    },
-  ],
-  permissions: [{name: 'Everything'}],
-  predefined: true,
-  nvtPreferences: [
-    {
-      alternativeValues: ['postgres', 'regress'],
-      default: 'postgres',
-      hrName: 'Postgres Username:',
-      id: 1,
-      name: 'Postgres Username:',
-      type: 'entry',
-      value: 'regress',
-      nvt: {
-        id: '1.3.6.1.4.1.25623.1.0.100151',
-        name: 'PostgreSQL Detection',
-      },
-    },
-  ],
-  scannerPreferences: [
-    {
-      alternativeValues: ['foo', 'bar'],
-      default: '1',
-      hrName: 'scanner_pref',
-      id: null,
-      name: 'scanner_pref',
-      type: null,
-      value: '1',
-    },
-  ],
-  tasks: [
-    {
-      name: 'foo',
-      id: '457',
-    },
-  ],
-  trash: false,
-  type: 'OPENVAS',
-  usageType: 'scan',
-  userTags: null,
-  writable: false,
-});
 
 describe('Task Details tests', () => {
   test('should render full task details', async () => {
@@ -109,7 +45,7 @@ describe('Task Details tests', () => {
     const [scheduleMock, resultFunc] = createGetScheduleQueryMock('foo');
     const [scanConfigMock, scanConfigResult] = createGetScanConfigQueryMock(
       '314',
-      taskScanConfig,
+      detailsScanConfig,
     );
 
     const {render, store} = rendererWith({

--- a/gsa/src/web/pages/tasks/__tests__/detailspage.js
+++ b/gsa/src/web/pages/tasks/__tests__/detailspage.js
@@ -38,13 +38,14 @@ import {
   createDeleteTaskQueryMock,
 } from 'web/graphql/__mocks__/tasks';
 
-import {getMockTasks} from 'web/pages/tasks/__mocks__/mocktasks';
+import {
+  detailsScanConfig,
+  getMockTasks,
+} from 'web/pages/tasks/__mocks__/mocktasks';
 import {entityLoadingActions} from 'web/store/entities/tasks';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
-
-import {taskScanConfig} from './details';
 
 import Detailspage, {ToolBarIcons} from '../detailspage';
 
@@ -113,7 +114,7 @@ describe('Task Detailspage tests', () => {
     });
     const [scanConfigMock, scanConfigResult] = createGetScanConfigQueryMock(
       '314',
-      taskScanConfig,
+      detailsScanConfig,
     );
 
     const {render, store} = rendererWith({

--- a/gsa/src/web/pages/tasks/__tests__/detailspage.js
+++ b/gsa/src/web/pages/tasks/__tests__/detailspage.js
@@ -44,6 +44,8 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
+import {taskScanConfig} from './details';
+
 import Detailspage, {ToolBarIcons} from '../detailspage';
 
 setLocale('en');
@@ -109,7 +111,10 @@ describe('Task Detailspage tests', () => {
     const [permissionMock, permissionResult] = createGetPermissionsQueryMock({
       filterString: 'resource_uuid=12345 first=1 rows=-1',
     });
-    const [scanConfigMock, scanConfigResult] = createGetScanConfigQueryMock();
+    const [scanConfigMock, scanConfigResult] = createGetScanConfigQueryMock(
+      '314',
+      taskScanConfig,
+    );
 
     const {render, store} = rendererWith({
       capabilities: caps,
@@ -191,8 +196,6 @@ describe('Task Detailspage tests', () => {
     expect(baseElement).toHaveTextContent('scanner 1');
     expect(baseElement).toHaveTextContent('OpenVAS Scanner');
     expect(detailslinks[6]).toHaveAttribute('href', '/scanconfig/314');
-    expect(baseElement).toHaveTextContent('Order for target hostssequential');
-    expect(baseElement).toHaveTextContent('Network Source Interface');
     expect(baseElement).toHaveTextContent(
       'Maximum concurrently executed NVTs per host4',
     );
@@ -212,7 +215,7 @@ describe('Task Detailspage tests', () => {
     expect(headings[6]).toHaveTextContent('Scan');
     expect(baseElement).toHaveTextContent('2 minutes');
     expect(baseElement).toHaveTextContent(
-      'Do not automatically delete reports',
+      'Automatically delete oldest reports but always keep newest 5 reports',
     );
   });
 

--- a/gsa/src/web/pages/tasks/__tests__/trend.js
+++ b/gsa/src/web/pages/tasks/__tests__/trend.js
@@ -18,6 +18,8 @@
 
 import React from 'react';
 
+import {TASK_TREND} from 'gmp/models/task';
+
 import {render} from 'web/utils/testing';
 
 import Trend from '../trend';
@@ -28,41 +30,41 @@ setLocale('en');
 
 describe('Task Trend tests', () => {
   test('should render', () => {
-    const {element} = render(<Trend name="UP" />);
+    const {element} = render(<Trend name={TASK_TREND.up} />);
 
     expect(element).toMatchSnapshot();
   });
 
   test('should render trend up icon', () => {
-    const {element} = render(<Trend name="UP" />);
+    const {element} = render(<Trend name={TASK_TREND.up} />);
 
     expect(element).toHaveAttribute('title', 'Severity increased');
     expect(element).toHaveTextContent('trend_up.svg');
   });
 
   test('should render trend down icon', () => {
-    const {element} = render(<Trend name="DOWN" />);
+    const {element} = render(<Trend name={TASK_TREND.down} />);
 
     expect(element).toHaveAttribute('title', 'Severity decreased');
     expect(element).toHaveTextContent('trend_down.svg');
   });
 
   test('should render trend less icon', () => {
-    const {element} = render(<Trend name="LESS" />);
+    const {element} = render(<Trend name={TASK_TREND.less} />);
 
     expect(element).toHaveAttribute('title', 'Vulnerability count decreased');
     expect(element).toHaveTextContent('trend_less.svg');
   });
 
   test('should render trend more icon', () => {
-    const {element} = render(<Trend name="MORE" />);
+    const {element} = render(<Trend name={TASK_TREND.more} />);
 
     expect(element).toHaveAttribute('title', 'Vulnerability count increased');
     expect(element).toHaveTextContent('trend_more.svg');
   });
 
   test('should render trend no change icon', () => {
-    const {element} = render(<Trend name="SAME" />);
+    const {element} = render(<Trend name={TASK_TREND.same} />);
 
     expect(element).toHaveAttribute('title', 'Vulnerabilities did not change');
     expect(element).toHaveTextContent('trend_nochange.svg');

--- a/gsa/src/web/pages/tasks/__tests__/trend.js
+++ b/gsa/src/web/pages/tasks/__tests__/trend.js
@@ -28,41 +28,41 @@ setLocale('en');
 
 describe('Task Trend tests', () => {
   test('should render', () => {
-    const {element} = render(<Trend name="up" />);
+    const {element} = render(<Trend name="UP" />);
 
     expect(element).toMatchSnapshot();
   });
 
   test('should render trend up icon', () => {
-    const {element} = render(<Trend name="up" />);
+    const {element} = render(<Trend name="UP" />);
 
     expect(element).toHaveAttribute('title', 'Severity increased');
     expect(element).toHaveTextContent('trend_up.svg');
   });
 
   test('should render trend down icon', () => {
-    const {element} = render(<Trend name="down" />);
+    const {element} = render(<Trend name="DOWN" />);
 
     expect(element).toHaveAttribute('title', 'Severity decreased');
     expect(element).toHaveTextContent('trend_down.svg');
   });
 
   test('should render trend less icon', () => {
-    const {element} = render(<Trend name="less" />);
+    const {element} = render(<Trend name="LESS" />);
 
     expect(element).toHaveAttribute('title', 'Vulnerability count decreased');
     expect(element).toHaveTextContent('trend_less.svg');
   });
 
   test('should render trend more icon', () => {
-    const {element} = render(<Trend name="more" />);
+    const {element} = render(<Trend name="MORE" />);
 
     expect(element).toHaveAttribute('title', 'Vulnerability count increased');
     expect(element).toHaveTextContent('trend_more.svg');
   });
 
   test('should render trend no change icon', () => {
-    const {element} = render(<Trend name="same" />);
+    const {element} = render(<Trend name="SAME" />);
 
     expect(element).toHaveAttribute('title', 'Vulnerabilities did not change');
     expect(element).toHaveTextContent('trend_nochange.svg');

--- a/gsa/src/web/pages/tasks/details.js
+++ b/gsa/src/web/pages/tasks/details.js
@@ -20,6 +20,7 @@ import React, {useEffect} from 'react';
 import _ from 'gmp/locale';
 
 import {duration} from 'gmp/models/date';
+import {SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 import {scannerTypeName} from 'gmp/models/scanner';
 
 import {hasValue, isDefined} from 'gmp/utils/identity';
@@ -170,7 +171,7 @@ const TaskDetails = ({entity, links = true}) => {
                 </TableRow>
               )}
               {hasValue(scanConfig) &&
-                scanConfig.scanConfigType === 'OPENVAS' &&
+                scanConfig.scanConfigType === SCAN_CONFIG_TYPE.openvas &&
                 hasValue(maxConcurrentNvts) && (
                   <TableRow>
                     <TableData>
@@ -180,7 +181,7 @@ const TaskDetails = ({entity, links = true}) => {
                   </TableRow>
                 )}
               {hasValue(scanConfig) &&
-                scanConfig.scanConfigType === 'OPENVAS' &&
+                scanConfig.scanConfigType === SCAN_CONFIG_TYPE.openvas &&
                 hasValue(maxConcurrentHosts) && (
                   <TableRow>
                     <TableData>
@@ -202,7 +203,7 @@ const TaskDetails = ({entity, links = true}) => {
               <TableData>{renderYesNo(createAssets)}</TableData>
             </TableRow>
 
-            {createAssets === true && ( // true value later!
+            {createAssets === true && (
               <TableRow>
                 <TableData>{_('Apply Overrides')}</TableData>
                 <TableData>{renderYesNo(createAssetsApplyOverrides)}</TableData>

--- a/gsa/src/web/pages/tasks/details.js
+++ b/gsa/src/web/pages/tasks/details.js
@@ -76,20 +76,21 @@ const TaskDetails = ({entity, links = true}) => {
 
   const {
     alerts,
-    applyOverrides,
-    autoDelete,
-    autoDeleteData,
     averageDuration,
-    hostsOrdering,
-    inAssets,
     reports,
-    minQod,
     scanner,
     target,
-    maxChecks,
-    maxHosts,
-    sourceIface = '',
+    preferences = {},
   } = entity;
+
+  const {
+    autoDeleteReports,
+    createAssets,
+    createAssetsApplyOverrides,
+    createAssetsMinQod,
+    maxConcurrentHosts,
+    maxConcurrentNvts,
+  } = preferences;
 
   const {lastReport} = reports;
 
@@ -172,38 +173,23 @@ const TaskDetails = ({entity, links = true}) => {
                 </TableRow>
               )}
               {hasValue(scanConfig) &&
-                scanConfig.scanConfigType === OPENVAS_SCAN_CONFIG_TYPE &&
-                hasValue(hostsOrdering) && (
-                  <TableRow>
-                    <TableData>{_('Order for target hosts')}</TableData>
-                    <TableData>{hostsOrdering}</TableData>
-                  </TableRow>
-                )}
-              {hasValue(scanConfig) &&
-                scanConfig.scanConfigType === OPENVAS_SCAN_CONFIG_TYPE && (
-                  <TableRow>
-                    <TableData>{_('Network Source Interface')}</TableData>
-                    <TableData>{sourceIface}</TableData>
-                  </TableRow>
-                )}
-              {hasValue(scanConfig) &&
-                scanConfig.scanConfigType === OPENVAS_SCAN_CONFIG_TYPE &&
-                hasValue(maxChecks) && (
+                scanConfig.scanConfigType === 'OPENVAS' &&
+                hasValue(maxConcurrentNvts) && (
                   <TableRow>
                     <TableData>
                       {_('Maximum concurrently executed NVTs per host')}
                     </TableData>
-                    <TableData>{maxChecks}</TableData>
+                    <TableData>{maxConcurrentNvts}</TableData>
                   </TableRow>
                 )}
               {hasValue(scanConfig) &&
-                scanConfig.scanConfigType === OPENVAS_SCAN_CONFIG_TYPE &&
-                hasValue(maxHosts) && (
+                scanConfig.scanConfigType === 'OPENVAS' &&
+                hasValue(maxConcurrentHosts) && (
                   <TableRow>
                     <TableData>
                       {_('Maximum concurrently scanned hosts')}
                     </TableData>
-                    <TableData>{maxHosts}</TableData>
+                    <TableData>{maxConcurrentHosts}</TableData>
                   </TableRow>
                 )}
             </TableBody>
@@ -216,20 +202,20 @@ const TaskDetails = ({entity, links = true}) => {
           <TableBody>
             <TableRow>
               <TableData>{_('Add to Assets')}</TableData>
-              <TableData>{renderYesNo(inAssets)}</TableData>
+              <TableData>{renderYesNo(createAssets)}</TableData>
             </TableRow>
 
-            {inAssets === YES_VALUE && (
+            {createAssets === YES_VALUE && (
               <TableRow>
                 <TableData>{_('Apply Overrides')}</TableData>
-                <TableData>{renderYesNo(applyOverrides)}</TableData>
+                <TableData>{renderYesNo(createAssetsApplyOverrides)}</TableData>
               </TableRow>
             )}
 
-            {inAssets === YES_VALUE && (
+            {createAssets === YES_VALUE && (
               <TableRow>
                 <TableData>{_('Min QoD')}</TableData>
-                <TableData>{minQod + ' %'}</TableData>
+                <TableData>{createAssetsMinQod + ' %'}</TableData>
               </TableRow>
             )}
           </TableBody>
@@ -287,11 +273,11 @@ const TaskDetails = ({entity, links = true}) => {
             <TableRow>
               <TableData>{_('Auto delete Reports')}</TableData>
               <TableData>
-                {autoDelete === 'keep'
+                {hasValue(autoDeleteReports)
                   ? _(
                       'Automatically delete oldest reports but always keep ' +
                         'newest {{nr}} reports',
-                      {nr: autoDeleteData},
+                      {nr: autoDeleteReports},
                     )
                   : _('Do not automatically delete reports')}
               </TableData>

--- a/gsa/src/web/pages/tasks/details.js
+++ b/gsa/src/web/pages/tasks/details.js
@@ -20,7 +20,6 @@ import React, {useEffect} from 'react';
 import _ from 'gmp/locale';
 
 import {duration} from 'gmp/models/date';
-import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 import {scannerTypeName} from 'gmp/models/scanner';
 
 import {YES_VALUE} from 'gmp/parser';

--- a/gsa/src/web/pages/tasks/details.js
+++ b/gsa/src/web/pages/tasks/details.js
@@ -22,8 +22,6 @@ import _ from 'gmp/locale';
 import {duration} from 'gmp/models/date';
 import {scannerTypeName} from 'gmp/models/scanner';
 
-import {YES_VALUE} from 'gmp/parser';
-
 import {hasValue, isDefined} from 'gmp/utils/identity';
 
 import DateTime from 'web/components/date/datetime';
@@ -204,14 +202,14 @@ const TaskDetails = ({entity, links = true}) => {
               <TableData>{renderYesNo(createAssets)}</TableData>
             </TableRow>
 
-            {createAssets === YES_VALUE && (
+            {createAssets === true && ( // true value later!
               <TableRow>
                 <TableData>{_('Apply Overrides')}</TableData>
                 <TableData>{renderYesNo(createAssetsApplyOverrides)}</TableData>
               </TableRow>
             )}
 
-            {createAssets === YES_VALUE && (
+            {createAssets === true && (
               <TableRow>
                 <TableData>{_('Min QoD')}</TableData>
                 <TableData>{createAssetsMinQod + ' %'}</TableData>

--- a/gsa/src/web/pages/tasks/row.js
+++ b/gsa/src/web/pages/tasks/row.js
@@ -61,7 +61,7 @@ export const renderReport = (report, links) => {
   return (
     <span>
       <DetailsLink type="report" id={report.id} textOnly={!links}>
-        <DateTime date={report.timestamp} />
+        <DateTime date={report.creationTime} />
       </DetailsLink>
     </span>
   );

--- a/gsa/src/web/pages/tasks/trend.js
+++ b/gsa/src/web/pages/tasks/trend.js
@@ -32,19 +32,19 @@ const Trend = ({name}) => {
   let title;
   let IconComponent;
 
-  if (name === 'up') {
+  if (name === 'UP') {
     title = _('Severity increased');
     IconComponent = TrendUpIcon;
-  } else if (name === 'down') {
+  } else if (name === 'DOWN') {
     title = _('Severity decreased');
     IconComponent = TrendDownIcon;
-  } else if (name === 'more') {
+  } else if (name === 'MORE') {
     title = _('Vulnerability count increased');
     IconComponent = TrendMoreIcon;
-  } else if (name === 'less') {
+  } else if (name === 'LESS') {
     title = _('Vulnerability count decreased');
     IconComponent = TrendLessIcon;
-  } else if (name === 'same') {
+  } else if (name === 'SAME') {
     title = _('Vulnerabilities did not change');
     IconComponent = TrendNoChangeIcon;
   } else {

--- a/gsa/src/web/pages/tasks/trend.js
+++ b/gsa/src/web/pages/tasks/trend.js
@@ -19,6 +19,7 @@
 import React from 'react';
 
 import _ from 'gmp/locale';
+import {TASK_TREND} from 'gmp/models/task';
 
 import TrendUpIcon from 'web/components/icon/trendupicon';
 import TrendDownIcon from 'web/components/icon/trenddownicon';
@@ -32,19 +33,19 @@ const Trend = ({name}) => {
   let title;
   let IconComponent;
 
-  if (name === 'UP') {
+  if (name === TASK_TREND.up) {
     title = _('Severity increased');
     IconComponent = TrendUpIcon;
-  } else if (name === 'DOWN') {
+  } else if (name === TASK_TREND.down) {
     title = _('Severity decreased');
     IconComponent = TrendDownIcon;
-  } else if (name === 'MORE') {
+  } else if (name === TASK_TREND.more) {
     title = _('Vulnerability count increased');
     IconComponent = TrendMoreIcon;
-  } else if (name === 'LESS') {
+  } else if (name === TASK_TREND.less) {
     title = _('Vulnerability count decreased');
     IconComponent = TrendLessIcon;
-  } else if (name === 'SAME') {
+  } else if (name === TASK_TREND.same) {
     title = _('Vulnerabilities did not change');
     IconComponent = TrendNoChangeIcon;
   } else {


### PR DESCRIPTION
**What**:

Carries over changes from https://github.com/greenbone/hyperion/pull/133 to ensure that audits listpage and detailspage do not crash and display the correct information. This only addresses changes to task/audit FIELDS to make sure everything displays. These changes are not complete and do not address everything in the linked pull request. Add back some tests that were missing to make sure both parseObject and parseElement work.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:
Manually testing and adjusting unit tests.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
