### PR TITLE
Fix setting whether to include related resources in new permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
 
 ### Fixed
+- Fixed setting whether to include related resources for new permissions [#2931](https://github.com/greenbone/gsa/pull/2891)
 - Fixed setting secret key in RADIUS dialog, backport from [#2891](https://github.com/greenbone/gsa/pull/2891), [#2915](https://github.com/greenbone/gsa/pull/2915)
 ### Removed
 

--- a/gsa/src/web/pages/permissions/multipledialog.js
+++ b/gsa/src/web/pages/permissions/multipledialog.js
@@ -200,7 +200,7 @@ const MultiplePermissionDialog = withCapabilities(
                     name="includeRelated"
                     value={state.includeRelated}
                     items={includeRelatedItems}
-                    onChange={onValueChange}
+                    onChange={onChange}
                   />
                 </Divider>
                 {hasRelated && (


### PR DESCRIPTION
**What**:
Use correct change handler for the `Select` to set whether to include related resources when creating new permissions in a resource.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Only the default to include related resources was sent to gvmd. The value of the dropdown could not be changed.
<!-- Why are these changes necessary? -->

**How**:
Manual tests whether the value was changeable and if the correct values was sent.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [X] Labels for ports to other branches
