### PR TITLE
Move LicenseNotification into own module

### DIFF
--- a/src/web/components/notification/__tests__/licensenotification.js
+++ b/src/web/components/notification/__tests__/licensenotification.js
@@ -1,0 +1,158 @@
+/* Copyright (C) 2022 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+
+import Capabilities from 'gmp/capabilities/capabilities';
+
+import {License} from 'gmp/commands/license';
+
+import {rendererWith, wait} from 'web/utils/testing';
+
+import LicenseNotification from '../licensenotification';
+
+const data1 = new License({
+  status: 'active',
+  content: {
+    meta: {
+      id: '12345',
+      version: '1.0.0',
+      title: 'Test License',
+      type: 'trial',
+      customer_name: 'Monsters Inc.',
+      created: '2021-08-27T06:05:21Z',
+      begins: '2021-08-27T07:05:21Z',
+      expires: '2021-09-04T07:05:21Z',
+      comment: 'Han shot first',
+    },
+    appliance: {
+      model: 'trial',
+      model_type: '450',
+      sensor: false,
+    },
+    keys: {
+      key: {
+        _name: 'feed',
+        __text: '*base64 GSF key*',
+      },
+    },
+    signatures: {
+      license: '*base64 signature*',
+    },
+  },
+});
+
+const data2 = new License({
+  status: 'active',
+  content: {
+    meta: {
+      id: '12345',
+      version: '1.0.0',
+      title: 'Test License',
+      type: 'trial',
+      customer_name: 'Monsters Inc.',
+      created: '2021-08-27T06:05:21Z',
+      begins: '2021-08-27T07:05:21Z',
+      expires: '2022-09-04T07:05:21Z',
+      comment: 'Han shot first',
+    },
+    appliance: {
+      model: 'trial',
+      model_type: '450',
+      sensor: false,
+    },
+    keys: {
+      key: {
+        _name: 'feed',
+        __text: '*base64 GSF key*',
+      },
+    },
+    signatures: {
+      license: '*base64 signature*',
+    },
+  },
+});
+
+const mockDate = new Date('2021-08-09T07:05:21Z');
+
+const caps = new Capabilities(['everything']);
+
+beforeEach(() => {
+  jest.spyOn(global.Date, 'now').mockImplementation(() => mockDate);
+});
+
+describe('LicenseNotification tests', () => {
+  test('should render if <=30 days valid', async () => {
+    const handler = jest.fn();
+    const gmp = {
+      license: {
+        getLicenseInformation: jest.fn().mockReturnValue(
+          Promise.resolve({
+            data: data1,
+          }),
+        ),
+      },
+      settings: {
+        manualUrl: 'http://foo.bar',
+      },
+    };
+    const {render} = rendererWith({
+      license: data1,
+      gmp,
+      store: true,
+    });
+    const {baseElement} = render(
+      <LicenseNotification capabilities={caps} onCloseClick={handler} />,
+    );
+
+    await wait();
+
+    expect(baseElement).toHaveTextContent('Your trial license ends in 26 days');
+  });
+
+  test('should not render if >30 days valid', async () => {
+    const handler = jest.fn();
+
+    const gmp = {
+      license: {
+        getLicenseInformation: jest.fn().mockReturnValue(
+          Promise.resolve({
+            data: data2,
+          }),
+        ),
+      },
+      settings: {
+        manualUrl: 'http://foo.bar',
+      },
+    };
+
+    const {render} = rendererWith({
+      license: data2,
+      gmp,
+      store: true,
+    });
+    const {baseElement} = render(
+      <LicenseNotification capabilities={caps} onCloseClick={handler} />,
+    );
+
+    await wait();
+
+    expect(baseElement).not.toHaveTextContent();
+  });
+});
+
+// vim: set ts=2 sw=2 tw=80:

--- a/src/web/components/notification/licensenotification.js
+++ b/src/web/components/notification/licensenotification.js
@@ -1,0 +1,77 @@
+/* Copyright (C) 2022 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+
+import _ from 'gmp/locale';
+
+import date from 'gmp/models/date';
+
+import {isDefined} from 'gmp/utils/identity';
+
+import InfoPanel from 'web/components/panel/infopanel';
+
+import PropTypes from 'web/utils/proptypes';
+import useLicense from 'web/utils/useLicense';
+
+const LICENSE_EXPIRATION_THRESHOLD = 30;
+
+const LicenseNotification = ({capabilities, onCloseClick}) => {
+  const {license} = useLicense();
+  const days = license?.expires
+    ? date(license?.expires).diff(date(), 'days')
+    : undefined;
+  const model = license?.model;
+
+  if (!isDefined(days) || days > LICENSE_EXPIRATION_THRESHOLD) {
+    return null;
+  }
+
+  const titleMessage = _('Your {{model}} license ends in {{days}} days!', {
+    model,
+    days,
+  });
+
+  const message = capabilities.mayOp('modify_license')
+    ? _(
+        'After that your appliance remains valid and you can still log in ' +
+          'and view or download all of your scan reports. You can re-activate ' +
+          'the security feed via menu item "Administration > License".',
+      )
+    : _(
+        'After that your appliance remains valid and you can still log in ' +
+          'and view or download all of your scan reports. Please contact your ' +
+          'administrator for re-activating the security feed.',
+      );
+  return (
+    <InfoPanel
+      noMargin={true}
+      heading={titleMessage}
+      onCloseClick={onCloseClick}
+    >
+      {message}
+    </InfoPanel>
+  );
+};
+
+LicenseNotification.propTypes = {
+  capabilities: PropTypes.capabilities.isRequired,
+  onCloseClick: PropTypes.func.isRequired,
+};
+
+export default LicenseNotification;

--- a/src/web/components/provider/licenseprovider.js
+++ b/src/web/components/provider/licenseprovider.js
@@ -27,24 +27,30 @@ const LicenseProvider = ({children}) => {
 
   const [license, setLicense] = useState({});
   const [licenseError, setLicenseError] = useState();
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     updateLicense();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const updateLicense = () => {
+    setIsLoading(true);
     gmp.license
       .getLicenseInformation()
       .then(response => {
         setLicense(response.data);
+        setIsLoading(false);
       })
       .catch(err => {
+        setIsLoading(false);
         setLicenseError(err);
       });
   };
 
   return (
-    <LicenseContext.Provider value={{license, licenseError, updateLicense}}>
+    <LicenseContext.Provider
+      value={{isLoading, license, licenseError, updateLicense}}
+    >
       {children}
     </LicenseContext.Provider>
   );

--- a/src/web/components/provider/licenseprovider.js
+++ b/src/web/components/provider/licenseprovider.js
@@ -1,0 +1,49 @@
+/* Copyright (C) 2022 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, {useEffect, useState} from 'react';
+
+import useGmp from 'web/utils/useGmp';
+
+export const LicenseContext = React.createContext({});
+
+const LicenseProvider = ({children}) => {
+  const gmp = useGmp();
+
+  const [license, setLicense] = useState({});
+
+  useEffect(() => {
+    updateLicense();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const updateLicense = () => {
+    gmp.license.getLicenseInformation().then(response => {
+      setLicense(response.data);
+    });
+  };
+
+  return (
+    <LicenseContext.Provider value={{license, updateLicense}}>
+      {children}
+    </LicenseContext.Provider>
+  );
+};
+
+export default LicenseProvider;
+
+// vim: set ts=2 sw=2 tw=80:

--- a/src/web/components/provider/licenseprovider.js
+++ b/src/web/components/provider/licenseprovider.js
@@ -26,19 +26,25 @@ const LicenseProvider = ({children}) => {
   const gmp = useGmp();
 
   const [license, setLicense] = useState({});
+  const [licenseError, setLicenseError] = useState();
 
   useEffect(() => {
     updateLicense();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const updateLicense = () => {
-    gmp.license.getLicenseInformation().then(response => {
-      setLicense(response.data);
-    });
+    gmp.license
+      .getLicenseInformation()
+      .then(response => {
+        setLicense(response.data);
+      })
+      .catch(err => {
+        setLicenseError(err);
+      });
   };
 
   return (
-    <LicenseContext.Provider value={{license, updateLicense}}>
+    <LicenseContext.Provider value={{license, licenseError, updateLicense}}>
       {children}
     </LicenseContext.Provider>
   );

--- a/src/web/pages/licenses/__tests__/licensepage.js
+++ b/src/web/pages/licenses/__tests__/licensepage.js
@@ -84,6 +84,7 @@ describe('LicensePage tests', () => {
   test('should render', async () => {
     const {render, store} = rendererWith({
       capabilities: caps,
+      license: data,
       gmp,
       router: true,
       store: true,

--- a/src/web/pages/licenses/licensepage.js
+++ b/src/web/pages/licenses/licensepage.js
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 
 import _ from 'gmp/locale';
 
@@ -44,6 +44,7 @@ import {Col} from 'web/entity/page';
 
 import PropTypes from 'web/utils/proptypes';
 import useGmp from 'web/utils/useGmp';
+import useLicense from 'web/utils/useLicense';
 
 import useCapabilities from 'web/utils/useCapabilities';
 
@@ -79,25 +80,11 @@ ToolBarIcons.propTypes = {
 
 const LicensePage = () => {
   const gmp = useGmp();
-
-  const [license, setLicense] = useState({});
+  const {license, updateLicense} = useLicense();
   const [file, setFile] = useState();
   const [error, setError] = useState();
   const [dialogError, setDialogError] = useState();
   const [newLicenseDialogVisible, setNewLicenseDialogVisible] = useState(false);
-
-  const updateLicenseInformation = () => {
-    gmp.license
-      .getLicenseInformation()
-      .then(response => {
-        setLicense(response.data);
-      })
-      .catch(err => setError(err));
-  };
-
-  useEffect(() => {
-    updateLicenseInformation();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleNewLicenseClick = () => {
     setNewLicenseDialogVisible(true);
@@ -114,7 +101,7 @@ const LicensePage = () => {
       .modifyLicense(file)
       .then(() => {
         handleCloseDialog();
-        updateLicenseInformation();
+        updateLicense();
       })
       .catch(err => {
         setDialogError(err.message);

--- a/src/web/pages/licenses/licensepage.js
+++ b/src/web/pages/licenses/licensepage.js
@@ -15,11 +15,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined} from 'gmp/utils/identity';
+import {isDefined, isEmpty} from 'gmp/utils/identity';
 
 import DateTime from 'web/components/date/datetime';
 
@@ -32,6 +32,8 @@ import NewIcon from 'web/components/icon/newicon';
 import IconDivider from 'web/components/layout/icondivider';
 import Layout from 'web/components/layout/layout';
 import PageTitle from 'web/components/layout/pagetitle';
+
+import Loading from 'web/components/loading/loading';
 
 import Section from 'web/components/section/section';
 
@@ -80,11 +82,15 @@ ToolBarIcons.propTypes = {
 
 const LicensePage = () => {
   const gmp = useGmp();
-  const {license, updateLicense} = useLicense();
+  const {license, licenseError, updateLicense} = useLicense();
   const [file, setFile] = useState();
-  const [error, setError] = useState();
+  const [error, setError] = useState(licenseError);
   const [dialogError, setDialogError] = useState();
   const [newLicenseDialogVisible, setNewLicenseDialogVisible] = useState(false);
+
+  useEffect(() => {
+    setError(licenseError);
+  }, [licenseError]);
 
   const handleNewLicenseClick = () => {
     setNewLicenseDialogVisible(true);

--- a/src/web/pages/licenses/licensepage.js
+++ b/src/web/pages/licenses/licensepage.js
@@ -19,7 +19,7 @@ import React, {useEffect, useState} from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined, isEmpty} from 'gmp/utils/identity';
+import {isDefined} from 'gmp/utils/identity';
 
 import DateTime from 'web/components/date/datetime';
 
@@ -82,7 +82,7 @@ ToolBarIcons.propTypes = {
 
 const LicensePage = () => {
   const gmp = useGmp();
-  const {license, licenseError, updateLicense} = useLicense();
+  const {isLoading, license, licenseError, updateLicense} = useLicense();
   const [file, setFile] = useState();
   const [error, setError] = useState(licenseError);
   const [dialogError, setDialogError] = useState();
@@ -142,70 +142,74 @@ const LicensePage = () => {
           img={<LicenseIcon size="large" />}
           title={_('License Management')}
         >
-          <Layout flex="column" grow>
-            <h3>Information</h3>
-            <InfoTable>
-              <colgroup>
-                <Col width="10%" />
-                <Col width="90%" />
-              </colgroup>
-              <TableBody>
-                <TableRow>
-                  <TableData>{_('ID')}</TableData>
-                  <TableData>{license.id}</TableData>
-                </TableRow>
-                <TableRow>
-                  <TableData>{_('Customer Name')}</TableData>
-                  <TableData>{license.customerName}</TableData>
-                </TableRow>
-                <TableRow>
-                  <TableData>{_('Creation Date')}</TableData>
-                  <TableData>
-                    <DateTime date={license.creationDate} />
-                  </TableData>
-                </TableRow>
-                <TableRow>
-                  <TableData>{_('Version')}</TableData>
-                  <TableData>{license.version}</TableData>
-                </TableRow>
-                <TableRow>
-                  <TableData>{_('Begins')}</TableData>
-                  <TableData>
-                    <DateTime date={license.begins} />
-                  </TableData>
-                </TableRow>
-                <TableRow>
-                  <TableData>{_('Expires')}</TableData>
-                  <TableData>
-                    <DateTime date={license.expires} />
-                  </TableData>
-                </TableRow>
-                {isDefined(license.comment) && (
+          {isLoading ? (
+            <Loading />
+          ) : (
+            <Layout flex="column" grow>
+              <h3>Information</h3>
+              <InfoTable>
+                <colgroup>
+                  <Col width="10%" />
+                  <Col width="90%" />
+                </colgroup>
+                <TableBody>
                   <TableRow>
-                    <TableData>{_('Comment')}</TableData>
-                    <TableData>{license.comment}</TableData>
+                    <TableData>{_('ID')}</TableData>
+                    <TableData>{license.id}</TableData>
                   </TableRow>
-                )}
-              </TableBody>
-            </InfoTable>
-            <h3>Model</h3>
-            <InfoTable>
-              <colgroup>
-                <Col width="10%" />
-                <Col width="90%" />
-              </colgroup>
-              <TableBody>
-                <TableRow>
-                  <TableData>{_('Model')}</TableData>
-                  <TableData>{license.model}</TableData>
-                </TableRow>
-                <TableRow>
-                  <TableData>{_('Model Type')}</TableData>
-                  <TableData>{license.modelType}</TableData>
-                </TableRow>
-              </TableBody>
-            </InfoTable>
-          </Layout>
+                  <TableRow>
+                    <TableData>{_('Customer Name')}</TableData>
+                    <TableData>{license.customerName}</TableData>
+                  </TableRow>
+                  <TableRow>
+                    <TableData>{_('Creation Date')}</TableData>
+                    <TableData>
+                      <DateTime date={license.creationDate} />
+                    </TableData>
+                  </TableRow>
+                  <TableRow>
+                    <TableData>{_('Version')}</TableData>
+                    <TableData>{license.version}</TableData>
+                  </TableRow>
+                  <TableRow>
+                    <TableData>{_('Begins')}</TableData>
+                    <TableData>
+                      <DateTime date={license.begins} />
+                    </TableData>
+                  </TableRow>
+                  <TableRow>
+                    <TableData>{_('Expires')}</TableData>
+                    <TableData>
+                      <DateTime date={license.expires} />
+                    </TableData>
+                  </TableRow>
+                  {isDefined(license.comment) && (
+                    <TableRow>
+                      <TableData>{_('Comment')}</TableData>
+                      <TableData>{license.comment}</TableData>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </InfoTable>
+              <h3>Model</h3>
+              <InfoTable>
+                <colgroup>
+                  <Col width="10%" />
+                  <Col width="90%" />
+                </colgroup>
+                <TableBody>
+                  <TableRow>
+                    <TableData>{_('Model')}</TableData>
+                    <TableData>{license.model}</TableData>
+                  </TableRow>
+                  <TableRow>
+                    <TableData>{_('Model Type')}</TableData>
+                    <TableData>{license.modelType}</TableData>
+                  </TableRow>
+                </TableBody>
+              </InfoTable>
+            </Layout>
+          )}
         </Section>
       </Layout>
       {newLicenseDialogVisible && (

--- a/src/web/utils/testing.js
+++ b/src/web/utils/testing.js
@@ -42,9 +42,7 @@ import {hasValue, isDefined} from 'gmp/utils/identity';
 
 import GmpContext from 'web/components/provider/gmpprovider';
 import CapabilitiesContext from 'web/components/provider/capabilitiesprovider';
-import LicenseProvider, {
-  LicenseContext,
-} from 'web/components/provider/licenseprovider';
+import LicenseProvider from 'web/components/provider/licenseprovider';
 
 import {createQueryHistory} from 'web/routes';
 import configureStore from 'web/store';

--- a/src/web/utils/testing.js
+++ b/src/web/utils/testing.js
@@ -42,6 +42,9 @@ import {hasValue, isDefined} from 'gmp/utils/identity';
 
 import GmpContext from 'web/components/provider/gmpprovider';
 import CapabilitiesContext from 'web/components/provider/capabilitiesprovider';
+import LicenseProvider, {
+  LicenseContext,
+} from 'web/components/provider/licenseprovider';
 
 import {createQueryHistory} from 'web/routes';
 import configureStore from 'web/store';
@@ -100,26 +103,30 @@ export const render = ui => {
   };
 };
 
-const withProvider = (name, key = name) => Component => ({
-  children,
-  ...props
-}) =>
-  isDefined(props[name]) ? (
-    <Component {...{[key]: props[name]}}>{children}</Component>
-  ) : (
-    children
-  );
+const withProvider =
+  (name, key = name) =>
+  Component =>
+  ({children, ...props}) =>
+    isDefined(props[name]) ? (
+      <Component {...{[key]: props[name]}}>{children}</Component>
+    ) : (
+      children
+    );
 
-const TestingGmpPropvider = withProvider('gmp', 'value')(GmpContext.Provider);
+const TestingGmpProvider = withProvider('gmp', 'value')(GmpContext.Provider);
 const TestingStoreProvider = withProvider('store')(Provider);
 const TestingRouter = withProvider('history')(Router);
 const TestingCapabilitiesProvider = withProvider(
   'capabilities',
   'value',
 )(CapabilitiesContext.Provider);
+const TestingLicenseProvider = withProvider(
+  'license',
+  'value',
+)(LicenseProvider);
 
 export const rendererWith = (
-  {capabilities, gmp, store, router} = {
+  {capabilities, gmp, license, store, router} = {
     store: true,
     router: true,
   },
@@ -136,16 +143,19 @@ export const rendererWith = (
   if (capabilities === true) {
     capabilities = new EverythingCapabilities();
   }
+
   return {
     render: ui =>
       render(
-        <TestingGmpPropvider gmp={gmp}>
+        <TestingGmpProvider gmp={gmp}>
           <TestingCapabilitiesProvider capabilities={capabilities}>
-            <TestingStoreProvider store={store}>
-              <TestingRouter history={history}>{ui}</TestingRouter>
-            </TestingStoreProvider>
+            <TestingLicenseProvider license={license}>
+              <TestingStoreProvider store={store}>
+                <TestingRouter history={history}>{ui}</TestingRouter>
+              </TestingStoreProvider>
+            </TestingLicenseProvider>
           </TestingCapabilitiesProvider>
-        </TestingGmpPropvider>,
+        </TestingGmpProvider>,
       ),
     gmp,
     store,

--- a/src/web/utils/useLicense.js
+++ b/src/web/utils/useLicense.js
@@ -1,0 +1,24 @@
+/* Copyright (C) 2022 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+import {useContext} from 'react';
+
+import {LicenseContext} from 'web/components/provider/licenseprovider';
+
+const useLicense = () => useContext(LicenseContext);
+
+export default useLicense;


### PR DESCRIPTION
**What**:
Extract logic and code behind the LicenseNotification out of the page.js into its own module
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The code will become more complex and this gives a good basis to keep page.js as clean and simple as possible
<!-- Why are these changes necessary? -->

**How**:
Manual tests were performed if the notification's behavior changed after moving the code.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests (currently not possible/senseful, because the test would need a reference to current server time, which obviously changes)
- [ ] PR merge commit message adjusted (Use: "Change: Move LicenseNotification into own module")
- [N/A] Labels for ports to other branches
