### PR TITLE
Use UNSET_VALUE as default for relation of severity values in powerfilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use greenbone sensor as default scanner type when opening the dialog if available [#2867](https://github.com/greenbone/gsa/pull/2867)
 
 ### Fixed
+- Use UNSET_VALUE as default for relation of severity values in powerfilter [#3052](https://github.com/greenbone/gsa/pull/3052)
 - Initialize severity value with 0 in powerfilter SeverityValuesGroup [#3031](https://github.com/greenbone/gsa/pull/3031)
 - Removed a CMake dependency in the CMakeLists, so GSA can be build again. [#3030](https://github.com/greenbone/gsa/pull/3030)
 - Fixed setting whether to include related resources for new permissions [#2931](https://github.com/greenbone/gsa/pull/2891)

--- a/gsa/src/web/components/powerfilter/__tests__/relationselector.js
+++ b/gsa/src/web/components/powerfilter/__tests__/relationselector.js
@@ -52,10 +52,11 @@ describe('Relation Selector Tests', () => {
 
     domItems = getItemElements(baseElement);
 
-    expect(domItems.length).toEqual(3);
-    expect(domItems[0]).toHaveTextContent('is equal to');
-    expect(domItems[1]).toHaveTextContent('is greater than');
-    expect(domItems[2]).toHaveTextContent('is less than');
+    expect(domItems.length).toEqual(4);
+    expect(domItems[0]).toHaveTextContent('--');
+    expect(domItems[1]).toHaveTextContent('is equal to');
+    expect(domItems[2]).toHaveTextContent('is greater than');
+    expect(domItems[3]).toHaveTextContent('is less than');
   });
 
   test('should call onChange handler', () => {
@@ -69,7 +70,7 @@ describe('Relation Selector Tests', () => {
 
     const domItems = getItemElements(baseElement);
 
-    fireEvent.click(domItems[0]);
+    fireEvent.click(domItems[1]);
 
     expect(onChange).toBeCalled();
     expect(onChange).toBeCalledWith('=', undefined);
@@ -89,7 +90,7 @@ describe('Relation Selector Tests', () => {
 
     const domItems = getItemElements(baseElement);
 
-    fireEvent.click(domItems[2]);
+    fireEvent.click(domItems[3]);
 
     expect(onChange).toBeCalled();
     expect(onChange).toBeCalledWith('<', undefined);
@@ -103,7 +104,7 @@ describe('Relation Selector Tests', () => {
     openSelectElement(element);
 
     let domItems = getItemElements(baseElement);
-    expect(domItems.length).toEqual(3);
+    expect(domItems.length).toEqual(4);
 
     const input = getInputBox(baseElement);
 

--- a/gsa/src/web/components/powerfilter/__tests__/severityvaluesgroup.js
+++ b/gsa/src/web/components/powerfilter/__tests__/severityvaluesgroup.js
@@ -128,7 +128,7 @@ describe('Severity Values Group Tests', () => {
 
     const domItems = getItemElements(baseElement);
 
-    fireEvent.click(domItems[2]);
+    fireEvent.click(domItems[3]);
 
     expect(onChange).toBeCalled();
     expect(onChange).toBeCalledWith(3, 'severity', '<');

--- a/gsa/src/web/components/powerfilter/relationselector.js
+++ b/gsa/src/web/components/powerfilter/relationselector.js
@@ -23,18 +23,22 @@ import _ from 'gmp/locale';
 
 import Select from 'web/components/form/select';
 import PropTypes from 'web/utils/proptypes.js';
+import {UNSET_LABEL, UNSET_VALUE} from 'web/utils/render';
 
-const RelationSelector = ({relation, onChange}) => (
-  <Select
-    value={relation}
-    onChange={onChange}
-    items={[
-      {label: _('is equal to'), value: '='},
-      {label: _('is greater than'), value: '>'},
-      {label: _('is less than'), value: '<'},
-    ]}
-  />
-);
+const RelationSelector = ({relation, onChange}) => {
+  return (
+    <Select
+      value={relation}
+      onChange={onChange}
+      items={[
+        {label: UNSET_LABEL, value: UNSET_VALUE},
+        {label: _('is equal to'), value: '='},
+        {label: _('is greater than'), value: '>'},
+        {label: _('is less than'), value: '<'},
+      ]}
+    />
+  );
+};
 
 RelationSelector.propTypes = {
   relation: PropTypes.string,

--- a/gsa/src/web/components/powerfilter/severityvaluesgroup.js
+++ b/gsa/src/web/components/powerfilter/severityvaluesgroup.js
@@ -26,6 +26,8 @@ import RelationSelector from 'web/components/powerfilter/relationselector';
 import NumberField from 'web/components/form/numberfield';
 import Divider from 'web/components/layout/divider';
 
+import {UNSET_VALUE} from 'web/utils/render';
+
 const SeverityValuesGroup = ({filter, name, title, onChange}) => {
   /* useState is analogous to setState in class components.
    * the first argument is the state variable.
@@ -39,7 +41,7 @@ const SeverityValuesGroup = ({filter, name, title, onChange}) => {
   const term = filter.getTerm(name);
   const severity = isDefined(term) ? parseSeverity(term.value) : 0;
 
-  const [rel, setRel] = useState(isDefined(term) ? term.relation : '='); // here rel is set to '='
+  const [rel, setRel] = useState(isDefined(term) ? term.relation : UNSET_VALUE);
   const keyword = name;
 
   return (


### PR DESCRIPTION
**What**:
Use UNSET_VALUE as default for relation of severity values in powerfilter
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The Select showed "is equal to" as default value, but when updating the filter, this setting was not applied. The displayed item is set to "--" (`UNSET_VALUE`) to prevent confusion. 
<!-- Why are these changes necessary? -->

**How**:
Manual testing - explicitly whether/which default value is applied when _not_ changing values in the filterdialog. Also adjusted automated tests.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [X] Labels for ports to other branches
