### PR TITLE
Fix: Show error message if user settings can't be saved

### DIFF
--- a/src/web/pages/usersettings/dialog.js
+++ b/src/web/pages/usersettings/dialog.js
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React, {useState} from 'react';
+import React, {useCallback, useState} from 'react';
 
 import styled from 'styled-components';
 
@@ -169,11 +169,17 @@ let UserSettingsDialog = ({
   const [error, setError] = useState();
   const [formValues, handleValueChange] = useFormValues(settings);
 
+  const handleSave = useCallback(values => {
+    onSave(values).catch(err => {
+      setError(err.message);
+    })
+  }, [onSave]);
+
   const {hasError, errors, validate} = useFormValidation(
     userSettingsRules,
     formValues,
     {
-      onValidationSuccess: onSave,
+      onValidationSuccess: handleSave,
       onValidationError: setError,
       fieldsToValidate,
     },


### PR DESCRIPTION

## What

Show error message if user settings can't be saved
## Why

When the http request returned an error the error message was not shown while changing the user settings in the corresponding dialog. It broke while introducing the JS form validation because its validate function isn't a promise in contrast to the onSave handler.

## References

GEA-175

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


