### PR TITLE
Build ARM64 images faster - use AMD64 for node

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION=unstable
 ARG DEBIAN_FRONTEND=noninteractive
 
-FROM debian:stable-slim as builder
+FROM --platform=linux/amd64 debian:stable-slim as builder
 
 ENV NODE_VERSION=node_14.x
 ENV NODE_KEYRING=/usr/share/keyrings/nodesource.gpg


### PR DESCRIPTION
We should use AMD64 to build the Web-Scripts and from there we can copy it also to ARM64 images.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add labels for ports to additional branches -->

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] PR merge commit message adjusted
- [ ] Labels for ports to other branches
