### PR TITLE
SSH elevate credential should not appear in dropdown for SSH credential

### DIFF
--- a/gsa/src/web/pages/targets/__tests__/dialog.js
+++ b/gsa/src/web/pages/targets/__tests__/dialog.js
@@ -22,6 +22,7 @@ import {setLocale} from 'gmp/locale/lang';
 import Credential, {
   USERNAME_PASSWORD_CREDENTIAL_TYPE,
   CLIENT_CERTIFICATE_CREDENTIAL_TYPE,
+  USERNAME_SSH_KEY_CREDENTIAL_TYPE,
 } from 'gmp/models/credential';
 
 import {rendererWith, fireEvent, screen} from 'web/utils/testing';
@@ -48,7 +49,13 @@ const cred3 = Credential.fromElement({
   type: USERNAME_PASSWORD_CREDENTIAL_TYPE,
 });
 
-const credentials = [cred1, cred2, cred3];
+const cred4 = Credential.fromElement({
+  id: '6536',
+  name: 'ssh_key',
+  type: USERNAME_SSH_KEY_CREDENTIAL_TYPE,
+});
+
+const credentials = [cred1, cred2, cred3, cred4];
 
 const gmp = {settings: {enableGreenboneSensor: true}};
 
@@ -574,10 +581,11 @@ describe('TargetDialog component tests', () => {
     fireEvent.click(selectOpenButton[2]);
 
     selectItems = queryAllByTestId('select-item');
-    expect(selectItems.length).toBe(2); // ssh elevate option removed
+    expect(selectItems.length).toBe(3); // ssh elevate option removed
 
     expect(selectItems[0]).toHaveTextContent('--'); // null option
     expect(selectItems[1]).toHaveTextContent('username+password');
+    expect(selectItems[2]).toHaveTextContent('ssh_key');
   });
 
   test('should disable editing certain fields if target is in use', () => {

--- a/gsa/src/web/pages/targets/__tests__/dialog.js
+++ b/gsa/src/web/pages/targets/__tests__/dialog.js
@@ -489,7 +489,7 @@ describe('TargetDialog component tests', () => {
         name={'target'}
         reverse_lookup_only={0}
         reverse_lookup_unify={0}
-        smb_credential_id={'23456'}
+        smb_credential_id={'5463'}
         ssh_credential_id={'2345'}
         target_title={'Edit Target target'}
         onClose={handleClose}
@@ -524,6 +524,62 @@ describe('TargetDialog component tests', () => {
     expect(selectItems[1]).toHaveTextContent('up2');
   });
 
+  test('ssh credential dropdown should remove ssh elevate credential from list', () => {
+    const handleClose = jest.fn();
+    const handleChange = jest.fn();
+    const handleSave = jest.fn();
+    const handleCreate = jest.fn();
+
+    const {render} = rendererWith({gmp, capabilities: true});
+
+    const {baseElement, queryAllByTestId} = render(
+      <TargetDialog
+        credentials={credentials}
+        id={'foo'}
+        alive_tests={'Scan Config Default'}
+        allowSimultaneousIPs={0}
+        comment={'hello world'}
+        exclude_hosts={''}
+        hosts={'123.455.67.434'}
+        in_use={false}
+        name={'target'}
+        reverse_lookup_only={0}
+        reverse_lookup_unify={0}
+        ssh_elevate_credential_id={'5463'}
+        ssh_credential_id={'2345'}
+        target_title={'Edit Target target'}
+        onClose={handleClose}
+        onNewCredentialsClick={handleCreate}
+        onNewPortListClick={handleCreate}
+        onPortListChange={handleChange}
+        onSnmpCredentialChange={handleChange}
+        onSshCredentialChange={handleChange}
+        onEsxiCredentialChange={handleChange}
+        onSmbCredentialChange={handleChange}
+        onSshElevateCredentialChange={handleChange}
+        onSave={handleSave}
+      />,
+    );
+
+    expect(baseElement).toHaveTextContent('Elevate privileges');
+
+    const selectedValues = screen.getAllByTestId('select-selected-value');
+    expect(selectedValues.length).toEqual(7); // Should have 7 selects
+
+    const selectOpenButton = screen.getAllByTestId('select-open-button');
+    let selectItems = queryAllByTestId('select-item');
+
+    expect(selectItems.length).toBe(0);
+
+    fireEvent.click(selectOpenButton[2]);
+
+    selectItems = queryAllByTestId('select-item');
+    expect(selectItems.length).toBe(2); // ssh elevate option removed
+
+    expect(selectItems[0]).toHaveTextContent('--'); // null option
+    expect(selectItems[1]).toHaveTextContent('username+password');
+  });
+
   test('should disable editing certain fields if target is in use', () => {
     const handleClose = jest.fn();
     const handleChange = jest.fn();
@@ -545,9 +601,8 @@ describe('TargetDialog component tests', () => {
         name={'target'}
         reverse_lookup_only={0}
         reverse_lookup_unify={0}
-        smb_credential_id={'23456'}
         ssh_credential_id={'2345'}
-        ssh_elevate_credential_id={'2345'}
+        ssh_elevate_credential_id={'5463'}
         target_title={'Edit Target target'}
         onClose={handleClose}
         onNewCredentialsClick={handleCreate}
@@ -577,9 +632,9 @@ describe('TargetDialog component tests', () => {
     expect(selectedValues[2]).toHaveTextContent('username+password');
     expect(selectedValues[2]).toHaveAttribute('disabled');
 
-    expect(selectedValues[3]).toHaveTextContent('2345');
+    expect(selectedValues[3]).toHaveTextContent('up2');
     expect(selectedValues[3]).toHaveAttribute('disabled');
-    expect(selectedValues[4]).toHaveTextContent('23456');
+    expect(selectedValues[4]).toHaveTextContent('--');
     expect(selectedValues[4]).toHaveAttribute('disabled');
 
     expect(selectedValues[5]).toHaveTextContent('--');

--- a/gsa/src/web/pages/targets/component.js
+++ b/gsa/src/web/pages/targets/component.js
@@ -272,6 +272,10 @@ class TargetComponent extends React.Component {
 
   handleSshCredentialChange(ssh_credential_id) {
     this.setState({ssh_credential_id});
+
+    if (ssh_credential_id === UNSET_VALUE) {
+      this.setState({ssh_elevate_credential_id: UNSET_VALUE}); // if ssh_credential_id is changed to UNSET_VALUE, elevate privileges option will not be rendered anymore. If we don't reset ssh_elevate_credential_id, then the previously set ssh_elevate_credential_id will never be available for the SSH dropdown again because it will still be set in the dialog state. ssh_elevate_credential_id should be available again if we ever unset ssh_credential_id
+    }
   }
 
   handleSshElevateCredentialChange(ssh_elevate_credential_id) {

--- a/gsa/src/web/pages/targets/dialog.js
+++ b/gsa/src/web/pages/targets/dialog.js
@@ -150,7 +150,9 @@ const TargetDialog = ({
   onSshElevateCredentialChange,
   ...initial
 }) => {
-  const ssh_credentials = credentials.filter(ssh_credential_filter);
+  const ssh_credentials = credentials
+    .filter(ssh_credential_filter)
+    .filter(value => value.id !== ssh_elevate_credential_id); // filter out ssh_elevate_credential_id. If ssh_elevate_credential_id is UNSET_VALUE, this is ok. Because the Select will add back the UNSET_VALUE
   const up_credentials = credentials.filter(
     value => value.credential_type === USERNAME_PASSWORD_CREDENTIAL_TYPE,
   );

--- a/gsa/src/web/pages/targets/dialog.js
+++ b/gsa/src/web/pages/targets/dialog.js
@@ -150,9 +150,10 @@ const TargetDialog = ({
   onSshElevateCredentialChange,
   ...initial
 }) => {
-  const ssh_credentials = credentials
-    .filter(ssh_credential_filter)
-    .filter(value => value.id !== ssh_elevate_credential_id); // filter out ssh_elevate_credential_id. If ssh_elevate_credential_id is UNSET_VALUE, this is ok. Because the Select will add back the UNSET_VALUE
+  const ssh_credentials = credentials.filter(
+    value =>
+      ssh_credential_filter(value) && value.id !== ssh_elevate_credential_id,
+  ); // filter out ssh_elevate_credential_id. If ssh_elevate_credential_id is UNSET_VALUE, this is ok. Because the Select will add back the UNSET_VALUE
   const up_credentials = credentials.filter(
     value => value.credential_type === USERNAME_PASSWORD_CREDENTIAL_TYPE,
   );


### PR DESCRIPTION
**What**:

Filter out ssh_elevate_credential_id from ssh_credential options so the user cannot set an ssh credential to be the same as an elevate credential.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

Manual and unit tests.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [x] Labels for ports to other branches
