### PR TITLE
Fix links to manual

### DIFF
--- a/src/gmp/gmpsettings.js
+++ b/src/gmp/gmpsettings.js
@@ -21,8 +21,8 @@ import {isDefined} from './utils/identity';
 export const DEFAULT_RELOAD_INTERVAL = 15 * 1000; // fifteen seconds
 export const DEFAULT_RELOAD_INTERVAL_ACTIVE = 3 * 1000; // three seconds
 export const DEFAULT_RELOAD_INTERVAL_INACTIVE = 60 * 1000; // one minute
-export const DEFAULT_MANUAL_URL = `https://docs.greenbone.net/GSM-Manual/gos-22.04/en/`;
-export const DEFAULT_PROTOCOLDOC_URL = `https://docs.greenbone.net/API/GMP/gmp-22.04.html`;
+export const DEFAULT_MANUAL_URL = `https://docs.greenbone.net/GSM-Manual/gos-22.04/`;
+export const DEFAULT_PROTOCOLDOC_URL = `https://docs.greenbone.net/API/GMP/gmp-22.4.html`;
 export const DEFAULT_REPORT_RESULTS_THRESHOLD = 25000;
 export const DEFAULT_LOG_LEVEL = 'warn';
 export const DEFAULT_TIMEOUT = 300000; // 5 minutes

--- a/src/web/pages/nvts/__tests__/detailspage.js
+++ b/src/web/pages/nvts/__tests__/detailspage.js
@@ -294,7 +294,7 @@ describe('Nvt Detailspage tests', () => {
     expect(screen.getAllByTitle('Help: NVTs')[0]).toBeInTheDocument();
     expect(links[0]).toHaveAttribute(
       'href',
-      'test/en/managing-secinfo.html#network-vulnerability-tests-nvt',
+      'test/en/managing-secinfo.html#vulnerability-tests-vt',
     );
 
     expect(screen.getAllByTitle('NVT List')[0]).toBeInTheDocument();
@@ -475,7 +475,7 @@ describe('Nvt ToolBarIcons tests', () => {
 
     expect(links[0]).toHaveAttribute(
       'href',
-      'test/en/managing-secinfo.html#network-vulnerability-tests-nvt',
+      'test/en/managing-secinfo.html#vulnerability-tests-vt',
     );
     expect(screen.getAllByTitle('Help: NVTs')[0]).toBeInTheDocument();
 

--- a/src/web/pages/nvts/__tests__/listpage.js
+++ b/src/web/pages/nvts/__tests__/listpage.js
@@ -472,7 +472,7 @@ describe('NvtsPage ToolBarIcons test', () => {
     expect(screen.getAllByTitle('Help: NVTs')[0]).toBeInTheDocument();
     expect(links[0]).toHaveAttribute(
       'href',
-      'test/en/managing-secinfo.html#network-vulnerability-tests-nvt',
+      'test/en/managing-secinfo.html#vulnerability-tests-vt',
     );
   });
 });

--- a/src/web/pages/nvts/detailspage.js
+++ b/src/web/pages/nvts/detailspage.js
@@ -85,7 +85,7 @@ export let ToolBarIcons = ({
       <IconDivider>
         <ManualIcon
           page="managing-secinfo"
-          anchor="network-vulnerability-tests-nvt"
+          anchor="vulnerability-tests-vt"
           title={_('Help: NVTs')}
         />
         <ListIcon title={_('NVT List')} page="nvts" />

--- a/src/web/pages/nvts/listpage.js
+++ b/src/web/pages/nvts/listpage.js
@@ -45,7 +45,7 @@ import NvtsDashboard, {NVTS_DASHBOARD_ID} from './dashboard';
 export const ToolBarIcons = () => (
   <ManualIcon
     page="managing-secinfo"
-    anchor="network-vulnerability-tests-nvt"
+    anchor="vulnerability-tests-vt"
     title={_('Help: NVTs')}
   />
 );


### PR DESCRIPTION
## What

Fix links to manual

## Why

The language must not be included in the default URL. It is added depending on the current user settings.

Also update the links to the GMP docs.

## References

Closes #3814
Closes GEA-262
Closes GEA-261


