### PR TITLE
Add Traditional Chinese language option

### DIFF
--- a/gsa/src/gmp/locale/languages.js
+++ b/gsa/src/gmp/locale/languages.js
@@ -29,6 +29,10 @@ const Languages = {
     name: 'English',
     native_name: 'English',
   },
+  zh_TW: { 
+    name: 'Traditional Chinese', 
+    native_name: '繁體中文',
+  },
 };
 
 export default Languages;


### PR DESCRIPTION
Add traditional Chinese language option to switch to "gsa-zh_TW.json"

**What**:

Add traditional Chinese language options to the list.

**Why**:

I have translated gsa-zh_TW.json before, but I did not add the ability to switch to Traditional Chinese language.

**How**:

Add to languages constant

**Checklist**:

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [x] Labels for ports to other branches
