### PR TITLE
Remove network source interface from tasks and audits (master)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 ### Removed
 - Remove OVAL Definitions [#2918](https://github.com/greenbone/gsa/pull/2918), [#2921](https://github.com/greenbone/gsa/pull/2921), [#2923](https://github.com/greenbone/gsa/pull/2923)
-- Remove Network Source Interface from GSA for Tasks and Audits [#2902](https://github.com/greenbone/gsa/pull/2902)
+- Remove Network Source Interface from GSA for Tasks and Audits [#2902](https://github.com/greenbone/gsa/pull/2902) [#2942](https://github.com/greenbone/gsa/pull/2942)
 
 [21.10]: https://github.com/greenbone/gsa/compare/gsa-21.04...gsa-21.10
 

--- a/gsa/src/gmp/commands/__tests__/audit.js
+++ b/gsa/src/gmp/commands/__tests__/audit.js
@@ -84,7 +84,6 @@ describe('AuditCommand tests', () => {
             scanner_type: OPENVAS_SCANNER_TYPE,
             schedule_id: undefined,
             schedule_periods: undefined,
-            source_iface: undefined,
             tag_id: undefined,
             target_id: 't1',
             usage_type: 'audit',
@@ -123,7 +122,6 @@ describe('AuditCommand tests', () => {
         scannerType: OPENVAS_SCANNER_TYPE,
         scheduleId: 's1',
         schedulePeriods: 1,
-        sourceIface: 'eth0',
         tagId: 't1',
         targetId: 't1',
       })
@@ -149,7 +147,6 @@ describe('AuditCommand tests', () => {
             scanner_type: OPENVAS_SCANNER_TYPE,
             schedule_id: 's1',
             schedule_periods: 1,
-            source_iface: 'eth0',
             tag_id: 't1',
             target_id: 't1',
             usage_type: 'audit',
@@ -203,7 +200,6 @@ describe('AuditCommand tests', () => {
             scanner_type: undefined,
             schedule_id: 0,
             schedule_periods: undefined,
-            source_iface: undefined,
             task_id: 'audit1',
             target_id: 0,
             usage_type: 'audit',
@@ -242,7 +238,6 @@ describe('AuditCommand tests', () => {
         scannerType: OPENVAS_SCANNER_TYPE,
         scheduleId: 's1',
         schedulePeriods: 1,
-        sourceIface: 'eth0',
         targetId: 't1',
       })
       .then(resp => {
@@ -266,7 +261,6 @@ describe('AuditCommand tests', () => {
             scanner_type: OPENVAS_SCANNER_TYPE,
             schedule_id: 's1',
             schedule_periods: 1,
-            source_iface: 'eth0',
             task_id: 'audit1',
             target_id: 't1',
             usage_type: 'audit',

--- a/gsa/src/gmp/commands/__tests__/task.js
+++ b/gsa/src/gmp/commands/__tests__/task.js
@@ -75,7 +75,6 @@ describe('TaskCommand tests', () => {
             scanner_type: OPENVAS_SCANNER_TYPE,
             schedule_id: undefined,
             schedule_periods: undefined,
-            source_iface: undefined,
             tag_id: undefined,
             target_id: 't1',
             usage_type: 'scan',
@@ -114,7 +113,6 @@ describe('TaskCommand tests', () => {
         scanner_type: OPENVAS_SCANNER_TYPE,
         schedule_id: 's1',
         schedule_periods: 1,
-        source_iface: 'eth0',
         tag_id: 't1',
         target_id: 't1',
       })
@@ -140,7 +138,6 @@ describe('TaskCommand tests', () => {
             scanner_type: OPENVAS_SCANNER_TYPE,
             schedule_id: 's1',
             schedule_periods: 1,
-            source_iface: 'eth0',
             tag_id: 't1',
             target_id: 't1',
             usage_type: 'scan',
@@ -222,7 +219,6 @@ describe('TaskCommand tests', () => {
             scanner_type: undefined,
             schedule_id: 0,
             schedule_periods: undefined,
-            source_iface: undefined,
             task_id: 'task1',
             target_id: 0,
             usage_type: 'scan',
@@ -261,7 +257,6 @@ describe('TaskCommand tests', () => {
         scanner_type: OPENVAS_SCANNER_TYPE,
         schedule_id: 's1',
         schedule_periods: 1,
-        source_iface: 'eth0',
         target_id: 't1',
       })
       .then(resp => {
@@ -285,7 +280,6 @@ describe('TaskCommand tests', () => {
             scanner_type: OPENVAS_SCANNER_TYPE,
             schedule_id: 's1',
             schedule_periods: 1,
-            source_iface: 'eth0',
             task_id: 'task1',
             target_id: 't1',
             usage_type: 'scan',

--- a/gsa/src/gmp/commands/audits.js
+++ b/gsa/src/gmp/commands/audits.js
@@ -102,7 +102,6 @@ export class AuditCommand extends EntityCommand {
       scannerId,
       scheduleId,
       schedulePeriods,
-      sourceIface,
       tagId,
       targetId,
     } = args;
@@ -127,7 +126,6 @@ export class AuditCommand extends EntityCommand {
       scanner_type: scannerType,
       schedule_id: scheduleId,
       schedule_periods: schedulePeriods,
-      source_iface: sourceIface,
       tag_id: tagId,
       target_id: targetId,
       usage_type: 'audit',
@@ -157,7 +155,6 @@ export class AuditCommand extends EntityCommand {
       scheduleId = NO_VALUE,
       schedulePeriods,
       targetId = NO_VALUE,
-      sourceIface,
     } = args;
     const data = {
       alterable,
@@ -178,7 +175,6 @@ export class AuditCommand extends EntityCommand {
       scanner_type: scannerType,
       schedule_id: scheduleId,
       schedule_periods: schedulePeriods,
-      source_iface: sourceIface,
       target_id: targetId,
       task_id: id,
       usage_type: 'audit',

--- a/gsa/src/gmp/commands/tasks.js
+++ b/gsa/src/gmp/commands/tasks.js
@@ -105,7 +105,6 @@ export class TaskCommand extends EntityCommand {
       scanner_id,
       schedule_id,
       schedule_periods,
-      source_iface,
       tag_id,
       target_id,
     } = args;
@@ -130,7 +129,6 @@ export class TaskCommand extends EntityCommand {
       scanner_type,
       schedule_id,
       schedule_periods,
-      source_iface,
       tag_id,
       target_id,
       usage_type: 'scan',
@@ -172,7 +170,6 @@ export class TaskCommand extends EntityCommand {
       schedule_id = NO_VALUE,
       schedule_periods,
       target_id = NO_VALUE,
-      source_iface,
     } = args;
     const data = {
       alterable,
@@ -193,7 +190,6 @@ export class TaskCommand extends EntityCommand {
       scanner_type,
       schedule_id,
       schedule_periods,
-      source_iface,
       target_id,
       task_id: id,
       usage_type: 'scan',

--- a/gsa/src/web/pages/policies/component.js
+++ b/gsa/src/web/pages/policies/component.js
@@ -316,7 +316,6 @@ const PolicyComponent = ({
         name: undefined,
         scheduleId: defaultScheduleId,
         schedulePeriods: undefined,
-        sourceIface: undefined,
         targetId: defaultTargetId,
         title: _('New Audit'),
       }),
@@ -704,7 +703,6 @@ const PolicyComponent = ({
     scanners,
     scheduleId,
     schedulePeriods,
-    sourceIface,
     targetId,
     title,
   } = state;
@@ -776,7 +774,6 @@ const PolicyComponent = ({
                             scheduleId={scheduleId}
                             schedulePeriods={schedulePeriods}
                             schedules={schedules}
-                            sourceIface={sourceIface}
                             targetId={targetId}
                             targets={targets}
                             title={title}

--- a/gsa/src/web/pages/tasks/component.js
+++ b/gsa/src/web/pages/tasks/component.js
@@ -547,7 +547,6 @@ const TaskComponent = ({
           createAssetsMinQod: undefined,
           name: undefined,
           schedulePeriods: undefined,
-          sourceIface: undefined,
           task: undefined,
         }),
       );

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -709,7 +709,6 @@ init_validator ()
                      "^(-1(\\.0)?|[0-9](\\.[0-9])?|10(\\.0)?)$");
   gvm_validator_add (validator, "severity_optional",
                      "^(-1(\\.0)?|[0-9](\\.[0-9])?|10(\\.0)?)?$");
-  gvm_validator_add (validator, "source_iface", "^(.*){1,16}$");
   gvm_validator_add (validator, "uuid", "^[0-9abcdefABCDEF\\-]{1,40}$");
   gvm_validator_add (validator, "usage_type", "^(audit|policy|scan|)$");
   /* This must be "login" with space and comma. */

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -2092,7 +2092,7 @@ create_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
   const char *name, *comment, *config_id, *target_id, *scanner_type;
   const char *scanner_id, *schedule_id, *schedule_periods;
   const char *max_checks, *max_hosts;
-  const char *in_assets, *hosts_ordering, *alterable, *source_iface;
+  const char *in_assets, *hosts_ordering, *alterable;
   const char *add_tag, *tag_id, *auto_delete, *auto_delete_data;
   const char *apply_overrides, *min_qod, *usage_type;
   gchar *name_escaped, *comment_escaped;
@@ -2116,7 +2116,6 @@ create_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
   scanner_type = params_value (params, "scanner_type");
   schedule_id = params_value (params, "schedule_id");
   schedule_periods = params_value (params, "schedule_periods");
-  source_iface = params_value (params, "source_iface");
   tag_id = params_value (params, "tag_id");
   target_id = params_value (params, "target_id");
   usage_type = params_value (params, "usage_type");
@@ -2126,7 +2125,6 @@ create_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
     {
       hosts_ordering = "";
       max_checks = "";
-      source_iface = "";
       max_hosts = "";
     }
   else if (!strcmp (scanner_type, "3"))
@@ -2134,7 +2132,6 @@ create_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
       config_id = "";
       hosts_ordering = "";
       max_checks = "";
-      source_iface = "";
       max_hosts = "";
     }
 
@@ -2180,7 +2177,6 @@ create_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
     }
 
   CHECK_VARIABLE_INVALID (max_checks, "Create Task");
-  CHECK_VARIABLE_INVALID (source_iface, "Create Task");
   CHECK_VARIABLE_INVALID (auto_delete, "Create Task");
   CHECK_VARIABLE_INVALID (auto_delete_data, "Create Task");
   CHECK_VARIABLE_INVALID (max_hosts, "Create Task");
@@ -2252,10 +2248,6 @@ create_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
     "<value>%s</value>"
     "</preference>"
     "<preference>"
-    "<scanner_name>source_iface</scanner_name>"
-    "<value>%s</value>"
-    "</preference>"
-    "<preference>"
     "<scanner_name>auto_delete</scanner_name>"
     "<value>%s</value>"
     "</preference>"
@@ -2270,7 +2262,7 @@ create_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
     config_id, schedule_periods, schedule_element, alert_element->str,
     target_id, scanner_id, hosts_ordering, name_escaped, comment_escaped,
     max_checks, max_hosts, strcmp (in_assets, "0") ? "yes" : "no",
-    strcmp (apply_overrides, "0") ? "yes" : "no", min_qod, source_iface,
+    strcmp (apply_overrides, "0") ? "yes" : "no", min_qod,
     auto_delete, auto_delete_data, alterable ? strcmp (alterable, "0") : 0,
     usage_type);
 
@@ -2439,7 +2431,7 @@ save_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
   gchar *html, *response, *format;
   const char *comment, *name, *schedule_id, *in_assets;
   const char *scanner_id, *task_id, *max_checks, *max_hosts;
-  const char *config_id, *target_id, *hosts_ordering, *alterable, *source_iface;
+  const char *config_id, *target_id, *hosts_ordering, *alterable;
   const char *scanner_type, *schedule_periods, *auto_delete, *auto_delete_data;
   const char *apply_overrides, *min_qod;
   int ret;
@@ -2463,7 +2455,6 @@ save_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
   scanner_type = params_value (params, "scanner_type");
   schedule_id = params_value (params, "schedule_id");
   schedule_periods = params_value (params, "schedule_periods");
-  source_iface = params_value (params, "source_iface");
   target_id = params_value (params, "target_id");
   task_id = params_value (params, "task_id");
 
@@ -2474,7 +2465,6 @@ save_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
         {
           hosts_ordering = "";
           max_checks = "";
-          source_iface = "";
           max_hosts = "";
         }
       else if (!strcmp (scanner_type, "3"))
@@ -2482,7 +2472,6 @@ save_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
           config_id = "0";
           hosts_ordering = "";
           max_checks = "";
-          source_iface = "";
           max_hosts = "";
         }
     }
@@ -2502,7 +2491,6 @@ save_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
   CHECK_VARIABLE_INVALID (scanner_id, "Save Task");
   CHECK_VARIABLE_INVALID (task_id, "Save Task");
   CHECK_VARIABLE_INVALID (max_checks, "Save Task");
-  CHECK_VARIABLE_INVALID (source_iface, "Save Task");
   CHECK_VARIABLE_INVALID (auto_delete, "Save Task");
   CHECK_VARIABLE_INVALID (auto_delete_data, "Save Task");
   CHECK_VARIABLE_INVALID (max_hosts, "Save Task");
@@ -2582,10 +2570,6 @@ save_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
     "<value>%%s</value>"
     "</preference>"
     "<preference>"
-    "<scanner_name>source_iface</scanner_name>"
-    "<value>%%s</value>"
-    "</preference>"
-    "<preference>"
     "<scanner_name>auto_delete</scanner_name>"
     "<value>%%s</value>"
     "</preference>"
@@ -2605,7 +2589,7 @@ save_task_gmp (gvm_connection_t *connection, credentials_t *credentials,
               schedule_periods, scanner_id, max_checks, max_hosts,
               strcmp (in_assets, "0") ? "yes" : "no",
               strcmp (apply_overrides, "0") ? "yes" : "no", min_qod,
-              source_iface, auto_delete, auto_delete_data);
+              auto_delete, auto_delete_data);
   g_free (format);
 
   g_string_free (alert_element, TRUE);


### PR DESCRIPTION
**What**:

Manually port changes from https://github.com/greenbone/gsa/pull/2902 and https://github.com/greenbone/gsa/pull/2942 from gsa-21.10

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

There are massive changes in tasks and audits between the two branches and required manual attention.

<!-- Why are these changes necessary? -->

**How**:

Tests are passing. Also did manual tests.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
