### PR TITLE
Add option to force LDAPS for authentication

### DIFF
--- a/src/gmp/commands/auth.js
+++ b/src/gmp/commands/auth.js
@@ -22,7 +22,7 @@ import HttpCommand from './http';
 import {convertBoolean} from './convert';
 
 export class AuthenticationCommand extends HttpCommand {
-  saveLdap({authdn, certificate, enable, ldaphost}) {
+  saveLdap({authdn, certificate, enable, ldaphost, ldapsOnly}) {
     return this.httpPost({
       cmd: 'save_auth',
       group: 'method:ldap_connect',
@@ -30,6 +30,7 @@ export class AuthenticationCommand extends HttpCommand {
       certificate,
       enable: convertBoolean(enable),
       ldaphost,
+      ldaps_only: convertBoolean(ldapsOnly),
     });
   }
 

--- a/src/gmp/commands/users.js
+++ b/src/gmp/commands/users.js
@@ -114,6 +114,8 @@ export class UserCommand extends EntityCommand {
           forEach(group.auth_conf_setting, setting => {
             if (setting.key === 'enable') {
               values.enabled = setting.value === true;
+            } else if (setting.key === 'ldaps-only') {
+              values.ldapsOnly = setting.value === true;
             } else {
               values[setting.key] = setting.value;
             }

--- a/src/web/pages/ldap/__tests__/__snapshots__/dialog.js.snap
+++ b/src/web/pages/ldap/__tests__/__snapshots__/dialog.js.snap
@@ -680,6 +680,42 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
                       </div>
                     </div>
                   </div>
+                  <div
+                    class="c9"
+                  >
+                    <label
+                      class="c10"
+                      data-testid="formgroup-title"
+                    >
+                      Use LDAPS only
+                    </label>
+                    <div
+                      class="c11"
+                      data-testid="formgroup-content"
+                      size="10"
+                    >
+                      <label
+                        class="c12"
+                      >
+                        <div
+                          class="c13"
+                        >
+                          <div
+                            class="c14"
+                            margin="5px"
+                          >
+                            <input
+                              checked=""
+                              class="c15 c16"
+                              data-testid="ldapsOnly-checkbox"
+                              name="ldapsOnly"
+                              type="checkbox"
+                            />
+                          </div>
+                        </div>
+                      </label>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/web/pages/ldap/__tests__/dialog.js
+++ b/src/web/pages/ldap/__tests__/dialog.js
@@ -32,6 +32,7 @@ describe('Ldap dialog component tests', () => {
         authdn="foo"
         enable={true}
         ldaphost="bar"
+        ldapsOnly={true}
         onChange={handleChange}
         onClose={handleClose}
         onSave={handleSave}
@@ -51,6 +52,7 @@ describe('Ldap dialog component tests', () => {
         authdn="foo"
         enable={true}
         ldaphost="bar"
+        ldapsOnly={true}
         onChange={handleValueChange}
         onClose={handleClose}
         onSave={handleSave}
@@ -63,6 +65,7 @@ describe('Ldap dialog component tests', () => {
       authdn: 'foo',
       enable: true,
       ldaphost: 'bar',
+      ldapsOnly: true,
     });
   });
 
@@ -96,6 +99,7 @@ describe('Ldap dialog component tests', () => {
         authdn="foo"
         enable={true}
         ldaphost="bar"
+        ldapsOnly={false}
         onClose={handleClose}
         onSave={handleSave}
       />,
@@ -110,10 +114,14 @@ describe('Ldap dialog component tests', () => {
     const ldapHostTextField = getByTestId('ldaphost-textfield');
     fireEvent.change(ldapHostTextField, {target: {value: 'ipsum'}});
 
+    const ldapsOnlyCheck = getByTestId('ldapsOnly-checkbox');
+    fireEvent.click(ldapsOnlyCheck);
+
     const saveButton = getByTestId('dialog-save-button');
     fireEvent.click(saveButton);
 
     expect(handleSave).toHaveBeenCalledWith({
+      ldapsOnly: true,
       authdn: 'lorem',
       enable: false,
       ldaphost: 'ipsum',

--- a/src/web/pages/ldap/dialog.js
+++ b/src/web/pages/ldap/dialog.js
@@ -35,6 +35,7 @@ const LdapDialog = ({
   authdn = '',
   enable = false,
   ldaphost = '',
+  ldapsOnly = false,
   onClose,
   onSave,
 }) => {
@@ -42,6 +43,7 @@ const LdapDialog = ({
     authdn,
     enable,
     ldaphost,
+    ldapsOnly,
   };
   return (
     <SaveDialog
@@ -86,6 +88,16 @@ const LdapDialog = ({
               <FileField name="certificate" onChange={onValueChange} />
             </Layout>
           </FormGroup>
+          <FormGroup title={_('Use LDAPS only')}>
+            <CheckBox
+              data-testid="ldapsOnly-checkbox"
+              name="ldapsOnly"
+              checked={values.ldapsOnly}
+              checkedValue={true}
+              unCheckedValue={false}
+              onChange={onValueChange}
+            />
+          </FormGroup>
         </Layout>
       )}
     </SaveDialog>
@@ -96,6 +108,7 @@ LdapDialog.propTypes = {
   authdn: PropTypes.string,
   enable: PropTypes.bool,
   ldaphost: PropTypes.string,
+  ldapsOnly: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
 };

--- a/src/web/pages/ldap/ldappage.js
+++ b/src/web/pages/ldap/ldappage.js
@@ -98,15 +98,15 @@ class LdapAuthentication extends React.Component {
       const {data: settings} = response;
       // ldap support is enabled in gvm-libs
       const hasLdapSupport = settings.has('method:ldap_connect');
-      const {authdn, certificateInfo, enabled, ldaphost} = settings.get(
-        'method:ldap_connect',
-      );
+      const {authdn, certificateInfo, enabled, ldaphost, ldapsOnly} =
+        settings.get('method:ldap_connect');
       this.setState({
         hasLdapSupport,
         authdn,
         certificateInfo,
         enabled,
         ldaphost,
+        ldapsOnly,
         loading: false,
         initial: false,
       });
@@ -120,7 +120,7 @@ class LdapAuthentication extends React.Component {
     }
   }
 
-  handleSaveSettings({authdn, certificate, enable, ldaphost}) {
+  handleSaveSettings({authdn, certificate, enable, ldaphost, ldapsOnly}) {
     const {gmp} = this.props;
 
     this.handleInteraction();
@@ -131,6 +131,7 @@ class LdapAuthentication extends React.Component {
         certificate,
         enable,
         ldaphost,
+        ldapsOnly,
       })
       .then(() => {
         this.loadLdapAuthSettings();
@@ -158,6 +159,7 @@ class LdapAuthentication extends React.Component {
       enabled,
       hasLdapSupport,
       ldaphost,
+      ldapsOnly,
     } = this.state;
 
     return (
@@ -206,6 +208,10 @@ class LdapAuthentication extends React.Component {
                   <TableData>{_('Issued by')}</TableData>
                   <TableData>{certificateInfo.issuer}</TableData>
                 </TableRow>
+                <TableRow>
+                  <TableData>{_('Use LDAPS only')}</TableData>
+                  <TableData>{renderYesNo(ldapsOnly)}</TableData>
+                </TableRow>
               </TableBody>
             </Table>
           ) : (
@@ -218,6 +224,7 @@ class LdapAuthentication extends React.Component {
             authdn={authdn}
             enable={enabled}
             ldaphost={ldaphost}
+            ldapsOnly={ldapsOnly}
             onClose={this.closeDialog}
             onSave={this.handleSaveSettings}
           />
@@ -238,10 +245,7 @@ const mapDispatchToProps = (dispatch, {gmp}) => ({
 
 export default compose(
   withGmp,
-  connect(
-    undefined,
-    mapDispatchToProps,
-  ),
+  connect(undefined, mapDispatchToProps),
 )(LdapAuthentication);
 
 // vim: set ts=2 sw=2 tw=80:


### PR DESCRIPTION
## What
This adds an extra authentication option to force LDAPS for LDAP authentication

## Why
The normal LDAP port may be blocked by a firewall, in which case only the LDAPS port should be tried.

## References
GEA-82
requires greenbone/gvm-libs/pull/747, greenbone/gvmd/pull/1928 and greenbone/gsad/pull/124 to work properly