### PR TITLE
Require node.js >= 14

### DIFF
--- a/.docker/testing/Dockerfile
+++ b/.docker/testing/Dockerfile
@@ -12,7 +12,7 @@ FROM greenbone/gvm-libs-$VERSION-$COMPILER-build
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install curl and gnupg to add remote repositories
-# Add repository for yarn
+# Add repository for yarn & nodejs
 RUN apt-get update && apt-get install --assume-yes \
     curl \
     gnupg \
@@ -21,13 +21,19 @@ RUN apt-get update && apt-get install --assume-yes \
     https://dl.yarnpkg.com/debian/pubkey.gpg \
     | apt-key add - && \
     echo "deb http://dl.yarnpkg.com/debian/ stable main" \
-    > /etc/apt/sources.list.d/yarn.list
+    > /etc/apt/sources.list.d/yarn.list \
+ && curl --silent --show-error \
+    https://deb.nodesource.com/gpgkey/nodesource.gpg.key \
+    | apt-key add - && \
+    echo "deb https://deb.nodesource.com/node_14.x buster main" \
+    > /etc/apt/sources.list.d/nodesource.list
 
 # Install node.js and yarn for gsa
 # Install Debian core dependencies required for building gsad
+
 RUN apt-get update && apt-get install --assume-yes \
-    nodejs \
     libmicrohttpd-dev \
+    nodejs \
     yarn \
     libxml2-dev \
     libxslt1-dev \

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -20,7 +20,7 @@ jobs:
         #          ubuntu lts: https://packages.ubuntu.com/focal/nodejs
         # 12.x for ubuntu-latest: https://packages.ubuntu.com/hirsute/nodejs
         # 14.x is recommended by https://nodejs.org/en/
-        node-version: [10.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Set up node ${{ matrix.python-version }}
@@ -65,7 +65,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [14.x]
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Set up node ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added new license page [#3138](https://github.com/greenbone/gsa/pull/3138), [#3160](https://github.com/greenbone/gsa/pull/3160)
 - Added command for getting appliance license information [#3137](https://github.com/greenbone/gsa/pull/3137)
 ### Changed
+- Require node.js >= 14 [#3164](https://github.com/greenbone/gsa/pull/3164)
 ### Fixed
 ### Removed
 - Removed interface access from users in GSA and gsad [#3123](https://github.com/greenbone/gsa/pull/3123)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,7 +95,8 @@ Prerequisites for using the GUI:
 
 Install node.js >= 14 on Debian GNU/Linux:
 ```sh
-curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+curl --silent --show-error https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+echo "deb https://deb.nodesource.com/node_14.x buster main" > /etc/apt/sources.list.d/nodesource.list
 apt-get install -y nodejs
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -90,9 +90,14 @@ Compiling Greenbone Security Assistant GUI
 ------------------------------------------
 
 Prerequisites for using the GUI:
-* node.js >= 8.0
+* node.js >= 14.0
 * Either yarn >= 1.0 or npm. yarn is faster and more reliable, but younger.
 
+Install node.js >= 14 on Debian GNU/Linux:
+```sh
+curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+apt-get install -y nodejs
+```
 
 Developing Greenbone Security Assistant GUI
 -------------------------------------------

--- a/gsa/CMakeLists.txt
+++ b/gsa/CMakeLists.txt
@@ -23,7 +23,7 @@ project (gsa VERSION 21.10.0 LANGUAGES)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-find_package (Node 10.0 REQUIRED)
+find_package (Node 14.0 REQUIRED)
 find_package (Yarn 1.0)
 
 if (NOT DEFINED PROJECT_VERSION_STRING)

--- a/gsa/package.json
+++ b/gsa/package.json
@@ -17,7 +17,7 @@
   "license": "AGPL-3.0+",
   "main": "src/index.js",
   "engines": {
-    "node": ">=10.0"
+    "node": ">=14.0"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
**What**:
Use a newer node.js version as minimum requirement, because 10 is EOL.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Support for it should outlast GVM 21.10 and we have the first 3rd party dependencies requiring node.js >= 12
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [ ] Labels for ports to other branches
