### PR TITLE
Change: Update fast-xml-parser to latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "d3-shape": "^2.1.0",
     "downshift": "^7.2.0",
     "fast-deep-equal": "^3.1.3",
-    "fast-xml-parser": "^3.21.1",
+    "fast-xml-parser": "^4.0.0",
     "glamor": "^2.20.40",
     "history": "^4.10.1",
     "hoist-non-react-statics": "^3.3.2",

--- a/src/gmp/http/transform/fastxml.js
+++ b/src/gmp/http/transform/fastxml.js
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import {parse} from 'fast-xml-parser';
+import {XMLParser} from 'fast-xml-parser';
 
 import {parseEnvelopeMeta, parseXmlEncodedString} from 'gmp/parser';
 
@@ -28,20 +28,23 @@ const PARSER_OPTIONS = {
   ignoreAttributes: false,
   ignoreNameSpace: true,
   textNodeName: '__text',
-  attrValueProcessor: attr => parseXmlEncodedString(attr),
-  tagValueProcessor: value => parseXmlEncodedString(value),
+  attributeValueProcessor: (name, value, jPath) => parseXmlEncodedString(value),
+  tagValueProcessor: (name, value, jPath, hasAttributes, isLeafNode) =>
+    parseXmlEncodedString(value),
 };
+
+const xmlParser = new XMLParser(PARSER_OPTIONS);
 
 const transformXmlData = response => {
   const xmlString = response.plainData('text');
-  const {envelope} = parse(xmlString, PARSER_OPTIONS);
+  const {envelope} = xmlParser.parse(xmlString);
   const meta = parseEnvelopeMeta(envelope);
   return response.set(envelope, meta);
 };
 
 const transformRejection = rej => {
   const xmlString = rej.plainData('text');
-  return isDefined(xmlString) ? parse(xmlString, PARSER_OPTIONS) : undefined;
+  return isDefined(xmlString) ? xmlParser.parse(xmlString) : undefined;
 };
 
 const transformObject = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5302,12 +5302,12 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-xml-parser@^3.21.1:
-  version "3.21.1"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz#152a1d51d445380f7046b304672dd55d15c9e736"
-  integrity sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==
+fast-xml-parser@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz#5a98c18238d28a57bbdfa9fe4cda01211fff8f4a"
+  integrity sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==
   dependencies:
-    strnum "^1.0.4"
+    strnum "^1.0.5"
 
 fastq@^1.6.0:
   version "1.15.0"
@@ -10218,7 +10218,7 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-strnum@^1.0.4:
+strnum@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
   integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==


### PR DESCRIPTION


## What

Update fast-xml-parser to latest release

## Why

This fixes a security vulnerability (see #3632).

## References

https://github.com/greenbone/gsa/pull/3632

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


