### PR TITLE
Fix: Show correct auth method in user details

### DIFF
--- a/src/web/pages/users/details.js
+++ b/src/web/pages/users/details.js
@@ -71,7 +71,7 @@ export const convert_allow = ({addresses, allow}) => {
 };
 
 const UserDetails = ({entity, links = true}) => {
-  const {auth_method, comment, groups = [], hosts = {}, roles = []} = entity;
+  const {authMethod, comment, groups = [], hosts = {}, roles = []} = entity;
   return (
     <Layout grow flex="column">
       <InfoTable>
@@ -129,7 +129,7 @@ const UserDetails = ({entity, links = true}) => {
 
           <TableRow>
             <TableData>{_('Authentication Type')}</TableData>
-            <TableData>{convert_auth_method(auth_method)}</TableData>
+            <TableData>{convert_auth_method(authMethod)}</TableData>
           </TableRow>
         </TableBody>
       </InfoTable>


### PR DESCRIPTION
## What
When viewing the details of a user, the correct authentication method is now shown.

## Why
Previously only the table showed the correct method while the details always showed "Local".

## References
GEA-27


