### PR TITLE
Further restrict content security policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 ### Changed
 * Changed default Content-Security-Policy (CSP) Header to
-  `default-src 'self'; script-src 'self'; style-src-elem 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob:;`
+  `default-src 'none'; object-src 'none'; base-uri 'none'; connect-src 'self'; script-src 'self'; frame-ancestors 'none'; form-action 'self'; style-src-elem 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob:;`
   [#3068](https://github.com/greenbone/gsa/pull/3068)
+  [#3095](https://github.com/greenbone/gsa/pull/3095)
 * Avoid caching of the index.html file [#3082](https://github.com/greenbone/gsa/pull/3082)
 
 ### Deprecated

--- a/gsad/src/gsad.c
+++ b/gsad/src/gsad.c
@@ -157,8 +157,13 @@
  * @brief Default value for HTTP header "Content-Security-Policy"
  */
 #define DEFAULT_GSAD_CONTENT_SECURITY_POLICY \
-  "default-src 'self'; "                     \
+  "default-src 'none'; "                     \
+  "object-src 'none'; "                      \
+  "base-uri 'none'; "                        \
+  "connect-src 'self'; "                     \
   "script-src 'self'; "                      \
+  "frame-ancestors 'none'; "                 \
+  "form-action 'self'; "                     \
   "style-src-elem 'self' 'unsafe-inline'; "  \
   "style-src 'self' 'unsafe-inline'; "       \
   "img-src 'self' blob:;"


### PR DESCRIPTION
**What**:

Adjust Content Security Policy even further and set

* frame-acestors
* default-src
* object-src
* base-uri

to 'none' and

* connect-src
* form-actions

to 'self'. This deactivates unused features by default and only allows
required ones to be used at the current origin.

It is still possible to change the CSP settings via a command line
parameter.

Fixes AP-1613


**Why**:

Improve rating at https://observatory.mozilla.org/

**How**:

Checked running gsad if the headers are included in the response. Logged in created a target. Exported a port list. Started a task.

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [x] Labels for ports to other branches
