### PR TITLE
Add origin and date from NVT severities to parseObject() in NVT model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Hyperion] - unreleased
 
 ### Added
+- Add origin and date from NVT severities to parseObject() in NVT model [#2955](https://github.com/greenbone/gsa/pull/2955)
 
 ### Changed
 - Adjust tasks and audits to reflect schema changes in Hyperion[#2906](https://github.com/greenbone/gsa/pull/2906) [#2918](https://github.com/greenbone/gsa/pull/2918) [#2930](https://github.com/greenbone/gsa/pull/2930)

--- a/gsa/src/gmp/models/__tests__/nvt.js
+++ b/gsa/src/gmp/models/__tests__/nvt.js
@@ -23,6 +23,34 @@ import Info from 'gmp/models/info';
 import {testModelFromElement, testModelMethods} from 'gmp/models/testing';
 import date from 'gmp/models/date';
 
+describe('NVT model parseObject tests', () => {
+  test('should parse severities origin and date', () => {
+    const nvt1 = Nvt.fromObject({
+      severities: [
+        {
+          origin: 'Vendor',
+          date: '2020-03-10T06:40:13Z',
+        },
+      ],
+    });
+    const nvt2 = Nvt.fromObject({id: '1.3.6.1.4.1.25623.1.0.146043'});
+    expect(nvt1.severityOrigin).toEqual('Vendor');
+    expect(nvt1.severityDate).toEqual(date('2020-03-10T06:40:13Z'));
+    expect(nvt2.severityOrigin).toBeUndefined();
+    expect(nvt2.severityDate).toBeUndefined();
+  });
+
+  test('should parse preferenceCount', () => {
+    const nvt1 = Nvt.fromObject({
+      // actually preferenceCount in the XML is -1 in get_info
+      // right now.
+      preferenceCount: -1,
+      preferences: [{}, {}],
+    });
+    expect(nvt1.preferenceCount).toEqual(2);
+  });
+});
+
 describe('nvt Model tests', () => {
   testModelFromElement(Nvt, 'nvt');
   testModelMethods(Nvt);

--- a/gsa/src/gmp/models/nvt.js
+++ b/gsa/src/gmp/models/nvt.js
@@ -127,6 +127,13 @@ class Nvt extends Info {
       ? parseScoreToSeverity(ret.score)
       : undefined;
 
+    if (isDefined(ret.severities)) {
+      const [severity = {}] = ret.severities;
+      const {origin, date} = severity;
+      ret.severityOrigin = hasValue(origin) ? parseText(origin) : undefined;
+      ret.severityDate = hasValue(date) ? parseDate(date) : undefined;
+    }
+
     if (ret.preferenceCount < 0) {
       // actually preferenceCount in the XML is -1 in get_info
       // right now.


### PR DESCRIPTION
**What**:
Add origin and date from NVT severities to parseObject() in NVT model.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
They are not parsed properly and don't show up in the NVT details
<!-- Why are these changes necessary? -->

**How**:
Visual inspection, if the info is shown. Automatic tests are still passing.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [N/A] Labels for ports to other branches
