### PR TITLE
Remove gsa-21.10 branch from mergify and workflows

### DIFF
--- a/.github/workflows/ci-c.yml
+++ b/.github/workflows/ci-c.yml
@@ -2,9 +2,9 @@ name: Build and test C
 
 on:
   push:
-    branches: [ master, gsa-21.10, gsa-21.04, gsa-20.08 ]
+    branches: [ master, gsa-21.04, gsa-20.08 ]
   pull_request:
-    branches: [ master, gsa-21.10, gsa-21.04, gsa-20.08 ]
+    branches: [ master, gsa-21.04, gsa-20.08 ]
 
 
 jobs:

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -2,9 +2,9 @@ name: Build and test JavaScript
 
 on:
   push:
-    branches: [ master, gsa-21.10, gsa-21.04, gsa-20.08 ]
+    branches: [ master, gsa-21.04, gsa-20.08 ]
   pull_request:
-    branches: [ master, gsa-21.10, gsa-21.04, gsa-20.08 ]
+    branches: [ master, gsa-21.04, gsa-20.08 ]
 
 jobs:
   testing:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, gsa-21.10, gsa-21.04, gsa-20.08 ]
+    branches: [ master, gsa-21.04, gsa-20.08 ]
   pull_request:
-    branches: [ master, gsa-21.10, gsa-21.04, gsa-20.08 ]
+    branches: [ master, gsa-21.04, gsa-20.08 ]
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -54,29 +54,3 @@ pull_request_rules:
         branches:
           - gsa-21.04
           
-  - name: port 20.08 patches to 21.10 branch
-    conditions:
-      - base=gsa-20.08
-      - label=port-to-21.10
-    actions:
-      backport:
-        branches:
-          - gsa-21.10
-          
-  - name: port 21.04 patches to 21.10 branch
-    conditions:
-      - base=gsa-21.04
-      - label=port-to-21.10
-    actions:
-      backport:
-        branches:
-          - gsa-21.10
-          
-  - name: port 21.10 patches to master branch
-    conditions:
-      - base=gsa-21.10
-      - label=port-to-master
-    actions:
-      backport:
-        branches:
-          - master


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Remove gsa-21.10 branch from mergify and workflows.

**Why**:

<!-- Why are these changes necessary? -->

gsa-21.10 has been deleted because it is no longer needed. Current development for gsa-21.10 is done on the master branch.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
