### PR TITLE
Fix unable to edit schedules with number only name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
 
 ### Fixed
+- name within schedules/dialog [2914](https://github.com/greenbone/gsa/pull/2914)
 - Fixed changing Trend and Select for NVT-families and whole selection only [#2905](https://github.com/greenbone/gsa/pull/2905)
 - Fixed missing name for CVE results on result detailspage [#2892](https://github.com/greenbone/gsa/pull/2892)
 - Fixed setting secret key in RADIUS dialog [#2891](https://github.com/greenbone/gsa/pull/2891)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
 
 ### Fixed
-- Fixed numer-only names within schedules/dialog [#2914](https://github.com/greenbone/gsa/pull/2914)
+- Fixed number-only names within schedules/dialog [#2914](https://github.com/greenbone/gsa/pull/2914)
 - Fixed changing Trend and Select for NVT-families and whole selection only [#2905](https://github.com/greenbone/gsa/pull/2905)
 - Fixed missing name for CVE results on result detailspage [#2892](https://github.com/greenbone/gsa/pull/2892)
 - Fixed setting secret key in RADIUS dialog [#2891](https://github.com/greenbone/gsa/pull/2891)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
 
 ### Fixed
-- name within schedules/dialog [2914](https://github.com/greenbone/gsa/pull/2914)
+- Fixed numer-only names within schedules/dialog [#2914](https://github.com/greenbone/gsa/pull/2914)
 - Fixed changing Trend and Select for NVT-families and whole selection only [#2905](https://github.com/greenbone/gsa/pull/2905)
 - Fixed missing name for CVE results on result detailspage [#2892](https://github.com/greenbone/gsa/pull/2892)
 - Fixed setting secret key in RADIUS dialog [#2891](https://github.com/greenbone/gsa/pull/2891)

--- a/gsa/src/web/pages/schedules/dialog.js
+++ b/gsa/src/web/pages/schedules/dialog.js
@@ -328,7 +328,10 @@ class ScheduleDialog extends React.Component {
         interval: isPreDefined ? 1 : interval,
         monthdays: setMonthydays ? monthdays : undefined,
         weekdays: setWeekdays ? weekdays : undefined,
-        summary: name,
+        // convert name to string explicitly to not run into:
+        // `TypeError: e.replace is not a function`
+        // when name is just numbers.
+        summary: name.toString(),
         startDate,
       },
       timezone,

--- a/gsa/src/web/pages/schedules/dialog.js
+++ b/gsa/src/web/pages/schedules/dialog.js
@@ -331,7 +331,7 @@ class ScheduleDialog extends React.Component {
         // convert name to string explicitly to not run into:
         // `TypeError: e.replace is not a function`
         // when name is just numbers.
-        summary: name.toString(),
+        summary: `${name}`,
         startDate,
       },
       timezone,


### PR DESCRIPTION
When adding a new schedule with a numbers only name `1234` and daily
re occurrence and trying to edit the new schedule than a:
```
TypeError: e.replace is not a function
```
occurs because name is a number and not a string.

To fix that name.toString() is called to explicitly cast it to string.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [x] Labels for ports to other branches
