### PR TITLE
Fix "Pre-select greenbone sensor as default scanner type"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
 
 ### Fixed
+- Fixed setting default scanner type to Greenbone Sensor [#2924](https://github.com/greenbone/gsa/pull/2924)
 - Fixed number-only names within schedules/dialog [#2914](https://github.com/greenbone/gsa/pull/2914)
 - Fixed changing Trend and Select for NVT-families and whole selection only [#2905](https://github.com/greenbone/gsa/pull/2905)
 - Fixed missing name for CVE results on result detailspage [#2892](https://github.com/greenbone/gsa/pull/2892)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added @testing-library/user-event as a dev-dependency [#2891](https://github.com/greenbone/gsa/pull/2891)
 
 ### Changed
-- Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
+- Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867), [#2924](https://github.com/greenbone/gsa/pull/2924)
 
 ### Fixed
-- Fixed setting default scanner type to Greenbone Sensor [#2924](https://github.com/greenbone/gsa/pull/2924)
 - Fixed number-only names within schedules/dialog [#2914](https://github.com/greenbone/gsa/pull/2914)
 - Fixed changing Trend and Select for NVT-families and whole selection only [#2905](https://github.com/greenbone/gsa/pull/2905)
 - Fixed missing name for CVE results on result detailspage [#2892](https://github.com/greenbone/gsa/pull/2892)

--- a/gsa/src/web/pages/scanners/component.js
+++ b/gsa/src/web/pages/scanners/component.js
@@ -21,8 +21,6 @@ import {connect} from 'react-redux';
 
 import _ from 'gmp/locale';
 
-import {OSP_SCANNER_TYPE} from 'gmp/models/scanner';
-
 import {isDefined} from 'gmp/utils/identity';
 import {shorten} from 'gmp/utils/string';
 import {hasId} from 'gmp/utils/id';
@@ -119,7 +117,7 @@ class ScannerComponent extends React.Component {
           scanner: undefined,
           scannerDialogVisible: true,
           title: undefined,
-          type: OSP_SCANNER_TYPE,
+          type: undefined,
           which_cert: undefined,
         }),
       );


### PR DESCRIPTION
**What**:
Make https://github.com/greenbone/gsa/pull/2867 work by not presetting the type parameter for the dialog
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Greenbone Sensor was still not pre-selected
<!-- Why are these changes necessary? -->

**How**:
manual test
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [X] Labels for ports to other branches
