### PR TITLE
Disallow using the same credential for ssh and elevate credential in targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Set SameSite=strict for the session cookie to avoid CSRF [#2948](https://github.com/greenbone/gsa/pull/2948)
 
 ### Changed
+- Disallow using the same credential for ssh and elevate credential in targets [#2994](https://github.com/greenbone/gsa/pull/2994)
 - Properly space and linebreak roles and groups in users table row [#2949](https://github.com/greenbone/gsa/pull/2949)
 - Make HorizontalSep component wrappable [#2949](https://github.com/greenbone/gsa/pull/2949)
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867), [#2924](https://github.com/greenbone/gsa/pull/2924)

--- a/gsa/src/web/pages/targets/__tests__/dialog.js
+++ b/gsa/src/web/pages/targets/__tests__/dialog.js
@@ -469,7 +469,7 @@ describe('TargetDialog component tests', () => {
     expect(createCredentialIcons.length).toEqual(10); // Each icon has both a span and an svg icon. There should be 5 total, including elevate privileges
   });
 
-  test('ssh elevate credential dropdown should only allow username + password options', () => {
+  test('ssh elevate credential dropdown should only allow username + password options and remove ssh credential from list', () => {
     const handleClose = jest.fn();
     const handleChange = jest.fn();
     const handleSave = jest.fn();
@@ -490,7 +490,7 @@ describe('TargetDialog component tests', () => {
         name={'target'}
         reverse_lookup_only={0}
         reverse_lookup_unify={0}
-        smb_credential_id={'2345'}
+        smb_credential_id={'23456'}
         ssh_credential_id={'2345'}
         target_title={'Edit Target target'}
         onClose={handleClose}
@@ -519,11 +519,10 @@ describe('TargetDialog component tests', () => {
     fireEvent.click(selectOpenButton[3]);
 
     selectItems = queryAllByTestId('select-item');
-    expect(selectItems.length).toBe(3);
+    expect(selectItems.length).toBe(2); // "original" ssh option removed
 
     expect(selectItems[0]).toHaveTextContent('--'); // null option
-    expect(selectItems[1]).toHaveTextContent('username+password');
-    expect(selectItems[2]).toHaveTextContent('up2');
+    expect(selectItems[1]).toHaveTextContent('up2');
   });
 
   test('should disable editing certain fields if target is in use', () => {
@@ -547,7 +546,7 @@ describe('TargetDialog component tests', () => {
         name={'target'}
         reverse_lookup_only={0}
         reverse_lookup_unify={0}
-        smb_credential_id={'2345'}
+        smb_credential_id={'23456'}
         ssh_credential_id={'2345'}
         ssh_elevate_credential_id={'2345'}
         target_title={'Edit Target target'}
@@ -579,9 +578,9 @@ describe('TargetDialog component tests', () => {
     expect(selectedValues[2]).toHaveTextContent('username+password');
     expect(selectedValues[2]).toHaveAttribute('disabled');
 
-    expect(selectedValues[3]).toHaveTextContent('username+password');
+    expect(selectedValues[3]).toHaveTextContent('2345');
     expect(selectedValues[3]).toHaveAttribute('disabled');
-    expect(selectedValues[4]).toHaveTextContent('username+password');
+    expect(selectedValues[4]).toHaveTextContent('23456');
     expect(selectedValues[4]).toHaveAttribute('disabled');
 
     expect(selectedValues[5]).toHaveTextContent('--');

--- a/gsa/src/web/pages/targets/dialog.js
+++ b/gsa/src/web/pages/targets/dialog.js
@@ -154,6 +154,9 @@ const TargetDialog = ({
   const up_credentials = credentials.filter(
     value => value.credential_type === USERNAME_PASSWORD_CREDENTIAL_TYPE,
   );
+  const elevateUpCredentials = up_credentials.filter(
+    value => value.id !== ssh_credential_id,
+  );
   const snmp_credentials = credentials.filter(snmp_credential_filter);
 
   const uncontrolledValues = {
@@ -388,7 +391,10 @@ const TargetDialog = ({
                       <Select
                         name="ssh_elevate_credential_id"
                         disabled={in_use}
-                        items={renderSelectItems(up_credentials, UNSET_VALUE)}
+                        items={renderSelectItems(
+                          elevateUpCredentials,
+                          UNSET_VALUE,
+                        )}
                         value={state.ssh_elevate_credential_id}
                         onChange={onSshElevateCredentialChange}
                       />


### PR DESCRIPTION
**What**:
Remove the credential from the elevate credential selection list, that has been used to unlock the option for elevate credentials in the first place.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:
Write a new test, manually inspect options in the dropdowns.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [X] Labels for ports to other branches
