### PR TITLE
Fix: Use removeNSPrefix in XML parser options

### DIFF
--- a/src/gmp/http/transform/fastxml.js
+++ b/src/gmp/http/transform/fastxml.js
@@ -26,7 +26,7 @@ import {success, rejection} from './xml';
 const PARSER_OPTIONS = {
   attributeNamePrefix: '_',
   ignoreAttributes: false,
-  ignoreNameSpace: true,
+  removeNSPrefix: true,
   textNodeName: '__text',
   attributeValueProcessor: (name, value, jPath) => parseXmlEncodedString(value),
   tagValueProcessor: (name, value, jPath, hasAttributes, isLeafNode) =>


### PR DESCRIPTION
## What
The ignoreNameSpace option for fast-xml-parser has been renamed to removeNSPrefix.

## Why
This fixes some undefined attributes on SecInfo pages.

## References
GEA-157
