### PR TITLE
Fix: Fix adding dist files to the release

### DIFF
--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -33,6 +33,9 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'major release')) &&
           github.event.pull_request.merged == true )
     runs-on: 'ubuntu-latest'
+    outputs:
+      git-release-tag: ${{ steps.release.outputs.git-release-tag }}
+      release-version: ${{ steps.release.outputs.release-version }}
     steps:
       - name: Selecting the Release type
         id: release-type


### PR DESCRIPTION


## What

Fix adding dist files to the release

## Why
Set missing outputs of the release job to allow uploading and signing of additional release artifact files.