### PR TITLE
CSP header adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 ### Changed
+* Changed default Content-Security-Policy (CSP) Header to
+  `default-src 'self'; script-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob:;`
+  [#3068](https://github.com/greenbone/gsa/pull/3068)
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/gsa/package.json
+++ b/gsa/package.json
@@ -71,7 +71,7 @@
     "test:coverage": "react-scripts test --coverage --maxWorkers 2",
     "lint": "eslint --max-warnings 0 src",
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "INLINE_RUNTIME_CHUNK=false react-scripts build",
     "eject": "react-scripts eject",
     "storybook": "NODE_PATH=src start-storybook",
     "build-storybook": "NODE_PATH=src build-storybook",

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -157,9 +157,11 @@
  * @brief Default value for HTTP header "Content-Security-Policy"
  */
 #define DEFAULT_GSAD_CONTENT_SECURITY_POLICY \
-  "default-src 'self' 'unsafe-inline';"      \
-  " img-src 'self' blob:;"                   \
-  " frame-ancestors 'self'"
+  "default-src 'self'; "                     \
+  "script-src 'self'; "                      \
+  "style-src-elem 'self' 'unsafe-inline'; "  \
+  "style-src 'self' 'unsafe-inline'; "       \
+  "img-src 'self' blob:;"
 
 /**
  * @brief Default "max-age" for HTTP header "Strict-Transport-Security"

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -174,7 +174,7 @@
 #define DEFAULT_GSAD_PER_IP_CONNECTION_LIMIT 30
 
 #define COPYRIGHT                                                        \
-  "Copyright (C) 2010 - 2020 Greenbone Networks GmbH\n"                  \
+  "Copyright (C) 2010 - 2021 Greenbone Networks GmbH\n"                  \
   "License: AGPL-3.0-or-later\n"                                         \
   "This is free software: you are free to change and redistribute it.\n" \
   "There is NO WARRANTY, to the extent permitted by law.\n\n"


### PR DESCRIPTION
Remove frame-acestors completely because it isn't included into an
iframe anymore. If this is still required the CSP settings can be
adjusted via a command line parameter.

More important don't allow executing javascript from inline html. Only
from references javascript files.

But allow to load CSS from inline <style> elements via style-src-elem
(not supported by firefox yet) and style-src CSP settings.

Fixes AP-1507


**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [x] Labels for ports to other branches
