### PR TITLE
Include dependabot commits in the release changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,8 +42,12 @@ updates:
       - dependency-name: '@vx/shape'
         versions:
           - '> 0.0.179'
+    commit-message:
+      prefix: "Deps"
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    commit-message:
+      prefix: "Deps"


### PR DESCRIPTION


## What

Include dependabot commits in the release changelog

## Why
Change the dependabot config to create commit messages that are parsed by our release changelog generator.
