### PR TITLE
Remove: scan_config_type and corresponding variables are removed

### DIFF
--- a/gsa/src/gmp/models/__tests__/policy.js
+++ b/gsa/src/gmp/models/__tests__/policy.js
@@ -202,12 +202,6 @@ describe('Policy model tests', () => {
     expect(policy.preferences.nvt).toEqual([]);
   });
 
-  test('should parse type', () => {
-    const policy = Policy.fromElement({type: '21'});
-
-    expect(policy.policy_type).toEqual(21);
-  });
-
   test('should parse scanner', () => {
     const elem = {
       scanner: {

--- a/gsa/src/gmp/models/__tests__/scanconfig.js
+++ b/gsa/src/gmp/models/__tests__/scanconfig.js
@@ -21,7 +21,6 @@
 import Model from 'gmp/model';
 import ScanConfig, {
   filterEmptyScanConfig,
-  openVasScanConfigsFilter,
   SCANCONFIG_TREND_DYNAMIC,
 } from 'gmp/models/scanconfig';
 import {testModel} from 'gmp/models/testing';
@@ -204,12 +203,6 @@ describe('ScanConfig model tests', () => {
     expect(scanConfig.preferences.nvt).toEqual([]);
   });
 
-  test('should parse type', () => {
-    const scanConfig = ScanConfig.fromElement({type: '21'});
-
-    expect(scanConfig.scan_config_type).toEqual(21);
-  });
-
   test('should parse scanner', () => {
     const elem = {
       scanner: {
@@ -266,14 +259,6 @@ describe('ScanConfigs model function test', () => {
 
     expect(filterEmptyScanConfig(config1)).toEqual(true);
     expect(filterEmptyScanConfig(config2)).toEqual(false);
-  });
-
-  test('openVasScanConfigsFilter() should return filter with correct true/false', () => {
-    const config1 = {scan_config_type: 4}; // unknown type
-    const config2 = {scan_config_type: 0}; // OpenVAS scanconfig type
-
-    expect(openVasScanConfigsFilter(config1)).toEqual(false);
-    expect(openVasScanConfigsFilter(config2)).toEqual(true);
   });
 });
 

--- a/gsa/src/gmp/models/policy.js
+++ b/gsa/src/gmp/models/policy.js
@@ -20,7 +20,7 @@ import {isDefined} from 'gmp/utils/identity';
 import {forEach, map} from 'gmp/utils/array';
 import {isEmpty} from 'gmp/utils/string';
 
-import {parseInt, parseBoolean} from 'gmp/parser';
+import {parseBoolean} from 'gmp/parser';
 
 import Model, {parseModelFromElement} from 'gmp/model';
 
@@ -111,8 +111,6 @@ class Policy extends Model {
       scanner: scanner_preferences,
       nvt: nvt_preferences,
     };
-
-    ret.policy_type = parseInt(element.type);
 
     if (isDefined(element.scanner)) {
       const scanner = {

--- a/gsa/src/gmp/models/scanconfig.js
+++ b/gsa/src/gmp/models/scanconfig.js
@@ -24,22 +24,13 @@ import {parseInt, parseBoolean} from 'gmp/parser';
 
 import Model, {parseModelFromElement} from 'gmp/model';
 
-import _ from 'gmp/locale';
-
 export const EMPTY_SCAN_CONFIG_ID = '085569ce-73ed-11df-83c3-002264764cea';
 export const FULL_AND_FAST_SCAN_CONFIG_ID =
   'daba56c8-73ec-11df-a475-002264764cea';
 export const BASE_SCAN_CONFIG_ID = 'd21f6c81-2b88-4ac1-b7b4-a2a9f2ad4663';
 
-export const OPENVAS_SCAN_CONFIG_TYPE = 0;
-
 export const SCANCONFIG_TREND_DYNAMIC = 1;
 export const SCANCONFIG_TREND_STATIC = 0;
-
-export const getTranslatedType = config => {
-  return _('OpenVAS'); // return OpenVAS as last type left. This needs to be
-  // extended with possible new scan config types
-};
 
 export const parseCount = count => {
   return !isEmpty(count) && count !== '-1' ? parseInt(count) : undefined;
@@ -47,9 +38,6 @@ export const parseCount = count => {
 
 export const filterEmptyScanConfig = config =>
   config.id !== EMPTY_SCAN_CONFIG_ID;
-
-export const openVasScanConfigsFilter = config =>
-  config.scan_config_type === OPENVAS_SCAN_CONFIG_TYPE;
 
 export const parseTrend = parseInt;
 
@@ -144,8 +132,6 @@ class ScanConfig extends Model {
       scanner: scanner_preferences,
       nvt: nvt_preferences,
     };
-
-    ret.scan_config_type = parseInt(element.type);
 
     if (isDefined(element.scanner)) {
       const scanner = {

--- a/gsa/src/web/pages/audits/__tests__/details.js
+++ b/gsa/src/web/pages/audits/__tests__/details.js
@@ -24,7 +24,6 @@ import Capabilities from 'gmp/capabilities/capabilities';
 import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
 import Policy from 'gmp/models/policy';
 import Schedule from 'gmp/models/schedule';
-import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 
 import {entityLoadingActions as policyActions} from 'web/store/entities/policies';
 import {entityLoadingActions as scheduleActions} from 'web/store/entities/schedules';
@@ -40,9 +39,11 @@ const policy = Policy.fromElement({
   name: 'foo',
   comment: 'bar',
   scanner: {name: 'scanner1', type: '0'},
-  policy_type: OPENVAS_SCAN_CONFIG_TYPE,
   tasks: {
-    task: [{id: '12345', name: 'foo'}, {id: '678910', name: 'audit2'}],
+    task: [
+      {id: '12345', name: 'foo'},
+      {id: '678910', name: 'audit2'},
+    ],
   },
 });
 

--- a/gsa/src/web/pages/audits/__tests__/detailspage.js
+++ b/gsa/src/web/pages/audits/__tests__/detailspage.js
@@ -29,7 +29,6 @@ import Filter from 'gmp/models/filter';
 import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
 import Policy from 'gmp/models/policy';
 import Schedule from 'gmp/models/schedule';
-import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 
 import {entityLoadingActions} from 'web/store/entities/audits';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
@@ -50,7 +49,6 @@ const policy = Policy.fromElement({
   name: 'foo',
   comment: 'bar',
   scanner: {name: 'scanner1', type: '0'},
-  policy_type: OPENVAS_SCAN_CONFIG_TYPE,
   tasks: {
     task: [
       {id: '12345', name: 'foo'},

--- a/gsa/src/web/pages/audits/details.js
+++ b/gsa/src/web/pages/audits/details.js
@@ -24,7 +24,6 @@ import _ from 'gmp/locale';
 import {isDefined} from 'gmp/utils/identity';
 
 import {duration} from 'gmp/models/date';
-import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 import {scannerTypeName} from 'gmp/models/scanner';
 
 import {
@@ -167,33 +166,28 @@ class AuditDetails extends React.Component {
                     </TableData>
                   </TableRow>
                 )}
-                {isDefined(policy) &&
-                  policy.policy_type === OPENVAS_SCAN_CONFIG_TYPE && (
-                    <TableRow>
-                      <TableData>{_('Order for target hosts')}</TableData>
-                      <TableData>{hosts_ordering}</TableData>
-                    </TableRow>
-                  )}
-                {isDefined(policy) &&
-                  policy.policy_type === OPENVAS_SCAN_CONFIG_TYPE &&
-                  isDefined(max_checks) && (
-                    <TableRow>
-                      <TableData>
-                        {_('Maximum concurrently executed NVTs per host')}
-                      </TableData>
-                      <TableData>{max_checks}</TableData>
-                    </TableRow>
-                  )}
-                {isDefined(policy) &&
-                  policy.policy_type === OPENVAS_SCAN_CONFIG_TYPE &&
-                  isDefined(max_hosts) && (
-                    <TableRow>
-                      <TableData>
-                        {_('Maximum concurrently scanned hosts')}
-                      </TableData>
-                      <TableData>{max_hosts}</TableData>
-                    </TableRow>
-                  )}
+                {isDefined(policy) && (
+                  <TableRow>
+                    <TableData>{_('Order for target hosts')}</TableData>
+                    <TableData>{hosts_ordering}</TableData>
+                  </TableRow>
+                )}
+                {isDefined(policy) && isDefined(max_checks) && (
+                  <TableRow>
+                    <TableData>
+                      {_('Maximum concurrently executed NVTs per host')}
+                    </TableData>
+                    <TableData>{max_checks}</TableData>
+                  </TableRow>
+                )}
+                {isDefined(policy) && isDefined(max_hosts) && (
+                  <TableRow>
+                    <TableData>
+                      {_('Maximum concurrently scanned hosts')}
+                    </TableData>
+                    <TableData>{max_hosts}</TableData>
+                  </TableRow>
+                )}
               </TableBody>
             </DetailsTable>
           </DetailsBlock>

--- a/gsa/src/web/pages/policies/__tests__/details.js
+++ b/gsa/src/web/pages/policies/__tests__/details.js
@@ -20,7 +20,6 @@ import React from 'react';
 import Capabilities from 'gmp/capabilities/capabilities';
 
 import Policy from 'gmp/models/policy';
-import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 
 import {rendererWith} from 'web/utils/testing';
 
@@ -32,9 +31,11 @@ describe('Policy Details tests', () => {
       name: 'foo',
       comment: 'bar',
       scanner: {name: 'scanner', type: '42'},
-      type: OPENVAS_SCAN_CONFIG_TYPE,
       tasks: {
-        task: [{id: '1234', name: 'audit1'}, {id: '5678', name: 'audit2'}],
+        task: [
+          {id: '1234', name: 'audit1'},
+          {id: '5678', name: 'audit2'},
+        ],
       },
     });
     const caps = new Capabilities(['everything']);

--- a/gsa/src/web/pages/policies/__tests__/detailspage.js
+++ b/gsa/src/web/pages/policies/__tests__/detailspage.js
@@ -27,7 +27,6 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 
 import Filter from 'gmp/models/filter';
 import Policy from 'gmp/models/policy';
-import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 
 import {entityLoadingActions} from 'web/store/entities/policies';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
@@ -128,7 +127,6 @@ const policy = Policy.fromElement({
   preferences: preferences,
   permissions: {permission: [{name: 'everything'}]},
   scanner: {name: 'scanner', type: '42'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   tasks: {
     task: [
       {id: '1234', name: 'audit1'},
@@ -156,7 +154,6 @@ const policy2 = Policy.fromElement({
   preferences: preferences,
   permissions: {permission: [{name: 'get_config'}]},
   scanner: {name: 'scanner', type: '42'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   tasks: {
     task: [
       {id: '1234', name: 'audit1'},
@@ -180,7 +177,6 @@ const policy3 = Policy.fromElement({
   preferences: preferences,
   permissions: {permission: [{name: 'everything'}]},
   scanner: {name: 'scanner', type: '42'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   tasks: {
     task: [
       {id: '1234', name: 'audit1'},
@@ -204,7 +200,6 @@ const policy4 = Policy.fromElement({
   preferences: preferences,
   permissions: {permission: [{name: 'everything'}]},
   scanner: {name: 'scanner', type: '42'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   tasks: {
     task: [
       {id: '1234', name: 'audit1'},

--- a/gsa/src/web/pages/policies/__tests__/listpage.js
+++ b/gsa/src/web/pages/policies/__tests__/listpage.js
@@ -25,7 +25,6 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 
 import Filter from 'gmp/models/filter';
 import Policy from 'gmp/models/policy';
-import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 
 import {setUsername} from 'web/store/usersettings/actions';
 
@@ -53,7 +52,6 @@ const policy = Policy.fromElement({
   usage_type: 'policy',
   permissions: {permission: [{name: 'everything'}]},
   scanner: {name: 'scanner', type: '42'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   tasks: {
     task: [
       {id: '1234', name: 'audit1'},

--- a/gsa/src/web/pages/policies/component.js
+++ b/gsa/src/web/pages/policies/component.js
@@ -748,7 +748,6 @@ class PolicyComponent extends React.Component {
                   configFamilies={policy.families}
                   configId={policy.id}
                   configIsInUse={policy.isInUse()}
-                  configType={policy.policy_type}
                   editNvtDetailsTitle={_('Edit Policy NVT Details')}
                   editNvtFamiliesTitle={_('Edit Policy Family')}
                   families={families}

--- a/gsa/src/web/pages/scanconfigs/__tests__/__snapshots__/listpage.js.snap
+++ b/gsa/src/web/pages/scanconfigs/__tests__/__snapshots__/listpage.js.snap
@@ -291,7 +291,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: center;
 }
 
-.c43 {
+.c42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -759,7 +759,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   color: #000;
   border-top: 1px solid #c8d3d9;
   font-weight: bold;
-  width: 5%;
+  width: 10%;
 }
 
 .c41 {
@@ -767,15 +767,15 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   color: #000;
   border-top: 1px solid #c8d3d9;
   font-weight: bold;
-  width: 10%;
+  width: 8%;
 }
 
-.c42 {
+.c43 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #c8d3d9;
   font-weight: bold;
-  width: 8%;
+  width: 5%;
 }
 
 .c13 {
@@ -978,7 +978,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
 }
 
 @media print {
-  .c42 {
+  .c43 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
@@ -1384,20 +1384,6 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </th>
                   <th
                     class="c40"
-                    rowspan="2"
-                  >
-                    <a
-                      class="c38"
-                    >
-                      <div
-                        class="c39"
-                      >
-                        Type
-                      </div>
-                    </a>
-                  </th>
-                  <th
-                    class="c41"
                     colspan="2"
                   >
                     <div
@@ -1407,7 +1393,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </div>
                   </th>
                   <th
-                    class="c41"
+                    class="c40"
                     colspan="2"
                   >
                     <div
@@ -1417,11 +1403,11 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </div>
                   </th>
                   <th
-                    class="c42"
+                    class="c41"
                     rowspan="2"
                   >
                     <div
-                      class="c43"
+                      class="c42"
                     >
                       Actions
                     </div>
@@ -1429,7 +1415,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                 </tr>
                 <tr>
                   <th
-                    class="c40"
+                    class="c43"
                   >
                     <a
                       class="c38"
@@ -1442,7 +1428,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c40"
+                    class="c43"
                   >
                     <a
                       class="c38"
@@ -1455,7 +1441,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c40"
+                    class="c43"
                   >
                     <a
                       class="c38"
@@ -1468,7 +1454,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c40"
+                    class="c43"
                   >
                     <a
                       class="c38"
@@ -1513,13 +1499,6 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                         bar
                         )
                       </div>
-                    </div>
-                  </td>
-                  <td>
-                    <div
-                      class="c44"
-                    >
-                      OpenVAS
                     </div>
                   </td>
                   <td>
@@ -1636,7 +1615,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               <tfoot>
                 <tr>
                   <td
-                    colspan="7"
+                    colspan="6"
                   >
                     <div
                       class="c49"

--- a/gsa/src/web/pages/scanconfigs/__tests__/__snapshots__/row.js.snap
+++ b/gsa/src/web/pages/scanconfigs/__tests__/__snapshots__/row.js.snap
@@ -194,13 +194,6 @@ exports[`Scan Config row tests should render 1`] = `
         <div
           class="c0"
         >
-          OpenVAS
-        </div>
-      </td>
-      <td>
-        <div
-          class="c0"
-        >
           2
         </div>
       </td>

--- a/gsa/src/web/pages/scanconfigs/__tests__/__snapshots__/table.js.snap
+++ b/gsa/src/web/pages/scanconfigs/__tests__/__snapshots__/table.js.snap
@@ -37,7 +37,7 @@ exports[`Scan Config table tests should render 1`] = `
   align-items: center;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -405,7 +405,7 @@ exports[`Scan Config table tests should render 1`] = `
   color: #000;
   border-top: 1px solid #c8d3d9;
   font-weight: bold;
-  width: 5%;
+  width: 10%;
 }
 
 .c15 {
@@ -413,15 +413,15 @@ exports[`Scan Config table tests should render 1`] = `
   color: #000;
   border-top: 1px solid #c8d3d9;
   font-weight: bold;
-  width: 10%;
+  width: 8%;
 }
 
-.c16 {
+.c17 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #c8d3d9;
   font-weight: bold;
-  width: 8%;
+  width: 5%;
 }
 
 .c33 {
@@ -580,7 +580,7 @@ exports[`Scan Config table tests should render 1`] = `
 }
 
 @media print {
-  .c16 {
+  .c17 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
@@ -731,16 +731,6 @@ exports[`Scan Config table tests should render 1`] = `
             </th>
             <th
               class="c14"
-              rowspan="2"
-            >
-              <div
-                class="c13"
-              >
-                Type
-              </div>
-            </th>
-            <th
-              class="c15"
               colspan="2"
             >
               <div
@@ -750,7 +740,7 @@ exports[`Scan Config table tests should render 1`] = `
               </div>
             </th>
             <th
-              class="c15"
+              class="c14"
               colspan="2"
             >
               <div
@@ -760,11 +750,11 @@ exports[`Scan Config table tests should render 1`] = `
               </div>
             </th>
             <th
-              class="c16"
+              class="c15"
               rowspan="2"
             >
               <div
-                class="c17"
+                class="c16"
               >
                 Actions
               </div>
@@ -772,7 +762,7 @@ exports[`Scan Config table tests should render 1`] = `
           </tr>
           <tr>
             <th
-              class="c14"
+              class="c17"
             >
               <div
                 class="c13"
@@ -781,7 +771,7 @@ exports[`Scan Config table tests should render 1`] = `
               </div>
             </th>
             <th
-              class="c14"
+              class="c17"
             >
               <div
                 class="c13"
@@ -790,7 +780,7 @@ exports[`Scan Config table tests should render 1`] = `
               </div>
             </th>
             <th
-              class="c14"
+              class="c17"
             >
               <div
                 class="c13"
@@ -799,7 +789,7 @@ exports[`Scan Config table tests should render 1`] = `
               </div>
             </th>
             <th
-              class="c14"
+              class="c17"
             >
               <div
                 class="c13"
@@ -840,13 +830,6 @@ exports[`Scan Config table tests should render 1`] = `
                   bar
                   )
                 </div>
-              </div>
-            </td>
-            <td>
-              <div
-                class="c18"
-              >
-                OpenVAS
               </div>
             </td>
             <td>
@@ -993,13 +976,6 @@ exports[`Scan Config table tests should render 1`] = `
               <div
                 class="c18"
               >
-                OpenVAS
-              </div>
-            </td>
-            <td>
-              <div
-                class="c18"
-              >
                 3
               </div>
             </td>
@@ -1140,13 +1116,6 @@ exports[`Scan Config table tests should render 1`] = `
               <div
                 class="c18"
               >
-                OpenVAS
-              </div>
-            </td>
-            <td>
-              <div
-                class="c18"
-              >
                 1
               </div>
             </td>
@@ -1257,7 +1226,7 @@ exports[`Scan Config table tests should render 1`] = `
         <tfoot>
           <tr>
             <td
-              colspan="7"
+              colspan="6"
             >
               <div
                 class="c24"

--- a/gsa/src/web/pages/scanconfigs/__tests__/details.js
+++ b/gsa/src/web/pages/scanconfigs/__tests__/details.js
@@ -19,7 +19,7 @@ import React from 'react';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
-import ScanConfig, {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
+import ScanConfig from 'gmp/models/scanconfig';
 
 import {OPENVAS_SCANNER_TYPE} from 'gmp/models/scanner';
 
@@ -33,7 +33,6 @@ describe('Scan Config Details tests', () => {
       name: 'foo',
       comment: 'bar',
       scanner: {name: 'scanner1', id: '42', type: OPENVAS_SCANNER_TYPE},
-      type: OPENVAS_SCAN_CONFIG_TYPE,
       tasks: {
         task: [
           {id: '1234', name: 'task1'},

--- a/gsa/src/web/pages/scanconfigs/__tests__/detailspage.js
+++ b/gsa/src/web/pages/scanconfigs/__tests__/detailspage.js
@@ -26,7 +26,7 @@ import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
 import Filter from 'gmp/models/filter';
-import ScanConfig, {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
+import ScanConfig from 'gmp/models/scanconfig';
 
 import {entityLoadingActions} from 'web/store/entities/scanconfigs';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
@@ -127,7 +127,6 @@ const config = ScanConfig.fromElement({
   preferences: preferences,
   permissions: {permission: [{name: 'everything'}]},
   scanner: {name: 'scanner', type: '42'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   tasks: {
     task: [
       {id: '1234', name: 'task1'},
@@ -155,7 +154,6 @@ const config2 = ScanConfig.fromElement({
   preferences: preferences,
   permissions: {permission: [{name: 'get_config'}]},
   scanner: {name: 'scanner', type: '42'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   tasks: {
     task: [
       {id: '1234', name: 'task1'},
@@ -179,7 +177,6 @@ const config3 = ScanConfig.fromElement({
   preferences: preferences,
   permissions: {permission: [{name: 'everything'}]},
   scanner: {name: 'scanner', type: '42'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   tasks: {
     task: [
       {id: '1234', name: 'task1'},
@@ -203,7 +200,6 @@ const config4 = ScanConfig.fromElement({
   preferences: preferences,
   permissions: {permission: [{name: 'everything'}]},
   scanner: {name: 'scanner', type: '42'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   tasks: {
     task: [
       {id: '1234', name: 'task1'},

--- a/gsa/src/web/pages/scanconfigs/__tests__/editdialog.js
+++ b/gsa/src/web/pages/scanconfigs/__tests__/editdialog.js
@@ -20,7 +20,6 @@ import React from 'react';
 import {setLocale} from 'gmp/locale/lang';
 
 import {
-  OPENVAS_SCAN_CONFIG_TYPE,
   SCANCONFIG_TREND_STATIC,
   SCANCONFIG_TREND_DYNAMIC,
 } from 'gmp/models/scanconfig';
@@ -148,7 +147,6 @@ describe('EditScanConfigDialog component tests', () => {
         configFamilies={configFamilies}
         configId="c1"
         configIsInUse={false}
-        configType={OPENVAS_SCAN_CONFIG_TYPE}
         editNvtDetailsTitle="Edit Scan Config NVT Details"
         editNvtFamiliesTitle="Edit Scan Config Family"
         families={families}
@@ -196,7 +194,6 @@ describe('EditScanConfigDialog component tests', () => {
         configFamilies={configFamilies}
         configId="c1"
         configIsInUse={true}
-        configType={OPENVAS_SCAN_CONFIG_TYPE}
         editNvtDetailsTitle="Edit Scan Config NVT Details"
         editNvtFamiliesTitle="Edit Scan Config Family"
         families={families}
@@ -251,7 +248,6 @@ describe('EditScanConfigDialog component tests', () => {
         configFamilies={configFamilies}
         configId="c1"
         configIsInUse={true}
-        configType={OPENVAS_SCAN_CONFIG_TYPE}
         editNvtDetailsTitle="Edit Policy NVT Details"
         editNvtFamiliesTitle="Edit Policy Family'"
         families={families}
@@ -304,7 +300,6 @@ describe('EditScanConfigDialog component tests', () => {
         configFamilies={configFamilies}
         configId="c1"
         configIsInUse={false}
-        configType={OPENVAS_SCAN_CONFIG_TYPE}
         editNvtDetailsTitle="Edit Scan Config NVT Details"
         editNvtFamiliesTitle="Edit Scan Config Family"
         families={families}
@@ -352,7 +347,6 @@ describe('EditScanConfigDialog component tests', () => {
         configFamilies={configFamilies}
         configId="c1"
         configIsInUse={false}
-        configType={OPENVAS_SCAN_CONFIG_TYPE}
         editNvtDetailsTitle="Edit Scan Config NVT Details"
         editNvtFamiliesTitle="Edit Scan Config Family"
         families={families}
@@ -392,7 +386,6 @@ describe('EditScanConfigDialog component tests', () => {
         configFamilies={configFamilies}
         configId="c1"
         configIsInUse={false}
-        configType={OPENVAS_SCAN_CONFIG_TYPE}
         editNvtDetailsTitle="Edit Scan Config NVT Details"
         editNvtFamiliesTitle="Edit Scan Config Family"
         families={families}
@@ -446,7 +439,6 @@ describe('EditScanConfigDialog component tests', () => {
         configFamilies={configFamilies}
         configId="c1"
         configIsInUse={false}
-        configType={OPENVAS_SCAN_CONFIG_TYPE}
         editNvtDetailsTitle="Edit Scan Config NVT Details"
         editNvtFamiliesTitle="Edit Scan Config Family"
         families={families}
@@ -516,7 +508,6 @@ describe('EditScanConfigDialog component tests', () => {
         configFamilies={configFamilies}
         configId="c1"
         configIsInUse={false}
-        configType={OPENVAS_SCAN_CONFIG_TYPE}
         editNvtDetailsTitle="Edit Scan Config NVT Details"
         editNvtFamiliesTitle="Edit Scan Config Family"
         families={families}

--- a/gsa/src/web/pages/scanconfigs/__tests__/listpage.js
+++ b/gsa/src/web/pages/scanconfigs/__tests__/listpage.js
@@ -23,7 +23,6 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 
 import Filter from 'gmp/models/filter';
 import ScanConfig, {
-  OPENVAS_SCAN_CONFIG_TYPE,
   SCANCONFIG_TREND_STATIC,
   SCANCONFIG_TREND_DYNAMIC,
 } from 'gmp/models/scanconfig';
@@ -52,7 +51,6 @@ const config = ScanConfig.fromElement({
   usage_type: 'scan',
   permissions: {permission: [{name: 'everything'}]},
   scanner: {name: 'scanner', type: '42'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   tasks: {
     task: [
       {id: '1234', name: 'task1'},

--- a/gsa/src/web/pages/scanconfigs/__tests__/row.js
+++ b/gsa/src/web/pages/scanconfigs/__tests__/row.js
@@ -22,7 +22,6 @@ import React from 'react';
 import Capabilities from 'gmp/capabilities/capabilities';
 
 import ScanConfig, {
-  OPENVAS_SCAN_CONFIG_TYPE,
   SCANCONFIG_TREND_STATIC,
   SCANCONFIG_TREND_DYNAMIC,
 } from 'gmp/models/scanconfig';
@@ -42,7 +41,6 @@ const entity = ScanConfig.fromElement({
   comment: 'bar',
   in_use: '0',
   writable: '1',
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   permissions: {permission: [{name: 'everything'}]},
   family_count: {
     __text: 2,
@@ -87,7 +85,6 @@ describe('Scan Config row tests', () => {
     expect(baseElement).toMatchSnapshot();
     expect(baseElement).toHaveTextContent('foo');
     expect(baseElement).toHaveTextContent('(bar)');
-    expect(baseElement).toHaveTextContent('OpenVAS');
 
     const icons = getAllByTestId('svg-icon');
     expect(icons[0]).toHaveAttribute(
@@ -110,7 +107,6 @@ describe('Scan Config row tests', () => {
       owner: {
         name: 'user',
       },
-      type: OPENVAS_SCAN_CONFIG_TYPE,
       permissions: {permission: [{name: 'everything'}]},
       family_count: {
         __text: 2,
@@ -211,7 +207,6 @@ describe('Scan Config row tests', () => {
       comment: 'bar',
       in_use: '0',
       writable: '1',
-      type: OPENVAS_SCAN_CONFIG_TYPE,
       family_count: {
         __text: 2,
         growing: SCANCONFIG_TREND_STATIC,
@@ -284,7 +279,6 @@ describe('Scan Config row tests', () => {
       comment: 'bar',
       in_use: '1',
       writable: '1',
-      type: OPENVAS_SCAN_CONFIG_TYPE,
       permissions: {permission: [{name: 'everything'}]},
       family_count: {
         __text: 2,
@@ -349,7 +343,6 @@ describe('Scan Config row tests', () => {
       comment: 'bar',
       in_use: '0',
       writable: '0',
-      type: OPENVAS_SCAN_CONFIG_TYPE,
       permissions: {permission: [{name: 'everything'}]},
       family_count: {
         __text: 2,

--- a/gsa/src/web/pages/scanconfigs/__tests__/table.js
+++ b/gsa/src/web/pages/scanconfigs/__tests__/table.js
@@ -21,7 +21,6 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 
 import Filter from 'gmp/models/filter';
 import ScanConfig, {
-  OPENVAS_SCAN_CONFIG_TYPE,
   SCANCONFIG_TREND_STATIC,
   SCANCONFIG_TREND_DYNAMIC,
 } from 'gmp/models/scanconfig';
@@ -37,7 +36,6 @@ const config = ScanConfig.fromElement({
   name: 'foo',
   comment: 'bar',
   owner: {name: 'admin'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   permissions: {permission: [{name: 'everything'}]},
   family_count: {
     __text: 2,
@@ -54,7 +52,6 @@ const config2 = ScanConfig.fromElement({
   name: 'lorem',
   comment: 'ipsum',
   owner: {name: 'admin'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   permissions: {permission: [{name: 'everything'}]},
   family_count: {
     __text: 3,
@@ -71,7 +68,6 @@ const config3 = ScanConfig.fromElement({
   name: 'hello',
   comment: 'world',
   owner: {name: 'admin'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   permissions: {permission: [{name: 'everything'}]},
   family_count: {
     __text: 1,
@@ -127,14 +123,13 @@ describe('Scan Config table tests', () => {
     expect(baseElement).toMatchSnapshot();
     const header = baseElement.querySelectorAll('th');
     expect(header[0]).toHaveTextContent('Name');
-    expect(header[1]).toHaveTextContent('Type');
-    expect(header[2]).toHaveTextContent('Family');
-    expect(header[3]).toHaveTextContent('NVTs');
-    expect(header[4]).toHaveTextContent('Actions');
-    expect(header[5]).toHaveTextContent('Total');
-    expect(header[6]).toHaveTextContent('Trend');
-    expect(header[7]).toHaveTextContent('Total');
-    expect(header[8]).toHaveTextContent('Trend');
+    expect(header[1]).toHaveTextContent('Family');
+    expect(header[2]).toHaveTextContent('NVTs');
+    expect(header[3]).toHaveTextContent('Actions');
+    expect(header[4]).toHaveTextContent('Total');
+    expect(header[5]).toHaveTextContent('Trend');
+    expect(header[6]).toHaveTextContent('Total');
+    expect(header[7]).toHaveTextContent('Trend');
   });
 
   test('should unfold all details', () => {

--- a/gsa/src/web/pages/scanconfigs/component.js
+++ b/gsa/src/web/pages/scanconfigs/component.js
@@ -504,7 +504,6 @@ class ScanConfigComponent extends React.Component {
                   configFamilies={config.families}
                   configId={config.id}
                   configIsInUse={config.isInUse()}
-                  configType={config.scan_config_type}
                   editNvtDetailsTitle={_('Edit Scan Config NVT Details')}
                   editNvtFamiliesTitle={_('Edit Scan Config Family')}
                   families={families}

--- a/gsa/src/web/pages/scanconfigs/editdialog.js
+++ b/gsa/src/web/pages/scanconfigs/editdialog.js
@@ -20,10 +20,7 @@ import React, {useReducer, useState, useEffect} from 'react';
 
 import _ from 'gmp/locale';
 
-import {
-  OPENVAS_SCAN_CONFIG_TYPE,
-  SCANCONFIG_TREND_STATIC,
-} from 'gmp/models/scanconfig';
+import {SCANCONFIG_TREND_STATIC} from 'gmp/models/scanconfig';
 
 import {YES_VALUE, NO_VALUE} from 'gmp/parser';
 
@@ -101,7 +98,6 @@ const EditScanConfigDialog = ({
   configId,
   configFamilies,
   configIsInUse = false,
-  configType,
   editNvtDetailsTitle,
   editNvtFamiliesTitle,
   families,
@@ -202,17 +198,15 @@ const EditScanConfigDialog = ({
               {isLoadingConfig || isLoadingFamilies ? (
                 <Loading />
               ) : (
-                configType === OPENVAS_SCAN_CONFIG_TYPE && (
-                  <NvtFamilies
-                    configFamilies={configFamilies}
-                    editTitle={editNvtFamiliesTitle}
-                    families={families}
-                    trend={trendValues}
-                    select={selectValues}
-                    onEditConfigFamilyClick={onEditConfigFamilyClick}
-                    onValueChange={onValueChange}
-                  />
-                )
+                <NvtFamilies
+                  configFamilies={configFamilies}
+                  editTitle={editNvtFamiliesTitle}
+                  families={families}
+                  trend={trendValues}
+                  select={selectValues}
+                  onEditConfigFamilyClick={onEditConfigFamilyClick}
+                  onValueChange={onValueChange}
+                />
               )}
 
               {isLoadingConfig ? (
@@ -228,13 +222,11 @@ const EditScanConfigDialog = ({
               {isLoadingConfig ? (
                 <Loading />
               ) : (
-                configType === OPENVAS_SCAN_CONFIG_TYPE && (
-                  <NvtPreferences
-                    editTitle={editNvtDetailsTitle}
-                    preferences={nvtPreferences}
-                    onEditNvtDetailsClick={onEditNvtDetailsClick}
-                  />
-                )
+                <NvtPreferences
+                  editTitle={editNvtDetailsTitle}
+                  preferences={nvtPreferences}
+                  onEditNvtDetailsClick={onEditNvtDetailsClick}
+                />
               )}
             </React.Fragment>
           )}
@@ -249,7 +241,6 @@ EditScanConfigDialog.propTypes = {
   configFamilies: PropTypes.object,
   configId: PropTypes.id.isRequired,
   configIsInUse: PropTypes.bool,
-  configType: PropTypes.number,
   editNvtDetailsTitle: PropTypes.string.isRequired,
   editNvtFamiliesTitle: PropTypes.string.isRequired,
   families: PropTypes.arrayOf(

--- a/gsa/src/web/pages/scanconfigs/header.js
+++ b/gsa/src/web/pages/scanconfigs/header.js
@@ -45,15 +45,6 @@ const Header = ({
           onSortChange={onSortChange}
           title={_('Name')}
         />
-        <TableHead
-          width="5%"
-          rowSpan="2"
-          currentSortDir={currentSortDir}
-          currentSortBy={currentSortBy}
-          sortBy={sort ? 'type' : false}
-          onSortChange={onSortChange}
-          title={_('Type')}
-        />
         <TableHead width="10%" colSpan="2">
           {_('Family')}
         </TableHead>

--- a/gsa/src/web/pages/scanconfigs/row.js
+++ b/gsa/src/web/pages/scanconfigs/row.js
@@ -20,8 +20,6 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {getTranslatedType} from 'gmp/models/scanconfig';
-
 import IconDivider from 'web/components/layout/icondivider';
 
 import ExportIcon from 'web/components/icon/exporticon';
@@ -102,7 +100,6 @@ const ScanConfigRow = ({
       displayName={_('Scan Config')}
       onToggleDetailsClick={onToggleDetailsClick}
     />
-    <TableData>{getTranslatedType(entity.scan_config_type)}</TableData>
     <TableData>{na(entity.families.count)}</TableData>
     <TableData>
       <Trend

--- a/gsa/src/web/pages/scanconfigs/table.js
+++ b/gsa/src/web/pages/scanconfigs/table.js
@@ -31,10 +31,6 @@ export const SORT_FIELDS = [
     displayName: _l('Name'),
   },
   {
-    name: 'type',
-    displayName: _l('Type'),
-  },
-  {
     name: 'families_total',
     displayName: _l('Families: Total'),
   },
@@ -59,7 +55,7 @@ const ScanConfigsTable = createEntitiesTable({
   rowDetails: withRowDetails('scanconfig')(ScanConfigDetails),
   footer: createEntitiesFooter({
     download: 'scanconfigs.xml',
-    span: 7,
+    span: 6,
     trash: true,
   }),
 });

--- a/gsa/src/web/pages/tasks/__tests__/details.js
+++ b/gsa/src/web/pages/tasks/__tests__/details.js
@@ -23,7 +23,7 @@ import Capabilities from 'gmp/capabilities/capabilities';
 
 import Task, {TASK_STATUS} from 'gmp/models/task';
 import Schedule from 'gmp/models/schedule';
-import ScanConfig, {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
+import ScanConfig from 'gmp/models/scanconfig';
 
 import {entityLoadingActions as scanconfigActions} from 'web/store/entities/scanconfigs';
 import {entityLoadingActions as scheduleActions} from 'web/store/entities/schedules';
@@ -39,9 +39,11 @@ const config = ScanConfig.fromElement({
   name: 'foo',
   comment: 'bar',
   scanner: {name: 'scanner1', type: '0'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   tasks: {
-    task: [{id: '12345', name: 'foo'}, {id: '678910', name: 'task2'}],
+    task: [
+      {id: '12345', name: 'foo'},
+      {id: '678910', name: 'task2'},
+    ],
   },
 });
 

--- a/gsa/src/web/pages/tasks/__tests__/detailspage.js
+++ b/gsa/src/web/pages/tasks/__tests__/detailspage.js
@@ -28,7 +28,7 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 import Filter from 'gmp/models/filter';
 import Task, {TASK_STATUS} from 'gmp/models/task';
 import Schedule from 'gmp/models/schedule';
-import ScanConfig, {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
+import ScanConfig from 'gmp/models/scanconfig';
 
 import {entityLoadingActions} from 'web/store/entities/tasks';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
@@ -49,7 +49,6 @@ const config = ScanConfig.fromElement({
   name: 'foo',
   comment: 'bar',
   scanner: {name: 'scanner1', type: '0'},
-  type: OPENVAS_SCAN_CONFIG_TYPE,
   tasks: {
     task: [
       {id: '12345', name: 'foo'},

--- a/gsa/src/web/pages/tasks/details.js
+++ b/gsa/src/web/pages/tasks/details.js
@@ -26,7 +26,6 @@ import {isDefined} from 'gmp/utils/identity';
 import {YES_VALUE} from 'gmp/parser';
 
 import {duration} from 'gmp/models/date';
-import {OPENVAS_SCAN_CONFIG_TYPE} from 'gmp/models/scanconfig';
 import {scannerTypeName} from 'gmp/models/scanner';
 
 import {
@@ -181,33 +180,28 @@ class TaskDetails extends React.Component {
                     </TableData>
                   </TableRow>
                 )}
-                {isDefined(scanConfig) &&
-                  scanConfig.scan_config_type === OPENVAS_SCAN_CONFIG_TYPE && (
-                    <TableRow>
-                      <TableData>{_('Order for target hosts')}</TableData>
-                      <TableData>{hosts_ordering}</TableData>
-                    </TableRow>
-                  )}
-                {isDefined(scanConfig) &&
-                  scanConfig.scan_config_type === OPENVAS_SCAN_CONFIG_TYPE &&
-                  isDefined(max_checks) && (
-                    <TableRow>
-                      <TableData>
-                        {_('Maximum concurrently executed NVTs per host')}
-                      </TableData>
-                      <TableData>{max_checks}</TableData>
-                    </TableRow>
-                  )}
-                {isDefined(scanConfig) &&
-                  scanConfig.scan_config_type === OPENVAS_SCAN_CONFIG_TYPE &&
-                  isDefined(max_hosts) && (
-                    <TableRow>
-                      <TableData>
-                        {_('Maximum concurrently scanned hosts')}
-                      </TableData>
-                      <TableData>{max_hosts}</TableData>
-                    </TableRow>
-                  )}
+                {isDefined(scanConfig) && (
+                  <TableRow>
+                    <TableData>{_('Order for target hosts')}</TableData>
+                    <TableData>{hosts_ordering}</TableData>
+                  </TableRow>
+                )}
+                {isDefined(scanConfig) && isDefined(max_checks) && (
+                  <TableRow>
+                    <TableData>
+                      {_('Maximum concurrently executed NVTs per host')}
+                    </TableData>
+                    <TableData>{max_checks}</TableData>
+                  </TableRow>
+                )}
+                {isDefined(scanConfig) && isDefined(max_hosts) && (
+                  <TableRow>
+                    <TableData>
+                      {_('Maximum concurrently scanned hosts')}
+                    </TableData>
+                    <TableData>{max_hosts}</TableData>
+                  </TableRow>
+                )}
               </TableBody>
             </DetailsTable>
           </DetailsBlock>

--- a/gsa/src/web/pages/usersettings/usersettingspage.js
+++ b/gsa/src/web/pages/usersettings/usersettingspage.js
@@ -22,10 +22,7 @@ import {connect} from 'react-redux';
 import _ from 'gmp/locale';
 
 import {ALL_FILTER} from 'gmp/models/filter';
-import {
-  filterEmptyScanConfig,
-  openVasScanConfigsFilter,
-} from 'gmp/models/scanconfig';
+import {filterEmptyScanConfig} from 'gmp/models/scanconfig';
 import {openVasScannersFilter} from 'gmp/models/scanner';
 
 import {YES_VALUE, parseYesNo} from 'gmp/parser';
@@ -379,7 +376,6 @@ class UserSettings extends React.Component {
     certBundFilter = hasValue(certBundFilter) ? certBundFilter : {};
     dfnCertFilter = hasValue(dfnCertFilter) ? dfnCertFilter : {};
 
-    const openVasScanConfigs = scanconfigs.filter(openVasScanConfigsFilter);
     const openVasScanners = scanners.filter(openVasScannersFilter);
 
     return (
@@ -739,7 +735,7 @@ class UserSettings extends React.Component {
               alerts={alerts}
               filters={filters}
               credentials={credentials}
-              openVasScanConfigs={openVasScanConfigs}
+              openVasScanConfigs={scanconfigs}
               openVasScanners={openVasScanners}
               portLists={portlists}
               reportFormats={reportformats}


### PR DESCRIPTION
**What**:
scan_config_type and resulting variables are removed from GSA
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
No support for different types
<!-- Why are these changes necessary? -->

**How**:
Some manual tests and automatic tests are still passing.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [N/A] [CHANGELOG](https://github.com/greenbone/gsa/blob/master/CHANGELOG.md) Entry
- [N/A] Labels for ports to other branches
