### PR TITLE
Remove default report format from usersettings

### DIFF
--- a/src/gmp/commands/users.js
+++ b/src/gmp/commands/users.js
@@ -295,8 +295,6 @@ export class UserCommand extends EntityCommand {
         data.defaultSnmpCredential,
       'settings_default:d74a9ee8-7d35-4879-9485-ab23f1bd45bc':
         data.defaultPortList,
-      'settings_default:353304fc-645e-11e6-ba7a-28d24461215b':
-        data.defaultReportFormat,
       'settings_default:f7d0f6ed-6f9e-45dc-8bd9-05cced84e80d':
         data.defaultOpenvasScanner,
       'settings_default:b20697c9-be0a-4cd4-8b4d-5fe7841ebb03':
@@ -313,9 +311,8 @@ export class UserCommand extends EntityCommand {
       [saveDefaultFilterSettingId('group')]: data.groupsFilter,
       [saveDefaultFilterSettingId('host')]: data.hostsFilter,
       [saveDefaultFilterSettingId('note')]: data.notesFilter,
-      [saveDefaultFilterSettingId(
-        'operatingsystem',
-      )]: data.operatingSystemsFilter,
+      [saveDefaultFilterSettingId('operatingsystem')]:
+        data.operatingSystemsFilter,
       [saveDefaultFilterSettingId('override')]: data.overridesFilter,
       [saveDefaultFilterSettingId('permission')]: data.permissionsFilter,
       [saveDefaultFilterSettingId('portlist')]: data.portListsFilter,
@@ -329,9 +326,8 @@ export class UserCommand extends EntityCommand {
       [saveDefaultFilterSettingId('target')]: data.targetsFilter,
       [saveDefaultFilterSettingId('task')]: data.tasksFilter,
       [saveDefaultFilterSettingId('ticket')]: data.ticketsFilter,
-      [saveDefaultFilterSettingId(
-        'tlscertificate',
-      )]: data.tlsCertificatesFilter,
+      [saveDefaultFilterSettingId('tlscertificate')]:
+        data.tlsCertificatesFilter,
       [saveDefaultFilterSettingId('user')]: data.usersFilter,
       [saveDefaultFilterSettingId('vulnerability')]: data.vulnerabilitiesFilter,
       [saveDefaultFilterSettingId('cpe')]: data.cpeFilter,

--- a/src/web/pages/usersettings/defaultspart.js
+++ b/src/web/pages/usersettings/defaultspart.js
@@ -35,7 +35,6 @@ const DefaultsPart = ({
   openVasScanners,
   ospScanners,
   portLists,
-  reportFormats,
   schedules,
   targets,
   defaultAlert,
@@ -45,7 +44,6 @@ const DefaultsPart = ({
   defaultOpenvasScanConfig,
   defaultOpenvasScanner,
   defaultPortList,
-  defaultReportFormat,
   defaultSmbCredential,
   defaultSnmpCredential,
   defaultSshCredential,
@@ -126,16 +124,6 @@ const DefaultsPart = ({
           />
         </FormGroup>
       )}
-      {capabilities.mayAccess('reportformat') && (
-        <FormGroup title={_('Default Report Format')} titleSize="3">
-          <Select
-            name="defaultReportFormat"
-            value={defaultReportFormat}
-            items={renderSelectItems(reportFormats, UNSET_VALUE)}
-            onChange={onChange}
-          />
-        </FormGroup>
-      )}
       {capabilities.mayAccess('credential') && (
         <FormGroup title={_('Default SMB Credential')} titleSize="3">
           <Select
@@ -201,7 +189,6 @@ DefaultsPart.propTypes = {
   defaultOspScanConfig: PropTypes.string,
   defaultOspScanner: PropTypes.string,
   defaultPortList: PropTypes.string,
-  defaultReportFormat: PropTypes.string,
   defaultSchedule: PropTypes.string,
   defaultSmbCredential: PropTypes.string,
   defaultSnmpCredential: PropTypes.string,
@@ -212,7 +199,6 @@ DefaultsPart.propTypes = {
   ospScanConfigs: PropTypes.array,
   ospScanners: PropTypes.array,
   portLists: PropTypes.array,
-  reportFormats: PropTypes.array,
   schedules: PropTypes.array,
   targets: PropTypes.array,
   onChange: PropTypes.func,

--- a/src/web/pages/usersettings/dialog.js
+++ b/src/web/pages/usersettings/dialog.js
@@ -60,7 +60,6 @@ let UserSettingsDialog = ({
   openVasScanners,
   ospScanners,
   portLists,
-  reportFormats,
   schedules,
   targets,
   timezone,
@@ -80,7 +79,6 @@ let UserSettingsDialog = ({
   defaultOpenvasScanConfig,
   defaultOpenvasScanner,
   defaultPortList,
-  defaultReportFormat,
   defaultSmbCredential,
   defaultSnmpCredential,
   defaultSshCredential,
@@ -140,7 +138,6 @@ let UserSettingsDialog = ({
     defaultOpenvasScanConfig,
     defaultOpenvasScanner,
     defaultPortList,
-    defaultReportFormat,
     defaultSmbCredential,
     defaultSnmpCredential,
     defaultSshCredential,
@@ -241,7 +238,6 @@ let UserSettingsDialog = ({
                 openVasScanners={openVasScanners}
                 ospScanners={ospScanners}
                 portLists={portLists}
-                reportFormats={reportFormats}
                 schedules={schedules}
                 targets={targets}
                 defaultAlert={values.defaultAlert}
@@ -251,7 +247,6 @@ let UserSettingsDialog = ({
                 defaultOpenvasScanConfig={values.defaultOpenvasScanConfig}
                 defaultOpenvasScanner={values.defaultOpenvasScanner}
                 defaultPortList={values.defaultPortList}
-                defaultReportFormat={values.defaultReportFormat}
                 defaultSmbCredential={values.defaultSmbCredential}
                 defaultSnmpCredential={values.defaultSnmpCredential}
                 defaultSshCredential={values.defaultSshCredential}
@@ -325,7 +320,6 @@ UserSettingsDialog.propTypes = {
   defaultOspScanConfig: PropTypes.string,
   defaultOspScanner: PropTypes.string,
   defaultPortList: PropTypes.string,
-  defaultReportFormat: PropTypes.string,
   defaultSchedule: PropTypes.string,
   defaultSeverity: PropTypes.number,
   defaultSmbCredential: PropTypes.string,
@@ -354,7 +348,6 @@ UserSettingsDialog.propTypes = {
   portLists: PropTypes.array,
   portListsFilter: PropTypes.string,
   reportExportFileName: PropTypes.string,
-  reportFormats: PropTypes.array,
   reportFormatsFilter: PropTypes.string,
   reportsFilter: PropTypes.string,
   resultsFilter: PropTypes.string,

--- a/src/web/pages/usersettings/usersettingspage.js
+++ b/src/web/pages/usersettings/usersettingspage.js
@@ -72,10 +72,6 @@ import {
   selector as portListsSelector,
 } from 'web/store/entities/portlists';
 import {
-  loadEntities as loadReportFormats,
-  selector as reportFormatsSelector,
-} from 'web/store/entities/reportformats';
-import {
   loadEntities as loadScanConfigs,
   selector as scanConfigsSelector,
 } from 'web/store/entities/scanconfigs';
@@ -213,7 +209,6 @@ class UserSettings extends React.Component {
     this.props.loadCredentials();
     this.props.loadFilters();
     this.props.loadPortLists();
-    this.props.loadReportFormats();
     this.props.loadScanConfigs();
     this.props.loadScanners();
     this.props.loadSchedules();
@@ -286,7 +281,6 @@ class UserSettings extends React.Component {
       scanconfigs = [],
       scanners = [],
       portlists,
-      reportformats,
       schedules,
       targets,
       isLoading = true,
@@ -306,7 +300,6 @@ class UserSettings extends React.Component {
       defaultOpenvasScanConfig = {},
       defaultOpenvasScanner = {},
       defaultPortList = {},
-      defaultReportFormat = {},
       defaultSmbCredential = {},
       defaultSnmpCredential = {},
       defaultSshCredential = {},
@@ -551,13 +544,6 @@ class UserSettings extends React.Component {
                             type="portlist"
                           />
                         )}
-                        {capabilities.mayAccess('reportformat') && (
-                          <SettingTableRow
-                            setting={defaultReportFormat}
-                            title={_('Default Report Format')}
-                            type="reportformat"
-                          />
-                        )}
                         {capabilities.mayAccess('credential') && (
                           <SettingTableRow
                             setting={defaultSmbCredential}
@@ -770,7 +756,6 @@ class UserSettings extends React.Component {
               openVasScanners={openVasScanners}
               ospScanners={ospScanners}
               portLists={portlists}
-              reportFormats={reportformats}
               schedules={schedules}
               targets={targets}
               timezone={timezone}
@@ -790,7 +775,6 @@ class UserSettings extends React.Component {
               defaultOpenvasScanConfig={defaultOpenvasScanConfig.id}
               defaultOpenvasScanner={defaultOpenvasScanner.id}
               defaultPortList={defaultPortList.id}
-              defaultReportFormat={defaultReportFormat.id}
               defaultSmbCredential={defaultSmbCredential.id}
               defaultSnmpCredential={defaultSnmpCredential.id}
               defaultSshCredential={defaultSshCredential.id}
@@ -855,7 +839,6 @@ UserSettings.propTypes = {
   defaultOspScanConfig: PropTypes.object,
   defaultOspScanner: PropTypes.object,
   defaultPortList: PropTypes.object,
-  defaultReportFormat: PropTypes.object,
   defaultSchedule: PropTypes.object,
   defaultSeverity: PropTypes.object,
   defaultSmbCredential: PropTypes.object,
@@ -877,7 +860,6 @@ UserSettings.propTypes = {
   loadFilterDefaults: PropTypes.func.isRequired,
   loadFilters: PropTypes.func.isRequired,
   loadPortLists: PropTypes.func.isRequired,
-  loadReportFormats: PropTypes.func.isRequired,
   loadScanConfigs: PropTypes.func.isRequired,
   loadScanners: PropTypes.func.isRequired,
   loadSchedules: PropTypes.func.isRequired,
@@ -894,7 +876,6 @@ UserSettings.propTypes = {
   portlists: PropTypes.array,
   reportExportFileName: PropTypes.object,
   reportFormatsFilter: PropTypes.object,
-  reportformats: PropTypes.array,
   reportsFilter: PropTypes.object,
   resultsFilter: PropTypes.object,
   rolesFilter: PropTypes.object,
@@ -930,9 +911,8 @@ const mapStateToProps = rootState => {
   const detailsExportFileName = userDefaultsSelector.getByName(
     'detailsexportfilename',
   );
-  const listExportFileName = userDefaultsSelector.getByName(
-    'listexportfilename',
-  );
+  const listExportFileName =
+    userDefaultsSelector.getByName('listexportfilename');
   const reportExportFileName = userDefaultsSelector.getByName(
     'reportexportfilename',
   );
@@ -949,9 +929,8 @@ const mapStateToProps = rootState => {
   const defaultOspScanConfigId = userDefaultsSelector.getValueByName(
     'defaultospscanconfig',
   );
-  const defaultOspScannerId = userDefaultsSelector.getValueByName(
-    'defaultospscanner',
-  );
+  const defaultOspScannerId =
+    userDefaultsSelector.getValueByName('defaultospscanner');
   const defaultOpenvasScanConfigId = userDefaultsSelector.getValueByName(
     'defaultopenvasscanconfig',
   );
@@ -959,12 +938,8 @@ const mapStateToProps = rootState => {
     'defaultopenvasscanner',
   );
 
-  const defaultPortListId = userDefaultsSelector.getValueByName(
-    'defaultportlist',
-  );
-  const defaultReportFormatId = userDefaultsSelector.getValueByName(
-    'defaultreportformat',
-  );
+  const defaultPortListId =
+    userDefaultsSelector.getValueByName('defaultportlist');
   const defaultSmbCredentialId = userDefaultsSelector.getValueByName(
     'defaultsmbcredential',
   );
@@ -974,16 +949,14 @@ const mapStateToProps = rootState => {
   const defaultSshCredentialId = userDefaultsSelector.getValueByName(
     'defaultsshcredential',
   );
-  const defaultScheduleId = userDefaultsSelector.getValueByName(
-    'defaultschedule',
-  );
+  const defaultScheduleId =
+    userDefaultsSelector.getValueByName('defaultschedule');
   const defaultTargetId = userDefaultsSelector.getValueByName('defaulttarget');
 
   const alertsSel = alertsSelector(rootState);
   const credentialsSel = credentialsSelector(rootState);
   const filtersSel = filtersSelector(rootState);
   const portListsSel = portListsSelector(rootState);
-  const reportFormatsSel = reportFormatsSelector(rootState);
   const scannersSel = scannersSelector(rootState);
   const scanConfigsSel = scanConfigsSelector(rootState);
   const schedulesSel = schedulesSelector(rootState);
@@ -1001,7 +974,6 @@ const mapStateToProps = rootState => {
   );
   const defaultOpenvasScanner = scannersSel.getEntity(defaultOpenvasScannerId);
   const defaultPortList = portListsSel.getEntity(defaultPortListId);
-  const defaultReportFormat = reportFormatsSel.getEntity(defaultReportFormatId);
   const defaultSmbCredential = credentialsSel.getEntity(defaultSmbCredentialId);
   const defaultSnmpCredential = credentialsSel.getEntity(
     defaultSnmpCredentialId,
@@ -1016,16 +988,14 @@ const mapStateToProps = rootState => {
   const groupsFilter = userDefaultFilterSelector.getFilter('group');
   const hostsFilter = userDefaultFilterSelector.getFilter('host');
   const notesFilter = userDefaultFilterSelector.getFilter('note');
-  const operatingSystemsFilter = userDefaultFilterSelector.getFilter(
-    'operatingsystem',
-  );
+  const operatingSystemsFilter =
+    userDefaultFilterSelector.getFilter('operatingsystem');
   const overridesFilter = userDefaultFilterSelector.getFilter('override');
   const permissionsFilter = userDefaultFilterSelector.getFilter('permission');
   const portListsFilter = userDefaultFilterSelector.getFilter('portlist');
   const reportsFilter = userDefaultFilterSelector.getFilter('report');
-  const reportFormatsFilter = userDefaultFilterSelector.getFilter(
-    'reportformat',
-  );
+  const reportFormatsFilter =
+    userDefaultFilterSelector.getFilter('reportformat');
   const resultsFilter = userDefaultFilterSelector.getFilter('result');
   const rolesFilter = userDefaultFilterSelector.getFilter('role');
   const scannersFilter = userDefaultFilterSelector.getFilter('scanner');
@@ -1034,13 +1004,11 @@ const mapStateToProps = rootState => {
   const targetsFilter = userDefaultFilterSelector.getFilter('target');
   const tasksFilter = userDefaultFilterSelector.getFilter('task');
   const ticketsFilter = userDefaultFilterSelector.getFilter('ticket');
-  const tlsCertificatesFilter = userDefaultFilterSelector.getFilter(
-    'tlscertificate',
-  );
+  const tlsCertificatesFilter =
+    userDefaultFilterSelector.getFilter('tlscertificate');
   const usersFilter = userDefaultFilterSelector.getFilter('user');
-  const vulnerabilitiesFilter = userDefaultFilterSelector.getFilter(
-    'vulnerability',
-  );
+  const vulnerabilitiesFilter =
+    userDefaultFilterSelector.getFilter('vulnerability');
   const cpeFilter = userDefaultFilterSelector.getFilter('cpe');
   const cveFilter = userDefaultFilterSelector.getFilter('cve');
   const certBundFilter = userDefaultFilterSelector.getFilter('certbund');
@@ -1058,7 +1026,6 @@ const mapStateToProps = rootState => {
     credentials: credentialsSel.getEntities(ALL_FILTER),
     filters: filtersSel.getEntities(ALL_FILTER),
     portlists: portListsSel.getEntities(ALL_FILTER),
-    reportformats: reportFormatsSel.getEntities(ALL_FILTER),
     scanconfigs,
     scanners: scannersSel.getEntities(ALL_FILTER),
     schedules: schedulesSel.getEntities(ALL_FILTER),
@@ -1080,7 +1047,6 @@ const mapStateToProps = rootState => {
     defaultOpenvasScanConfig,
     defaultOpenvasScanner,
     defaultPortList,
-    defaultReportFormat,
     defaultSmbCredential,
     defaultSnmpCredential,
     defaultSshCredential,
@@ -1158,7 +1124,6 @@ const mapDispatchToProps = (dispatch, {gmp}) => ({
       dispatch(loadUserSettingsDefaultFilter(gmp)('ovaldef')),
     ]),
   loadPortLists: () => dispatch(loadPortLists(gmp)(ALL_FILTER)),
-  loadReportFormats: () => dispatch(loadReportFormats(gmp)(ALL_FILTER)),
   loadScanConfigs: () => dispatch(loadScanConfigs(gmp)(ALL_FILTER)),
   loadScanners: () => dispatch(loadScanners(gmp)(ALL_FILTER)),
   loadSchedules: () => dispatch(loadSchedules(gmp)(ALL_FILTER)),


### PR DESCRIPTION
**What**:
Remove the optoion to set/change a default report format
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The setting is obsolete, because the default report format is now set in the content composer defaults
<!-- Why are these changes necessary? -->

**How**:
Manual test of the page if the options are gone. Automatic tests are still passing
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [N/A] Tests
- [ ] PR merge commit message adjusted (use: "Remove: Default report format usersetting")
- [X] Labels for ports to other branches
