### PR TITLE
release-pontos: also create gsa-node-modules release artifact

### DIFF
--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -81,12 +81,13 @@ jobs:
         run: yarn install --prefer-offline
       - name: Build dist files
         run: yarn build
-      - name: Create tarball
+      - name: Create tarballs
         run: |
           tar -C build -czvf gsa-dist-${{ needs.release.outputs.release-version }}.tar.gz .
-      - name: Upload dist file to release
+          XZ_OPT='-T0 -9' tar -acf gsa-node-modules-${{ needs.release.outputs.release-version }}.tar.xz node_modules
+      - name: Upload dist files to release
         run: |
-          gh release upload ${{ needs.release.outputs.git-release-tag }} gsa-dist-${{ needs.release.outputs.release-version }}.tar.gz
+          gh release upload ${{ needs.release.outputs.git-release-tag }} gsa-dist-${{ needs.release.outputs.release-version }}.tar.gz gsa-node-modules-${{ needs.release.outputs.release-version }}.tar.xz
         env:
           GH_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}
 


### PR DESCRIPTION
For Gentoo, we ideally want to build the node modules as part of our "emerge" process. That means we do not want to consume the -dist artifact. What we instead want is the gsa source and the contents of the node_modules/ directory.

Therefore, add a second release artifact to release-ponto, that only contains the content of the node_modules/ directory.

Please consider this addition, as it would reduce the friction of packaging gsa in Gentoo.

Note that this is untested, since I do not know how to test github workflows, but the change seems trivial enough.