### PR TITLE
Initialize severity value with 0 in powerfilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
 
 ### Fixed
+- Initialize severity value with 0 in powerfilter SeverityValuesGroup [#3031](https://github.com/greenbone/gsa/pull/3031)
 - Fixed setting whether to include related resources for new permissions [#2931](https://github.com/greenbone/gsa/pull/2891)
 - Fixed setting secret key in RADIUS dialog, backport from [#2891](https://github.com/greenbone/gsa/pull/2891), [#2915](https://github.com/greenbone/gsa/pull/2915)
 

--- a/gsa/src/web/components/powerfilter/__tests__/__snapshots__/severityvaluesgroup.js.snap
+++ b/gsa/src/web/components/powerfilter/__tests__/__snapshots__/severityvaluesgroup.js.snap
@@ -470,7 +470,7 @@ exports[`Severity Values Group Tests should render 1`] = `
         <input
           max="10"
           min="0"
-          name="cvss_base"
+          name="severity"
           size="5"
           value="3"
         />

--- a/gsa/src/web/components/powerfilter/__tests__/severityvaluesgroup.js
+++ b/gsa/src/web/components/powerfilter/__tests__/severityvaluesgroup.js
@@ -31,8 +31,8 @@ import Filter from 'gmp/models/filter';
 
 describe('Severity Values Group Tests', () => {
   test('should render', () => {
-    const filter = Filter.fromString('cvss_base>3');
-    const name = 'cvss_base';
+    const filter = Filter.fromString('severity>3');
+    const name = 'severity';
     const onChange = jest.fn();
 
     const {element} = render(
@@ -49,8 +49,8 @@ describe('Severity Values Group Tests', () => {
 
   test('arguments are processed correctly', () => {
     const onChange = jest.fn();
-    const filter = Filter.fromString('cvss_base=3');
-    const name = 'cvss_base';
+    const filter = Filter.fromString('severity=3');
+    const name = 'severity';
 
     const {element} = render(
       <SeverityValuesGroup
@@ -65,14 +65,34 @@ describe('Severity Values Group Tests', () => {
     const numField = element.querySelectorAll('input');
 
     expect(formTitle[0]).toHaveTextContent('foo');
-    expect(numField[0]).toHaveAttribute('name', 'cvss_base');
+    expect(numField[0]).toHaveAttribute('name', 'severity');
     expect(numField[0]).toHaveAttribute('value', '3');
+  });
+
+  test('should initialize value with 0 in case no filter value is given', () => {
+    const onChange = jest.fn();
+    const filter = Filter.fromString('rows=10');
+    const name = 'severity';
+
+    const {element} = render(
+      <SeverityValuesGroup
+        filter={filter}
+        name={name}
+        title="foo"
+        onChange={onChange}
+      />,
+    );
+
+    const numField = element.querySelectorAll('input');
+
+    expect(numField[0]).toHaveAttribute('name', 'severity');
+    expect(numField[0]).toHaveAttribute('value', '0');
   });
 
   test('should change value', () => {
     const onChange = jest.fn();
-    const filter = Filter.fromString('cvss_base=3');
-    const name = 'cvss_base';
+    const filter = Filter.fromString('severity=3');
+    const name = 'severity';
 
     const {element} = render(
       <SeverityValuesGroup
@@ -87,13 +107,13 @@ describe('Severity Values Group Tests', () => {
 
     fireEvent.change(numField[0], {target: {value: '9'}});
 
-    expect(onChange).toHaveBeenCalledWith(9, 'cvss_base', '=');
+    expect(onChange).toHaveBeenCalledWith(9, 'severity', '=');
   });
 
   test('should change relationship', () => {
     const onChange = jest.fn();
-    const filter = Filter.fromString('cvss_base=3');
-    const name = 'cvss_base';
+    const filter = Filter.fromString('severity=3');
+    const name = 'severity';
 
     const {element, baseElement} = render(
       <SeverityValuesGroup
@@ -111,6 +131,6 @@ describe('Severity Values Group Tests', () => {
     fireEvent.click(domItems[2]);
 
     expect(onChange).toBeCalled();
-    expect(onChange).toBeCalledWith(3, 'cvss_base', '<');
+    expect(onChange).toBeCalledWith(3, 'severity', '<');
   });
 });

--- a/gsa/src/web/components/powerfilter/severityvaluesgroup.js
+++ b/gsa/src/web/components/powerfilter/severityvaluesgroup.js
@@ -37,7 +37,7 @@ const SeverityValuesGroup = ({filter, name, title, onChange}) => {
    */
 
   const term = filter.getTerm(name);
-  const severity = isDefined(term) ? parseSeverity(term.value) : undefined;
+  const severity = isDefined(term) ? parseSeverity(term.value) : 0;
 
   const [rel, setRel] = useState(isDefined(term) ? term.relation : '='); // here rel is set to '='
   const keyword = name;

--- a/gsa/src/web/pages/results/filterdialog.js
+++ b/gsa/src/web/pages/results/filterdialog.js
@@ -122,7 +122,7 @@ const ResultsFilterDialogComponent = ({
       />
 
       <SeverityValuesGroup
-        name="cvss_base"
+        name="severity"
         filter={filter}
         title={_('Severity')}
         onChange={onFilterValueChange}


### PR DESCRIPTION
**What**:
- Initialize severity value in the powerfilter's SeverityValuesGroup with 0.
- Use severity as filter keyword for result filter instead of cvss_base
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
- The 0 was the default value of the NumberField, which was displayed, but was not stored in the dialog state to be 
sent with the filter update.
- Using severity is more consistent with other entities' filters
<!-- Why are these changes necessary? -->

**How**:
Manuel tests and new automatic test added
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [X] Labels for ports to other branches
