### PR TITLE
Improve displaying license

### DIFF
--- a/src/gmp/commands/__tests__/license.js
+++ b/src/gmp/commands/__tests__/license.js
@@ -42,7 +42,7 @@ describe('LicenseCommand tests', () => {
               },
               appliance: {
                 model: 'trial',
-                model_type: '450',
+                model_type: 'virtual',
                 sensor: false,
               },
             },
@@ -63,13 +63,14 @@ describe('LicenseCommand tests', () => {
       const {data: license} = resp;
       expect(license.id).toEqual('12345');
       expect(license.customerName).toEqual('Monsters Inc.');
-      expect(license.creationDate).toEqual(parseDate('2021-08-27T06:05:21Z'));
       expect(license.version).toEqual('1.0.0');
+      expect(license.created).toEqual(parseDate('2021-08-27T06:05:21Z'));
       expect(license.begins).toEqual(parseDate('2021-08-27T07:05:21Z'));
       expect(license.expires).toEqual(parseDate('2021-09-04T07:05:21Z'));
       expect(license.comment).toEqual('foo');
-      expect(license.model).toEqual('trial');
-      expect(license.modelType).toEqual('450');
+      expect(license.applianceModel).toEqual('trial');
+      expect(license.applianceModelType).toEqual('virtual');
+      expect(license.type).toEqual('trial');
     });
   });
 });

--- a/src/gmp/commands/license.js
+++ b/src/gmp/commands/license.js
@@ -18,25 +18,9 @@
 
 import registerCommand from 'gmp/command';
 
-import {parseDate} from 'gmp/parser';
+import {License} from 'gmp/models/license';
 
 import GMPCommand from './gmp';
-
-export class License {
-  constructor({content, status}) {
-    this.status = status;
-    this.id = content?.meta?.id;
-    this.customerName = content?.meta?.customer_name;
-    this.creationDate = parseDate(content?.meta?.created);
-    this.version = content?.meta?.version;
-    this.begins = parseDate(content?.meta?.begins);
-    this.expires = parseDate(content?.meta?.expires);
-    this.comment = content?.meta?.comment;
-
-    this.model = content?.appliance?.model;
-    this.modelType = content?.appliance?.model_type;
-  }
-}
 
 export class LicenseCommand extends GMPCommand {
   constructor(http) {
@@ -47,7 +31,7 @@ export class LicenseCommand extends GMPCommand {
     return this.httpGet().then(response => {
       const {data: envelope} = response;
       const {get_license_response: licenseResponse} = envelope.get_license;
-      const license = new License(licenseResponse.license);
+      const license = License.fromElement(licenseResponse.license);
 
       return response.setData(license);
     });

--- a/src/gmp/models/__tests__/license.js
+++ b/src/gmp/models/__tests__/license.js
@@ -1,0 +1,87 @@
+/* Copyright (C) 2022 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {parseDate} from 'gmp/parser';
+
+import {License} from '../license';
+
+describe('License tests', () => {
+  test('should init license data via constructor', () => {
+    const license = new License({
+      status: 'active',
+      id: '12345',
+      version: '1.0.0',
+      title: 'Test License',
+      type: 'trial',
+      customerName: 'Monsters Inc.',
+      created: parseDate('2021-08-27T06:05:21Z'),
+      begins: parseDate('2021-08-27T07:05:21Z'),
+      expires: parseDate('2021-09-04T07:05:21Z'),
+      comment: 'foo',
+      applianceModel: 'trial',
+      applianceModelType: 'virtual',
+      sensor: false,
+    });
+
+    expect(license.id).toEqual('12345');
+    expect(license.customerName).toEqual('Monsters Inc.');
+    expect(license.version).toEqual('1.0.0');
+    expect(license.created).toEqual(parseDate('2021-08-27T06:05:21Z'));
+    expect(license.begins).toEqual(parseDate('2021-08-27T07:05:21Z'));
+    expect(license.expires).toEqual(parseDate('2021-09-04T07:05:21Z'));
+    expect(license.comment).toEqual('foo');
+    expect(license.applianceModel).toEqual('trial');
+    expect(license.applianceModelType).toEqual('virtual');
+    expect(license.type).toEqual('trial');
+  });
+
+  test('should parse license data from element', () => {
+    const license = License.fromElement({
+      status: 'active',
+      content: {
+        meta: {
+          id: '12345',
+          version: '1.0.0',
+          title: 'Test License',
+          type: 'trial',
+          customer_name: 'Monsters Inc.',
+          created: '2021-08-27T06:05:21Z',
+          begins: '2021-08-27T07:05:21Z',
+          expires: '2021-09-04T07:05:21Z',
+          comment: 'foo',
+        },
+        appliance: {
+          model: 'trial',
+          model_type: 'virtual',
+          sensor: false,
+        },
+      },
+    });
+
+    expect(license.id).toEqual('12345');
+    expect(license.customerName).toEqual('Monsters Inc.');
+    expect(license.version).toEqual('1.0.0');
+    expect(license.created).toEqual(parseDate('2021-08-27T06:05:21Z'));
+    expect(license.begins).toEqual(parseDate('2021-08-27T07:05:21Z'));
+    expect(license.expires).toEqual(parseDate('2021-09-04T07:05:21Z'));
+    expect(license.comment).toEqual('foo');
+    expect(license.applianceModel).toEqual('trial');
+    expect(license.applianceModelType).toEqual('virtual');
+    expect(license.type).toEqual('trial');
+  });
+});

--- a/src/gmp/models/license.js
+++ b/src/gmp/models/license.js
@@ -16,7 +16,62 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import _ from 'gmp/locale';
+
 import {parseDate} from 'gmp/parser';
+
+import {isDefined} from 'gmp/utils/identity';
+
+const LICENSE_MODEL = {
+  trial: 'Greenbone Enterprise TRIAL',
+  '25v': 'Greenbone Enterprise 25V',
+  25: 'Greenbone Enterprise 25',
+  35: 'Greenbone Enterprise 35',
+  maven: 'Greenbone Enterprise MAVEN',
+  one: 'Greenbone Enterprise ONE',
+  100: 'Greenbone Enterprise 100',
+  150: 'Greenbone Enterprise 150',
+  ceno: 'Greenbone Enterprise CENO',
+  deca: 'Greenbone Enterprise DECA',
+  400: 'Greenbone Enterprise 400',
+  '400r2': 'Greenbone Enterprise 400',
+  450: 'Greenbone Enterprise 450',
+  '450r2': 'Greenbone Enterprise 450',
+  tera: 'Greenbone Enterprise TERA',
+  500: 'Greenbone Enterprise 500',
+  510: 'Greenbone Enterprise 510',
+  550: 'Greenbone Enterprise 550',
+  600: 'Greenbone Enterprise 600',
+  '600r2': 'Greenbone Enterprise 600',
+  peta: 'Greenbone Enterprise PETA',
+  650: 'Greenbone Enterprise 650',
+  '650r2': 'Greenbone Enterprise 650',
+  exa: 'Greenbone Enterprise EXA',
+  5300: 'Greenbone Enterprise 5300',
+  6400: 'Greenbone Enterprise 6400',
+  5400: 'Greenbone Enterprise 5400',
+  6500: 'Greenbone Enterprise 6500',
+  expo: 'Greenbone Enterprise EXPO',
+  '150c-siesta': 'Greenbone Enterprise 150C-SiESTA',
+};
+
+export const getLicenseApplianceModelName = value => {
+  const name = LICENSE_MODEL[value];
+  return isDefined(name) ? name : value;
+};
+
+export const getLicenseApplianceModelType = value => {
+  if (!isDefined(value)) {
+    return value;
+  }
+  if (value === 'virtual') {
+    return 'Virtual Appliance';
+  }
+  if (value === 'hardware') {
+    return 'Hardware Appliance';
+  }
+  return _('Unknown');
+};
 
 export class License {
   constructor({

--- a/src/gmp/models/license.js
+++ b/src/gmp/models/license.js
@@ -1,0 +1,67 @@
+/* Copyright (C) 2022 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {parseDate} from 'gmp/parser';
+
+export class License {
+  constructor({
+    id,
+    status,
+    customerName,
+    created,
+    version,
+    begins,
+    expires,
+    comment,
+    type,
+    applianceModel,
+    applianceModelType,
+  }) {
+    this.status = status;
+    this.id = id;
+    this.customerName = customerName;
+    this.version = version;
+    this.created = created;
+    this.begins = begins;
+    this.expires = expires;
+    this.comment = comment;
+    this.type = type;
+
+    this.applianceModel = applianceModel;
+    this.applianceModelType = applianceModelType;
+  }
+
+  static fromElement(element) {
+    const {content, status} = element;
+    return new License({
+      status: status,
+      id: content?.meta?.id,
+      customerName: content?.meta?.customer_name,
+      created: parseDate(content?.meta?.created),
+      version: content?.meta?.version,
+      begins: parseDate(content?.meta?.begins),
+      expires: parseDate(content?.meta?.expires),
+      comment: content?.meta?.comment,
+      type: content?.meta?.type,
+      applianceModel: content?.appliance?.model,
+      applianceModelType: content?.appliance?.model_type,
+    });
+  }
+}
+
+export default License;

--- a/src/web/components/notification/__tests__/licensenotification.js
+++ b/src/web/components/notification/__tests__/licensenotification.js
@@ -40,8 +40,8 @@ const data1 = License.fromElement({
       comment: 'Han shot first',
     },
     appliance: {
-      model: 'trial',
-      model_type: '450',
+      model: '450',
+      model_type: 'hardware',
       sensor: false,
     },
   },
@@ -62,8 +62,8 @@ const data2 = License.fromElement({
       comment: 'Han shot first',
     },
     appliance: {
-      model: 'trial',
-      model_type: '450',
+      model: '450',
+      model_type: 'hardware',
       sensor: false,
     },
   },
@@ -103,7 +103,9 @@ describe('LicenseNotification tests', () => {
 
     await wait();
 
-    expect(baseElement).toHaveTextContent('Your trial license ends in 26 days');
+    expect(baseElement).toHaveTextContent(
+      'Your Greenbone Enterprise License ends in 26 days',
+    );
   });
 
   test('should not render if >30 days valid', async () => {

--- a/src/web/components/notification/__tests__/licensenotification.js
+++ b/src/web/components/notification/__tests__/licensenotification.js
@@ -19,13 +19,13 @@ import React from 'react';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
-import {License} from 'gmp/commands/license';
+import {License} from 'gmp/models/license';
 
 import {rendererWith, wait} from 'web/utils/testing';
 
 import LicenseNotification from '../licensenotification';
 
-const data1 = new License({
+const data1 = License.fromElement({
   status: 'active',
   content: {
     meta: {
@@ -47,7 +47,7 @@ const data1 = new License({
   },
 });
 
-const data2 = new License({
+const data2 = License.fromElement({
   status: 'active',
   content: {
     meta: {

--- a/src/web/components/notification/licensenotification.js
+++ b/src/web/components/notification/licensenotification.js
@@ -36,16 +36,17 @@ const LicenseNotification = ({capabilities, onCloseClick}) => {
   const days = license?.expires
     ? date(license?.expires).diff(date(), 'days')
     : undefined;
-  const model = license?.model;
 
   if (!isDefined(days) || days > LICENSE_EXPIRATION_THRESHOLD) {
     return null;
   }
 
-  const titleMessage = _('Your {{model}} license ends in {{days}} days!', {
-    model,
-    days,
-  });
+  const titleMessage = _(
+    'Your Greenbone Enterprise License ends in {{days}} days!',
+    {
+      days,
+    },
+  );
 
   const message = capabilities.mayOp('modify_license')
     ? _(

--- a/src/web/pages/licenses/__tests__/licensepage.js
+++ b/src/web/pages/licenses/__tests__/licensepage.js
@@ -48,8 +48,8 @@ const data = License.fromElement({
       comment: 'Han shot first',
     },
     appliance: {
-      model: 'trial',
-      model_type: '450',
+      model: '450',
+      model_type: 'hardware',
       sensor: false,
     },
   },
@@ -70,8 +70,8 @@ const data2 = License.fromElement({
       comment: 'Han shot first',
     },
     appliance: {
-      model: 'trial',
-      model_type: '450',
+      model: '450',
+      model_type: 'hardware',
       sensor: false,
     },
     keys: {
@@ -169,9 +169,9 @@ describe('LicensePage tests', () => {
     expect(element).toHaveTextContent('Comment');
     expect(element).toHaveTextContent('Han shot first');
     expect(element).toHaveTextContent('Model');
-    expect(element).toHaveTextContent('trial');
+    expect(element).toHaveTextContent('Greenbone Enterprise 450');
     expect(element).toHaveTextContent('Model Type');
-    expect(element).toHaveTextContent('450');
+    expect(element).toHaveTextContent('Hardware Appliance');
 
     // Headings
     const headings = getAllByRole('heading');
@@ -249,9 +249,9 @@ describe('LicensePage tests', () => {
     expect(element).toHaveTextContent('Comment');
     expect(element).toHaveTextContent('Han shot first');
     expect(element).toHaveTextContent('Model');
-    expect(element).toHaveTextContent('trial');
+    expect(element).toHaveTextContent('Greenbone Enterprise 450');
     expect(element).toHaveTextContent('Model Type');
-    expect(element).toHaveTextContent('450');
+    expect(element).toHaveTextContent('Hardware Appliance');
 
     // Headings
     const headings = getAllByRole('heading');

--- a/src/web/pages/licenses/__tests__/licensepage.js
+++ b/src/web/pages/licenses/__tests__/licensepage.js
@@ -21,18 +21,19 @@ import Capabilities from 'gmp/capabilities/capabilities';
 
 import {setLocale} from 'gmp/locale/lang';
 
-import {License} from 'gmp/commands/license';
+import {License} from 'gmp/models/license';
 
 import Response from 'gmp/http/response';
 
 import {setTimezone} from 'web/store/usersettings/actions';
 
 import {rendererWith, waitFor, wait} from 'web/utils/testing';
+
 import LicensePage from '../licensepage';
 
 setLocale('en');
 
-const data = new License({
+const data = License.fromElement({
   status: 'active',
   content: {
     meta: {
@@ -54,7 +55,7 @@ const data = new License({
   },
 });
 
-const data2 = new License({
+const data2 = License.fromElement({
   status: 'active',
   content: {
     meta: {

--- a/src/web/pages/licenses/licensepage.js
+++ b/src/web/pages/licenses/licensepage.js
@@ -22,6 +22,10 @@ import styled from 'styled-components';
 import _ from 'gmp/locale';
 
 import date from 'gmp/models/date';
+import {
+  getLicenseApplianceModelName,
+  getLicenseApplianceModelType,
+} from 'gmp/models/license';
 
 import {isDefined} from 'gmp/utils/identity';
 
@@ -226,11 +230,15 @@ const LicensePage = () => {
                 <TableBody>
                   <TableRow>
                     <TableData>{_('Model')}</TableData>
-                    <TableData>{license.model}</TableData>
+                    <TableData>
+                      {getLicenseApplianceModelName(license.applianceModel)}
+                    </TableData>
                   </TableRow>
                   <TableRow>
                     <TableData>{_('Model Type')}</TableData>
-                    <TableData>{license.modelType}</TableData>
+                    <TableData>
+                      {getLicenseApplianceModelType(license.applianceModelType)}
+                    </TableData>
                   </TableRow>
                 </TableBody>
               </InfoTable>

--- a/src/web/pages/licenses/licensepage.js
+++ b/src/web/pages/licenses/licensepage.js
@@ -63,7 +63,7 @@ const HowToDiv = styled.div`
 
 const ToolBarIcons = ({onNewLicenseClick}) => {
   const capabilities = useCapabilities();
-  const mayModify = capabilities.mayOp('modify_license');
+  const mayModify = capabilities.mayEdit('license');
 
   return (
     <Layout>

--- a/src/web/pages/licenses/licensepage.js
+++ b/src/web/pages/licenses/licensepage.js
@@ -190,7 +190,7 @@ const LicensePage = () => {
                   <TableRow>
                     <TableData>{_('Creation Date')}</TableData>
                     <TableData>
-                      <DateTime date={license.creationDate} />
+                      <DateTime date={license.created} />
                     </TableData>
                   </TableRow>
                   <TableRow>

--- a/src/web/pages/licenses/licensepage.js
+++ b/src/web/pages/licenses/licensepage.js
@@ -217,7 +217,7 @@ const LicensePage = () => {
                   )}
                 </TableBody>
               </InfoTable>
-              <h3>Model</h3>
+              <h3>{_('Model')}</h3>
               <InfoTable>
                 <colgroup>
                   <Col width="10%" />


### PR DESCRIPTION
**What**:

* Move license into a model module and adjust its parsing
* Introduce functions to display descriptive model names and types
* Fix model and model_type usage in tests

**Why**:

For example trial and 450 are just values for the models. A model type can be virtual or hardware. But both values should not be displayed 1:1 to the user.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
- [ ] Labels for ports to other branches
