### PR TITLE
Display confirmation dialog only when replacing a valid license

### DIFF
--- a/src/web/pages/licenses/__tests__/dialog.js
+++ b/src/web/pages/licenses/__tests__/dialog.js
@@ -1,0 +1,136 @@
+/* Copyright (C) 2022 Greenbone Networks GmbH
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+
+import {setLocale} from 'gmp/models/date';
+
+import {render} from 'web/utils/testing';
+
+import Dialog from '../dialog';
+
+setLocale('en');
+
+describe('LicenseDialog component tests', () => {
+  test('should render dialog with file selection', () => {
+    const handleClose = jest.fn();
+    const handleSave = jest.fn();
+
+    const {baseElement, getByName} = render(
+      <Dialog
+        onClose={handleClose}
+        onErrorClose={handleClose}
+        onSave={handleSave}
+      />,
+    );
+
+    expect(baseElement).toHaveTextContent('New License');
+    expect(baseElement).toHaveTextContent('License File');
+
+    const button = getByName('file');
+    expect(button).toBeDefined();
+  });
+
+  test('should close Dialog with close button', () => {
+    const handleClose = jest.fn();
+    const handleSave = jest.fn();
+
+    const {getByTestId} = render(
+      <Dialog
+        onClose={handleClose}
+        onErrorClose={handleClose}
+        onSave={handleSave}
+      />,
+    );
+    const closeButton = getByTestId('dialog-title-close-button');
+
+    expect(closeButton).toBeInTheDocument();
+
+    userEvent.click(closeButton);
+
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  test('should close Dialog with cancel button', () => {
+    const handleClose = jest.fn();
+    const handleSave = jest.fn();
+
+    const {getByTestId} = render(
+      <Dialog
+        onClose={handleClose}
+        onErrorClose={handleClose}
+        onSave={handleSave}
+      />,
+    );
+    const cancelButton = getByTestId('dialog-close-button');
+
+    expect(cancelButton).toBeInTheDocument();
+
+    userEvent.click(cancelButton);
+
+    expect(handleClose).toHaveBeenCalled();
+  });
+
+  test('should call clickhandler for save button if license not active', () => {
+    const handleClose = jest.fn();
+    const handleSave = jest.fn();
+    const license = {status: 'corrupt'};
+
+    const {getByTestId} = render(
+      <Dialog
+        license={license}
+        onClose={handleClose}
+        onErrorClose={handleClose}
+        onSave={handleSave}
+      />,
+    );
+    const saveButton = getByTestId('dialog-save-button');
+
+    expect(saveButton).toBeInTheDocument();
+
+    userEvent.click(saveButton);
+
+    expect(handleSave).toHaveBeenCalled();
+  });
+
+  test('should not call clickhandler for save button if license active', () => {
+    // this indirectly figures out if the click handler was intercepted by the
+    // ConfirmationDialog, which should pop up for valid/active licenses
+    const handleClose = jest.fn();
+    const handleSave = jest.fn();
+    const license = {status: 'active'};
+
+    const {getByTestId} = render(
+      <Dialog
+        license={license}
+        onClose={handleClose}
+        onErrorClose={handleClose}
+        onSave={handleSave}
+      />,
+    );
+    const saveButton = getByTestId('dialog-save-button');
+
+    expect(saveButton).toBeInTheDocument();
+
+    userEvent.click(saveButton);
+
+    expect(handleSave).not.toHaveBeenCalled();
+  });
+});
+
+// vim: set ts=2 sw=2 tw=80:

--- a/src/web/pages/licenses/__tests__/dialog.js
+++ b/src/web/pages/licenses/__tests__/dialog.js
@@ -89,11 +89,10 @@ describe('LicenseDialog component tests', () => {
   test('should call clickhandler for save button if license not active', () => {
     const handleClose = jest.fn();
     const handleSave = jest.fn();
-    const license = {status: 'corrupt'};
 
     const {getByTestId} = render(
       <Dialog
-        license={license}
+        status="corrupt"
         onClose={handleClose}
         onErrorClose={handleClose}
         onSave={handleSave}
@@ -113,11 +112,10 @@ describe('LicenseDialog component tests', () => {
     // ConfirmationDialog, which should pop up for valid/active licenses
     const handleClose = jest.fn();
     const handleSave = jest.fn();
-    const license = {status: 'active'};
 
     const {getByTestId} = render(
       <Dialog
-        license={license}
+        status="active"
         onClose={handleClose}
         onErrorClose={handleClose}
         onSave={handleSave}

--- a/src/web/pages/licenses/dialog.js
+++ b/src/web/pages/licenses/dialog.js
@@ -89,7 +89,7 @@ const LicenseDialog = ({
 
 LicenseDialog.propTypes = {
   error: PropTypes.string,
-  license: PropTypes.string,
+  license: PropTypes.object,
   onClose: PropTypes.func.isRequired,
   onErrorClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,

--- a/src/web/pages/licenses/dialog.js
+++ b/src/web/pages/licenses/dialog.js
@@ -29,7 +29,7 @@ import PropTypes from 'web/utils/proptypes';
 
 const LicenseDialog = ({
   error,
-  license,
+  status,
   onClose,
   onErrorClose,
   onSave,
@@ -43,7 +43,7 @@ const LicenseDialog = ({
   };
 
   const handleSaveClick = data => {
-    if (license.status === 'active') {
+    if (status === 'active') {
       setConfirmationDialogVisible(true);
     } else {
       onSave(data);
@@ -89,7 +89,7 @@ const LicenseDialog = ({
 
 LicenseDialog.propTypes = {
   error: PropTypes.string,
-  license: PropTypes.object,
+  status: PropTypes.string,
   onClose: PropTypes.func.isRequired,
   onErrorClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,

--- a/src/web/pages/licenses/dialog.js
+++ b/src/web/pages/licenses/dialog.js
@@ -37,17 +37,24 @@ const LicenseDialog = ({
 }) => {
   const [confirmationDialogVisible, setConfirmationDialogVisible] =
     useState(false);
+
   const closeConfirmationDialog = () => {
     setConfirmationDialogVisible(false);
   };
 
   const handleSaveClick = data => {
-    setConfirmationDialogVisible(true);
+    if (license.status === 'active') {
+      setConfirmationDialogVisible(true);
+    } else {
+      onSave(data);
+    }
   };
+
   const handleResumeClick = data => {
     closeConfirmationDialog();
     onSave(data);
   };
+
   return (
     <SaveDialog
       error={error}

--- a/src/web/pages/licenses/licensepage.js
+++ b/src/web/pages/licenses/licensepage.js
@@ -272,8 +272,8 @@ const LicensePage = () => {
       </Layout>
       {newLicenseDialogVisible && (
         <LicenseDialog
-          license={license}
           error={dialogError}
+          status={license.status}
           onClose={handleCloseDialog}
           onErrorClose={handleDialogErrorClose}
           onSave={handleSaveLicense}

--- a/src/web/pages/licenses/licensepage.js
+++ b/src/web/pages/licenses/licensepage.js
@@ -272,6 +272,7 @@ const LicensePage = () => {
       </Layout>
       {newLicenseDialogVisible && (
         <LicenseDialog
+          license={license}
           error={dialogError}
           onClose={handleCloseDialog}
           onErrorClose={handleDialogErrorClose}


### PR DESCRIPTION
**What**:
Display confirmation dialog only when replacing a valid license.

Also add tests for LicenseDialog.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
AP-1978:
The admin user must confirm overriding a valid license
No confirmation is displayed if the current license is invalid/corrupted or expired
No confirmation is displayed if no current license is available
<!-- Why are these changes necessary? -->

**How**:
Manual tests uploading a valid license given either:
- a corrupt license -> no confirmation dialog
- a valid license -> -> confirmation dialog
- an expired license -> no confirmation dialog
- no license -> no confirmation dialog

If the confirmation dialog pops up, is also indirectly tested in an automated test.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] PR merge commit message adjusted
- [N/A] Labels for ports to other branches
