### PR TITLE
Change: Do not fail CI if codecov upload fails

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Submit test coverage to codecov.io
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   linting:
     env:


### PR DESCRIPTION
## What
Do not fail CI if codecov upload fails

## Why
The coverage upload randomly fails, causing the whole CI workflow to fail with the previous settings.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


