### PR TITLE
Add smb_max_protocol to alert method data

### DIFF
--- a/src/gmp/commands/alerts.js
+++ b/src/gmp/commands/alerts.js
@@ -68,6 +68,7 @@ const method_data_fields = [
   'scp_report_format',
   'smb_credential',
   'smb_file_path',
+  'smb_max_protocol',
   'smb_report_format',
   'smb_share_path',
   'tp_sms_hostname',

--- a/src/web/pages/alerts/component.js
+++ b/src/web/pages/alerts/component.js
@@ -111,53 +111,42 @@ class AlertComponent extends React.Component {
     };
 
     this.handleCreateCredential = this.handleCreateCredential.bind(this);
-    this.handleEmailCredentialChange = this.handleEmailCredentialChange.bind(
-      this,
-    );
+    this.handleEmailCredentialChange =
+      this.handleEmailCredentialChange.bind(this);
     this.handleFilterIdChange = this.handleFilterIdChange.bind(this);
     this.handleTestAlert = this.handleTestAlert.bind(this);
-    this.handlePasswordOnlyCredentialChange = this.handlePasswordOnlyCredentialChange.bind(
-      this,
-    );
+    this.handlePasswordOnlyCredentialChange =
+      this.handlePasswordOnlyCredentialChange.bind(this);
     this.handleScpCredentialChange = this.handleScpCredentialChange.bind(this);
     this.handleSaveComposerContent = this.handleSaveComposerContent.bind(this);
     this.handleSmbCredentialChange = this.handleSmbCredentialChange.bind(this);
     this.handleValueChange = this.handleValueChange.bind(this);
-    this.handleVeriniceCredentialChange = this.handleVeriniceCredentialChange.bind(
-      this,
-    );
-    this.handleTippingPointCredentialChange = this.handleTippingPointCredentialChange.bind(
-      this,
-    );
-    this.handleVfireCredentialChange = this.handleVfireCredentialChange.bind(
-      this,
-    );
+    this.handleVeriniceCredentialChange =
+      this.handleVeriniceCredentialChange.bind(this);
+    this.handleTippingPointCredentialChange =
+      this.handleTippingPointCredentialChange.bind(this);
+    this.handleVfireCredentialChange =
+      this.handleVfireCredentialChange.bind(this);
     this.handleReportFormatsChange = this.handleReportFormatsChange.bind(this);
 
     this.openAlertDialog = this.openAlertDialog.bind(this);
     this.handleCloseAlertDialog = this.handleCloseAlertDialog.bind(this);
-    this.handleOpenContentComposerDialog = this.handleOpenContentComposerDialog.bind(
-      this,
-    );
-    this.closeContentComposerDialog = this.closeContentComposerDialog.bind(
-      this,
-    );
-    this.openPasswordOnlyCredentialDialog = this.openPasswordOnlyCredentialDialog.bind(
-      this,
-    );
+    this.handleOpenContentComposerDialog =
+      this.handleOpenContentComposerDialog.bind(this);
+    this.closeContentComposerDialog =
+      this.closeContentComposerDialog.bind(this);
+    this.openPasswordOnlyCredentialDialog =
+      this.openPasswordOnlyCredentialDialog.bind(this);
     this.openScpCredentialDialog = this.openScpCredentialDialog.bind(this);
     this.openSmbCredentialDialog = this.openSmbCredentialDialog.bind(this);
-    this.openVeriniceCredentialDialog = this.openVeriniceCredentialDialog.bind(
-      this,
-    );
+    this.openVeriniceCredentialDialog =
+      this.openVeriniceCredentialDialog.bind(this);
     this.openVfireCredentialDialog = this.openVfireCredentialDialog.bind(this);
-    this.openTippingPointCredentialDialog = this.openTippingPointCredentialDialog.bind(
-      this,
-    );
+    this.openTippingPointCredentialDialog =
+      this.openTippingPointCredentialDialog.bind(this);
     this.openEmailCredentialDialog = this.openEmailCredentialDialog.bind(this);
-    this.handleCloseCredentialDialog = this.handleCloseCredentialDialog.bind(
-      this,
-    );
+    this.handleCloseCredentialDialog =
+      this.handleCloseCredentialDialog.bind(this);
   }
 
   handleCreateCredential(credentialdata) {
@@ -573,6 +562,10 @@ class AlertComponent extends React.Component {
               method.data.smb_file_path_type,
               '',
             ),
+            method_data_smb_max_protocol: getValue(
+              method.data.smb_max_protocol,
+              '',
+            ),
             method_data_smb_report_format: getValue(
               method.data.smb_report_format,
               '',
@@ -606,10 +599,11 @@ class AlertComponent extends React.Component {
               getValue(method.data.tp_sms_hostname, NO_VALUE),
             ),
 
-            method_data_verinice_server_report_format: select_verinice_report_id(
-              report_formats,
-              getValue(method.data.verinice_server_report_format),
-            ),
+            method_data_verinice_server_report_format:
+              select_verinice_report_id(
+                report_formats,
+                getValue(method.data.verinice_server_report_format),
+              ),
             method_data_verinice_server_url: getValue(
               method.data.verinice_server_url,
             ),
@@ -753,9 +747,8 @@ class AlertComponent extends React.Component {
             method_data_smb_share_path: undefined,
             method_data_smb_file_path: undefined,
             method_data_smb_file_path_type: undefined,
-            method_data_verinice_server_report_format: select_verinice_report_id(
-              report_formats,
-            ),
+            method_data_verinice_server_report_format:
+              select_verinice_report_id(report_formats),
             method_data_pkcs12_credential: UNSET_VALUE,
             method_data_vfire_credential: undefined,
             method_data_vfire_base_url: undefined,
@@ -972,6 +965,7 @@ class AlertComponent extends React.Component {
       method_data_smb_credential,
       method_data_smb_file_path,
       method_data_smb_file_path_type,
+      method_data_smb_max_protocol,
       method_data_smb_report_format,
       method_data_smb_share_path,
       method_data_snmp_agent,
@@ -1092,6 +1086,7 @@ class AlertComponent extends React.Component {
                 method_data_smb_credential={method_data_smb_credential}
                 method_data_smb_file_path={method_data_smb_file_path}
                 method_data_smb_file_path_type={method_data_smb_file_path_type}
+                method_data_smb_max_protocol={method_data_smb_max_protocol}
                 method_data_smb_report_format={method_data_smb_report_format}
                 method_data_smb_share_path={method_data_smb_share_path}
                 method_data_snmp_agent={method_data_snmp_agent}

--- a/src/web/pages/alerts/dialog.js
+++ b/src/web/pages/alerts/dialog.js
@@ -753,6 +753,7 @@ class AlertDialog extends React.Component {
                   reportFormats={report_formats}
                   smbCredential={values.method_data_smb_credential}
                   smbFilePath={values.method_data_smb_file_path}
+                  smbMaxProtocol={values.method_data_smb_max_protocol}
                   smbSharePath={values.method_data_smb_share_path}
                   smbReportFormat={values.method_data_smb_report_format}
                   onNewCredentialClick={onNewSmbCredentialClick}

--- a/src/web/pages/alerts/method.js
+++ b/src/web/pages/alerts/method.js
@@ -309,6 +309,12 @@ const Method = ({method = {}, details = false, reportFormats = []}) => {
                   </TableData>
                 </TableRow>
               )}
+              {isDefined(data.smb_max_protocol?.value) && (
+                <TableRow>
+                  <TableData>{_('Max Protocol')}</TableData>
+                  <TableData>{data.smb_max_protocol.value}</TableData>
+                </TableRow>
+              )}
             </TableBody>
           </Table>
         </div>

--- a/src/web/pages/alerts/smbmethodpart.js
+++ b/src/web/pages/alerts/smbmethodpart.js
@@ -44,6 +44,7 @@ const SmbMethodPart = ({
   reportFormats,
   smbCredential,
   smbFilePath,
+  smbMaxProtocol,
   smbReportFormat,
   smbSharePath,
   onChange,
@@ -108,6 +109,14 @@ const SmbMethodPart = ({
           onChange={onChange}
         />
       </FormGroup>
+
+      <FormGroup title={_('Max Protocol')}>
+        <TextField
+          name={prefix + 'smb_max_protocol'}
+          value={smbMaxProtocol}
+          onChange={onChange}
+        />
+      </FormGroup>
     </Layout>
   );
 };
@@ -118,6 +127,7 @@ SmbMethodPart.propTypes = {
   reportFormats: PropTypes.array,
   smbCredential: PropTypes.id,
   smbFilePath: PropTypes.string.isRequired,
+  smbMaxProtocol: PropTypes.string,
   smbReportFormat: PropTypes.id,
   smbSharePath: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,


### PR DESCRIPTION
## What
The smb_max_protocol field is added to the SMB method data in the Alert dialog and details.

## Why

To allow setting the option if the SMB server only supports older versions.

## References

GEA-38

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


