### PR TITLE
Fall back to cvss_base when severity subelement is missing from NVT severities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867), [#2924](https://github.com/greenbone/gsa/pull/2924)
 
 ### Fixed
+- Fall back to cvss_base when severity subelement is missing from NVT severities [#2944](https://github.com/greenbone/gsa/pull/2944)
 - Fix loading NVT information in result details [#2934](https://github.com/greenbone/gsa/pull/2934)
 - Fixed setting whether to include related resources for new permissions [#2931](https://github.com/greenbone/gsa/pull/2931)
 - Fixed number-only names within schedules/dialog [#2914](https://github.com/greenbone/gsa/pull/2914)

--- a/gsa/src/gmp/models/__tests__/nvt.js
+++ b/gsa/src/gmp/models/__tests__/nvt.js
@@ -201,6 +201,18 @@ describe('nvt Model tests', () => {
     expect(nvt3.severityDate).toBeUndefined();
   });
 
+  test('should fall back to cvss_base when <severity> is missing from <severities>', () => {
+    const nvt = Nvt.fromElement({
+      cvss_base: '10.0',
+      severities: {},
+    });
+
+    expect(nvt.severity).toEqual(10.0);
+    expect(nvt.severityOrigin).toBeUndefined();
+    expect(nvt.severityDate).toBeUndefined();
+    expect(nvt.cvss_base).toBeUndefined();
+  });
+
   test('should parse preferences', () => {
     const elem = {
       preferences: {

--- a/gsa/src/gmp/models/nvt.js
+++ b/gsa/src/gmp/models/nvt.js
@@ -140,7 +140,7 @@ class Nvt extends Info {
 
     delete ret.refs;
 
-    if (isDefined(ret.severities)) {
+    if (isDefined(ret?.severities?.severity)) {
       const {severity} = ret.severities;
       ret.severity = parseSeverity(severity.score);
       ret.severityOrigin = parseText(severity.origin);


### PR DESCRIPTION
**What**:
Fall back to cvss_base when severity subelement is missing from NVT severities
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
It's possible that after some migration without gvmd -rebuild the severity subelement is missing in the NVT severities. GSA broke in that case and just threw an error without proper fallback.
<!-- Why are these changes necessary? -->

**How**:
Added a new test. Also manual check which information is shown on the detailspage for which condition.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [X] Labels for ports to other branches
