### PR TITLE
Fix: Show CVSS value "10.0" correctly in charts

### DIFF
--- a/src/web/components/dashboard/display/cvss/cvsstransform.js
+++ b/src/web/components/dashboard/display/cvss/cvsstransform.js
@@ -103,7 +103,12 @@ const transformCvssData = (data = {}) => {
       let toolTip;
       let filterValue;
 
-      if (value > 0) {
+      if (value === 10) {
+        filterValue = {
+          start: value,
+        };
+        toolTip = `10.0 (${label}): ${perc}% (${count})`;
+      } else if (value > 0) {
         filterValue = {
           start: format(value - 0.1),
           end: format(value + 1),


### PR DESCRIPTION
## What
The value "10.0" is now shown instead of the invalid range "10.0 - 10.9" in the charts, e.g. in the bar tooltip of "Results by CVSS".

## Why
CVSS scores above 10.0 are not valid.

## References
GEA-265


