### PR TITLE
Fix: Use correct TippingPoint credential in dialog

### DIFF
--- a/src/web/pages/alerts/component.js
+++ b/src/web/pages/alerts/component.js
@@ -408,7 +408,7 @@ class AlertComponent extends React.Component {
             : undefined;
 
           const tp_sms_credential_id = isDefined(method.data.tp_sms_credential)
-            ? getValue(method.data.tp_sms_credential.credential)
+            ? getValue(method.data.tp_sms_credential)
             : undefined;
 
           const recipient_credential_id = isDefined(


### PR DESCRIPTION
## What
When editing an alert, the currently configured TippingPoint credential is now selected in the dialog.

## Why
Before it mistakenly always switched to the first available credential.

## References
GEA-158



