### PR TITLE
Add: New "Port" field for SCP alert method

### DIFF
--- a/src/gmp/commands/alerts.js
+++ b/src/gmp/commands/alerts.js
@@ -65,6 +65,7 @@ const method_data_fields = [
   'scp_host',
   'scp_known_hosts',
   'scp_path',
+  'scp_port',
   'scp_report_format',
   'smb_credential',
   'smb_file_path',

--- a/src/web/pages/alerts/component.js
+++ b/src/web/pages/alerts/component.js
@@ -541,6 +541,7 @@ class AlertComponent extends React.Component {
               DEFAULT_SCP_PATH,
             ),
             method_data_scp_host: getValue(method.data.scp_host, ''),
+            method_data_scp_port: getValue(method.data.scp_port, 22),
             method_data_scp_known_hosts: getValue(
               method.data.scp_known_hosts,
               '',
@@ -726,6 +727,7 @@ class AlertComponent extends React.Component {
             method_data_scp_path: DEFAULT_SCP_PATH,
             method_data_scp_report_format: report_format_id,
             method_data_scp_host: undefined,
+            method_data_scp_port: 22,
             method_data_scp_known_hosts: undefined,
             method_data_send_port: undefined,
             method_data_send_host: undefined,
@@ -958,6 +960,7 @@ class AlertComponent extends React.Component {
       method_data_scp_report_format,
       method_data_scp_path,
       method_data_scp_host,
+      method_data_scp_port,
       method_data_scp_known_hosts,
       method_data_send_port,
       method_data_send_host,
@@ -1079,6 +1082,7 @@ class AlertComponent extends React.Component {
                 method_data_scp_report_format={method_data_scp_report_format}
                 method_data_scp_path={method_data_scp_path}
                 method_data_scp_host={method_data_scp_host}
+                method_data_scp_port={method_data_scp_port}
                 method_data_scp_known_hosts={method_data_scp_known_hosts}
                 method_data_send_port={method_data_send_port}
                 method_data_send_host={method_data_send_host}

--- a/src/web/pages/alerts/dialog.js
+++ b/src/web/pages/alerts/dialog.js
@@ -210,6 +210,7 @@ const DEFAULTS = {
   method_data_notice_report_format: DEFAULT_NOTICE_REPORT_FORMAT,
   method_data_scp_path: DEFAULT_SCP_PATH,
   method_data_scp_host: '',
+  method_data_scp_port: 22,
   method_data_scp_known_hosts: '',
   method_data_send_host: '',
   method_data_send_port: '',
@@ -717,6 +718,7 @@ class AlertDialog extends React.Component {
                   reportFormats={report_formats}
                   scpCredential={values.method_data_scp_credential}
                   scpHost={values.method_data_scp_host}
+                  scpPort={values.method_data_scp_port}
                   scpKnownHosts={values.method_data_scp_known_hosts}
                   scpPath={values.method_data_scp_path}
                   scpReportFormat={values.method_data_scp_report_format}
@@ -905,6 +907,7 @@ AlertDialog.propTypes = {
   method_data_scp_host: PropTypes.string,
   method_data_scp_known_hosts: PropTypes.string,
   method_data_scp_path: PropTypes.string,
+  method_data_scp_port: PropTypes.number,
   method_data_scp_report_format: PropTypes.id,
   method_data_send_host: PropTypes.string,
   method_data_send_port: PropTypes.string,

--- a/src/web/pages/alerts/method.js
+++ b/src/web/pages/alerts/method.js
@@ -198,6 +198,13 @@ const Method = ({method = {}, details = false, reportFormats = []}) => {
                 </TableRow>
               )}
 
+              {isDefined(data.scp_port?.value) && (
+                <TableRow>
+                  <TableData>{_('Port')}</TableData>
+                  <TableData>{data.scp_port.value}</TableData>
+                </TableRow>
+              )}
+
               {isDefined(credential) && isDefined(credential.id) && (
                 <TableRow>
                   <TableData>{_('Credential')}</TableData>

--- a/src/web/pages/alerts/scpmethodpart.js
+++ b/src/web/pages/alerts/scpmethodpart.js
@@ -34,6 +34,7 @@ import withPrefix from '../../utils/withPrefix.js';
 
 import Select from '../../components/form/select.js';
 import FormGroup from '../../components/form/formgroup.js';
+import Spinner from '../../components/form/spinner.js';
 import TextField from '../../components/form/textfield.js';
 import TextArea from '../../components/form/textarea.js';
 
@@ -45,6 +46,7 @@ const ScpMethodPart = ({
   reportFormats,
   scpCredential,
   scpHost,
+  scpPort,
   scpKnownHosts,
   scpPath,
   scpReportFormat,
@@ -80,6 +82,17 @@ const ScpMethodPart = ({
           name={prefix + 'scp_host'}
           value={scpHost}
           onChange={onChange}
+        />
+      </FormGroup>
+
+      <FormGroup title={_('Port')}>
+        <Spinner
+          name={prefix + 'scp_port'}
+          value={scpPort}
+          type="int"
+          onChange={onChange}
+          min={1}
+          max={65535}
         />
       </FormGroup>
 
@@ -122,6 +135,7 @@ ScpMethodPart.propTypes = {
   scpHost: PropTypes.string.isRequired,
   scpKnownHosts: PropTypes.string.isRequired,
   scpPath: PropTypes.string.isRequired,
+  scpPort: PropTypes.number.isRequired,
   scpReportFormat: PropTypes.id,
   onChange: PropTypes.func.isRequired,
   onCredentialChange: PropTypes.func.isRequired,


### PR DESCRIPTION
## What
The alert dialog and details now have a new "Port" field for the SCP alert method.

## Why
This allows using a host with a non-default SSH port as the destination.

## References
GEA-280
requires greenbone/gvmd#2057 and greenbone/gsad#139

