### PR TITLE
Fixes: TLS Certificates identified by issuer? #2847

### DIFF
--- a/gsa/src/gmp/models/tlscertificate.js
+++ b/gsa/src/gmp/models/tlscertificate.js
@@ -51,8 +51,7 @@ class TlsCertificate extends Model {
       ? element.certificate.__text
       : undefined;
 
-    ret.name = element.issuer_dn;
-    delete ret.issuer_dn;
+    ret.name = element.subject_dn;
 
     ret.activationTime =
       element.activation_time === 'undefined' ||

--- a/gsa/src/web/pages/tlscertificates/details.js
+++ b/gsa/src/web/pages/tlscertificates/details.js
@@ -53,6 +53,12 @@ const TlsCertificateDetails = ({entity, links = true}) => {
           <Col width="90%" />
         </colgroup>
         <TableBody>
+          {isDefined(entity.issuer_dn) && (
+            <TableRow>
+              <TableData>{_('Issuer DN')}</TableData>
+              <TableData>{entity.issuer_dn}</TableData>
+            </TableRow>
+          )}
           {isDefined(entity.valid) && (
             <TableRow>
               <TableData>{_('Valid')}</TableData>

--- a/gsa/src/web/pages/tlscertificates/filterdialog.js
+++ b/gsa/src/web/pages/tlscertificates/filterdialog.js
@@ -22,7 +22,7 @@ import {createFilterDialog} from 'web/components/powerfilter/dialog';
 const SORT_FIELDS = [
   {
     name: 'name',
-    displayName: _l('Issuer DN'),
+    displayName: _l('Subject DN'),
   },
   {
     name: 'serial',

--- a/gsa/src/web/pages/tlscertificates/table.js
+++ b/gsa/src/web/pages/tlscertificates/table.js
@@ -46,9 +46,9 @@ const Header = ({
           width="30%"
           currentSortDir={currentSortDir}
           currentSortBy={currentSortBy}
-          sortBy={sort ? 'issuer_dn' : false}
+          sortBy={sort ? 'subject_dn' : false}
           onSortChange={onSortChange}
-          title={_('Issuer DN')}
+          title={_('Subject DN')}
         />
         <TableHead
           width="26%"


### PR DESCRIPTION
Show subject DN as name and put issuer DN into detail view

**Why**:

Because certificates can not reliably be identified by the issuer DN

**How**:

Compiled and listed the certificates in the webgui

**Checklist**:

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
