### PR TITLE
Fix: Fix creating a new user with added check

### DIFF
--- a/src/web/pages/users/dialog.js
+++ b/src/web/pages/users/dialog.js
@@ -118,7 +118,10 @@ class Dialog extends React.Component {
        * or you have already confirmed that you want to save the user data
        * without any role.
        */
-      if (this.props.username === this.props.user.name) {
+      if (
+        isDefined(this.props.user) &&
+        this.props.username === this.props.user.name
+      ) {
         /*
          * You reach this point only as a Super Admin, when you try to save your
          * own personal user data. The confirmation dialog opens. The data can


### PR DESCRIPTION
## What
When determining whether to show the superuser confirmation in the user dialog, also check if there is a user being edited.

## Why
Without this check, attempting to create a new user would cause an error when saving.

## References
Fixes #3798
GEA-234
