### PR TITLE
[AP1571] Add ErrorDialog to LicensePage

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -559,6 +559,7 @@
   "Error": "Fehler",
   "Error Message": "Fehlermeldung",
   "Error Messages": "Fehlermeldungen",
+  "Error while loading license information": "Fehler beim Laden der Lizenzinformationen",
   "Error while loading Report {{reportId}}": "Fehler beim Laden des Berichts {{reportId}}",
   "Error while loading Results for Report {{reportId}}": "Fehler beim Laden von Ergebnissen des Berichts {{reportId}}",
   "Event": "Ereignis",

--- a/src/web/pages/licenses/licensepage.js
+++ b/src/web/pages/licenses/licensepage.js
@@ -23,6 +23,8 @@ import {isDefined} from 'gmp/utils/identity';
 
 import DateTime from 'web/components/date/datetime';
 
+import ErrorDialog from 'web/components/dialog/errordialog';
+
 import LicenseIcon from 'web/components/icon/licenseicon';
 import ManualIcon from 'web/components/icon/manualicon';
 import NewIcon from 'web/components/icon/newicon';
@@ -78,12 +80,16 @@ const LicensePage = () => {
   const gmp = useGmp();
 
   const [license, setLicense] = useState({});
+  const [error, setError] = useState();
   const [newLicenseDialogVisible, setNewLicenseDialogVisible] = useState(false);
 
   useEffect(() => {
-    gmp.license.getLicenseInformation().then(response => {
-      setLicense(response.data);
-    });
+    gmp.license
+      .getLicenseInformation()
+      .then(response => {
+        setLicense(response.data);
+      })
+      .catch(err => setError(err));
   }, [gmp.license]);
 
   const handleNewLicenseClick = () => {
@@ -100,11 +106,22 @@ const LicensePage = () => {
     setLicense(value);
   };
 
+  const handleErrorClose = () => {
+    setError(undefined);
+  };
+
   return (
     <React.Fragment>
       <PageTitle title={_('License Management')} />
       <Layout flex="column">
         <ToolBarIcons onNewLicenseClick={handleNewLicenseClick} />
+        {error && (
+          <ErrorDialog
+            text={error.message}
+            title={_('Error while loading license information')}
+            onClose={handleErrorClose}
+          />
+        )}
         <Section
           img={<LicenseIcon size="large" />}
           title={_('License Management')}


### PR DESCRIPTION
**What**:
Add ErrorDialog to catch errors while loading license information
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Proper error handling
<!-- Why are these changes necessary? -->

**How**:
I let the license command `throw` instead of returning data and checked whether the dialog displayed the corresponding message
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted (use: "Add: ErrorDialog on LicensePage")
- [N/A] Labels for ports to other branches
