### PR TITLE
gsa-21.04: Fix duplicated and broken CHANGELOG.md entries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed number-only names within schedules/dialog [#2914](https://github.com/greenbone/gsa/pull/2914)
 - Fixed changing Trend and Select for NVT-families and whole selection only [#2905](https://github.com/greenbone/gsa/pull/2905)
 - Fixed missing name for CVE results on result detailspage [#2892](https://github.com/greenbone/gsa/pull/2892)
-- Fixed setting secret key in RADIUS dialog [#2891](https://github.com/greenbone/gsa/pull/2891)
+- Fixed setting secret key in RADIUS dialog, backport from [#2891](https://github.com/greenbone/gsa/pull/2891), [#2915](https://github.com/greenbone/gsa/pull/2915)
 - Fixed setting result UUID in notes dialog [#2889](https://github.com/greenbone/gsa/pull/2889)
-- Fixed setting whether to include related resources for new permissions [#2931](https://github.com/greenbone/gsa/pull/2891)
-- Fixed setting secret key in RADIUS dialog, backport from [#2891](https://github.com/greenbone/gsa/pull/2891), [#2915](https://github.com/greenbone/gsa/pull
+
 ### Removed
 
 [Unreleased]: https://github.com/greenbone/gsa/compare/v21.4.0...gsa-21.04
@@ -59,7 +58,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#2756](https://github.com/greenbone/gsa/pull/2756)
 - CVE Tables Page can now be used with the updated xml-format and CVSSv3(.1). [#2583](https://github.com/greenbone/gsa/pull/2583)
 - The CVSS v2 BaseScore calculator calculates the score on the client side now. [#2536](https://github.com/greenbone/gsa/pull/2536)
-
 
 ### Fixed
 - Fixed dynamic severity checkbox not being checked upon clicking [#2882](https://github.com/greenbone/gsa/pull/2882)


### PR DESCRIPTION
As mentioned in https://github.com/greenbone/gsa/pull/2958#discussion_r646312539 some problems have been introduced in this backport:

- The entry on `#2931` already existed in the CHANGELOG.md
- The duplicated entry of `#2931` had linked to the unrelated PR `#2891`
- The entry on `#2891` already existed in the CHANGELOG.md and the second one was broken like seen here:

![Screenshot_2021-06-14_10-31-07](https://user-images.githubusercontent.com/34644702/121864008-b7a80980-ccfc-11eb-9e33-4543edffab5f.png)

The master branch seems to be only affected by the duplicated entries, will create another MR for that in a few minutes.