### PR TITLE
Show xref type in NVT details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [20.8.2] - Unreleased
 
 ### Added
+- Show type of xrefs in NVT details [#2980](https://github.com/greenbone/gsa/pull/2980)
 - Set SameSite=strict for the session cookie to avoid CSRF [#2948](https://github.com/greenbone/gsa/pull/2948)
 
 ### Changed

--- a/gsa/src/web/pages/nvts/references.js
+++ b/gsa/src/web/pages/nvts/references.js
@@ -19,6 +19,8 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
+import {isDefined} from 'gmp/utils/identity';
+
 import DetailsBlock from 'web/entity/block';
 
 import PropTypes from 'web/utils/proptypes';
@@ -94,6 +96,9 @@ const References = ({nvt, links = true}) => {
                       textOnly={!links || xref.type !== 'url'}
                       to={xref.ref}
                     >
+                      {isDefined(xref.type) &&
+                        xref.type !== 'url' &&
+                        xref.type + ': '}
                       {xref.ref}
                     </ExternalLink>
                   </span>


### PR DESCRIPTION
**What**:
Show the type of xrefs in the reference section of NVTs, except url.

![xrefs1](https://user-images.githubusercontent.com/32056637/121352150-d7ba8000-c92c-11eb-855a-cec80ff56ba0.png)
![xrefs2](https://user-images.githubusercontent.com/32056637/121352168-dab57080-c92c-11eb-87b5-cfcd62deb50f.png)
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
There seemed to be changes made in the NASL scripts that altered the content of `name` and `type` of xrefs.

NOTE: It is not 100% clear how the change of behavior happened but GSA is already getting the type in lower case only, therefore it will appear as that in the details as well..
<!-- Why are these changes necessary? -->

**How**:
Visually check whether the type is included.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [X] Labels for ports to other branches
