### PR TITLE
Use $GITHUB_OUTPUT in ci-js.yml, fix release-pontos.yml

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -25,7 +25,7 @@ jobs:
         # See: https://github.com/actions/cache/blob/main/examples.md#node---yarn
       - name: Get Yarn cache directory
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Use Yarn cache
         uses: actions/cache@v3
         id: yarn-cache
@@ -66,7 +66,7 @@ jobs:
         # See: https://github.com/actions/cache/blob/main/examples.md#node---yarn
       - name: Get Yarn cache directory
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Use Yarn cache
         uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -49,7 +49,7 @@ jobs:
           node-version: "14.x"
       - name: Get Yarn cache directory
         id: yarn-cache-dir-path
-        run: echo "name=$(yarn cache dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       - name: Use Yarn cache
         uses: actions/cache@v3
         id: yarn-cache


### PR DESCRIPTION
## What
The new $GITHUB_OUTPUT env variable is now used instead of the deprecated ::set-output.
Also, the variable name for the yarn cache dir in release-pontos.yml is fixed.

## Why
GitHub announced that the old function will be removed eventually.

## References
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/



