### PR TITLE
Fix setting Radius secret key in dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
 
 ### Fixed
+- Fixed setting secret key in RADIUS dialog, backport from [#2891](https://github.com/greenbone/gsa/pull/2891), [#2915](https://github.com/greenbone/gsa/pull/2915)
 ### Removed
 
 [20.8.2]: https://github.com/greenbone/gsa/compare/v20.8.1...gsa-20.08

--- a/gsa/src/web/pages/radius/dialog.js
+++ b/gsa/src/web/pages/radius/dialog.js
@@ -77,7 +77,7 @@ const RadiusDialog = ({
               data-testid="radiuskey-textfield"
               name="radiuskey"
               size="50"
-              value={radiuskey}
+              value={values.radiuskey}
               onChange={onValueChange}
             />
           </FormGroup>


### PR DESCRIPTION
**What**:
Backport from [#2891](https://github.com/greenbone/gsa/pull/2891)

Use value of dialog internal state for secret key in radius dialog.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The value was fixed and unchangeable.
<!-- Why are these changes necessary? -->

**How**:
Manual tests
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests, due to older dependencies, the tests will remain as given, instead of updating them to use userEvent() as done in the newer branches
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [N/A] Labels for ports to other branches
