### PR TITLE
Avoid cross origin forgery by using same-site cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [20.8.2] - Unreleased
 
 ### Added
+- Set SameSite=strict for the session cookie to avoid CSRF [#2948](https://github.com/greenbone/gsa/pull/2948)
+
 ### Changed
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
 
 ### Fixed
 - Fixed setting whether to include related resources for new permissions [#2931](https://github.com/greenbone/gsa/pull/2891)
 - Fixed setting secret key in RADIUS dialog, backport from [#2891](https://github.com/greenbone/gsa/pull/2891), [#2915](https://github.com/greenbone/gsa/pull/2915)
+
 ### Removed
 
 [20.8.2]: https://github.com/greenbone/gsa/compare/v20.8.1...gsa-20.08

--- a/gsad/src/gsad_http.c
+++ b/gsad/src/gsad_http.c
@@ -516,9 +516,9 @@ remove_sid (http_response_t *response)
    * Tim Brown's suggested cookie included a domain attribute.  How would
    * we get the domain in here?  Maybe a --domain option. */
 
-  value =
-    g_strdup_printf (SID_COOKIE_NAME "=0; expires=%s; path=/; %sHTTPonly",
-                     expires, (is_use_secure_cookie () ? "secure; " : ""));
+  value = g_strdup_printf (
+    SID_COOKIE_NAME "=0; expires=%s; path=/; %sHTTPonly; SameSite=strict",
+    expires, (is_use_secure_cookie () ? "secure; " : ""));
   ret = MHD_add_response_header (response, "Set-Cookie", value);
   g_free (value);
   return ret;
@@ -592,8 +592,9 @@ attach_sid (http_response_t *response, const char *sid)
    * we get the domain in here?  Maybe a --domain option. */
 
   value = g_strdup_printf (
-    SID_COOKIE_NAME "=%s; expires=%s; max-age=%d; path=/; %sHTTPonly", sid,
-    expires, timeout, (is_use_secure_cookie () ? "secure; " : ""));
+    SID_COOKIE_NAME
+    "=%s; expires=%s; max-age=%d; path=/; %sHTTPonly; SameSite=strict",
+    sid, expires, timeout, (is_use_secure_cookie () ? "secure; " : ""));
   ret = MHD_add_response_header (response, "Set-Cookie", value);
   g_free (value);
   return ret;


### PR DESCRIPTION
**What**:

Only allow access to the session cookie from the same site and not for
third parties. 

**Why**:

This avoids CSRF attacks like like e.g.
[BREACH](http://breachattack.com/).

For more details please take a look at
http://www.sjoerdlangkemper.nl/2016/04/14/preventing-csrf-with-samesite-cookie-attribute/

**How**:

Build new gsad and did take a look if the samesite cookie settings are present in the response of the login request. Additionally I've clicked though several pages to test if something did break.

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [x] Labels for ports to other branches
