### PR TITLE
Show status of "Use workaround for default certificate" of alerts correctly.

### DIFF
--- a/src/web/pages/alerts/method.js
+++ b/src/web/pages/alerts/method.js
@@ -626,7 +626,7 @@ const Method = ({method = {}, details = false, reportFormats = []}) => {
                     {_('Use workaround for default certificate')}
                   </TableData>
                   <TableData>
-                    {data.tp_sms_tls_workaround.value === '1' ? 'Yes' : 'No'}
+                    {data.tp_sms_tls_workaround.value === 1 ? 'Yes' : 'No'}
                   </TableData>
                 </TableRow>
               )}


### PR DESCRIPTION

## What
Small correction to display the status of "Use workaround for default certificate" of alerts
(method "TippingPoint SMS") correctly.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
GEA-230
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


