### PR TITLE
Change build command to npm in release-pontos.yml

### DIFF
--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -69,7 +69,7 @@ jobs:
           node-version: "14"
           cache: "npm"
       - name: Build dist files
-        run: node run build
+        run: npm run build
       - name: Create tarballs
         run: |
           tar -C build -czvf gsa-dist-${{ needs.release.outputs.release-version }}.tar.gz .


### PR DESCRIPTION
## What
The command has been changed from `node run build` to `npm run build`.


## Why
The release did not work because of the invalid command.

## References
#3862
