### PR TITLE
Fix: "Default" label of SMB Max Version dropdown

### DIFF
--- a/src/web/pages/alerts/smbmethodpart.js
+++ b/src/web/pages/alerts/smbmethodpart.js
@@ -18,6 +18,7 @@
 import React from 'react';
 
 import _ from 'gmp/locale';
+import {_l} from 'gmp/locale/lang';
 
 import {
   SMB_CREDENTIAL_TYPES,
@@ -39,7 +40,7 @@ import TextField from 'web/components/form/textfield';
 import NewIcon from 'web/components/icon/newicon';
 
 const smbMaxProtocolItems = [
-  {label: _('Default'), value: ''},
+  {label: _l('Default'), value: ''},
   {label: 'NT1', value: 'NT1'},
   {label: 'SMB2', value: 'SMB2'},
   {label: 'SMB3', value: 'SMB3'},


### PR DESCRIPTION
## What
The drop-down selection for Max Version for SMB alerts now correctly shows the default option as "Default".

## Why
It was incorrectly shown as "undefined".

## References
GEA-161




