### PR TITLE
Avoid caching of the index.html page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Changed default Content-Security-Policy (CSP) Header to
   `default-src 'self'; script-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob:;`
   [#3068](https://github.com/greenbone/gsa/pull/3068)
+* Avoid caching of the index.html file [#3082](https://github.com/greenbone/gsa/pull/3082)
 
 ### Deprecated
 ### Removed

--- a/gsad/src/gsad_http_handler.c
+++ b/gsad/src/gsad_http_handler.c
@@ -670,7 +670,7 @@ handle_index (http_connection_t *connection, const char *method,
   cmd_response_data_t *response_data;
 
   response_data = cmd_response_data_new ();
-  cmd_response_data_set_allow_caching (response_data, 1);
+  cmd_response_data_set_allow_caching (response_data, FALSE);
 
   response =
     file_content_response (connection, url, "index.html", response_data);


### PR DESCRIPTION
When updating to a newer GSA version the client's browser may still have
an old version of that index.html file in its cache. In that case it
wont load the new JavaScript files. Therefore don't cache all URLs where
the index.html file is returned. This ensures the browers always loads
the newest JavaScript files.

AP-1550

**Checklist**:

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
