### PR TITLE
Fix: Also convert dates for nextDate comparisons

### DIFF
--- a/src/gmp/models/event.js
+++ b/src/gmp/models/event.js
@@ -383,7 +383,7 @@ class Event {
       const start = convertIcalDate(this.event.startDate, this.timezone);
 
       if (start.unix() >= now.unix()) {
-        return convertIcalDate(this.event.startDate, this.timezone);
+        return start;
       }
     }
     return undefined;

--- a/src/gmp/models/event.js
+++ b/src/gmp/models/event.js
@@ -356,7 +356,7 @@ class Event {
       while (true && retries <= 5) {
         try {
           const next = it.next();
-          if (next.toUnixTime() >= now.unix()) {
+          if (convertIcalDate(next, this.timezone).unix() >= now.unix()) {
             return convertIcalDate(next, this.timezone);
           }
           retries = 0;
@@ -380,8 +380,9 @@ class Event {
       // the event is not recurring
       // it should only occur once on its start date
       const now = date();
+      const start = convertIcalDate(this.event.startDate, this.timezone);
 
-      if (this.event.startDate.toUnixTime() >= now.unix()) {
+      if (start.unix() >= now.unix()) {
         return convertIcalDate(this.event.startDate, this.timezone);
       }
     }


### PR DESCRIPTION
## What

In Event.nextDate convert dates with the timezone before comparing to now.  This is similar to converting the dates before returning them.

## Why

The dates have floating timezones so they need to be converted, else they are treated as UTC when being converted to Unix time.

To reproduce:

1. set machine tz to America/Los_Angeles
2. `faketime '2022-12-05 08:15:42' gsad...`
1. `faketime '2022-12-05 08:15:42' gvmd...`
1. create schedule with this

> BEGIN:VCALENDAR
> VERSION:2.0
> PRODID:-//XXX//NONSGML//EN
> BEGIN:VEVENT
> DTSTART;TZID=/America/New_York:20221220T000100
> RRULE:FREQ=MONTHLY;BYDAY=3WE;
> END:VEVENT
> END:VCALENDAR

4. `export TZ=America/New_York`
1. `faketime '2023-02-14 17:56' some_web_browser`
1. GSA menu: Configuration > Schedules
1. Next Run is in March but should be in Feb

To also confirm that task starts:

1. In a VM:
1. sudo timedatectl set-timezone America/Los_Angeles
1. sudo service postgresql stop
2. sudo date --set="20 December 2022 07:00:00"  # 10:00:00 NY  create
3. sudo service postgresql start
4. start gsa and gvmd and browser
5. GSA > Schedules > New > Custom > Monthly > Wednesday, with TZ America/New_York and first run 0:01
6. kill gsa,gvmd,browser
1. sudo service postgresql stop
7. sudo date --set="14 February 2023 20:56:00"  # 23:56:00 NY  just before issue
3. sudo service postgresql start
9. start gsa,gvmd,brower
10. note that Next Run column in GSA has March
11. tail -F ~/alts/main/var/log/gvm/gvmd.log # watch for task start

## References

Closes /greenbone/gvmd/issues/1911.

## Checklist

- [x] Tests


