### PR TITLE
Fix: Use GSA version to create links to manual and GMP documentation

### DIFF
--- a/src/__tests__/version.js
+++ b/src/__tests__/version.js
@@ -16,10 +16,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import VERSION from '../version';
+import {RELEASE_VERSION} from '../version';
 
 describe('Version tests', () => {
-  test('should only be major.minor', () => {
-    expect(VERSION.split('.').length).toEqual(2);
+  test('release version should only contain major.minor', () => {
+    expect(RELEASE_VERSION.split('.').length).toEqual(2);
   });
 });

--- a/src/__tests__/version.js
+++ b/src/__tests__/version.js
@@ -1,0 +1,25 @@
+/* Copyright (C) 2022 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import VERSION from '../version';
+
+describe('Version tests', () => {
+  test('should only be major.minor', () => {
+    expect(VERSION.split('.').length).toEqual(2);
+  });
+});

--- a/src/gmp/gmpsettings.js
+++ b/src/gmp/gmpsettings.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {GSA_VERSION} from '../version';
+import GSA_VERSION from '../version';
 
 import {isDefined} from './utils/identity';
 

--- a/src/gmp/gmpsettings.js
+++ b/src/gmp/gmpsettings.js
@@ -15,15 +15,16 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+
+import {GSA_VERSION} from '../version';
+
 import {isDefined} from './utils/identity';
 
 export const DEFAULT_RELOAD_INTERVAL = 15 * 1000; // fifteen seconds
 export const DEFAULT_RELOAD_INTERVAL_ACTIVE = 3 * 1000; // three seconds
 export const DEFAULT_RELOAD_INTERVAL_INACTIVE = 60 * 1000; // one minute
-export const DEFAULT_MANUAL_URL =
-  'http://docs.greenbone.net/GSM-Manual/gos-20.08/';
-export const DEFAULT_PROTOCOLDOC_URL =
-  'https://docs.greenbone.net/API/GMP/gmp-20.08.html';
+export const DEFAULT_MANUAL_URL = `http://docs.greenbone.net/GSM-Manual/gos-${GSA_VERSION}/`;
+export const DEFAULT_PROTOCOLDOC_URL = `https://docs.greenbone.net/API/GMP/gmp-${GSA_VERSION}.html`;
 export const DEFAULT_REPORT_RESULTS_THRESHOLD = 25000;
 export const DEFAULT_LOG_LEVEL = 'warn';
 export const DEFAULT_TIMEOUT = 300000; // 5 minutes

--- a/src/gmp/gmpsettings.js
+++ b/src/gmp/gmpsettings.js
@@ -16,15 +16,15 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import GSA_VERSION from '../version';
+import {RELEASE_VERSION} from '../version';
 
 import {isDefined} from './utils/identity';
 
 export const DEFAULT_RELOAD_INTERVAL = 15 * 1000; // fifteen seconds
 export const DEFAULT_RELOAD_INTERVAL_ACTIVE = 3 * 1000; // three seconds
 export const DEFAULT_RELOAD_INTERVAL_INACTIVE = 60 * 1000; // one minute
-export const DEFAULT_MANUAL_URL = `http://docs.greenbone.net/GSM-Manual/gos-${GSA_VERSION}/`;
-export const DEFAULT_PROTOCOLDOC_URL = `https://docs.greenbone.net/API/GMP/gmp-${GSA_VERSION}.html`;
+export const DEFAULT_MANUAL_URL = `http://docs.greenbone.net/GSM-Manual/gos-${RELEASE_VERSION}/`;
+export const DEFAULT_PROTOCOLDOC_URL = `https://docs.greenbone.net/API/GMP/gmp-${RELEASE_VERSION}.html`;
 export const DEFAULT_REPORT_RESULTS_THRESHOLD = 25000;
 export const DEFAULT_LOG_LEVEL = 'warn';
 export const DEFAULT_TIMEOUT = 300000; // 5 minutes

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ import ReactDOM from 'react-dom';
 
 import * as Sentry from '@sentry/react';
 
-import {GSA_VERSION} from 'version';
+import GSA_VERSION from 'version';
 
 import {isDefined} from 'gmp/utils/identity';
 

--- a/src/version.js
+++ b/src/version.js
@@ -16,7 +16,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-// must be only major.minor
-export const VERSION = '22.04';
+const getMajorMinorVersion = () => {
+  // eslint-disable-next-line no-unused-vars
+  const [major, minor, ...rest] = VERSION.split('.');
+  return `${major}.${minor}`;
+};
+
+export const VERSION = '22.04.1';
+
+export const RELEASE_VERSION = getMajorMinorVersion();
 
 export default VERSION;

--- a/src/version.js
+++ b/src/version.js
@@ -16,4 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const GSA_VERSION = process.env.REACT_APP_VERSION || '22.04';
+// must be only major.minor
+export const VERSION = '22.04';
+
+export default VERSION;

--- a/src/web/pages/help/about.js
+++ b/src/web/pages/help/about.js
@@ -19,7 +19,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import {GSA_VERSION} from 'version';
+import GSA_VERSION from 'version';
 
 import _ from 'gmp/locale';
 


### PR DESCRIPTION
**What**:

Fix creating the URL for the links to the manual and GMP documentation
by versioning them.

AP-1966

**Why**:

Use correct links for a specific GSA version.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] PR merge commit message adjusted
- [x] Labels for ports to other branches
