### PR TITLE
[AP1447] Change conditions for enabling CreateTicketIcon on results detailspage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 ### Changed
+- Changed conditions for enabling CreateTicketIcon on results detailspage [#3154](https://github.com/greenbone/gsa/pull/3154)
 
 ### Deprecated
 

--- a/gsa/public/locales/gsa-de.json
+++ b/gsa/public/locales/gsa-de.json
@@ -1196,6 +1196,7 @@
   "Permissions": "Berechtigungen",
   "Permissions ({{count}})": "Berechtigungen ({{count}})",
   "Permissions Filter": "Berechtigungen-Filter",
+  "Permissions to create a ticket are insufficient. You need the create_permission and get_users permissions.": "Die Berechtigungen ein Ticket zu erstellen sind unzureichend. Sie benötigen die create_permission- und get_users-Berechtigungen.",
   "Physical": "Physisch",
   "Platform": "Plattform",
   "Please be aware that:": "Bitte beachten Sie, dass:",

--- a/gsa/src/web/pages/results/detailspage.js
+++ b/gsa/src/web/pages/results/detailspage.js
@@ -100,6 +100,15 @@ export const ToolBarIcons = ({
 }) => {
   const capabilities = useCapabilities();
 
+  const isMissingPermissions =
+    !capabilities.mayCreate('permission') || !capabilities.mayAccess('users');
+  const createTicketIconTitle = isMissingPermissions
+    ? _(
+        'Permissions to create a ticket are insufficient. You need the ' +
+          'create_permission and get_users permissions.',
+      )
+    : _('Create new Ticket');
+
   return (
     <Divider margin="10px">
       <IconDivider>
@@ -132,7 +141,8 @@ export const ToolBarIcons = ({
         )}
         {capabilities.mayCreate('ticket') && (
           <NewTicketIcon
-            title={_('Create new Ticket')}
+            title={createTicketIconTitle}
+            disabled={isMissingPermissions}
             value={entity}
             onClick={onTicketCreateClick}
           />


### PR DESCRIPTION
**What**:
Change enabling conditions to:
- not showing the icon when create_ticket permission is missing
- graying out the icon if create_permission and/or get_users permissions are missing
- enabling icon completely only if all three permissions are given
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
To prevent the user from misunderstandings whether they can actually create a ticket or not, because simply having create_ticket might seem sufficient, but it's not.
<!-- Why are these changes necessary? -->

**How**:
Automated tests are still succeeding, manually testing the icon with several users with different combinations of permissions.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [X] Labels for ports to other branches
