### PR TITLE
[AP1581] Don't crash target table when port_list is undefined (fix trashcan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 ### Fixed
+- Don't crash target table when port_list is undefined [#3120](https://github.com/greenbone/gsa/pull/3120)
+
 
 [Unreleased]: https://github.com/greenbone/gsa/compare/v21.4.2...gsa-21.04
 

--- a/gsa/src/web/pages/targets/__tests__/row.js
+++ b/gsa/src/web/pages/targets/__tests__/row.js
@@ -89,6 +89,55 @@ const target_elevate = Target.fromElement({
   },
 });
 
+const target_no_portlist = Target.fromElement({
+  _id: 'foo',
+  name: 'target',
+  owner: {name: 'admin'},
+  alive_tests: 'Scan Config Default',
+  comment: 'hello world',
+  writable: '1',
+  in_use: '1',
+  permissions: {permission: [{name: 'Everything'}]},
+  hosts: '127.0.0.1, 192.168.0.1',
+  exclude_hosts: '',
+  max_hosts: '2',
+  reverse_lookup_only: '1',
+  reverse_lookup_unify: '0',
+  ssh_credential: {
+    _id: '1235',
+    name: 'ssh',
+    port: '22',
+    trash: '0',
+  },
+  ssh_elevate_credential: {
+    _id: '3456',
+    name: 'ssh_elevate',
+    trash: '0',
+  },
+  smb_credential: {
+    _id: '4784',
+    name: 'smb_credential',
+  },
+  esxi_credential: {
+    _id: '',
+    name: '',
+    trash: '0',
+  },
+  snmp_credential: {
+    _id: '',
+    name: '',
+    trash: '0',
+  },
+  tasks: {
+    task: [
+      {
+        _id: 'task_id',
+        name: 'task1',
+      },
+    ],
+  },
+});
+
 const target_no_elevate = Target.fromElement({
   _id: 'foo',
   name: 'target',
@@ -240,6 +289,44 @@ describe('Target row tests', () => {
     expect(baseElement).toHaveTextContent('SMB');
     expect(links[3]).toHaveAttribute('href', '/credential/4784');
     expect(links[3]).toHaveTextContent('smb_credential');
+  });
+
+  test('should render with undefined portlist', () => {
+    const handleToggleDetailsClick = jest.fn();
+    const handleTargetCloneClick = jest.fn();
+    const handleTargetDeleteClick = jest.fn();
+    const handleTargetDownloadClick = jest.fn();
+    const handleTargetEditClick = jest.fn();
+
+    const {render, store} = rendererWith({
+      gmp,
+      capabilities: caps,
+      router: true,
+      store: true,
+    });
+
+    store.dispatch(setTimezone('CET'));
+    store.dispatch(setUsername('admin'));
+
+    const {baseElement} = render(
+      <Row
+        entity={target_no_portlist}
+        onToggleDetailsClick={handleToggleDetailsClick}
+        onTargetCloneClick={handleTargetCloneClick}
+        onTargetDeleteClick={handleTargetDeleteClick}
+        onTargetDownloadClick={handleTargetDownloadClick}
+        onTargetEditClick={handleTargetEditClick}
+      />,
+    );
+
+    const links = baseElement.querySelectorAll('a');
+
+    expect(baseElement).toHaveTextContent('target');
+    expect(baseElement).toHaveTextContent('(hello world)');
+
+    // First link is no longer to portlist, because it shouldn't be in the table
+    expect(links[0]).toHaveAttribute('href', '/credential/1235');
+    expect(links[0]).toHaveTextContent('ssh');
   });
 
   test('should call click handlers', () => {

--- a/gsa/src/web/pages/targets/row.js
+++ b/gsa/src/web/pages/targets/row.js
@@ -128,11 +128,17 @@ export const Row = ({
     <TableData>{shorten(entity.hosts.join(', '), 500)}</TableData>
     <TableData>{entity.max_hosts}</TableData>
     <TableData>
-      <span>
-        <DetailsLink type="portlist" id={entity.port_list.id} textOnly={!links}>
-          {entity.port_list.name}
-        </DetailsLink>
-      </span>
+      {isDefined(entity.port_list) && (
+        <span>
+          <DetailsLink
+            type="portlist"
+            id={entity.port_list.id}
+            textOnly={!links}
+          >
+            {entity.port_list.name}
+          </DetailsLink>
+        </span>
+      )}
     </TableData>
     <TableData flex="column" align="center">
       <Cred cred={entity.ssh_credential} title={'SSH'} links={links} />


### PR DESCRIPTION
**What**:
Don't crash the target table when target.port_list is undefined.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Seems like the trashcan doesn't provide the target's portlist and therefore breaks the target table
<!-- Why are these changes necessary? -->

**How**:
Visual check if table cell is empty (no crash) and added automatic test.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [X] Labels for ports to other branches
