### PR TITLE
Fix: Get/save TippingPoint TLS workaround correctly

### DIFF
--- a/src/web/pages/alerts/component.js
+++ b/src/web/pages/alerts/component.js
@@ -596,7 +596,7 @@ class AlertComponent extends React.Component {
               '',
             ),
             method_data_tp_sms_tls_workaround: parseYesNo(
-              getValue(method.data.tp_sms_hostname, NO_VALUE),
+              getValue(method.data.tp_sms_tls_workaround, NO_VALUE),
             ),
 
             method_data_verinice_server_report_format:


### PR DESCRIPTION
## What
The alert dialog now uses the correct field for TLS workaround option of the TippingPoint SMS method.


## Why
Previously the wrong field was used, so the dialog did not work correctly.

## References
GEA-181

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


