### PR TITLE
Fix "Pre-select greenbone sensor as default scanner type" (backport from #2924)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added @testing-library/user-event as a dev-dependency [#2891](https://github.com/greenbone/gsa/pull/2891)
 
 ### Changed
-- Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
+- Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867), [#2924](https://github.com/greenbone/gsa/pull/2924)
 
 ### Fixed
 - Fixed number-only names within schedules/dialog [#2914](https://github.com/greenbone/gsa/pull/2914)

--- a/gsa/src/web/pages/scanners/component.js
+++ b/gsa/src/web/pages/scanners/component.js
@@ -270,7 +270,7 @@ const ScannerComponent = ({
             id: undefined,
             name: undefined,
             port: undefined,
-            type: OSP_SCANNER_TYPE,
+            type: undefined,
             title: undefined, // use default title from dialog
             whichCert: undefined,
             visible: true,

--- a/gsa/src/web/pages/scanners/component.js
+++ b/gsa/src/web/pages/scanners/component.js
@@ -23,8 +23,6 @@ import _ from 'gmp/locale';
 
 import {CLIENT_CERTIFICATE_CREDENTIAL_TYPE} from 'gmp/models/credential';
 
-import {OSP_SCANNER_TYPE} from 'gmp/models/scanner';
-
 import {hasId} from 'gmp/utils/id';
 import {isDefined} from 'gmp/utils/identity';
 import {shorten} from 'gmp/utils/string';


### PR DESCRIPTION
**What**:
This is a manual backport of https://github.com/greenbone/gsa/pull/2924 because the differences between branches were too big to handle such a small change well.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
