### PR TITLE
Fix release activated workflow via labels

### DIFF
--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -57,7 +57,6 @@ jobs:
 
   build-dist:
     name: Build JavaScript files
-    if: (github.event_name == 'workflow_dispatch') || (contains( github.event.pull_request.labels.*.name, 'make release') && github.event.pull_request.merged == true)
     runs-on: "ubuntu-latest"
     needs: release
     steps:
@@ -94,7 +93,6 @@ jobs:
   sign:
     runs-on: "ubuntu-latest"
     needs: [release, build-dist]
-    if: (github.event_name == 'workflow_dispatch') || (contains( github.event.pull_request.labels.*.name, 'make release') && github.event.pull_request.merged == true)
     steps:
       - name: Sign release files
         uses: greenbone/actions/sign-release-files@v3


### PR DESCRIPTION

## What

Fix release activated workflow via labels

## Why

The if clauses of the dependent jobs haven't been adjusted for the new release process and its different labels. Therefore using a release label didn't run the jobs. This change removes the if statements from the dependent jobs completely because the first job will check them and otherwise the dependent jobs wont run at all.

## References

https://github.com/greenbone/gsa/issues/3816