### PR TITLE
Reworded GVM to GSM in alerts dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Create alerts in task dialog via graphql [#2425](https://github.com/greenbone/gsa/pull/2425)
 - Added getOverrides query [#2405](https://github.com/greenbone/gsa/pull/2405)
 - Added missing fields for getScanners query and parseObject() for scanner model [#2301](https://github.com/greenbone/gsa/pull/2301)
+- Changed wording in alerts dialog menu from GVM to GSM [#2943](https://github.com/greenbone/gsa/pull/2943)
 
 ### Fixed
 

--- a/gsa/src/web/pages/alerts/dialog.js
+++ b/gsa/src/web/pages/alerts/dialog.js
@@ -110,8 +110,8 @@ export const DEFAULT_NOTICE_REPORT_FORMAT =
 export const DEFAULT_NOTICE_ATTACH_FORMAT =
   'a0b5bfb2-1f62-11e1-85db-406186ea4fc5';
 
-export const TASK_SUBJECT = "[GVM] Task '$n': $e";
-export const SECINFO_SUBJECT = '[GVM] $T $q $S since $d';
+export const TASK_SUBJECT = "[GSM] Task '$n': $e";
+export const SECINFO_SUBJECT = '[GSM] $T $q $S since $d';
 
 export const INCLUDE_MESSAGE_DEFAULT = `Task '$n': $e'
 


### PR DESCRIPTION
, since it is more contextually accurate.

**What**:

Reworded GVM to GSM in alerts dialog

**Why**:

It is more contextually accurate, since the alerts come from the GSM (the machine itself) and not GVM (just the manager).

**How**:

Just  changed the two rows that were affected.

**Checklist**:

- [x] Tests (not necessary)
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [x] Labels for ports to other branches
  - [x] 21.04+
