### PR TITLE
[AP1032] Fix condition for dead host notification in empty report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 
 ### Fixed
-- Show dead hosts as possible reason in empty report when scan finishes [#3124](https://github.com/greenbone/gsa/pull/3124)
+- Show dead hosts as possible reason in empty report when scan finishes [#3124](https://github.com/greenbone/gsa/pull/3124), [#3157](https://github.com/greenbone/gsa/pull/3157)
 
 [Unreleased]: https://github.com/greenbone/gsa/compare/v20.8.3...gsa-20.08
 

--- a/gsa/src/web/pages/reports/details/emptyreport.js
+++ b/gsa/src/web/pages/reports/details/emptyreport.js
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2020 Greenbone Networks GmbH
+/* Copyright (C) 2017-2021 Greenbone Networks GmbH
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
@@ -19,7 +19,7 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {isActive} from 'gmp/models/task';
+import {isActive, TASK_STATUS} from 'gmp/models/task';
 
 import TaskIcon from 'web/components/icon/taskicon';
 import RefreshIcon from 'web/components/icon/refreshicon';
@@ -94,7 +94,7 @@ const EmptyReport = ({
             {_('Just wait for results to arrive.')}
           </ReportPanel>
         )}
-        {progress < 1 && hasTarget && (
+        {progress < 1 && hasTarget && status !== TASK_STATUS.interrupted && (
           <ReportPanel
             icon={props => <TargetIcon {...props} />}
             title={_('The target hosts could be regarded dead')}


### PR DESCRIPTION
**What**:
Don't show a second "Hosts might be dead" notification when a task was interrupted
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
It was shown twice
<!-- Why are these changes necessary? -->

**How**:
Tests still pass
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [X] Labels for ports to other branches
