### PR TITLE
Fix: Make version compatible with semantic versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsa",
-  "version": "22.4.2.dev1",
+  "version": "22.4.2-dev1",
   "description": "Greenbone Security Assistant",
   "keywords": [
     "openvas",

--- a/src/version.js
+++ b/src/version.js
@@ -27,7 +27,7 @@ const getMajorMinorVersion = () => {
   return `${major}.${minor}`;
 };
 
-export const VERSION = '22.4.2.dev1';
+export const VERSION = '22.4.2-dev1';
 
 export const RELEASE_VERSION = getMajorMinorVersion();
 


### PR DESCRIPTION
## What
Make version compatible with semantic versioning

## Why
Correct semver syntax is required for automatic releases



