### PR TITLE
Fix links to the manual and GMP documentation

### DIFF
--- a/src/gmp/gmpsettings.js
+++ b/src/gmp/gmpsettings.js
@@ -16,15 +16,13 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {RELEASE_VERSION} from '../version';
-
 import {isDefined} from './utils/identity';
 
 export const DEFAULT_RELOAD_INTERVAL = 15 * 1000; // fifteen seconds
 export const DEFAULT_RELOAD_INTERVAL_ACTIVE = 3 * 1000; // three seconds
 export const DEFAULT_RELOAD_INTERVAL_INACTIVE = 60 * 1000; // one minute
-export const DEFAULT_MANUAL_URL = `http://docs.greenbone.net/GSM-Manual/gos-${RELEASE_VERSION}/`;
-export const DEFAULT_PROTOCOLDOC_URL = `https://docs.greenbone.net/API/GMP/gmp-${RELEASE_VERSION}.html`;
+export const DEFAULT_MANUAL_URL = `https://docs.greenbone.net/GSM-Manual/gos-22.04/en/`;
+export const DEFAULT_PROTOCOLDOC_URL = `https://docs.greenbone.net/API/GMP/gmp-22.04.html`;
 export const DEFAULT_REPORT_RESULTS_THRESHOLD = 25000;
 export const DEFAULT_LOG_LEVEL = 'warn';
 export const DEFAULT_TIMEOUT = 300000; // 5 minutes


### PR DESCRIPTION


## What

Fix links to the manual and GMP documentation

## Why
Despite the fact we are using 22.x.y as versions for our components now the GMP version will stay on 22.04. The URL to the manual requires the language now.
