### PR TITLE
Fix: Add CVSS missing range (0.1-0.9)

### DIFF
--- a/src/web/components/dashboard/display/cvss/cvssdisplay.js
+++ b/src/web/components/dashboard/display/cvss/cvssdisplay.js
@@ -52,7 +52,7 @@ class CvssDisplay extends React.Component {
 
     let statusFilter;
 
-    if (isDefined(start) && start >= 0 && end < 10) {
+    if (isDefined(start) && isDefined(end) && start >= 0) {
       const startTerm = FilterTerm.fromString(`severity>${start}`);
       const endTerm = FilterTerm.fromString(`severity<${end}`);
 
@@ -69,9 +69,7 @@ class CvssDisplay extends React.Component {
       let statusTerm;
 
       if (isDefined(start)) {
-        if (start > 0) {
-          statusTerm = FilterTerm.fromString(`severity>${start}`);
-        } else if (start === NA_VALUE) {
+        if (start === NA_VALUE) {
           statusTerm = FilterTerm.fromString('severity=""');
         } else {
           statusTerm = FilterTerm.fromString(`severity=${start}`);

--- a/src/web/components/dashboard/display/cvss/cvssdisplay.js
+++ b/src/web/components/dashboard/display/cvss/cvssdisplay.js
@@ -52,7 +52,7 @@ class CvssDisplay extends React.Component {
 
     let statusFilter;
 
-    if (isDefined(start) && start > 0 && end < 10) {
+    if (isDefined(start) && start >= 0 && end < 10) {
       const startTerm = FilterTerm.fromString(`severity>${start}`);
       const endTerm = FilterTerm.fromString(`severity<${end}`);
 

--- a/src/web/components/dashboard/display/cvss/cvsstransform.js
+++ b/src/web/components/dashboard/display/cvss/cvsstransform.js
@@ -61,6 +61,7 @@ const transformCvssData = (data = {}) => {
   const cvssData = {
     [NA_VALUE]: 0,
     [LOG_VALUE]: 0,
+    0.1: 0,
     1: 0,
     2: 0,
     3: 0,
@@ -78,7 +79,14 @@ const transformCvssData = (data = {}) => {
 
     const severity = parseSeverity(value);
 
-    const cvss = isDefined(severity) ? Math.floor(severity) : NA_VALUE;
+    let cvss;
+    if (!isDefined(severity)) {
+      cvss = NA_VALUE;
+    } else if (severity >= 0.1 && severity <= 0.9) {
+      cvss = 0.1;
+    } else {
+      cvss = Math.floor(severity);
+    }
 
     count = parseInt(count);
 
@@ -108,12 +116,18 @@ const transformCvssData = (data = {}) => {
           start: value,
         };
         toolTip = `10.0 (${label}): ${perc}% (${count})`;
-      } else if (value > 0) {
+      } else if (value > 1) {
         filterValue = {
           start: format(value - 0.1),
           end: format(value + 1),
         };
         toolTip = `${value}.0 - ${value}.9 (${label}): ${perc}% (${count})`;
+      } else if (value > 0) {
+        filterValue = {
+          start: format(value - 0.1),
+          end: '1.0',
+        };
+        toolTip = `${value} - 0.9 (${label}): ${perc}% (${count})`;
       } else {
         filterValue = {
           start: value,


### PR DESCRIPTION
## What

The range (0.1-0.9) is now shown in the CVSS chart and the corresponding tooltip and filter are consistent with the range.

Fixed the filter ranges for severity values 9 and 10. Value 9 should exclude 10 and Value 10 filter should filter only for 10 and not for > 10.

## Why

The CVSS range (0.1-0.9) was missing.

## References

GEA-266