### PR TITLE
Fix loading NVT information in result details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
 
 ### Fixed
+- Fix loading NVT information in result details [#2934](https://github.com/greenbone/gsa/pull/2934)
 - Fixed number-only names within schedules/dialog [#2914](https://github.com/greenbone/gsa/pull/2914)
 - Fixed changing Trend and Select for NVT-families and whole selection only [#2905](https://github.com/greenbone/gsa/pull/2905)
 - Fixed missing name for CVE results on result detailspage [#2892](https://github.com/greenbone/gsa/pull/2892)

--- a/gsa/src/web/pages/results/detailspage.js
+++ b/gsa/src/web/pages/results/detailspage.js
@@ -314,11 +314,11 @@ class Page extends React.Component {
   }
 
   openDialog(result = {}, createfunc) {
-    const {nvt = {}, task = {}, host = {}} = result;
+    const {information = {}, task = {}, host = {}} = result;
     createfunc({
       fixed: true,
-      oid: nvt.oid,
-      nvt_name: nvt.name,
+      oid: information.id,
+      nvt_name: information.name,
       task_id: TASK_SELECTED,
       task_name: task.name,
       result_id: RESULT_ANY,


### PR DESCRIPTION
**What**:
Adjust `result.nvt` according to renamed field to `result.information`.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
This allows to actually get the NVT OID to create notes and overrides in the dialogs.
<!-- Why are these changes necessary? -->

**How**:
Manual tests to create notes and overrides from the result detailspage.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [X] Labels for ports to other branches
