### PR TITLE
Fix: Do not let host auth failures override successes

### DIFF
--- a/src/gmp/models/report/host.js
+++ b/src/gmp/models/report/host.js
@@ -127,8 +127,10 @@ class Host {
         }
         if (name.startsWith('Auth')) {
           const authArray = name.split('-');
-          copy.authSuccess[authArray[1].toLowerCase()] =
-            authArray[2] === 'Success';
+          if (copy.authSuccess[authArray[1].toLowerCase()] !== true) {
+            copy.authSuccess[authArray[1].toLowerCase()] =
+              authArray[2] === 'Success';
+          }
         }
         copy.details.appsCount = appsCount;
       });


### PR DESCRIPTION
## What

In the report hosts table, authentication methods are now shown as
 successful whenever there is a "Auth-...-Success" detail for
 a given authentication type.
"Auth-...-Failure" details will no longer override this.

## Why
This can happen if SNMP authentication with one protocol version fails but another version succeeds.


## References
GEA-131



