### PR TITLE
Make SSH elevate credential optional in gsad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Initialize severity value with 0 in powerfilter SeverityValuesGroup [#3031](https://github.com/greenbone/gsa/pull/3031)
+- Make SSH elevate credential optional in gsad [#3085](https://github.com/greenbone/gsa/pull/3085)
 
 [Unreleased]: https://github.com/greenbone/gsa/compare/v21.4.1...gsa-21.04
 

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -5326,7 +5326,8 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
   CHECK_VARIABLE_INVALID (target_ssh_credential, "Create Target");
   if (strcmp (target_ssh_credential, "--"))
     CHECK_VARIABLE_INVALID (port, "Create Target");
-  CHECK_VARIABLE_INVALID (target_ssh_elevate_credential, "Create Target");
+  if (params_given (params, "ssh_elevate_credential_id"))
+    CHECK_VARIABLE_INVALID (target_ssh_elevate_credential, "Create Target");
   CHECK_VARIABLE_INVALID (target_smb_credential, "Create Target");
   CHECK_VARIABLE_INVALID (target_esxi_credential, "Create Target");
   CHECK_VARIABLE_INVALID (target_snmp_credential, "Create Target");
@@ -5349,8 +5350,11 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
                                                  "<port>%s</port>"
                                                  "</ssh_credential>",
                                                  target_ssh_credential, port);
-      ssh_elevate_credentials_element = g_strdup_printf (
-        "<ssh_elevate_credential id=\"%s\"/>", target_ssh_elevate_credential);
+      if (target_ssh_elevate_credential)
+        ssh_elevate_credentials_element = g_strdup_printf (
+          "<ssh_elevate_credential id=\"%s\"/>", target_ssh_elevate_credential);
+      else
+        ssh_elevate_credentials_element = NULL;
     }
 
   if (strcmp (target_smb_credential, "0") == 0)
@@ -5405,7 +5409,8 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
                              "%s%s%s%s%s%s%s%s"
                              "</create_target>",
                              xml->str, comment_element, ssh_credentials_element,
-                             ssh_elevate_credentials_element,
+                             ssh_elevate_credentials_element
+                              ? ssh_elevate_credentials_element : "",
                              smb_credentials_element, esxi_credentials_element,
                              snmp_credentials_element, asset_hosts_element);
 
@@ -6296,7 +6301,8 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
       && strcmp (target_ssh_credential, "0"))
     {
       CHECK_VARIABLE_INVALID (port, "Save Target");
-      CHECK_VARIABLE_INVALID (target_ssh_elevate_credential, "Save Target");
+      if (params_given (params, "ssh_elevate_credential_id"))
+        CHECK_VARIABLE_INVALID (target_ssh_elevate_credential, "Save Target");
     }
 
   if (str_equal (target_source, "manual"))
@@ -6328,8 +6334,12 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
                                                    "<port>%s</port>"
                                                    "</ssh_credential>",
                                                    target_ssh_credential, port);
-        ssh_elevate_credentials_element = g_strdup_printf (
-          "<ssh_elevate_credential id=\"%s\"/>", target_ssh_elevate_credential);
+        if (target_ssh_elevate_credential)
+          ssh_elevate_credentials_element = g_strdup_printf (
+            "<ssh_elevate_credential id=\"%s\"/>",
+            target_ssh_elevate_credential);
+        else
+          ssh_elevate_credentials_element = NULL;
       }
 
     if (str_equal (target_smb_credential, "--"))
@@ -6375,7 +6385,8 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
                             "%s%s%s%s%s%s"
                             "</modify_target>",
                             comment_element, ssh_credentials_element,
-                            ssh_elevate_credentials_element,
+                            ssh_elevate_credentials_element
+                              ? ssh_elevate_credentials_element : "",
                             smb_credentials_element, esxi_credentials_element,
                             snmp_credentials_element);
 

--- a/gsad/src/gsad_gmp.c
+++ b/gsad/src/gsad_gmp.c
@@ -5405,14 +5405,14 @@ create_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
     reverse_lookup_unify ? reverse_lookup_unify : "0", port_list_id,
     alive_tests, allow_simultaneous_ips ? allow_simultaneous_ips : "1");
 
-  command = g_strdup_printf ("<create_target>"
-                             "%s%s%s%s%s%s%s%s"
-                             "</create_target>",
-                             xml->str, comment_element, ssh_credentials_element,
-                             ssh_elevate_credentials_element
-                              ? ssh_elevate_credentials_element : "",
-                             smb_credentials_element, esxi_credentials_element,
-                             snmp_credentials_element, asset_hosts_element);
+  command = g_strdup_printf (
+    "<create_target>"
+    "%s%s%s%s%s%s%s%s"
+    "</create_target>",
+    xml->str, comment_element, ssh_credentials_element,
+    ssh_elevate_credentials_element ? ssh_elevate_credentials_element : "",
+    smb_credentials_element, esxi_credentials_element, snmp_credentials_element,
+    asset_hosts_element);
 
   g_string_free (xml, TRUE);
   g_free (comment_element);
@@ -6335,9 +6335,9 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
                                                    "</ssh_credential>",
                                                    target_ssh_credential, port);
         if (target_ssh_elevate_credential)
-          ssh_elevate_credentials_element = g_strdup_printf (
-            "<ssh_elevate_credential id=\"%s\"/>",
-            target_ssh_elevate_credential);
+          ssh_elevate_credentials_element =
+            g_strdup_printf ("<ssh_elevate_credential id=\"%s\"/>",
+                             target_ssh_elevate_credential);
         else
           ssh_elevate_credentials_element = NULL;
       }
@@ -6381,14 +6381,14 @@ save_target_gmp (gvm_connection_t *connection, credentials_t *credentials,
       reverse_lookup_unify ? reverse_lookup_unify : "0", port_list_id,
       alive_tests, allow_simultaneous_ips ? allow_simultaneous_ips : "1");
 
-    g_string_append_printf (command,
-                            "%s%s%s%s%s%s"
-                            "</modify_target>",
-                            comment_element, ssh_credentials_element,
-                            ssh_elevate_credentials_element
-                              ? ssh_elevate_credentials_element : "",
-                            smb_credentials_element, esxi_credentials_element,
-                            snmp_credentials_element);
+    g_string_append_printf (
+      command,
+      "%s%s%s%s%s%s"
+      "</modify_target>",
+      comment_element, ssh_credentials_element,
+      ssh_elevate_credentials_element ? ssh_elevate_credentials_element : "",
+      smb_credentials_element, esxi_credentials_element,
+      snmp_credentials_element);
 
     g_free (comment_element);
     g_free (ssh_credentials_element);


### PR DESCRIPTION
Creating or modifying a target will no longer fail if the HTTP request
does not contain the ssh_elevate_credential_id parameter.

This addresses AP-1472 where targets are rejected if an older version
of GSA is still in the browser cache.

This was tested by temporarily modifying GSA to no longer send
ssh_elevate_credential_id when modifying or creating a target.

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [x] Labels for ports to other branches
