### PR TITLE
[AP1032] Show dead hosts as possible reason in empty report when scan finishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 ### Fixed
+- Show dead hosts as possible reason in empty report when scan finishes [#3124](https://github.com/greenbone/gsa/pull/3124)
 
 [Unreleased]: https://github.com/greenbone/gsa/compare/v20.8.3...gsa-20.08
 

--- a/gsa/src/web/pages/reports/details/emptyreport.js
+++ b/gsa/src/web/pages/reports/details/emptyreport.js
@@ -53,12 +53,28 @@ const EmptyReport = ({
       />
       <Divider wrap>
         {!isActiveReport && (
-          <ReportPanel
-            icon={props => <TaskIcon {...props} />}
-            title={_('The scan did not collect any results')}
-          >
-            {_('If the scan got interrupted you can try to re-start the task.')}
-          </ReportPanel>
+          <React.Fragment>
+            <ReportPanel
+              icon={props => <TaskIcon {...props} />}
+              title={_('The scan did not collect any results')}
+            >
+              {_(
+                'If the scan got interrupted you can try to re-start the task.',
+              )}
+            </ReportPanel>
+            <ReportPanel
+              icon={props => <TargetIcon {...props} />}
+              title={_('The target hosts could be regarded dead')}
+              onClick={may_edit_target ? onTargetEditClick : undefined}
+            >
+              {_(
+                'You should change the Alive Test Method of the ' +
+                  'target for the next scan. However, if the target hosts ' +
+                  'are indeed dead, the scan duration might increase ' +
+                  'significantly.',
+              )}
+            </ReportPanel>
+          </React.Fragment>
         )}
         {isActiveReport && progress === 1 && (
           <ReportPanel


### PR DESCRIPTION
**What**:
Show possibility of dead hosts also for finished scans, not only `progress < 0`
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The notification was not shown after scanning a dead host and was reported missing
<!-- Why are these changes necessary? -->

**How**:
1. Create a target with a non-existing host.
2. Scan that target to produce an empty report.
3. Check that the notification is listed in the Results tab in the report details.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [X] Labels for ports to other branches
