### PR TITLE
Update styled components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "redux": "^4.2.1",
         "redux-logger": "^3.0.6",
         "redux-thunk": "^2.4.2",
-        "styled-components": "^4.4.1",
+        "styled-components": "^6.0.8",
         "uuid": "^9.0.1",
         "whatwg-fetch": "^3.6.19"
       },
@@ -65,7 +65,7 @@
         "husky": "^2.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "jest-junit": "^16.0.0",
-        "jest-styled-components": "^6.3.4",
+        "jest-styled-components": "^7.1.1",
         "lint-staged": "^13.1.0",
         "prettier": "^3.0.3"
       },
@@ -109,7 +109,6 @@
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.0.tgz",
       "integrity": "sha512-17E1oSkGk2IwNILM4jtfAvgjt+ohmpfBky8aLerUfYZhiPNg7ca+CRCxZn8QDxwNhV/upsc2VHBCqGFIR+iBfA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.17",
         "commander": "^4.0.1",
@@ -137,14 +136,12 @@
     "node_modules/@babel/cli/node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "node_modules/@babel/cli/node_modules/make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^4.0.1",
@@ -158,7 +155,6 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
@@ -168,7 +164,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -334,12 +329,11 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
-      "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
-      "license": "MIT",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
+      "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -374,19 +368,19 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.20.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.12.tgz",
-      "integrity": "sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==",
-      "license": "MIT",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.15.tgz",
+      "integrity": "sha512-jKkwA59IXcvSaiK2UN45kKwSC9o+KuoXsBDvHvU/7BecYIp8GQ2UwrVvFgJASUT+hBnwJx6MhvMCuMzwZZ7jlg==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-function-name": "^7.19.0",
-        "@babel/helper-member-expression-to-functions": "^7.20.7",
-        "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/helper-replace-supers": "^7.20.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
-        "@babel/helper-split-export-declaration": "^7.18.6"
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-environment-visitor": "^7.22.5",
+        "@babel/helper-function-name": "^7.22.5",
+        "@babel/helper-member-expression-to-functions": "^7.22.15",
+        "@babel/helper-optimise-call-expression": "^7.22.5",
+        "@babel/helper-replace-supers": "^7.22.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -473,12 +467,11 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.20.7.tgz",
-      "integrity": "sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==",
-      "license": "MIT",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz",
+      "integrity": "sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==",
       "dependencies": {
-        "@babel/types": "^7.20.7"
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -514,22 +507,20 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
-      "integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
-      "license": "MIT",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz",
+      "integrity": "sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==",
       "dependencies": {
-        "@babel/types": "^7.18.6"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
-      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
-      "license": "MIT",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -553,20 +544,19 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.20.7.tgz",
-      "integrity": "sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==",
-      "license": "MIT",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.20.tgz",
+      "integrity": "sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.18.9",
-        "@babel/helper-member-expression-to-functions": "^7.20.7",
-        "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/template": "^7.20.7",
-        "@babel/traverse": "^7.20.7",
-        "@babel/types": "^7.20.7"
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-member-expression-to-functions": "^7.22.15",
+        "@babel/helper-optimise-call-expression": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
@@ -582,12 +572,11 @@
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz",
-      "integrity": "sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==",
-      "license": "MIT",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
+      "integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
       "dependencies": {
-        "@babel/types": "^7.20.0"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -775,6 +764,20 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.13.0"
+      }
+    },
+    "node_modules/@babel/plugin-external-helpers": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.22.5.tgz",
+      "integrity": "sha512-ngnNEWxmykPk82mH4ajZT0qTztr3Je6hrMuKAslZVM8G1YZTENJSYwrIGtt6KOtznug3exmAtF4so/nPqJuA4A==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-async-generator-functions": {
@@ -1190,12 +1193,11 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz",
-      "integrity": "sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==",
-      "license": "MIT",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
+      "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1307,12 +1309,11 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.20.0.tgz",
-      "integrity": "sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==",
-      "license": "MIT",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.22.5.tgz",
+      "integrity": "sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.19.0"
+        "@babel/helper-plugin-utils": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1579,14 +1580,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.20.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.20.11.tgz",
-      "integrity": "sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==",
-      "license": "MIT",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.0.tgz",
+      "integrity": "sha512-32Xzss14/UVc7k9g775yMIvkVK8xwKE0DPdP5JTapr3+Z9w4tzeOuLNY6BXDQR6BdnzIlXnCGAzsk/ICHBLVWQ==",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.20.11",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/helper-simple-access": "^7.20.2"
+        "@babel/helper-module-transforms": "^7.23.0",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-simple-access": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1914,14 +1914,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.20.13.tgz",
-      "integrity": "sha512-O7I/THxarGcDZxkgWKMUrk7NK1/WbHAg3Xx86gqS6x9MTrNL6AwIluuZ96ms4xeDe6AVx6rjHbWHP7x26EPQBA==",
-      "license": "MIT",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.22.15.tgz",
+      "integrity": "sha512-1uirS0TnijxvQLnlv5wQBwOX3E1wCFX7ITv+9pBV2wKEk4K+M5tqDaoNXnTH8tjEIYHLO98MwiTWO04Ggz4XuA==",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.20.12",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-typescript": "^7.20.0"
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-create-class-features-plugin": "^7.22.15",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/plugin-syntax-typescript": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2087,14 +2087,15 @@
       }
     },
     "node_modules/@babel/preset-typescript": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.18.6.tgz",
-      "integrity": "sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==",
-      "license": "MIT",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.23.0.tgz",
+      "integrity": "sha512-6P6VVa/NM/VlAYj5s2Aq/gdVg8FSENCg3wlZ6Qau9AcPaoF5LbN1nyGlR9DTRIw9PpxI94e+ReydsJHcjwAweg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6",
-        "@babel/helper-validator-option": "^7.18.6",
-        "@babel/plugin-transform-typescript": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-validator-option": "^7.22.15",
+        "@babel/plugin-syntax-jsx": "^7.22.5",
+        "@babel/plugin-transform-modules-commonjs": "^7.23.0",
+        "@babel/plugin-transform-typescript": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2470,19 +2471,17 @@
       "license": "MIT"
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
-      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
       "dependencies": {
-        "@emotion/memoize": "0.7.4"
+        "@emotion/memoize": "^0.8.1"
       }
     },
     "node_modules/@emotion/memoize": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "license": "MIT"
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
     },
     "node_modules/@emotion/stylis": {
       "version": "0.8.5",
@@ -2579,32 +2578,6 @@
         "prop-types": "^15",
         "react": "^16",
         "react-dom": "^16"
-      }
-    },
-    "node_modules/@greenbone/ui-components/node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz",
-      "integrity": "sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.8.0"
-      }
-    },
-    "node_modules/@greenbone/ui-components/node_modules/@emotion/memoize": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.0.tgz",
-      "integrity": "sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==",
-      "license": "MIT"
-    },
-    "node_modules/@greenbone/ui-components/node_modules/css-to-react-native": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "camelize": "^1.0.0",
-        "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/@greenbone/ui-components/node_modules/has-flag": {
@@ -4060,7 +4033,6 @@
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -5227,6 +5199,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
     },
+    "node_modules/@types/stylis": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.1.tgz",
+      "integrity": "sha512-OSaMrXUKxVigGlKRrET39V2xdhzlztQ9Aqumn1WbCBKHOi9ry7jKSd7rkyj0GzmWaU960Rd+LpOFpLfx5bMQAg=="
+    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
@@ -6336,19 +6313,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true,
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
       }
     },
     "node_modules/autoprefixer": {
@@ -7542,7 +7506,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -7862,19 +7825,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/css": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
-      }
-    },
     "node_modules/css-blank-pseudo": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-3.0.3.tgz",
@@ -8076,21 +8026,14 @@
       "license": "MIT"
     },
     "node_modules/css-to-react-native": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
-      "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
       "dependencies": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^3.3.0"
+        "postcss-value-parser": "^4.0.2"
       }
-    },
-    "node_modules/css-to-react-native/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "license": "MIT"
     },
     "node_modules/css-tree": {
       "version": "1.1.3",
@@ -8270,10 +8213,9 @@
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "license": "MIT"
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/d3-array": {
       "version": "2.12.1",
@@ -8481,16 +8423,6 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
       "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "license": "MIT"
-    },
-    "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/dedent": {
       "version": "1.5.1",
@@ -10492,7 +10424,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
       "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fs.realpath": {
@@ -12111,12 +12042,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-what": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
-      "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
-      "license": "MIT"
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
@@ -14920,16 +14845,18 @@
       "peer": true
     },
     "node_modules/jest-styled-components": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-6.3.4.tgz",
-      "integrity": "sha512-dc32l0/6n3FtsILODpvKNz6SLg50OmbJ/3r3oRh9jc2VIPPGZT5jWv7BKIcNCYH7E38ZK7uejNl3zJsCOIenng==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-7.1.1.tgz",
+      "integrity": "sha512-OUq31R5CivBF8oy81dnegNQrRW13TugMol/Dz6ZnFfEyo03exLASod7YGwyHGuayYlKmCstPtz0RQ1+NrAbIIA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "css": "^2.2.4"
+        "@adobe/css-tools": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 12"
       },
       "peerDependencies": {
-        "styled-components": "^2 || ^3 || ^4"
+        "styled-components": ">= 5"
       }
     },
     "node_modules/jest-util": {
@@ -15968,15 +15895,6 @@
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
     },
-    "node_modules/merge-anything": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-2.4.4.tgz",
-      "integrity": "sha512-l5XlriUDJKQT12bH+rVhAHjwIuXWdAIecGwsYjv2LJo+dA1AeRTmeQS+3QBpO6lEthBMDi2IUMpLC1yyRvGlwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-what": "^3.3.1"
-      }
-    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -16172,10 +16090,15 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
-      "license": "MIT",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -16871,7 +16794,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -17014,9 +16936,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -17025,11 +16947,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -20624,13 +20549,6 @@
       "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
       "license": "MIT"
     },
-    "node_modules/resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/resolve-url-loader": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-4.0.0.tgz",
@@ -21400,20 +21318,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-resolve": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
-      }
-    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -21423,13 +21327,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/source-map-url": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
-      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
@@ -21777,63 +21674,52 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.4.1.tgz",
-      "integrity": "sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==",
-      "hasInstallScript": true,
-      "license": "MIT",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.0.8.tgz",
+      "integrity": "sha512-AwI02MTWZwqjzfXgR5QcbmcSn5xVjY4N2TLjSuYnmuBGF3y7GicHz3ysbpUq2EMJP5M8/Nc22vcmF3V3WNZDFA==",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@emotion/is-prop-valid": "^0.8.1",
-        "@emotion/unitless": "^0.7.0",
-        "babel-plugin-styled-components": ">= 1",
-        "css-to-react-native": "^2.2.2",
-        "memoize-one": "^5.0.0",
-        "merge-anything": "^2.2.4",
-        "prop-types": "^15.5.4",
-        "react-is": "^16.6.0",
-        "stylis": "^3.5.0",
-        "stylis-rule-sheet": "^0.0.10",
-        "supports-color": "^5.5.0"
+        "@babel/cli": "^7.21.0",
+        "@babel/core": "^7.21.0",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/plugin-external-helpers": "^7.18.6",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
+        "@babel/preset-env": "^7.20.2",
+        "@babel/preset-react": "^7.18.6",
+        "@babel/preset-typescript": "^7.21.0",
+        "@babel/traverse": "^7.21.2",
+        "@emotion/is-prop-valid": "^1.2.1",
+        "@emotion/unitless": "^0.8.0",
+        "@types/stylis": "^4.0.2",
+        "css-to-react-native": "^3.2.0",
+        "csstype": "^3.1.2",
+        "postcss": "^8.4.23",
+        "shallowequal": "^1.1.0",
+        "stylis": "^4.3.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
       },
       "peerDependencies": {
-        "react": ">= 16.3.0",
-        "react-dom": ">= 16.3.0"
-      }
-    },
-    "node_modules/styled-components/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/styled-components/node_modules/memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "license": "MIT"
-    },
-    "node_modules/styled-components/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
-    "node_modules/styled-components/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
+        "babel-plugin-styled-components": ">= 2",
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0"
       },
-      "engines": {
-        "node": ">=4"
+      "peerDependenciesMeta": {
+        "babel-plugin-styled-components": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/styled-components/node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
     },
     "node_modules/stylehacks": {
       "version": "5.1.1",
@@ -21852,19 +21738,9 @@
       }
     },
     "node_modules/stylis": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
-      "license": "MIT"
-    },
-    "node_modules/stylis-rule-sheet": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "stylis": "^3.5.0"
-      }
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
+      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -22712,13 +22588,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/urix": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/url-parse": {
       "version": "1.5.10",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "https://github.com/greenbone/gsa/"
   },
-  "author": "Bj\u00f6rn Ricks <bjoern.ricks@greenbone.net>",
+  "author": "Björn Ricks <bjoern.ricks@greenbone.net>",
   "license": "AGPL-3.0+",
   "main": "src/index.js",
   "engines": {
@@ -64,7 +64,7 @@
     "redux": "^4.2.1",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.4.2",
-    "styled-components": "^4.4.1",
+    "styled-components": "^6.0.8",
     "uuid": "^9.0.1",
     "whatwg-fetch": "^3.6.19"
   },
@@ -89,7 +89,7 @@
     "husky": "^2.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-junit": "^16.0.0",
-    "jest-styled-components": "^6.3.4",
+    "jest-styled-components": "^7.1.1",
     "lint-staged": "^13.1.0",
     "prettier": "^3.0.3"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,8 @@ import {isDefined} from 'gmp/utils/identity';
 
 import App from './web/app.js';
 
+import {StyleSheetManager} from 'styled-components';
+
 const config = isDefined(global.config) ? global.config : {};
 const {sentryDSN, sentryEnvironment} = config;
 
@@ -38,6 +40,11 @@ Sentry.init({
   release: GSA_VERSION,
 });
 
-ReactDOM.render(<App />, document.getElementById('app'));
+ReactDOM.render(
+  <StyleSheetManager enableVendorPrefixes>
+    <App />
+  </StyleSheetManager>,
+  document.getElementById('app'),
+);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/src/web/components/badge/__tests__/__snapshots__/badge.js.snap
+++ b/src/web/components/badge/__tests__/__snapshots__/badge.js.snap
@@ -29,12 +29,13 @@ exports[`Badge tests should render badge 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -59,6 +60,7 @@ exports[`Badge tests should render badge 1`] = `
 
 <div
   class="c0"
+  margin="0"
 >
   <span
     class="c1"
@@ -71,6 +73,7 @@ exports[`Badge tests should render badge 1`] = `
   <span
     class="c2"
     data-testid="badge-icon"
+    margin="0"
   >
     1
   </span>

--- a/src/web/components/bar/__tests__/__snapshots__/compliancestatusbar.js.snap
+++ b/src/web/components/bar/__tests__/__snapshots__/compliancestatusbar.js.snap
@@ -48,13 +48,16 @@ exports[`ComplianceStatusBar tests should render 1`] = `
 }
 
 <div
+  boxbackground="#c83814"
   class="c0"
   data-testid="progressbar-box"
   title="75%"
 >
   <div
+    background="#70c000"
     class="c1"
     data-testid="progress"
+    progress="75"
   />
   <div
     class="c2"

--- a/src/web/components/bar/__tests__/__snapshots__/progressbar.js.snap
+++ b/src/web/components/bar/__tests__/__snapshots__/progressbar.js.snap
@@ -48,13 +48,16 @@ exports[`ProgressBar tests should render 1`] = `
 }
 
 <div
+  boxbackground="#4C4C4C"
   class="c0"
   data-testid="progressbar-box"
   title="Progress"
 >
   <div
+    background="low"
     class="c1"
     data-testid="progress"
+    progress="10"
   />
   <div
     class="c2"

--- a/src/web/components/bar/__tests__/__snapshots__/severitybar.js.snap
+++ b/src/web/components/bar/__tests__/__snapshots__/severitybar.js.snap
@@ -48,13 +48,16 @@ exports[`SeverityBar tests should render 1`] = `
 }
 
 <div
+  boxbackground="#4C4C4C"
   class="c0"
   data-testid="progressbar-box"
   title="High"
 >
   <div
+    background="error"
     class="c1"
     data-testid="progress"
+    progress="95"
   />
   <div
     class="c2"

--- a/src/web/components/bar/__tests__/__snapshots__/statusbar.js.snap
+++ b/src/web/components/bar/__tests__/__snapshots__/statusbar.js.snap
@@ -51,6 +51,7 @@ exports[`StatusBar tests should render 1`] = `
 }
 
 <div
+  boxbackground="#4C4C4C"
   class="c0"
   data-testid="progressbar-box"
   title="undefined"
@@ -58,6 +59,7 @@ exports[`StatusBar tests should render 1`] = `
   <div
     class="c1"
     data-testid="progress"
+    progress="100"
   />
   <div
     class="c2"

--- a/src/web/components/bar/__tests__/__snapshots__/titlebar.js.snap
+++ b/src/web/components/bar/__tests__/__snapshots__/titlebar.js.snap
@@ -1,11 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Titlebar tests should not render content if user is logged out 1`] = `
-<body>
-  <div
-    id="portals"
-  />
-  .c2 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -14,8 +10,8 @@ exports[`Titlebar tests should not render content if user is logged out 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -44,7 +40,6 @@ exports[`Titlebar tests should not render content if user is logged out 1`] = `
   display: flex;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -64,7 +59,11 @@ exports[`Titlebar tests should not render content if user is logged out 1`] = `
   height: 42px;
 }
 
-<div>
+<body>
+  <div
+    id="portals"
+  />
+  <div>
     <div
       class="c0"
     />
@@ -103,8 +102,8 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -119,80 +118,50 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   display: inline-flex;
 }
 
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c15 {
   margin-left: -5px;
 }
 
-.c14 > * {
+.c15>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c14 > * {
+.c15>* {
   margin-left: 5px;
 }
 
-.c13 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c16 {
+.c17 {
   cursor: pointer;
 }
 
-.c8 {
+.c9 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c8 * {
+.c9 * {
   height: inherit;
   width: inherit;
 }
 
-.c15 {
+.c16 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c15 * {
+.c16 * {
   height: inherit;
   width: inherit;
 }
@@ -207,18 +176,18 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   flex-direction: column;
 }
 
-.c10 {
+.c11 {
   position: relative;
   display: none;
-  -webkit-animation: iKjwYD 0.1s ease-in;
-  animation: iKjwYD 0.1s ease-in;
+  -webkit-animation: bNcXmX 0.1s ease-in;
+  animation: bNcXmX 0.1s ease-in;
 }
 
-.c6:hover .c10 {
+.c6:hover .c11 {
   display: block;
 }
 
-.c11 {
+.c12 {
   position: absolute;
   margin: 0;
   padding: 0;
@@ -230,7 +199,7 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   width: 300px;
 }
 
-.c12 {
+.c13 {
   height: 30px;
   width: 300px;
   border-left: 1px solid #7F7F7F;
@@ -247,54 +216,48 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   padding-left: 12px;
 }
 
-.c12:hover {
+.c13:hover {
   background: #11ab51;
   color: #fff;
   cursor: pointer;
 }
 
-.c12:first-child {
+.c13:first-child {
   border-top: 1px solid #7F7F7F;
   cursor: default;
-  background-color: #f3f3f3;
 }
 
-.c12:first-child:hover {
+background-color:#f3f3f3 .c13:first-child:hover {
   color: #000;
 }
 
-.c12:nth-child(2) {
+.c13:nth-child(2) {
   cursor: default;
-  background-color: #f3f3f3;
 }
 
-.c12:nth-child(2):hover {
+background-color:#f3f3f3 .c13:nth-child(2):hover {
   color: #000;
 }
 
-.c12:last-child {
+.c13:last-child {
   border-top: 1px solid #7F7F7F;
   border-bottom: 1px solid #7F7F7F;
 }
 
-.c9 {
+.c10 {
   margin-right: 10px;
 }
 
-.c17 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+.c18 {
   width: 100%;
   height: 100%;
 }
 
-.c17:link,
-.c17:hover,
-.c17:active,
-.c17:visited,
-.c17:hover {
+.c18:link,
+.c18:hover,
+.c18:active,
+.c18:visited,
+.c18:hover {
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -321,7 +284,6 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   display: flex;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -342,7 +304,7 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
 }
 
 @media print {
-  .c16 {
+  .c8 {
     display: none;
   }
 }
@@ -383,7 +345,7 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
         data-testid="usermenu"
       >
         <span
-          class="c8 c9"
+          class="c8 c9 c10"
           data-testid="svg-icon"
         >
           <svg>
@@ -391,24 +353,24 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
           </svg>
         </span>
         <div
-          class="c10"
+          class="c11"
         >
           <ul
-            class="c11"
+            class="c12"
           >
             <li
-              class="c12"
+              class="c13"
               title="Logged in as: username"
             >
               <div
-                class="c13"
+                class="c3 c14"
               >
                 <div
-                  class="c14"
+                  class="c3 c15"
                   margin="5px"
                 >
                   <span
-                    class="c15"
+                    class="c8 c16"
                     data-testid="svg-icon"
                   >
                     <svg>
@@ -422,17 +384,17 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
               </div>
             </li>
             <li
-              class="c12"
+              class="c13"
             >
               <div
-                class="c13"
+                class="c3 c14"
               >
                 <div
-                  class="c14"
+                  class="c3 c15"
                   margin="5px"
                 >
                   <span
-                    class="c15"
+                    class="c8 c16"
                     data-testid="svg-icon"
                   >
                     <svg>
@@ -443,7 +405,7 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
                     Session timeout: 
                   </span>
                   <span
-                    class="c16 c15"
+                    class="c8 c17 c16"
                     data-testid="svg-icon"
                     title="Renew session timeout"
                   >
@@ -457,22 +419,22 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
               </div>
             </li>
             <li
-              class="c12"
+              class="c13"
             >
               <a
-                class="c17"
+                class="c2 c18"
                 data-testid="usermenu-settings"
                 href="/usersettings"
               >
                 <div
-                  class="c13"
+                  class="c3 c14"
                 >
                   <div
-                    class="c14"
+                    class="c3 c15"
                     margin="5px"
                   >
                     <span
-                      class="c15"
+                      class="c8 c16"
                       data-testid="svg-icon"
                     >
                       <svg>
@@ -487,18 +449,18 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
               </a>
             </li>
             <li
-              class="c12"
+              class="c13"
               data-testid="usermenu-logout"
             >
               <div
-                class="c13"
+                class="c3 c14"
               >
                 <div
-                  class="c14"
+                  class="c3 c15"
                   margin="5px"
                 >
                   <span
-                    class="c15"
+                    class="c8 c16"
                     data-testid="svg-icon"
                   >
                     <svg>

--- a/src/web/components/bar/__tests__/__snapshots__/toolbar.js.snap
+++ b/src/web/components/bar/__tests__/__snapshots__/toolbar.js.snap
@@ -11,7 +11,6 @@ exports[`Toolbar tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;

--- a/src/web/components/dialog/__tests__/__snapshots__/button.js.snap
+++ b/src/web/components/dialog/__tests__/__snapshots__/button.js.snap
@@ -62,8 +62,8 @@ exports[`Dialog Button tests should render button 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -77,7 +77,7 @@ exports[`Dialog Button tests should render button 1`] = `
   background: #11ab51;
 }
 
-.c2:hover {
+.c2 :hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -149,8 +149,8 @@ exports[`Dialog Button tests should render button when loading 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -160,12 +160,12 @@ exports[`Dialog Button tests should render button when loading 1`] = `
 
 .c2 {
   border: 1px solid #7F7F7F;
-  color: rgba(0,0,0,0.0);
+  color: rgba(0, 0, 0, 0.0);
   background: #11ab51 url(/img/loading.gif) center center no-repeat;
 }
 
-.c2:hover {
-  color: rgba(0,0,0,0.0);
+.c2 :hover {
+  color: rgba(0, 0, 0, 0.0);
   background: #11ab51 url(/img/loading.gif) center center no-repeat;
 }
 

--- a/src/web/components/dialog/__tests__/__snapshots__/closebutton.js.snap
+++ b/src/web/components/dialog/__tests__/__snapshots__/closebutton.js.snap
@@ -18,15 +18,15 @@ exports[`Dialog CloseButton tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c0:hover {
+.c0 :hover {
   border: 1px solid #074320;
 }
 

--- a/src/web/components/dialog/__tests__/__snapshots__/confirmationdialog.js.snap
+++ b/src/web/components/dialog/__tests__/__snapshots__/confirmationdialog.js.snap
@@ -1,6 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ConfirmationDialog component tests should render ConfirmationDialog with text and title 1`] = `
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 .c1 {
   position: relative;
   display: -webkit-box;
@@ -26,7 +86,7 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -50,7 +110,7 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -67,30 +127,30 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c9 {
+.c13 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -110,12 +170,12 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   z-index: 1;
 }
 
-.c9:focus,
-.c9:hover {
+.c13:focus,
+.c13:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c9:hover {
+.c13:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -123,26 +183,26 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   color: #fff;
 }
 
-.c9[disabled] {
+.c13[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c9 img {
+.c13 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c9:link {
+.c13:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c10 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -151,8 +211,8 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -160,63 +220,32 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   align-items: center;
 }
 
-.c11 {
+.c15 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c11:hover {
+.c15 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c11 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c12 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -230,43 +259,22 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
   height: 100%;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
@@ -290,14 +298,14 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 bar
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -305,27 +313,27 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="confirmationdialog-content"
               >
                 foo
               </div>
             </div>
             <div
-              class="c8"
+              class="c10 c11 c12"
             >
               <button
-                class="c9 c10 c11"
+                class="c13 c14 c15"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c9 c10 c11"
+                class="c13 c14 c15"
                 data-testid="dialog-save-button"
                 title="OK"
               >

--- a/src/web/components/dialog/__tests__/__snapshots__/dialog.js.snap
+++ b/src/web/components/dialog/__tests__/__snapshots__/dialog.js.snap
@@ -26,7 +26,7 @@ exports[`Dialog component tests should render a Dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -49,7 +49,7 @@ exports[`Dialog component tests should render a Dialog 1`] = `
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 <body>

--- a/src/web/components/dialog/__tests__/__snapshots__/errordialog.js.snap
+++ b/src/web/components/dialog/__tests__/__snapshots__/errordialog.js.snap
@@ -1,6 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ErrorDialog component tests should render ErrorDialog with text and title 1`] = `
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 .c1 {
   position: relative;
   display: -webkit-box;
@@ -26,7 +86,7 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -50,7 +110,7 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -67,30 +127,30 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c9 {
+.c12 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -110,12 +170,12 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   z-index: 1;
 }
 
-.c9:focus,
-.c9:hover {
+.c12:focus,
+.c12:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c9:hover {
+.c12:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -123,26 +183,26 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   color: #fff;
 }
 
-.c9[disabled] {
+.c12[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c9 img {
+.c12 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c9:link {
+.c12:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c10 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -151,8 +211,8 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -160,36 +220,18 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   align-items: center;
 }
 
-.c11 {
+.c14 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c11:hover {
+.c14 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c11 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
@@ -197,22 +239,7 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   padding: 10px 20px 10px 20px;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -226,43 +253,22 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
   height: 100%;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
@@ -286,14 +292,14 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 bar
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -301,20 +307,20 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="errordialog-content"
               >
                 foo
               </div>
             </div>
             <div
-              class="c8"
+              class="c10 c11"
             >
               <button
-                class="c9 c10 c11"
+                class="c12 c13 c14"
                 title="OK"
               >
                 OK

--- a/src/web/components/dialog/__tests__/__snapshots__/multistepfooter.js.snap
+++ b/src/web/components/dialog/__tests__/__snapshots__/multistepfooter.js.snap
@@ -1,7 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MultiStepFooter tests should render 1`] = `
-.c5 {
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,50 +31,38 @@ exports[`MultiStepFooter tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c8 {
   margin-left: -5px;
 }
 
-.c5 > * {
+.c8>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5 > * {
+.c8>* {
   margin-left: 5px;
 }
 
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c7 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c1 {
+.c3 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -73,12 +82,12 @@ exports[`MultiStepFooter tests should render 1`] = `
   z-index: 1;
 }
 
-.c1:focus,
-.c1:hover {
+.c3:focus,
+.c3:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c1:hover {
+.c3:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -86,26 +95,26 @@ exports[`MultiStepFooter tests should render 1`] = `
   color: #fff;
 }
 
-.c1[disabled] {
+.c3[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c1 img {
+.c3 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c1:link {
+.c3:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c2 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -114,8 +123,8 @@ exports[`MultiStepFooter tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -123,105 +132,74 @@ exports[`MultiStepFooter tests should render 1`] = `
   align-items: center;
 }
 
-.c3 {
+.c5 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c3:hover {
+.c5 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #4C4C4C;
-  background: #fff;
-}
-
-.c6:hover {
-  color: #fff;
-  background: #11ab51;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c1 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c9 {
+  color: #4C4C4C;
+  background: #fff;
+}
+
+.c9 :hover {
+  color: #fff;
+  background: #11ab51;
+}
+
+.c2 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
 <div
-  class="c0"
+  class="c0 c1 c2"
 >
   <button
-    class="c1 c2 c3"
+    class="c3 c4 c5"
     data-testid="dialog-close-button"
     title="Cancel"
   >
     Cancel
   </button>
   <div
-    class="c4"
+    class="c6 c7"
   >
     <div
-      class="c5"
+      class="c6 c8"
       margin="5px"
     >
       <button
-        class="c1 c6"
+        class="c3 c4 c9"
         data-testid="dialog-previous-button"
         title="🠬"
       >
         🠬
       </button>
       <button
-        class="c1 c6"
+        class="c3 c4 c9"
         data-testid="dialog-next-button"
         title="🠮"
       >
         🠮
       </button>
       <button
-        class="c1 c2 c3"
+        class="c3 c4 c5"
         data-testid="dialog-save-button"
         title="Foo"
       >
@@ -233,7 +211,28 @@ exports[`MultiStepFooter tests should render 1`] = `
 `;
 
 exports[`MultiStepFooter tests should render loading and disable cancel button 1`] = `
-.c5 {
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -242,50 +241,38 @@ exports[`MultiStepFooter tests should render loading and disable cancel button 1
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c8 {
   margin-left: -5px;
 }
 
-.c5 > * {
+.c8>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5 > * {
+.c8>* {
   margin-left: 5px;
 }
 
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c7 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c1 {
+.c3 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -305,12 +292,12 @@ exports[`MultiStepFooter tests should render loading and disable cancel button 1
   z-index: 1;
 }
 
-.c1:focus,
-.c1:hover {
+.c3:focus,
+.c3:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c1:hover {
+.c3:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -318,26 +305,26 @@ exports[`MultiStepFooter tests should render loading and disable cancel button 1
   color: #fff;
 }
 
-.c1[disabled] {
+.c3[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c1 img {
+.c3 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c1:link {
+.c3:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c2 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -346,8 +333,8 @@ exports[`MultiStepFooter tests should render loading and disable cancel button 1
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -355,88 +342,57 @@ exports[`MultiStepFooter tests should render loading and disable cancel button 1
   align-items: center;
 }
 
-.c3 {
+.c5 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c3:hover {
+.c5 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c7 {
+.c10 {
   border: 1px solid #7F7F7F;
-  color: rgba(0,0,0,0.0);
+  color: rgba(0, 0, 0, 0.0);
   background: #11ab51 url(/img/loading.gif) center center no-repeat;
 }
 
-.c7:hover {
-  color: rgba(0,0,0,0.0);
+.c10 :hover {
+  color: rgba(0, 0, 0, 0.0);
   background: #11ab51 url(/img/loading.gif) center center no-repeat;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #4C4C4C;
-  background: #fff;
-}
-
-.c6:hover {
-  color: #fff;
-  background: #11ab51;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c1 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c9 {
+  color: #4C4C4C;
+  background: #fff;
+}
+
+.c9 :hover {
+  color: #fff;
+  background: #11ab51;
+}
+
+.c2 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
 <div
-  class="c0"
+  class="c0 c1 c2"
 >
   <button
-    class="c1 c2 c3"
+    class="c3 c4 c5"
     data-testid="dialog-close-button"
     disabled=""
     title="Cancel"
@@ -444,28 +400,28 @@ exports[`MultiStepFooter tests should render loading and disable cancel button 1
     Cancel
   </button>
   <div
-    class="c4"
+    class="c6 c7"
   >
     <div
-      class="c5"
+      class="c6 c8"
       margin="5px"
     >
       <button
-        class="c1 c6"
+        class="c3 c4 c9"
         data-testid="dialog-previous-button"
         title="🠬"
       >
         🠬
       </button>
       <button
-        class="c1 c6"
+        class="c3 c4 c9"
         data-testid="dialog-next-button"
         title="🠮"
       >
         🠮
       </button>
       <button
-        class="c1 c2 c7"
+        class="c3 c4 c10"
         data-testid="dialog-save-button"
         title="Foo"
       >

--- a/src/web/components/dialog/__tests__/__snapshots__/twobuttonfooter.js.snap
+++ b/src/web/components/dialog/__tests__/__snapshots__/twobuttonfooter.js.snap
@@ -1,7 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DialogTwoButtonFooter tests should render 1`] = `
-.c1 {
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -21,12 +42,12 @@ exports[`DialogTwoButtonFooter tests should render 1`] = `
   z-index: 1;
 }
 
-.c1:focus,
-.c1:hover {
+.c3:focus,
+.c3:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c1:hover {
+.c3:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -34,26 +55,26 @@ exports[`DialogTwoButtonFooter tests should render 1`] = `
   color: #fff;
 }
 
-.c1[disabled] {
+.c3[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c1 img {
+.c3 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c1:link {
+.c3:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c2 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -62,8 +83,8 @@ exports[`DialogTwoButtonFooter tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -71,59 +92,43 @@ exports[`DialogTwoButtonFooter tests should render 1`] = `
   align-items: center;
 }
 
-.c3 {
+.c5 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c3:hover {
+.c5 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c1 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c2 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
 <div
-  class="c0"
+  class="c0 c1 c2"
 >
   <button
-    class="c1 c2 c3"
+    class="c3 c4 c5"
     data-testid="dialog-close-button"
     title="Cancel"
   >
     Cancel
   </button>
   <button
-    class="c1 c2 c3"
+    class="c3 c4 c5"
     data-testid="dialog-save-button"
     title="Foo"
   >
@@ -133,7 +138,28 @@ exports[`DialogTwoButtonFooter tests should render 1`] = `
 `;
 
 exports[`DialogTwoButtonFooter tests should render loading and disable cancel button 1`] = `
-.c1 {
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -153,12 +179,12 @@ exports[`DialogTwoButtonFooter tests should render loading and disable cancel bu
   z-index: 1;
 }
 
-.c1:focus,
-.c1:hover {
+.c3:focus,
+.c3:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c1:hover {
+.c3:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -166,26 +192,26 @@ exports[`DialogTwoButtonFooter tests should render loading and disable cancel bu
   color: #fff;
 }
 
-.c1[disabled] {
+.c3[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c1 img {
+.c3 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c1:link {
+.c3:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c2 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -194,8 +220,8 @@ exports[`DialogTwoButtonFooter tests should render loading and disable cancel bu
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -203,63 +229,47 @@ exports[`DialogTwoButtonFooter tests should render loading and disable cancel bu
   align-items: center;
 }
 
-.c3 {
+.c5 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c3:hover {
+.c5 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c4 {
+.c6 {
   border: 1px solid #7F7F7F;
-  color: rgba(0,0,0,0.0);
+  color: rgba(0, 0, 0, 0.0);
   background: #11ab51 url(/img/loading.gif) center center no-repeat;
 }
 
-.c4:hover {
-  color: rgba(0,0,0,0.0);
+.c6 :hover {
+  color: rgba(0, 0, 0, 0.0);
   background: #11ab51 url(/img/loading.gif) center center no-repeat;
 }
 
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c1 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c2 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
 <div
-  class="c0"
+  class="c0 c1 c2"
 >
   <button
-    class="c1 c2 c3"
+    class="c3 c4 c5"
     data-testid="dialog-close-button"
     disabled=""
     title="Cancel"
@@ -267,7 +277,7 @@ exports[`DialogTwoButtonFooter tests should render loading and disable cancel bu
     Cancel
   </button>
   <button
-    class="c1 c2 c4"
+    class="c3 c4 c6"
     data-testid="dialog-save-button"
     title="Foo"
   >

--- a/src/web/components/error/__tests__/__snapshots__/errorcontainer.js.snap
+++ b/src/web/components/error/__tests__/__snapshots__/errorcontainer.js.snap
@@ -10,13 +10,16 @@ exports[`ErrorContainer tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c1 {
   padding: 15px;
   margin: 15px 15px 15px 15px;
   border: 1px solid #f4b1b2;
@@ -25,7 +28,7 @@ exports[`ErrorContainer tests should render 1`] = `
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <span>
     An error

--- a/src/web/components/error/__tests__/__snapshots__/errormessage.js.snap
+++ b/src/web/components/error/__tests__/__snapshots__/errormessage.js.snap
@@ -1,117 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ErrorMessage tests should render 1`] = `
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  margin-left: -15px;
-}
-
-.c2 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c2 > * {
-  margin-left: 15px;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c5 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c5 > * {
-  margin-left: 5px;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c3 {
-  height: 24px;
-  width: 24px;
-  line-height: 24px;
-}
-
-.c3 * {
-  height: inherit;
-  width: inherit;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -121,13 +10,82 @@ exports[`ErrorMessage tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c4 {
+  margin-left: -15px;
+}
+
+.c4>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4>* {
+  margin-left: 15px;
+}
+
+.c6 {
+  margin-left: -5px;
+}
+
+.c6>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6>* {
+  margin-left: 5px;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c5 {
+  height: 24px;
+  width: 24px;
+  line-height: 24px;
+}
+
+.c5 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c1 {
   padding: 15px;
   margin: 15px 15px 15px 15px;
   border: 1px solid #f4b1b2;
@@ -136,17 +94,17 @@ exports[`ErrorMessage tests should render 1`] = `
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <div
-    class="c1"
+    class="c0 c2"
   >
     <div
-      class="c2"
+      class="c3 c4"
       margin="15px"
     >
       <span
-        class="c3"
+        class="c5"
         data-testid="svg-icon"
       >
         <svg>
@@ -154,13 +112,13 @@ exports[`ErrorMessage tests should render 1`] = `
         </svg>
       </span>
       <div
-        class="c4"
+        class="c0"
       >
         <div
-          class="c1"
+          class="c0 c2"
         >
           <div
-            class="c5"
+            class="c0 c6"
             margin="5px"
           >
             <b

--- a/src/web/components/footnote/__tests__/__snapshots__/footnote.js.snap
+++ b/src/web/components/footnote/__tests__/__snapshots__/footnote.js.snap
@@ -10,19 +10,22 @@ exports[`Footnote tests should render footnote 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c1 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 />
 `;

--- a/src/web/components/form/__tests__/__snapshots__/button.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/button.js.snap
@@ -62,8 +62,8 @@ exports[`Button tests should render button 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/form/__tests__/__snapshots__/checkbox.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/checkbox.js.snap
@@ -1,36 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CheckBox component tests should render with children 1`] = `
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c2 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c2 > * {
-  margin-left: 5px;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -40,13 +10,31 @@ exports[`CheckBox component tests should render with children 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c3 {
+  margin-left: -5px;
+}
+
+.c3>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c3>* {
+  margin-left: 5px;
+}
+
+.c2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -69,7 +57,7 @@ exports[`CheckBox component tests should render with children 1`] = `
   cursor: pointer;
 }
 
-.c3 {
+.c4 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -80,7 +68,7 @@ exports[`CheckBox component tests should render with children 1`] = `
   height: auto;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -89,8 +77,8 @@ exports[`CheckBox component tests should render with children 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -102,14 +90,14 @@ exports[`CheckBox component tests should render with children 1`] = `
   class="c0"
 >
   <div
-    class="c1"
+    class="c1 c2"
   >
     <div
-      class="c2"
+      class="c1 c3"
       margin="5px"
     >
       <input
-        class="c3 c4"
+        class="c4 c5"
         type="checkbox"
       />
       <span>

--- a/src/web/components/form/__tests__/__snapshots__/field.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/field.js.snap
@@ -28,8 +28,8 @@ exports[`Field tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -39,7 +39,6 @@ exports[`Field tests should render 1`] = `
 
 <input
   class="c0 c1"
-  value=""
 />
 `;
 
@@ -74,8 +73,8 @@ exports[`Field tests should render in disabled state 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -86,6 +85,5 @@ exports[`Field tests should render in disabled state 1`] = `
 <input
   class="c0 c1"
   disabled=""
-  value=""
 />
 `;

--- a/src/web/components/form/__tests__/__snapshots__/filefield.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/filefield.js.snap
@@ -10,8 +10,8 @@ exports[`FileField tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -35,8 +35,8 @@ exports[`FileField tests should render in disabled state 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/form/__tests__/__snapshots__/formgroup.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/formgroup.js.snap
@@ -1,22 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FormGroup tests should render 1`] = `
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  padding-bottom: 10px;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -26,8 +10,8 @@ exports[`FormGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -35,17 +19,6 @@ exports[`FormGroup tests should render 1`] = `
   align-items: center;
 }
 
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    data-testid="formgroup-content"
-  />
-</div>
-`;
-
-exports[`FormGroup tests should render with title 1`] = `
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -56,8 +29,53 @@ exports[`FormGroup tests should render with title 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  padding-bottom: 10px;
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 "
+    data-testid="formgroup-content"
+  />
+</div>
+`;
+
+exports[`FormGroup tests should render with title 1`] = `
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -73,22 +91,7 @@ exports[`FormGroup tests should render with title 1`] = `
   margin-left: 0;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c3 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
@@ -100,11 +103,13 @@ exports[`FormGroup tests should render with title 1`] = `
   <label
     class="c1"
     data-testid="formgroup-title"
+    titleoffset="0"
+    titlesize="2"
   >
     Foo
   </label>
   <div
-    class="c2"
+    class="c2 c3"
     data-testid="formgroup-content"
     size="10"
   />

--- a/src/web/components/form/__tests__/__snapshots__/loadingbutton.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/loadingbutton.js.snap
@@ -62,24 +62,27 @@ exports[`LoadingButton tests should render loading 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  color: rgba(0,0,0,0.0);
+}
+
+.c2 {
+  color: rgba(0, 0, 0, 0.0);
   background: #A1DDBA url(/img/loading.gif) center center no-repeat;
 }
 
-.c1:hover {
-  color: rgba(0,0,0,0.0);
+.c2 :hover {
+  color: rgba(0, 0, 0, 0.0);
   background: #11ab51 url(/img/loading.gif) center center no-repeat;
 }
 
 <button
-  class="c0 c1"
+  class="c0 c1 c2"
 />
 `;
 
@@ -145,23 +148,26 @@ exports[`LoadingButton tests should render non loading 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c2 {
   color: #4C4C4C;
   background: #fff;
 }
 
-.c1:hover {
+.c2 :hover {
   color: #fff;
   background: #11ab51;
 }
 
 <button
-  class="c0 c1"
+  class="c0 c1 c2"
 />
 `;

--- a/src/web/components/form/__tests__/__snapshots__/multiselect.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/multiselect.js.snap
@@ -13,12 +13,13 @@ exports[`MultiSelect component tests should render 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
+  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -35,8 +36,8 @@ exports[`MultiSelect component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -57,8 +58,8 @@ exports[`MultiSelect component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;

--- a/src/web/components/form/__tests__/__snapshots__/passwordfield.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/passwordfield.js.snap
@@ -28,8 +28,8 @@ exports[`PasswordField tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -40,7 +40,6 @@ exports[`PasswordField tests should render 1`] = `
 <input
   class="c0 c1"
   type="password"
-  value=""
 />
 `;
 
@@ -75,8 +74,8 @@ exports[`PasswordField tests should render in disabled state 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -88,6 +87,5 @@ exports[`PasswordField tests should render in disabled state 1`] = `
   class="c0 c1"
   disabled=""
   type="password"
-  value=""
 />
 `;

--- a/src/web/components/form/__tests__/__snapshots__/radio.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/radio.js.snap
@@ -1,36 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Radio tests should render radio 1`] = `
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c2 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c2 > * {
-  margin-left: 5px;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -40,13 +10,31 @@ exports[`Radio tests should render radio 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c3 {
+  margin-left: -5px;
+}
+
+.c3>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c3>* {
+  margin-left: 5px;
+}
+
+.c2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -69,7 +57,7 @@ exports[`Radio tests should render radio 1`] = `
   cursor: pointer;
 }
 
-.c3 {
+.c4 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -80,7 +68,7 @@ exports[`Radio tests should render radio 1`] = `
   height: auto;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -89,8 +77,8 @@ exports[`Radio tests should render radio 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -102,17 +90,16 @@ exports[`Radio tests should render radio 1`] = `
   class="c0"
 >
   <div
-    class="c1"
+    class="c1 c2"
   >
     <div
-      class="c2"
+      class="c1 c3"
       margin="5px"
     >
       <input
-        class="c3 c4"
+        class="c4 c5"
         data-testid="radio-input"
         type="radio"
-        value=""
       />
     </div>
   </div>
@@ -120,36 +107,6 @@ exports[`Radio tests should render radio 1`] = `
 `;
 
 exports[`Radio tests should render radio with children 1`] = `
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c2 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c2 > * {
-  margin-left: 5px;
-}
-
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -159,13 +116,31 @@ exports[`Radio tests should render radio with children 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c3 {
+  margin-left: -5px;
+}
+
+.c3>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c3>* {
+  margin-left: 5px;
+}
+
+.c2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -188,7 +163,7 @@ exports[`Radio tests should render radio with children 1`] = `
   cursor: pointer;
 }
 
-.c3 {
+.c4 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -199,7 +174,7 @@ exports[`Radio tests should render radio with children 1`] = `
   height: auto;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -208,8 +183,8 @@ exports[`Radio tests should render radio with children 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -221,17 +196,16 @@ exports[`Radio tests should render radio with children 1`] = `
   class="c0"
 >
   <div
-    class="c1"
+    class="c1 c2"
   >
     <div
-      class="c2"
+      class="c1 c3"
       margin="5px"
     >
       <input
-        class="c3 c4"
+        class="c4 c5"
         data-testid="radio-input"
         type="radio"
-        value=""
       />
       <span>
         child1

--- a/src/web/components/form/__tests__/__snapshots__/select.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/select.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select component tests should render 1`] = `
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,8 +10,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -19,7 +19,7 @@ exports[`Select component tests should render 1`] = `
   align-items: center;
 }
 
-.c5 {
+.c6 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -32,8 +32,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -44,13 +44,13 @@ exports[`Select component tests should render 1`] = `
   cursor: pointer;
 }
 
-.c6 {
+.c7 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c7 * {
   height: inherit;
   width: inherit;
 }
@@ -92,15 +92,6 @@ exports[`Select component tests should render 1`] = `
   width: 180px;
 }
 
-.c7 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -118,6 +109,18 @@ exports[`Select component tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: default;
+}
+
+.c8 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c4 {
   cursor: default;
 }
 
@@ -149,15 +152,15 @@ exports[`Select component tests should render 1`] = `
       type="button"
     >
       <div
-        class="c3"
+        class="c3 c4"
         data-testid="select-selected-value"
         disabled=""
       />
       <div
-        class="c4"
+        class="c5"
       >
         <span
-          class="c5 c6"
+          class="c6 c7"
           data-testid="select-open-button"
         >
           ▼
@@ -166,7 +169,7 @@ exports[`Select component tests should render 1`] = `
     </div>
   </div>
   <div
-    class="c7"
+    class="c8"
     data-testid="error-marker"
   >
     ×

--- a/src/web/components/form/__tests__/__snapshots__/selectelement.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/selectelement.js.snap
@@ -187,7 +187,7 @@ exports[`Menu tests should render 1`] = `
   border-radius: 0 0 4px 4px;
   -webkit-transition: opacity 0.1s ease;
   transition: opacity 0.1s ease;
-  box-shadow: 0 2px 3px 0 rgba(34,36,38,0.15);
+  box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
   border: 1px solid #bfbfbf;
   background-color: #fff;
   display: -webkit-box;
@@ -209,6 +209,7 @@ exports[`Menu tests should render 1`] = `
 <div
   class="c0"
   data-testid="select-menu"
+  right="0"
   width="0"
   x="0"
   y="0"
@@ -221,7 +222,7 @@ exports[`Menu tests should render with position adjust 1`] = `
   border-radius: 0 0 4px 4px;
   -webkit-transition: opacity 0.1s ease;
   transition: opacity 0.1s ease;
-  box-shadow: 0 2px 3px 0 rgba(34,36,38,0.15);
+  box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
   border: 1px solid #bfbfbf;
   background-color: #fff;
   display: -webkit-box;
@@ -243,6 +244,8 @@ exports[`Menu tests should render with position adjust 1`] = `
 <div
   class="c0"
   data-testid="select-menu"
+  position="adjust"
+  right="0"
   width="0"
   x="0"
   y="0"
@@ -255,7 +258,7 @@ exports[`Menu tests should render with position reference to parent element 1`] 
   border-radius: 0 0 4px 4px;
   -webkit-transition: opacity 0.1s ease;
   transition: opacity 0.1s ease;
-  box-shadow: 0 2px 3px 0 rgba(34,36,38,0.15);
+  box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
   border: 1px solid #bfbfbf;
   background-color: #fff;
   display: -webkit-box;
@@ -277,6 +280,7 @@ exports[`Menu tests should render with position reference to parent element 1`] 
 <div
   class="c0"
   data-testid="select-menu"
+  right="-10"
   width="100"
   x="50"
   y="120"
@@ -289,7 +293,7 @@ exports[`Menu tests should render with position right 1`] = `
   border-radius: 0 0 4px 4px;
   -webkit-transition: opacity 0.1s ease;
   transition: opacity 0.1s ease;
-  box-shadow: 0 2px 3px 0 rgba(34,36,38,0.15);
+  box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
   border: 1px solid #bfbfbf;
   background-color: #fff;
   display: -webkit-box;
@@ -311,6 +315,8 @@ exports[`Menu tests should render with position right 1`] = `
 <div
   class="c0"
   data-testid="select-menu"
+  position="right"
+  right="0"
   width="0"
   x="0"
   y="0"

--- a/src/web/components/form/__tests__/__snapshots__/spinner.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/spinner.js.snap
@@ -49,8 +49,6 @@ exports[`Spinner tests should render 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  border-top-right-radius: 1px;
-  top: 0;
 }
 
 .c2:hover {
@@ -68,43 +66,13 @@ exports[`Spinner tests should render 1`] = `
 }
 
 .c3 {
-  background-color: #e5e5e5;
-  color: #7F7F7F;
-  border-left: 1px solid #4C4C4C;
-  width: 16px;
-  height: 50%;
-  font-size: 0.6em;
-  padding: 0;
-  margin: 0;
-  text-align: center;
-  vertical-align: middle;
-  position: absolute;
-  right: 0;
-  cursor: default;
-  display: block;
-  overflow: hidden;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
+  border-top-right-radius: 1px;
+  top: 0;
+}
+
+.c4 {
   border-bottom-right-radius: 1px;
   bottom: 0;
-}
-
-.c3:hover {
-  background-color: #11ab51;
-  color: #fff;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c3:active {
-  background-color: #fff;
-  color: #074320;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 <span
@@ -118,13 +86,13 @@ exports[`Spinner tests should render 1`] = `
     value="1"
   />
   <span
-    class="c2"
+    class="c2 c3"
     data-testid="spinner-up"
   >
     ▲
   </span>
   <span
-    class="c3"
+    class="c2 c4"
     data-testid="spinner-down"
   >
     ▼

--- a/src/web/components/form/__tests__/__snapshots__/textarea.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/textarea.js.snap
@@ -21,8 +21,8 @@ exports[`TextArea tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -59,8 +59,8 @@ exports[`TextArea tests should render in disabled state 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/form/__tests__/__snapshots__/textfield.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/textfield.js.snap
@@ -28,8 +28,8 @@ exports[`TextField tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -40,7 +40,6 @@ exports[`TextField tests should render 1`] = `
 <input
   class="c0 c1"
   type="text"
-  value=""
 />
 `;
 
@@ -75,8 +74,8 @@ exports[`TextField tests should render in disabled state 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -88,6 +87,5 @@ exports[`TextField tests should render in disabled state 1`] = `
   class="c0 c1"
   disabled=""
   type="text"
-  value=""
 />
 `;

--- a/src/web/components/form/__tests__/__snapshots__/timezoneselect.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/timezoneselect.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TimezoneSelect tests should render 1`] = `
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,8 +10,8 @@ exports[`TimezoneSelect tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -19,7 +19,7 @@ exports[`TimezoneSelect tests should render 1`] = `
   align-items: center;
 }
 
-.c5 {
+.c6 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -32,8 +32,8 @@ exports[`TimezoneSelect tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -44,13 +44,13 @@ exports[`TimezoneSelect tests should render 1`] = `
   cursor: pointer;
 }
 
-.c6 {
+.c7 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c7 * {
   height: inherit;
   width: inherit;
 }
@@ -91,15 +91,6 @@ exports[`TimezoneSelect tests should render 1`] = `
   width: 230px;
 }
 
-.c7 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -117,6 +108,18 @@ exports[`TimezoneSelect tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
+}
+
+.c8 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c4 {
   cursor: default;
 }
 
@@ -147,17 +150,17 @@ exports[`TimezoneSelect tests should render 1`] = `
       type="button"
     >
       <div
-        class="c3"
+        class="c3 c4"
         data-testid="select-selected-value"
         title="Coordinated Universal Time/UTC"
       >
         Coordinated Universal Time/UTC
       </div>
       <div
-        class="c4"
+        class="c5"
       >
         <span
-          class="c5 c6"
+          class="c6 c7"
           data-testid="select-open-button"
         >
           ▼
@@ -166,7 +169,7 @@ exports[`TimezoneSelect tests should render 1`] = `
     </div>
   </div>
   <div
-    class="c7"
+    class="c8"
     data-testid="error-marker"
   >
     ×

--- a/src/web/components/form/__tests__/__snapshots__/yesnoradio.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/yesnoradio.js.snap
@@ -10,8 +10,8 @@ exports[`YesNoRadio tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -20,51 +20,21 @@ exports[`YesNoRadio tests should render 1`] = `
 }
 
 .c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   margin-left: -5px;
 }
 
-.c2 > * {
+.c2>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2 > * {
+.c2>* {
   margin-left: 5px;
 }
 
 .c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -111,8 +81,8 @@ exports[`YesNoRadio tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -124,20 +94,20 @@ exports[`YesNoRadio tests should render 1`] = `
   class="c0"
 >
   <div
-    class="c1"
+    class="c0 c1"
   >
     <div
-      class="c2"
+      class="c0 c2"
       margin="5px"
     >
       <label
         class="c3"
       >
         <div
-          class="c1"
+          class="c0 c1"
         >
           <div
-            class="c2"
+            class="c0 c2"
             margin="5px"
           >
             <input
@@ -159,10 +129,10 @@ exports[`YesNoRadio tests should render 1`] = `
         class="c3"
       >
         <div
-          class="c1"
+          class="c0 c1"
         >
           <div
-            class="c2"
+            class="c0 c2"
             margin="5px"
           >
             <input

--- a/src/web/components/form/__tests__/selectelement.js
+++ b/src/web/components/form/__tests__/selectelement.js
@@ -261,7 +261,7 @@ describe('Menu tests', () => {
   test('should render with position reference to parent element', () => {
     const {getByTestId} = renderTest({mockBoundingClientRect: true});
     const menu = getByTestId('select-menu');
-    expect(menu).toHaveStyle({top: '120px'});
+    expect(menu).toHaveStyleRule({top: '120px'});
     expect(menu).toMatchSnapshot();
   });
 

--- a/src/web/components/icon/__tests__/__snapshots__/arrowicon.js.snap
+++ b/src/web/components/icon/__tests__/__snapshots__/arrowicon.js.snap
@@ -14,8 +14,8 @@ exports[`ArrowIcon component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;

--- a/src/web/components/icon/__tests__/__snapshots__/svgicon.js.snap
+++ b/src/web/components/icon/__tests__/__snapshots__/svgicon.js.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SVG icon component tests should render icon 1`] = `
-.c0 {
+.c1 {
   cursor: pointer;
 }
 
-.c1 {
+.c2 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c1 * {
+.c2 * {
   height: inherit;
   width: inherit;
 }
@@ -23,7 +23,7 @@ exports[`SVG icon component tests should render icon 1`] = `
 }
 
 <span
-  class="c0 c1"
+  class="c0 c1 c2"
   data-testid="svg-icon"
   title="Clone Entity"
 >

--- a/src/web/components/label/__tests__/__snapshots__/severityclass.js.snap
+++ b/src/web/components/label/__tests__/__snapshots__/severityclass.js.snap
@@ -16,6 +16,8 @@ exports[`SeverityClassLabel tests should render 1`] = `
 }
 
 <div
+  backgroundcolor="#C83814"
+  bordercolor="#C83814"
   class="c0"
 >
   High

--- a/src/web/components/layout/__tests__/__snapshots__/Layout.js.snap
+++ b/src/web/components/layout/__tests__/__snapshots__/Layout.js.snap
@@ -10,8 +10,8 @@ exports[`Layout tests should create Layout with align="start" 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
@@ -30,8 +30,8 @@ exports[`Layout tests should create Layout with align=[start, end] 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -54,8 +54,8 @@ exports[`Layout tests should create Layout with align=[stretch, center] 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: stretch;
-  -webkit-justify-content: stretch;
   -ms-flex-pack: stretch;
+  -webkit-justify-content: stretch;
   justify-content: stretch;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -81,8 +81,8 @@ exports[`Layout tests should create Layout with basis="20%" 1`] = `
   -ms-flex-preferred-size: 20%;
   flex-basis: 20%;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -108,8 +108,8 @@ exports[`Layout tests should create Layout with basis="auto" 1`] = `
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -132,8 +132,8 @@ exports[`Layout tests should create Layout with flex="column" align=[stretch, ce
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: stretch;
-  -webkit-justify-content: stretch;
   -ms-flex-pack: stretch;
+  -webkit-justify-content: stretch;
   justify-content: stretch;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -156,8 +156,8 @@ exports[`Layout tests should create Layout with flex="column" and align="start" 
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
@@ -180,8 +180,8 @@ exports[`Layout tests should create Layout with grow 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -208,8 +208,8 @@ exports[`Layout tests should create Layout with grow="1" 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -236,8 +236,8 @@ exports[`Layout tests should create Layout with grow="666" 1`] = `
   -ms-flex-positive: 666;
   flex-grow: 666;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -263,8 +263,8 @@ exports[`Layout tests should create Layout with shrink 1`] = `
   -ms-flex-negative: 1;
   flex-shrink: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -290,8 +290,8 @@ exports[`Layout tests should create Layout with shrink="1" 1`] = `
   -ms-flex-negative: 1;
   flex-shrink: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -317,8 +317,8 @@ exports[`Layout tests should create Layout with shrink="666" 1`] = `
   -ms-flex-negative: 666;
   flex-shrink: 666;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -340,12 +340,13 @@ exports[`Layout tests should create Layout with wrap 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -367,12 +368,13 @@ exports[`Layout tests should create Layout with wrap=nowrap 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -394,12 +396,13 @@ exports[`Layout tests should create Layout with wrap=wrap 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -422,8 +425,8 @@ exports[`Layout tests should render Layout 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -446,8 +449,8 @@ exports[`Layout tests should render Layout with flex 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -470,8 +473,8 @@ exports[`Layout tests should render Layout with flex="column" 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -494,8 +497,8 @@ exports[`Layout tests should render Layout with flex="row" 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/layout/__tests__/__snapshots__/horizontalsep.js.snap
+++ b/src/web/components/layout/__tests__/__snapshots__/horizontalsep.js.snap
@@ -1,39 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HorizontalSep tests should allow to wrap 1`] = `
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c1 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 > * {
-  margin-left: 5px;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -43,71 +10,82 @@ exports[`HorizontalSep tests should allow to wrap 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  margin-left: -5px;
+}
+
+.c3>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2 {
+.c3>* {
+  margin-left: 5px;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4 {
+  -webkit-box-flex-wrap: true;
   -webkit-flex-wrap: true;
   -ms-flex-wrap: true;
   flex-wrap: true;
 }
 
-.c2 > *:not(:last-child)::after {
+.c4>*:not(:last-child)::after {
   content: '•';
   margin-left: 5px;
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <div
-    class="c1 c2"
+    class="c2 c3 c4"
     margin="5px"
   />
 </div>
 `;
 
 exports[`HorizontalSep tests should render 1`] = `
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c1 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 > * {
-  margin-left: 5px;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -117,65 +95,53 @@ exports[`HorizontalSep tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c2 {
+  margin-left: -5px;
+}
+
+.c2>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2 > *:not(:last-child)::after {
+.c2>* {
+  margin-left: 5px;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c3>*:not(:last-child)::after {
   content: '•';
   margin-left: 5px;
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <div
-    class="c1 c2"
+    class="c0 c2 c3"
     margin="5px"
   />
 </div>
 `;
 
 exports[`HorizontalSep tests should render with separator option 1`] = `
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c1 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 > * {
-  margin-left: 5px;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -185,29 +151,47 @@ exports[`HorizontalSep tests should render with separator option 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c2 {
+  margin-left: -5px;
+}
+
+.c2>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2 > *:not(:last-child)::after {
+.c2>* {
+  margin-left: 5px;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c3>*:not(:last-child)::after {
   content: '|';
   margin-left: 5px;
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <div
-    class="c1 c2"
+    class="c0 c2 c3"
     margin="5px"
     separator="|"
   />
@@ -215,36 +199,6 @@ exports[`HorizontalSep tests should render with separator option 1`] = `
 `;
 
 exports[`HorizontalSep tests should render with spacing 1`] = `
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c1 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 > * {
-  margin-left: 5px;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -254,29 +208,47 @@ exports[`HorizontalSep tests should render with spacing 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c2 {
+  margin-left: -5px;
+}
+
+.c2>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2 > *:not(:last-child)::after {
+.c2>* {
+  margin-left: 5px;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c3>*:not(:last-child)::after {
   content: '|';
   margin-left: 10px;
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <div
-    class="c1 c2"
+    class="c0 c2 c3"
     margin="5px"
     separator="|"
     spacing="10px"

--- a/src/web/components/layout/__tests__/__snapshots__/withLayout.js.snap
+++ b/src/web/components/layout/__tests__/__snapshots__/withLayout.js.snap
@@ -10,8 +10,8 @@ exports[`withLayout HOC tests should create a new component 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -34,8 +34,8 @@ exports[`withLayout HOC tests should create a new component with align: [center,
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -58,8 +58,8 @@ exports[`withLayout HOC tests should create a new component with align: [start, 
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -82,8 +82,8 @@ exports[`withLayout HOC tests should create a new component with align: start 1`
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
@@ -105,8 +105,8 @@ exports[`withLayout HOC tests should create a new component with basis: 20% 1`] 
   -ms-flex-preferred-size: 20%;
   flex-basis: 20%;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -132,8 +132,8 @@ exports[`withLayout HOC tests should create a new component with basis: auto 1`]
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -156,8 +156,8 @@ exports[`withLayout HOC tests should create a new component with flex 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -180,8 +180,8 @@ exports[`withLayout HOC tests should create a new component with flex: column 1`
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -204,8 +204,8 @@ exports[`withLayout HOC tests should create a new component with flex: column, a
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -228,8 +228,8 @@ exports[`withLayout HOC tests should create a new component with flex: column, a
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
@@ -248,8 +248,8 @@ exports[`withLayout HOC tests should create a new component with flex: row 1`] =
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -276,8 +276,8 @@ exports[`withLayout HOC tests should create a new component with grow 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -304,8 +304,8 @@ exports[`withLayout HOC tests should create a new component with grow: 1 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -332,8 +332,8 @@ exports[`withLayout HOC tests should create a new component with grow: 666 1`] =
   -ms-flex-positive: 666;
   flex-grow: 666;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -359,8 +359,8 @@ exports[`withLayout HOC tests should create a new component with shrink 1`] = `
   -ms-flex-negative: 1;
   flex-shrink: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -386,8 +386,8 @@ exports[`withLayout HOC tests should create a new component with shrink: 1 1`] =
   -ms-flex-negative: 1;
   flex-shrink: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -413,8 +413,8 @@ exports[`withLayout HOC tests should create a new component with shrink: 666 1`]
   -ms-flex-negative: 666;
   flex-shrink: 666;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -436,12 +436,13 @@ exports[`withLayout HOC tests should create a new component with wrap 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -463,12 +464,13 @@ exports[`withLayout HOC tests should create a new component with wrap: nowrap 1`
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -490,12 +492,13 @@ exports[`withLayout HOC tests should create a new component with wrap: wrap 1`] 
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/loading/__tests__/__snapshots__/loading.js.snap
+++ b/src/web/components/loading/__tests__/__snapshots__/loading.js.snap
@@ -1,18 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Loading component tests should render 1`] = `
-.c1 {
-  width: 80px;
-  height: 80px;
-  margin: 40px auto;
-  background-image: url(greenbone.svg);
-  background-size: 90%;
-  background-position: center;
-  background-repeat: no-repeat;
-  -webkit-animation: fSFzYT 2s infinite ease-in-out;
-  animation: fSFzYT 2s infinite ease-in-out;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -22,22 +10,39 @@ exports[`Loading component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c2 {
+  width: 80px;
+  height: 80px;
+  margin: 40px auto;
+  background-image: url(greenbone.svg);
+  -webkit-background-size: 90%;
+  background-size: 90%;
+  -webkit-background-position: center;
+  background-position: center;
+  background-repeat: no-repeat;
+  -webkit-animation: hGzRiT 2s infinite ease-in-out;
+  animation: hGzRiT 2s infinite ease-in-out;
+}
+
+.c1 {
   width: 100%;
 }
 
 <div
-  class="c0"
+  class="c0 c1"
   data-testid="loading"
 >
   <div
-    class="c1"
+    class="c2"
   />
 </div>
 `;

--- a/src/web/components/menu/__tests__/__snapshots__/usermenu.js.snap
+++ b/src/web/components/menu/__tests__/__snapshots__/usermenu.js.snap
@@ -10,43 +10,16 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-left: -5px;
 }
 
-.c8 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c8 > * {
-  margin-left: 5px;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c13 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -54,27 +27,49 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
 }
 
 .c10 {
+  margin-left: -5px;
+}
+
+.c10>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c10>* {
+  margin-left: 5px;
+}
+
+.c9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c12 {
   cursor: pointer;
 }
 
-.c2 {
+.c3 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c2 * {
+.c3 * {
   height: inherit;
   width: inherit;
 }
 
-.c9 {
+.c11 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c9 * {
+.c11 * {
   height: inherit;
   width: inherit;
 }
@@ -89,18 +84,18 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   flex-direction: column;
 }
 
-.c4 {
+.c5 {
   position: relative;
   display: none;
-  -webkit-animation: iKjwYD 0.1s ease-in;
-  animation: iKjwYD 0.1s ease-in;
+  -webkit-animation: bNcXmX 0.1s ease-in;
+  animation: bNcXmX 0.1s ease-in;
 }
 
-.c0:hover .c4 {
+.c0:hover .c5 {
   display: block;
 }
 
-.c5 {
+.c6 {
   position: absolute;
   margin: 0;
   padding: 0;
@@ -112,7 +107,7 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   width: 300px;
 }
 
-.c6 {
+.c7 {
   height: 30px;
   width: 300px;
   border-left: 1px solid #7F7F7F;
@@ -129,61 +124,55 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   padding-left: 12px;
 }
 
-.c6:hover {
+.c7:hover {
   background: #11ab51;
   color: #fff;
   cursor: pointer;
 }
 
-.c6:first-child {
+.c7:first-child {
   border-top: 1px solid #7F7F7F;
   cursor: default;
-  background-color: #f3f3f3;
 }
 
-.c6:first-child:hover {
+background-color:#f3f3f3 .c7:first-child:hover {
   color: #000;
 }
 
-.c6:nth-child(2) {
+.c7:nth-child(2) {
   cursor: default;
-  background-color: #f3f3f3;
 }
 
-.c6:nth-child(2):hover {
+background-color:#f3f3f3 .c7:nth-child(2):hover {
   color: #000;
 }
 
-.c6:last-child {
+.c7:last-child {
   border-top: 1px solid #7F7F7F;
   border-bottom: 1px solid #7F7F7F;
 }
 
-.c3 {
+.c4 {
   margin-right: 10px;
 }
 
-.c11 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+.c14 {
   width: 100%;
   height: 100%;
 }
 
-.c11:link,
-.c11:hover,
-.c11:active,
-.c11:visited,
-.c11:hover {
+.c14:link,
+.c14:hover,
+.c14:active,
+.c14:visited,
+.c14:hover {
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 @media print {
-  .c10 {
+  .c2 {
     display: none;
   }
 }
@@ -193,7 +182,7 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   data-testid="usermenu"
 >
   <span
-    class="c2 c3"
+    class="c2 c3 c4"
     data-testid="svg-icon"
   >
     <svg>
@@ -201,24 +190,24 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
     </svg>
   </span>
   <div
-    class="c4"
+    class="c5"
   >
     <ul
-      class="c5"
+      class="c6"
     >
       <li
-        class="c6"
+        class="c7"
         title="Logged in as: "
       >
         <div
-          class="c7"
+          class="c8 c9"
         >
           <div
-            class="c8"
+            class="c8 c10"
             margin="5px"
           >
             <span
-              class="c9"
+              class="c2 c11"
               data-testid="svg-icon"
             >
               <svg>
@@ -230,17 +219,17 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
         </div>
       </li>
       <li
-        class="c6"
+        class="c7"
       >
         <div
-          class="c7"
+          class="c8 c9"
         >
           <div
-            class="c8"
+            class="c8 c10"
             margin="5px"
           >
             <span
-              class="c9"
+              class="c2 c11"
               data-testid="svg-icon"
             >
               <svg>
@@ -251,7 +240,7 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
               Session timeout: 
             </span>
             <span
-              class="c10 c9"
+              class="c2 c12 c11"
               data-testid="svg-icon"
               title="Renew session timeout"
             >
@@ -265,22 +254,22 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
         </div>
       </li>
       <li
-        class="c6"
+        class="c7"
       >
         <a
-          class="c11"
+          class="c13 c14"
           data-testid="usermenu-settings"
           href="/usersettings"
         >
           <div
-            class="c7"
+            class="c8 c9"
           >
             <div
-              class="c8"
+              class="c8 c10"
               margin="5px"
             >
               <span
-                class="c9"
+                class="c2 c11"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -295,18 +284,18 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
         </a>
       </li>
       <li
-        class="c6"
+        class="c7"
         data-testid="usermenu-logout"
       >
         <div
-          class="c7"
+          class="c8 c9"
         >
           <div
-            class="c8"
+            class="c8 c10"
             margin="5px"
           >
             <span
-              class="c9"
+              class="c2 c11"
               data-testid="svg-icon"
             >
               <svg>

--- a/src/web/components/panel/__tests__/__snapshots__/button.js.snap
+++ b/src/web/components/panel/__tests__/__snapshots__/button.js.snap
@@ -55,8 +55,8 @@ exports[`InfoPanel button tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/powerfilter/__tests__/__snapshots__/applyoverridesgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/applyoverridesgroup.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApplyOverridesGroup tests should render 1`] = `
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,8 +10,8 @@ exports[`ApplyOverridesGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -20,51 +20,21 @@ exports[`ApplyOverridesGroup tests should render 1`] = `
 }
 
 .c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   margin-left: -5px;
 }
 
-.c5 > * {
+.c5>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5 > * {
+.c5>* {
   margin-left: 5px;
 }
 
 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -81,8 +51,8 @@ exports[`ApplyOverridesGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -98,22 +68,7 @@ exports[`ApplyOverridesGroup tests should render 1`] = `
   margin-left: 0;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c3 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
@@ -159,8 +114,8 @@ exports[`ApplyOverridesGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -174,32 +129,34 @@ exports[`ApplyOverridesGroup tests should render 1`] = `
   <label
     class="c1"
     data-testid="formgroup-title"
+    titleoffset="0"
+    titlesize="2"
   >
     Apply Overrides
   </label>
   <div
-    class="c2"
+    class="c2 c3"
     data-testid="formgroup-content"
     size="10"
   >
     <div
-      class="c3"
+      class="c2"
     >
       <div
-        class="c4"
+        class="c2 c4"
       >
         <div
-          class="c5"
+          class="c2 c5"
           margin="5px"
         >
           <label
             class="c6"
           >
             <div
-              class="c4"
+              class="c2 c4"
             >
               <div
-                class="c5"
+                class="c2 c5"
                 margin="5px"
               >
                 <input
@@ -222,10 +179,10 @@ exports[`ApplyOverridesGroup tests should render 1`] = `
             class="c6"
           >
             <div
-              class="c4"
+              class="c2 c4"
             >
               <div
-                class="c5"
+                class="c2 c5"
                 margin="5px"
               >
                 <input

--- a/src/web/components/powerfilter/__tests__/__snapshots__/booleanfiltergroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/booleanfiltergroup.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BooleanFilterGroup tests should render 1`] = `
-.c3 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,8 +10,8 @@ exports[`BooleanFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -20,51 +20,21 @@ exports[`BooleanFilterGroup tests should render 1`] = `
 }
 
 .c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   margin-left: -5px;
 }
 
-.c5 > * {
+.c5>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5 > * {
+.c5>* {
   margin-left: 5px;
 }
 
 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -81,8 +51,8 @@ exports[`BooleanFilterGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -98,22 +68,7 @@ exports[`BooleanFilterGroup tests should render 1`] = `
   margin-left: 0;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c3 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
@@ -159,8 +114,8 @@ exports[`BooleanFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -174,32 +129,34 @@ exports[`BooleanFilterGroup tests should render 1`] = `
   <label
     class="c1"
     data-testid="formgroup-title"
+    titleoffset="0"
+    titlesize="2"
   >
     foo
   </label>
   <div
-    class="c2"
+    class="c2 c3"
     data-testid="formgroup-content"
     size="10"
   >
     <div
-      class="c3"
+      class="c2"
     >
       <div
-        class="c4"
+        class="c2 c4"
       >
         <div
-          class="c5"
+          class="c2 c5"
           margin="5px"
         >
           <label
             class="c6"
           >
             <div
-              class="c4"
+              class="c2 c4"
             >
               <div
-                class="c5"
+                class="c2 c5"
                 margin="5px"
               >
                 <input
@@ -222,10 +179,10 @@ exports[`BooleanFilterGroup tests should render 1`] = `
             class="c6"
           >
             <div
-              class="c4"
+              class="c2 c4"
             >
               <div
-                class="c5"
+                class="c2 c5"
                 margin="5px"
               >
                 <input

--- a/src/web/components/powerfilter/__tests__/__snapshots__/createnamedfiltergroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/createnamedfiltergroup.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CreateNamedFilterGroup tests should render 1`] = `
-.c2 {
+.c0 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,50 +10,38 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c3 {
   margin-left: -5px;
 }
 
-.c2 > * {
+.c3>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2 > * {
+.c3>* {
   margin-left: 5px;
 }
 
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c9 {
+.c10 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -62,7 +50,7 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
   display: none;
 }
 
-.c7 {
+.c8 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -79,11 +67,11 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
   opacity: 0.65;
 }
 
-.c7:-webkit-autofill {
+.c8:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -92,8 +80,8 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -101,7 +89,7 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
   align-items: center;
 }
 
-.c3 {
+.c4 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -117,7 +105,7 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
   cursor: pointer;
 }
 
-.c4 {
+.c5 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -128,11 +116,11 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
   height: auto;
 }
 
-.c6 {
+.c7 {
   opacity: 1;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -141,8 +129,8 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -150,53 +138,38 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
   align-items: center;
 }
 
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c1 {
   margin-top: 15px;
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <div
-    class="c1"
+    class="c0 c2"
   >
     <div
-      class="c2"
+      class="c0 c3"
       margin="5px"
     >
       <label
-        class="c3"
+        class="c4"
       >
         <div
-          class="c1"
+          class="c0 c2"
         >
           <div
-            class="c2"
+            class="c0 c3"
             margin="5px"
           >
             <input
-              class="c4 c5"
+              class="c5 c6"
               data-testid="createnamedfiltergroup-checkbox"
               name="saveNamedFilter"
               type="checkbox"
             />
             <span
-              class="c6"
+              class="c7"
               data-testid="checkbox-title"
             >
               Store filter as: 
@@ -205,7 +178,7 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
         </div>
       </label>
       <input
-        class="c7 c8"
+        class="c8 c9"
         data-testid="createnamedfiltergroup-textfield"
         disabled=""
         maxlength="80"
@@ -216,7 +189,7 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
         value=""
       />
       <div
-        class="c9"
+        class="c10"
         data-testid="error-marker"
       >
         ×

--- a/src/web/components/powerfilter/__tests__/__snapshots__/filtersearchgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/filtersearchgroup.js.snap
@@ -1,6 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FilterSearchGroup tests should render 1`] = `
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -11,28 +29,10 @@ exports[`FilterSearchGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
 }
 
 .c4 {
@@ -71,8 +71,8 @@ exports[`FilterSearchGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -84,7 +84,7 @@ exports[`FilterSearchGroup tests should render 1`] = `
   class="c0"
 >
   <div
-    class="c1"
+    class="c1 "
     data-testid="formgroup-content"
   >
     <input

--- a/src/web/components/powerfilter/__tests__/__snapshots__/filterstringgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/filterstringgroup.js.snap
@@ -1,6 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FilterStringGroup tests should render 1`] = `
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -11,8 +29,8 @@ exports[`FilterStringGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -28,28 +46,13 @@ exports[`FilterStringGroup tests should render 1`] = `
   margin-left: 0;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c3 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c5 {
+.c6 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -58,7 +61,7 @@ exports[`FilterStringGroup tests should render 1`] = `
   display: none;
 }
 
-.c3 {
+.c4 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -72,11 +75,11 @@ exports[`FilterStringGroup tests should render 1`] = `
   padding: 1px 8px;
 }
 
-.c3:-webkit-autofill {
+.c4:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -89,8 +92,8 @@ exports[`FilterStringGroup tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -104,23 +107,25 @@ exports[`FilterStringGroup tests should render 1`] = `
   <label
     class="c1"
     data-testid="formgroup-title"
+    titleoffset="0"
+    titlesize="2"
   >
     Filter
   </label>
   <div
-    class="c2"
+    class="c2 c3"
     data-testid="formgroup-content"
     size="10"
   >
     <input
-      class="c3 c4"
+      class="c4 c5"
       name="name"
       size="30"
       type="text"
       value=""
     />
     <div
-      class="c5"
+      class="c6"
       data-testid="error-marker"
     >
       ×

--- a/src/web/components/powerfilter/__tests__/__snapshots__/firstresultgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/firstresultgroup.js.snap
@@ -1,6 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FirstresultGroup tests should render 1`] = `
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -11,8 +29,8 @@ exports[`FirstresultGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -28,28 +46,13 @@ exports[`FirstresultGroup tests should render 1`] = `
   margin-left: 0;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c3 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c3 {
+.c4 {
   border-radius: 2px;
   border: 1px solid #bfbfbf;
   background-color: #fff;
@@ -61,7 +64,7 @@ exports[`FirstresultGroup tests should render 1`] = `
   vertical-align: middle;
 }
 
-.c4 {
+.c5 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -73,46 +76,6 @@ exports[`FirstresultGroup tests should render 1`] = `
   vertical-align: middle;
   margin-left: 0.4em;
   margin-right: 22px;
-}
-
-.c5 {
-  background-color: #e5e5e5;
-  color: #7F7F7F;
-  border-left: 1px solid #4C4C4C;
-  width: 16px;
-  height: 50%;
-  font-size: 0.6em;
-  padding: 0;
-  margin: 0;
-  text-align: center;
-  vertical-align: middle;
-  position: absolute;
-  right: 0;
-  cursor: default;
-  display: block;
-  overflow: hidden;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  border-top-right-radius: 1px;
-  top: 0;
-}
-
-.c5:hover {
-  background-color: #11ab51;
-  color: #fff;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c5:active {
-  background-color: #fff;
-  color: #074320;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c6 {
@@ -137,8 +100,6 @@ exports[`FirstresultGroup tests should render 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  border-bottom-right-radius: 1px;
-  bottom: 0;
 }
 
 .c6:hover {
@@ -155,25 +116,37 @@ exports[`FirstresultGroup tests should render 1`] = `
   text-decoration: none;
 }
 
+.c7 {
+  border-top-right-radius: 1px;
+  top: 0;
+}
+
+.c8 {
+  border-bottom-right-radius: 1px;
+  bottom: 0;
+}
+
 <div
   class="c0"
 >
   <label
     class="c1"
     data-testid="formgroup-title"
+    titleoffset="0"
+    titlesize="2"
   >
     First result
   </label>
   <div
-    class="c2"
+    class="c2 c3"
     data-testid="formgroup-content"
     size="10"
   >
     <span
-      class="c3"
+      class="c4"
     >
       <input
-        class="c4"
+        class="c5"
         data-testid="spinner-input"
         maxlength="5"
         name="name"
@@ -181,13 +154,13 @@ exports[`FirstresultGroup tests should render 1`] = `
         value="1"
       />
       <span
-        class="c5"
+        class="c6 c7"
         data-testid="spinner-up"
       >
         ▲
       </span>
       <span
-        class="c6"
+        class="c6 c8"
         data-testid="spinner-down"
       >
         ▼

--- a/src/web/components/powerfilter/__tests__/__snapshots__/minqodgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/minqodgroup.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MinQodGroup tests should render 1`] = `
-.c4 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,43 +10,31 @@ exports[`MinQodGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c5 {
   margin-left: -5px;
 }
 
-.c4 > * {
+.c5>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4 > * {
+.c5>* {
   margin-left: 5px;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -63,8 +51,8 @@ exports[`MinQodGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -80,28 +68,13 @@ exports[`MinQodGroup tests should render 1`] = `
   margin-left: 0;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c3 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c5 {
+.c6 {
   border-radius: 2px;
   border: 1px solid #bfbfbf;
   background-color: #fff;
@@ -113,7 +86,7 @@ exports[`MinQodGroup tests should render 1`] = `
   vertical-align: middle;
 }
 
-.c6 {
+.c7 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -125,46 +98,6 @@ exports[`MinQodGroup tests should render 1`] = `
   vertical-align: middle;
   margin-left: 0.4em;
   margin-right: 22px;
-}
-
-.c7 {
-  background-color: #e5e5e5;
-  color: #7F7F7F;
-  border-left: 1px solid #4C4C4C;
-  width: 16px;
-  height: 50%;
-  font-size: 0.6em;
-  padding: 0;
-  margin: 0;
-  text-align: center;
-  vertical-align: middle;
-  position: absolute;
-  right: 0;
-  cursor: default;
-  display: block;
-  overflow: hidden;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  border-top-right-radius: 1px;
-  top: 0;
-}
-
-.c7:hover {
-  background-color: #11ab51;
-  color: #fff;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c7:active {
-  background-color: #fff;
-  color: #074320;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c8 {
@@ -189,8 +122,6 @@ exports[`MinQodGroup tests should render 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  border-bottom-right-radius: 1px;
-  bottom: 0;
 }
 
 .c8:hover {
@@ -207,35 +138,47 @@ exports[`MinQodGroup tests should render 1`] = `
   text-decoration: none;
 }
 
+.c9 {
+  border-top-right-radius: 1px;
+  top: 0;
+}
+
+.c10 {
+  border-bottom-right-radius: 1px;
+  bottom: 0;
+}
+
 <div
   class="c0"
 >
   <label
     class="c1"
     data-testid="formgroup-title"
+    titleoffset="0"
+    titlesize="2"
   >
     QoD
   </label>
   <div
-    class="c2"
+    class="c2 c3"
     data-testid="formgroup-content"
     size="10"
   >
     <div
-      class="c3"
+      class="c2 c4"
     >
       <div
-        class="c4"
+        class="c2 c5"
         margin="5px"
       >
         <span>
           must be at least
         </span>
         <span
-          class="c5"
+          class="c6"
         >
           <input
-            class="c6"
+            class="c7"
             data-testid="spinner-input"
             max="100"
             maxlength="5"
@@ -245,13 +188,13 @@ exports[`MinQodGroup tests should render 1`] = `
             value="20"
           />
           <span
-            class="c7"
+            class="c8 c9"
             data-testid="spinner-up"
           >
             ▲
           </span>
           <span
-            class="c8"
+            class="c8 c10"
             data-testid="spinner-down"
           >
             ▼

--- a/src/web/components/powerfilter/__tests__/__snapshots__/relationselector.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/relationselector.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Relation Selector Tests should render 1`] = `
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,8 +10,8 @@ exports[`Relation Selector Tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -19,7 +19,7 @@ exports[`Relation Selector Tests should render 1`] = `
   align-items: center;
 }
 
-.c5 {
+.c6 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -32,8 +32,8 @@ exports[`Relation Selector Tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -44,13 +44,13 @@ exports[`Relation Selector Tests should render 1`] = `
   cursor: pointer;
 }
 
-.c6 {
+.c7 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c7 * {
   height: inherit;
   width: inherit;
 }
@@ -91,15 +91,6 @@ exports[`Relation Selector Tests should render 1`] = `
   width: 180px;
 }
 
-.c7 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -117,6 +108,18 @@ exports[`Relation Selector Tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
+}
+
+.c8 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c4 {
   cursor: default;
 }
 
@@ -147,17 +150,17 @@ exports[`Relation Selector Tests should render 1`] = `
       type="button"
     >
       <div
-        class="c3"
+        class="c3 c4"
         data-testid="select-selected-value"
         title="is less than"
       >
         is less than
       </div>
       <div
-        class="c4"
+        class="c5"
       >
         <span
-          class="c5 c6"
+          class="c6 c7"
           data-testid="select-open-button"
         >
           ▼
@@ -166,7 +169,7 @@ exports[`Relation Selector Tests should render 1`] = `
     </div>
   </div>
   <div
-    class="c7"
+    class="c8"
     data-testid="error-marker"
   >
     ×
@@ -175,7 +178,7 @@ exports[`Relation Selector Tests should render 1`] = `
 `;
 
 exports[`Select component tests should render 1`] = `
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -184,8 +187,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -193,7 +196,7 @@ exports[`Select component tests should render 1`] = `
   align-items: center;
 }
 
-.c5 {
+.c6 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -206,8 +209,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -218,13 +221,13 @@ exports[`Select component tests should render 1`] = `
   cursor: pointer;
 }
 
-.c6 {
+.c7 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c7 * {
   height: inherit;
   width: inherit;
 }
@@ -266,15 +269,6 @@ exports[`Select component tests should render 1`] = `
   width: 180px;
 }
 
-.c7 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -292,6 +286,18 @@ exports[`Select component tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: default;
+}
+
+.c8 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c4 {
   cursor: default;
 }
 
@@ -323,15 +329,15 @@ exports[`Select component tests should render 1`] = `
       type="button"
     >
       <div
-        class="c3"
+        class="c3 c4"
         data-testid="select-selected-value"
         disabled=""
       />
       <div
-        class="c4"
+        class="c5"
       >
         <span
-          class="c5 c6"
+          class="c6 c7"
           data-testid="select-open-button"
         >
           ▼
@@ -340,7 +346,7 @@ exports[`Select component tests should render 1`] = `
     </div>
   </div>
   <div
-    class="c7"
+    class="c8"
     data-testid="error-marker"
   >
     ×

--- a/src/web/components/powerfilter/__tests__/__snapshots__/resultsperpagegroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/resultsperpagegroup.js.snap
@@ -1,6 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ResultsPerPageGroup tests should render 1`] = `
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -11,8 +29,8 @@ exports[`ResultsPerPageGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -28,28 +46,13 @@ exports[`ResultsPerPageGroup tests should render 1`] = `
   margin-left: 0;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c3 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c3 {
+.c4 {
   border-radius: 2px;
   border: 1px solid #bfbfbf;
   background-color: #fff;
@@ -61,7 +64,7 @@ exports[`ResultsPerPageGroup tests should render 1`] = `
   vertical-align: middle;
 }
 
-.c4 {
+.c5 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -73,46 +76,6 @@ exports[`ResultsPerPageGroup tests should render 1`] = `
   vertical-align: middle;
   margin-left: 0.4em;
   margin-right: 22px;
-}
-
-.c5 {
-  background-color: #e5e5e5;
-  color: #7F7F7F;
-  border-left: 1px solid #4C4C4C;
-  width: 16px;
-  height: 50%;
-  font-size: 0.6em;
-  padding: 0;
-  margin: 0;
-  text-align: center;
-  vertical-align: middle;
-  position: absolute;
-  right: 0;
-  cursor: default;
-  display: block;
-  overflow: hidden;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  border-top-right-radius: 1px;
-  top: 0;
-}
-
-.c5:hover {
-  background-color: #11ab51;
-  color: #fff;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c5:active {
-  background-color: #fff;
-  color: #074320;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c6 {
@@ -137,8 +100,6 @@ exports[`ResultsPerPageGroup tests should render 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  border-bottom-right-radius: 1px;
-  bottom: 0;
 }
 
 .c6:hover {
@@ -155,25 +116,37 @@ exports[`ResultsPerPageGroup tests should render 1`] = `
   text-decoration: none;
 }
 
+.c7 {
+  border-top-right-radius: 1px;
+  top: 0;
+}
+
+.c8 {
+  border-bottom-right-radius: 1px;
+  bottom: 0;
+}
+
 <div
   class="c0"
 >
   <label
     class="c1"
     data-testid="formgroup-title"
+    titleoffset="0"
+    titlesize="2"
   >
     Results per page
   </label>
   <div
-    class="c2"
+    class="c2 c3"
     data-testid="formgroup-content"
     size="10"
   >
     <span
-      class="c3"
+      class="c4"
     >
       <input
-        class="c4"
+        class="c5"
         data-testid="spinner-input"
         maxlength="5"
         name="name"
@@ -181,13 +154,13 @@ exports[`ResultsPerPageGroup tests should render 1`] = `
         value="10"
       />
       <span
-        class="c5"
+        class="c6 c7"
         data-testid="spinner-up"
       >
         ▲
       </span>
       <span
-        class="c6"
+        class="c6 c8"
         data-testid="spinner-down"
       >
         ▼

--- a/src/web/components/powerfilter/__tests__/__snapshots__/severitylevelsgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/severitylevelsgroup.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SeverityLevelsFilterGroup tests should render 1`] = `
-.c4 {
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,43 +10,31 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c5 {
   margin-left: -5px;
 }
 
-.c4 > * {
+.c5>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4 > * {
+.c5>* {
   margin-left: 5px;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -63,8 +51,8 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -80,28 +68,13 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   margin-left: 0;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c3 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c5 {
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -117,7 +90,7 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   cursor: pointer;
 }
 
-.c6 {
+.c7 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -128,7 +101,7 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   height: auto;
 }
 
-.c7 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -137,8 +110,8 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -146,7 +119,7 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   align-items: center;
 }
 
-.c8 {
+.c9 {
   text-align: center;
   font-weight: normal;
   font-style: normal;
@@ -160,7 +133,7 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   border-color: #C83814;
 }
 
-.c9 {
+.c10 {
   text-align: center;
   font-weight: normal;
   font-style: normal;
@@ -174,7 +147,7 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   border-color: #F0A519;
 }
 
-.c10 {
+.c11 {
   text-align: center;
   font-weight: normal;
   font-style: normal;
@@ -188,7 +161,7 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   border-color: #4F91C7;
 }
 
-.c11 {
+.c12 {
   text-align: center;
   font-weight: normal;
   font-style: normal;
@@ -208,39 +181,43 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   <label
     class="c1"
     data-testid="formgroup-title"
+    titleoffset="0"
+    titlesize="2"
   >
     Severity (Class)
   </label>
   <div
-    class="c2"
+    class="c2 c3"
     data-testid="formgroup-content"
     size="10"
   >
     <div
-      class="c3"
+      class="c2 c4"
     >
       <div
-        class="c4"
+        class="c2 c5"
         margin="5px"
       >
         <label
-          class="c5"
+          class="c6"
         >
           <div
-            class="c3"
+            class="c2 c4"
           >
             <div
-              class="c4"
+              class="c2 c5"
               margin="5px"
             >
               <input
                 checked=""
-                class="c6 c7"
+                class="c7 c8"
                 name="h"
                 type="checkbox"
               />
               <div
-                class="c8"
+                backgroundcolor="#C83814"
+                bordercolor="#C83814"
+                class="c9"
               >
                 High
               </div>
@@ -248,22 +225,24 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
           </div>
         </label>
         <label
-          class="c5"
+          class="c6"
         >
           <div
-            class="c3"
+            class="c2 c4"
           >
             <div
-              class="c4"
+              class="c2 c5"
               margin="5px"
             >
               <input
-                class="c6 c7"
+                class="c7 c8"
                 name="m"
                 type="checkbox"
               />
               <div
-                class="c9"
+                backgroundcolor="#F0A519"
+                bordercolor="#F0A519"
+                class="c10"
               >
                 Medium
               </div>
@@ -271,22 +250,24 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
           </div>
         </label>
         <label
-          class="c5"
+          class="c6"
         >
           <div
-            class="c3"
+            class="c2 c4"
           >
             <div
-              class="c4"
+              class="c2 c5"
               margin="5px"
             >
               <input
-                class="c6 c7"
+                class="c7 c8"
                 name="l"
                 type="checkbox"
               />
               <div
-                class="c10"
+                backgroundcolor="#4F91C7"
+                bordercolor="#4F91C7"
+                class="c11"
               >
                 Low
               </div>
@@ -294,22 +275,24 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
           </div>
         </label>
         <label
-          class="c5"
+          class="c6"
         >
           <div
-            class="c3"
+            class="c2 c4"
           >
             <div
-              class="c4"
+              class="c2 c5"
               margin="5px"
             >
               <input
-                class="c6 c7"
+                class="c7 c8"
                 name="g"
                 type="checkbox"
               />
               <div
-                class="c11"
+                backgroundcolor="#191919"
+                bordercolor="#191919"
+                class="c12"
               >
                 Log
               </div>
@@ -317,22 +300,24 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
           </div>
         </label>
         <label
-          class="c5"
+          class="c6"
         >
           <div
-            class="c3"
+            class="c2 c4"
           >
             <div
-              class="c4"
+              class="c2 c5"
               margin="5px"
             >
               <input
-                class="c6 c7"
+                class="c7 c8"
                 name="f"
                 type="checkbox"
               />
               <div
-                class="c11"
+                backgroundcolor="#191919"
+                bordercolor="#191919"
+                class="c12"
               >
                 False Pos.
               </div>

--- a/src/web/components/powerfilter/__tests__/__snapshots__/severityvaluesgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/severityvaluesgroup.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select component tests should render 1`] = `
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,8 +10,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -19,7 +19,7 @@ exports[`Select component tests should render 1`] = `
   align-items: center;
 }
 
-.c5 {
+.c6 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -32,8 +32,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -44,13 +44,13 @@ exports[`Select component tests should render 1`] = `
   cursor: pointer;
 }
 
-.c6 {
+.c7 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c7 * {
   height: inherit;
   width: inherit;
 }
@@ -92,15 +92,6 @@ exports[`Select component tests should render 1`] = `
   width: 180px;
 }
 
-.c7 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -118,6 +109,18 @@ exports[`Select component tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: default;
+}
+
+.c8 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c4 {
   cursor: default;
 }
 
@@ -149,15 +152,15 @@ exports[`Select component tests should render 1`] = `
       type="button"
     >
       <div
-        class="c3"
+        class="c3 c4"
         data-testid="select-selected-value"
         disabled=""
       />
       <div
-        class="c4"
+        class="c5"
       >
         <span
-          class="c5 c6"
+          class="c6 c7"
           data-testid="select-open-button"
         >
           ▼
@@ -166,7 +169,7 @@ exports[`Select component tests should render 1`] = `
     </div>
   </div>
   <div
-    class="c7"
+    class="c8"
     data-testid="error-marker"
   >
     ×
@@ -175,7 +178,25 @@ exports[`Select component tests should render 1`] = `
 `;
 
 exports[`Severity Values Group Tests should render 1`] = `
-.c9 {
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -184,8 +205,8 @@ exports[`Severity Values Group Tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -193,52 +214,22 @@ exports[`Severity Values Group Tests should render 1`] = `
   align-items: center;
 }
 
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c5 {
   margin-left: -5px;
 }
 
-.c4 > * {
+.c5>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4 > * {
+.c5>* {
   margin-left: 5px;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -255,8 +246,8 @@ exports[`Severity Values Group Tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -272,28 +263,13 @@ exports[`Severity Values Group Tests should render 1`] = `
   margin-left: 0;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c3 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c10 {
+.c12 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -306,8 +282,8 @@ exports[`Severity Values Group Tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -318,18 +294,18 @@ exports[`Severity Values Group Tests should render 1`] = `
   cursor: pointer;
 }
 
-.c11 {
+.c13 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c11 * {
+.c13 * {
   height: inherit;
   width: inherit;
 }
 
-.c7 {
+.c8 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -353,7 +329,7 @@ exports[`Severity Values Group Tests should render 1`] = `
   font-weight: normal;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -365,16 +341,7 @@ exports[`Severity Values Group Tests should render 1`] = `
   width: 180px;
 }
 
-.c12 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -391,10 +358,22 @@ exports[`Severity Values Group Tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
+}
+
+.c14 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c10 {
   cursor: default;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -407,52 +386,54 @@ exports[`Severity Values Group Tests should render 1`] = `
   <label
     class="c1"
     data-testid="formgroup-title"
+    titleoffset="0"
+    titlesize="2"
   >
     foo
   </label>
   <div
-    class="c2"
+    class="c2 c3"
     data-testid="formgroup-content"
     size="10"
   >
     <div
-      class="c3"
+      class="c2 c4"
     >
       <div
-        class="c4"
+        class="c2 c5"
         margin="5px"
       >
         <div
           aria-expanded="false"
           aria-haspopup="listbox"
           aria-labelledby="downshift-8-label"
-          class="c5"
+          class="c6"
           role="combobox"
         >
           <div
-            class="c6"
+            class="c7"
             width="180px"
           >
             <div
               aria-haspopup="true"
               aria-label="open menu"
-              class="c7"
+              class="c8"
               data-toggle="true"
               role="button"
               type="button"
             >
               <div
-                class="c8"
+                class="c9 c10"
                 data-testid="select-selected-value"
                 title="is greater than"
               >
                 is greater than
               </div>
               <div
-                class="c9"
+                class="c11"
               >
                 <span
-                  class="c10 c11"
+                  class="c12 c13"
                   data-testid="select-open-button"
                 >
                   ▼
@@ -461,7 +442,7 @@ exports[`Severity Values Group Tests should render 1`] = `
             </div>
           </div>
           <div
-            class="c12"
+            class="c14"
             data-testid="error-marker"
           >
             ×

--- a/src/web/components/powerfilter/__tests__/__snapshots__/solutiontypegroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/solutiontypegroup.js.snap
@@ -1,7 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SolutionTypesFilterGroup tests should render 1`] = `
-.c5 {
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,8 +28,8 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -19,65 +37,35 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   align-items: stretch;
 }
 
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c9 {
   margin-left: -5px;
 }
 
-.c8 > * {
+.c9>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c8 > * {
+.c9>* {
   margin-left: 5px;
 }
 
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c8 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c11 {
+.c12 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c11 * {
+.c12 * {
   height: inherit;
   width: inherit;
 }
@@ -92,8 +80,8 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -109,28 +97,13 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   margin-left: 0;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c3 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c4 {
+.c5 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -139,7 +112,7 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   width: 100%;
 }
 
-.c6 {
+.c7 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -155,7 +128,7 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   cursor: pointer;
 }
 
-.c9 {
+.c10 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -166,7 +139,7 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   height: auto;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -175,8 +148,8 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -184,22 +157,7 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   align-items: center;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   -webkit-box-flex: 0;
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
@@ -207,7 +165,7 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
 }
 
 @media print {
-  .c4 {
+  .c5 {
     border-collapse: collapse;
   }
 }
@@ -218,19 +176,21 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   <label
     class="c1"
     data-testid="formgroup-title"
+    titleoffset="0"
+    titlesize="2"
   >
     Solution Type
   </label>
   <div
-    class="c2"
+    class="c2 c3"
     data-testid="formgroup-content"
     size="10"
   >
     <div
-      class="c3"
+      class="c2 c4"
     >
       <table
-        class="c4"
+        class="c5"
       >
         <tbody
           class=""
@@ -238,25 +198,24 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c5"
+                class="c6"
               >
                 <label
-                  class="c6"
+                  class="c7"
                 >
                   <div
-                    class="c7"
+                    class="c2 c8"
                   >
                     <div
-                      class="c8"
+                      class="c2 c9"
                       margin="5px"
                     >
                       <input
                         checked=""
-                        class="c9 c10"
+                        class="c10 c11"
                         data-testid="radio-input"
                         name="All"
                         type="radio"
-                        value=""
                       />
                       <span>
                         All
@@ -268,28 +227,27 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c5"
+                class="c6"
               >
                 <label
-                  class="c6"
+                  class="c7"
                 >
                   <div
-                    class="c7"
+                    class="c2 c8"
                   >
                     <div
-                      class="c8"
+                      class="c2 c9"
                       margin="5px"
                     >
                       <input
-                        class="c9 c10"
+                        class="c10 c11"
                         data-testid="radio-input"
                         name="Workaround"
                         type="radio"
-                        value=""
                       />
                       <span
                         alt="Workaround"
-                        class="c11"
+                        class="c12"
                         data-testid="svg-icon"
                         title="Workaround"
                       >
@@ -309,28 +267,27 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c5"
+                class="c6"
               >
                 <label
-                  class="c6"
+                  class="c7"
                 >
                   <div
-                    class="c7"
+                    class="c2 c8"
                   >
                     <div
-                      class="c8"
+                      class="c2 c9"
                       margin="5px"
                     >
                       <input
-                        class="c9 c10"
+                        class="c10 c11"
                         data-testid="radio-input"
                         name="Mitigation"
                         type="radio"
-                        value=""
                       />
                       <span
                         alt="Mitigation"
-                        class="c11"
+                        class="c12"
                         data-testid="svg-icon"
                         title="Mitigation"
                       >
@@ -352,28 +309,27 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c5"
+                class="c6"
               >
                 <label
-                  class="c6"
+                  class="c7"
                 >
                   <div
-                    class="c7"
+                    class="c2 c8"
                   >
                     <div
-                      class="c8"
+                      class="c2 c9"
                       margin="5px"
                     >
                       <input
-                        class="c9 c10"
+                        class="c10 c11"
                         data-testid="radio-input"
                         name="VendorFix"
                         type="radio"
-                        value=""
                       />
                       <span
                         alt="Vendorfix"
-                        class="c11"
+                        class="c12"
                         data-testid="svg-icon"
                         title="Vendorfix"
                       >
@@ -393,28 +349,27 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c5"
+                class="c6"
               >
                 <label
-                  class="c6"
+                  class="c7"
                 >
                   <div
-                    class="c7"
+                    class="c2 c8"
                   >
                     <div
-                      class="c8"
+                      class="c2 c9"
                       margin="5px"
                     >
                       <input
-                        class="c9 c10"
+                        class="c10 c11"
                         data-testid="radio-input"
                         name="NoneAvailable"
                         type="radio"
-                        value=""
                       />
                       <span
                         alt="None available"
-                        class="c11"
+                        class="c12"
                         data-testid="svg-icon"
                         title="None available"
                       >
@@ -434,28 +389,27 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c5"
+                class="c6"
               >
                 <label
-                  class="c6"
+                  class="c7"
                 >
                   <div
-                    class="c7"
+                    class="c2 c8"
                   >
                     <div
-                      class="c8"
+                      class="c2 c9"
                       margin="5px"
                     >
                       <input
-                        class="c9 c10"
+                        class="c10 c11"
                         data-testid="radio-input"
                         name="WillNotFix"
                         type="radio"
-                        value=""
                       />
                       <span
                         alt="Will not fix"
-                        class="c11"
+                        class="c12"
                         data-testid="svg-icon"
                         title="Will not fix"
                       >

--- a/src/web/components/powerfilter/__tests__/__snapshots__/sortbygroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/sortbygroup.js.snap
@@ -1,7 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SortByGroup tests should render 1`] = `
-.c7 {
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,8 +28,8 @@ exports[`SortByGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -19,52 +37,22 @@ exports[`SortByGroup tests should render 1`] = `
   align-items: center;
 }
 
-.c13 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c15 {
   margin-left: -5px;
 }
 
-.c13 > * {
+.c15>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c13 > * {
+.c15>* {
   margin-left: 5px;
 }
 
-.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -81,8 +69,8 @@ exports[`SortByGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -98,28 +86,13 @@ exports[`SortByGroup tests should render 1`] = `
   margin-left: 0;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c3 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c8 {
+.c10 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -132,8 +105,8 @@ exports[`SortByGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -144,18 +117,18 @@ exports[`SortByGroup tests should render 1`] = `
   cursor: pointer;
 }
 
-.c9 {
+.c11 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c9 * {
+.c11 * {
   height: inherit;
   width: inherit;
 }
 
-.c5 {
+.c6 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -179,7 +152,7 @@ exports[`SortByGroup tests should render 1`] = `
   font-weight: normal;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -191,16 +164,7 @@ exports[`SortByGroup tests should render 1`] = `
   width: 180px;
 }
 
-.c10 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -217,17 +181,29 @@ exports[`SortByGroup tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
+}
+
+.c12 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c8 {
   cursor: default;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c11 {
+.c13 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -243,7 +219,7 @@ exports[`SortByGroup tests should render 1`] = `
   cursor: pointer;
 }
 
-.c14 {
+.c16 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -254,11 +230,11 @@ exports[`SortByGroup tests should render 1`] = `
   height: auto;
 }
 
-.c16 {
+.c18 {
   opacity: 1;
 }
 
-.c15 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -267,8 +243,8 @@ exports[`SortByGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -282,11 +258,13 @@ exports[`SortByGroup tests should render 1`] = `
   <label
     class="c1"
     data-testid="formgroup-title"
+    titleoffset="0"
+    titlesize="2"
   >
     Sort by
   </label>
   <div
-    class="c2"
+    class="c2 c3"
     data-testid="formgroup-content"
     size="10"
   >
@@ -294,30 +272,30 @@ exports[`SortByGroup tests should render 1`] = `
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-labelledby="downshift-0-label"
-      class="c3"
+      class="c4"
       role="combobox"
     >
       <div
-        class="c4"
+        class="c5"
         width="180px"
       >
         <div
           aria-haspopup="true"
           aria-label="open menu"
-          class="c5"
+          class="c6"
           data-toggle="true"
           role="button"
           type="button"
         >
           <div
-            class="c6"
+            class="c7 c8"
             data-testid="select-selected-value"
           />
           <div
-            class="c7"
+            class="c9"
           >
             <span
-              class="c8 c9"
+              class="c10 c11"
               data-testid="select-open-button"
             >
               ▼
@@ -326,32 +304,32 @@ exports[`SortByGroup tests should render 1`] = `
         </div>
       </div>
       <div
-        class="c10"
+        class="c12"
         data-testid="error-marker"
       >
         ×
       </div>
     </div>
     <label
-      class="c11"
+      class="c13"
     >
       <div
-        class="c12"
+        class="c2 c14"
       >
         <div
-          class="c13"
+          class="c2 c15"
           margin="5px"
         >
           <input
             checked=""
-            class="c14 c15"
+            class="c16 c17"
             data-testid="radio-input"
             name="sort_order"
             type="radio"
             value="sort"
           />
           <span
-            class="c16"
+            class="c18"
             data-testid="radio-title"
           >
             Ascending
@@ -360,24 +338,24 @@ exports[`SortByGroup tests should render 1`] = `
       </div>
     </label>
     <label
-      class="c11"
+      class="c13"
     >
       <div
-        class="c12"
+        class="c2 c14"
       >
         <div
-          class="c13"
+          class="c2 c15"
           margin="5px"
         >
           <input
-            class="c14 c15"
+            class="c16 c17"
             data-testid="radio-input"
             name="sort_order"
             type="radio"
             value="sort-reverse"
           />
           <span
-            class="c16"
+            class="c18"
             data-testid="radio-title"
           >
             Descending

--- a/src/web/components/powerfilter/__tests__/__snapshots__/tasktrendgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/tasktrendgroup.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select component tests should render 1`] = `
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,8 +10,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -19,7 +19,7 @@ exports[`Select component tests should render 1`] = `
   align-items: center;
 }
 
-.c5 {
+.c6 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -32,8 +32,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -44,13 +44,13 @@ exports[`Select component tests should render 1`] = `
   cursor: pointer;
 }
 
-.c6 {
+.c7 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c7 * {
   height: inherit;
   width: inherit;
 }
@@ -92,15 +92,6 @@ exports[`Select component tests should render 1`] = `
   width: 180px;
 }
 
-.c7 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -118,6 +109,18 @@ exports[`Select component tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: default;
+}
+
+.c8 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c4 {
   cursor: default;
 }
 
@@ -149,15 +152,15 @@ exports[`Select component tests should render 1`] = `
       type="button"
     >
       <div
-        class="c3"
+        class="c3 c4"
         data-testid="select-selected-value"
         disabled=""
       />
       <div
-        class="c4"
+        class="c5"
       >
         <span
-          class="c5 c6"
+          class="c6 c7"
           data-testid="select-open-button"
         >
           ▼
@@ -166,7 +169,7 @@ exports[`Select component tests should render 1`] = `
     </div>
   </div>
   <div
-    class="c7"
+    class="c8"
     data-testid="error-marker"
   >
     ×
@@ -175,7 +178,25 @@ exports[`Select component tests should render 1`] = `
 `;
 
 exports[`Task Trend Selector Tests should render 1`] = `
-.c7 {
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -184,8 +205,8 @@ exports[`Task Trend Selector Tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -203,8 +224,8 @@ exports[`Task Trend Selector Tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -220,28 +241,13 @@ exports[`Task Trend Selector Tests should render 1`] = `
   margin-left: 0;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c3 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c8 {
+.c10 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -254,8 +260,8 @@ exports[`Task Trend Selector Tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -266,18 +272,18 @@ exports[`Task Trend Selector Tests should render 1`] = `
   cursor: pointer;
 }
 
-.c9 {
+.c11 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c9 * {
+.c11 * {
   height: inherit;
   width: inherit;
 }
 
-.c5 {
+.c6 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -301,7 +307,7 @@ exports[`Task Trend Selector Tests should render 1`] = `
   font-weight: normal;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -313,16 +319,7 @@ exports[`Task Trend Selector Tests should render 1`] = `
   width: 180px;
 }
 
-.c10 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -339,10 +336,22 @@ exports[`Task Trend Selector Tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
+}
+
+.c12 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c8 {
   cursor: default;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -355,11 +364,13 @@ exports[`Task Trend Selector Tests should render 1`] = `
   <label
     class="c1"
     data-testid="formgroup-title"
+    titleoffset="0"
+    titlesize="2"
   >
     Trend
   </label>
   <div
-    class="c2"
+    class="c2 c3"
     data-testid="formgroup-content"
     size="10"
   >
@@ -367,33 +378,33 @@ exports[`Task Trend Selector Tests should render 1`] = `
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-labelledby="downshift-8-label"
-      class="c3"
+      class="c4"
       role="combobox"
     >
       <div
-        class="c4"
+        class="c5"
         width="180px"
       >
         <div
           aria-haspopup="true"
           aria-label="open menu"
-          class="c5"
+          class="c6"
           data-toggle="true"
           role="button"
           type="button"
         >
           <div
-            class="c6"
+            class="c7 c8"
             data-testid="select-selected-value"
             title="Severity decreased"
           >
             Severity decreased
           </div>
           <div
-            class="c7"
+            class="c9"
           >
             <span
-              class="c8 c9"
+              class="c10 c11"
               data-testid="select-open-button"
             >
               ▼
@@ -402,7 +413,7 @@ exports[`Task Trend Selector Tests should render 1`] = `
         </div>
       </div>
       <div
-        class="c10"
+        class="c12"
         data-testid="error-marker"
       >
         ×

--- a/src/web/components/powerfilter/__tests__/__snapshots__/ticketstatusgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/ticketstatusgroup.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Select component tests should render 1`] = `
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,8 +10,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -19,7 +19,7 @@ exports[`Select component tests should render 1`] = `
   align-items: center;
 }
 
-.c5 {
+.c6 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -32,8 +32,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -44,13 +44,13 @@ exports[`Select component tests should render 1`] = `
   cursor: pointer;
 }
 
-.c6 {
+.c7 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c7 * {
   height: inherit;
   width: inherit;
 }
@@ -92,15 +92,6 @@ exports[`Select component tests should render 1`] = `
   width: 180px;
 }
 
-.c7 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
 .c3 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -118,6 +109,18 @@ exports[`Select component tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: default;
+}
+
+.c8 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c4 {
   cursor: default;
 }
 
@@ -149,15 +152,15 @@ exports[`Select component tests should render 1`] = `
       type="button"
     >
       <div
-        class="c3"
+        class="c3 c4"
         data-testid="select-selected-value"
         disabled=""
       />
       <div
-        class="c4"
+        class="c5"
       >
         <span
-          class="c5 c6"
+          class="c6 c7"
           data-testid="select-open-button"
         >
           ▼
@@ -166,7 +169,7 @@ exports[`Select component tests should render 1`] = `
     </div>
   </div>
   <div
-    class="c7"
+    class="c8"
     data-testid="error-marker"
   >
     ×
@@ -175,7 +178,25 @@ exports[`Select component tests should render 1`] = `
 `;
 
 exports[`TicketStatusGroup tests should render 1`] = `
-.c7 {
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -184,8 +205,8 @@ exports[`TicketStatusGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -203,8 +224,8 @@ exports[`TicketStatusGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -220,28 +241,13 @@ exports[`TicketStatusGroup tests should render 1`] = `
   margin-left: 0;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c3 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c8 {
+.c10 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -254,8 +260,8 @@ exports[`TicketStatusGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -266,18 +272,18 @@ exports[`TicketStatusGroup tests should render 1`] = `
   cursor: pointer;
 }
 
-.c9 {
+.c11 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c9 * {
+.c11 * {
   height: inherit;
   width: inherit;
 }
 
-.c5 {
+.c6 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -301,7 +307,7 @@ exports[`TicketStatusGroup tests should render 1`] = `
   font-weight: normal;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -313,16 +319,7 @@ exports[`TicketStatusGroup tests should render 1`] = `
   width: 180px;
 }
 
-.c10 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -339,10 +336,22 @@ exports[`TicketStatusGroup tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
+}
+
+.c12 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c8 {
   cursor: default;
 }
 
-.c3 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -355,11 +364,13 @@ exports[`TicketStatusGroup tests should render 1`] = `
   <label
     class="c1"
     data-testid="formgroup-title"
+    titleoffset="0"
+    titlesize="2"
   >
     Ticket Status
   </label>
   <div
-    class="c2"
+    class="c2 c3"
     data-testid="formgroup-content"
     size="10"
   >
@@ -367,33 +378,33 @@ exports[`TicketStatusGroup tests should render 1`] = `
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-labelledby="downshift-8-label"
-      class="c3"
+      class="c4"
       role="combobox"
     >
       <div
-        class="c4"
+        class="c5"
         width="180px"
       >
         <div
           aria-haspopup="true"
           aria-label="open menu"
-          class="c5"
+          class="c6"
           data-toggle="true"
           role="button"
           type="button"
         >
           <div
-            class="c6"
+            class="c7 c8"
             data-testid="select-selected-value"
             title="Closed"
           >
             Closed
           </div>
           <div
-            class="c7"
+            class="c9"
           >
             <span
-              class="c8 c9"
+              class="c10 c11"
               data-testid="select-open-button"
             >
               ▼
@@ -402,7 +413,7 @@ exports[`TicketStatusGroup tests should render 1`] = `
         </div>
       </div>
       <div
-        class="c10"
+        class="c12"
         data-testid="error-marker"
       >
         ×

--- a/src/web/components/snackbar/__tests__/__snapshots__/snackbar.js.snap
+++ b/src/web/components/snackbar/__tests__/__snapshots__/snackbar.js.snap
@@ -17,8 +17,8 @@ exports[`Snackbar tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: space-around;
-  -webkit-justify-content: space-around;
   -ms-flex-pack: space-around;
+  -webkit-justify-content: space-around;
   justify-content: space-around;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -32,8 +32,8 @@ exports[`Snackbar tests should render 1`] = `
   background-color: #4C4C4C;
   color: #fff;
   font-family: Trebuchet MS,Tahoma,Verdana,Arial,sans-serif;
-  -webkit-animation: hRwsCZ 5s ease-in-out;
-  animation: hRwsCZ 5s ease-in-out;
+  -webkit-animation: dHXyTQ 5s ease-in-out;
+  animation: dHXyTQ 5s ease-in-out;
 }
 
 <span>

--- a/src/web/components/structure/__tests__/__snapshots__/header.js.snap
+++ b/src/web/components/structure/__tests__/__snapshots__/header.js.snap
@@ -10,8 +10,8 @@ exports[`Header tests should render header 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -40,7 +40,6 @@ exports[`Header tests should render header 1`] = `
   display: flex;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/structure/__tests__/__snapshots__/main.js.snap
+++ b/src/web/components/structure/__tests__/__snapshots__/main.js.snap
@@ -16,8 +16,8 @@ exports[`Main tests should render main 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 

--- a/src/web/components/table/__tests__/__snapshots__/detailstable.js.snap
+++ b/src/web/components/table/__tests__/__snapshots__/detailstable.js.snap
@@ -10,8 +10,8 @@ exports[`DetailsTable tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;

--- a/src/web/entities/__tests__/__snapshots__/tagsdialog.js.snap
+++ b/src/web/entities/__tests__/__snapshots__/tagsdialog.js.snap
@@ -1,11 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TagsDialog dialog component tests should disable tag selection when no options available 1`] = `
-<body>
-  <div
-    id="portals"
-  >
-    .c8 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -14,31 +49,13 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
 }
 
 .c13 {
@@ -50,28 +67,16 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-left: -5px;
 }
 
-.c13 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c13 > * {
-  margin-left: 5px;
-}
-
-.c12 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -79,31 +84,70 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c16 {
+  margin-left: -5px;
+}
+
+.c16>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c22 {
+.c16>* {
+  margin-left: 5px;
+}
+
+.c15 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c27 {
   cursor: pointer;
 }
 
-.c23 {
+.c28 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c23 * {
+.c28 * {
   height: inherit;
   width: inherit;
 }
@@ -133,7 +177,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -141,7 +185,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   height: 100%;
 }
 
-.c29 {
+.c36 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -150,13 +194,13 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   border-top: 20px solid #fff;
 }
 
-.c28 {
+.c35 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -175,7 +219,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -192,30 +236,30 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c25 {
+.c32 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -235,12 +279,12 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   z-index: 1;
 }
 
-.c25:focus,
-.c25:hover {
+.c32:focus,
+.c32:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c25:hover {
+.c32:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -248,26 +292,26 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   color: #fff;
 }
 
-.c25[disabled] {
+.c32[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c25 img {
+.c32 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c25:link {
+.c32:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c26 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -276,8 +320,8 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -285,63 +329,32 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   align-items: center;
 }
 
-.c27 {
+.c34 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c27:hover {
+.c34 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c30 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c31 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -355,17 +368,15 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -373,31 +384,12 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -407,13 +399,13 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   max-width: 100%;
   font-weight: bold;
@@ -424,28 +416,13 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   margin-left: 0;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   width: 66.66666667%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c19 {
+.c23 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -458,8 +435,8 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -470,18 +447,18 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   cursor: pointer;
 }
 
-.c20 {
+.c24 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c20 * {
+.c24 * {
   height: inherit;
   width: inherit;
 }
 
-.c16 {
+.c19 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -506,7 +483,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   background-color: #f3f3f3;
 }
 
-.c15 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -518,16 +495,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   width: 230px;
 }
 
-.c21 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c17 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -544,10 +512,22 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   white-space: nowrap;
   overflow: hidden;
   cursor: default;
+}
+
+.c25 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c21 {
   cursor: default;
 }
 
-.c14 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -555,12 +535,16 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
 }
 
 @media print {
-  .c22 {
+  .c26 {
     display: none;
   }
 }
 
-<div>
+<body>
+  <div
+    id="portals"
+  >
+    <div>
       <div
         class="c0"
       >
@@ -575,14 +559,14 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 Add Tag
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -590,66 +574,69 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="4"
                     >
                       Choose Tag
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="8"
                     >
                       <div
-                        class="c12"
+                        class="c13 c15"
                       >
                         <div
-                          class="c13"
+                          class="c13 c16"
                           margin="5px"
                         >
                           <div
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="downshift-1-label"
-                            class="c14"
+                            class="c17"
                             role="combobox"
                           >
                             <div
-                              class="c15"
+                              class="c18"
                               width="230px"
                             >
                               <div
                                 aria-haspopup="true"
                                 aria-label="open menu"
-                                class="c16"
+                                class="c19"
                                 data-toggle="true"
                                 disabled=""
                                 role="button"
                                 type="button"
                               >
                                 <div
-                                  class="c17"
+                                  class="c20 c21"
                                   data-testid="select-selected-value"
                                   disabled=""
                                 />
                                 <div
-                                  class="c18"
+                                  class="c22"
                                 >
                                   <span
-                                    class="c19 c20"
+                                    class="c23 c24"
                                     data-testid="select-open-button"
                                   >
                                     ▼
@@ -658,14 +645,14 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
                               </div>
                             </div>
                             <div
-                              class="c21"
+                              class="c25"
                               data-testid="error-marker"
                             >
                               ×
                             </div>
                           </div>
                           <span
-                            class="c22 c23"
+                            class="c26 c27 c28"
                             data-testid="svg-icon"
                             title="Create a new Tag"
                           >
@@ -680,31 +667,35 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="4"
                     >
                       Value
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="8"
                     />
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="4"
                     >
                       Comment
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="8"
                     />
@@ -713,17 +704,17 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
               </div>
             </div>
             <div
-              class="c24"
+              class="c29 c30 c31"
             >
               <button
-                class="c25 c26 c27"
+                class="c32 c33 c34"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c25 c26 c27"
+                class="c32 c33 c34"
                 data-testid="dialog-save-button"
                 title="Add Tag"
               >
@@ -732,10 +723,10 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
             </div>
           </div>
           <div
-            class="c28"
+            class="c35"
           >
             <div
-              class="c29"
+              class="c36"
             />
           </div>
         </div>
@@ -747,7 +738,46 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
 `;
 
 exports[`TagsDialog dialog component tests should render dialog 1`] = `
-.c8 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -756,31 +786,13 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
 }
 
 .c13 {
@@ -792,28 +804,16 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-left: -5px;
 }
 
-.c13 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c13 > * {
-  margin-left: 5px;
-}
-
-.c12 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -821,31 +821,70 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c16 {
+  margin-left: -5px;
+}
+
+.c16>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c22 {
+.c16>* {
+  margin-left: 5px;
+}
+
+.c15 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c27 {
   cursor: pointer;
 }
 
-.c23 {
+.c28 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c23 * {
+.c28 * {
   height: inherit;
   width: inherit;
 }
@@ -875,7 +914,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -883,7 +922,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   height: 100%;
 }
 
-.c29 {
+.c36 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -892,13 +931,13 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c28 {
+.c35 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -917,7 +956,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -934,30 +973,30 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c25 {
+.c32 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -977,12 +1016,12 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   z-index: 1;
 }
 
-.c25:focus,
-.c25:hover {
+.c32:focus,
+.c32:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c25:hover {
+.c32:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -990,26 +1029,26 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   color: #fff;
 }
 
-.c25[disabled] {
+.c32[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c25 img {
+.c32 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c25:link {
+.c32:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c26 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1018,8 +1057,8 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1027,63 +1066,32 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c27 {
+.c34 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c27:hover {
+.c34 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c30 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c31 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -1097,17 +1105,15 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -1115,31 +1121,12 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1149,13 +1136,13 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   max-width: 100%;
   font-weight: bold;
@@ -1166,28 +1153,13 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   margin-left: 0;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   width: 66.66666667%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c19 {
+.c23 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -1200,8 +1172,8 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -1212,18 +1184,18 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   cursor: pointer;
 }
 
-.c20 {
+.c24 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c20 * {
+.c24 * {
   height: inherit;
   width: inherit;
 }
 
-.c16 {
+.c19 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -1247,7 +1219,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   font-weight: normal;
 }
 
-.c15 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1259,16 +1231,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   width: 230px;
 }
 
-.c21 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c17 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1285,10 +1248,22 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
+}
+
+.c25 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c21 {
   cursor: default;
 }
 
-.c14 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1296,7 +1271,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
 }
 
 @media print {
-  .c22 {
+  .c26 {
     display: none;
   }
 }
@@ -1320,14 +1295,14 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 Add Tag
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -1335,64 +1310,67 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="4"
                     >
                       Choose Tag
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="8"
                     >
                       <div
-                        class="c12"
+                        class="c13 c15"
                       >
                         <div
-                          class="c13"
+                          class="c13 c16"
                           margin="5px"
                         >
                           <div
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="downshift-0-label"
-                            class="c14"
+                            class="c17"
                             role="combobox"
                           >
                             <div
-                              class="c15"
+                              class="c18"
                               width="230px"
                             >
                               <div
                                 aria-haspopup="true"
                                 aria-label="open menu"
-                                class="c16"
+                                class="c19"
                                 data-toggle="true"
                                 role="button"
                                 type="button"
                               >
                                 <div
-                                  class="c17"
+                                  class="c20 c21"
                                   data-testid="select-selected-value"
                                 />
                                 <div
-                                  class="c18"
+                                  class="c22"
                                 >
                                   <span
-                                    class="c19 c20"
+                                    class="c23 c24"
                                     data-testid="select-open-button"
                                   >
                                     ▼
@@ -1401,14 +1379,14 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
                               </div>
                             </div>
                             <div
-                              class="c21"
+                              class="c25"
                               data-testid="error-marker"
                             >
                               ×
                             </div>
                           </div>
                           <span
-                            class="c22 c23"
+                            class="c26 c27 c28"
                             data-testid="svg-icon"
                             title="Create a new Tag"
                           >
@@ -1423,31 +1401,35 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="4"
                     >
                       Value
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="8"
                     />
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="4"
                     >
                       Comment
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="8"
                     />
@@ -1456,17 +1438,17 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c24"
+              class="c29 c30 c31"
             >
               <button
-                class="c25 c26 c27"
+                class="c32 c33 c34"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c25 c26 c27"
+                class="c32 c33 c34"
                 data-testid="dialog-save-button"
                 title="Add Tag"
               >
@@ -1475,10 +1457,10 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
             </div>
           </div>
           <div
-            class="c28"
+            class="c35"
           >
             <div
-              class="c29"
+              class="c36"
             />
           </div>
         </div>

--- a/src/web/pages/audits/__tests__/__snapshots__/actions.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/actions.js.snap
@@ -14,47 +14,13 @@ exports[`Audit Actions tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c2 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c2 > * {
-  margin-left: 5px;
 }
 
 .c1 {
@@ -70,40 +36,80 @@ exports[`Audit Actions tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c4 {
+  margin-left: -5px;
+}
+
+.c4>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c3 {
+.c4>* {
+  margin-left: 5px;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
   cursor: pointer;
 }
 
-.c5 svg path {
+.c8 svg path {
   fill: #bfbfbf;
 }
 
-.c4 {
+.c7 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c4 * {
+.c7 * {
   height: inherit;
   width: inherit;
 }
 
 @media print {
-  .c3 {
+  .c5 {
     display: none;
   }
 }
@@ -118,14 +124,14 @@ exports[`Audit Actions tests should render 1`] = `
         class="c0"
       >
         <div
-          class="c1"
+          class="c1 c2"
         >
           <div
-            class="c2"
+            class="c3 c4"
             margin="5px"
           >
             <span
-              class="c3 c4"
+              class="c5 c6 c7"
               data-testid="svg-icon"
               title="Start"
             >
@@ -137,7 +143,7 @@ exports[`Audit Actions tests should render 1`] = `
             </span>
             <span
               alt="Resume"
-              class="c5 c4"
+              class="c5 c8 c7"
               data-testid="svg-icon"
               title="Audit is not stopped"
             >
@@ -148,7 +154,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c3 c4"
+              class="c5 c6 c7"
               data-testid="svg-icon"
               title="Move Audit to trashcan"
             >
@@ -159,7 +165,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c3 c4"
+              class="c5 c6 c7"
               data-testid="svg-icon"
               title="Edit Audit"
             >
@@ -170,7 +176,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c3 c4"
+              class="c5 c6 c7"
               data-testid="svg-icon"
               title="Clone Audit"
             >
@@ -181,7 +187,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c3 c4"
+              class="c5 c6 c7"
               data-testid="svg-icon"
               title="Export Audit"
             >
@@ -192,7 +198,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c3 c4"
+              class="c5 c6 c7"
               data-testid="svg-icon"
               title="Download Greenbone Compliance Report"
             >

--- a/src/web/pages/audits/__tests__/__snapshots__/details.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/details.js.snap
@@ -14,8 +14,8 @@ exports[`Audit Details tests should render full audit details 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -32,50 +32,13 @@ exports[`Audit Details tests should render full audit details 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-.c2 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c4 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4 > * {
-  margin-left: 5px;
 }
 
 .c3 {
@@ -87,20 +50,45 @@ exports[`Audit Details tests should render full audit details 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c6 {
+.c5 {
+  margin-left: -5px;
+}
+
+.c5>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c5>* {
+  margin-left: 5px;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c7 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -109,29 +97,29 @@ exports[`Audit Details tests should render full audit details 1`] = `
   width: 100%;
 }
 
-.c5 > *:not(:last-child)::after {
+.c6>*:not(:last-child)::after {
   content: '•';
   margin-left: 5px;
 }
 
-.c7 td {
+.c8 td {
   padding: 4px 4px 4px 0;
 }
 
-.c7 tr td:first-child {
+.c8 tr td:first-child {
   padding-right: 5px;
 }
 
-.c8 {
+.c9 {
   width: 10%;
 }
 
-.c9 {
+.c10 {
   width: 90%;
 }
 
 @media print {
-  .c6 {
+  .c7 {
     border-collapse: collapse;
   }
 }
@@ -163,10 +151,10 @@ exports[`Audit Details tests should render full audit details 1`] = `
     </h2>
     <div>
       <div
-        class="c3"
+        class="c3 c4"
       >
         <div
-          class="c4 c5"
+          class="c3 c5 c6"
           margin="5px"
         >
           <span>
@@ -190,15 +178,15 @@ exports[`Audit Details tests should render full audit details 1`] = `
     </h2>
     <div>
       <table
-        class="c6 c7"
+        class="c7 c8"
       >
         <colgroup>
           <col
-            class="c8"
+            class="c9"
             width="10%"
           />
           <col
-            class="c9"
+            class="c10"
             width="90%"
           />
         </colgroup>
@@ -257,15 +245,15 @@ exports[`Audit Details tests should render full audit details 1`] = `
     </h2>
     <div>
       <table
-        class="c6 c7"
+        class="c7 c8"
       >
         <colgroup>
           <col
-            class="c8"
+            class="c9"
             width="10%"
           />
           <col
-            class="c9"
+            class="c10"
             width="90%"
           />
         </colgroup>
@@ -300,15 +288,15 @@ exports[`Audit Details tests should render full audit details 1`] = `
     </h2>
     <div>
       <table
-        class="c6 c7"
+        class="c7 c8"
       >
         <colgroup>
           <col
-            class="c8"
+            class="c9"
             width="10%"
           />
           <col
-            class="c9"
+            class="c10"
             width="90%"
           />
         </colgroup>

--- a/src/web/pages/audits/__tests__/__snapshots__/detailspage.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/detailspage.js.snap
@@ -14,8 +14,8 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
@@ -29,12 +29,64 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
 .c18 {
@@ -45,9 +97,26 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -55,7 +124,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   align-items: center;
 }
 
-.c19 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -64,12 +133,12 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
-.c21 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -82,27 +151,9 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c23 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -114,17 +165,21 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
 .c28 {
@@ -132,12 +187,48 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c31 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c33 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -145,216 +236,89 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c6 {
+.c9 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -10px;
-}
-
-.c3 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c3 > * {
-  margin-left: 10px;
 }
 
 .c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  margin-left: -10px;
+}
+
+.c4>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4>* {
+  margin-left: 10px;
+}
+
+.c6 {
   margin-left: -5px;
 }
 
-.c4 > * {
+.c6>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4 > * {
+.c6>* {
   margin-left: 5px;
 }
 
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c7 > * {
+.c3 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c7 > * {
-  margin-left: 5px;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c8 {
+.c10 {
   cursor: pointer;
 }
 
-.c9 svg path {
+.c11 svg path {
   fill: #bfbfbf;
 }
 
-.c5 {
+.c8 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c5 * {
+.c8 * {
   height: inherit;
   width: inherit;
 }
 
-.c16 {
+.c20 {
   height: 50px;
   width: 50px;
   line-height: 50px;
 }
 
-.c16 * {
+.c20 * {
   height: inherit;
   width: inherit;
 }
 
-.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+.c15 {
   margin: 10px 0px;
   padding-bottom: 1px;
   border-bottom: 2px solid #e5e5e5;
   position: relative;
 }
 
-.c13 {
+.c16 {
   margin: 0 0 1px 0;
-}
-
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  margin-right: 5px;
 }
 
 .c17 {
@@ -366,18 +330,25 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c19 {
+  margin-right: 5px;
+}
+
+.c21 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c24 {
+.c29 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -404,11 +375,11 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #11ab51;
 }
 
-.c24:first-child {
+.c29 :first-child {
   border-left: 1px solid #e5e5e5;
 }
 
-.c25 {
+.c30 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -432,40 +403,21 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #fff;
 }
 
-.c25:hover {
+.c30 :hover {
   border-top: 2px solid #e5e5e5;
 }
 
-.c25:first-child {
+.c30 :first-child {
   border-left: 1px solid #fff;
 }
 
-.c22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+.c27 {
   border-bottom: 2px solid #11ab51;
   margin-top: 30px;
   margin-bottom: 15px;
 }
 
-.c29 {
+.c34 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -473,7 +425,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   table-layout: auto;
 }
 
-.c39 {
+.c44 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -482,61 +434,46 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   width: 100%;
 }
 
-.c38 > *:not(:last-child)::after {
+.c43>*:not(:last-child)::after {
   content: '•';
   margin-left: 5px;
 }
 
-.c30 td {
+.c35 td {
   padding: 4px 4px 4px 0;
 }
 
-.c30 tr td:first-child {
+.c35 tr td:first-child {
   padding-right: 5px;
 }
 
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c24 {
   border-spacing: 0px;
   color: #7F7F7F;
   font-size: 10px;
 }
 
-.c20 :nth-child(even) {
+.c24 :nth-child(even) {
   margin-left: 3px;
 }
 
-.c20 :nth-child(odd) {
+.c24 :nth-child(odd) {
   margin-left: 30px;
 }
 
-.c31 {
+.c36 {
   width: 10%;
 }
 
-.c32 {
+.c37 {
   width: 90%;
 }
 
-.c27 {
+.c32 {
   font-size: 0.7em;
 }
 
-.c34 {
+.c39 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -546,7 +483,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   text-align: center;
 }
 
-.c36 {
+.c41 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -557,22 +494,22 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   padding-top: 1px;
 }
 
-.c35 {
+.c40 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
 }
 
-.c37 {
+.c42 {
   white-space: nowrap;
 }
 
-.c33:hover {
+.c38:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c10 {
+.c12 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -581,7 +518,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   margin-right: 0px;
 }
 
-.c11 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -589,12 +526,13 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -618,38 +556,38 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
 }
 
 @media print {
-  .c8 {
+  .c7 {
     display: none;
   }
 }
 
 @media print {
-  .c29 {
+  .c34 {
+    border-collapse: collapse;
+  }
+}
+
+@media print {
+  .c44 {
     border-collapse: collapse;
   }
 }
 
 @media print {
   .c39 {
-    border-collapse: collapse;
-  }
-}
-
-@media print {
-  .c34 {
     background: none;
     border: 0;
   }
 }
 
 @media print {
-  .c36 {
+  .c41 {
     color: black;
   }
 }
 
 @media print {
-  .c35 {
+  .c40 {
     background: none;
   }
 }
@@ -661,17 +599,17 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
     class="c1 toolbar"
   >
     <div
-      class="c2"
+      class="c2 c3"
     >
       <div
-        class="c3"
+        class="c2 c4"
         margin="10px"
       >
         <div
-          class="c2"
+          class="c2 c3"
         >
           <div
-            class="c4"
+            class="c5 c6"
             margin="5px"
           >
             <a
@@ -680,8 +618,9 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               target="_blank"
             >
               <span
-                class="c5"
+                class="c7 c8"
                 data-testid="svg-icon"
+                iconsize="small"
                 title="Help: Audits"
               >
                 <svg
@@ -692,12 +631,13 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <a
-              class="c6"
+              class="c9"
               href="/audits"
             >
               <span
-                class="c5"
+                class="c7 c8"
                 data-testid="svg-icon"
+                iconsize="small"
                 title="Audit List"
               >
                 <svg
@@ -708,8 +648,9 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <span
-              class="c5"
+              class="c7 c8"
               data-testid="svg-icon"
+              iconsize="small"
               title="This is an Alterable Audit. Reports may not relate to current Policy or Target!"
             >
               <svg
@@ -721,15 +662,16 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
           </div>
         </div>
         <div
-          class="c2"
+          class="c2 c3"
         >
           <div
-            class="c7"
+            class="c2 c6"
             margin="5px"
           >
             <span
-              class="c8 c5"
+              class="c7 c10 c8"
               data-testid="svg-icon"
+              iconsize="small"
               title="Clone Audit"
             >
               <svg
@@ -739,8 +681,9 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c8 c5"
+              class="c7 c10 c8"
               data-testid="svg-icon"
+              iconsize="small"
               title="Edit Audit"
             >
               <svg
@@ -750,8 +693,9 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c8 c5"
+              class="c7 c10 c8"
               data-testid="svg-icon"
+              iconsize="small"
               title="Move Audit to trashcan"
             >
               <svg
@@ -761,8 +705,9 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c8 c5"
+              class="c7 c10 c8"
               data-testid="svg-icon"
+              iconsize="small"
               title="Export Audit as XML"
             >
               <svg
@@ -774,15 +719,16 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
           </div>
         </div>
         <div
-          class="c2"
+          class="c2 c3"
         >
           <div
-            class="c7"
+            class="c2 c6"
             margin="5px"
           >
             <span
-              class="c8 c5"
+              class="c7 c10 c8"
               data-testid="svg-icon"
+              iconsize="small"
               title="Start"
             >
               <svg
@@ -793,8 +739,9 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </span>
             <span
               alt="Resume"
-              class="c9 c5"
+              class="c7 c11 c8"
               data-testid="svg-icon"
+              iconsize="small"
               title="Audit is not stopped"
             >
               <svg
@@ -806,28 +753,29 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
           </div>
         </div>
         <div
-          class="c2"
+          class="c2 c3"
         >
           <div
-            class="c3"
+            class="c2 c4"
             margin="10px"
           >
             <div
-              class="c2"
+              class="c2 c3"
             >
               <div
-                class="c7"
+                class="c2 c6"
                 margin="5px"
               >
                 <a
-                  class="c6"
+                  class="c9"
                   data-testid="details-link"
                   href="/report/1234"
                   title="Last Report for Audit foo from 07/30/2019"
                 >
                   <span
-                    class="c5"
+                    class="c7 c8"
                     data-testid="svg-icon"
+                    iconsize="small"
                   >
                     <svg>
                       report.svg
@@ -835,24 +783,27 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   </span>
                 </a>
                 <a
-                  class="c6"
+                  class="c9"
                   href="/reports?filter=task_id%3D12345"
                   title="Total Reports for Audit foo"
                 >
                   <div
-                    class="c10"
+                    class="c12"
+                    margin="0"
                   >
                     <span
-                      class="c5"
+                      class="c7 c8"
                       data-testid="svg-icon"
+                      iconsize="small"
                     >
                       <svg>
                         report.svg
                       </svg>
                     </span>
                     <span
-                      class="c11"
+                      class="c13"
                       data-testid="badge-icon"
+                      margin="0"
                     >
                       1
                     </span>
@@ -861,24 +812,27 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </div>
             </div>
             <a
-              class="c6"
+              class="c9"
               href="/results?filter=task_id%3D12345"
               title="Results for Audit foo"
             >
               <div
-                class="c10"
+                class="c12"
+                margin="0"
               >
                 <span
-                  class="c5"
+                  class="c7 c8"
                   data-testid="svg-icon"
+                  iconsize="small"
                 >
                   <svg>
                     result.svg
                   </svg>
                 </span>
                 <span
-                  class="c11"
+                  class="c13"
                   data-testid="badge-icon"
+                  margin="0"
                 >
                   1
                 </span>
@@ -893,16 +847,16 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
     class="entity-section"
   >
     <div
-      class="c12 section-header"
+      class="c14 c15 section-header"
     >
       <h2
-        class="c13 c14"
+        class="c16 c17"
       >
         <div
-          class="c15"
+          class="c18 c19"
         >
           <span
-            class="c16"
+            class="c7 c20"
             data-testid="svg-icon"
           >
             <svg>
@@ -911,19 +865,19 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
           </span>
         </div>
         <div
-          class="c17"
+          class="c18 c21"
         >
           Audit: foo
         </div>
       </h2>
       <div
-        class="c18"
+        class="c22"
       >
         <div
-          class="c19"
+          class="c23"
         >
           <div
-            class="c20"
+            class="c2 c24"
           >
             <div>
               ID:
@@ -954,30 +908,30 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
       </div>
     </div>
     <div
-      class="c21"
+      class="c25"
     >
       <div
-        class="c22"
+        class="c26 c27"
       >
         <div
-          class="c23"
+          class="c28"
         >
           <div
-            class="c24"
+            class="c29"
           >
             Information
           </div>
           <div
-            class="c25"
+            class="c30"
           >
             <div
-              class="c26"
+              class="c31"
             >
               <span>
                 Permissions
               </span>
               <span
-                class="c27"
+                class="c32"
               >
                 (
                 <i>
@@ -990,18 +944,18 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
         </div>
       </div>
       <div
-        class="c28"
+        class="c33"
       >
         <table
-          class="c29 c30"
+          class="c34 c35"
         >
           <colgroup>
             <col
-              class="c31"
+              class="c36"
               width="10%"
             />
             <col
-              class="c32"
+              class="c37"
               width="90%"
             />
           </colgroup>
@@ -1011,14 +965,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c28"
+                  class="c33"
                 >
                   Name
                 </div>
               </td>
               <td>
                 <div
-                  class="c28"
+                  class="c33"
                 >
                   foo
                 </div>
@@ -1027,14 +981,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c28"
+                  class="c33"
                 >
                   Comment
                 </div>
               </td>
               <td>
                 <div
-                  class="c28"
+                  class="c33"
                 >
                   bar
                 </div>
@@ -1043,14 +997,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c28"
+                  class="c33"
                 >
                   Alterable
                 </div>
               </td>
               <td>
                 <div
-                  class="c28"
+                  class="c33"
                 >
                   Yes
                 </div>
@@ -1059,34 +1013,37 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c28"
+                  class="c33"
                 >
                   Status
                 </div>
               </td>
               <td>
                 <div
-                  class="c28"
+                  class="c33"
                 >
                   <a
-                    class="c6 c33"
+                    class="c9 c38"
                     data-testid="details-link"
                     href="/report/1234"
                   >
                     <div
-                      class="c34"
+                      boxbackground="#4C4C4C"
+                      class="c39"
                       data-testid="progressbar-box"
                       title="Done"
                     >
                       <div
-                        class="c35"
+                        background="low"
+                        class="c40"
                         data-testid="progress"
+                        progress="100"
                       />
                       <div
-                        class="c36"
+                        class="c41"
                       >
                         <span
-                          class="c37"
+                          class="c42"
                         >
                           Done
                         </span>
@@ -1099,17 +1056,17 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
           </tbody>
         </table>
         <div
-          class="c21"
+          class="c25"
         >
           <div
-            class="c28"
+            class="c33"
           >
             <h2>
               Target
             </h2>
             <div>
               <a
-                class="c6"
+                class="c9"
                 data-testid="details-link"
                 href="/target/5678"
               >
@@ -1118,22 +1075,22 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c28"
+            class="c33"
           >
             <h2>
               Alerts
             </h2>
             <div>
               <div
-                class="c2"
+                class="c2 c3"
               >
                 <div
-                  class="c7 c38"
+                  class="c2 c6 c43"
                   margin="5px"
                 >
                   <span>
                     <a
-                      class="c6"
+                      class="c9"
                       data-testid="details-link"
                       href="/alert/91011"
                     >
@@ -1145,22 +1102,22 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c28"
+            class="c33"
           >
             <h2>
               Scanner
             </h2>
             <div>
               <table
-                class="c39 c30"
+                class="c44 c35"
               >
                 <colgroup>
                   <col
-                    class="c31"
+                    class="c36"
                     width="10%"
                   />
                   <col
-                    class="c32"
+                    class="c37"
                     width="90%"
                   />
                 </colgroup>
@@ -1170,18 +1127,18 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c28"
+                        class="c33"
                       >
                         Name
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c28"
+                        class="c33"
                       >
                         <span>
                           <a
-                            class="c6"
+                            class="c9"
                             data-testid="details-link"
                             href="/scanner/1516"
                           >
@@ -1194,14 +1151,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c28"
+                        class="c33"
                       >
                         Type
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c28"
+                        class="c33"
                       >
                         OpenVAS Scanner
                       </div>
@@ -1212,22 +1169,22 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c28"
+            class="c33"
           >
             <h2>
               Assets
             </h2>
             <div>
               <table
-                class="c39 c30"
+                class="c44 c35"
               >
                 <colgroup>
                   <col
-                    class="c31"
+                    class="c36"
                     width="10%"
                   />
                   <col
-                    class="c32"
+                    class="c37"
                     width="90%"
                   />
                 </colgroup>
@@ -1237,14 +1194,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c28"
+                        class="c33"
                       >
                         Add to Assets
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c28"
+                        class="c33"
                       >
                         Yes
                       </div>
@@ -1255,22 +1212,22 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c28"
+            class="c33"
           >
             <h2>
               Scan
             </h2>
             <div>
               <table
-                class="c39 c30"
+                class="c44 c35"
               >
                 <colgroup>
                   <col
-                    class="c31"
+                    class="c36"
                     width="10%"
                   />
                   <col
-                    class="c32"
+                    class="c37"
                     width="90%"
                   />
                 </colgroup>
@@ -1280,14 +1237,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c28"
+                        class="c33"
                       >
                         Duration of last Scan
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c28"
+                        class="c33"
                       >
                         2 minutes
                       </div>
@@ -1296,14 +1253,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c28"
+                        class="c33"
                       >
                         Auto delete Reports
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c28"
+                        class="c33"
                       >
                         Do not automatically delete reports
                       </div>
@@ -1321,103 +1278,6 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
 `;
 
 exports[`Audit ToolBarIcons tests should render 1`] = `
-.c4 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -10px;
-}
-
-.c1 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 > * {
-  margin-left: 10px;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  margin-left: -5px;
-}
-
-.c2 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c2 > * {
-  margin-left: 5px;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c5 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c5 > * {
-  margin-left: 5px;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1427,39 +1287,97 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c7 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c6 {
+.c2 {
+  margin-left: -10px;
+}
+
+.c2>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c2>* {
+  margin-left: 10px;
+}
+
+.c4 {
+  margin-left: -5px;
+}
+
+.c4>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4>* {
+  margin-left: 5px;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c8 {
   cursor: pointer;
 }
 
-.c7 svg path {
+.c9 svg path {
   fill: #bfbfbf;
 }
 
-.c3 {
+.c6 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c3 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c8 {
+.c10 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1468,7 +1386,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
   margin-right: 0px;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1476,12 +1394,13 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -1505,23 +1424,23 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
 }
 
 @media print {
-  .c6 {
+  .c5 {
     display: none;
   }
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <div
-    class="c1"
+    class="c0 c2"
     margin="10px"
   >
     <div
-      class="c0"
+      class="c0 c1"
     >
       <div
-        class="c2"
+        class="c3 c4"
         margin="5px"
       >
         <a
@@ -1530,7 +1449,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           target="_blank"
         >
           <span
-            class="c3"
+            class="c5 c6"
             data-testid="svg-icon"
             title="Help: Audits"
           >
@@ -1542,11 +1461,11 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <a
-          class="c4"
+          class="c7"
           href="/audits"
         >
           <span
-            class="c3"
+            class="c5 c6"
             data-testid="svg-icon"
             title="Audit List"
           >
@@ -1558,7 +1477,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <span
-          class="c3"
+          class="c5 c6"
           data-testid="svg-icon"
           title="This is an Alterable Audit. Reports may not relate to current Policy or Target!"
         >
@@ -1571,14 +1490,14 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
       </div>
     </div>
     <div
-      class="c0"
+      class="c0 c1"
     >
       <div
-        class="c5"
+        class="c0 c4"
         margin="5px"
       >
         <span
-          class="c6 c3"
+          class="c5 c8 c6"
           data-testid="svg-icon"
           title="Clone Audit"
         >
@@ -1589,7 +1508,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c6 c3"
+          class="c5 c8 c6"
           data-testid="svg-icon"
           title="Edit Audit"
         >
@@ -1600,7 +1519,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c6 c3"
+          class="c5 c8 c6"
           data-testid="svg-icon"
           title="Move Audit to trashcan"
         >
@@ -1611,7 +1530,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c6 c3"
+          class="c5 c8 c6"
           data-testid="svg-icon"
           title="Export Audit as XML"
         >
@@ -1624,14 +1543,14 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
       </div>
     </div>
     <div
-      class="c0"
+      class="c0 c1"
     >
       <div
-        class="c5"
+        class="c0 c4"
         margin="5px"
       >
         <span
-          class="c6 c3"
+          class="c5 c8 c6"
           data-testid="svg-icon"
           title="Start"
         >
@@ -1643,7 +1562,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
         </span>
         <span
           alt="Resume"
-          class="c7 c3"
+          class="c5 c9 c6"
           data-testid="svg-icon"
           title="Audit is not stopped"
         >
@@ -1656,27 +1575,27 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
       </div>
     </div>
     <div
-      class="c0"
+      class="c0 c1"
     >
       <div
-        class="c1"
+        class="c0 c2"
         margin="10px"
       >
         <div
-          class="c0"
+          class="c0 c1"
         >
           <div
-            class="c5"
+            class="c0 c4"
             margin="5px"
           >
             <a
-              class="c4"
+              class="c7"
               data-testid="details-link"
               href="/report/1234"
               title="Last Report for Audit foo from 07/30/2019"
             >
               <span
-                class="c3"
+                class="c5 c6"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -1685,15 +1604,16 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
               </span>
             </a>
             <a
-              class="c4"
+              class="c7"
               href="/reports?filter=task_id%3D12345"
               title="Total Reports for Audit foo"
             >
               <div
-                class="c8"
+                class="c10"
+                margin="0"
               >
                 <span
-                  class="c3"
+                  class="c5 c6"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -1701,8 +1621,9 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c9"
+                  class="c11"
                   data-testid="badge-icon"
+                  margin="0"
                 >
                   1
                 </span>
@@ -1711,15 +1632,16 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </div>
         </div>
         <a
-          class="c4"
+          class="c7"
           href="/results?filter=task_id%3D12345"
           title="Results for Audit foo"
         >
           <div
-            class="c8"
+            class="c10"
+            margin="0"
           >
             <span
-              class="c3"
+              class="c5 c6"
               data-testid="svg-icon"
             >
               <svg>
@@ -1727,8 +1649,9 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c9"
+              class="c11"
               data-testid="badge-icon"
+              margin="0"
             >
               1
             </span>

--- a/src/web/pages/audits/__tests__/__snapshots__/listpage.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/listpage.js.snap
@@ -1,36 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AuditPage ToolBarIcons test should render 1`] = `
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c1 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 > * {
-  margin-left: 5px;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -40,30 +10,48 @@ exports[`AuditPage ToolBarIcons test should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c2 {
+  margin-left: -5px;
+}
+
+.c2>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c3 {
+.c2>* {
+  margin-left: 5px;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c5 {
   cursor: pointer;
 }
 
-.c2 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c2 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
@@ -75,10 +63,10 @@ exports[`AuditPage ToolBarIcons test should render 1`] = `
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <div
-    class="c1"
+    class="c0 c2"
     margin="5px"
   >
     <a
@@ -87,7 +75,7 @@ exports[`AuditPage ToolBarIcons test should render 1`] = `
       target="_blank"
     >
       <span
-        class="c2"
+        class="c3 c4"
         data-testid="svg-icon"
         title="Help: Audits"
       >
@@ -99,7 +87,7 @@ exports[`AuditPage ToolBarIcons test should render 1`] = `
       </span>
     </a>
     <span
-      class="c3 c2"
+      class="c3 c5 c4"
       data-testid="svg-icon"
       title="New Audit"
     >
@@ -127,8 +115,8 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -146,7 +134,6 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -154,7 +141,25 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: flex-start;
 }
 
-.c6 {
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -167,12 +172,12 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
   -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
   justify-content: flex-end;
 }
 
-.c7 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -181,8 +186,8 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: stetch;
   -webkit-box-align: stetch;
@@ -190,7 +195,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: stetch;
 }
 
-.c8 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -200,7 +205,6 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -217,8 +221,8 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -226,7 +230,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c20 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -235,318 +239,13 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.c30 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c39 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c43 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c44 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c45 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c57 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c47 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c3 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c3 > * {
-  margin-left: 5px;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c9 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c9 > * {
-  margin-left: 5px;
-}
-
-.c56 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c56 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c56 > * {
-  margin-left: 5px;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c55 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c5 {
-  cursor: pointer;
-}
-
-.c33 svg path {
-  fill: #bfbfbf;
-}
-
-.c4 {
-  height: 16px;
-  width: 16px;
-  line-height: 16px;
-}
-
-.c4 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c27 {
-  height: 50px;
-  width: 50px;
-  line-height: 50px;
-}
-
-.c27 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c23 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  margin: 10px 0px;
-  padding-bottom: 1px;
-  border-bottom: 2px solid #e5e5e5;
-  position: relative;
-}
-
-.c24 {
-  margin: 0 0 1px 0;
 }
 
 .c25 {
@@ -557,17 +256,16 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
-.c26 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -576,14 +274,207 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
   align-items: flex-end;
-  margin-right: 5px;
+}
+
+.c34 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+
+.c36 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c49 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+}
+
+.c50 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c51 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+
+.c61 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c62 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c53 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4 {
+  margin-left: -5px;
+}
+
+.c4>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4>* {
+  margin-left: 5px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c7 {
+  cursor: pointer;
+}
+
+.c38 svg path {
+  fill: #bfbfbf;
+}
+
+.c6 {
+  height: 16px;
+  width: 16px;
+  line-height: 16px;
+}
+
+.c6 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c31 {
+  height: 50px;
+  width: 50px;
+  line-height: 50px;
+}
+
+.c31 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c26 {
+  margin: 10px 0px;
+  padding-bottom: 1px;
+  border-bottom: 2px solid #e5e5e5;
+  position: relative;
+}
+
+.c27 {
+  margin: 0 0 1px 0;
 }
 
 .c28 {
@@ -595,18 +486,25 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c30 {
+  margin-right: 5px;
+}
+
+.c32 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c21 {
+.c23 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -619,8 +517,8 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -631,18 +529,18 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   cursor: pointer;
 }
 
-.c22 {
+.c24 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c22 * {
+.c24 * {
   height: inherit;
   width: inherit;
 }
 
-.c18 {
+.c19 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -666,7 +564,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   font-weight: normal;
 }
 
-.c17 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -678,7 +576,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 150px;
 }
 
-.c58 {
+.c63 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -690,16 +588,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 180px;
 }
 
-.c15 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c19 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -716,33 +605,68 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
-  cursor: default;
 }
 
 .c16 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c21 {
+  cursor: default;
+}
+
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c36 a {
+.c40 {
+  border: 0;
+  border-spacing: 0px;
+  font-size: 12px;
+  text-align: left;
+  table-layout: auto;
+  width: 100%;
+}
+
+.c41 th,
+.c41 td {
+  padding: 4px 10px;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.c41 tfoot tr {
+  background: #fff;
+}
+
+.c41 tfoot tr td {
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.c43 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c36 a:hover {
+.c43 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c38 {
+.c45 {
   cursor: pointer;
 }
 
-.c37 {
+.c44 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -750,7 +674,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 52%;
 }
 
-.c40 {
+.c46 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -758,7 +682,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 8%;
 }
 
-.c41 {
+.c47 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -766,7 +690,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 24%;
 }
 
-.c42 {
+.c48 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -774,7 +698,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 10em;
 }
 
-.c13 {
+.c14 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -788,11 +712,11 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   padding: 1px 8px;
 }
 
-.c13:-webkit-autofill {
+.c14:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -801,133 +725,64 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c13 {
+  margin-right: 5px;
 }
 
 .c12 {
   margin-right: 5px;
 }
 
-.c10 {
-  margin-right: 5px;
-}
-
-.c59 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c64 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c34 {
+.c39 {
   margin: 0 3px;
 }
 
-.c32 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c37 {
   margin: 2px 3px;
 }
 
-.c35 {
-  border: 0;
-  border-spacing: 0px;
-  font-size: 12px;
-  text-align: left;
-  table-layout: auto;
-  width: 100%;
+.c42 {
   opacity: 1.0;
 }
 
-.c35 th,
-.c35 td {
-  padding: 4px 10px;
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c35 tfoot tr {
-  background: #fff;
-}
-
-.c35 tfoot tr td {
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c31 {
+.c35 {
   margin-top: 2px;
   margin-left: 2px;
 }
 
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+.c33 {
   margin-top: 20px;
 }
 
-.c46 {
+.c52 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c46:hover {
+.c52 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
-.c49 {
+.c55 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -937,7 +792,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   text-align: center;
 }
 
-.c53 {
+.c59 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -947,7 +802,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   text-align: center;
 }
 
-.c51 {
+.c57 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -958,23 +813,23 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   padding-top: 1px;
 }
 
-.c50 {
+.c56 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
 }
 
-.c54 {
+.c60 {
   height: 13px;
   width: 50%;
   background: #70c000;
 }
 
-.c52 {
+.c58 {
   white-space: nowrap;
 }
 
-.c48:hover {
+.c54:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -986,12 +841,30 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
 }
 
 @media print {
-  .c36 {
+  .c40 {
+    border-collapse: collapse;
+  }
+}
+
+@media screen {
+  .c41>tbody:nth-of-type(even),
+  .c41>tbody:only-of-type>tr:nth-of-type(even) {
+    background: #f3f3f3;
+  }
+
+  .c41>tbody:not(:only-of-type):hover,
+  .c41>tbody:only-of-type>tr:hover {
+    background: #e5e5e5;
+  }
+}
+
+@media print {
+  .c43 {
     border-bottom: 1px solid black;
   }
 
-  .c36 a,
-  .c36 a:hover {
+  .c43 a,
+  .c43 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -999,99 +872,81 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
 }
 
 @media print {
-  .c37 {
+  .c44 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
     font-weight: bold;
-  }
-}
-
-@media print {
-  .c40 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: none;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c41 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: none;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c42 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: none;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c32 svg {
-    display: none;
-  }
-}
-
-@media print {
-  .c35 {
-    border-collapse: collapse;
-  }
-}
-
-@media screen {
-  .c35 > tbody:nth-of-type(even),
-  .c35 > tbody:only-of-type > tr:nth-of-type(even) {
-    background: #f3f3f3;
-  }
-
-  .c35 > tbody:not(:only-of-type):hover,
-  .c35 > tbody:only-of-type > tr:hover {
-    background: #e5e5e5;
   }
 }
 
 @media print {
   .c46 {
     color: #000;
+    font-size: 1.2em;
+    background-color: none;
+    font-weight: bold;
   }
 }
 
 @media print {
-  .c49 {
+  .c47 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: none;
+    font-weight: bold;
+  }
+}
+
+@media print {
+  .c48 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: none;
+    font-weight: bold;
+  }
+}
+
+@media print {
+  .c37 svg {
+    display: none;
+  }
+}
+
+@media print {
+  .c52 {
+    color: #000;
+  }
+}
+
+@media print {
+  .c55 {
     background: none;
     border: 0;
   }
 }
 
 @media print {
-  .c53 {
+  .c59 {
     background: none;
     border: 0;
   }
 }
 
 @media print {
-  .c51 {
+  .c57 {
     color: black;
   }
 }
 
 @media print {
-  .c50 {
+  .c56 {
     background: none;
   }
 }
 
 @media print {
-  .c54 {
+  .c60 {
     background: none;
   }
 }
@@ -1108,10 +963,10 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
         class="c1 toolbar"
       >
         <div
-          class="c2"
+          class="c2 c3"
         >
           <div
-            class="c3"
+            class="c2 c4"
             margin="5px"
           >
             <a
@@ -1120,8 +975,9 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               target="_blank"
             >
               <span
-                class="c4"
+                class="c5 c6"
                 data-testid="svg-icon"
+                iconsize="small"
                 title="Help: Audits"
               >
                 <svg
@@ -1132,8 +988,9 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               </span>
             </a>
             <span
-              class="c5 c4"
+              class="c5 c7 c6"
               data-testid="svg-icon"
+              iconsize="small"
               title="New Audit"
             >
               <svg
@@ -1145,33 +1002,33 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
           </div>
         </div>
         <div
-          class="c6"
+          class="c8"
         >
           <div
-            class="c7 powerfilter"
+            class="c9 powerfilter"
           >
             <div
-              class="c8"
+              class="c10"
             >
               <div
-                class="c2"
+                class="c2 c3"
               >
                 <div
-                  class="c9 c10"
+                  class="c11 c4 c12"
                   margin="5px"
                 >
                   <div
                     class="c11"
                   >
                     <label
-                      class="c12"
+                      class="c13"
                     >
                       <b>
                         Filter
                       </b>
                     </label>
                     <input
-                      class="c13 c14"
+                      class="c14 c15"
                       maxlength="1000"
                       name="userFilterString"
                       size="53"
@@ -1179,22 +1036,23 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       value=""
                     />
                     <div
-                      class="c15"
+                      class="c16"
                       data-testid="error-marker"
                     >
                       ×
                     </div>
                   </div>
                   <div
-                    class="c2"
+                    class="c2 c3"
                   >
                     <div
-                      class="c9"
+                      class="c11 c4"
                       margin="5px"
                     >
                       <span
-                        class="c5 c4"
+                        class="c5 c7 c6"
                         data-testid="svg-icon"
+                        iconsize="small"
                         title="Update Filter"
                       >
                         <svg
@@ -1204,8 +1062,9 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c4"
+                        class="c5 c7 c6"
                         data-testid="svg-icon"
+                        iconsize="small"
                         title="Remove Filter"
                       >
                         <svg
@@ -1215,8 +1074,9 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c4"
+                        class="c5 c7 c6"
                         data-testid="svg-icon"
+                        iconsize="small"
                         title="Reset to Default Filter"
                       >
                         <svg
@@ -1231,8 +1091,9 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                         target="_blank"
                       >
                         <span
-                          class="c4"
+                          class="c5 c6"
                           data-testid="svg-icon"
+                          iconsize="small"
                           title="Help: Powerfilter"
                         >
                           <svg
@@ -1250,35 +1111,36 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="downshift-0-label"
-                class="c16"
+                class="c17"
                 role="combobox"
               >
                 <div
-                  class="c17"
+                  class="c18"
                   width="150px"
                 >
                   <div
                     aria-haspopup="true"
                     aria-label="open menu"
-                    class="c18"
+                    class="c19"
                     data-toggle="true"
                     role="button"
                     title="Loaded filter"
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20 c21"
                       data-testid="select-selected-value"
                       title="Loaded filter"
                     >
                       --
                     </div>
                     <div
-                      class="c20"
+                      class="c22"
                     >
                       <span
-                        class="c21 c22"
+                        class="c23 c24"
                         data-testid="select-open-button"
+                        iconsize="small"
                       >
                         ▼
                       </span>
@@ -1286,7 +1148,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c15"
+                  class="c16"
                   data-testid="error-marker"
                 >
                   ×
@@ -1300,16 +1162,16 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
         class="entities-section"
       >
         <div
-          class="c23 section-header"
+          class="c25 c26 section-header"
         >
           <h2
-            class="c24 c25"
+            class="c27 c28"
           >
             <div
-              class="c26"
+              class="c29 c30"
             >
               <span
-                class="c27"
+                class="c5 c31"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -1318,26 +1180,26 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               </span>
             </div>
             <div
-              class="c28"
+              class="c29 c32"
             >
               Audits 0 of 0
             </div>
           </h2>
           <div
-            class="c8"
+            class="c10"
           />
         </div>
         <div
           class="c0"
         >
           <div
-            class="c29 entities-table"
+            class="c0 c33 entities-table"
           >
             <div
-              class="c30"
+              class="c34"
             >
               <span
-                class="c5 c4 c31"
+                class="c5 c7 c6 c35"
                 data-testid="svg-icon"
                 title="Unfold all details"
               >
@@ -1348,17 +1210,17 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                 </svg>
               </span>
               <div
-                class="c32"
+                class="c36 c37"
               >
                 <div
-                  class="c2"
+                  class="c2 c3"
                 >
                   <div
-                    class="c3"
+                    class="c2 c4"
                     margin="5px"
                   >
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1369,7 +1231,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1382,19 +1244,19 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c34"
+                  class="c39"
                 >
                   0 - 0 of 0
                 </span>
                 <div
-                  class="c2"
+                  class="c2 c3"
                 >
                   <div
-                    class="c3"
+                    class="c2 c4"
                     margin="5px"
                   >
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1405,7 +1267,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Last"
                     >
@@ -1420,65 +1282,65 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               </div>
             </div>
             <table
-              class="c35"
+              class="c40 c41 c42"
             >
               <thead
-                class="c36"
+                class="c43"
               >
                 <tr>
                   <th
-                    class="c37"
+                    class="c44"
                   >
                     <a
-                      class="c38"
+                      class="c45"
                     >
                       <div
-                        class="c39"
+                        class="c2"
                       >
                         Name
                       </div>
                     </a>
                   </th>
                   <th
-                    class="c40"
+                    class="c46"
                   >
                     <a
-                      class="c38"
+                      class="c45"
                     >
                       <div
-                        class="c39"
+                        class="c2"
                       >
                         Status
                       </div>
                     </a>
                   </th>
                   <th
-                    class="c41"
+                    class="c47"
                   >
                     <a
-                      class="c38"
+                      class="c45"
                     >
                       <div
-                        class="c39"
+                        class="c2"
                       >
                         Report
                       </div>
                     </a>
                   </th>
                   <th
-                    class="c40"
+                    class="c46"
                   >
                     <div
-                      class="c39"
+                      class="c2"
                     >
                       Compliance Status
                     </div>
                   </th>
                   <th
-                    class="c42"
+                    class="c48"
                   >
                     <div
-                      class="c43"
+                      class="c49"
                     >
                       Actions
                     </div>
@@ -1491,22 +1353,22 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                 <tr>
                   <td>
                     <div
-                      class="c44"
+                      class="c50"
                     >
                       <div
-                        class="c45"
+                        class="c51"
                       >
                         <span
-                          class="c46"
+                          class="c52"
                           name="1234"
                         >
                           foo
                         </span>
                         <div
-                          class="c2"
+                          class="c2 c3"
                         >
                           <div
-                            class="c3"
+                            class="c2 c4"
                             margin="5px"
                           />
                         </div>
@@ -1522,27 +1384,30 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c44"
+                      class="c50"
                     >
                       <a
-                        class="c47 c48"
+                        class="c53 c54"
                         data-testid="details-link"
                         href="/report/1234"
                       >
                         <div
-                          class="c49"
+                          boxbackground="#4C4C4C"
+                          class="c55"
                           data-testid="progressbar-box"
                           title="Done"
                         >
                           <div
-                            class="c50"
+                            background="low"
+                            class="c56"
                             data-testid="progress"
+                            progress="100"
                           />
                           <div
-                            class="c51"
+                            class="c57"
                           >
                             <span
-                              class="c52"
+                              class="c58"
                             >
                               Done
                             </span>
@@ -1553,11 +1418,11 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c44"
+                      class="c50"
                     >
                       <span>
                         <a
-                          class="c47"
+                          class="c53"
                           data-testid="details-link"
                           href="/report/1234"
                         >
@@ -1568,19 +1433,22 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c44"
+                      class="c50"
                     >
                       <div
-                        class="c53"
+                        boxbackground="#c83814"
+                        class="c59"
                         data-testid="progressbar-box"
                         title="50%"
                       >
                         <div
-                          class="c54"
+                          background="#70c000"
+                          class="c60"
                           data-testid="progress"
+                          progress="50"
                         />
                         <div
-                          class="c51"
+                          class="c57"
                         >
                           50%
                         </div>
@@ -1592,14 +1460,14 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       class="c0"
                     >
                       <div
-                        class="c55"
+                        class="c61 c3"
                       >
                         <div
-                          class="c56"
+                          class="c62 c4"
                           margin="5px"
                         >
                           <span
-                            class="c5 c4"
+                            class="c5 c7 c6"
                             data-testid="svg-icon"
                             title="Start"
                           >
@@ -1611,7 +1479,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                           </span>
                           <span
                             alt="Resume"
-                            class="c33 c4"
+                            class="c5 c38 c6"
                             data-testid="svg-icon"
                             title="Audit is not stopped"
                           >
@@ -1622,7 +1490,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c4"
+                            class="c5 c7 c6"
                             data-testid="svg-icon"
                             title="Move Audit to trashcan"
                           >
@@ -1633,7 +1501,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c4"
+                            class="c5 c7 c6"
                             data-testid="svg-icon"
                             title="Edit Audit"
                           >
@@ -1644,7 +1512,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c4"
+                            class="c5 c7 c6"
                             data-testid="svg-icon"
                             title="Clone Audit"
                           >
@@ -1655,7 +1523,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c4"
+                            class="c5 c7 c6"
                             data-testid="svg-icon"
                             title="Export Audit"
                           >
@@ -1666,7 +1534,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c33 c4"
+                            class="c5 c38 c6"
                             data-testid="svg-icon"
                             title="Report download not available"
                           >
@@ -1688,46 +1556,46 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     colspan="5"
                   >
                     <div
-                      class="c57"
+                      class="c36"
                     >
                       <div
-                        class="c2"
+                        class="c2 c3"
                       >
                         <div
-                          class="c3"
+                          class="c2 c4"
                           margin="5px"
                         >
                           <div
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="downshift-1-label"
-                            class="c16"
+                            class="c17"
                             role="combobox"
                           >
                             <div
-                              class="c58"
+                              class="c63"
                               width="180px"
                             >
                               <div
                                 aria-haspopup="true"
                                 aria-label="open menu"
-                                class="c18"
+                                class="c19"
                                 data-toggle="true"
                                 role="button"
                                 type="button"
                               >
                                 <div
-                                  class="c19"
+                                  class="c20 c21"
                                   data-testid="select-selected-value"
                                   title="Apply to page contents"
                                 >
                                   Apply to page contents
                                 </div>
                                 <div
-                                  class="c20"
+                                  class="c22"
                                 >
                                   <span
-                                    class="c21 c22"
+                                    class="c23 c24"
                                     data-testid="select-open-button"
                                   >
                                     ▼
@@ -1736,21 +1604,21 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                               </div>
                             </div>
                             <div
-                              class="c15"
+                              class="c16"
                               data-testid="error-marker"
                             >
                               ×
                             </div>
                           </div>
                           <div
-                            class="c2"
+                            class="c2 c3"
                           >
                             <div
-                              class="c3"
+                              class="c2 c4"
                               margin="5px"
                             >
                               <span
-                                class="c5 c4"
+                                class="c5 c7 c6"
                                 data-testid="svg-icon"
                                 title="Move page contents to trashcan"
                               >
@@ -1761,7 +1629,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                                 </svg>
                               </span>
                               <span
-                                class="c5 c4"
+                                class="c5 c7 c6"
                                 data-testid="svg-icon"
                                 title="Export page contents"
                               >
@@ -1781,25 +1649,25 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               </tfoot>
             </table>
             <div
-              class="c45"
+              class="c51"
             >
               <div
-                class="c59"
+                class="c2 c64"
               >
                 (Applied filter: )
               </div>
               <div
-                class="c32"
+                class="c36 c37"
               >
                 <div
-                  class="c2"
+                  class="c2 c3"
                 >
                   <div
-                    class="c3"
+                    class="c2 c4"
                     margin="5px"
                   >
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1810,7 +1678,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1823,19 +1691,19 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c34"
+                  class="c39"
                 >
                   0 - 0 of 0
                 </span>
                 <div
-                  class="c2"
+                  class="c2 c3"
                 >
                   <div
-                    class="c3"
+                    class="c2 c4"
                     margin="5px"
                   >
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1846,7 +1714,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Last"
                     >

--- a/src/web/pages/audits/__tests__/__snapshots__/row.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/row.js.snap
@@ -10,8 +10,8 @@ exports[`Audit Row tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -29,11 +29,28 @@ exports[`Audit Row tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c13 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -46,50 +63,13 @@ exports[`Audit Row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-.c5 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c4 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4 > * {
-  margin-left: 5px;
 }
 
 .c15 {
@@ -104,51 +84,17 @@ exports[`Audit Row tests should render 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c15 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c15 > * {
-  margin-left: 5px;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
-.c14 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -160,35 +106,60 @@ exports[`Audit Row tests should render 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c16 {
+.c5 {
+  margin-left: -5px;
+}
+
+.c5>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c5>* {
+  margin-left: 5px;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c18 {
   cursor: pointer;
 }
 
-.c18 svg path {
+.c20 svg path {
   fill: #bfbfbf;
 }
 
-.c17 {
+.c19 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c17 * {
+.c19 * {
   height: inherit;
   width: inherit;
 }
@@ -200,13 +171,13 @@ exports[`Audit Row tests should render 1`] = `
   color: #0a53b8;
 }
 
-.c2:hover {
+.c2 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
-.c7 {
+.c8 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -216,7 +187,7 @@ exports[`Audit Row tests should render 1`] = `
   text-align: center;
 }
 
-.c11 {
+.c12 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -226,7 +197,7 @@ exports[`Audit Row tests should render 1`] = `
   text-align: center;
 }
 
-.c9 {
+.c10 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -237,29 +208,29 @@ exports[`Audit Row tests should render 1`] = `
   padding-top: 1px;
 }
 
-.c8 {
+.c9 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
 }
 
-.c12 {
+.c13 {
   height: 13px;
   width: 50%;
   background: #70c000;
 }
 
-.c10 {
+.c11 {
   white-space: nowrap;
 }
 
-.c6:hover {
+.c7:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 @media print {
-  .c16 {
+  .c17 {
     display: none;
   }
 }
@@ -271,33 +242,33 @@ exports[`Audit Row tests should render 1`] = `
 }
 
 @media print {
-  .c7 {
-    background: none;
-    border: 0;
-  }
-}
-
-@media print {
-  .c11 {
-    background: none;
-    border: 0;
-  }
-}
-
-@media print {
-  .c9 {
-    color: black;
-  }
-}
-
-@media print {
   .c8 {
     background: none;
+    border: 0;
   }
 }
 
 @media print {
   .c12 {
+    background: none;
+    border: 0;
+  }
+}
+
+@media print {
+  .c10 {
+    color: black;
+  }
+}
+
+@media print {
+  .c9 {
+    background: none;
+  }
+}
+
+@media print {
+  .c13 {
     background: none;
   }
 }
@@ -322,10 +293,10 @@ exports[`Audit Row tests should render 1`] = `
               foo
             </span>
             <div
-              class="c3"
+              class="c3 c4"
             >
               <div
-                class="c4"
+                class="c3 c5"
                 margin="5px"
               />
             </div>
@@ -344,24 +315,27 @@ exports[`Audit Row tests should render 1`] = `
           class="c0"
         >
           <a
-            class="c5 c6"
+            class="c6 c7"
             data-testid="details-link"
             href="/report/1234"
           >
             <div
-              class="c7"
+              boxbackground="#4C4C4C"
+              class="c8"
               data-testid="progressbar-box"
               title="Done"
             >
               <div
-                class="c8"
+                background="low"
+                class="c9"
                 data-testid="progress"
+                progress="100"
               />
               <div
-                class="c9"
+                class="c10"
               >
                 <span
-                  class="c10"
+                  class="c11"
                 >
                   Done
                 </span>
@@ -376,7 +350,7 @@ exports[`Audit Row tests should render 1`] = `
         >
           <span>
             <a
-              class="c5"
+              class="c6"
               data-testid="details-link"
               href="/report/1234"
             >
@@ -390,16 +364,19 @@ exports[`Audit Row tests should render 1`] = `
           class="c0"
         >
           <div
-            class="c11"
+            boxbackground="#c83814"
+            class="c12"
             data-testid="progressbar-box"
             title="50%"
           >
             <div
-              class="c12"
+              background="#70c000"
+              class="c13"
               data-testid="progress"
+              progress="50"
             />
             <div
-              class="c9"
+              class="c10"
             >
               50%
             </div>
@@ -408,17 +385,17 @@ exports[`Audit Row tests should render 1`] = `
       </td>
       <td>
         <div
-          class="c13"
+          class="c14"
         >
           <div
-            class="c14"
+            class="c15 c4"
           >
             <div
-              class="c15"
+              class="c16 c5"
               margin="5px"
             >
               <span
-                class="c16 c17"
+                class="c17 c18 c19"
                 data-testid="svg-icon"
                 title="Start"
               >
@@ -430,7 +407,7 @@ exports[`Audit Row tests should render 1`] = `
               </span>
               <span
                 alt="Resume"
-                class="c18 c17"
+                class="c17 c20 c19"
                 data-testid="svg-icon"
                 title="Audit is not stopped"
               >
@@ -441,7 +418,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c16 c17"
+                class="c17 c18 c19"
                 data-testid="svg-icon"
                 title="Move Audit to trashcan"
               >
@@ -452,7 +429,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c16 c17"
+                class="c17 c18 c19"
                 data-testid="svg-icon"
                 title="Edit Audit"
               >
@@ -463,7 +440,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c16 c17"
+                class="c17 c18 c19"
                 data-testid="svg-icon"
                 title="Clone Audit"
               >
@@ -474,7 +451,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c16 c17"
+                class="c17 c18 c19"
                 data-testid="svg-icon"
                 title="Export Audit"
               >
@@ -485,7 +462,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c16 c17"
+                class="c17 c18 c19"
                 data-testid="svg-icon"
                 title="Download Greenbone Compliance Report"
               >

--- a/src/web/pages/audits/__tests__/__snapshots__/table.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/table.js.snap
@@ -1,7 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Audits table tests should render 1`] = `
-.c1 {
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15,137 +37,7 @@ exports[`Audits table tests should render 1`] = `
   flex-grow: 1;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c13 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c34 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c39 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c21 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
 .c7 {
@@ -156,29 +48,102 @@ exports[`Audits table tests should render 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-left: -5px;
 }
 
-.c7 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+.c22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
 }
 
-.c7 > * {
-  margin-left: 5px;
+.c23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
 }
 
-.c31 {
+.c24 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+
+.c34 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -191,95 +156,82 @@ exports[`Audits table tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c43 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c26 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c11 {
   margin-left: -5px;
 }
 
-.c31 > * {
+.c11>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c31 > * {
+.c11>* {
   margin-left: 5px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c10 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c30 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c2 {
+.c4 {
   cursor: pointer;
 }
 
-.c8 svg path {
+.c12 svg path {
   fill: #bfbfbf;
 }
 
-.c3 {
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c3 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
-.c40 {
+.c44 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -292,8 +244,8 @@ exports[`Audits table tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -304,18 +256,18 @@ exports[`Audits table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c41 {
+.c45 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c41 * {
+.c45 * {
   height: inherit;
   width: inherit;
 }
 
-.c37 {
+.c40 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -339,7 +291,7 @@ exports[`Audits table tests should render 1`] = `
   font-weight: normal;
 }
 
-.c36 {
+.c39 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -351,16 +303,7 @@ exports[`Audits table tests should render 1`] = `
   width: 180px;
 }
 
-.c42 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c38 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -377,29 +320,64 @@ exports[`Audits table tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
+}
+
+.c46 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c42 {
   cursor: default;
 }
 
-.c35 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c11 a {
+.c14 {
+  border: 0;
+  border-spacing: 0px;
+  font-size: 12px;
+  text-align: left;
+  table-layout: auto;
+  width: 100%;
+}
+
+.c15 th,
+.c15 td {
+  padding: 4px 10px;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.c15 tfoot tr {
+  background: #fff;
+}
+
+.c15 tfoot tr td {
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.c17 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c11 a:hover {
+.c17 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c12 {
+.c18 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -407,7 +385,7 @@ exports[`Audits table tests should render 1`] = `
   width: 52%;
 }
 
-.c14 {
+.c19 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -415,7 +393,7 @@ exports[`Audits table tests should render 1`] = `
   width: 8%;
 }
 
-.c15 {
+.c20 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -423,7 +401,7 @@ exports[`Audits table tests should render 1`] = `
   width: 24%;
 }
 
-.c16 {
+.c21 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -431,116 +409,47 @@ exports[`Audits table tests should render 1`] = `
   width: 10em;
 }
 
-.c43 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c47 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c9 {
+.c13 {
   margin: 0 3px;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c8 {
   margin: 2px 3px;
 }
 
-.c10 {
-  border: 0;
-  border-spacing: 0px;
-  font-size: 12px;
-  text-align: left;
-  table-layout: auto;
-  width: 100%;
+.c16 {
   opacity: 1.0;
 }
 
-.c10 th,
-.c10 td {
-  padding: 4px 10px;
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c10 tfoot tr {
-  background: #fff;
-}
-
-.c10 tfoot tr td {
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c4 {
+.c6 {
   margin-top: 2px;
   margin-left: 2px;
 }
 
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+.c1 {
   margin-top: 20px;
 }
 
-.c20 {
+.c25 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c20:hover {
+.c25 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
-.c23 {
+.c28 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -550,7 +459,7 @@ exports[`Audits table tests should render 1`] = `
   text-align: center;
 }
 
-.c27 {
+.c32 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -560,7 +469,7 @@ exports[`Audits table tests should render 1`] = `
   text-align: center;
 }
 
-.c25 {
+.c30 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -571,52 +480,70 @@ exports[`Audits table tests should render 1`] = `
   padding-top: 1px;
 }
 
-.c24 {
+.c29 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
 }
 
-.c28 {
+.c33 {
   height: 13px;
   width: 50%;
   background: #70c000;
 }
 
-.c32 {
+.c36 {
   height: 13px;
   width: 100%;
   background: #99be48;
 }
 
-.c33 {
+.c37 {
   height: 13px;
   width: 0%;
   background: #70c000;
 }
 
-.c26 {
+.c31 {
   white-space: nowrap;
 }
 
-.c22:hover {
+.c27:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 @media print {
-  .c2 {
+  .c3 {
     display: none;
   }
 }
 
 @media print {
-  .c11 {
+  .c14 {
+    border-collapse: collapse;
+  }
+}
+
+@media screen {
+  .c15>tbody:nth-of-type(even),
+  .c15>tbody:only-of-type>tr:nth-of-type(even) {
+    background: #f3f3f3;
+  }
+
+  .c15>tbody:not(:only-of-type):hover,
+  .c15>tbody:only-of-type>tr:hover {
+    background: #e5e5e5;
+  }
+}
+
+@media print {
+  .c17 {
     border-bottom: 1px solid black;
   }
 
-  .c11 a,
-  .c11 a:hover {
+  .c17 a,
+  .c17 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -624,7 +551,7 @@ exports[`Audits table tests should render 1`] = `
 }
 
 @media print {
-  .c12 {
+  .c18 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
@@ -633,96 +560,66 @@ exports[`Audits table tests should render 1`] = `
 }
 
 @media print {
-  .c14 {
+  .c19 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
     font-weight: bold;
-  }
-}
-
-@media print {
-  .c15 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: none;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: none;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c5 svg {
-    display: none;
-  }
-}
-
-@media print {
-  .c10 {
-    border-collapse: collapse;
-  }
-}
-
-@media screen {
-  .c10 > tbody:nth-of-type(even),
-  .c10 > tbody:only-of-type > tr:nth-of-type(even) {
-    background: #f3f3f3;
-  }
-
-  .c10 > tbody:not(:only-of-type):hover,
-  .c10 > tbody:only-of-type > tr:hover {
-    background: #e5e5e5;
   }
 }
 
 @media print {
   .c20 {
     color: #000;
+    font-size: 1.2em;
+    background-color: none;
+    font-weight: bold;
   }
 }
 
 @media print {
-  .c23 {
-    background: none;
-    border: 0;
+  .c21 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: none;
+    font-weight: bold;
   }
 }
 
 @media print {
-  .c27 {
-    background: none;
-    border: 0;
+  .c8 svg {
+    display: none;
   }
 }
 
 @media print {
   .c25 {
-    color: black;
-  }
-}
-
-@media print {
-  .c24 {
-    background: none;
+    color: #000;
   }
 }
 
 @media print {
   .c28 {
     background: none;
+    border: 0;
   }
 }
 
 @media print {
   .c32 {
+    background: none;
+    border: 0;
+  }
+}
+
+@media print {
+  .c30 {
+    color: black;
+  }
+}
+
+@media print {
+  .c29 {
     background: none;
   }
 }
@@ -733,19 +630,31 @@ exports[`Audits table tests should render 1`] = `
   }
 }
 
+@media print {
+  .c36 {
+    background: none;
+  }
+}
+
+@media print {
+  .c37 {
+    background: none;
+  }
+}
+
 <body>
   <div
     id="portals"
   />
   <div>
     <div
-      class="c0 entities-table"
+      class="c0 c1 entities-table"
     >
       <div
-        class="c1"
+        class="c2"
       >
         <span
-          class="c2 c3 c4"
+          class="c3 c4 c5 c6"
           data-testid="svg-icon"
           title="Unfold all details"
         >
@@ -756,17 +665,17 @@ exports[`Audits table tests should render 1`] = `
           </svg>
         </span>
         <div
-          class="c5"
+          class="c7 c8"
         >
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -777,7 +686,7 @@ exports[`Audits table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -790,19 +699,19 @@ exports[`Audits table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c9"
+            class="c13"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -813,7 +722,7 @@ exports[`Audits table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Last"
               >
@@ -828,53 +737,53 @@ exports[`Audits table tests should render 1`] = `
         </div>
       </div>
       <table
-        class="c10"
+        class="c14 c15 c16"
       >
         <thead
-          class="c11"
+          class="c17"
         >
           <tr>
             <th
-              class="c12"
+              class="c18"
             >
               <div
-                class="c13"
+                class="c9"
               >
                 Name
               </div>
             </th>
             <th
-              class="c14"
+              class="c19"
             >
               <div
-                class="c13"
+                class="c9"
               >
                 Status
               </div>
             </th>
             <th
-              class="c15"
+              class="c20"
             >
               <div
-                class="c13"
+                class="c9"
               >
                 Report
               </div>
             </th>
             <th
-              class="c14"
+              class="c19"
             >
               <div
-                class="c13"
+                class="c9"
               >
                 Compliance Status
               </div>
             </th>
             <th
-              class="c16"
+              class="c21"
             >
               <div
-                class="c17"
+                class="c22"
               >
                 Actions
               </div>
@@ -887,22 +796,22 @@ exports[`Audits table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <div
-                  class="c19"
+                  class="c24"
                 >
                   <span
-                    class="c20"
+                    class="c25"
                     name="1234"
                   >
                     foo
                   </span>
                   <div
-                    class="c6"
+                    class="c9 c10"
                   >
                     <div
-                      class="c7"
+                      class="c9 c11"
                       margin="5px"
                     />
                   </div>
@@ -918,27 +827,30 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <a
-                  class="c21 c22"
+                  class="c26 c27"
                   data-testid="details-link"
                   href="/report/1234"
                 >
                   <div
-                    class="c23"
+                    boxbackground="#4C4C4C"
+                    class="c28"
                     data-testid="progressbar-box"
                     title="Done"
                   >
                     <div
-                      class="c24"
+                      background="low"
+                      class="c29"
                       data-testid="progress"
+                      progress="100"
                     />
                     <div
-                      class="c25"
+                      class="c30"
                     >
                       <span
-                        class="c26"
+                        class="c31"
                       >
                         Done
                       </span>
@@ -949,11 +861,11 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <span>
                   <a
-                    class="c21"
+                    class="c26"
                     data-testid="details-link"
                     href="/report/1234"
                   >
@@ -964,19 +876,22 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <div
-                  class="c27"
+                  boxbackground="#c83814"
+                  class="c32"
                   data-testid="progressbar-box"
                   title="50%"
                 >
                   <div
-                    class="c28"
+                    background="#70c000"
+                    class="c33"
                     data-testid="progress"
+                    progress="50"
                   />
                   <div
-                    class="c25"
+                    class="c30"
                   >
                     50%
                   </div>
@@ -985,17 +900,17 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c29"
+                class="c0"
               >
                 <div
-                  class="c30"
+                  class="c34 c10"
                 >
                   <div
-                    class="c31"
+                    class="c35 c11"
                     margin="5px"
                   >
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Start"
                     >
@@ -1007,7 +922,7 @@ exports[`Audits table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c8 c3"
+                      class="c3 c12 c5"
                       data-testid="svg-icon"
                       title="Audit is not stopped"
                     >
@@ -1018,7 +933,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Move Audit to trashcan"
                     >
@@ -1029,7 +944,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Edit Audit"
                     >
@@ -1040,7 +955,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Clone Audit"
                     >
@@ -1051,7 +966,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Export Audit"
                     >
@@ -1062,7 +977,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c8 c3"
+                      class="c3 c12 c5"
                       data-testid="svg-icon"
                       title="Report download not available"
                     >
@@ -1080,27 +995,27 @@ exports[`Audits table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <div
-                  class="c19"
+                  class="c24"
                 >
                   <span
-                    class="c20"
+                    class="c25"
                     name="12345"
                   >
                     lorem
                   </span>
                   <div
-                    class="c6"
+                    class="c9 c10"
                   >
                     <div
-                      class="c7"
+                      class="c9 c11"
                       margin="5px"
                     >
                       <span
                         alt="Audit owned by user"
-                        class="c3"
+                        class="c3 c5"
                         data-testid="svg-icon"
                         title="Audit owned by user"
                       >
@@ -1124,25 +1039,28 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <span
-                  class="c21 c22"
+                  class="c26 c27"
                 >
                   <div
-                    class="c23"
+                    boxbackground="#4C4C4C"
+                    class="c28"
                     data-testid="progressbar-box"
                     title="New"
                   >
                     <div
-                      class="c32"
+                      background="new"
+                      class="c36"
                       data-testid="progress"
+                      progress="100"
                     />
                     <div
-                      class="c25"
+                      class="c30"
                     >
                       <span
-                        class="c26"
+                        class="c31"
                       >
                         New
                       </span>
@@ -1153,27 +1071,27 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               />
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               />
             </td>
             <td>
               <div
-                class="c29"
+                class="c0"
               >
                 <div
-                  class="c30"
+                  class="c34 c10"
                 >
                   <div
-                    class="c31"
+                    class="c35 c11"
                     margin="5px"
                   >
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Start"
                     >
@@ -1185,7 +1103,7 @@ exports[`Audits table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c8 c3"
+                      class="c3 c12 c5"
                       data-testid="svg-icon"
                       title="Audit is not stopped"
                     >
@@ -1196,7 +1114,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Move Audit to trashcan"
                     >
@@ -1207,7 +1125,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Edit Audit"
                     >
@@ -1218,7 +1136,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Clone Audit"
                     >
@@ -1229,7 +1147,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Export Audit"
                     >
@@ -1240,7 +1158,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c8 c3"
+                      class="c3 c12 c5"
                       data-testid="svg-icon"
                       title="Report download not available"
                     >
@@ -1258,27 +1176,27 @@ exports[`Audits table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <div
-                  class="c19"
+                  class="c24"
                 >
                   <span
-                    class="c20"
+                    class="c25"
                     name="123456"
                   >
                     hello
                   </span>
                   <div
-                    class="c6"
+                    class="c9 c10"
                   >
                     <div
-                      class="c7"
+                      class="c9 c11"
                       margin="5px"
                     >
                       <span
                         alt="Audit owned by user"
-                        class="c3"
+                        class="c3 c5"
                         data-testid="svg-icon"
                         title="Audit owned by user"
                       >
@@ -1302,27 +1220,30 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <a
-                  class="c21 c22"
+                  class="c26 c27"
                   data-testid="details-link"
                   href="/report/5678"
                 >
                   <div
-                    class="c23"
+                    boxbackground="#4C4C4C"
+                    class="c28"
                     data-testid="progressbar-box"
                     title="Running"
                   >
                     <div
-                      class="c33"
+                      background="run"
+                      class="c37"
                       data-testid="progress"
+                      progress="0"
                     />
                     <div
-                      class="c25"
+                      class="c30"
                     >
                       <span
-                        class="c26"
+                        class="c31"
                       >
                         0 %
                       </span>
@@ -1333,11 +1254,11 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <span>
                   <a
-                    class="c21"
+                    class="c26"
                     data-testid="details-link"
                     href="/report/1234"
                   >
@@ -1348,19 +1269,22 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <div
-                  class="c27"
+                  boxbackground="#c83814"
+                  class="c32"
                   data-testid="progressbar-box"
                   title="50%"
                 >
                   <div
-                    class="c28"
+                    background="#70c000"
+                    class="c33"
                     data-testid="progress"
+                    progress="50"
                   />
                   <div
-                    class="c25"
+                    class="c30"
                   >
                     50%
                   </div>
@@ -1369,17 +1293,17 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c29"
+                class="c0"
               >
                 <div
-                  class="c30"
+                  class="c34 c10"
                 >
                   <div
-                    class="c31"
+                    class="c35 c11"
                     margin="5px"
                   >
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Stop"
                     >
@@ -1391,7 +1315,7 @@ exports[`Audits table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c8 c3"
+                      class="c3 c12 c5"
                       data-testid="svg-icon"
                       title="Audit is not stopped"
                     >
@@ -1402,7 +1326,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Move Audit to trashcan"
                     >
@@ -1413,7 +1337,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Edit Audit"
                     >
@@ -1424,7 +1348,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Clone Audit"
                     >
@@ -1435,7 +1359,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Export Audit"
                     >
@@ -1446,7 +1370,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c8 c3"
+                      class="c3 c12 c5"
                       data-testid="svg-icon"
                       title="Report download not available"
                     >
@@ -1468,43 +1392,43 @@ exports[`Audits table tests should render 1`] = `
               colspan="5"
             >
               <div
-                class="c34"
+                class="c7"
               >
                 <div
-                  class="c6"
+                  class="c9 c10"
                 >
                   <div
-                    class="c7"
+                    class="c9 c11"
                     margin="5px"
                   >
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-labelledby="downshift-0-label"
-                      class="c35"
+                      class="c38"
                       role="combobox"
                     >
                       <div
-                        class="c36"
+                        class="c39"
                         width="180px"
                       >
                         <div
                           aria-haspopup="true"
                           aria-label="open menu"
-                          class="c37"
+                          class="c40"
                           data-toggle="true"
                           role="button"
                           type="button"
                         >
                           <div
-                            class="c38"
+                            class="c41 c42"
                             data-testid="select-selected-value"
                           />
                           <div
-                            class="c39"
+                            class="c43"
                           >
                             <span
-                              class="c40 c41"
+                              class="c44 c45"
                               data-testid="select-open-button"
                             >
                               ▼
@@ -1513,21 +1437,21 @@ exports[`Audits table tests should render 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c42"
+                        class="c46"
                         data-testid="error-marker"
                       >
                         ×
                       </div>
                     </div>
                     <div
-                      class="c6"
+                      class="c9 c10"
                     >
                       <div
-                        class="c7"
+                        class="c9 c11"
                         margin="5px"
                       >
                         <span
-                          class="c3"
+                          class="c3 c5"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1535,7 +1459,7 @@ exports[`Audits table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3"
+                          class="c3 c5"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1552,25 +1476,25 @@ exports[`Audits table tests should render 1`] = `
         </tfoot>
       </table>
       <div
-        class="c19"
+        class="c24"
       >
         <div
-          class="c43"
+          class="c9 c47"
         >
           (Applied filter: rows=2)
         </div>
         <div
-          class="c5"
+          class="c7 c8"
         >
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -1581,7 +1505,7 @@ exports[`Audits table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -1594,19 +1518,19 @@ exports[`Audits table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c9"
+            class="c13"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -1617,7 +1541,7 @@ exports[`Audits table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Last"
               >

--- a/src/web/pages/ldap/__tests__/__snapshots__/dialog.js.snap
+++ b/src/web/pages/ldap/__tests__/__snapshots__/dialog.js.snap
@@ -1,7 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Ldap dialog component tests should render dialog 1`] = `
-.c8 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,43 +49,13 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c14 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c14 > * {
-  margin-left: 5px;
 }
 
 .c13 {
@@ -58,13 +67,52 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c24 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c17 {
+  margin-left: -5px;
+}
+
+.c17>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c17>* {
+  margin-left: 5px;
+}
+
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -96,7 +144,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -104,7 +152,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   height: 100%;
 }
 
-.c26 {
+.c31 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -113,13 +161,13 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c25 {
+.c30 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -138,7 +186,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -155,30 +203,30 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c22 {
+.c27 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -198,12 +246,12 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   z-index: 1;
 }
 
-.c22:focus,
-.c22:hover {
+.c27:focus,
+.c27:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c22:hover {
+.c27:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -211,26 +259,26 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   color: #fff;
 }
 
-.c22[disabled] {
+.c27[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c22 img {
+.c27 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c22:link {
+.c27:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c23 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -239,8 +287,8 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -248,63 +296,32 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c24 {
+.c29 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c24:hover {
+.c29 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c21 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c25 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c26 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -318,17 +335,15 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -336,31 +351,12 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -370,13 +366,13 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   max-width: 100%;
   font-weight: bold;
@@ -387,28 +383,13 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   margin-left: 0;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c19 {
+.c22 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -417,7 +398,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   display: none;
 }
 
-.c17 {
+.c20 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -431,11 +412,11 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   padding: 1px 8px;
 }
 
-.c17:-webkit-autofill {
+.c20:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c18 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -444,8 +425,8 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -453,7 +434,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c12 {
+.c15 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -469,7 +450,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   cursor: pointer;
 }
 
-.c15 {
+.c18 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -480,7 +461,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   height: auto;
 }
 
-.c16 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -489,8 +470,8 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -498,7 +479,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c20 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -507,8 +488,8 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -535,14 +516,14 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 Edit LDAP per-User Authentication
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -550,42 +531,45 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Enable
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <label
-                        class="c12"
+                        class="c15"
                       >
                         <div
-                          class="c13"
+                          class="c13 c16"
                         >
                           <div
-                            class="c14"
+                            class="c13 c17"
                             margin="5px"
                           >
                             <input
                               checked=""
-                              class="c15 c16"
+                              class="c18 c19"
                               data-testid="enable-checkbox"
                               name="enable"
                               type="checkbox"
@@ -596,21 +580,23 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       LDAP Host
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c17 c18"
+                        class="c20 c21"
                         data-testid="ldaphost-textfield"
                         name="ldaphost"
                         size="30"
@@ -618,7 +604,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
                         value="bar"
                       />
                       <div
-                        class="c19"
+                        class="c22"
                         data-testid="error-marker"
                       >
                         ×
@@ -626,21 +612,23 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Auth. DN
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c17 c18"
+                        class="c20 c21"
                         data-testid="authdn-textfield"
                         name="authdn"
                         size="30"
@@ -648,7 +636,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
                         value="foo"
                       />
                       <div
-                        class="c19"
+                        class="c22"
                         data-testid="error-marker"
                       >
                         ×
@@ -656,24 +644,26 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       CA Certificate
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <div
-                        class="c8"
+                        class="c10"
                       >
                         <input
-                          class="c20"
+                          class="c23"
                           name="certificate"
                           type="file"
                         />
@@ -681,32 +671,34 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Use LDAPS only
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <label
-                        class="c12"
+                        class="c15"
                       >
                         <div
-                          class="c13"
+                          class="c13 c16"
                         >
                           <div
-                            class="c14"
+                            class="c13 c17"
                             margin="5px"
                           >
                             <input
                               checked=""
-                              class="c15 c16"
+                              class="c18 c19"
                               data-testid="ldapsOnly-checkbox"
                               name="ldapsOnly"
                               type="checkbox"
@@ -720,17 +712,17 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c21"
+              class="c24 c25 c26"
             >
               <button
-                class="c22 c23 c24"
+                class="c27 c28 c29"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c22 c23 c24"
+                class="c27 c28 c29"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -739,10 +731,10 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
             </div>
           </div>
           <div
-            class="c25"
+            class="c30"
           >
             <div
-              class="c26"
+              class="c31"
             />
           </div>
         </div>

--- a/src/web/pages/performance/__tests__/__snapshots__/startendtimeselection.js.snap
+++ b/src/web/pages/performance/__tests__/__snapshots__/startendtimeselection.js.snap
@@ -10,8 +10,8 @@ exports[`StartTimeSelection tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -19,100 +19,73 @@ exports[`StartTimeSelection tests should render 1`] = `
   align-items: stretch;
 }
 
-.c5 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c6 {
   margin-top: -5px;
 }
 
-.c5 > * {
+.c6>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5 > * {
+.c6>* {
   margin-top: 5px;
 }
 
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c10 {
   margin-left: -20px;
 }
 
-.c9 > * {
+.c10>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c9 > * {
+.c10>* {
   margin-left: 20px;
 }
 
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c5 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c7 {
+.c8 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c7 * {
+.c8 * {
   height: inherit;
   width: inherit;
 }
 
-.c15 {
+.c17 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -132,12 +105,12 @@ exports[`StartTimeSelection tests should render 1`] = `
   z-index: 1;
 }
 
-.c15:focus,
-.c15:hover {
+.c17:focus,
+.c17:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c15:hover {
+.c17:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -145,26 +118,26 @@ exports[`StartTimeSelection tests should render 1`] = `
   color: #fff;
 }
 
-.c15[disabled] {
+.c17[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c15 img {
+.c17 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c15:link {
+.c17:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c16 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -173,8 +146,8 @@ exports[`StartTimeSelection tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -192,8 +165,8 @@ exports[`StartTimeSelection tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -209,47 +182,17 @@ exports[`StartTimeSelection tests should render 1`] = `
   margin-left: 0;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c16 {
   margin-left: 33.33333333%;
 }
 
-.c10 {
+.c11 {
   border-radius: 2px;
   border: 1px solid #bfbfbf;
   background-color: #fff;
@@ -261,7 +204,7 @@ exports[`StartTimeSelection tests should render 1`] = `
   vertical-align: middle;
 }
 
-.c11 {
+.c12 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -273,46 +216,6 @@ exports[`StartTimeSelection tests should render 1`] = `
   vertical-align: middle;
   margin-left: 0.4em;
   margin-right: 22px;
-}
-
-.c12 {
-  background-color: #e5e5e5;
-  color: #7F7F7F;
-  border-left: 1px solid #4C4C4C;
-  width: 16px;
-  height: 50%;
-  font-size: 0.6em;
-  padding: 0;
-  margin: 0;
-  text-align: center;
-  vertical-align: middle;
-  position: absolute;
-  right: 0;
-  cursor: default;
-  display: block;
-  overflow: hidden;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  border-top-right-radius: 1px;
-  top: 0;
-}
-
-.c12:hover {
-  background-color: #11ab51;
-  color: #fff;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c12:active {
-  background-color: #fff;
-  color: #074320;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 .c13 {
@@ -337,8 +240,6 @@ exports[`StartTimeSelection tests should render 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  border-bottom-right-radius: 1px;
-  bottom: 0;
 }
 
 .c13:hover {
@@ -355,15 +256,25 @@ exports[`StartTimeSelection tests should render 1`] = `
   text-decoration: none;
 }
 
-.c8 {
+.c14 {
+  border-top-right-radius: 1px;
+  top: 0;
+}
+
+.c15 {
+  border-bottom-right-radius: 1px;
+  bottom: 0;
+}
+
+.c9 {
   margin-left: 5px;
 }
 
-.c8:hover {
+.c9 :hover {
   cursor: pointer;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -381,11 +292,13 @@ exports[`StartTimeSelection tests should render 1`] = `
     <label
       class="c2"
       data-testid="formgroup-title"
+      titleoffset="0"
+      titlesize="2"
     >
       Timezone
     </label>
     <div
-      class="c3"
+      class="c3 c4"
       data-testid="timezone"
       size="10"
     >
@@ -398,19 +311,21 @@ exports[`StartTimeSelection tests should render 1`] = `
     <label
       class="c2"
       data-testid="formgroup-title"
+      titleoffset="0"
+      titlesize="2"
     >
       Start Time
     </label>
     <div
-      class="c3"
+      class="c3 c4"
       data-testid="formgroup-content"
       size="10"
     >
       <div
-        class="c4"
+        class="c3 c5"
       >
         <div
-          class="c5"
+          class="c0 c6"
           margin="5px"
         >
           <div
@@ -420,12 +335,12 @@ exports[`StartTimeSelection tests should render 1`] = `
               class="react-datepicker__input-container"
             >
               <div
-                class="c6"
+                class="c7"
                 width="auto"
               >
                 01/01/2019
                 <span
-                  class="c7 c8"
+                  class="c8 c9"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -436,17 +351,17 @@ exports[`StartTimeSelection tests should render 1`] = `
             </div>
           </div>
           <div
-            class="c4"
+            class="c3 c5"
           >
             <div
-              class="c9"
+              class="c3 c10"
               margin="20px"
             >
               <span
-                class="c10"
+                class="c11"
               >
                 <input
-                  class="c11"
+                  class="c12"
                   data-testid="spinner-input"
                   max="23"
                   maxlength="5"
@@ -456,13 +371,13 @@ exports[`StartTimeSelection tests should render 1`] = `
                   value="13"
                 />
                 <span
-                  class="c12"
+                  class="c13 c14"
                   data-testid="spinner-up"
                 >
                   ▲
                 </span>
                 <span
-                  class="c13"
+                  class="c13 c15"
                   data-testid="spinner-down"
                 >
                   ▼
@@ -471,10 +386,10 @@ exports[`StartTimeSelection tests should render 1`] = `
                
               h
               <span
-                class="c10"
+                class="c11"
               >
                 <input
-                  class="c11"
+                  class="c12"
                   data-testid="spinner-input"
                   max="59"
                   maxlength="5"
@@ -484,13 +399,13 @@ exports[`StartTimeSelection tests should render 1`] = `
                   value="0"
                 />
                 <span
-                  class="c12"
+                  class="c13 c14"
                   data-testid="spinner-up"
                 >
                   ▲
                 </span>
                 <span
-                  class="c13"
+                  class="c13 c15"
                   data-testid="spinner-down"
                 >
                   ▼
@@ -510,19 +425,21 @@ exports[`StartTimeSelection tests should render 1`] = `
     <label
       class="c2"
       data-testid="formgroup-title"
+      titleoffset="0"
+      titlesize="2"
     >
       End Time
     </label>
     <div
-      class="c3"
+      class="c3 c4"
       data-testid="formgroup-content"
       size="10"
     >
       <div
-        class="c4"
+        class="c3 c5"
       >
         <div
-          class="c5"
+          class="c0 c6"
           margin="5px"
         >
           <div
@@ -532,12 +449,12 @@ exports[`StartTimeSelection tests should render 1`] = `
               class="react-datepicker__input-container"
             >
               <div
-                class="c6"
+                class="c7"
                 width="auto"
               >
                 01/01/2019
                 <span
-                  class="c7 c8"
+                  class="c8 c9"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -548,17 +465,17 @@ exports[`StartTimeSelection tests should render 1`] = `
             </div>
           </div>
           <div
-            class="c4"
+            class="c3 c5"
           >
             <div
-              class="c9"
+              class="c3 c10"
               margin="20px"
             >
               <span
-                class="c10"
+                class="c11"
               >
                 <input
-                  class="c11"
+                  class="c12"
                   data-testid="spinner-input"
                   max="23"
                   maxlength="5"
@@ -568,13 +485,13 @@ exports[`StartTimeSelection tests should render 1`] = `
                   value="14"
                 />
                 <span
-                  class="c12"
+                  class="c13 c14"
                   data-testid="spinner-up"
                 >
                   ▲
                 </span>
                 <span
-                  class="c13"
+                  class="c13 c15"
                   data-testid="spinner-down"
                 >
                   ▼
@@ -583,10 +500,10 @@ exports[`StartTimeSelection tests should render 1`] = `
                
               h
               <span
-                class="c10"
+                class="c11"
               >
                 <input
-                  class="c11"
+                  class="c12"
                   data-testid="spinner-input"
                   max="59"
                   maxlength="5"
@@ -596,13 +513,13 @@ exports[`StartTimeSelection tests should render 1`] = `
                   value="0"
                 />
                 <span
-                  class="c12"
+                  class="c13 c14"
                   data-testid="spinner-up"
                 >
                   ▲
                 </span>
                 <span
-                  class="c13"
+                  class="c13 c15"
                   data-testid="spinner-down"
                 >
                   ▼
@@ -620,12 +537,12 @@ exports[`StartTimeSelection tests should render 1`] = `
     class="c1"
   >
     <div
-      class="c14"
+      class="c3 c16"
       data-testid="formgroup-content"
       offset="4"
     >
       <button
-        class="c15 c16"
+        class="c17 c18"
         data-testid="update-button"
       >
         Update

--- a/src/web/pages/policies/__tests__/__snapshots__/details.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/details.js.snap
@@ -14,8 +14,8 @@ exports[`Policy Details tests should render full Details 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -32,53 +32,13 @@ exports[`Policy Details tests should render full Details 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-.c8 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c7 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c7 > * {
-  margin-left: 5px;
 }
 
 .c6 {
@@ -90,13 +50,60 @@ exports[`Policy Details tests should render full Details 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c9 {
+  margin-left: -5px;
+}
+
+.c9>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c9>* {
+  margin-left: 5px;
+}
+
+.c7 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -181,14 +188,14 @@ exports[`Policy Details tests should render full Details 1`] = `
             class="c5"
           >
             <div
-              class="c6"
+              class="c6 c7"
             >
               <div
-                class="c7"
+                class="c8 c9"
                 margin="5px"
               >
                 <a
-                  class="c8"
+                  class="c10"
                   data-testid="details-link"
                   href="/audit/1234"
                 >
@@ -196,7 +203,7 @@ exports[`Policy Details tests should render full Details 1`] = `
                 </a>
                 ,
                 <a
-                  class="c8"
+                  class="c10"
                   data-testid="details-link"
                   href="/audit/5678"
                 >

--- a/src/web/pages/policies/__tests__/__snapshots__/detailspage.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/detailspage.js.snap
@@ -14,8 +14,8 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
@@ -29,12 +29,46 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
 .c14 {
@@ -45,9 +79,26 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -55,7 +106,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   align-items: center;
 }
 
-.c15 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -64,12 +115,12 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
-.c17 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -82,27 +133,9 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -114,17 +147,21 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
 .c24 {
@@ -132,84 +169,35 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
 }
 
-.c6 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c3 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-left: -10px;
-}
-
-.c3 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c3 > * {
-  margin-left: 10px;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c4 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4 > * {
-  margin-left: 5px;
 }
 
 .c29 {
@@ -217,127 +205,20 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c29 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c29 > * {
-  margin-left: 5px;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c7 {
-  cursor: pointer;
-}
-
-.c5 {
-  height: 16px;
-  width: 16px;
-  line-height: 16px;
-}
-
-.c5 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c12 {
-  height: 50px;
-  width: 50px;
-  line-height: 50px;
-}
-
-.c12 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  margin: 10px 0px;
-  padding-bottom: 1px;
-  border-bottom: 2px solid #e5e5e5;
-  position: relative;
-}
-
-.c9 {
-  margin: 0 0 1px 0;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
 }
 
-.c11 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -345,15 +226,99 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  margin-right: 5px;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4 {
+  margin-left: -10px;
+}
+
+.c4>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4>* {
+  margin-left: 10px;
+}
+
+.c5 {
+  margin-left: -5px;
+}
+
+.c5>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c5>* {
+  margin-left: 5px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c9 {
+  cursor: pointer;
+}
+
+.c7 {
+  height: 16px;
+  width: 16px;
+  line-height: 16px;
+}
+
+.c7 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c16 {
+  height: 50px;
+  width: 50px;
+  line-height: 50px;
+}
+
+.c16 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c11 {
+  margin: 10px 0px;
+  padding-bottom: 1px;
+  border-bottom: 2px solid #e5e5e5;
+  position: relative;
+}
+
+.c12 {
+  margin: 0 0 1px 0;
 }
 
 .c13 {
@@ -365,18 +330,25 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c15 {
+  margin-right: 5px;
+}
+
+.c17 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c20 {
+.c25 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -403,11 +375,11 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #11ab51;
 }
 
-.c20:first-child {
+.c25 :first-child {
   border-left: 1px solid #e5e5e5;
 }
 
-.c21 {
+.c26 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -431,40 +403,21 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #fff;
 }
 
-.c21:hover {
+.c26 :hover {
   border-top: 2px solid #e5e5e5;
 }
 
-.c21:first-child {
+.c26 :first-child {
   border-left: 1px solid #fff;
 }
 
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+.c23 {
   border-bottom: 2px solid #11ab51;
   margin-top: 30px;
   margin-bottom: 15px;
 }
 
-.c25 {
+.c30 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -472,63 +425,48 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   table-layout: auto;
 }
 
-.c26 td {
+.c31 td {
   padding: 4px 4px 4px 0;
 }
 
-.c26 tr td:first-child {
+.c31 tr td:first-child {
   padding-right: 5px;
 }
 
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c20 {
   border-spacing: 0px;
   color: #7F7F7F;
   font-size: 10px;
 }
 
-.c16 :nth-child(even) {
+.c20 :nth-child(even) {
   margin-left: 3px;
 }
 
-.c16 :nth-child(odd) {
+.c20 :nth-child(odd) {
   margin-left: 30px;
 }
 
-.c27 {
+.c32 {
   width: 10%;
 }
 
-.c28 {
+.c33 {
   width: 90%;
 }
 
-.c23 {
+.c28 {
   font-size: 0.7em;
 }
 
 @media print {
-  .c7 {
+  .c6 {
     display: none;
   }
 }
 
 @media print {
-  .c25 {
+  .c30 {
     border-collapse: collapse;
   }
 }
@@ -540,17 +478,17 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
     class="c1 toolbar"
   >
     <div
-      class="c2"
+      class="c2 c3"
     >
       <div
-        class="c3"
+        class="c2 c4"
         margin="10px"
       >
         <div
-          class="c2"
+          class="c2 c3"
         >
           <div
-            class="c4"
+            class="c2 c5"
             margin="5px"
           >
             <a
@@ -559,8 +497,9 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               target="_blank"
             >
               <span
-                class="c5"
+                class="c6 c7"
                 data-testid="svg-icon"
+                iconsize="small"
                 title="Help: Policies"
               >
                 <svg
@@ -571,12 +510,13 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <a
-              class="c6"
+              class="c8"
               href="/policies"
             >
               <span
-                class="c5"
+                class="c6 c7"
                 data-testid="svg-icon"
+                iconsize="small"
                 title="Policies List"
               >
                 <svg
@@ -589,15 +529,16 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
           </div>
         </div>
         <div
-          class="c2"
+          class="c2 c3"
         >
           <div
-            class="c4"
+            class="c2 c5"
             margin="5px"
           >
             <span
-              class="c7 c5"
+              class="c6 c9 c7"
               data-testid="svg-icon"
+              iconsize="small"
               title="Clone Policy"
             >
               <svg
@@ -607,8 +548,9 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c5"
+              class="c6 c9 c7"
               data-testid="svg-icon"
+              iconsize="small"
               title="Edit Policy"
             >
               <svg
@@ -618,8 +560,9 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c5"
+              class="c6 c9 c7"
               data-testid="svg-icon"
+              iconsize="small"
               title="Move Policy to trashcan"
             >
               <svg
@@ -629,8 +572,9 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c5"
+              class="c6 c9 c7"
               data-testid="svg-icon"
+              iconsize="small"
               title="Export Policy as XML"
             >
               <svg
@@ -648,16 +592,16 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
     class="entity-section"
   >
     <div
-      class="c8 section-header"
+      class="c10 c11 section-header"
     >
       <h2
-        class="c9 c10"
+        class="c12 c13"
       >
         <div
-          class="c11"
+          class="c14 c15"
         >
           <span
-            class="c12"
+            class="c6 c16"
             data-testid="svg-icon"
           >
             <svg>
@@ -666,19 +610,19 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
           </span>
         </div>
         <div
-          class="c13"
+          class="c14 c17"
         >
           Policy: foo
         </div>
       </h2>
       <div
-        class="c14"
+        class="c18"
       >
         <div
-          class="c15"
+          class="c19"
         >
           <div
-            class="c16"
+            class="c2 c20"
           >
             <div>
               ID:
@@ -709,30 +653,30 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
       </div>
     </div>
     <div
-      class="c17"
+      class="c21"
     >
       <div
-        class="c18"
+        class="c22 c23"
       >
         <div
-          class="c19"
+          class="c24"
         >
           <div
-            class="c20"
+            class="c25"
           >
             Information
           </div>
           <div
-            class="c21"
+            class="c26"
           >
             <div
-              class="c22"
+              class="c27"
             >
               <span>
                 Scanner Preferences
               </span>
               <span
-                class="c23"
+                class="c28"
               >
                 (
                 <i>
@@ -743,16 +687,16 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c21"
+            class="c26"
           >
             <div
-              class="c22"
+              class="c27"
             >
               <span>
                 NVT Families
               </span>
               <span
-                class="c23"
+                class="c28"
               >
                 (
                 <i>
@@ -763,16 +707,16 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c21"
+            class="c26"
           >
             <div
-              class="c22"
+              class="c27"
             >
               <span>
                 NVT Preferences
               </span>
               <span
-                class="c23"
+                class="c28"
               >
                 (
                 <i>
@@ -783,16 +727,16 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c21"
+            class="c26"
           >
             <div
-              class="c22"
+              class="c27"
             >
               <span>
                 Permissions
               </span>
               <span
-                class="c23"
+                class="c28"
               >
                 (
                 <i>
@@ -805,21 +749,21 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
         </div>
       </div>
       <div
-        class="c24"
+        class="c29"
       >
         <div
-          class="c17"
+          class="c21"
         >
           <table
-            class="c25 c26"
+            class="c30 c31"
           >
             <colgroup>
               <col
-                class="c27"
+                class="c32"
                 width="10%"
               />
               <col
-                class="c28"
+                class="c33"
                 width="90%"
               />
             </colgroup>
@@ -829,14 +773,14 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               <tr>
                 <td>
                   <div
-                    class="c24"
+                    class="c29"
                   >
                     Comment
                   </div>
                 </td>
                 <td>
                   <div
-                    class="c24"
+                    class="c29"
                   >
                     bar
                   </div>
@@ -845,24 +789,24 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               <tr>
                 <td>
                   <div
-                    class="c24"
+                    class="c29"
                   >
                     Audits using this Policy
                   </div>
                 </td>
                 <td>
                   <div
-                    class="c24"
+                    class="c29"
                   >
                     <div
-                      class="c2"
+                      class="c2 c3"
                     >
                       <div
-                        class="c29"
+                        class="c34 c5"
                         margin="5px"
                       >
                         <a
-                          class="c6"
+                          class="c8"
                           data-testid="details-link"
                           href="/audit/1234"
                         >
@@ -870,7 +814,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
                         </a>
                         ,
                         <a
-                          class="c6"
+                          class="c8"
                           data-testid="details-link"
                           href="/audit/5678"
                         >
@@ -891,73 +835,6 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
 `;
 
 exports[`Policy ToolBarIcons tests should render 1`] = `
-.c4 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -10px;
-}
-
-.c1 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 > * {
-  margin-left: 10px;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c2 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c2 > * {
-  margin-left: 5px;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -967,52 +844,92 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5 {
-  cursor: pointer;
+.c2 {
+  margin-left: -10px;
+}
+
+.c2>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c2>* {
+  margin-left: 10px;
 }
 
 .c3 {
+  margin-left: -5px;
+}
+
+.c3>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c3>* {
+  margin-left: 5px;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c7 {
+  cursor: pointer;
+}
+
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c3 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
 @media print {
-  .c5 {
+  .c4 {
     display: none;
   }
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <div
-    class="c1"
+    class="c0 c2"
     margin="10px"
   >
     <div
-      class="c0"
+      class="c0 c1"
     >
       <div
-        class="c2"
+        class="c0 c3"
         margin="5px"
       >
         <a
@@ -1021,7 +938,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           target="_blank"
         >
           <span
-            class="c3"
+            class="c4 c5"
             data-testid="svg-icon"
             title="Help: Policies"
           >
@@ -1033,11 +950,11 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <a
-          class="c4"
+          class="c6"
           href="/policies"
         >
           <span
-            class="c3"
+            class="c4 c5"
             data-testid="svg-icon"
             title="Policies List"
           >
@@ -1051,14 +968,14 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
       </div>
     </div>
     <div
-      class="c0"
+      class="c0 c1"
     >
       <div
-        class="c2"
+        class="c0 c3"
         margin="5px"
       >
         <span
-          class="c5 c3"
+          class="c4 c7 c5"
           data-testid="svg-icon"
           title="Clone Policy"
         >
@@ -1069,7 +986,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c3"
+          class="c4 c7 c5"
           data-testid="svg-icon"
           title="Edit Policy"
         >
@@ -1080,7 +997,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c3"
+          class="c4 c7 c5"
           data-testid="svg-icon"
           title="Move Policy to trashcan"
         >
@@ -1091,7 +1008,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c3"
+          class="c4 c7 c5"
           data-testid="svg-icon"
           title="Export Policy as XML"
         >

--- a/src/web/pages/policies/__tests__/__snapshots__/dialog.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/dialog.js.snap
@@ -1,7 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CreatePolicyDialog component tests should render dialog 1`] = `
-.c8 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,13 +49,52 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c1 {
@@ -44,7 +122,7 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -52,7 +130,7 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   height: 100%;
 }
 
-.c20 {
+.c25 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -61,13 +139,13 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c19 {
+.c24 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -86,7 +164,7 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -103,30 +181,30 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c16 {
+.c21 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -146,12 +224,12 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   z-index: 1;
 }
 
-.c16:focus,
-.c16:hover {
+.c21:focus,
+.c21:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c16:hover {
+.c21:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -159,26 +237,26 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   color: #fff;
 }
 
-.c16[disabled] {
+.c21[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c16 img {
+.c21 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c16:link {
+.c21:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c17 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -187,8 +265,8 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -196,63 +274,32 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c18 {
+.c23 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c18:hover {
+.c23 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c19 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c20 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -266,17 +313,15 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -284,31 +329,12 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -318,13 +344,13 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   max-width: 100%;
   font-weight: bold;
@@ -335,28 +361,13 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   margin-left: 0;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c14 {
+.c17 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -365,7 +376,7 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   display: none;
 }
 
-.c12 {
+.c15 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -379,11 +390,11 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   padding: 1px 8px;
 }
 
-.c12:-webkit-autofill {
+.c15:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c13 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -396,8 +407,8 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -424,14 +435,14 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 New Policy
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -439,38 +450,41 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Name
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="name"
                         size="30"
                         type="text"
                         value="Unnamed"
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -478,28 +492,30 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Comment
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="comment"
                         size="30"
                         type="text"
                         value=""
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -510,17 +526,17 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c15"
+              class="c18 c19 c20"
             >
               <button
-                class="c16 c17 c18"
+                class="c21 c22 c23"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c16 c17 c18"
+                class="c21 c22 c23"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -529,10 +545,10 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
             </div>
           </div>
           <div
-            class="c19"
+            class="c24"
           >
             <div
-              class="c20"
+              class="c25"
             />
           </div>
         </div>

--- a/src/web/pages/policies/__tests__/__snapshots__/listpage.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/listpage.js.snap
@@ -1,36 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PoliciesPage ToolBarIcons test should render 1`] = `
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c1 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 > * {
-  margin-left: 5px;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -40,30 +10,48 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c2 {
+  margin-left: -5px;
+}
+
+.c2>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c3 {
+.c2>* {
+  margin-left: 5px;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c5 {
   cursor: pointer;
 }
 
-.c2 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c2 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
@@ -75,10 +63,10 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <div
-    class="c1"
+    class="c0 c2"
     margin="5px"
   >
     <a
@@ -87,7 +75,7 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
       target="_blank"
     >
       <span
-        class="c2"
+        class="c3 c4"
         data-testid="svg-icon"
         title="Help: Policies"
       >
@@ -99,7 +87,7 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
       </span>
     </a>
     <span
-      class="c3 c2"
+      class="c3 c5 c4"
       data-testid="svg-icon"
       title="New Policy"
     >
@@ -110,7 +98,7 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
       </svg>
     </span>
     <span
-      class="c3 c2"
+      class="c3 c5 c4"
       data-testid="svg-icon"
       title="Import Policy"
     >
@@ -138,8 +126,8 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -157,7 +145,6 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -165,7 +152,25 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: flex-start;
 }
 
-.c6 {
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -178,12 +183,12 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
   -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
   justify-content: flex-end;
 }
 
-.c7 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -192,8 +197,8 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: stetch;
   -webkit-box-align: stetch;
@@ -201,7 +206,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: stetch;
 }
 
-.c8 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -211,7 +216,6 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -228,8 +232,8 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -237,7 +241,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: center;
 }
 
-.c20 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -246,311 +250,13 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.c30 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c39 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c41 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c42 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c43 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c47 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c3 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c3 > * {
-  margin-left: 5px;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c9 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c9 > * {
-  margin-left: 5px;
-}
-
-.c46 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c46 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c46 > * {
-  margin-left: 5px;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c45 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c5 {
-  cursor: pointer;
-}
-
-.c33 svg path {
-  fill: #bfbfbf;
-}
-
-.c4 {
-  height: 16px;
-  width: 16px;
-  line-height: 16px;
-}
-
-.c4 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c27 {
-  height: 50px;
-  width: 50px;
-  line-height: 50px;
-}
-
-.c27 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c23 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  margin: 10px 0px;
-  padding-bottom: 1px;
-  border-bottom: 2px solid #e5e5e5;
-  position: relative;
-}
-
-.c24 {
-  margin: 0 0 1px 0;
 }
 
 .c25 {
@@ -561,17 +267,16 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
-.c26 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -580,14 +285,200 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
   align-items: flex-end;
-  margin-right: 5px;
+}
+
+.c34 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+
+.c36 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c47 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+}
+
+.c48 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c49 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+
+.c51 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c52 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c4 {
+  margin-left: -5px;
+}
+
+.c4>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4>* {
+  margin-left: 5px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c7 {
+  cursor: pointer;
+}
+
+.c38 svg path {
+  fill: #bfbfbf;
+}
+
+.c6 {
+  height: 16px;
+  width: 16px;
+  line-height: 16px;
+}
+
+.c6 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c31 {
+  height: 50px;
+  width: 50px;
+  line-height: 50px;
+}
+
+.c31 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c26 {
+  margin: 10px 0px;
+  padding-bottom: 1px;
+  border-bottom: 2px solid #e5e5e5;
+  position: relative;
+}
+
+.c27 {
+  margin: 0 0 1px 0;
 }
 
 .c28 {
@@ -599,18 +490,25 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c30 {
+  margin-right: 5px;
+}
+
+.c32 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c21 {
+.c23 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -623,8 +521,8 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -635,18 +533,18 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   cursor: pointer;
 }
 
-.c22 {
+.c24 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c22 * {
+.c24 * {
   height: inherit;
   width: inherit;
 }
 
-.c18 {
+.c19 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -670,7 +568,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   font-weight: normal;
 }
 
-.c17 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -682,7 +580,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   width: 150px;
 }
 
-.c48 {
+.c53 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -694,16 +592,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   width: 180px;
 }
 
-.c15 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c19 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -720,33 +609,68 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
-  cursor: default;
 }
 
 .c16 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c21 {
+  cursor: default;
+}
+
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c36 a {
+.c40 {
+  border: 0;
+  border-spacing: 0px;
+  font-size: 12px;
+  text-align: left;
+  table-layout: auto;
+  width: 100%;
+}
+
+.c41 th,
+.c41 td {
+  padding: 4px 10px;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.c41 tfoot tr {
+  background: #fff;
+}
+
+.c41 tfoot tr td {
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.c43 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c36 a:hover {
+.c43 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c38 {
+.c45 {
   cursor: pointer;
 }
 
-.c37 {
+.c44 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -754,7 +678,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   width: 92%;
 }
 
-.c40 {
+.c46 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -762,7 +686,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   width: 8%;
 }
 
-.c13 {
+.c14 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -776,11 +700,11 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   padding: 1px 8px;
 }
 
-.c13:-webkit-autofill {
+.c14:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -789,127 +713,58 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c13 {
+  margin-right: 5px;
 }
 
 .c12 {
   margin-right: 5px;
 }
 
-.c10 {
-  margin-right: 5px;
-}
-
-.c49 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c54 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c34 {
+.c39 {
   margin: 0 3px;
 }
 
-.c32 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c37 {
   margin: 2px 3px;
 }
 
-.c35 {
-  border: 0;
-  border-spacing: 0px;
-  font-size: 12px;
-  text-align: left;
-  table-layout: auto;
-  width: 100%;
+.c42 {
   opacity: 1.0;
 }
 
-.c35 th,
-.c35 td {
-  padding: 4px 10px;
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c35 tfoot tr {
-  background: #fff;
-}
-
-.c35 tfoot tr td {
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c31 {
+.c35 {
   margin-top: 2px;
   margin-left: 2px;
 }
 
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+.c33 {
   margin-top: 20px;
 }
 
-.c44 {
+.c50 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c44:hover {
+.c50 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
@@ -922,12 +777,30 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
 }
 
 @media print {
-  .c36 {
+  .c40 {
+    border-collapse: collapse;
+  }
+}
+
+@media screen {
+  .c41>tbody:nth-of-type(even),
+  .c41>tbody:only-of-type>tr:nth-of-type(even) {
+    background: #f3f3f3;
+  }
+
+  .c41>tbody:not(:only-of-type):hover,
+  .c41>tbody:only-of-type>tr:hover {
+    background: #e5e5e5;
+  }
+}
+
+@media print {
+  .c43 {
     border-bottom: 1px solid black;
   }
 
-  .c36 a,
-  .c36 a:hover {
+  .c43 a,
+  .c43 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -935,7 +808,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
 }
 
 @media print {
-  .c37 {
+  .c44 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
@@ -944,7 +817,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
 }
 
 @media print {
-  .c40 {
+  .c46 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
@@ -953,31 +826,13 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
 }
 
 @media print {
-  .c32 svg {
+  .c37 svg {
     display: none;
   }
 }
 
 @media print {
-  .c35 {
-    border-collapse: collapse;
-  }
-}
-
-@media screen {
-  .c35 > tbody:nth-of-type(even),
-  .c35 > tbody:only-of-type > tr:nth-of-type(even) {
-    background: #f3f3f3;
-  }
-
-  .c35 > tbody:not(:only-of-type):hover,
-  .c35 > tbody:only-of-type > tr:hover {
-    background: #e5e5e5;
-  }
-}
-
-@media print {
-  .c44 {
+  .c50 {
     color: #000;
   }
 }
@@ -994,10 +849,10 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
         class="c1 toolbar"
       >
         <div
-          class="c2"
+          class="c2 c3"
         >
           <div
-            class="c3"
+            class="c2 c4"
             margin="5px"
           >
             <a
@@ -1006,8 +861,9 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               target="_blank"
             >
               <span
-                class="c4"
+                class="c5 c6"
                 data-testid="svg-icon"
+                iconsize="small"
                 title="Help: Policies"
               >
                 <svg
@@ -1018,8 +874,9 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </span>
             </a>
             <span
-              class="c5 c4"
+              class="c5 c7 c6"
               data-testid="svg-icon"
+              iconsize="small"
               title="New Policy"
             >
               <svg
@@ -1029,8 +886,9 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c4"
+              class="c5 c7 c6"
               data-testid="svg-icon"
+              iconsize="small"
               title="Import Policy"
             >
               <svg
@@ -1042,33 +900,33 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
           </div>
         </div>
         <div
-          class="c6"
+          class="c8"
         >
           <div
-            class="c7 powerfilter"
+            class="c9 powerfilter"
           >
             <div
-              class="c8"
+              class="c10"
             >
               <div
-                class="c2"
+                class="c2 c3"
               >
                 <div
-                  class="c9 c10"
+                  class="c11 c4 c12"
                   margin="5px"
                 >
                   <div
                     class="c11"
                   >
                     <label
-                      class="c12"
+                      class="c13"
                     >
                       <b>
                         Filter
                       </b>
                     </label>
                     <input
-                      class="c13 c14"
+                      class="c14 c15"
                       maxlength="1000"
                       name="userFilterString"
                       size="53"
@@ -1076,22 +934,23 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       value=""
                     />
                     <div
-                      class="c15"
+                      class="c16"
                       data-testid="error-marker"
                     >
                       ×
                     </div>
                   </div>
                   <div
-                    class="c2"
+                    class="c2 c3"
                   >
                     <div
-                      class="c9"
+                      class="c11 c4"
                       margin="5px"
                     >
                       <span
-                        class="c5 c4"
+                        class="c5 c7 c6"
                         data-testid="svg-icon"
+                        iconsize="small"
                         title="Update Filter"
                       >
                         <svg
@@ -1101,8 +960,9 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c4"
+                        class="c5 c7 c6"
                         data-testid="svg-icon"
+                        iconsize="small"
                         title="Remove Filter"
                       >
                         <svg
@@ -1112,8 +972,9 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c4"
+                        class="c5 c7 c6"
                         data-testid="svg-icon"
+                        iconsize="small"
                         title="Reset to Default Filter"
                       >
                         <svg
@@ -1128,8 +989,9 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                         target="_blank"
                       >
                         <span
-                          class="c4"
+                          class="c5 c6"
                           data-testid="svg-icon"
+                          iconsize="small"
                           title="Help: Powerfilter"
                         >
                           <svg
@@ -1147,35 +1009,36 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="downshift-0-label"
-                class="c16"
+                class="c17"
                 role="combobox"
               >
                 <div
-                  class="c17"
+                  class="c18"
                   width="150px"
                 >
                   <div
                     aria-haspopup="true"
                     aria-label="open menu"
-                    class="c18"
+                    class="c19"
                     data-toggle="true"
                     role="button"
                     title="Loaded filter"
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20 c21"
                       data-testid="select-selected-value"
                       title="Loaded filter"
                     >
                       --
                     </div>
                     <div
-                      class="c20"
+                      class="c22"
                     >
                       <span
-                        class="c21 c22"
+                        class="c23 c24"
                         data-testid="select-open-button"
+                        iconsize="small"
                       >
                         ▼
                       </span>
@@ -1183,7 +1046,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c15"
+                  class="c16"
                   data-testid="error-marker"
                 >
                   ×
@@ -1197,16 +1060,16 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
         class="entities-section"
       >
         <div
-          class="c23 section-header"
+          class="c25 c26 section-header"
         >
           <h2
-            class="c24 c25"
+            class="c27 c28"
           >
             <div
-              class="c26"
+              class="c29 c30"
             >
               <span
-                class="c27"
+                class="c5 c31"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -1215,26 +1078,26 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </span>
             </div>
             <div
-              class="c28"
+              class="c29 c32"
             >
               Policies 0 of 0
             </div>
           </h2>
           <div
-            class="c8"
+            class="c10"
           />
         </div>
         <div
           class="c0"
         >
           <div
-            class="c29 entities-table"
+            class="c0 c33 entities-table"
           >
             <div
-              class="c30"
+              class="c34"
             >
               <span
-                class="c5 c4 c31"
+                class="c5 c7 c6 c35"
                 data-testid="svg-icon"
                 title="Unfold all details"
               >
@@ -1245,17 +1108,17 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                 </svg>
               </span>
               <div
-                class="c32"
+                class="c36 c37"
               >
                 <div
-                  class="c2"
+                  class="c2 c3"
                 >
                   <div
-                    class="c3"
+                    class="c2 c4"
                     margin="5px"
                   >
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1266,7 +1129,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1279,19 +1142,19 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c34"
+                  class="c39"
                 >
                   0 - 0 of 0
                 </span>
                 <div
-                  class="c2"
+                  class="c2 c3"
                 >
                   <div
-                    class="c3"
+                    class="c2 c4"
                     margin="5px"
                   >
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1302,7 +1165,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Last"
                     >
@@ -1317,30 +1180,30 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </div>
             </div>
             <table
-              class="c35"
+              class="c40 c41 c42"
             >
               <thead
-                class="c36"
+                class="c43"
               >
                 <tr>
                   <th
-                    class="c37"
+                    class="c44"
                   >
                     <a
-                      class="c38"
+                      class="c45"
                     >
                       <div
-                        class="c39"
+                        class="c2"
                       >
                         Name
                       </div>
                     </a>
                   </th>
                   <th
-                    class="c40"
+                    class="c46"
                   >
                     <div
-                      class="c41"
+                      class="c47"
                     >
                       Actions
                     </div>
@@ -1353,17 +1216,17 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                 <tr>
                   <td>
                     <div
-                      class="c42"
+                      class="c48"
                     >
                       <div
-                        class="c43"
+                        class="c49"
                       >
                         <div
-                          class="c42"
+                          class="c48"
                         >
                           <span>
                             <span
-                              class="c44"
+                              class="c50"
                               name="12345"
                             >
                               foo
@@ -1385,14 +1248,14 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       class="c0"
                     >
                       <div
-                        class="c45"
+                        class="c51 c3"
                       >
                         <div
-                          class="c46"
+                          class="c52 c4"
                           margin="5px"
                         >
                           <span
-                            class="c5 c4"
+                            class="c5 c7 c6"
                             data-testid="svg-icon"
                             title="Move Policy to trashcan"
                           >
@@ -1403,7 +1266,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c4"
+                            class="c5 c7 c6"
                             data-testid="svg-icon"
                             title="Edit Policy"
                           >
@@ -1414,7 +1277,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c4"
+                            class="c5 c7 c6"
                             data-testid="svg-icon"
                             title="Clone Policy"
                           >
@@ -1425,7 +1288,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c4"
+                            class="c5 c7 c6"
                             data-testid="svg-icon"
                             title="Create Audit from Policy"
                           >
@@ -1436,7 +1299,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c4"
+                            class="c5 c7 c6"
                             data-testid="svg-icon"
                             title="Export Policy"
                           >
@@ -1458,46 +1321,46 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     colspan="2"
                   >
                     <div
-                      class="c47"
+                      class="c36"
                     >
                       <div
-                        class="c2"
+                        class="c2 c3"
                       >
                         <div
-                          class="c3"
+                          class="c2 c4"
                           margin="5px"
                         >
                           <div
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="downshift-1-label"
-                            class="c16"
+                            class="c17"
                             role="combobox"
                           >
                             <div
-                              class="c48"
+                              class="c53"
                               width="180px"
                             >
                               <div
                                 aria-haspopup="true"
                                 aria-label="open menu"
-                                class="c18"
+                                class="c19"
                                 data-toggle="true"
                                 role="button"
                                 type="button"
                               >
                                 <div
-                                  class="c19"
+                                  class="c20 c21"
                                   data-testid="select-selected-value"
                                   title="Apply to page contents"
                                 >
                                   Apply to page contents
                                 </div>
                                 <div
-                                  class="c20"
+                                  class="c22"
                                 >
                                   <span
-                                    class="c21 c22"
+                                    class="c23 c24"
                                     data-testid="select-open-button"
                                   >
                                     ▼
@@ -1506,21 +1369,21 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                               </div>
                             </div>
                             <div
-                              class="c15"
+                              class="c16"
                               data-testid="error-marker"
                             >
                               ×
                             </div>
                           </div>
                           <div
-                            class="c2"
+                            class="c2 c3"
                           >
                             <div
-                              class="c3"
+                              class="c2 c4"
                               margin="5px"
                             >
                               <span
-                                class="c5 c4"
+                                class="c5 c7 c6"
                                 data-testid="svg-icon"
                                 title="Move page contents to trashcan"
                               >
@@ -1531,7 +1394,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                                 </svg>
                               </span>
                               <span
-                                class="c5 c4"
+                                class="c5 c7 c6"
                                 data-testid="svg-icon"
                                 title="Export page contents"
                               >
@@ -1551,25 +1414,25 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </tfoot>
             </table>
             <div
-              class="c43"
+              class="c49"
             >
               <div
-                class="c49"
+                class="c2 c54"
               >
                 (Applied filter: )
               </div>
               <div
-                class="c32"
+                class="c36 c37"
               >
                 <div
-                  class="c2"
+                  class="c2 c3"
                 >
                   <div
-                    class="c3"
+                    class="c2 c4"
                     margin="5px"
                   >
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1580,7 +1443,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1593,19 +1456,19 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c34"
+                  class="c39"
                 >
                   0 - 0 of 0
                 </span>
                 <div
-                  class="c2"
+                  class="c2 c3"
                 >
                   <div
-                    class="c3"
+                    class="c2 c4"
                     margin="5px"
                   >
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1616,7 +1479,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Last"
                     >

--- a/src/web/pages/policies/__tests__/__snapshots__/row.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/row.js.snap
@@ -10,8 +10,8 @@ exports[`Row tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -29,7 +29,6 @@ exports[`Row tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -46,47 +45,13 @@ exports[`Row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c5 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c5 > * {
-  margin-left: 5px;
 }
 
 .c4 {
@@ -102,30 +67,70 @@ exports[`Row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  margin-left: -5px;
+}
+
+.c7>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c6 {
+.c7>* {
+  margin-left: 5px;
+}
+
+.c5 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c9 {
   cursor: pointer;
 }
 
-.c7 {
+.c10 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c7 * {
+.c10 * {
   height: inherit;
   width: inherit;
 }
@@ -137,14 +142,14 @@ exports[`Row tests should render 1`] = `
   color: #0a53b8;
 }
 
-.c2:hover {
+.c2 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
 @media print {
-  .c6 {
+  .c8 {
     display: none;
   }
 }
@@ -195,14 +200,14 @@ exports[`Row tests should render 1`] = `
           class="c3"
         >
           <div
-            class="c4"
+            class="c4 c5"
           >
             <div
-              class="c5"
+              class="c6 c7"
               margin="5px"
             >
               <span
-                class="c6 c7"
+                class="c8 c9 c10"
                 data-testid="svg-icon"
                 title="Move Policy to trashcan"
               >
@@ -213,7 +218,7 @@ exports[`Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c6 c7"
+                class="c8 c9 c10"
                 data-testid="svg-icon"
                 title="Edit Policy"
               >
@@ -224,7 +229,7 @@ exports[`Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c6 c7"
+                class="c8 c9 c10"
                 data-testid="svg-icon"
                 title="Clone Policy"
               >
@@ -235,7 +240,7 @@ exports[`Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c6 c7"
+                class="c8 c9 c10"
                 data-testid="svg-icon"
                 title="Create Audit from Policy"
               >
@@ -246,7 +251,7 @@ exports[`Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c6 c7"
+                class="c8 c9 c10"
                 data-testid="svg-icon"
                 title="Export Policy"
               >

--- a/src/web/pages/policies/__tests__/__snapshots__/table.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/table.js.snap
@@ -1,7 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Policies table tests should render 1`] = `
-.c1 {
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15,11 +37,28 @@ exports[`Policies table tests should render 1`] = `
   flex-grow: 1;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c13 {
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -28,8 +67,8 @@ exports[`Policies table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -37,7 +76,7 @@ exports[`Policies table tests should render 1`] = `
   align-items: center;
 }
 
-.c15 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -46,12 +85,12 @@ exports[`Policies table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
 }
 
-.c16 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -60,44 +99,8 @@ exports[`Policies table tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c17 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
   -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -113,121 +116,12 @@ exports[`Policies table tests should render 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
 }
 
-.c27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c7 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c7 > * {
-  margin-left: 5px;
-}
-
-.c21 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c21 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c21 > * {
-  margin-left: 5px;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c20 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -240,39 +134,97 @@ exports[`Policies table tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c25 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c31 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c11 {
+  margin-left: -5px;
+}
+
+.c11>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2 {
+.c11>* {
+  margin-left: 5px;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4 {
   cursor: pointer;
 }
 
-.c8 svg path {
+.c12 svg path {
   fill: #bfbfbf;
 }
 
-.c3 {
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c3 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
-.c28 {
+.c32 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -285,8 +237,8 @@ exports[`Policies table tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -297,18 +249,18 @@ exports[`Policies table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c29 {
+.c33 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c29 * {
+.c33 * {
   height: inherit;
   width: inherit;
 }
 
-.c25 {
+.c28 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -332,7 +284,7 @@ exports[`Policies table tests should render 1`] = `
   font-weight: normal;
 }
 
-.c24 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -344,16 +296,7 @@ exports[`Policies table tests should render 1`] = `
   width: 180px;
 }
 
-.c30 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c26 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -370,29 +313,64 @@ exports[`Policies table tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
+}
+
+.c34 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c30 {
   cursor: default;
 }
 
-.c23 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c11 a {
+.c14 {
+  border: 0;
+  border-spacing: 0px;
+  font-size: 12px;
+  text-align: left;
+  table-layout: auto;
+  width: 100%;
+}
+
+.c15 th,
+.c15 td {
+  padding: 4px 10px;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.c15 tfoot tr {
+  background: #fff;
+}
+
+.c15 tfoot tr td {
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.c17 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c11 a:hover {
+.c17 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c12 {
+.c18 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -400,7 +378,7 @@ exports[`Policies table tests should render 1`] = `
   width: 92%;
 }
 
-.c14 {
+.c19 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -408,128 +386,77 @@ exports[`Policies table tests should render 1`] = `
   width: 8%;
 }
 
-.c31 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c35 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c9 {
+.c13 {
   margin: 0 3px;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c8 {
   margin: 2px 3px;
 }
 
-.c10 {
-  border: 0;
-  border-spacing: 0px;
-  font-size: 12px;
-  text-align: left;
-  table-layout: auto;
-  width: 100%;
+.c16 {
   opacity: 1.0;
 }
 
-.c10 th,
-.c10 td {
-  padding: 4px 10px;
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c10 tfoot tr {
-  background: #fff;
-}
-
-.c10 tfoot tr td {
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c4 {
+.c6 {
   margin-top: 2px;
   margin-left: 2px;
 }
 
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+.c1 {
   margin-top: 20px;
 }
 
-.c18 {
+.c23 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c18:hover {
+.c23 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
 @media print {
-  .c2 {
+  .c3 {
     display: none;
   }
 }
 
 @media print {
-  .c11 {
+  .c14 {
+    border-collapse: collapse;
+  }
+}
+
+@media screen {
+  .c15>tbody:nth-of-type(even),
+  .c15>tbody:only-of-type>tr:nth-of-type(even) {
+    background: #f3f3f3;
+  }
+
+  .c15>tbody:not(:only-of-type):hover,
+  .c15>tbody:only-of-type>tr:hover {
+    background: #e5e5e5;
+  }
+}
+
+@media print {
+  .c17 {
     border-bottom: 1px solid black;
   }
 
-  .c11 a,
-  .c11 a:hover {
+  .c17 a,
+  .c17 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -537,7 +464,7 @@ exports[`Policies table tests should render 1`] = `
 }
 
 @media print {
-  .c12 {
+  .c18 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
@@ -546,7 +473,7 @@ exports[`Policies table tests should render 1`] = `
 }
 
 @media print {
-  .c14 {
+  .c19 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
@@ -555,31 +482,13 @@ exports[`Policies table tests should render 1`] = `
 }
 
 @media print {
-  .c5 svg {
+  .c8 svg {
     display: none;
   }
 }
 
 @media print {
-  .c10 {
-    border-collapse: collapse;
-  }
-}
-
-@media screen {
-  .c10 > tbody:nth-of-type(even),
-  .c10 > tbody:only-of-type > tr:nth-of-type(even) {
-    background: #f3f3f3;
-  }
-
-  .c10 > tbody:not(:only-of-type):hover,
-  .c10 > tbody:only-of-type > tr:hover {
-    background: #e5e5e5;
-  }
-}
-
-@media print {
-  .c18 {
+  .c23 {
     color: #000;
   }
 }
@@ -590,13 +499,13 @@ exports[`Policies table tests should render 1`] = `
   />
   <div>
     <div
-      class="c0 entities-table"
+      class="c0 c1 entities-table"
     >
       <div
-        class="c1"
+        class="c2"
       >
         <span
-          class="c2 c3 c4"
+          class="c3 c4 c5 c6"
           data-testid="svg-icon"
           title="Unfold all details"
         >
@@ -607,17 +516,17 @@ exports[`Policies table tests should render 1`] = `
           </svg>
         </span>
         <div
-          class="c5"
+          class="c7 c8"
         >
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -628,7 +537,7 @@ exports[`Policies table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -641,19 +550,19 @@ exports[`Policies table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c9"
+            class="c13"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -664,7 +573,7 @@ exports[`Policies table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Last"
               >
@@ -679,26 +588,26 @@ exports[`Policies table tests should render 1`] = `
         </div>
       </div>
       <table
-        class="c10"
+        class="c14 c15 c16"
       >
         <thead
-          class="c11"
+          class="c17"
         >
           <tr>
             <th
-              class="c12"
+              class="c18"
             >
               <div
-                class="c13"
+                class="c9"
               >
                 Name
               </div>
             </th>
             <th
-              class="c14"
+              class="c19"
             >
               <div
-                class="c15"
+                class="c20"
               >
                 Actions
               </div>
@@ -711,17 +620,17 @@ exports[`Policies table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c16"
+                class="c21"
               >
                 <div
-                  class="c17"
+                  class="c22"
                 >
                   <div
-                    class="c16"
+                    class="c21"
                   >
                     <span>
                       <span
-                        class="c18"
+                        class="c23"
                         name="12345"
                       >
                         foo
@@ -740,17 +649,17 @@ exports[`Policies table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c19"
+                class="c0"
               >
                 <div
-                  class="c20"
+                  class="c24 c10"
                 >
                   <div
-                    class="c21"
+                    class="c25 c11"
                     margin="5px"
                   >
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Move Policy to trashcan"
                     >
@@ -761,7 +670,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Edit Policy"
                     >
@@ -772,7 +681,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Clone Policy"
                     >
@@ -783,7 +692,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Create Audit from Policy"
                     >
@@ -794,7 +703,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Export Policy"
                     >
@@ -812,17 +721,17 @@ exports[`Policies table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c16"
+                class="c21"
               >
                 <div
-                  class="c17"
+                  class="c22"
                 >
                   <div
-                    class="c16"
+                    class="c21"
                   >
                     <span>
                       <span
-                        class="c18"
+                        class="c23"
                         name="123456"
                       >
                         lorem
@@ -841,17 +750,17 @@ exports[`Policies table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c19"
+                class="c0"
               >
                 <div
-                  class="c20"
+                  class="c24 c10"
                 >
                   <div
-                    class="c21"
+                    class="c25 c11"
                     margin="5px"
                   >
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Move Policy to trashcan"
                     >
@@ -862,7 +771,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Edit Policy"
                     >
@@ -873,7 +782,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Clone Policy"
                     >
@@ -884,7 +793,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Create Audit from Policy"
                     >
@@ -895,7 +804,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Export Policy"
                     >
@@ -913,17 +822,17 @@ exports[`Policies table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c16"
+                class="c21"
               >
                 <div
-                  class="c17"
+                  class="c22"
                 >
                   <div
-                    class="c16"
+                    class="c21"
                   >
                     <span>
                       <span
-                        class="c18"
+                        class="c23"
                         name="1234567"
                       >
                         hello
@@ -942,17 +851,17 @@ exports[`Policies table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c19"
+                class="c0"
               >
                 <div
-                  class="c20"
+                  class="c24 c10"
                 >
                   <div
-                    class="c21"
+                    class="c25 c11"
                     margin="5px"
                   >
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Move Policy to trashcan"
                     >
@@ -963,7 +872,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Edit Policy"
                     >
@@ -974,7 +883,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Clone Policy"
                     >
@@ -985,7 +894,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Create Audit from Policy"
                     >
@@ -996,7 +905,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Export Policy"
                     >
@@ -1018,43 +927,43 @@ exports[`Policies table tests should render 1`] = `
               colspan="2"
             >
               <div
-                class="c22"
+                class="c7"
               >
                 <div
-                  class="c6"
+                  class="c9 c10"
                 >
                   <div
-                    class="c7"
+                    class="c9 c11"
                     margin="5px"
                   >
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-labelledby="downshift-0-label"
-                      class="c23"
+                      class="c26"
                       role="combobox"
                     >
                       <div
-                        class="c24"
+                        class="c27"
                         width="180px"
                       >
                         <div
                           aria-haspopup="true"
                           aria-label="open menu"
-                          class="c25"
+                          class="c28"
                           data-toggle="true"
                           role="button"
                           type="button"
                         >
                           <div
-                            class="c26"
+                            class="c29 c30"
                             data-testid="select-selected-value"
                           />
                           <div
-                            class="c27"
+                            class="c31"
                           >
                             <span
-                              class="c28 c29"
+                              class="c32 c33"
                               data-testid="select-open-button"
                             >
                               ▼
@@ -1063,21 +972,21 @@ exports[`Policies table tests should render 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c30"
+                        class="c34"
                         data-testid="error-marker"
                       >
                         ×
                       </div>
                     </div>
                     <div
-                      class="c6"
+                      class="c9 c10"
                     >
                       <div
-                        class="c7"
+                        class="c9 c11"
                         margin="5px"
                       >
                         <span
-                          class="c3"
+                          class="c3 c5"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1085,7 +994,7 @@ exports[`Policies table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3"
+                          class="c3 c5"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1102,25 +1011,25 @@ exports[`Policies table tests should render 1`] = `
         </tfoot>
       </table>
       <div
-        class="c17"
+        class="c22"
       >
         <div
-          class="c31"
+          class="c9 c35"
         >
           (Applied filter: rows=2)
         </div>
         <div
-          class="c5"
+          class="c7 c8"
         >
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -1131,7 +1040,7 @@ exports[`Policies table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -1144,19 +1053,19 @@ exports[`Policies table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c9"
+            class="c13"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -1167,7 +1076,7 @@ exports[`Policies table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Last"
               >

--- a/src/web/pages/radius/__tests__/__snapshots__/dialog.js.snap
+++ b/src/web/pages/radius/__tests__/__snapshots__/dialog.js.snap
@@ -1,7 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RADIUS dialog component tests should render dialog 1`] = `
-.c8 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,43 +49,13 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c14 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c14 > * {
-  margin-left: 5px;
 }
 
 .c13 {
@@ -58,13 +67,52 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c17 {
+  margin-left: -5px;
+}
+
+.c17>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c17>* {
+  margin-left: 5px;
+}
+
+.c16 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -96,7 +144,7 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -104,7 +152,7 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   height: 100%;
 }
 
-.c25 {
+.c30 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -113,13 +161,13 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c24 {
+.c29 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -138,7 +186,7 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -155,30 +203,30 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c21 {
+.c26 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -198,12 +246,12 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   z-index: 1;
 }
 
-.c21:focus,
-.c21:hover {
+.c26:focus,
+.c26:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c21:hover {
+.c26:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -211,26 +259,26 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   color: #fff;
 }
 
-.c21[disabled] {
+.c26[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c21 img {
+.c26 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c21:link {
+.c26:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c22 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -239,8 +287,8 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -248,63 +296,32 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c23 {
+.c28 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c23:hover {
+.c28 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c24 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c25 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -318,17 +335,15 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -336,31 +351,12 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -370,13 +366,13 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   max-width: 100%;
   font-weight: bold;
@@ -387,28 +383,13 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   margin-left: 0;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c19 {
+.c22 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -417,7 +398,7 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   display: none;
 }
 
-.c17 {
+.c20 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -431,11 +412,11 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   padding: 1px 8px;
 }
 
-.c17:-webkit-autofill {
+.c20:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c18 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -444,8 +425,8 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -453,7 +434,7 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c12 {
+.c15 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -469,7 +450,7 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   cursor: pointer;
 }
 
-.c15 {
+.c18 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -480,7 +461,7 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   height: auto;
 }
 
-.c16 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -489,8 +470,8 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -517,14 +498,14 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 Edit RADIUS Authentication
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -532,42 +513,45 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Enable
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <label
-                        class="c12"
+                        class="c15"
                       >
                         <div
-                          class="c13"
+                          class="c13 c16"
                         >
                           <div
-                            class="c14"
+                            class="c13 c17"
                             margin="5px"
                           >
                             <input
                               checked=""
-                              class="c15 c16"
+                              class="c18 c19"
                               data-testid="enable-checkbox"
                               name="enable"
                               type="checkbox"
@@ -578,21 +562,23 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       RADIUS Host
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c17 c18"
+                        class="c20 c21"
                         data-testid="radiushost-textfield"
                         name="radiushost"
                         size="50"
@@ -600,7 +586,7 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
                         value="foo"
                       />
                       <div
-                        class="c19"
+                        class="c22"
                         data-testid="error-marker"
                       >
                         ×
@@ -608,21 +594,23 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Secret Key
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c17 c18"
+                        class="c20 c21"
                         data-testid="radiuskey-textfield"
                         name="radiuskey"
                         size="50"
@@ -635,17 +623,17 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c20"
+              class="c23 c24 c25"
             >
               <button
-                class="c21 c22 c23"
+                class="c26 c27 c28"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c21 c22 c23"
+                class="c26 c27 c28"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -654,10 +642,10 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
             </div>
           </div>
           <div
-            class="c24"
+            class="c29"
           >
             <div
-              class="c25"
+              class="c30"
             />
           </div>
         </div>

--- a/src/web/pages/results/__tests__/__snapshots__/diff.js.snap
+++ b/src/web/pages/results/__tests__/__snapshots__/diff.js.snap
@@ -8,24 +8,15 @@ exports[`Diff component tests should render 1`] = `
 }
 
 .c2 {
-  white-space: pre-wrap;
-  word-wrap: normal;
-  font-family: monospace;
   background-color: #ffeef0;
 }
 
 .c3 {
-  white-space: pre-wrap;
-  word-wrap: normal;
-  font-family: monospace;
   background-color: #e6ffed;
 }
 
 .c1 {
-  white-space: pre-wrap;
-  word-wrap: normal;
-  font-family: monospace;
-  color: rgba(0,0,0,0.3);
+  color: rgba(0, 0, 0, 0.3);
 }
 
 <div>
@@ -33,17 +24,17 @@ exports[`Diff component tests should render 1`] = `
     class="c0"
   />
   <div
-    class="c1"
+    class="c0 c1"
   >
     @@ -1,9 +1,14 @@
   </div>
   <div
-    class="c2"
+    class="c0 c2"
   >
     -Remote SSH server version: SSH-2.0-OpenSSH_7.6p1 Ubuntu-4
   </div>
   <div
-    class="c3"
+    class="c0 c3"
   >
     +Remote SSH server banner: SSH-2.0-OpenSSH_7.6p1 Ubuntu-4ubuntu0.3
   </div>
@@ -53,32 +44,32 @@ exports[`Diff component tests should render 1`] = `
      Remote SSH supported authentication: password,publickey
   </div>
   <div
-    class="c2"
+    class="c0 c2"
   >
     -Remote SSH banner: (not available)
   </div>
   <div
-    class="c3"
+    class="c0 c3"
   >
     +Remote SSH text/login banner: (not available)
   </div>
   <div
-    class="c3"
+    class="c0 c3"
   >
     +
   </div>
   <div
-    class="c3"
+    class="c0 c3"
   >
     +This is probably:
   </div>
   <div
-    class="c3"
+    class="c0 c3"
   >
     +
   </div>
   <div
-    class="c3"
+    class="c0 c3"
   >
     +- OpenSSH
   </div>
@@ -99,27 +90,27 @@ exports[`Diff component tests should render 1`] = `
      Concluded from remote connection attempt with credentials:
   </div>
   <div
-    class="c2"
+    class="c0 c2"
   >
     -  Login: VulnScan
   </div>
   <div
-    class="c2"
+    class="c0 c2"
   >
     -  Password: VulnScan
   </div>
   <div
-    class="c3"
+    class="c0 c3"
   >
     +
   </div>
   <div
-    class="c3"
+    class="c0 c3"
   >
     +Login:    OpenVAS-VT
   </div>
   <div
-    class="c3"
+    class="c0 c3"
   >
     +Password: OpenVAS-VT
   </div>

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/details.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/details.js.snap
@@ -14,8 +14,8 @@ exports[`Scan Config Details tests should render full Details 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -32,53 +32,13 @@ exports[`Scan Config Details tests should render full Details 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-.c8 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c7 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c7 > * {
-  margin-left: 5px;
 }
 
 .c6 {
@@ -90,13 +50,60 @@ exports[`Scan Config Details tests should render full Details 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c9 {
+  margin-left: -5px;
+}
+
+.c9>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c9>* {
+  margin-left: 5px;
+}
+
+.c7 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -181,14 +188,14 @@ exports[`Scan Config Details tests should render full Details 1`] = `
             class="c5"
           >
             <div
-              class="c6"
+              class="c6 c7"
             >
               <div
-                class="c7"
+                class="c8 c9"
                 margin="5px"
               >
                 <a
-                  class="c8"
+                  class="c10"
                   data-testid="details-link"
                   href="/task/1234"
                 >
@@ -196,7 +203,7 @@ exports[`Scan Config Details tests should render full Details 1`] = `
                 </a>
                 ,
                 <a
-                  class="c8"
+                  class="c10"
                   data-testid="details-link"
                   href="/task/5678"
                 >

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/detailspage.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/detailspage.js.snap
@@ -14,8 +14,8 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
@@ -29,12 +29,46 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
 .c14 {
@@ -45,9 +79,26 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -55,7 +106,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   align-items: center;
 }
 
-.c15 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -64,12 +115,12 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
-.c17 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -82,27 +133,9 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
@@ -114,17 +147,21 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
 .c24 {
@@ -132,84 +169,35 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
 }
 
-.c6 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c3 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-left: -10px;
-}
-
-.c3 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c3 > * {
-  margin-left: 10px;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c4 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4 > * {
-  margin-left: 5px;
 }
 
 .c29 {
@@ -217,127 +205,20 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c29 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c29 > * {
-  margin-left: 5px;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c7 {
-  cursor: pointer;
-}
-
-.c5 {
-  height: 16px;
-  width: 16px;
-  line-height: 16px;
-}
-
-.c5 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c12 {
-  height: 50px;
-  width: 50px;
-  line-height: 50px;
-}
-
-.c12 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  margin: 10px 0px;
-  padding-bottom: 1px;
-  border-bottom: 2px solid #e5e5e5;
-  position: relative;
-}
-
-.c9 {
-  margin: 0 0 1px 0;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
 }
 
-.c11 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -345,15 +226,99 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  margin-right: 5px;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4 {
+  margin-left: -10px;
+}
+
+.c4>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4>* {
+  margin-left: 10px;
+}
+
+.c5 {
+  margin-left: -5px;
+}
+
+.c5>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c5>* {
+  margin-left: 5px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c9 {
+  cursor: pointer;
+}
+
+.c7 {
+  height: 16px;
+  width: 16px;
+  line-height: 16px;
+}
+
+.c7 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c16 {
+  height: 50px;
+  width: 50px;
+  line-height: 50px;
+}
+
+.c16 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c11 {
+  margin: 10px 0px;
+  padding-bottom: 1px;
+  border-bottom: 2px solid #e5e5e5;
+  position: relative;
+}
+
+.c12 {
+  margin: 0 0 1px 0;
 }
 
 .c13 {
@@ -365,18 +330,25 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c15 {
+  margin-right: 5px;
+}
+
+.c17 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c20 {
+.c25 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -403,11 +375,11 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #11ab51;
 }
 
-.c20:first-child {
+.c25 :first-child {
   border-left: 1px solid #e5e5e5;
 }
 
-.c21 {
+.c26 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -431,40 +403,21 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #fff;
 }
 
-.c21:hover {
+.c26 :hover {
   border-top: 2px solid #e5e5e5;
 }
 
-.c21:first-child {
+.c26 :first-child {
   border-left: 1px solid #fff;
 }
 
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+.c23 {
   border-bottom: 2px solid #11ab51;
   margin-top: 30px;
   margin-bottom: 15px;
 }
 
-.c25 {
+.c30 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -472,63 +425,48 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   table-layout: auto;
 }
 
-.c26 td {
+.c31 td {
   padding: 4px 4px 4px 0;
 }
 
-.c26 tr td:first-child {
+.c31 tr td:first-child {
   padding-right: 5px;
 }
 
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c20 {
   border-spacing: 0px;
   color: #7F7F7F;
   font-size: 10px;
 }
 
-.c16 :nth-child(even) {
+.c20 :nth-child(even) {
   margin-left: 3px;
 }
 
-.c16 :nth-child(odd) {
+.c20 :nth-child(odd) {
   margin-left: 30px;
 }
 
-.c27 {
+.c32 {
   width: 10%;
 }
 
-.c28 {
+.c33 {
   width: 90%;
 }
 
-.c23 {
+.c28 {
   font-size: 0.7em;
 }
 
 @media print {
-  .c7 {
+  .c6 {
     display: none;
   }
 }
 
 @media print {
-  .c25 {
+  .c30 {
     border-collapse: collapse;
   }
 }
@@ -540,17 +478,17 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
     class="c1 toolbar"
   >
     <div
-      class="c2"
+      class="c2 c3"
     >
       <div
-        class="c3"
+        class="c2 c4"
         margin="10px"
       >
         <div
-          class="c2"
+          class="c2 c3"
         >
           <div
-            class="c4"
+            class="c2 c5"
             margin="5px"
           >
             <a
@@ -559,8 +497,9 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               target="_blank"
             >
               <span
-                class="c5"
+                class="c6 c7"
                 data-testid="svg-icon"
+                iconsize="small"
                 title="Help: ScanConfigs"
               >
                 <svg
@@ -571,12 +510,13 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <a
-              class="c6"
+              class="c8"
               href="/scanconfigs"
             >
               <span
-                class="c5"
+                class="c6 c7"
                 data-testid="svg-icon"
+                iconsize="small"
                 title="ScanConfig List"
               >
                 <svg
@@ -589,15 +529,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
           </div>
         </div>
         <div
-          class="c2"
+          class="c2 c3"
         >
           <div
-            class="c4"
+            class="c2 c5"
             margin="5px"
           >
             <span
-              class="c7 c5"
+              class="c6 c9 c7"
               data-testid="svg-icon"
+              iconsize="small"
               title="Create new Scan Config"
             >
               <svg
@@ -607,8 +548,9 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c5"
+              class="c6 c9 c7"
               data-testid="svg-icon"
+              iconsize="small"
               title="Clone Scan Config"
             >
               <svg
@@ -618,8 +560,9 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c5"
+              class="c6 c9 c7"
               data-testid="svg-icon"
+              iconsize="small"
               title="Edit Scan Config"
             >
               <svg
@@ -629,8 +572,9 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c5"
+              class="c6 c9 c7"
               data-testid="svg-icon"
+              iconsize="small"
               title="Move Scan Config to trashcan"
             >
               <svg
@@ -640,8 +584,9 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c5"
+              class="c6 c9 c7"
               data-testid="svg-icon"
+              iconsize="small"
               title="Export Scan Config as XML"
             >
               <svg
@@ -651,8 +596,9 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c5"
+              class="c6 c9 c7"
               data-testid="svg-icon"
+              iconsize="small"
               title="Import Scan Config"
             >
               <svg
@@ -670,16 +616,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
     class="entity-section"
   >
     <div
-      class="c8 section-header"
+      class="c10 c11 section-header"
     >
       <h2
-        class="c9 c10"
+        class="c12 c13"
       >
         <div
-          class="c11"
+          class="c14 c15"
         >
           <span
-            class="c12"
+            class="c6 c16"
             data-testid="svg-icon"
           >
             <svg>
@@ -688,19 +634,19 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
           </span>
         </div>
         <div
-          class="c13"
+          class="c14 c17"
         >
           Scan Config: foo
         </div>
       </h2>
       <div
-        class="c14"
+        class="c18"
       >
         <div
-          class="c15"
+          class="c19"
         >
           <div
-            class="c16"
+            class="c2 c20"
           >
             <div>
               ID:
@@ -731,30 +677,30 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
       </div>
     </div>
     <div
-      class="c17"
+      class="c21"
     >
       <div
-        class="c18"
+        class="c22 c23"
       >
         <div
-          class="c19"
+          class="c24"
         >
           <div
-            class="c20"
+            class="c25"
           >
             Information
           </div>
           <div
-            class="c21"
+            class="c26"
           >
             <div
-              class="c22"
+              class="c27"
             >
               <span>
                 Scanner Preferences
               </span>
               <span
-                class="c23"
+                class="c28"
               >
                 (
                 <i>
@@ -765,16 +711,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c21"
+            class="c26"
           >
             <div
-              class="c22"
+              class="c27"
             >
               <span>
                 NVT Families
               </span>
               <span
-                class="c23"
+                class="c28"
               >
                 (
                 <i>
@@ -785,16 +731,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c21"
+            class="c26"
           >
             <div
-              class="c22"
+              class="c27"
             >
               <span>
                 NVT Preferences
               </span>
               <span
-                class="c23"
+                class="c28"
               >
                 (
                 <i>
@@ -805,16 +751,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c21"
+            class="c26"
           >
             <div
-              class="c22"
+              class="c27"
             >
               <span>
                 User Tags
               </span>
               <span
-                class="c23"
+                class="c28"
               >
                 (
                 <i>
@@ -825,16 +771,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c21"
+            class="c26"
           >
             <div
-              class="c22"
+              class="c27"
             >
               <span>
                 Permissions
               </span>
               <span
-                class="c23"
+                class="c28"
               >
                 (
                 <i>
@@ -847,21 +793,21 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
         </div>
       </div>
       <div
-        class="c24"
+        class="c29"
       >
         <div
-          class="c17"
+          class="c21"
         >
           <table
-            class="c25 c26"
+            class="c30 c31"
           >
             <colgroup>
               <col
-                class="c27"
+                class="c32"
                 width="10%"
               />
               <col
-                class="c28"
+                class="c33"
                 width="90%"
               />
             </colgroup>
@@ -871,14 +817,14 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               <tr>
                 <td>
                   <div
-                    class="c24"
+                    class="c29"
                   >
                     Comment
                   </div>
                 </td>
                 <td>
                   <div
-                    class="c24"
+                    class="c29"
                   >
                     bar
                   </div>
@@ -887,24 +833,24 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               <tr>
                 <td>
                   <div
-                    class="c24"
+                    class="c29"
                   >
                     Tasks using this Scan Config
                   </div>
                 </td>
                 <td>
                   <div
-                    class="c24"
+                    class="c29"
                   >
                     <div
-                      class="c2"
+                      class="c2 c3"
                     >
                       <div
-                        class="c29"
+                        class="c34 c5"
                         margin="5px"
                       >
                         <a
-                          class="c6"
+                          class="c8"
                           data-testid="details-link"
                           href="/task/1234"
                         >
@@ -912,7 +858,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
                         </a>
                         ,
                         <a
-                          class="c6"
+                          class="c8"
                           data-testid="details-link"
                           href="/task/5678"
                         >
@@ -933,73 +879,6 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
 `;
 
 exports[`Scan Config ToolBarIcons tests should render 1`] = `
-.c4 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -10px;
-}
-
-.c1 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 > * {
-  margin-left: 10px;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c2 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c2 > * {
-  margin-left: 5px;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -1009,52 +888,92 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5 {
-  cursor: pointer;
+.c2 {
+  margin-left: -10px;
+}
+
+.c2>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c2>* {
+  margin-left: 10px;
 }
 
 .c3 {
+  margin-left: -5px;
+}
+
+.c3>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c3>* {
+  margin-left: 5px;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c7 {
+  cursor: pointer;
+}
+
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c3 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
 @media print {
-  .c5 {
+  .c4 {
     display: none;
   }
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <div
-    class="c1"
+    class="c0 c2"
     margin="10px"
   >
     <div
-      class="c0"
+      class="c0 c1"
     >
       <div
-        class="c2"
+        class="c0 c3"
         margin="5px"
       >
         <a
@@ -1063,7 +982,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           target="_blank"
         >
           <span
-            class="c3"
+            class="c4 c5"
             data-testid="svg-icon"
             title="Help: ScanConfigs"
           >
@@ -1075,11 +994,11 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <a
-          class="c4"
+          class="c6"
           href="/scanconfigs"
         >
           <span
-            class="c3"
+            class="c4 c5"
             data-testid="svg-icon"
             title="ScanConfig List"
           >
@@ -1093,14 +1012,14 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
       </div>
     </div>
     <div
-      class="c0"
+      class="c0 c1"
     >
       <div
-        class="c2"
+        class="c0 c3"
         margin="5px"
       >
         <span
-          class="c5 c3"
+          class="c4 c7 c5"
           data-testid="svg-icon"
           title="Create new Scan Config"
         >
@@ -1111,7 +1030,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c3"
+          class="c4 c7 c5"
           data-testid="svg-icon"
           title="Clone Scan Config"
         >
@@ -1122,7 +1041,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c3"
+          class="c4 c7 c5"
           data-testid="svg-icon"
           title="Edit Scan Config"
         >
@@ -1133,7 +1052,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c3"
+          class="c4 c7 c5"
           data-testid="svg-icon"
           title="Move Scan Config to trashcan"
         >
@@ -1144,7 +1063,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c3"
+          class="c4 c7 c5"
           data-testid="svg-icon"
           title="Export Scan Config as XML"
         >
@@ -1155,7 +1074,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c3"
+          class="c4 c7 c5"
           data-testid="svg-icon"
           title="Import Scan Config"
         >

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/editconfigfamilydialog.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/editconfigfamilydialog.js.snap
@@ -1,25 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c14 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -29,7 +11,6 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -37,39 +18,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c24 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -77,95 +26,18 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c30 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
   -webkit-justify-content: center;
-  -ms-flex-pack: center;
   justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c27 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c27 > * {
-  margin-left: 5px;
-}
-
-.c26 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c31 {
-  cursor: pointer;
-}
-
-.c32 {
-  height: 16px;
-  width: 16px;
-  line-height: 16px;
-}
-
-.c32 * {
-  height: inherit;
-  width: inherit;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
 .c10 {
@@ -173,25 +45,17 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  margin: 10px 0px;
-  padding-bottom: 1px;
-  border-bottom: 2px solid #e5e5e5;
-  position: relative;
-}
-
-.c11 {
-  margin: 0 0 1px 0;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
 }
 
 .c12 {
@@ -202,17 +66,16 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
-.c13 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -221,13 +84,167 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
   align-items: flex-end;
+}
+
+.c23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c24 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+}
+
+.c28 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+}
+
+.c34 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c39 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c31 {
+  margin-left: -5px;
+}
+
+.c31>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c31>* {
+  margin-left: 5px;
+}
+
+.c30 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c36 {
+  cursor: pointer;
+}
+
+.c37 {
+  height: 16px;
+  width: 16px;
+  line-height: 16px;
+}
+
+.c37 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c13 {
+  margin: 10px 0px;
+  padding-bottom: 1px;
+  border-bottom: 2px solid #e5e5e5;
+  position: relative;
+}
+
+.c14 {
+  margin: 0 0 1px 0;
+}
+
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c17 {
   word-break: break-all;
   min-width: 100px;
 }
@@ -257,7 +274,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -265,7 +282,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   height: 100%;
 }
 
-.c39 {
+.c46 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -274,13 +291,13 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c38 {
+.c45 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -299,7 +316,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -316,30 +333,30 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c35 {
+.c42 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -359,12 +376,12 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   z-index: 1;
 }
 
-.c35:focus,
-.c35:hover {
+.c42:focus,
+.c42:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c35:hover {
+.c42:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -372,26 +389,26 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   color: #fff;
 }
 
-.c35[disabled] {
+.c42[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c35 img {
+.c42 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c35:link {
+.c42:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c36 {
+.c43 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -400,8 +417,8 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -409,63 +426,32 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c37 {
+.c44 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c37:hover {
+.c44 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c34 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c40 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c41 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -479,17 +465,15 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -497,31 +481,12 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-.c9 {
+.c11 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -529,7 +494,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   table-layout: auto;
 }
 
-.c15 {
+.c18 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -538,44 +503,44 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   width: 100%;
 }
 
-.c15 th,
-.c15 td {
+.c19 th,
+.c19 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c15 tfoot tr {
+.c19 tfoot tr {
   background: #fff;
 }
 
-.c15 tfoot tr td {
+.c19 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c16 a {
+.c20 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c16 a:hover {
+.c20 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c18 {
+.c22 {
   cursor: pointer;
 }
 
-.c17 {
+.c21 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
   font-weight: bold;
 }
 
-.c25 {
+.c29 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -591,7 +556,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   cursor: pointer;
 }
 
-.c28 {
+.c32 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -602,7 +567,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   height: auto;
 }
 
-.c29 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -611,8 +576,8 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -620,7 +585,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c21 {
+.c25 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -630,7 +595,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   text-align: center;
 }
 
-.c23 {
+.c27 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -641,55 +606,55 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   padding-top: 1px;
 }
 
-.c22 {
+.c26 {
   height: 13px;
   width: 10%;
   background: #4f91c7;
 }
 
-.c33 {
+.c38 {
   height: 13px;
   width: 100%;
   background: #c83814;
 }
 
 @media print {
-  .c31 {
+  .c35 {
     display: none;
   }
 }
 
 @media print {
-  .c9 {
+  .c11 {
     border-collapse: collapse;
   }
 }
 
 @media print {
-  .c15 {
+  .c18 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c15 > tbody:nth-of-type(even),
-  .c15 > tbody:only-of-type > tr:nth-of-type(even) {
+  .c19>tbody:nth-of-type(even),
+  .c19>tbody:only-of-type>tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c15 > tbody:not(:only-of-type):hover,
-  .c15 > tbody:only-of-type > tr:hover {
+  .c19>tbody:not(:only-of-type):hover,
+  .c19>tbody:only-of-type>tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c16 {
+  .c20 {
     border-bottom: 1px solid black;
   }
 
-  .c16 a,
-  .c16 a:hover {
+  .c20 a,
+  .c20 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -697,7 +662,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
 }
 
 @media print {
-  .c17 {
+  .c21 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
@@ -706,26 +671,26 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
 }
 
 @media print {
-  .c21 {
+  .c25 {
     background: none;
     border: 0;
   }
 }
 
 @media print {
-  .c23 {
+  .c27 {
     color: black;
   }
 }
 
 @media print {
-  .c22 {
+  .c26 {
     background: none;
   }
 }
 
 @media print {
-  .c33 {
+  .c38 {
     background: none;
   }
 }
@@ -749,14 +714,14 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 Foo title
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -764,17 +729,18 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <table
-                    class="c9"
+                    class="c11"
                   >
                     <tbody
                       class=""
@@ -782,14 +748,14 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                       <tr>
                         <td>
                           <div
-                            class="c8"
+                            class="c10"
                           >
                             Config
                           </div>
                         </td>
                         <td>
                           <div
-                            class="c8"
+                            class="c10"
                           >
                             foo
                           </div>
@@ -798,14 +764,14 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                       <tr>
                         <td>
                           <div
-                            class="c8"
+                            class="c10"
                           >
                             Family
                           </div>
                         </td>
                         <td>
                           <div
-                            class="c8"
+                            class="c10"
                           >
                             family
                           </div>
@@ -815,36 +781,36 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                   </table>
                   <section>
                     <div
-                      class="c10 section-header"
+                      class="c12 c13 section-header"
                     >
                       <h2
-                        class="c11 c12"
+                        class="c14 c15"
                       >
                         <div
-                          class="c13"
+                          class="c16 c17"
                         >
                           Edit Network Vulnerability Tests
                         </div>
                       </h2>
                       <div
-                        class="c14"
+                        class="c3"
                       />
                     </div>
                     <table
-                      class="c15"
+                      class="c18 c19"
                     >
                       <thead
-                        class="c16"
+                        class="c20"
                       >
                         <tr>
                           <th
-                            class="c17"
+                            class="c21"
                           >
                             <a
-                              class="c18"
+                              class="c22"
                             >
                               <div
-                                class="c19"
+                                class="c23"
                               >
                                 Name
                                 <span
@@ -856,71 +822,71 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                             </a>
                           </th>
                           <th
-                            class="c17"
+                            class="c21"
                           >
                             <a
-                              class="c18"
+                              class="c22"
                             >
                               <div
-                                class="c19"
+                                class="c23"
                               >
                                 OID
                               </div>
                             </a>
                           </th>
                           <th
-                            class="c17"
+                            class="c21"
                           >
                             <a
-                              class="c18"
+                              class="c22"
                             >
                               <div
-                                class="c19"
+                                class="c23"
                               >
                                 Severity
                               </div>
                             </a>
                           </th>
                           <th
-                            class="c17"
+                            class="c21"
                           >
                             <a
-                              class="c18"
+                              class="c22"
                             >
                               <div
-                                class="c19"
+                                class="c23"
                               >
                                 Timeout
                               </div>
                             </a>
                           </th>
                           <th
-                            class="c17"
+                            class="c21"
                           >
                             <div
-                              class="c19"
+                              class="c23"
                             >
                               Prefs
                             </div>
                           </th>
                           <th
-                            class="c17"
+                            class="c21"
                           >
                             <a
-                              class="c18"
+                              class="c22"
                             >
                               <div
-                                class="c20"
+                                class="c24"
                               >
                                 Selected
                               </div>
                             </a>
                           </th>
                           <th
-                            class="c17"
+                            class="c21"
                           >
                             <div
-                              class="c20"
+                              class="c24"
                             >
                               Actions
                             </div>
@@ -933,33 +899,36 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                         <tr>
                           <td>
                             <div
-                              class="c8"
+                              class="c10"
                             >
                               nvt
                             </div>
                           </td>
                           <td>
                             <div
-                              class="c8"
+                              class="c10"
                             >
                               1234
                             </div>
                           </td>
                           <td>
                             <div
-                              class="c8"
+                              class="c10"
                             >
                               <div
-                                class="c21"
+                                boxbackground="#4C4C4C"
+                                class="c25"
                                 data-testid="progressbar-box"
                                 title="Low"
                               >
                                 <div
-                                  class="c22"
+                                  background="low"
+                                  class="c26"
                                   data-testid="progress"
+                                  progress="10"
                                 />
                                 <div
-                                  class="c23"
+                                  class="c27"
                                 >
                                   1.0 (Low)
                                 </div>
@@ -968,7 +937,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                           </td>
                           <td>
                             <div
-                              class="c8"
+                              class="c10"
                             >
                               default
                               
@@ -976,28 +945,28 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                           </td>
                           <td>
                             <div
-                              class="c8"
+                              class="c10"
                             >
                               3
                             </div>
                           </td>
                           <td>
                             <div
-                              class="c24"
+                              class="c28"
                             >
                               <div>
                                 <label
-                                  class="c25"
+                                  class="c29"
                                 >
                                   <div
-                                    class="c26"
+                                    class="c23 c30"
                                   >
                                     <div
-                                      class="c27"
+                                      class="c23 c31"
                                       margin="5px"
                                     >
                                       <input
-                                        class="c28 c29"
+                                        class="c32 c33"
                                         name="1234"
                                         type="checkbox"
                                       />
@@ -1009,10 +978,10 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                           </td>
                           <td>
                             <div
-                              class="c30"
+                              class="c34"
                             >
                               <span
-                                class="c31 c32"
+                                class="c35 c36 c37"
                                 data-testid="svg-icon"
                                 title="Select and edit NVT details"
                               >
@@ -1028,33 +997,36 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                         <tr>
                           <td>
                             <div
-                              class="c8"
+                              class="c10"
                             >
                               nvt2
                             </div>
                           </td>
                           <td>
                             <div
-                              class="c8"
+                              class="c10"
                             >
                               5678
                             </div>
                           </td>
                           <td>
                             <div
-                              class="c8"
+                              class="c10"
                             >
                               <div
-                                class="c21"
+                                boxbackground="#4C4C4C"
+                                class="c25"
                                 data-testid="progressbar-box"
                                 title="High"
                               >
                                 <div
-                                  class="c33"
+                                  background="error"
+                                  class="c38"
                                   data-testid="progress"
+                                  progress="100"
                                 />
                                 <div
-                                  class="c23"
+                                  class="c27"
                                 >
                                   10.0 (High)
                                 </div>
@@ -1063,7 +1035,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                           </td>
                           <td>
                             <div
-                              class="c8"
+                              class="c10"
                             >
                               1
                               
@@ -1071,28 +1043,28 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                           </td>
                           <td>
                             <div
-                              class="c8"
+                              class="c10"
                             >
                               4
                             </div>
                           </td>
                           <td>
                             <div
-                              class="c24"
+                              class="c28"
                             >
                               <div>
                                 <label
-                                  class="c25"
+                                  class="c29"
                                 >
                                   <div
-                                    class="c26"
+                                    class="c23 c30"
                                   >
                                     <div
-                                      class="c27"
+                                      class="c23 c31"
                                       margin="5px"
                                     >
                                       <input
-                                        class="c28 c29"
+                                        class="c32 c33"
                                         name="5678"
                                         type="checkbox"
                                       />
@@ -1104,10 +1076,10 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                           </td>
                           <td>
                             <div
-                              class="c30"
+                              class="c34"
                             >
                               <span
-                                class="c31 c32"
+                                class="c35 c36 c37"
                                 data-testid="svg-icon"
                                 title="Select and edit NVT details"
                               >
@@ -1127,17 +1099,17 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c34"
+              class="c39 c40 c41"
             >
               <button
-                class="c35 c36 c37"
+                class="c42 c43 c44"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c35 c36 c37"
+                class="c42 c43 c44"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -1146,10 +1118,10 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
             </div>
           </div>
           <div
-            class="c38"
+            class="c45"
           >
             <div
-              class="c39"
+              class="c46"
             />
           </div>
         </div>
@@ -1161,23 +1133,46 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
 `;
 
 exports[`EditConfigFamilyDialog component tests should render loading indicator 1`] = `
-<body>
-  <div
-    id="portals"
-  >
-    .c9 {
-  width: 80px;
-  height: 80px;
-  margin: 40px auto;
-  background-image: url(greenbone.svg);
-  background-size: 90%;
-  background-position: center;
-  background-repeat: no-repeat;
-  -webkit-animation: fSFzYT 2s infinite ease-in-out;
-  animation: fSFzYT 2s infinite ease-in-out;
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
-.c8 {
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1186,13 +1181,51 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c12 {
+  width: 80px;
+  height: 80px;
+  margin: 40px auto;
+  background-image: url(greenbone.svg);
+  -webkit-background-size: 90%;
+  background-size: 90%;
+  -webkit-background-position: center;
+  background-position: center;
+  background-repeat: no-repeat;
+  -webkit-animation: hGzRiT 2s infinite ease-in-out;
+  animation: hGzRiT 2s infinite ease-in-out;
+}
+
+.c11 {
   width: 100%;
 }
 
@@ -1221,7 +1254,7 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -1229,7 +1262,7 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   height: 100%;
 }
 
-.c15 {
+.c20 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -1238,13 +1271,13 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   border-top: 20px solid #fff;
 }
 
-.c14 {
+.c19 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -1263,7 +1296,7 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1280,30 +1313,30 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c11 {
+.c16 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -1323,12 +1356,12 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   z-index: 1;
 }
 
-.c11:focus,
-.c11:hover {
+.c16:focus,
+.c16:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c11:hover {
+.c16:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -1336,26 +1369,26 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   color: #fff;
 }
 
-.c11[disabled] {
+.c16[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c11 img {
+.c16 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c11:link {
+.c16:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c12 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1364,8 +1397,8 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1373,63 +1406,32 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   align-items: center;
 }
 
-.c13 {
+.c18 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c13:hover {
+.c18 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c15 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -1443,17 +1445,15 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -1461,31 +1461,16 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-<div>
+<body>
+  <div
+    id="portals"
+  >
+    <div>
       <div
         class="c0"
       >
@@ -1500,14 +1485,14 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 Foo title
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -1515,34 +1500,35 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10 c11"
                   data-testid="loading"
                 >
                   <div
-                    class="c9"
+                    class="c12"
                   />
                 </div>
               </div>
             </div>
             <div
-              class="c10"
+              class="c13 c14 c15"
             >
               <button
-                class="c11 c12 c13"
+                class="c16 c17 c18"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c11 c12 c13"
+                class="c16 c17 c18"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -1551,10 +1537,10 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
             </div>
           </div>
           <div
-            class="c14"
+            class="c19"
           >
             <div
-              class="c15"
+              class="c20"
             />
           </div>
         </div>

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/editdialog.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/editdialog.js.snap
@@ -1,25 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EditScanConfigDialog component tests should render dialog 1`] = `
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c19 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -29,7 +11,6 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -37,7 +18,100 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c24 {
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -50,8 +124,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -59,25 +133,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c28 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c30 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -86,12 +142,12 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
 }
 
-.c31 {
+.c36 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -100,12 +156,12 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
-.c32 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -114,8 +170,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -123,7 +179,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: flex-start;
 }
 
-.c38 {
+.c43 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -132,8 +188,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -141,7 +197,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c40 {
+.c45 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -150,8 +206,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -159,7 +215,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c34 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -167,72 +223,63 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c39 {
   margin-left: -5px;
 }
 
-.c34 > * {
+.c39>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c34 > * {
+.c39>* {
   margin-left: 5px;
 }
 
-.c33 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c38 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c21 {
+.c26 {
   cursor: pointer;
 }
 
-.c22 {
+.c27 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c22 * {
+.c27 * {
   height: inherit;
   width: inherit;
 }
 
-.c23 {
+.c28 {
   overflow: hidden;
   -webkit-transition: 0.4s;
   transition: 0.4s;
 }
 
-.c41 {
+.c46 {
   overflow: hidden;
   -webkit-transition: 0.4s;
   transition: 0.4s;
@@ -240,33 +287,18 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   height: 0;
 }
 
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+.c19 {
   margin: 10px 0px;
   padding-bottom: 1px;
   border-bottom: 2px solid #e5e5e5;
   position: relative;
 }
 
-.c16 {
+.c20 {
   margin: 0 0 1px 0;
 }
 
-.c17 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -275,8 +307,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -284,42 +316,12 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: stretch;
 }
 
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+.c23 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c24 {
   margin-left: 3px;
   margin-top: -2px;
 }
@@ -349,7 +351,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -357,7 +359,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   height: 100%;
 }
 
-.c52 {
+.c59 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -366,13 +368,13 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c51 {
+.c58 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -391,7 +393,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -408,30 +410,30 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c48 {
+.c55 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -451,12 +453,12 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   z-index: 1;
 }
 
-.c48:focus,
-.c48:hover {
+.c55:focus,
+.c55:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c48:hover {
+.c55:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -464,26 +466,26 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   color: #fff;
 }
 
-.c48[disabled] {
+.c55[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c48 img {
+.c55 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c48:link {
+.c55:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c49 {
+.c56 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -492,8 +494,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -501,63 +503,32 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c50 {
+.c57 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c50:hover {
+.c57 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c47 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c53 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c54 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -571,17 +542,15 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -589,31 +558,12 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -623,13 +573,13 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   max-width: 100%;
   font-weight: bold;
@@ -640,28 +590,13 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   margin-left: 0;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c14 {
+.c17 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -670,7 +605,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   display: none;
 }
 
-.c25 {
+.c30 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -679,21 +614,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   width: 100%;
 }
 
-.c25 th,
-.c25 td {
-  padding: 4px 10px;
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c25 tfoot tr {
-  background: #fff;
-}
-
-.c25 tfoot tr td {
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c43 {
+.c48 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -702,40 +623,40 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   width: 100%;
 }
 
-.c43 th,
-.c43 td {
+.c31 th,
+.c31 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c43 tfoot tr {
+.c31 tfoot tr {
   background: #fff;
 }
 
-.c43 tfoot tr td {
+.c31 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c26 a {
+.c32 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c26 a:hover {
+.c32 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c27 {
+.c33 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
   font-weight: bold;
 }
 
-.c29 {
+.c34 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -743,7 +664,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   width: 9em;
 }
 
-.c44 {
+.c49 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -751,7 +672,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   width: 30%;
 }
 
-.c45 {
+.c50 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -759,7 +680,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   width: 10%;
 }
 
-.c12 {
+.c15 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -773,11 +694,11 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   padding: 1px 8px;
 }
 
-.c12:-webkit-autofill {
+.c15:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c13 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -790,8 +711,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -799,7 +720,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c42 {
+.c47 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -808,8 +729,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -817,7 +738,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c35 {
+.c40 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -833,7 +754,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   cursor: pointer;
 }
 
-.c36 {
+.c41 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -844,7 +765,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   height: auto;
 }
 
-.c37 {
+.c42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -853,8 +774,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -862,7 +783,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c39 {
+.c44 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -871,8 +792,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -880,59 +801,47 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c46 {
+.c51 {
   overflow-wrap: break-word;
 }
 
 @media print {
-  .c21 {
+  .c25 {
     display: none;
   }
 }
 
 @media print {
-  .c25 {
+  .c30 {
+    border-collapse: collapse;
+  }
+}
+
+@media print {
+  .c48 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c25 > tbody:nth-of-type(even),
-  .c25 > tbody:only-of-type > tr:nth-of-type(even) {
+  .c31>tbody:nth-of-type(even),
+  .c31>tbody:only-of-type>tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c25 > tbody:not(:only-of-type):hover,
-  .c25 > tbody:only-of-type > tr:hover {
+  .c31>tbody:not(:only-of-type):hover,
+  .c31>tbody:only-of-type>tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c43 {
-    border-collapse: collapse;
-  }
-}
-
-@media screen {
-  .c43 > tbody:nth-of-type(even),
-  .c43 > tbody:only-of-type > tr:nth-of-type(even) {
-    background: #f3f3f3;
-  }
-
-  .c43 > tbody:not(:only-of-type):hover,
-  .c43 > tbody:only-of-type > tr:hover {
-    background: #e5e5e5;
-  }
-}
-
-@media print {
-  .c26 {
+  .c32 {
     border-bottom: 1px solid black;
   }
 
-  .c26 a,
-  .c26 a:hover {
+  .c32 a,
+  .c32 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -940,7 +849,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
 }
 
 @media print {
-  .c27 {
+  .c33 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
@@ -949,7 +858,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
 }
 
 @media print {
-  .c29 {
+  .c34 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
@@ -958,7 +867,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
 }
 
 @media print {
-  .c44 {
+  .c49 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
@@ -967,7 +876,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
 }
 
 @media print {
-  .c45 {
+  .c50 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
@@ -994,14 +903,14 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 Edit Scan Config
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -1009,38 +918,41 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Name
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="name"
                         size="30"
                         type="text"
                         value="Config"
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -1048,28 +960,30 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Comment
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="comment"
                         size="30"
                         type="text"
                         value="bar"
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -1078,25 +992,25 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                   </div>
                   <section>
                     <div
-                      class="c15 section-header"
+                      class="c18 c19 section-header"
                     >
                       <h2
-                        class="c16 c17"
+                        class="c20 c21"
                       >
                         <div
-                          class="c18"
+                          class="c22 c23"
                         >
                           Edit Network Vulnerability Test Families (4)
                         </div>
                       </h2>
                       <div
-                        class="c19"
+                        class="c3"
                       >
                         <div
-                          class="c20"
+                          class="c13 c24"
                         >
                           <span
-                            class="c21 c22 section-fold-icon"
+                            class="c25 c26 c27 section-fold-icon"
                             data-testid="svg-icon"
                             title="Fold"
                           >
@@ -1110,59 +1024,60 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c23"
+                      class="c28"
+                      foldstate="UNFOLDED"
                     >
                       <div
-                        class="c24"
+                        class="c29"
                       >
                         <table
-                          class="c25"
+                          class="c30 c31"
                         >
                           <thead
-                            class="c26"
+                            class="c32"
                           >
                             <tr>
                               <th
-                                class="c27"
+                                class="c33"
                               >
                                 <div
-                                  class="c28"
+                                  class="c13"
                                 >
                                   Family
                                 </div>
                               </th>
                               <th
-                                class="c27"
+                                class="c33"
                               >
                                 <div
-                                  class="c28"
+                                  class="c13"
                                 >
                                   NVTs selected
                                 </div>
                               </th>
                               <th
-                                class="c27"
+                                class="c33"
                               >
                                 <div
-                                  class="c28"
+                                  class="c13"
                                 >
                                   Trend
                                 </div>
                               </th>
                               <th
-                                class="c29"
+                                class="c34"
                               >
                                 <div
-                                  class="c28"
+                                  class="c13"
                                 >
                                   Select all NVTs
                                 </div>
                               </th>
                               <th
-                                class="c27"
+                                class="c33"
                               >
                                 <div
-                                  class="c30"
+                                  class="c35"
                                 >
                                   Actions
                                 </div>
@@ -1175,42 +1090,42 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                             <tr>
                               <td>
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   family1
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c31"
+                                  class="c36"
                                 >
                                   1 of 1
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c32"
+                                  class="c37"
                                 >
                                   <div
-                                    class="c33"
+                                    class="c13 c38"
                                   >
                                     <div
-                                      class="c34"
+                                      class="c13 c39"
                                       margin="5px"
                                     >
                                       <label
-                                        class="c35"
+                                        class="c40"
                                       >
                                         <div
-                                          class="c33"
+                                          class="c13 c38"
                                         >
                                           <div
-                                            class="c34"
+                                            class="c13 c39"
                                             margin="5px"
                                           >
                                             <input
                                               checked=""
-                                              class="c36 c37"
+                                              class="c41 c42"
                                               data-testid="radio-input"
                                               name="family1"
                                               type="radio"
@@ -1221,7 +1136,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Dynamic"
-                                        class="c22"
+                                        class="c25 c27"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1229,17 +1144,17 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                         </svg>
                                       </span>
                                       <label
-                                        class="c35"
+                                        class="c40"
                                       >
                                         <div
-                                          class="c33"
+                                          class="c13 c38"
                                         >
                                           <div
-                                            class="c34"
+                                            class="c13 c39"
                                             margin="5px"
                                           >
                                             <input
-                                              class="c36 c37"
+                                              class="c41 c42"
                                               data-testid="radio-input"
                                               name="family1"
                                               type="radio"
@@ -1250,7 +1165,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Static"
-                                        class="c22"
+                                        class="c25 c27"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1263,21 +1178,21 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c38"
+                                  class="c43"
                                 >
                                   <label
-                                    class="c35"
+                                    class="c40"
                                   >
                                     <div
-                                      class="c33"
+                                      class="c13 c38"
                                     >
                                       <div
-                                        class="c34"
+                                        class="c13 c39"
                                         margin="5px"
                                       >
                                         <input
                                           checked=""
-                                          class="c36 c39"
+                                          class="c41 c44"
                                           name="family1"
                                           type="checkbox"
                                         />
@@ -1288,10 +1203,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c40"
+                                  class="c45"
                                 >
                                   <span
-                                    class="c21 c22"
+                                    class="c25 c26 c27"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config Family"
                                   >
@@ -1307,41 +1222,41 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                             <tr>
                               <td>
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   family2
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c31"
+                                  class="c36"
                                 >
                                   2 of 4
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c32"
+                                  class="c37"
                                 >
                                   <div
-                                    class="c33"
+                                    class="c13 c38"
                                   >
                                     <div
-                                      class="c34"
+                                      class="c13 c39"
                                       margin="5px"
                                     >
                                       <label
-                                        class="c35"
+                                        class="c40"
                                       >
                                         <div
-                                          class="c33"
+                                          class="c13 c38"
                                         >
                                           <div
-                                            class="c34"
+                                            class="c13 c39"
                                             margin="5px"
                                           >
                                             <input
-                                              class="c36 c37"
+                                              class="c41 c42"
                                               data-testid="radio-input"
                                               name="family2"
                                               type="radio"
@@ -1352,7 +1267,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Dynamic"
-                                        class="c22"
+                                        class="c25 c27"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1360,18 +1275,18 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                         </svg>
                                       </span>
                                       <label
-                                        class="c35"
+                                        class="c40"
                                       >
                                         <div
-                                          class="c33"
+                                          class="c13 c38"
                                         >
                                           <div
-                                            class="c34"
+                                            class="c13 c39"
                                             margin="5px"
                                           >
                                             <input
                                               checked=""
-                                              class="c36 c37"
+                                              class="c41 c42"
                                               data-testid="radio-input"
                                               name="family2"
                                               type="radio"
@@ -1382,7 +1297,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Static"
-                                        class="c22"
+                                        class="c25 c27"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1395,20 +1310,20 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c38"
+                                  class="c43"
                                 >
                                   <label
-                                    class="c35"
+                                    class="c40"
                                   >
                                     <div
-                                      class="c33"
+                                      class="c13 c38"
                                     >
                                       <div
-                                        class="c34"
+                                        class="c13 c39"
                                         margin="5px"
                                       >
                                         <input
-                                          class="c36 c39"
+                                          class="c41 c44"
                                           name="family2"
                                           type="checkbox"
                                         />
@@ -1419,10 +1334,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c40"
+                                  class="c45"
                                 >
                                   <span
-                                    class="c21 c22"
+                                    class="c25 c26 c27"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config Family"
                                   >
@@ -1438,41 +1353,41 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                             <tr>
                               <td>
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   family3
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c31"
+                                  class="c36"
                                 >
                                   0 of 2
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c32"
+                                  class="c37"
                                 >
                                   <div
-                                    class="c33"
+                                    class="c13 c38"
                                   >
                                     <div
-                                      class="c34"
+                                      class="c13 c39"
                                       margin="5px"
                                     >
                                       <label
-                                        class="c35"
+                                        class="c40"
                                       >
                                         <div
-                                          class="c33"
+                                          class="c13 c38"
                                         >
                                           <div
-                                            class="c34"
+                                            class="c13 c39"
                                             margin="5px"
                                           >
                                             <input
-                                              class="c36 c37"
+                                              class="c41 c42"
                                               data-testid="radio-input"
                                               name="family3"
                                               type="radio"
@@ -1483,7 +1398,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Dynamic"
-                                        class="c22"
+                                        class="c25 c27"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1491,18 +1406,18 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                         </svg>
                                       </span>
                                       <label
-                                        class="c35"
+                                        class="c40"
                                       >
                                         <div
-                                          class="c33"
+                                          class="c13 c38"
                                         >
                                           <div
-                                            class="c34"
+                                            class="c13 c39"
                                             margin="5px"
                                           >
                                             <input
                                               checked=""
-                                              class="c36 c37"
+                                              class="c41 c42"
                                               data-testid="radio-input"
                                               name="family3"
                                               type="radio"
@@ -1513,7 +1428,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Static"
-                                        class="c22"
+                                        class="c25 c27"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1526,20 +1441,20 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c38"
+                                  class="c43"
                                 >
                                   <label
-                                    class="c35"
+                                    class="c40"
                                   >
                                     <div
-                                      class="c33"
+                                      class="c13 c38"
                                     >
                                       <div
-                                        class="c34"
+                                        class="c13 c39"
                                         margin="5px"
                                       >
                                         <input
-                                          class="c36 c39"
+                                          class="c41 c44"
                                           name="family3"
                                           type="checkbox"
                                         />
@@ -1550,10 +1465,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c40"
+                                  class="c45"
                                 >
                                   <span
-                                    class="c21 c22"
+                                    class="c25 c26 c27"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config Family"
                                   >
@@ -1569,41 +1484,41 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                             <tr>
                               <td>
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   family4
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c31"
+                                  class="c36"
                                 >
                                   0 of 6
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c32"
+                                  class="c37"
                                 >
                                   <div
-                                    class="c33"
+                                    class="c13 c38"
                                   >
                                     <div
-                                      class="c34"
+                                      class="c13 c39"
                                       margin="5px"
                                     >
                                       <label
-                                        class="c35"
+                                        class="c40"
                                       >
                                         <div
-                                          class="c33"
+                                          class="c13 c38"
                                         >
                                           <div
-                                            class="c34"
+                                            class="c13 c39"
                                             margin="5px"
                                           >
                                             <input
-                                              class="c36 c37"
+                                              class="c41 c42"
                                               data-testid="radio-input"
                                               name="family4"
                                               type="radio"
@@ -1614,7 +1529,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Dynamic"
-                                        class="c22"
+                                        class="c25 c27"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1622,18 +1537,18 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                         </svg>
                                       </span>
                                       <label
-                                        class="c35"
+                                        class="c40"
                                       >
                                         <div
-                                          class="c33"
+                                          class="c13 c38"
                                         >
                                           <div
-                                            class="c34"
+                                            class="c13 c39"
                                             margin="5px"
                                           >
                                             <input
                                               checked=""
-                                              class="c36 c37"
+                                              class="c41 c42"
                                               data-testid="radio-input"
                                               name="family4"
                                               type="radio"
@@ -1644,7 +1559,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Static"
-                                        class="c22"
+                                        class="c25 c27"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1657,20 +1572,20 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c38"
+                                  class="c43"
                                 >
                                   <label
-                                    class="c35"
+                                    class="c40"
                                   >
                                     <div
-                                      class="c33"
+                                      class="c13 c38"
                                     >
                                       <div
-                                        class="c34"
+                                        class="c13 c39"
                                         margin="5px"
                                       >
                                         <input
-                                          class="c36 c39"
+                                          class="c41 c44"
                                           name="family4"
                                           type="checkbox"
                                         />
@@ -1681,10 +1596,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c40"
+                                  class="c45"
                                 >
                                   <span
-                                    class="c21 c22"
+                                    class="c25 c26 c27"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config Family"
                                   >
@@ -1704,25 +1619,25 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                   </section>
                   <section>
                     <div
-                      class="c15 section-header"
+                      class="c18 c19 section-header"
                     >
                       <h2
-                        class="c16 c17"
+                        class="c20 c21"
                       >
                         <div
-                          class="c18"
+                          class="c22 c23"
                         >
                           Edit Scanner Preferences (1)
                         </div>
                       </h2>
                       <div
-                        class="c19"
+                        class="c3"
                       >
                         <div
-                          class="c20"
+                          class="c13 c24"
                         >
                           <span
-                            class="c21 c22 section-fold-icon"
+                            class="c25 c26 c27 section-fold-icon"
                             data-testid="svg-icon"
                             title="Unfold"
                           >
@@ -1736,41 +1651,42 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c41"
+                      class="c46"
+                      foldstate="FOLDED"
                     >
                       <div
-                        class="c24"
+                        class="c29"
                       >
                         <table
-                          class="c25"
+                          class="c30 c31"
                         >
                           <thead
-                            class="c26"
+                            class="c32"
                           >
                             <tr>
                               <th
-                                class="c27"
+                                class="c33"
                               >
                                 <div
-                                  class="c28"
+                                  class="c13"
                                 >
                                   Name
                                 </div>
                               </th>
                               <th
-                                class="c27"
+                                class="c33"
                               >
                                 <div
-                                  class="c28"
+                                  class="c13"
                                 >
                                   New Value
                                 </div>
                               </th>
                               <th
-                                class="c27"
+                                class="c33"
                               >
                                 <div
-                                  class="c28"
+                                  class="c13"
                                 >
                                   Default Value
                                 </div>
@@ -1783,23 +1699,23 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                             <tr>
                               <td>
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   Scanner Preference 1
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   <input
-                                    class="c12 c42"
+                                    class="c15 c47"
                                     name="scannerpref0"
                                     type="text"
                                     value="0"
                                   />
                                   <div
-                                    class="c14"
+                                    class="c17"
                                     data-testid="error-marker"
                                   >
                                     ×
@@ -1808,7 +1724,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 />
                               </td>
                             </tr>
@@ -1819,25 +1735,25 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                   </section>
                   <section>
                     <div
-                      class="c15 section-header"
+                      class="c18 c19 section-header"
                     >
                       <h2
-                        class="c16 c17"
+                        class="c20 c21"
                       >
                         <div
-                          class="c18"
+                          class="c22 c23"
                         >
                           Network Vulnerability Test Preferences (3)
                         </div>
                       </h2>
                       <div
-                        class="c19"
+                        class="c3"
                       >
                         <div
-                          class="c20"
+                          class="c13 c24"
                         >
                           <span
-                            class="c21 c22 section-fold-icon"
+                            class="c25 c26 c27 section-fold-icon"
                             data-testid="svg-icon"
                             title="Unfold"
                           >
@@ -1851,50 +1767,51 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c41"
+                      class="c46"
+                      foldstate="FOLDED"
                     >
                       <div
-                        class="c24"
+                        class="c29"
                       >
                         <table
-                          class="c43"
+                          class="c48 c31"
                         >
                           <thead
-                            class="c26"
+                            class="c32"
                           >
                             <tr>
                               <th
-                                class="c44"
+                                class="c49"
                               >
                                 <div
-                                  class="c28"
+                                  class="c13"
                                 >
                                   NVT
                                 </div>
                               </th>
                               <th
-                                class="c44"
+                                class="c49"
                               >
                                 <div
-                                  class="c28"
+                                  class="c13"
                                 >
                                   Name
                                 </div>
                               </th>
                               <th
-                                class="c44"
+                                class="c49"
                               >
                                 <div
-                                  class="c28"
+                                  class="c13"
                                 >
                                   Value
                                 </div>
                               </th>
                               <th
-                                class="c45"
+                                class="c50"
                               >
                                 <div
-                                  class="c30"
+                                  class="c35"
                                 >
                                   Actions
                                 </div>
@@ -1906,38 +1823,38 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                           >
                             <tr>
                               <td
-                                class="c46"
+                                class="c51"
                               >
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   preference0
                                 </div>
                               </td>
                               <td
-                                class="c46"
+                                class="c51"
                               >
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   preference1
                                 </div>
                               </td>
                               <td
-                                class="c46"
+                                class="c51"
                               >
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   3
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c40"
+                                  class="c45"
                                 >
                                   <span
-                                    class="c21 c22"
+                                    class="c25 c26 c27"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config NVT Details"
                                   >
@@ -1952,38 +1869,38 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                             </tr>
                             <tr>
                               <td
-                                class="c46"
+                                class="c51"
                               >
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   preference1
                                 </div>
                               </td>
                               <td
-                                class="c46"
+                                class="c51"
                               >
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   preference2
                                 </div>
                               </td>
                               <td
-                                class="c46"
+                                class="c51"
                               >
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   4
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c40"
+                                  class="c45"
                                 >
                                   <span
-                                    class="c21 c22"
+                                    class="c25 c26 c27"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config NVT Details"
                                   >
@@ -1998,38 +1915,38 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                             </tr>
                             <tr>
                               <td
-                                class="c46"
+                                class="c51"
                               >
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   preference2
                                 </div>
                               </td>
                               <td
-                                class="c46"
+                                class="c51"
                               >
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   preference
                                 </div>
                               </td>
                               <td
-                                class="c46"
+                                class="c51"
                               >
                                 <div
-                                  class="c8"
+                                  class="c10"
                                 >
                                   5
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c40"
+                                  class="c45"
                                 >
                                   <span
-                                    class="c21 c22"
+                                    class="c25 c26 c27"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config NVT Details"
                                   >
@@ -2051,17 +1968,17 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c47"
+              class="c52 c53 c54"
             >
               <button
-                class="c48 c49 c50"
+                class="c55 c56 c57"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c48 c49 c50"
+                class="c55 c56 c57"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -2070,10 +1987,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
             </div>
           </div>
           <div
-            class="c51"
+            class="c58"
           >
             <div
-              class="c52"
+              class="c59"
             />
           </div>
         </div>
@@ -2085,11 +2002,46 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
 `;
 
 exports[`EditScanConfigDialog component tests should render dialog for config in use 1`] = `
-<body>
-  <div
-    id="portals"
-  >
-    .c8 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2098,13 +2050,52 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c1 {
@@ -2132,7 +2123,7 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -2140,7 +2131,7 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   height: 100%;
 }
 
-.c21 {
+.c26 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -2149,13 +2140,13 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   border-top: 20px solid #fff;
 }
 
-.c20 {
+.c25 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -2174,7 +2165,7 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2191,30 +2182,30 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c17 {
+.c22 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -2234,12 +2225,12 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   z-index: 1;
 }
 
-.c17:focus,
-.c17:hover {
+.c22:focus,
+.c22:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c17:hover {
+.c22:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -2247,26 +2238,26 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   color: #fff;
 }
 
-.c17[disabled] {
+.c22[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c17 img {
+.c22 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c17:link {
+.c22:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c18 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2275,8 +2266,8 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2284,63 +2275,32 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   align-items: center;
 }
 
-.c19 {
+.c24 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c19:hover {
+.c24 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c20 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c21 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -2354,17 +2314,15 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -2372,31 +2330,12 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2406,13 +2345,13 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   max-width: 100%;
   font-weight: bold;
@@ -2423,28 +2362,13 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   margin-left: 0;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c14 {
+.c17 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -2453,7 +2377,7 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   display: none;
 }
 
-.c12 {
+.c15 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -2467,11 +2391,11 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   padding: 1px 8px;
 }
 
-.c12:-webkit-autofill {
+.c15:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c13 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2484,8 +2408,8 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2493,7 +2417,7 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   align-items: center;
 }
 
-.c15 {
+.c18 {
   font-size: 14px;
   margin-bottom: 0px;
   display: -webkit-box;
@@ -2501,12 +2425,16 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   display: -ms-flexbox;
   display: flex;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
 }
 
-<div>
+<body>
+  <div
+    id="portals"
+  >
+    <div>
       <div
         class="c0"
       >
@@ -2521,14 +2449,14 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 Edit Scan Config
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -2536,38 +2464,41 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Name
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="name"
                         size="30"
                         type="text"
                         value="Config"
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -2575,28 +2506,30 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Comment
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="comment"
                         size="30"
                         type="text"
                         value="bar"
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -2604,7 +2537,7 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
                     </div>
                   </div>
                   <div
-                    class="c15"
+                    class="c18"
                     data-testid="inline-notification"
                   >
                     The scan config is currently in use by one or more tasks, therefore only name and comment can be modified.
@@ -2613,17 +2546,17 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
               </div>
             </div>
             <div
-              class="c16"
+              class="c19 c20 c21"
             >
               <button
-                class="c17 c18 c19"
+                class="c22 c23 c24"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c17 c18 c19"
+                class="c22 c23 c24"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -2632,10 +2565,10 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
             </div>
           </div>
           <div
-            class="c20"
+            class="c25"
           >
             <div
-              class="c21"
+              class="c26"
             />
           </div>
         </div>
@@ -2647,11 +2580,46 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
 `;
 
 exports[`EditScanConfigDialog component tests should render dialog inline notification for policy in use 1`] = `
-<body>
-  <div
-    id="portals"
-  >
-    .c8 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2660,13 +2628,52 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c1 {
@@ -2694,7 +2701,7 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -2702,7 +2709,7 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   height: 100%;
 }
 
-.c21 {
+.c26 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -2711,13 +2718,13 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   border-top: 20px solid #fff;
 }
 
-.c20 {
+.c25 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -2736,7 +2743,7 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2753,30 +2760,30 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c17 {
+.c22 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -2796,12 +2803,12 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   z-index: 1;
 }
 
-.c17:focus,
-.c17:hover {
+.c22:focus,
+.c22:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c17:hover {
+.c22:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -2809,26 +2816,26 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   color: #fff;
 }
 
-.c17[disabled] {
+.c22[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c17 img {
+.c22 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c17:link {
+.c22:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c18 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2837,8 +2844,8 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2846,63 +2853,32 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   align-items: center;
 }
 
-.c19 {
+.c24 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c19:hover {
+.c24 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c20 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c21 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -2916,17 +2892,15 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -2934,31 +2908,12 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -2968,13 +2923,13 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   max-width: 100%;
   font-weight: bold;
@@ -2985,28 +2940,13 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   margin-left: 0;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c14 {
+.c17 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -3015,7 +2955,7 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   display: none;
 }
 
-.c12 {
+.c15 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -3029,11 +2969,11 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   padding: 1px 8px;
 }
 
-.c12:-webkit-autofill {
+.c15:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c13 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -3046,8 +2986,8 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -3055,7 +2995,7 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   align-items: center;
 }
 
-.c15 {
+.c18 {
   font-size: 14px;
   margin-bottom: 0px;
   display: -webkit-box;
@@ -3063,12 +3003,16 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   display: -ms-flexbox;
   display: flex;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
 }
 
-<div>
+<body>
+  <div
+    id="portals"
+  >
+    <div>
       <div
         class="c0"
       >
@@ -3083,14 +3027,14 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 Edit Policy
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -3098,38 +3042,41 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Name
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="name"
                         size="30"
                         type="text"
                         value="Policy"
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -3137,28 +3084,30 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Comment
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="comment"
                         size="30"
                         type="text"
                         value="bar"
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -3166,7 +3115,7 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
                     </div>
                   </div>
                   <div
-                    class="c15"
+                    class="c18"
                     data-testid="inline-notification"
                   >
                     The policy is currently in use by one or more audits, therefore only name and comment can be modified.
@@ -3175,17 +3124,17 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
               </div>
             </div>
             <div
-              class="c16"
+              class="c19 c20 c21"
             >
               <button
-                class="c17 c18 c19"
+                class="c22 c23 c24"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c17 c18 c19"
+                class="c22 c23 c24"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -3194,10 +3143,10 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
             </div>
           </div>
           <div
-            class="c20"
+            class="c25"
           >
             <div
-              class="c21"
+              class="c26"
             />
           </div>
         </div>

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/listpage.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/listpage.js.snap
@@ -1,36 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c1 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 > * {
-  margin-left: 5px;
-}
-
 .c0 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -40,30 +10,48 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c2 {
+  margin-left: -5px;
+}
+
+.c2>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c3 {
+.c2>* {
+  margin-left: 5px;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c5 {
   cursor: pointer;
 }
 
-.c2 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c2 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
@@ -75,10 +63,10 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <div
-    class="c1"
+    class="c0 c2"
     margin="5px"
   >
     <a
@@ -87,7 +75,7 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
       target="_blank"
     >
       <span
-        class="c2"
+        class="c3 c4"
         data-testid="svg-icon"
         title="Help: Scan Configs"
       >
@@ -99,7 +87,7 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
       </span>
     </a>
     <span
-      class="c3 c2"
+      class="c3 c5 c4"
       data-testid="svg-icon"
       title="New Scan Config"
     >
@@ -110,7 +98,7 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
       </svg>
     </span>
     <span
-      class="c3 c2"
+      class="c3 c5 c4"
       data-testid="svg-icon"
       title="Import Scan Config"
     >
@@ -138,8 +126,8 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -157,7 +145,6 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -165,7 +152,25 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: flex-start;
 }
 
-.c6 {
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -178,12 +183,12 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
   -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
   justify-content: flex-end;
 }
 
-.c7 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -192,8 +197,8 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: stetch;
   -webkit-box-align: stetch;
@@ -201,7 +206,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: stetch;
 }
 
-.c8 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -211,7 +216,6 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -228,8 +232,8 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -237,7 +241,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: center;
 }
 
-.c20 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -246,311 +250,13 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.c30 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c39 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c42 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c44 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c45 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c49 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c3 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c3 > * {
-  margin-left: 5px;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c9 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c9 > * {
-  margin-left: 5px;
-}
-
-.c48 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c48 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c48 > * {
-  margin-left: 5px;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c47 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c5 {
-  cursor: pointer;
-}
-
-.c33 svg path {
-  fill: #bfbfbf;
-}
-
-.c4 {
-  height: 16px;
-  width: 16px;
-  line-height: 16px;
-}
-
-.c4 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c27 {
-  height: 50px;
-  width: 50px;
-  line-height: 50px;
-}
-
-.c27 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c23 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  margin: 10px 0px;
-  padding-bottom: 1px;
-  border-bottom: 2px solid #e5e5e5;
-  position: relative;
-}
-
-.c24 {
-  margin: 0 0 1px 0;
 }
 
 .c25 {
@@ -561,17 +267,16 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
-.c26 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -580,14 +285,200 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
   align-items: flex-end;
-  margin-right: 5px;
+}
+
+.c34 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+
+.c36 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c48 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+}
+
+.c50 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c51 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+
+.c53 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c54 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c4 {
+  margin-left: -5px;
+}
+
+.c4>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4>* {
+  margin-left: 5px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c7 {
+  cursor: pointer;
+}
+
+.c38 svg path {
+  fill: #bfbfbf;
+}
+
+.c6 {
+  height: 16px;
+  width: 16px;
+  line-height: 16px;
+}
+
+.c6 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c31 {
+  height: 50px;
+  width: 50px;
+  line-height: 50px;
+}
+
+.c31 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c26 {
+  margin: 10px 0px;
+  padding-bottom: 1px;
+  border-bottom: 2px solid #e5e5e5;
+  position: relative;
+}
+
+.c27 {
+  margin: 0 0 1px 0;
 }
 
 .c28 {
@@ -599,18 +490,25 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c30 {
+  margin-right: 5px;
+}
+
+.c32 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c21 {
+.c23 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -623,8 +521,8 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -635,18 +533,18 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   cursor: pointer;
 }
 
-.c22 {
+.c24 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c22 * {
+.c24 * {
   height: inherit;
   width: inherit;
 }
 
-.c18 {
+.c19 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -670,7 +568,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   font-weight: normal;
 }
 
-.c17 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -682,7 +580,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 150px;
 }
 
-.c50 {
+.c55 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -694,16 +592,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 180px;
 }
 
-.c15 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c19 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -720,33 +609,68 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
-  cursor: default;
 }
 
 .c16 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c21 {
+  cursor: default;
+}
+
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c36 a {
+.c40 {
+  border: 0;
+  border-spacing: 0px;
+  font-size: 12px;
+  text-align: left;
+  table-layout: auto;
+  width: 100%;
+}
+
+.c41 th,
+.c41 td {
+  padding: 4px 10px;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.c41 tfoot tr {
+  background: #fff;
+}
+
+.c41 tfoot tr td {
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.c43 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c36 a:hover {
+.c43 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c38 {
+.c45 {
   cursor: pointer;
 }
 
-.c37 {
+.c44 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -754,7 +678,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 72%;
 }
 
-.c40 {
+.c46 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -762,7 +686,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 10%;
 }
 
-.c41 {
+.c47 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -770,7 +694,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 8%;
 }
 
-.c43 {
+.c49 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -778,7 +702,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 5%;
 }
 
-.c13 {
+.c14 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -792,11 +716,11 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   padding: 1px 8px;
 }
 
-.c13:-webkit-autofill {
+.c14:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c14 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -805,127 +729,58 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c13 {
+  margin-right: 5px;
 }
 
 .c12 {
   margin-right: 5px;
 }
 
-.c10 {
-  margin-right: 5px;
-}
-
-.c51 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c56 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c34 {
+.c39 {
   margin: 0 3px;
 }
 
-.c32 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c37 {
   margin: 2px 3px;
 }
 
-.c35 {
-  border: 0;
-  border-spacing: 0px;
-  font-size: 12px;
-  text-align: left;
-  table-layout: auto;
-  width: 100%;
+.c42 {
   opacity: 1.0;
 }
 
-.c35 th,
-.c35 td {
-  padding: 4px 10px;
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c35 tfoot tr {
-  background: #fff;
-}
-
-.c35 tfoot tr td {
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c31 {
+.c35 {
   margin-top: 2px;
   margin-left: 2px;
 }
 
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+.c33 {
   margin-top: 20px;
 }
 
-.c46 {
+.c52 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c46:hover {
+.c52 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
@@ -938,12 +793,30 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
 }
 
 @media print {
-  .c36 {
+  .c40 {
+    border-collapse: collapse;
+  }
+}
+
+@media screen {
+  .c41>tbody:nth-of-type(even),
+  .c41>tbody:only-of-type>tr:nth-of-type(even) {
+    background: #f3f3f3;
+  }
+
+  .c41>tbody:not(:only-of-type):hover,
+  .c41>tbody:only-of-type>tr:hover {
+    background: #e5e5e5;
+  }
+}
+
+@media print {
+  .c43 {
     border-bottom: 1px solid black;
   }
 
-  .c36 a,
-  .c36 a:hover {
+  .c43 a,
+  .c43 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -951,67 +824,49 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
 }
 
 @media print {
-  .c37 {
+  .c44 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
     font-weight: bold;
-  }
-}
-
-@media print {
-  .c40 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: none;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c41 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: none;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c43 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: none;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c32 svg {
-    display: none;
-  }
-}
-
-@media print {
-  .c35 {
-    border-collapse: collapse;
-  }
-}
-
-@media screen {
-  .c35 > tbody:nth-of-type(even),
-  .c35 > tbody:only-of-type > tr:nth-of-type(even) {
-    background: #f3f3f3;
-  }
-
-  .c35 > tbody:not(:only-of-type):hover,
-  .c35 > tbody:only-of-type > tr:hover {
-    background: #e5e5e5;
   }
 }
 
 @media print {
   .c46 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: none;
+    font-weight: bold;
+  }
+}
+
+@media print {
+  .c47 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: none;
+    font-weight: bold;
+  }
+}
+
+@media print {
+  .c49 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: none;
+    font-weight: bold;
+  }
+}
+
+@media print {
+  .c37 svg {
+    display: none;
+  }
+}
+
+@media print {
+  .c52 {
     color: #000;
   }
 }
@@ -1028,10 +883,10 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
         class="c1 toolbar"
       >
         <div
-          class="c2"
+          class="c2 c3"
         >
           <div
-            class="c3"
+            class="c2 c4"
             margin="5px"
           >
             <a
@@ -1040,8 +895,9 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               target="_blank"
             >
               <span
-                class="c4"
+                class="c5 c6"
                 data-testid="svg-icon"
+                iconsize="small"
                 title="Help: Scan Configs"
               >
                 <svg
@@ -1052,8 +908,9 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </span>
             </a>
             <span
-              class="c5 c4"
+              class="c5 c7 c6"
               data-testid="svg-icon"
+              iconsize="small"
               title="New Scan Config"
             >
               <svg
@@ -1063,8 +920,9 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c4"
+              class="c5 c7 c6"
               data-testid="svg-icon"
+              iconsize="small"
               title="Import Scan Config"
             >
               <svg
@@ -1076,33 +934,33 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
           </div>
         </div>
         <div
-          class="c6"
+          class="c8"
         >
           <div
-            class="c7 powerfilter"
+            class="c9 powerfilter"
           >
             <div
-              class="c8"
+              class="c10"
             >
               <div
-                class="c2"
+                class="c2 c3"
               >
                 <div
-                  class="c9 c10"
+                  class="c11 c4 c12"
                   margin="5px"
                 >
                   <div
                     class="c11"
                   >
                     <label
-                      class="c12"
+                      class="c13"
                     >
                       <b>
                         Filter
                       </b>
                     </label>
                     <input
-                      class="c13 c14"
+                      class="c14 c15"
                       maxlength="1000"
                       name="userFilterString"
                       size="53"
@@ -1110,22 +968,23 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       value=""
                     />
                     <div
-                      class="c15"
+                      class="c16"
                       data-testid="error-marker"
                     >
                       ×
                     </div>
                   </div>
                   <div
-                    class="c2"
+                    class="c2 c3"
                   >
                     <div
-                      class="c9"
+                      class="c11 c4"
                       margin="5px"
                     >
                       <span
-                        class="c5 c4"
+                        class="c5 c7 c6"
                         data-testid="svg-icon"
+                        iconsize="small"
                         title="Update Filter"
                       >
                         <svg
@@ -1135,8 +994,9 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c4"
+                        class="c5 c7 c6"
                         data-testid="svg-icon"
+                        iconsize="small"
                         title="Remove Filter"
                       >
                         <svg
@@ -1146,8 +1006,9 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c4"
+                        class="c5 c7 c6"
                         data-testid="svg-icon"
+                        iconsize="small"
                         title="Reset to Default Filter"
                       >
                         <svg
@@ -1162,8 +1023,9 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                         target="_blank"
                       >
                         <span
-                          class="c4"
+                          class="c5 c6"
                           data-testid="svg-icon"
+                          iconsize="small"
                           title="Help: Powerfilter"
                         >
                           <svg
@@ -1174,8 +1036,9 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                         </span>
                       </a>
                       <span
-                        class="c5 c4"
+                        class="c5 c7 c6"
                         data-testid="svg-icon"
+                        iconsize="small"
                         title="Edit Filter"
                       >
                         <svg
@@ -1192,35 +1055,36 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="downshift-0-label"
-                class="c16"
+                class="c17"
                 role="combobox"
               >
                 <div
-                  class="c17"
+                  class="c18"
                   width="150px"
                 >
                   <div
                     aria-haspopup="true"
                     aria-label="open menu"
-                    class="c18"
+                    class="c19"
                     data-toggle="true"
                     role="button"
                     title="Loaded filter"
                     type="button"
                   >
                     <div
-                      class="c19"
+                      class="c20 c21"
                       data-testid="select-selected-value"
                       title="Loaded filter"
                     >
                       --
                     </div>
                     <div
-                      class="c20"
+                      class="c22"
                     >
                       <span
-                        class="c21 c22"
+                        class="c23 c24"
                         data-testid="select-open-button"
+                        iconsize="small"
                       >
                         ▼
                       </span>
@@ -1228,7 +1092,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c15"
+                  class="c16"
                   data-testid="error-marker"
                 >
                   ×
@@ -1242,16 +1106,16 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
         class="entities-section"
       >
         <div
-          class="c23 section-header"
+          class="c25 c26 section-header"
         >
           <h2
-            class="c24 c25"
+            class="c27 c28"
           >
             <div
-              class="c26"
+              class="c29 c30"
             >
               <span
-                class="c27"
+                class="c5 c31"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -1260,26 +1124,26 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </span>
             </div>
             <div
-              class="c28"
+              class="c29 c32"
             >
               Scan Configs 0 of 0
             </div>
           </h2>
           <div
-            class="c8"
+            class="c10"
           />
         </div>
         <div
           class="c0"
         >
           <div
-            class="c29 entities-table"
+            class="c0 c33 entities-table"
           >
             <div
-              class="c30"
+              class="c34"
             >
               <span
-                class="c5 c4 c31"
+                class="c5 c7 c6 c35"
                 data-testid="svg-icon"
                 title="Unfold all details"
               >
@@ -1290,17 +1154,17 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                 </svg>
               </span>
               <div
-                class="c32"
+                class="c36 c37"
               >
                 <div
-                  class="c2"
+                  class="c2 c3"
                 >
                   <div
-                    class="c3"
+                    class="c2 c4"
                     margin="5px"
                   >
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1311,7 +1175,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1324,19 +1188,19 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c34"
+                  class="c39"
                 >
                   0 - 0 of 0
                 </span>
                 <div
-                  class="c2"
+                  class="c2 c3"
                 >
                   <div
-                    class="c3"
+                    class="c2 c4"
                     margin="5px"
                   >
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1347,7 +1211,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Last"
                     >
@@ -1362,52 +1226,52 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </div>
             </div>
             <table
-              class="c35"
+              class="c40 c41 c42"
             >
               <thead
-                class="c36"
+                class="c43"
               >
                 <tr>
                   <th
-                    class="c37"
+                    class="c44"
                     rowspan="2"
                   >
                     <a
-                      class="c38"
+                      class="c45"
                     >
                       <div
-                        class="c39"
+                        class="c2"
                       >
                         Name
                       </div>
                     </a>
                   </th>
                   <th
-                    class="c40"
+                    class="c46"
                     colspan="2"
                   >
                     <div
-                      class="c39"
+                      class="c2"
                     >
                       Family
                     </div>
                   </th>
                   <th
-                    class="c40"
+                    class="c46"
                     colspan="2"
                   >
                     <div
-                      class="c39"
+                      class="c2"
                     >
                       NVTs
                     </div>
                   </th>
                   <th
-                    class="c41"
+                    class="c47"
                     rowspan="2"
                   >
                     <div
-                      class="c42"
+                      class="c48"
                     >
                       Actions
                     </div>
@@ -1415,52 +1279,52 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                 </tr>
                 <tr>
                   <th
-                    class="c43"
+                    class="c49"
                   >
                     <a
-                      class="c38"
+                      class="c45"
                     >
                       <div
-                        class="c39"
+                        class="c2"
                       >
                         Total
                       </div>
                     </a>
                   </th>
                   <th
-                    class="c43"
+                    class="c49"
                   >
                     <a
-                      class="c38"
+                      class="c45"
                     >
                       <div
-                        class="c39"
+                        class="c2"
                       >
                         Trend
                       </div>
                     </a>
                   </th>
                   <th
-                    class="c43"
+                    class="c49"
                   >
                     <a
-                      class="c38"
+                      class="c45"
                     >
                       <div
-                        class="c39"
+                        class="c2"
                       >
                         Total
                       </div>
                     </a>
                   </th>
                   <th
-                    class="c43"
+                    class="c49"
                   >
                     <a
-                      class="c38"
+                      class="c45"
                     >
                       <div
-                        class="c39"
+                        class="c2"
                       >
                         Trend
                       </div>
@@ -1474,17 +1338,17 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                 <tr>
                   <td>
                     <div
-                      class="c44"
+                      class="c50"
                     >
                       <div
-                        class="c45"
+                        class="c51"
                       >
                         <div
-                          class="c44"
+                          class="c50"
                         >
                           <span>
                             <span
-                              class="c46"
+                              class="c52"
                               name="12345"
                             >
                               foo
@@ -1503,18 +1367,18 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c44"
+                      class="c50"
                     >
                       2
                     </div>
                   </td>
                   <td>
                     <div
-                      class="c44"
+                      class="c50"
                     >
                       <span
                         alt="Static"
-                        class="c4"
+                        class="c5 c6"
                         data-testid="svg-icon"
                         title="The family selection is STATIC. New families will NOT automatically be added and considered."
                       >
@@ -1528,18 +1392,18 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c44"
+                      class="c50"
                     >
                       4
                     </div>
                   </td>
                   <td>
                     <div
-                      class="c44"
+                      class="c50"
                     >
                       <span
                         alt="Dynamic"
-                        class="c4"
+                        class="c5 c6"
                         data-testid="svg-icon"
                         title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
                       >
@@ -1556,14 +1420,14 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       class="c0"
                     >
                       <div
-                        class="c47"
+                        class="c53 c3"
                       >
                         <div
-                          class="c48"
+                          class="c54 c4"
                           margin="5px"
                         >
                           <span
-                            class="c5 c4"
+                            class="c5 c7 c6"
                             data-testid="svg-icon"
                             title="Move Scan Config to trashcan"
                           >
@@ -1574,7 +1438,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c4"
+                            class="c5 c7 c6"
                             data-testid="svg-icon"
                             title="Edit Scan Config"
                           >
@@ -1585,7 +1449,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c4"
+                            class="c5 c7 c6"
                             data-testid="svg-icon"
                             title="Clone Scan Config"
                           >
@@ -1596,7 +1460,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c4"
+                            class="c5 c7 c6"
                             data-testid="svg-icon"
                             title="Export Scan Config"
                           >
@@ -1618,46 +1482,46 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     colspan="6"
                   >
                     <div
-                      class="c49"
+                      class="c36"
                     >
                       <div
-                        class="c2"
+                        class="c2 c3"
                       >
                         <div
-                          class="c3"
+                          class="c2 c4"
                           margin="5px"
                         >
                           <div
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="downshift-1-label"
-                            class="c16"
+                            class="c17"
                             role="combobox"
                           >
                             <div
-                              class="c50"
+                              class="c55"
                               width="180px"
                             >
                               <div
                                 aria-haspopup="true"
                                 aria-label="open menu"
-                                class="c18"
+                                class="c19"
                                 data-toggle="true"
                                 role="button"
                                 type="button"
                               >
                                 <div
-                                  class="c19"
+                                  class="c20 c21"
                                   data-testid="select-selected-value"
                                   title="Apply to page contents"
                                 >
                                   Apply to page contents
                                 </div>
                                 <div
-                                  class="c20"
+                                  class="c22"
                                 >
                                   <span
-                                    class="c21 c22"
+                                    class="c23 c24"
                                     data-testid="select-open-button"
                                   >
                                     ▼
@@ -1666,21 +1530,21 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                               </div>
                             </div>
                             <div
-                              class="c15"
+                              class="c16"
                               data-testid="error-marker"
                             >
                               ×
                             </div>
                           </div>
                           <div
-                            class="c2"
+                            class="c2 c3"
                           >
                             <div
-                              class="c3"
+                              class="c2 c4"
                               margin="5px"
                             >
                               <span
-                                class="c5 c4"
+                                class="c5 c7 c6"
                                 data-testid="svg-icon"
                                 title="Add tag to page contents"
                               >
@@ -1691,7 +1555,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                                 </svg>
                               </span>
                               <span
-                                class="c5 c4"
+                                class="c5 c7 c6"
                                 data-testid="svg-icon"
                                 title="Move page contents to trashcan"
                               >
@@ -1702,7 +1566,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                                 </svg>
                               </span>
                               <span
-                                class="c5 c4"
+                                class="c5 c7 c6"
                                 data-testid="svg-icon"
                                 title="Export page contents"
                               >
@@ -1722,25 +1586,25 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </tfoot>
             </table>
             <div
-              class="c45"
+              class="c51"
             >
               <div
-                class="c51"
+                class="c2 c56"
               >
                 (Applied filter: )
               </div>
               <div
-                class="c32"
+                class="c36 c37"
               >
                 <div
-                  class="c2"
+                  class="c2 c3"
                 >
                   <div
-                    class="c3"
+                    class="c2 c4"
                     margin="5px"
                   >
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1751,7 +1615,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1764,19 +1628,19 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c34"
+                  class="c39"
                 >
                   0 - 0 of 0
                 </span>
                 <div
-                  class="c2"
+                  class="c2 c3"
                 >
                   <div
-                    class="c3"
+                    class="c2 c4"
                     margin="5px"
                   >
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1787,7 +1651,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c33 c4"
+                      class="c5 c38 c6"
                       data-testid="svg-icon"
                       title="Last"
                     >

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/row.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/row.js.snap
@@ -10,8 +10,8 @@ exports[`Scan Config row tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -29,11 +29,10 @@ exports[`Scan Config row tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -46,8 +45,8 @@ exports[`Scan Config row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -67,29 +66,17 @@ exports[`Scan Config row tests should render 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-left: -5px;
 }
 
-.c6 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c6 > * {
-  margin-left: 5px;
-}
-
-.c5 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -101,31 +88,49 @@ exports[`Scan Config row tests should render 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c9 {
+  margin-left: -5px;
+}
+
+.c9>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
+.c9>* {
+  margin-left: 5px;
+}
+
 .c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c10 {
   cursor: pointer;
 }
 
-.c3 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c3 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
@@ -137,14 +142,14 @@ exports[`Scan Config row tests should render 1`] = `
   color: #0a53b8;
 }
 
-.c2:hover {
+.c2 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
 @media print {
-  .c7 {
+  .c3 {
     display: none;
   }
 }
@@ -203,7 +208,7 @@ exports[`Scan Config row tests should render 1`] = `
         >
           <span
             alt="Static"
-            class="c3"
+            class="c3 c4"
             data-testid="svg-icon"
             title="The family selection is STATIC. New families will NOT automatically be added and considered."
           >
@@ -228,7 +233,7 @@ exports[`Scan Config row tests should render 1`] = `
         >
           <span
             alt="Dynamic"
-            class="c3"
+            class="c3 c4"
             data-testid="svg-icon"
             title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
           >
@@ -242,17 +247,17 @@ exports[`Scan Config row tests should render 1`] = `
       </td>
       <td>
         <div
-          class="c4"
+          class="c5"
         >
           <div
-            class="c5"
+            class="c6 c7"
           >
             <div
-              class="c6"
+              class="c8 c9"
               margin="5px"
             >
               <span
-                class="c7 c3"
+                class="c3 c10 c4"
                 data-testid="svg-icon"
                 title="Move Scan Config to trashcan"
               >
@@ -263,7 +268,7 @@ exports[`Scan Config row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c7 c3"
+                class="c3 c10 c4"
                 data-testid="svg-icon"
                 title="Edit Scan Config"
               >
@@ -274,7 +279,7 @@ exports[`Scan Config row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c7 c3"
+                class="c3 c10 c4"
                 data-testid="svg-icon"
                 title="Clone Scan Config"
               >
@@ -285,7 +290,7 @@ exports[`Scan Config row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c7 c3"
+                class="c3 c10 c4"
                 data-testid="svg-icon"
                 title="Export Scan Config"
               >

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/table.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/table.js.snap
@@ -1,7 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Scan Config table tests should render 1`] = `
-.c1 {
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15,11 +37,28 @@ exports[`Scan Config table tests should render 1`] = `
   flex-grow: 1;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c13 {
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -28,8 +67,8 @@ exports[`Scan Config table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -37,67 +76,31 @@ exports[`Scan Config table tests should render 1`] = `
   align-items: center;
 }
 
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
 .c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+}
+
+.c23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -113,121 +116,12 @@ exports[`Scan Config table tests should render 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
 }
 
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c7 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c7 > * {
-  margin-left: 5px;
-}
-
-.c23 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c23 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c23 > * {
-  margin-left: 5px;
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c22 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -240,39 +134,97 @@ exports[`Scan Config table tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c27 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c33 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c11 {
+  margin-left: -5px;
+}
+
+.c11>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2 {
+.c11>* {
+  margin-left: 5px;
+}
+
+.c10 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4 {
   cursor: pointer;
 }
 
-.c8 svg path {
+.c12 svg path {
   fill: #bfbfbf;
 }
 
-.c3 {
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c3 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
-.c30 {
+.c34 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -285,8 +237,8 @@ exports[`Scan Config table tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -297,18 +249,18 @@ exports[`Scan Config table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c31 {
+.c35 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c31 * {
+.c35 * {
   height: inherit;
   width: inherit;
 }
 
-.c27 {
+.c30 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -332,7 +284,7 @@ exports[`Scan Config table tests should render 1`] = `
   font-weight: normal;
 }
 
-.c26 {
+.c29 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -344,16 +296,7 @@ exports[`Scan Config table tests should render 1`] = `
   width: 180px;
 }
 
-.c32 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c28 {
+.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -370,29 +313,64 @@ exports[`Scan Config table tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
+}
+
+.c36 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c32 {
   cursor: default;
 }
 
-.c25 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c11 a {
+.c14 {
+  border: 0;
+  border-spacing: 0px;
+  font-size: 12px;
+  text-align: left;
+  table-layout: auto;
+  width: 100%;
+}
+
+.c15 th,
+.c15 td {
+  padding: 4px 10px;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.c15 tfoot tr {
+  background: #fff;
+}
+
+.c15 tfoot tr td {
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.c17 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c11 a:hover {
+.c17 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c12 {
+.c18 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -400,7 +378,7 @@ exports[`Scan Config table tests should render 1`] = `
   width: 72%;
 }
 
-.c14 {
+.c19 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -408,7 +386,7 @@ exports[`Scan Config table tests should render 1`] = `
   width: 10%;
 }
 
-.c15 {
+.c20 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -416,7 +394,7 @@ exports[`Scan Config table tests should render 1`] = `
   width: 8%;
 }
 
-.c17 {
+.c22 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -424,128 +402,77 @@ exports[`Scan Config table tests should render 1`] = `
   width: 5%;
 }
 
-.c33 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c37 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c9 {
+.c13 {
   margin: 0 3px;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c8 {
   margin: 2px 3px;
 }
 
-.c10 {
-  border: 0;
-  border-spacing: 0px;
-  font-size: 12px;
-  text-align: left;
-  table-layout: auto;
-  width: 100%;
+.c16 {
   opacity: 1.0;
 }
 
-.c10 th,
-.c10 td {
-  padding: 4px 10px;
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c10 tfoot tr {
-  background: #fff;
-}
-
-.c10 tfoot tr td {
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c4 {
+.c6 {
   margin-top: 2px;
   margin-left: 2px;
 }
 
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+.c1 {
   margin-top: 20px;
 }
 
-.c20 {
+.c25 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c20:hover {
+.c25 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
 @media print {
-  .c2 {
+  .c3 {
     display: none;
   }
 }
 
 @media print {
-  .c11 {
+  .c14 {
+    border-collapse: collapse;
+  }
+}
+
+@media screen {
+  .c15>tbody:nth-of-type(even),
+  .c15>tbody:only-of-type>tr:nth-of-type(even) {
+    background: #f3f3f3;
+  }
+
+  .c15>tbody:not(:only-of-type):hover,
+  .c15>tbody:only-of-type>tr:hover {
+    background: #e5e5e5;
+  }
+}
+
+@media print {
+  .c17 {
     border-bottom: 1px solid black;
   }
 
-  .c11 a,
-  .c11 a:hover {
+  .c17 a,
+  .c17 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -553,7 +480,7 @@ exports[`Scan Config table tests should render 1`] = `
 }
 
 @media print {
-  .c12 {
+  .c18 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
@@ -562,58 +489,40 @@ exports[`Scan Config table tests should render 1`] = `
 }
 
 @media print {
-  .c14 {
+  .c19 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
     font-weight: bold;
-  }
-}
-
-@media print {
-  .c15 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: none;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c17 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: none;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c5 svg {
-    display: none;
-  }
-}
-
-@media print {
-  .c10 {
-    border-collapse: collapse;
-  }
-}
-
-@media screen {
-  .c10 > tbody:nth-of-type(even),
-  .c10 > tbody:only-of-type > tr:nth-of-type(even) {
-    background: #f3f3f3;
-  }
-
-  .c10 > tbody:not(:only-of-type):hover,
-  .c10 > tbody:only-of-type > tr:hover {
-    background: #e5e5e5;
   }
 }
 
 @media print {
   .c20 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: none;
+    font-weight: bold;
+  }
+}
+
+@media print {
+  .c22 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: none;
+    font-weight: bold;
+  }
+}
+
+@media print {
+  .c8 svg {
+    display: none;
+  }
+}
+
+@media print {
+  .c25 {
     color: #000;
   }
 }
@@ -624,13 +533,13 @@ exports[`Scan Config table tests should render 1`] = `
   />
   <div>
     <div
-      class="c0 entities-table"
+      class="c0 c1 entities-table"
     >
       <div
-        class="c1"
+        class="c2"
       >
         <span
-          class="c2 c3 c4"
+          class="c3 c4 c5 c6"
           data-testid="svg-icon"
           title="Unfold all details"
         >
@@ -641,17 +550,17 @@ exports[`Scan Config table tests should render 1`] = `
           </svg>
         </span>
         <div
-          class="c5"
+          class="c7 c8"
         >
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -662,7 +571,7 @@ exports[`Scan Config table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -675,19 +584,19 @@ exports[`Scan Config table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c9"
+            class="c13"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -698,7 +607,7 @@ exports[`Scan Config table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Last"
               >
@@ -713,48 +622,48 @@ exports[`Scan Config table tests should render 1`] = `
         </div>
       </div>
       <table
-        class="c10"
+        class="c14 c15 c16"
       >
         <thead
-          class="c11"
+          class="c17"
         >
           <tr>
             <th
-              class="c12"
+              class="c18"
               rowspan="2"
             >
               <div
-                class="c13"
+                class="c9"
               >
                 Name
               </div>
             </th>
             <th
-              class="c14"
+              class="c19"
               colspan="2"
             >
               <div
-                class="c13"
+                class="c9"
               >
                 Family
               </div>
             </th>
             <th
-              class="c14"
+              class="c19"
               colspan="2"
             >
               <div
-                class="c13"
+                class="c9"
               >
                 NVTs
               </div>
             </th>
             <th
-              class="c15"
+              class="c20"
               rowspan="2"
             >
               <div
-                class="c16"
+                class="c21"
               >
                 Actions
               </div>
@@ -762,37 +671,37 @@ exports[`Scan Config table tests should render 1`] = `
           </tr>
           <tr>
             <th
-              class="c17"
+              class="c22"
             >
               <div
-                class="c13"
+                class="c9"
               >
                 Total
               </div>
             </th>
             <th
-              class="c17"
+              class="c22"
             >
               <div
-                class="c13"
+                class="c9"
               >
                 Trend
               </div>
             </th>
             <th
-              class="c17"
+              class="c22"
             >
               <div
-                class="c13"
+                class="c9"
               >
                 Total
               </div>
             </th>
             <th
-              class="c17"
+              class="c22"
             >
               <div
-                class="c13"
+                class="c9"
               >
                 Trend
               </div>
@@ -805,17 +714,17 @@ exports[`Scan Config table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <div
-                  class="c19"
+                  class="c24"
                 >
                   <div
-                    class="c18"
+                    class="c23"
                   >
                     <span>
                       <span
-                        class="c20"
+                        class="c25"
                         name="12345"
                       >
                         foo
@@ -834,18 +743,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 2
               </div>
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <span
                   alt="Static"
-                  class="c3"
+                  class="c3 c5"
                   data-testid="svg-icon"
                   title="The family selection is STATIC. New families will NOT automatically be added and considered."
                 >
@@ -859,18 +768,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 4
               </div>
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <span
                   alt="Dynamic"
-                  class="c3"
+                  class="c3 c5"
                   data-testid="svg-icon"
                   title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
                 >
@@ -884,17 +793,17 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c21"
+                class="c0"
               >
                 <div
-                  class="c22"
+                  class="c26 c10"
                 >
                   <div
-                    class="c23"
+                    class="c27 c11"
                     margin="5px"
                   >
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Move Scan Config to trashcan"
                     >
@@ -905,7 +814,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Edit Scan Config"
                     >
@@ -916,7 +825,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Clone Scan Config"
                     >
@@ -927,7 +836,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Export Scan Config"
                     >
@@ -945,17 +854,17 @@ exports[`Scan Config table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <div
-                  class="c19"
+                  class="c24"
                 >
                   <div
-                    class="c18"
+                    class="c23"
                   >
                     <span>
                       <span
-                        class="c20"
+                        class="c25"
                         name="123456"
                       >
                         lorem
@@ -974,18 +883,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 3
               </div>
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <span
                   alt="Static"
-                  class="c3"
+                  class="c3 c5"
                   data-testid="svg-icon"
                   title="The family selection is STATIC. New families will NOT automatically be added and considered."
                 >
@@ -999,18 +908,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 5
               </div>
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <span
                   alt="Dynamic"
-                  class="c3"
+                  class="c3 c5"
                   data-testid="svg-icon"
                   title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
                 >
@@ -1024,17 +933,17 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c21"
+                class="c0"
               >
                 <div
-                  class="c22"
+                  class="c26 c10"
                 >
                   <div
-                    class="c23"
+                    class="c27 c11"
                     margin="5px"
                   >
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Move Scan Config to trashcan"
                     >
@@ -1045,7 +954,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Edit Scan Config"
                     >
@@ -1056,7 +965,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Clone Scan Config"
                     >
@@ -1067,7 +976,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Export Scan Config"
                     >
@@ -1085,17 +994,17 @@ exports[`Scan Config table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <div
-                  class="c19"
+                  class="c24"
                 >
                   <div
-                    class="c18"
+                    class="c23"
                   >
                     <span>
                       <span
-                        class="c20"
+                        class="c25"
                         name="1234567"
                       >
                         hello
@@ -1114,18 +1023,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 1
               </div>
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <span
                   alt="Static"
-                  class="c3"
+                  class="c3 c5"
                   data-testid="svg-icon"
                   title="The family selection is STATIC. New families will NOT automatically be added and considered."
                 >
@@ -1139,18 +1048,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 1
               </div>
             </td>
             <td>
               <div
-                class="c18"
+                class="c23"
               >
                 <span
                   alt="Dynamic"
-                  class="c3"
+                  class="c3 c5"
                   data-testid="svg-icon"
                   title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
                 >
@@ -1164,17 +1073,17 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c21"
+                class="c0"
               >
                 <div
-                  class="c22"
+                  class="c26 c10"
                 >
                   <div
-                    class="c23"
+                    class="c27 c11"
                     margin="5px"
                   >
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Move Scan Config to trashcan"
                     >
@@ -1185,7 +1094,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Edit Scan Config"
                     >
@@ -1196,7 +1105,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Clone Scan Config"
                     >
@@ -1207,7 +1116,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Export Scan Config"
                     >
@@ -1229,43 +1138,43 @@ exports[`Scan Config table tests should render 1`] = `
               colspan="6"
             >
               <div
-                class="c24"
+                class="c7"
               >
                 <div
-                  class="c6"
+                  class="c9 c10"
                 >
                   <div
-                    class="c7"
+                    class="c9 c11"
                     margin="5px"
                   >
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-labelledby="downshift-0-label"
-                      class="c25"
+                      class="c28"
                       role="combobox"
                     >
                       <div
-                        class="c26"
+                        class="c29"
                         width="180px"
                       >
                         <div
                           aria-haspopup="true"
                           aria-label="open menu"
-                          class="c27"
+                          class="c30"
                           data-toggle="true"
                           role="button"
                           type="button"
                         >
                           <div
-                            class="c28"
+                            class="c31 c32"
                             data-testid="select-selected-value"
                           />
                           <div
-                            class="c29"
+                            class="c33"
                           >
                             <span
-                              class="c30 c31"
+                              class="c34 c35"
                               data-testid="select-open-button"
                             >
                               ▼
@@ -1274,21 +1183,21 @@ exports[`Scan Config table tests should render 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c32"
+                        class="c36"
                         data-testid="error-marker"
                       >
                         ×
                       </div>
                     </div>
                     <div
-                      class="c6"
+                      class="c9 c10"
                     >
                       <div
-                        class="c7"
+                        class="c9 c11"
                         margin="5px"
                       >
                         <span
-                          class="c3"
+                          class="c3 c5"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1296,7 +1205,7 @@ exports[`Scan Config table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3"
+                          class="c3 c5"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1304,7 +1213,7 @@ exports[`Scan Config table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3"
+                          class="c3 c5"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1321,25 +1230,25 @@ exports[`Scan Config table tests should render 1`] = `
         </tfoot>
       </table>
       <div
-        class="c19"
+        class="c24"
       >
         <div
-          class="c33"
+          class="c9 c37"
         >
           (Applied filter: rows=2)
         </div>
         <div
-          class="c5"
+          class="c7 c8"
         >
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -1350,7 +1259,7 @@ exports[`Scan Config table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -1363,19 +1272,19 @@ exports[`Scan Config table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c9"
+            class="c13"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -1386,7 +1295,7 @@ exports[`Scan Config table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Last"
               >

--- a/src/web/pages/scanners/__tests__/__snapshots__/dialog.js.snap
+++ b/src/web/pages/scanners/__tests__/__snapshots__/dialog.js.snap
@@ -1,7 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ScannerDialog component tests should render 1`] = `
-.c8 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,8 +49,8 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -19,7 +58,25 @@ exports[`ScannerDialog component tests should render 1`] = `
   align-items: stretch;
 }
 
-.c19 {
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -28,9 +85,30 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -62,7 +140,7 @@ exports[`ScannerDialog component tests should render 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -70,7 +148,7 @@ exports[`ScannerDialog component tests should render 1`] = `
   height: 100%;
 }
 
-.c27 {
+.c33 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -79,13 +157,13 @@ exports[`ScannerDialog component tests should render 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c26 {
+.c32 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -104,7 +182,7 @@ exports[`ScannerDialog component tests should render 1`] = `
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -121,30 +199,30 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c23 {
+.c29 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -164,12 +242,12 @@ exports[`ScannerDialog component tests should render 1`] = `
   z-index: 1;
 }
 
-.c23:focus,
-.c23:hover {
+.c29:focus,
+.c29:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c23:hover {
+.c29:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -177,26 +255,26 @@ exports[`ScannerDialog component tests should render 1`] = `
   color: #fff;
 }
 
-.c23[disabled] {
+.c29[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c23 img {
+.c29 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c23:link {
+.c29:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c24 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -205,8 +283,8 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -214,63 +292,32 @@ exports[`ScannerDialog component tests should render 1`] = `
   align-items: center;
 }
 
-.c25 {
+.c31 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c25:hover {
+.c31 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c27 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c28 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -284,17 +331,15 @@ exports[`ScannerDialog component tests should render 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -302,31 +347,12 @@ exports[`ScannerDialog component tests should render 1`] = `
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -336,13 +362,13 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   max-width: 100%;
   font-weight: bold;
@@ -353,28 +379,13 @@ exports[`ScannerDialog component tests should render 1`] = `
   margin-left: 0;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c20 {
+.c24 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -387,8 +398,8 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -399,18 +410,18 @@ exports[`ScannerDialog component tests should render 1`] = `
   cursor: pointer;
 }
 
-.c21 {
+.c25 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c21 * {
+.c25 * {
   height: inherit;
   width: inherit;
 }
 
-.c17 {
+.c20 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -434,7 +445,7 @@ exports[`ScannerDialog component tests should render 1`] = `
   font-weight: normal;
 }
 
-.c16 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -446,16 +457,7 @@ exports[`ScannerDialog component tests should render 1`] = `
   width: 180px;
 }
 
-.c14 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c18 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -472,17 +474,29 @@ exports[`ScannerDialog component tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
+}
+
+.c17 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c22 {
   cursor: default;
 }
 
-.c15 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c12 {
+.c15 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -496,11 +510,11 @@ exports[`ScannerDialog component tests should render 1`] = `
   padding: 1px 8px;
 }
 
-.c12:-webkit-autofill {
+.c15:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c13 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -513,8 +527,8 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -541,14 +555,14 @@ exports[`ScannerDialog component tests should render 1`] = `
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 New Scanner
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -556,37 +570,40 @@ exports[`ScannerDialog component tests should render 1`] = `
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Name
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="name"
                         type="text"
                         value="Unnamed"
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -594,27 +611,29 @@ exports[`ScannerDialog component tests should render 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Comment
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="comment"
                         type="text"
                         value=""
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -622,16 +641,18 @@ exports[`ScannerDialog component tests should render 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Type
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
@@ -639,33 +660,33 @@ exports[`ScannerDialog component tests should render 1`] = `
                         aria-expanded="false"
                         aria-haspopup="listbox"
                         aria-labelledby="downshift-0-label"
-                        class="c15"
+                        class="c18"
                         role="combobox"
                       >
                         <div
-                          class="c16"
+                          class="c19"
                           width="180px"
                         >
                           <div
                             aria-haspopup="true"
                             aria-label="open menu"
-                            class="c17"
+                            class="c20"
                             data-toggle="true"
                             role="button"
                             type="button"
                           >
                             <div
-                              class="c18"
+                              class="c21 c22"
                               data-testid="select-selected-value"
                               title="Greenbone Sensor"
                             >
                               Greenbone Sensor
                             </div>
                             <div
-                              class="c19"
+                              class="c23"
                             >
                               <span
-                                class="c20 c21"
+                                class="c24 c25"
                                 data-testid="select-open-button"
                               >
                                 ▼
@@ -674,7 +695,7 @@ exports[`ScannerDialog component tests should render 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c14"
+                          class="c17"
                           data-testid="error-marker"
                         >
                           ×
@@ -683,27 +704,29 @@ exports[`ScannerDialog component tests should render 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Host
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="host"
                         type="text"
                         value="localhost"
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -714,17 +737,17 @@ exports[`ScannerDialog component tests should render 1`] = `
               </div>
             </div>
             <div
-              class="c22"
+              class="c26 c27 c28"
             >
               <button
-                class="c23 c24 c25"
+                class="c29 c30 c31"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c23 c24 c25"
+                class="c29 c30 c31"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -733,10 +756,10 @@ exports[`ScannerDialog component tests should render 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c32"
           >
             <div
-              class="c27"
+              class="c33"
             />
           </div>
         </div>

--- a/src/web/pages/tasks/__tests__/__snapshots__/actions.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/actions.js.snap
@@ -14,47 +14,13 @@ exports[`Task Actions tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c2 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c2 > * {
-  margin-left: 5px;
 }
 
 .c1 {
@@ -70,40 +36,80 @@ exports[`Task Actions tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c4 {
+  margin-left: -5px;
+}
+
+.c4>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c3 {
+.c4>* {
+  margin-left: 5px;
+}
+
+.c2 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 {
   cursor: pointer;
 }
 
-.c5 svg path {
+.c8 svg path {
   fill: #bfbfbf;
 }
 
-.c4 {
+.c7 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c4 * {
+.c7 * {
   height: inherit;
   width: inherit;
 }
 
 @media print {
-  .c3 {
+  .c5 {
     display: none;
   }
 }
@@ -118,14 +124,14 @@ exports[`Task Actions tests should render 1`] = `
         class="c0"
       >
         <div
-          class="c1"
+          class="c1 c2"
         >
           <div
-            class="c2"
+            class="c3 c4"
             margin="5px"
           >
             <span
-              class="c3 c4"
+              class="c5 c6 c7"
               data-testid="svg-icon"
               title="Start"
             >
@@ -137,7 +143,7 @@ exports[`Task Actions tests should render 1`] = `
             </span>
             <span
               alt="Resume"
-              class="c5 c4"
+              class="c5 c8 c7"
               data-testid="svg-icon"
               title="Task is not stopped"
             >
@@ -148,7 +154,7 @@ exports[`Task Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c3 c4"
+              class="c5 c6 c7"
               data-testid="svg-icon"
               title="Move Task to trashcan"
             >
@@ -159,7 +165,7 @@ exports[`Task Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c3 c4"
+              class="c5 c6 c7"
               data-testid="svg-icon"
               title="Edit Task"
             >
@@ -170,7 +176,7 @@ exports[`Task Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c3 c4"
+              class="c5 c6 c7"
               data-testid="svg-icon"
               title="Clone Task"
             >
@@ -181,7 +187,7 @@ exports[`Task Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c3 c4"
+              class="c5 c6 c7"
               data-testid="svg-icon"
               title="Export Task"
             >

--- a/src/web/pages/tasks/__tests__/__snapshots__/autodeletereportsgroup.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/autodeletereportsgroup.js.snap
@@ -1,6 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
 .c5 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -10,43 +28,31 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c7 {
   margin-left: -5px;
 }
 
-.c5 > * {
+.c7>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5 > * {
+.c7>* {
   margin-left: 5px;
 }
 
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -63,8 +69,8 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -80,28 +86,13 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   margin-left: 0;
 }
 
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+.c3 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c3 {
+.c4 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -117,7 +108,7 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   cursor: pointer;
 }
 
-.c6 {
+.c8 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -128,11 +119,11 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   height: auto;
 }
 
-.c8 {
+.c10 {
   opacity: 1;
 }
 
-.c7 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -141,8 +132,8 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -150,7 +141,7 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c11 {
   border-radius: 2px;
   border: 1px solid #bfbfbf;
   background-color: #fff;
@@ -162,7 +153,7 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   vertical-align: middle;
 }
 
-.c10 {
+.c12 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -176,7 +167,7 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   margin-right: 22px;
 }
 
-.c11 {
+.c13 {
   background-color: #e5e5e5;
   color: #7F7F7F;
   border-left: 1px solid #4C4C4C;
@@ -198,62 +189,30 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+}
+
+.c13:hover {
+  background-color: #11ab51;
+  color: #fff;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c13:active {
+  background-color: #fff;
+  color: #074320;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c14 {
   border-top-right-radius: 1px;
   top: 0;
 }
 
-.c11:hover {
-  background-color: #11ab51;
-  color: #fff;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c11:active {
-  background-color: #fff;
-  color: #074320;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c12 {
-  background-color: #e5e5e5;
-  color: #7F7F7F;
-  border-left: 1px solid #4C4C4C;
-  width: 16px;
-  height: 50%;
-  font-size: 0.6em;
-  padding: 0;
-  margin: 0;
-  text-align: center;
-  vertical-align: middle;
-  position: absolute;
-  right: 0;
-  cursor: default;
-  display: block;
-  overflow: hidden;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
+.c15 {
   border-bottom-right-radius: 1px;
   bottom: 0;
-}
-
-.c12:hover {
-  background-color: #11ab51;
-  color: #fff;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c12:active {
-  background-color: #fff;
-  color: #074320;
-  -webkit-text-decoration: none;
-  text-decoration: none;
 }
 
 <div
@@ -262,33 +221,35 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   <label
     class="c1"
     data-testid="formgroup-title"
+    titleoffset="0"
+    titlesize="2"
   >
     Auto Delete Reports
   </label>
   <div
-    class="c2"
+    class="c2 c3"
     data-testid="formgroup-content"
     size="10"
   >
     <label
-      class="c3"
+      class="c4"
     >
       <div
-        class="c4"
+        class="c5 c6"
       >
         <div
-          class="c5"
+          class="c5 c7"
           margin="5px"
         >
           <input
-            class="c6 c7"
+            class="c8 c9"
             data-testid="radio-input"
             name="auto_delete"
             type="radio"
             value="no"
           />
           <span
-            class="c8"
+            class="c10"
             data-testid="radio-title"
           >
             Do not automatically delete reports
@@ -297,32 +258,32 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
       </div>
     </label>
     <div
-      class="c4"
+      class="c5 c6"
     >
       <div
-        class="c5"
+        class="c5 c7"
         margin="5px"
       >
         <label
-          class="c3"
+          class="c4"
         >
           <div
-            class="c4"
+            class="c5 c6"
           >
             <div
-              class="c5"
+              class="c5 c7"
               margin="5px"
             >
               <input
                 checked=""
-                class="c6 c7"
+                class="c8 c9"
                 data-testid="radio-input"
                 name="auto_delete"
                 type="radio"
                 value="keep"
               />
               <span
-                class="c8"
+                class="c10"
                 data-testid="radio-title"
               >
                 Automatically delete oldest reports but always keep newest
@@ -331,10 +292,10 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
           </div>
         </label>
         <span
-          class="c9"
+          class="c11"
         >
           <input
-            class="c10"
+            class="c12"
             data-testid="spinner-input"
             max="1200"
             maxlength="5"
@@ -344,13 +305,13 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
             value="5"
           />
           <span
-            class="c11"
+            class="c13 c14"
             data-testid="spinner-up"
           >
             ▲
           </span>
           <span
-            class="c12"
+            class="c13 c15"
             data-testid="spinner-down"
           >
             ▼

--- a/src/web/pages/tasks/__tests__/__snapshots__/containerdialog.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/containerdialog.js.snap
@@ -1,7 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ContainerDialog tests should render create dialog 1`] = `
-.c8 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,13 +49,52 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
+}
+
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c1 {
@@ -44,7 +122,7 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -52,7 +130,7 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   height: 100%;
 }
 
-.c20 {
+.c25 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -61,13 +139,13 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c19 {
+.c24 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -86,7 +164,7 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -103,30 +181,30 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c16 {
+.c21 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -146,12 +224,12 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   z-index: 1;
 }
 
-.c16:focus,
-.c16:hover {
+.c21:focus,
+.c21:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c16:hover {
+.c21:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -159,26 +237,26 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   color: #fff;
 }
 
-.c16[disabled] {
+.c21[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c16 img {
+.c21 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c16:link {
+.c21:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c17 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -187,8 +265,8 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -196,63 +274,32 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   align-items: center;
 }
 
-.c18 {
+.c23 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c18:hover {
+.c23 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c19 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c20 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -266,17 +313,15 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -284,31 +329,12 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -318,13 +344,13 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   max-width: 100%;
   font-weight: bold;
@@ -335,28 +361,13 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   margin-left: 0;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c14 {
+.c17 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -365,7 +376,7 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   display: none;
 }
 
-.c12 {
+.c15 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -379,11 +390,11 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   padding: 1px 8px;
 }
 
-.c12:-webkit-autofill {
+.c15:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c13 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -396,8 +407,8 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -424,14 +435,14 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 New Container Task
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -439,38 +450,41 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Name
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="name"
                         size="30"
                         type="text"
                         value=""
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -478,28 +492,30 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Comment
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="comment"
                         size="30"
                         type="text"
                         value=""
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -510,17 +526,17 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
               </div>
             </div>
             <div
-              class="c15"
+              class="c18 c19 c20"
             >
               <button
-                class="c16 c17 c18"
+                class="c21 c22 c23"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c16 c17 c18"
+                class="c21 c22 c23"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -529,10 +545,10 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
             </div>
           </div>
           <div
-            class="c19"
+            class="c24"
           >
             <div
-              class="c20"
+              class="c25"
             />
           </div>
         </div>
@@ -544,11 +560,46 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
 `;
 
 exports[`ContainerDialog tests should render edit dialog 1`] = `
-<body>
-  <div
-    id="portals"
-  >
-    .c8 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -557,8 +608,8 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -566,7 +617,7 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   align-items: stretch;
 }
 
-.c15 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -575,8 +626,8 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -584,7 +635,7 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   align-items: center;
 }
 
-.c17 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -592,44 +643,35 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c19 {
   margin-left: -5px;
 }
 
-.c17 > * {
+.c19>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c17 > * {
+.c19>* {
   margin-left: 5px;
 }
 
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c18 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -661,7 +703,7 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -669,7 +711,7 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   height: 100%;
 }
 
-.c27 {
+.c31 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -678,13 +720,13 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c26 {
+.c30 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -703,7 +745,7 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -720,30 +762,30 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c23 {
+.c27 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -763,12 +805,12 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   z-index: 1;
 }
 
-.c23:focus,
-.c23:hover {
+.c27:focus,
+.c27:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c23:hover {
+.c27:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -776,26 +818,26 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   color: #fff;
 }
 
-.c23[disabled] {
+.c27[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c23 img {
+.c27 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c23:link {
+.c27:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c24 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -804,8 +846,8 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -813,63 +855,32 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   align-items: center;
 }
 
-.c25 {
+.c29 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c25:hover {
+.c29 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c25 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c26 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -883,17 +894,15 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -901,31 +910,12 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -935,13 +925,13 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   max-width: 100%;
   font-weight: bold;
@@ -952,28 +942,13 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   margin-left: 0;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c14 {
+.c17 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -982,7 +957,7 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   display: none;
 }
 
-.c12 {
+.c15 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -996,11 +971,11 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   padding: 1px 8px;
 }
 
-.c12:-webkit-autofill {
+.c15:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c13 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1013,8 +988,8 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1022,7 +997,7 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   align-items: center;
 }
 
-.c18 {
+.c20 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1038,7 +1013,7 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   cursor: pointer;
 }
 
-.c19 {
+.c21 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -1049,11 +1024,11 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   height: auto;
 }
 
-.c21 {
+.c23 {
   opacity: 1;
 }
 
-.c20 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1062,8 +1037,8 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1071,7 +1046,11 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   align-items: center;
 }
 
-<div>
+<body>
+  <div
+    id="portals"
+  >
+    <div>
       <div
         class="c0"
       >
@@ -1086,14 +1065,14 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 New Container Task
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -1101,38 +1080,41 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Name
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="name"
                         size="30"
                         type="text"
                         value=""
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -1140,28 +1122,30 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Comment
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <input
-                        class="c12 c13"
+                        class="c15 c16"
                         name="comment"
                         size="30"
                         type="text"
                         value=""
                       />
                       <div
-                        class="c14"
+                        class="c17"
                         data-testid="error-marker"
                       >
                         ×
@@ -1169,49 +1153,51 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Add results to Assets
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <div
-                        class="c15"
+                        class="c13"
                       >
                         <div
-                          class="c16"
+                          class="c13 c18"
                         >
                           <div
-                            class="c17"
+                            class="c13 c19"
                             margin="5px"
                           >
                             <label
-                              class="c18"
+                              class="c20"
                             >
                               <div
-                                class="c16"
+                                class="c13 c18"
                               >
                                 <div
-                                  class="c17"
+                                  class="c13 c19"
                                   margin="5px"
                                 >
                                   <input
                                     checked=""
-                                    class="c19 c20"
+                                    class="c21 c22"
                                     data-testid="radio-input"
                                     name="in_assets"
                                     type="radio"
                                     value="1"
                                   />
                                   <span
-                                    class="c21"
+                                    class="c23"
                                     data-testid="radio-title"
                                   >
                                     Yes
@@ -1220,24 +1206,24 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
                               </div>
                             </label>
                             <label
-                              class="c18"
+                              class="c20"
                             >
                               <div
-                                class="c16"
+                                class="c13 c18"
                               >
                                 <div
-                                  class="c17"
+                                  class="c13 c19"
                                   margin="5px"
                                 >
                                   <input
-                                    class="c19 c20"
+                                    class="c21 c22"
                                     data-testid="radio-input"
                                     name="in_assets"
                                     type="radio"
                                     value="0"
                                   />
                                   <span
-                                    class="c21"
+                                    class="c23"
                                     data-testid="radio-title"
                                   >
                                     No
@@ -1254,17 +1240,17 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
               </div>
             </div>
             <div
-              class="c22"
+              class="c24 c25 c26"
             >
               <button
-                class="c23 c24 c25"
+                class="c27 c28 c29"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c23 c24 c25"
+                class="c27 c28 c29"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -1273,10 +1259,10 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c30"
           >
             <div
-              class="c27"
+              class="c31"
             />
           </div>
         </div>

--- a/src/web/pages/tasks/__tests__/__snapshots__/details.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/details.js.snap
@@ -14,8 +14,8 @@ exports[`Task Details tests should render full task details 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -32,50 +32,13 @@ exports[`Task Details tests should render full task details 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-.c2 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c4 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4 > * {
-  margin-left: 5px;
 }
 
 .c3 {
@@ -87,20 +50,45 @@ exports[`Task Details tests should render full task details 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c2 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c6 {
+.c5 {
+  margin-left: -5px;
+}
+
+.c5>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c5>* {
+  margin-left: 5px;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c7 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -109,29 +97,29 @@ exports[`Task Details tests should render full task details 1`] = `
   width: 100%;
 }
 
-.c5 > *:not(:last-child)::after {
+.c6>*:not(:last-child)::after {
   content: '•';
   margin-left: 5px;
 }
 
-.c7 td {
+.c8 td {
   padding: 4px 4px 4px 0;
 }
 
-.c7 tr td:first-child {
+.c8 tr td:first-child {
   padding-right: 5px;
 }
 
-.c8 {
+.c9 {
   width: 10%;
 }
 
-.c9 {
+.c10 {
   width: 90%;
 }
 
 @media print {
-  .c6 {
+  .c7 {
     border-collapse: collapse;
   }
 }
@@ -163,10 +151,10 @@ exports[`Task Details tests should render full task details 1`] = `
     </h2>
     <div>
       <div
-        class="c3"
+        class="c3 c4"
       >
         <div
-          class="c4 c5"
+          class="c3 c5 c6"
           margin="5px"
         >
           <span>
@@ -190,15 +178,15 @@ exports[`Task Details tests should render full task details 1`] = `
     </h2>
     <div>
       <table
-        class="c6 c7"
+        class="c7 c8"
       >
         <colgroup>
           <col
-            class="c8"
+            class="c9"
             width="10%"
           />
           <col
-            class="c9"
+            class="c10"
             width="90%"
           />
         </colgroup>
@@ -257,15 +245,15 @@ exports[`Task Details tests should render full task details 1`] = `
     </h2>
     <div>
       <table
-        class="c6 c7"
+        class="c7 c8"
       >
         <colgroup>
           <col
-            class="c8"
+            class="c9"
             width="10%"
           />
           <col
-            class="c9"
+            class="c10"
             width="90%"
           />
         </colgroup>
@@ -332,15 +320,15 @@ exports[`Task Details tests should render full task details 1`] = `
     </h2>
     <div>
       <table
-        class="c6 c7"
+        class="c7 c8"
       >
         <colgroup>
           <col
-            class="c8"
+            class="c9"
             width="10%"
           />
           <col
-            class="c9"
+            class="c10"
             width="90%"
           />
         </colgroup>

--- a/src/web/pages/tasks/__tests__/__snapshots__/detailspage.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/detailspage.js.snap
@@ -14,8 +14,8 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
@@ -29,239 +29,11 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
   -ms-flex-align: flex-start;
   align-items: flex-start;
-}
-
-.c13 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c25 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-}
-
-.c27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c32 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c34 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c6 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -10px;
-}
-
-.c3 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c3 > * {
-  margin-left: 10px;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  margin-left: -5px;
-}
-
-.c4 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4 > * {
-  margin-left: 5px;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c7 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c7 > * {
-  margin-left: 5px;
 }
 
 .c2 {
@@ -273,50 +45,16 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c14 {
-  cursor: pointer;
-}
-
-.c15 svg path {
-  fill: #bfbfbf;
 }
 
 .c5 {
-  height: 16px;
-  width: 16px;
-  line-height: 16px;
-}
-
-.c5 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c22 {
-  height: 50px;
-  width: 50px;
-  line-height: 50px;
-}
-
-.c22 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -324,22 +62,36 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  margin: 10px 0px;
-  padding-bottom: 1px;
-  border-bottom: 2px solid #e5e5e5;
-  position: relative;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
 }
 
-.c19 {
-  margin: 0 0 1px 0;
+.c15 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c20 {
@@ -350,17 +102,16 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
-.c21 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -369,14 +120,227 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
   align-items: flex-end;
-  margin-right: 5px;
+}
+
+.c28 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+}
+
+.c31 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c32 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c34 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c37 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c39 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4 {
+  margin-left: -10px;
+}
+
+.c4>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4>* {
+  margin-left: 10px;
+}
+
+.c6 {
+  margin-left: -5px;
+}
+
+.c6>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6>* {
+  margin-left: 5px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c16 {
+  cursor: pointer;
+}
+
+.c17 svg path {
+  fill: #bfbfbf;
+}
+
+.c8 {
+  height: 16px;
+  width: 16px;
+  line-height: 16px;
+}
+
+.c8 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c26 {
+  height: 50px;
+  width: 50px;
+  line-height: 50px;
+}
+
+.c26 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c21 {
+  margin: 10px 0px;
+  padding-bottom: 1px;
+  border-bottom: 2px solid #e5e5e5;
+  position: relative;
+}
+
+.c22 {
+  margin: 0 0 1px 0;
 }
 
 .c23 {
@@ -388,18 +352,25 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c25 {
+  margin-right: 5px;
+}
+
+.c27 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c30 {
+.c35 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -426,11 +397,11 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #11ab51;
 }
 
-.c30:first-child {
+.c35 :first-child {
   border-left: 1px solid #e5e5e5;
 }
 
-.c31 {
+.c36 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -454,15 +425,1151 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #fff;
 }
 
-.c31:hover {
+.c36 :hover {
   border-top: 2px solid #e5e5e5;
 }
 
-.c31:first-child {
+.c36 :first-child {
   border-left: 1px solid #fff;
 }
 
-.c28 {
+.c33 {
+  border-bottom: 2px solid #11ab51;
+  margin-top: 30px;
+  margin-bottom: 15px;
+}
+
+.c40 {
+  border: 0;
+  border-spacing: 0px;
+  font-size: 12px;
+  text-align: left;
+  table-layout: auto;
+}
+
+.c50 {
+  border: 0;
+  border-spacing: 0px;
+  font-size: 12px;
+  text-align: left;
+  table-layout: auto;
+  width: 100%;
+}
+
+.c49>*:not(:last-child)::after {
+  content: '•';
+  margin-left: 5px;
+}
+
+.c41 td {
+  padding: 4px 4px 4px 0;
+}
+
+.c41 tr td:first-child {
+  padding-right: 5px;
+}
+
+.c30 {
+  border-spacing: 0px;
+  color: #7F7F7F;
+  font-size: 10px;
+}
+
+.c30 :nth-child(even) {
+  margin-left: 3px;
+}
+
+.c30 :nth-child(odd) {
+  margin-left: 30px;
+}
+
+.c42 {
+  width: 10%;
+}
+
+.c43 {
+  width: 90%;
+}
+
+.c38 {
+  font-size: 0.7em;
+}
+
+.c45 {
+  height: 13px;
+  box-sizing: content-box;
+  display: inline-block;
+  width: 100px;
+  background: #4C4C4C;
+  vertical-align: middle;
+  text-align: center;
+}
+
+.c47 {
+  z-index: 1;
+  font-weight: bold;
+  color: #fff;
+  font-size: 9px;
+  margin: 0;
+  position: relative;
+  top: -13px;
+  padding-top: 1px;
+}
+
+.c46 {
+  height: 13px;
+  width: 100%;
+  background: #4f91c7;
+}
+
+.c48 {
+  white-space: nowrap;
+}
+
+.c44:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c11 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c12 {
+  position: relative;
+  display: none;
+}
+
+.c10:hover .c12 {
+  display: block;
+}
+
+.c13 {
+  position: absolute;
+  margin: 0;
+  padding: 0;
+  left: 0;
+  top: 0;
+  z-index: 100;
+  list-style: none;
+  font-size: 10px;
+  width: 255px;
+}
+
+.c14 {
+  height: 22px;
+  width: 255px;
+  border-left: 1px solid #7F7F7F;
+  border-right: 1px solid #7F7F7F;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  background-color: #fff;
+  font-weight: bold;
+  text-indent: 12px;
+  text-align: left;
+}
+
+.c14:first-child {
+  border-top: 1px solid #7F7F7F;
+}
+
+.c14:last-child {
+  border-bottom: 1px solid #7F7F7F;
+}
+
+.c14:hover {
+  background: #11ab51;
+  color: #fff;
+}
+
+.c14 div {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  cursor: pointer;
+}
+
+.c18 {
+  position: relative;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-right: 0px;
+}
+
+.c19 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  position: absolute;
+  font-size: 10px;
+  background-color: red;
+  font-weight: bold;
+  border-radius: 10px;
+  min-width: 10px;
+  padding: 3px 5px;
+  z-index: 1;
+  background-color: #11ab51;
+  color: #fff;
+  bottom: -8px;
+  right: 0px;
+}
+
+@media print {
+  .c7 {
+    display: none;
+  }
+}
+
+@media print {
+  .c40 {
+    border-collapse: collapse;
+  }
+}
+
+@media print {
+  .c50 {
+    border-collapse: collapse;
+  }
+}
+
+@media print {
+  .c45 {
+    background: none;
+    border: 0;
+  }
+}
+
+@media print {
+  .c47 {
+    color: black;
+  }
+}
+
+@media print {
+  .c46 {
+    background: none;
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1 toolbar"
+  >
+    <div
+      class="c2 c3"
+    >
+      <div
+        class="c2 c4"
+        margin="10px"
+      >
+        <div
+          class="c2 c3"
+        >
+          <div
+            class="c5 c6"
+            margin="5px"
+          >
+            <a
+              href="test/en/scanning.html#managing-tasks"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <span
+                class="c7 c8"
+                data-testid="svg-icon"
+                iconsize="small"
+                title="Help: Tasks"
+              >
+                <svg
+                  title="Help: Tasks"
+                >
+                  help.svg
+                </svg>
+              </span>
+            </a>
+            <a
+              class="c9"
+              href="/tasks"
+            >
+              <span
+                class="c7 c8"
+                data-testid="svg-icon"
+                iconsize="small"
+                title="Task List"
+              >
+                <svg
+                  title="Task List"
+                >
+                  list.svg
+                </svg>
+              </span>
+            </a>
+            <span
+              class="c7 c8"
+              data-testid="svg-icon"
+              iconsize="small"
+              title="This is an Alterable Task. Reports may not relate to current Scan Config or Target!"
+            >
+              <svg
+                title="This is an Alterable Task. Reports may not relate to current Scan Config or Target!"
+              >
+                alterable.svg
+              </svg>
+            </span>
+          </div>
+        </div>
+        <div
+          class="c2 c3"
+        >
+          <div
+            class="c2 c6"
+            margin="5px"
+          >
+            <span
+              class="c10 c11"
+            >
+              <span
+                class="c7 c8"
+                data-testid="svg-icon"
+                iconsize="small"
+              >
+                <svg>
+                  new.svg
+                </svg>
+              </span>
+              <div
+                class="c12"
+              >
+                <ul
+                  class="c13"
+                >
+                  <li
+                    class="c14"
+                  >
+                    <div
+                      class="c15"
+                    >
+                      New Task
+                    </div>
+                  </li>
+                  <li
+                    class="c14"
+                  >
+                    <div
+                      class="c15"
+                    >
+                      New Container Task
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </span>
+            <span
+              class="c7 c16 c8"
+              data-testid="svg-icon"
+              iconsize="small"
+              title="Clone Task"
+            >
+              <svg
+                title="Clone Task"
+              >
+                clone.svg
+              </svg>
+            </span>
+            <span
+              class="c7 c16 c8"
+              data-testid="svg-icon"
+              iconsize="small"
+              title="Edit Task"
+            >
+              <svg
+                title="Edit Task"
+              >
+                edit.svg
+              </svg>
+            </span>
+            <span
+              class="c7 c16 c8"
+              data-testid="svg-icon"
+              iconsize="small"
+              title="Move Task to trashcan"
+            >
+              <svg
+                title="Move Task to trashcan"
+              >
+                trashcan.svg
+              </svg>
+            </span>
+            <span
+              class="c7 c16 c8"
+              data-testid="svg-icon"
+              iconsize="small"
+              title="Export Task as XML"
+            >
+              <svg
+                title="Export Task as XML"
+              >
+                export.svg
+              </svg>
+            </span>
+          </div>
+        </div>
+        <div
+          class="c2 c3"
+        >
+          <div
+            class="c2 c6"
+            margin="5px"
+          >
+            <span
+              class="c7 c16 c8"
+              data-testid="svg-icon"
+              iconsize="small"
+              title="Start"
+            >
+              <svg
+                title="Start"
+              >
+                start.svg
+              </svg>
+            </span>
+            <span
+              alt="Resume"
+              class="c7 c17 c8"
+              data-testid="svg-icon"
+              iconsize="small"
+              title="Task is not stopped"
+            >
+              <svg
+                title="Task is not stopped"
+              >
+                resume.svg
+              </svg>
+            </span>
+          </div>
+        </div>
+        <div
+          class="c2 c3"
+        >
+          <div
+            class="c2 c4"
+            margin="10px"
+          >
+            <div
+              class="c2 c3"
+            >
+              <div
+                class="c2 c6"
+                margin="5px"
+              >
+                <a
+                  class="c9"
+                  data-testid="details-link"
+                  href="/report/1234"
+                  title="Last Report for Task foo from 07/30/2019"
+                >
+                  <span
+                    class="c7 c8"
+                    data-testid="svg-icon"
+                    iconsize="small"
+                  >
+                    <svg>
+                      report.svg
+                    </svg>
+                  </span>
+                </a>
+                <a
+                  class="c9"
+                  href="/reports?filter=task_id%3D12345"
+                  title="Total Reports for Task foo"
+                >
+                  <div
+                    class="c18"
+                    margin="0"
+                  >
+                    <span
+                      class="c7 c8"
+                      data-testid="svg-icon"
+                      iconsize="small"
+                    >
+                      <svg>
+                        report.svg
+                      </svg>
+                    </span>
+                    <span
+                      class="c19"
+                      data-testid="badge-icon"
+                      margin="0"
+                    >
+                      1
+                    </span>
+                  </div>
+                </a>
+              </div>
+            </div>
+            <a
+              class="c9"
+              href="/results?filter=task_id%3D12345"
+              title="Results for Task foo"
+            >
+              <div
+                class="c18"
+                margin="0"
+              >
+                <span
+                  class="c7 c8"
+                  data-testid="svg-icon"
+                  iconsize="small"
+                >
+                  <svg>
+                    result.svg
+                  </svg>
+                </span>
+                <span
+                  class="c19"
+                  data-testid="badge-icon"
+                  margin="0"
+                >
+                  1
+                </span>
+              </div>
+            </a>
+            <div
+              class="c2 c3"
+            >
+              <div
+                class="c2 c6"
+                margin="5px"
+              >
+                <a
+                  class="c9"
+                  href="/notes?filter=task_id%3D12345"
+                  title="Notes for Task foo"
+                >
+                  <div
+                    class="c18"
+                    margin="0"
+                  >
+                    <span
+                      class="c7 c8"
+                      data-testid="svg-icon"
+                      iconsize="small"
+                    >
+                      <svg>
+                        note.svg
+                      </svg>
+                    </span>
+                    <span
+                      class="c19"
+                      data-testid="badge-icon"
+                      margin="0"
+                    >
+                      0
+                    </span>
+                  </div>
+                </a>
+                <a
+                  class="c9"
+                  href="/overrides?filter=task_id%3D12345"
+                  title="Overrides for Task foo"
+                >
+                  <div
+                    class="c18"
+                    margin="0"
+                  >
+                    <span
+                      class="c7 c8"
+                      data-testid="svg-icon"
+                      iconsize="small"
+                    >
+                      <svg>
+                        override.svg
+                      </svg>
+                    </span>
+                    <span
+                      class="c19"
+                      data-testid="badge-icon"
+                      margin="0"
+                    >
+                      0
+                    </span>
+                  </div>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <section
+    class="entity-section"
+  >
+    <div
+      class="c20 c21 section-header"
+    >
+      <h2
+        class="c22 c23"
+      >
+        <div
+          class="c24 c25"
+        >
+          <span
+            class="c7 c26"
+            data-testid="svg-icon"
+          >
+            <svg>
+              task.svg
+            </svg>
+          </span>
+        </div>
+        <div
+          class="c24 c27"
+        >
+          Task: foo
+        </div>
+      </h2>
+      <div
+        class="c28"
+      >
+        <div
+          class="c29"
+        >
+          <div
+            class="c2 c30"
+          >
+            <div>
+              ID:
+            </div>
+            <div>
+              12345
+            </div>
+            <div>
+              Created:
+            </div>
+            <div>
+              Tue, Jul 16, 2019 8:31 AM CEST
+            </div>
+            <div>
+              Modified:
+            </div>
+            <div>
+              Tue, Jul 16, 2019 8:44 AM CEST
+            </div>
+            <div>
+              Owner:
+            </div>
+            <span>
+              admin
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c31"
+    >
+      <div
+        class="c32 c33"
+      >
+        <div
+          class="c34"
+        >
+          <div
+            class="c35"
+          >
+            Information
+          </div>
+          <div
+            class="c36"
+          >
+            <div
+              class="c37"
+            >
+              <span>
+                User Tags
+              </span>
+              <span
+                class="c38"
+              >
+                (
+                <i>
+                  0
+                </i>
+                )
+              </span>
+            </div>
+          </div>
+          <div
+            class="c36"
+          >
+            <div
+              class="c37"
+            >
+              <span>
+                Permissions
+              </span>
+              <span
+                class="c38"
+              >
+                (
+                <i>
+                  0
+                </i>
+                )
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="c39"
+      >
+        <table
+          class="c40 c41"
+        >
+          <colgroup>
+            <col
+              class="c42"
+              width="10%"
+            />
+            <col
+              class="c43"
+              width="90%"
+            />
+          </colgroup>
+          <tbody
+            class=""
+          >
+            <tr>
+              <td>
+                <div
+                  class="c39"
+                >
+                  Name
+                </div>
+              </td>
+              <td>
+                <div
+                  class="c39"
+                >
+                  foo
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <div
+                  class="c39"
+                >
+                  Comment
+                </div>
+              </td>
+              <td>
+                <div
+                  class="c39"
+                >
+                  bar
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <div
+                  class="c39"
+                >
+                  Alterable
+                </div>
+              </td>
+              <td>
+                <div
+                  class="c39"
+                >
+                  Yes
+                </div>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <div
+                  class="c39"
+                >
+                  Status
+                </div>
+              </td>
+              <td>
+                <div
+                  class="c39"
+                >
+                  <a
+                    class="c9 c44"
+                    data-testid="details-link"
+                    href="/report/1234"
+                  >
+                    <div
+                      boxbackground="#4C4C4C"
+                      class="c45"
+                      data-testid="progressbar-box"
+                      title="Done"
+                    >
+                      <div
+                        background="low"
+                        class="c46"
+                        data-testid="progress"
+                        progress="100"
+                      />
+                      <div
+                        class="c47"
+                      >
+                        <span
+                          class="c48"
+                        >
+                          Done
+                        </span>
+                      </div>
+                    </div>
+                  </a>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div
+          class="c31"
+        >
+          <div
+            class="c39"
+          >
+            <h2>
+              Target
+            </h2>
+            <div>
+              <a
+                class="c9"
+                data-testid="details-link"
+                href="/target/5678"
+              >
+                target1
+              </a>
+            </div>
+          </div>
+          <div
+            class="c39"
+          >
+            <h2>
+              Alerts
+            </h2>
+            <div>
+              <div
+                class="c2 c3"
+              >
+                <div
+                  class="c2 c6 c49"
+                  margin="5px"
+                >
+                  <span>
+                    <a
+                      class="c9"
+                      data-testid="details-link"
+                      href="/alert/91011"
+                    >
+                      alert1
+                    </a>
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="c39"
+          >
+            <h2>
+              Scanner
+            </h2>
+            <div>
+              <table
+                class="c50 c41"
+              >
+                <colgroup>
+                  <col
+                    class="c42"
+                    width="10%"
+                  />
+                  <col
+                    class="c43"
+                    width="90%"
+                  />
+                </colgroup>
+                <tbody
+                  class=""
+                >
+                  <tr>
+                    <td>
+                      <div
+                        class="c39"
+                      >
+                        Name
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="c39"
+                      >
+                        <span>
+                          <a
+                            class="c9"
+                            data-testid="details-link"
+                            href="/scanner/1516"
+                          >
+                            scanner1
+                          </a>
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div
+                        class="c39"
+                      >
+                        Type
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="c39"
+                      >
+                        OpenVAS Scanner
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div
+            class="c39"
+          >
+            <h2>
+              Assets
+            </h2>
+            <div>
+              <table
+                class="c50 c41"
+              >
+                <colgroup>
+                  <col
+                    class="c42"
+                    width="10%"
+                  />
+                  <col
+                    class="c43"
+                    width="90%"
+                  />
+                </colgroup>
+                <tbody
+                  class=""
+                >
+                  <tr>
+                    <td>
+                      <div
+                        class="c39"
+                      >
+                        Add to Assets
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="c39"
+                      >
+                        Yes
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div
+                        class="c39"
+                      >
+                        Apply Overrides
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="c39"
+                      >
+                        Yes
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div
+                        class="c39"
+                      >
+                        Min QoD
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="c39"
+                      >
+                        70 %
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div
+            class="c39"
+          >
+            <h2>
+              Scan
+            </h2>
+            <div>
+              <table
+                class="c50 c41"
+              >
+                <colgroup>
+                  <col
+                    class="c42"
+                    width="10%"
+                  />
+                  <col
+                    class="c43"
+                    width="90%"
+                  />
+                </colgroup>
+                <tbody
+                  class=""
+                >
+                  <tr>
+                    <td>
+                      <div
+                        class="c39"
+                      >
+                        Duration of last Scan
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="c39"
+                      >
+                        2 minutes
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <div
+                        class="c39"
+                      >
+                        Auto delete Reports
+                      </div>
+                    </td>
+                    <td>
+                      <div
+                        class="c39"
+                      >
+                        Do not automatically delete reports
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+`;
+
+exports[`Task ToolBarIcons tests should render 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -475,123 +1582,76 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
+  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
   justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-  border-bottom: 2px solid #11ab51;
-  margin-top: 30px;
-  margin-bottom: 15px;
-}
-
-.c35 {
-  border: 0;
-  border-spacing: 0px;
-  font-size: 12px;
-  text-align: left;
-  table-layout: auto;
-}
-
-.c45 {
-  border: 0;
-  border-spacing: 0px;
-  font-size: 12px;
-  text-align: left;
-  table-layout: auto;
-  width: 100%;
-}
-
-.c44 > *:not(:last-child)::after {
-  content: '•';
-  margin-left: 5px;
-}
-
-.c36 td {
-  padding: 4px 4px 4px 0;
-}
-
-.c36 tr td:first-child {
-  padding-right: 5px;
-}
-
-.c26 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  border-spacing: 0px;
-  color: #7F7F7F;
-  font-size: 10px;
 }
 
-.c26 :nth-child(even) {
-  margin-left: 3px;
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
-.c26 :nth-child(odd) {
-  margin-left: 30px;
+.c2 {
+  margin-left: -10px;
 }
 
-.c37 {
-  width: 10%;
+.c2>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
-.c38 {
-  width: 90%;
+.c2>* {
+  margin-left: 10px;
 }
 
-.c33 {
-  font-size: 0.7em;
+.c4 {
+  margin-left: -5px;
 }
 
-.c40 {
-  height: 13px;
-  box-sizing: content-box;
-  display: inline-block;
-  width: 100px;
-  background: #4C4C4C;
-  vertical-align: middle;
-  text-align: center;
+.c4>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
-.c42 {
-  z-index: 1;
-  font-weight: bold;
-  color: #fff;
-  font-size: 9px;
-  margin: 0;
-  position: relative;
-  top: -13px;
-  padding-top: 1px;
+.c4>* {
+  margin-left: 5px;
 }
 
-.c41 {
-  height: 13px;
-  width: 100%;
-  background: #4f91c7;
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
 }
 
-.c43 {
-  white-space: nowrap;
+.c14 {
+  cursor: pointer;
 }
 
-.c39:hover {
-  -webkit-text-decoration: none;
-  text-decoration: none;
+.c15 svg path {
+  fill: #bfbfbf;
+}
+
+.c6 {
+  height: 16px;
+  width: 16px;
+  line-height: 16px;
+}
+
+.c6 * {
+  height: inherit;
+  width: inherit;
 }
 
 .c9 {
@@ -690,12 +1750,13 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -719,1158 +1780,23 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
 }
 
 @media print {
-  .c14 {
-    display: none;
-  }
-}
-
-@media print {
-  .c35 {
-    border-collapse: collapse;
-  }
-}
-
-@media print {
-  .c45 {
-    border-collapse: collapse;
-  }
-}
-
-@media print {
-  .c40 {
-    background: none;
-    border: 0;
-  }
-}
-
-@media print {
-  .c42 {
-    color: black;
-  }
-}
-
-@media print {
-  .c41 {
-    background: none;
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1 toolbar"
-  >
-    <div
-      class="c2"
-    >
-      <div
-        class="c3"
-        margin="10px"
-      >
-        <div
-          class="c2"
-        >
-          <div
-            class="c4"
-            margin="5px"
-          >
-            <a
-              href="test/en/scanning.html#managing-tasks"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              <span
-                class="c5"
-                data-testid="svg-icon"
-                title="Help: Tasks"
-              >
-                <svg
-                  title="Help: Tasks"
-                >
-                  help.svg
-                </svg>
-              </span>
-            </a>
-            <a
-              class="c6"
-              href="/tasks"
-            >
-              <span
-                class="c5"
-                data-testid="svg-icon"
-                title="Task List"
-              >
-                <svg
-                  title="Task List"
-                >
-                  list.svg
-                </svg>
-              </span>
-            </a>
-            <span
-              class="c5"
-              data-testid="svg-icon"
-              title="This is an Alterable Task. Reports may not relate to current Scan Config or Target!"
-            >
-              <svg
-                title="This is an Alterable Task. Reports may not relate to current Scan Config or Target!"
-              >
-                alterable.svg
-              </svg>
-            </span>
-          </div>
-        </div>
-        <div
-          class="c2"
-        >
-          <div
-            class="c7"
-            margin="5px"
-          >
-            <span
-              class="c8 c9"
-            >
-              <span
-                class="c5"
-                data-testid="svg-icon"
-              >
-                <svg>
-                  new.svg
-                </svg>
-              </span>
-              <div
-                class="c10"
-              >
-                <ul
-                  class="c11"
-                >
-                  <li
-                    class="c12"
-                  >
-                    <div
-                      class="c13"
-                    >
-                      New Task
-                    </div>
-                  </li>
-                  <li
-                    class="c12"
-                  >
-                    <div
-                      class="c13"
-                    >
-                      New Container Task
-                    </div>
-                  </li>
-                </ul>
-              </div>
-            </span>
-            <span
-              class="c14 c5"
-              data-testid="svg-icon"
-              title="Clone Task"
-            >
-              <svg
-                title="Clone Task"
-              >
-                clone.svg
-              </svg>
-            </span>
-            <span
-              class="c14 c5"
-              data-testid="svg-icon"
-              title="Edit Task"
-            >
-              <svg
-                title="Edit Task"
-              >
-                edit.svg
-              </svg>
-            </span>
-            <span
-              class="c14 c5"
-              data-testid="svg-icon"
-              title="Move Task to trashcan"
-            >
-              <svg
-                title="Move Task to trashcan"
-              >
-                trashcan.svg
-              </svg>
-            </span>
-            <span
-              class="c14 c5"
-              data-testid="svg-icon"
-              title="Export Task as XML"
-            >
-              <svg
-                title="Export Task as XML"
-              >
-                export.svg
-              </svg>
-            </span>
-          </div>
-        </div>
-        <div
-          class="c2"
-        >
-          <div
-            class="c7"
-            margin="5px"
-          >
-            <span
-              class="c14 c5"
-              data-testid="svg-icon"
-              title="Start"
-            >
-              <svg
-                title="Start"
-              >
-                start.svg
-              </svg>
-            </span>
-            <span
-              alt="Resume"
-              class="c15 c5"
-              data-testid="svg-icon"
-              title="Task is not stopped"
-            >
-              <svg
-                title="Task is not stopped"
-              >
-                resume.svg
-              </svg>
-            </span>
-          </div>
-        </div>
-        <div
-          class="c2"
-        >
-          <div
-            class="c3"
-            margin="10px"
-          >
-            <div
-              class="c2"
-            >
-              <div
-                class="c7"
-                margin="5px"
-              >
-                <a
-                  class="c6"
-                  data-testid="details-link"
-                  href="/report/1234"
-                  title="Last Report for Task foo from 07/30/2019"
-                >
-                  <span
-                    class="c5"
-                    data-testid="svg-icon"
-                  >
-                    <svg>
-                      report.svg
-                    </svg>
-                  </span>
-                </a>
-                <a
-                  class="c6"
-                  href="/reports?filter=task_id%3D12345"
-                  title="Total Reports for Task foo"
-                >
-                  <div
-                    class="c16"
-                  >
-                    <span
-                      class="c5"
-                      data-testid="svg-icon"
-                    >
-                      <svg>
-                        report.svg
-                      </svg>
-                    </span>
-                    <span
-                      class="c17"
-                      data-testid="badge-icon"
-                    >
-                      1
-                    </span>
-                  </div>
-                </a>
-              </div>
-            </div>
-            <a
-              class="c6"
-              href="/results?filter=task_id%3D12345"
-              title="Results for Task foo"
-            >
-              <div
-                class="c16"
-              >
-                <span
-                  class="c5"
-                  data-testid="svg-icon"
-                >
-                  <svg>
-                    result.svg
-                  </svg>
-                </span>
-                <span
-                  class="c17"
-                  data-testid="badge-icon"
-                >
-                  1
-                </span>
-              </div>
-            </a>
-            <div
-              class="c2"
-            >
-              <div
-                class="c7"
-                margin="5px"
-              >
-                <a
-                  class="c6"
-                  href="/notes?filter=task_id%3D12345"
-                  title="Notes for Task foo"
-                >
-                  <div
-                    class="c16"
-                  >
-                    <span
-                      class="c5"
-                      data-testid="svg-icon"
-                    >
-                      <svg>
-                        note.svg
-                      </svg>
-                    </span>
-                    <span
-                      class="c17"
-                      data-testid="badge-icon"
-                    >
-                      0
-                    </span>
-                  </div>
-                </a>
-                <a
-                  class="c6"
-                  href="/overrides?filter=task_id%3D12345"
-                  title="Overrides for Task foo"
-                >
-                  <div
-                    class="c16"
-                  >
-                    <span
-                      class="c5"
-                      data-testid="svg-icon"
-                    >
-                      <svg>
-                        override.svg
-                      </svg>
-                    </span>
-                    <span
-                      class="c17"
-                      data-testid="badge-icon"
-                    >
-                      0
-                    </span>
-                  </div>
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <section
-    class="entity-section"
-  >
-    <div
-      class="c18 section-header"
-    >
-      <h2
-        class="c19 c20"
-      >
-        <div
-          class="c21"
-        >
-          <span
-            class="c22"
-            data-testid="svg-icon"
-          >
-            <svg>
-              task.svg
-            </svg>
-          </span>
-        </div>
-        <div
-          class="c23"
-        >
-          Task: foo
-        </div>
-      </h2>
-      <div
-        class="c24"
-      >
-        <div
-          class="c25"
-        >
-          <div
-            class="c26"
-          >
-            <div>
-              ID:
-            </div>
-            <div>
-              12345
-            </div>
-            <div>
-              Created:
-            </div>
-            <div>
-              Tue, Jul 16, 2019 8:31 AM CEST
-            </div>
-            <div>
-              Modified:
-            </div>
-            <div>
-              Tue, Jul 16, 2019 8:44 AM CEST
-            </div>
-            <div>
-              Owner:
-            </div>
-            <span>
-              admin
-            </span>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="c27"
-    >
-      <div
-        class="c28"
-      >
-        <div
-          class="c29"
-        >
-          <div
-            class="c30"
-          >
-            Information
-          </div>
-          <div
-            class="c31"
-          >
-            <div
-              class="c32"
-            >
-              <span>
-                User Tags
-              </span>
-              <span
-                class="c33"
-              >
-                (
-                <i>
-                  0
-                </i>
-                )
-              </span>
-            </div>
-          </div>
-          <div
-            class="c31"
-          >
-            <div
-              class="c32"
-            >
-              <span>
-                Permissions
-              </span>
-              <span
-                class="c33"
-              >
-                (
-                <i>
-                  0
-                </i>
-                )
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="c34"
-      >
-        <table
-          class="c35 c36"
-        >
-          <colgroup>
-            <col
-              class="c37"
-              width="10%"
-            />
-            <col
-              class="c38"
-              width="90%"
-            />
-          </colgroup>
-          <tbody
-            class=""
-          >
-            <tr>
-              <td>
-                <div
-                  class="c34"
-                >
-                  Name
-                </div>
-              </td>
-              <td>
-                <div
-                  class="c34"
-                >
-                  foo
-                </div>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <div
-                  class="c34"
-                >
-                  Comment
-                </div>
-              </td>
-              <td>
-                <div
-                  class="c34"
-                >
-                  bar
-                </div>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <div
-                  class="c34"
-                >
-                  Alterable
-                </div>
-              </td>
-              <td>
-                <div
-                  class="c34"
-                >
-                  Yes
-                </div>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <div
-                  class="c34"
-                >
-                  Status
-                </div>
-              </td>
-              <td>
-                <div
-                  class="c34"
-                >
-                  <a
-                    class="c6 c39"
-                    data-testid="details-link"
-                    href="/report/1234"
-                  >
-                    <div
-                      class="c40"
-                      data-testid="progressbar-box"
-                      title="Done"
-                    >
-                      <div
-                        class="c41"
-                        data-testid="progress"
-                      />
-                      <div
-                        class="c42"
-                      >
-                        <span
-                          class="c43"
-                        >
-                          Done
-                        </span>
-                      </div>
-                    </div>
-                  </a>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <div
-          class="c27"
-        >
-          <div
-            class="c34"
-          >
-            <h2>
-              Target
-            </h2>
-            <div>
-              <a
-                class="c6"
-                data-testid="details-link"
-                href="/target/5678"
-              >
-                target1
-              </a>
-            </div>
-          </div>
-          <div
-            class="c34"
-          >
-            <h2>
-              Alerts
-            </h2>
-            <div>
-              <div
-                class="c2"
-              >
-                <div
-                  class="c7 c44"
-                  margin="5px"
-                >
-                  <span>
-                    <a
-                      class="c6"
-                      data-testid="details-link"
-                      href="/alert/91011"
-                    >
-                      alert1
-                    </a>
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="c34"
-          >
-            <h2>
-              Scanner
-            </h2>
-            <div>
-              <table
-                class="c45 c36"
-              >
-                <colgroup>
-                  <col
-                    class="c37"
-                    width="10%"
-                  />
-                  <col
-                    class="c38"
-                    width="90%"
-                  />
-                </colgroup>
-                <tbody
-                  class=""
-                >
-                  <tr>
-                    <td>
-                      <div
-                        class="c34"
-                      >
-                        Name
-                      </div>
-                    </td>
-                    <td>
-                      <div
-                        class="c34"
-                      >
-                        <span>
-                          <a
-                            class="c6"
-                            data-testid="details-link"
-                            href="/scanner/1516"
-                          >
-                            scanner1
-                          </a>
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div
-                        class="c34"
-                      >
-                        Type
-                      </div>
-                    </td>
-                    <td>
-                      <div
-                        class="c34"
-                      >
-                        OpenVAS Scanner
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-          <div
-            class="c34"
-          >
-            <h2>
-              Assets
-            </h2>
-            <div>
-              <table
-                class="c45 c36"
-              >
-                <colgroup>
-                  <col
-                    class="c37"
-                    width="10%"
-                  />
-                  <col
-                    class="c38"
-                    width="90%"
-                  />
-                </colgroup>
-                <tbody
-                  class=""
-                >
-                  <tr>
-                    <td>
-                      <div
-                        class="c34"
-                      >
-                        Add to Assets
-                      </div>
-                    </td>
-                    <td>
-                      <div
-                        class="c34"
-                      >
-                        Yes
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div
-                        class="c34"
-                      >
-                        Apply Overrides
-                      </div>
-                    </td>
-                    <td>
-                      <div
-                        class="c34"
-                      >
-                        Yes
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div
-                        class="c34"
-                      >
-                        Min QoD
-                      </div>
-                    </td>
-                    <td>
-                      <div
-                        class="c34"
-                      >
-                        70 %
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-          <div
-            class="c34"
-          >
-            <h2>
-              Scan
-            </h2>
-            <div>
-              <table
-                class="c45 c36"
-              >
-                <colgroup>
-                  <col
-                    class="c37"
-                    width="10%"
-                  />
-                  <col
-                    class="c38"
-                    width="90%"
-                  />
-                </colgroup>
-                <tbody
-                  class=""
-                >
-                  <tr>
-                    <td>
-                      <div
-                        class="c34"
-                      >
-                        Duration of last Scan
-                      </div>
-                    </td>
-                    <td>
-                      <div
-                        class="c34"
-                      >
-                        2 minutes
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      <div
-                        class="c34"
-                      >
-                        Auto delete Reports
-                      </div>
-                    </td>
-                    <td>
-                      <div
-                        class="c34"
-                      >
-                        Do not automatically delete reports
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-</div>
-`;
-
-exports[`Task ToolBarIcons tests should render 1`] = `
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c4 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -10px;
-}
-
-.c1 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c1 > * {
-  margin-left: 10px;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
-  -ms-flex-pack: start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  margin-left: -5px;
-}
-
-.c2 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c2 > * {
-  margin-left: 5px;
-}
-
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c5 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c5 > * {
-  margin-left: 5px;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c12 {
-  cursor: pointer;
-}
-
-.c13 svg path {
-  fill: #bfbfbf;
-}
-
-.c3 {
-  height: 16px;
-  width: 16px;
-  line-height: 16px;
-}
-
-.c3 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c7 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c8 {
-  position: relative;
-  display: none;
-}
-
-.c6:hover .c8 {
-  display: block;
-}
-
-.c9 {
-  position: absolute;
-  margin: 0;
-  padding: 0;
-  left: 0;
-  top: 0;
-  z-index: 100;
-  list-style: none;
-  font-size: 10px;
-  width: 255px;
-}
-
-.c10 {
-  height: 22px;
-  width: 255px;
-  border-left: 1px solid #7F7F7F;
-  border-right: 1px solid #7F7F7F;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  background-color: #fff;
-  font-weight: bold;
-  text-indent: 12px;
-  text-align: left;
-}
-
-.c10:first-child {
-  border-top: 1px solid #7F7F7F;
-}
-
-.c10:last-child {
-  border-bottom: 1px solid #7F7F7F;
-}
-
-.c10:hover {
-  background: #11ab51;
-  color: #fff;
-}
-
-.c10 div {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  cursor: pointer;
-}
-
-.c14 {
-  position: relative;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  margin-right: 0px;
-}
-
-.c15 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-content: center;
-  -ms-flex-line-pack: center;
-  align-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  position: absolute;
-  font-size: 10px;
-  background-color: red;
-  font-weight: bold;
-  border-radius: 10px;
-  min-width: 10px;
-  padding: 3px 5px;
-  z-index: 1;
-  background-color: #11ab51;
-  color: #fff;
-  bottom: -8px;
-  right: 0px;
-}
-
-@media print {
-  .c12 {
+  .c5 {
     display: none;
   }
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <div
-    class="c1"
+    class="c0 c2"
     margin="10px"
   >
     <div
-      class="c0"
+      class="c0 c1"
     >
       <div
-        class="c2"
+        class="c3 c4"
         margin="5px"
       >
         <a
@@ -1879,7 +1805,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           target="_blank"
         >
           <span
-            class="c3"
+            class="c5 c6"
             data-testid="svg-icon"
             title="Help: Tasks"
           >
@@ -1891,11 +1817,11 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <a
-          class="c4"
+          class="c7"
           href="/tasks"
         >
           <span
-            class="c3"
+            class="c5 c6"
             data-testid="svg-icon"
             title="Task List"
           >
@@ -1907,7 +1833,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <span
-          class="c3"
+          class="c5 c6"
           data-testid="svg-icon"
           title="This is an Alterable Task. Reports may not relate to current Scan Config or Target!"
         >
@@ -1920,17 +1846,17 @@ exports[`Task ToolBarIcons tests should render 1`] = `
       </div>
     </div>
     <div
-      class="c0"
+      class="c0 c1"
     >
       <div
-        class="c5"
+        class="c0 c4"
         margin="5px"
       >
         <span
-          class="c6 c7"
+          class="c8 c9"
         >
           <span
-            class="c3"
+            class="c5 c6"
             data-testid="svg-icon"
           >
             <svg>
@@ -1938,25 +1864,25 @@ exports[`Task ToolBarIcons tests should render 1`] = `
             </svg>
           </span>
           <div
-            class="c8"
+            class="c10"
           >
             <ul
-              class="c9"
+              class="c11"
             >
               <li
-                class="c10"
+                class="c12"
               >
                 <div
-                  class="c11"
+                  class="c13"
                 >
                   New Task
                 </div>
               </li>
               <li
-                class="c10"
+                class="c12"
               >
                 <div
-                  class="c11"
+                  class="c13"
                 >
                   New Container Task
                 </div>
@@ -1965,7 +1891,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </div>
         </span>
         <span
-          class="c12 c3"
+          class="c5 c14 c6"
           data-testid="svg-icon"
           title="Clone Task"
         >
@@ -1976,7 +1902,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c12 c3"
+          class="c5 c14 c6"
           data-testid="svg-icon"
           title="Edit Task"
         >
@@ -1987,7 +1913,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c12 c3"
+          class="c5 c14 c6"
           data-testid="svg-icon"
           title="Move Task to trashcan"
         >
@@ -1998,7 +1924,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c12 c3"
+          class="c5 c14 c6"
           data-testid="svg-icon"
           title="Export Task as XML"
         >
@@ -2011,14 +1937,14 @@ exports[`Task ToolBarIcons tests should render 1`] = `
       </div>
     </div>
     <div
-      class="c0"
+      class="c0 c1"
     >
       <div
-        class="c5"
+        class="c0 c4"
         margin="5px"
       >
         <span
-          class="c12 c3"
+          class="c5 c14 c6"
           data-testid="svg-icon"
           title="Start"
         >
@@ -2030,7 +1956,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
         </span>
         <span
           alt="Resume"
-          class="c13 c3"
+          class="c5 c15 c6"
           data-testid="svg-icon"
           title="Task is not stopped"
         >
@@ -2043,27 +1969,27 @@ exports[`Task ToolBarIcons tests should render 1`] = `
       </div>
     </div>
     <div
-      class="c0"
+      class="c0 c1"
     >
       <div
-        class="c1"
+        class="c0 c2"
         margin="10px"
       >
         <div
-          class="c0"
+          class="c0 c1"
         >
           <div
-            class="c5"
+            class="c0 c4"
             margin="5px"
           >
             <a
-              class="c4"
+              class="c7"
               data-testid="details-link"
               href="/report/1234"
               title="Last Report for Task foo from 07/30/2019"
             >
               <span
-                class="c3"
+                class="c5 c6"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -2072,15 +1998,16 @@ exports[`Task ToolBarIcons tests should render 1`] = `
               </span>
             </a>
             <a
-              class="c4"
+              class="c7"
               href="/reports?filter=task_id%3D12345"
               title="Total Reports for Task foo"
             >
               <div
-                class="c14"
+                class="c16"
+                margin="0"
               >
                 <span
-                  class="c3"
+                  class="c5 c6"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -2088,8 +2015,9 @@ exports[`Task ToolBarIcons tests should render 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c15"
+                  class="c17"
                   data-testid="badge-icon"
+                  margin="0"
                 >
                   1
                 </span>
@@ -2098,15 +2026,16 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </div>
         </div>
         <a
-          class="c4"
+          class="c7"
           href="/results?filter=task_id%3D12345"
           title="Results for Task foo"
         >
           <div
-            class="c14"
+            class="c16"
+            margin="0"
           >
             <span
-              class="c3"
+              class="c5 c6"
               data-testid="svg-icon"
             >
               <svg>
@@ -2114,30 +2043,32 @@ exports[`Task ToolBarIcons tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c15"
+              class="c17"
               data-testid="badge-icon"
+              margin="0"
             >
               1
             </span>
           </div>
         </a>
         <div
-          class="c0"
+          class="c0 c1"
         >
           <div
-            class="c5"
+            class="c0 c4"
             margin="5px"
           >
             <a
-              class="c4"
+              class="c7"
               href="/notes?filter=task_id%3D12345"
               title="Notes for Task foo"
             >
               <div
-                class="c14"
+                class="c16"
+                margin="0"
               >
                 <span
-                  class="c3"
+                  class="c5 c6"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -2145,23 +2076,25 @@ exports[`Task ToolBarIcons tests should render 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c15"
+                  class="c17"
                   data-testid="badge-icon"
+                  margin="0"
                 >
                   2
                 </span>
               </div>
             </a>
             <a
-              class="c4"
+              class="c7"
               href="/overrides?filter=task_id%3D12345"
               title="Overrides for Task foo"
             >
               <div
-                class="c14"
+                class="c16"
+                margin="0"
               >
                 <span
-                  class="c3"
+                  class="c5 c6"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -2169,8 +2102,9 @@ exports[`Task ToolBarIcons tests should render 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c15"
+                  class="c17"
                   data-testid="badge-icon"
+                  margin="0"
                 >
                   3
                 </span>

--- a/src/web/pages/tasks/__tests__/__snapshots__/listpage.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/listpage.js.snap
@@ -1,7 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TaskPage ToolBarIcons test should render 1`] = `
-.c8 {
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -14,8 +32,8 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: flex-start;
   -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23,70 +41,40 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
   align-items: center;
 }
 
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c2 {
   margin-left: -5px;
 }
 
-.c1 > * {
+.c2>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c1 > * {
+.c2>* {
   margin-left: 5px;
 }
 
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c1 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2 {
+.c3 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c2 * {
+.c3 * {
   height: inherit;
   width: inherit;
 }
 
-.c4 {
+.c5 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -96,16 +84,16 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
   flex-direction: column;
 }
 
-.c5 {
+.c6 {
   position: relative;
   display: none;
 }
 
-.c3:hover .c5 {
+.c4:hover .c6 {
   display: block;
 }
 
-.c6 {
+.c7 {
   position: absolute;
   margin: 0;
   padding: 0;
@@ -117,7 +105,7 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
   width: 255px;
 }
 
-.c7 {
+.c8 {
   height: 22px;
   width: 255px;
   border-left: 1px solid #7F7F7F;
@@ -136,20 +124,20 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
   text-align: left;
 }
 
-.c7:first-child {
+.c8:first-child {
   border-top: 1px solid #7F7F7F;
 }
 
-.c7:last-child {
+.c8:last-child {
   border-bottom: 1px solid #7F7F7F;
 }
 
-.c7:hover {
+.c8:hover {
   background: #11ab51;
   color: #fff;
 }
 
-.c7 div {
+.c8 div {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -166,10 +154,10 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
 }
 
 <div
-  class="c0"
+  class="c0 c1"
 >
   <div
-    class="c1"
+    class="c0 c2"
     margin="5px"
   >
     <a
@@ -178,7 +166,7 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
       target="_blank"
     >
       <span
-        class="c2"
+        class="c3"
         data-testid="svg-icon"
         title="Help: Tasks"
       >
@@ -190,10 +178,10 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
       </span>
     </a>
     <span
-      class="c3 c4"
+      class="c4 c5"
     >
       <span
-        class="c2"
+        class="c3"
         data-testid="svg-icon"
       >
         <svg>
@@ -201,34 +189,34 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
         </svg>
       </span>
       <div
-        class="c5"
+        class="c6"
       >
         <ul
-          class="c6"
+          class="c7"
         >
           <li
-            class="c7"
+            class="c8"
           >
             <div
-              class="c8"
+              class="c9"
             >
               Task Wizard
             </div>
           </li>
           <li
-            class="c7"
+            class="c8"
           >
             <div
-              class="c8"
+              class="c9"
             >
               Advanced Task Wizard
             </div>
           </li>
           <li
-            class="c7"
+            class="c8"
           >
             <div
-              class="c8"
+              class="c9"
             >
               Modify Task Wizard
             </div>
@@ -237,10 +225,10 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
       </div>
     </span>
     <span
-      class="c3 c4"
+      class="c4 c5"
     >
       <span
-        class="c2"
+        class="c3"
         data-testid="svg-icon"
       >
         <svg>
@@ -248,25 +236,25 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
         </svg>
       </span>
       <div
-        class="c5"
+        class="c6"
       >
         <ul
-          class="c6"
+          class="c7"
         >
           <li
-            class="c7"
+            class="c8"
           >
             <div
-              class="c8"
+              class="c9"
             >
               New Task
             </div>
           </li>
           <li
-            class="c7"
+            class="c8"
           >
             <div
-              class="c8"
+              class="c9"
             >
               New Container Task
             </div>

--- a/src/web/pages/tasks/__tests__/__snapshots__/row.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/row.js.snap
@@ -10,8 +10,8 @@ exports[`Task Row tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -29,11 +29,10 @@ exports[`Task Row tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c11 {
+.c3 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -42,8 +41,8 @@ exports[`Task Row tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -60,12 +59,12 @@ exports[`Task Row tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
 }
 
-.c15 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -78,50 +77,13 @@ exports[`Task Row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
-}
-
-.c5 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c4 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4 > * {
-  margin-left: 5px;
 }
 
 .c17 {
@@ -136,51 +98,17 @@ exports[`Task Row tests should render 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: -5px;
-}
-
-.c17 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c17 > * {
-  margin-left: 5px;
-}
-
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
-.c16 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -192,35 +120,60 @@ exports[`Task Row tests should render 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c18 {
+.c5 {
+  margin-left: -5px;
+}
+
+.c5>* {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c5>* {
+  margin-left: 5px;
+}
+
+.c4 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c19 {
   cursor: pointer;
 }
 
-.c19 svg path {
+.c20 svg path {
   fill: #bfbfbf;
 }
 
-.c14 {
+.c15 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c14 * {
+.c15 * {
   height: inherit;
   width: inherit;
 }
@@ -232,13 +185,13 @@ exports[`Task Row tests should render 1`] = `
   color: #0a53b8;
 }
 
-.c2:hover {
+.c2 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
-.c7 {
+.c8 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -248,7 +201,7 @@ exports[`Task Row tests should render 1`] = `
   text-align: center;
 }
 
-.c9 {
+.c10 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -259,7 +212,7 @@ exports[`Task Row tests should render 1`] = `
   padding-top: 1px;
 }
 
-.c8 {
+.c9 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
@@ -271,17 +224,17 @@ exports[`Task Row tests should render 1`] = `
   background: #f0a519;
 }
 
-.c10 {
+.c11 {
   white-space: nowrap;
 }
 
-.c6:hover {
+.c7:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 @media print {
-  .c18 {
+  .c14 {
     display: none;
   }
 }
@@ -293,20 +246,20 @@ exports[`Task Row tests should render 1`] = `
 }
 
 @media print {
-  .c7 {
+  .c8 {
     background: none;
     border: 0;
   }
 }
 
 @media print {
-  .c9 {
+  .c10 {
     color: black;
   }
 }
 
 @media print {
-  .c8 {
+  .c9 {
     background: none;
   }
 }
@@ -337,10 +290,10 @@ exports[`Task Row tests should render 1`] = `
               foo
             </span>
             <div
-              class="c3"
+              class="c3 c4"
             >
               <div
-                class="c4"
+                class="c3 c5"
                 margin="5px"
               />
             </div>
@@ -359,24 +312,27 @@ exports[`Task Row tests should render 1`] = `
           class="c0"
         >
           <a
-            class="c5 c6"
+            class="c6 c7"
             data-testid="details-link"
             href="/report/1234"
           >
             <div
-              class="c7"
+              boxbackground="#4C4C4C"
+              class="c8"
               data-testid="progressbar-box"
               title="Done"
             >
               <div
-                class="c8"
+                background="low"
+                class="c9"
                 data-testid="progress"
+                progress="100"
               />
               <div
-                class="c9"
+                class="c10"
               >
                 <span
-                  class="c10"
+                  class="c11"
                 >
                   Done
                 </span>
@@ -390,10 +346,10 @@ exports[`Task Row tests should render 1`] = `
           class="c0"
         >
           <div
-            class="c11"
+            class="c3"
           >
             <a
-              class="c5"
+              class="c6"
               href="/reports?filter=task_id%3D314%20sort-reverse%3Ddate"
               title="View list of all reports for Task foo, including unfinished ones"
             >
@@ -408,7 +364,7 @@ exports[`Task Row tests should render 1`] = `
         >
           <span>
             <a
-              class="c5"
+              class="c6"
               data-testid="details-link"
               href="/report/1234"
             >
@@ -422,16 +378,19 @@ exports[`Task Row tests should render 1`] = `
           class="c0"
         >
           <div
-            class="c7"
+            boxbackground="#4C4C4C"
+            class="c8"
             data-testid="progressbar-box"
             title="Medium"
           >
             <div
+              background="warn"
               class="c12"
               data-testid="progress"
+              progress="50"
             />
             <div
-              class="c9"
+              class="c10"
             >
               5.0 (Medium)
             </div>
@@ -444,7 +403,7 @@ exports[`Task Row tests should render 1`] = `
         >
           <span
             alt="Severity increased"
-            class="c14"
+            class="c14 c15"
             data-testid="svg-icon"
             title="Severity increased"
           >
@@ -458,17 +417,17 @@ exports[`Task Row tests should render 1`] = `
       </td>
       <td>
         <div
-          class="c15"
+          class="c16"
         >
           <div
-            class="c16"
+            class="c17 c4"
           >
             <div
-              class="c17"
+              class="c18 c5"
               margin="5px"
             >
               <span
-                class="c18 c14"
+                class="c14 c19 c15"
                 data-testid="svg-icon"
                 title="Start"
               >
@@ -480,7 +439,7 @@ exports[`Task Row tests should render 1`] = `
               </span>
               <span
                 alt="Resume"
-                class="c19 c14"
+                class="c14 c20 c15"
                 data-testid="svg-icon"
                 title="Task is not stopped"
               >
@@ -491,7 +450,7 @@ exports[`Task Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c18 c14"
+                class="c14 c19 c15"
                 data-testid="svg-icon"
                 title="Move Task to trashcan"
               >
@@ -502,7 +461,7 @@ exports[`Task Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c18 c14"
+                class="c14 c19 c15"
                 data-testid="svg-icon"
                 title="Edit Task"
               >
@@ -513,7 +472,7 @@ exports[`Task Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c18 c14"
+                class="c14 c19 c15"
                 data-testid="svg-icon"
                 title="Clone Task"
               >
@@ -524,7 +483,7 @@ exports[`Task Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c18 c14"
+                class="c14 c19 c15"
                 data-testid="svg-icon"
                 title="Export Task"
               >

--- a/src/web/pages/tasks/__tests__/__snapshots__/status.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/status.js.snap
@@ -67,13 +67,16 @@ exports[`Task Status tests should render 1`] = `
   class="c0 c1"
 >
   <div
+    boxbackground="#4C4C4C"
     class="c2"
     data-testid="progressbar-box"
     title="New"
   >
     <div
+      background="new"
       class="c3"
       data-testid="progress"
+      progress="100"
     />
     <div
       class="c4"

--- a/src/web/pages/tasks/__tests__/__snapshots__/table.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/table.js.snap
@@ -1,7 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tasks table tests should render 1`] = `
-.c1 {
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c2 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -15,151 +37,7 @@ exports[`Tasks table tests should render 1`] = `
   flex-grow: 1;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
-}
-
-.c13 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c20 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c21 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-}
-
-.c30 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.c31 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c37 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c42 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c23 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
 .c7 {
@@ -170,29 +48,116 @@ exports[`Tasks table tests should render 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  margin-left: -5px;
 }
 
-.c7 > * {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
+.c23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
 }
 
-.c7 > * {
-  margin-left: 5px;
+.c25 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
 }
 
-.c33 {
+.c26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+
+.c35 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+}
+
+.c36 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -205,95 +170,82 @@ exports[`Tasks table tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+}
+
+.c46 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c28 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c11 {
   margin-left: -5px;
 }
 
-.c33 > * {
+.c11>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c33 > * {
+.c11>* {
   margin-left: 5px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c10 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c32 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c2 {
+.c4 {
   cursor: pointer;
 }
 
-.c8 svg path {
+.c12 svg path {
   fill: #bfbfbf;
 }
 
-.c3 {
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c3 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
-.c43 {
+.c47 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -306,8 +258,8 @@ exports[`Tasks table tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -318,18 +270,18 @@ exports[`Tasks table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c44 {
+.c48 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c44 * {
+.c48 * {
   height: inherit;
   width: inherit;
 }
 
-.c40 {
+.c43 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -353,7 +305,7 @@ exports[`Tasks table tests should render 1`] = `
   font-weight: normal;
 }
 
-.c39 {
+.c42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -365,16 +317,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 180px;
 }
 
-.c45 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c41 {
+.c44 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -391,29 +334,64 @@ exports[`Tasks table tests should render 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
+}
+
+.c49 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c45 {
   cursor: default;
 }
 
-.c38 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c11 a {
+.c14 {
+  border: 0;
+  border-spacing: 0px;
+  font-size: 12px;
+  text-align: left;
+  table-layout: auto;
+  width: 100%;
+}
+
+.c15 th,
+.c15 td {
+  padding: 4px 10px;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.c15 tfoot tr {
+  background: #fff;
+}
+
+.c15 tfoot tr td {
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.c17 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c11 a:hover {
+.c17 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c12 {
+.c18 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -421,7 +399,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 41%;
 }
 
-.c14 {
+.c19 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -429,7 +407,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 8%;
 }
 
-.c15 {
+.c20 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -437,7 +415,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 6%;
 }
 
-.c16 {
+.c21 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -445,7 +423,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 24%;
 }
 
-.c17 {
+.c22 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -453,7 +431,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 5%;
 }
 
-.c19 {
+.c24 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -461,116 +439,47 @@ exports[`Tasks table tests should render 1`] = `
   width: 10em;
 }
 
-.c46 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c50 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c9 {
+.c13 {
   margin: 0 3px;
 }
 
-.c5 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c8 {
   margin: 2px 3px;
 }
 
-.c10 {
-  border: 0;
-  border-spacing: 0px;
-  font-size: 12px;
-  text-align: left;
-  table-layout: auto;
-  width: 100%;
+.c16 {
   opacity: 1.0;
 }
 
-.c10 th,
-.c10 td {
-  padding: 4px 10px;
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c10 tfoot tr {
-  background: #fff;
-}
-
-.c10 tfoot tr td {
-  border-bottom: 1px solid #e5e5e5;
-}
-
-.c4 {
+.c6 {
   margin-top: 2px;
   margin-left: 2px;
 }
 
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
+.c1 {
   margin-top: 20px;
 }
 
-.c22 {
+.c27 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c22:hover {
+.c27 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
-.c25 {
+.c30 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -580,7 +489,7 @@ exports[`Tasks table tests should render 1`] = `
   text-align: center;
 }
 
-.c27 {
+.c32 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -591,58 +500,76 @@ exports[`Tasks table tests should render 1`] = `
   padding-top: 1px;
 }
 
-.c26 {
+.c31 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
 }
 
-.c29 {
+.c34 {
   height: 13px;
   width: 50%;
   background: #f0a519;
 }
 
-.c34 {
+.c38 {
   height: 13px;
   width: 100%;
   background: #99be48;
 }
 
-.c35 {
+.c39 {
   height: 13px;
   width: 0%;
   background: #70c000;
 }
 
-.c36 {
+.c40 {
   height: 13px;
   width: 100%;
   background: #c83814;
 }
 
-.c28 {
+.c33 {
   white-space: nowrap;
 }
 
-.c24:hover {
+.c29:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 @media print {
-  .c2 {
+  .c3 {
     display: none;
   }
 }
 
 @media print {
-  .c11 {
+  .c14 {
+    border-collapse: collapse;
+  }
+}
+
+@media screen {
+  .c15>tbody:nth-of-type(even),
+  .c15>tbody:only-of-type>tr:nth-of-type(even) {
+    background: #f3f3f3;
+  }
+
+  .c15>tbody:not(:only-of-type):hover,
+  .c15>tbody:only-of-type>tr:hover {
+    background: #e5e5e5;
+  }
+}
+
+@media print {
+  .c17 {
     border-bottom: 1px solid black;
   }
 
-  .c11 a,
-  .c11 a:hover {
+  .c17 a,
+  .c17 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -650,43 +577,7 @@ exports[`Tasks table tests should render 1`] = `
 }
 
 @media print {
-  .c12 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: none;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c14 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: none;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c15 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: none;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: none;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c17 {
+  .c18 {
     color: #000;
     font-size: 1.2em;
     background-color: none;
@@ -704,56 +595,68 @@ exports[`Tasks table tests should render 1`] = `
 }
 
 @media print {
-  .c5 svg {
-    display: none;
+  .c20 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: none;
+    font-weight: bold;
   }
 }
 
 @media print {
-  .c10 {
-    border-collapse: collapse;
-  }
-}
-
-@media screen {
-  .c10 > tbody:nth-of-type(even),
-  .c10 > tbody:only-of-type > tr:nth-of-type(even) {
-    background: #f3f3f3;
-  }
-
-  .c10 > tbody:not(:only-of-type):hover,
-  .c10 > tbody:only-of-type > tr:hover {
-    background: #e5e5e5;
+  .c21 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: none;
+    font-weight: bold;
   }
 }
 
 @media print {
   .c22 {
     color: #000;
+    font-size: 1.2em;
+    background-color: none;
+    font-weight: bold;
   }
 }
 
 @media print {
-  .c25 {
+  .c24 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: none;
+    font-weight: bold;
+  }
+}
+
+@media print {
+  .c8 svg {
+    display: none;
+  }
+}
+
+@media print {
+  .c27 {
+    color: #000;
+  }
+}
+
+@media print {
+  .c30 {
     background: none;
     border: 0;
   }
 }
 
 @media print {
-  .c27 {
+  .c32 {
     color: black;
   }
 }
 
 @media print {
-  .c26 {
-    background: none;
-  }
-}
-
-@media print {
-  .c29 {
+  .c31 {
     background: none;
   }
 }
@@ -765,13 +668,19 @@ exports[`Tasks table tests should render 1`] = `
 }
 
 @media print {
-  .c35 {
+  .c38 {
     background: none;
   }
 }
 
 @media print {
-  .c36 {
+  .c39 {
+    background: none;
+  }
+}
+
+@media print {
+  .c40 {
     background: none;
   }
 }
@@ -782,13 +691,13 @@ exports[`Tasks table tests should render 1`] = `
   />
   <div>
     <div
-      class="c0 entities-table"
+      class="c0 c1 entities-table"
     >
       <div
-        class="c1"
+        class="c2"
       >
         <span
-          class="c2 c3 c4"
+          class="c3 c4 c5 c6"
           data-testid="svg-icon"
           title="Unfold all details"
         >
@@ -799,17 +708,17 @@ exports[`Tasks table tests should render 1`] = `
           </svg>
         </span>
         <div
-          class="c5"
+          class="c7 c8"
         >
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -820,7 +729,7 @@ exports[`Tasks table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -833,19 +742,19 @@ exports[`Tasks table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c9"
+            class="c13"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -856,7 +765,7 @@ exports[`Tasks table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Last"
               >
@@ -871,71 +780,71 @@ exports[`Tasks table tests should render 1`] = `
         </div>
       </div>
       <table
-        class="c10"
+        class="c14 c15 c16"
       >
         <thead
-          class="c11"
+          class="c17"
         >
           <tr>
             <th
-              class="c12"
+              class="c18"
             >
               <div
-                class="c13"
+                class="c9"
               >
                 Name
-              </div>
-            </th>
-            <th
-              class="c14"
-            >
-              <div
-                class="c13"
-              >
-                Status
-              </div>
-            </th>
-            <th
-              class="c15"
-            >
-              <div
-                class="c13"
-              >
-                Reports
-              </div>
-            </th>
-            <th
-              class="c16"
-            >
-              <div
-                class="c13"
-              >
-                Last Report
-              </div>
-            </th>
-            <th
-              class="c14"
-            >
-              <div
-                class="c13"
-              >
-                Severity
-              </div>
-            </th>
-            <th
-              class="c17"
-            >
-              <div
-                class="c18"
-              >
-                Trend
               </div>
             </th>
             <th
               class="c19"
             >
               <div
-                class="c18"
+                class="c9"
+              >
+                Status
+              </div>
+            </th>
+            <th
+              class="c20"
+            >
+              <div
+                class="c9"
+              >
+                Reports
+              </div>
+            </th>
+            <th
+              class="c21"
+            >
+              <div
+                class="c9"
+              >
+                Last Report
+              </div>
+            </th>
+            <th
+              class="c19"
+            >
+              <div
+                class="c9"
+              >
+                Severity
+              </div>
+            </th>
+            <th
+              class="c22"
+            >
+              <div
+                class="c23"
+              >
+                Trend
+              </div>
+            </th>
+            <th
+              class="c24"
+            >
+              <div
+                class="c23"
               >
                 Actions
               </div>
@@ -948,22 +857,22 @@ exports[`Tasks table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c20"
+                class="c25"
               >
                 <div
-                  class="c21"
+                  class="c26"
                 >
                   <span
-                    class="c22"
+                    class="c27"
                     name="1234"
                   >
                     foo
                   </span>
                   <div
-                    class="c6"
+                    class="c9 c10"
                   >
                     <div
-                      class="c7"
+                      class="c9 c11"
                       margin="5px"
                     />
                   </div>
@@ -979,27 +888,30 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c20"
+                class="c25"
               >
                 <a
-                  class="c23 c24"
+                  class="c28 c29"
                   data-testid="details-link"
                   href="/report/1234"
                 >
                   <div
-                    class="c25"
+                    boxbackground="#4C4C4C"
+                    class="c30"
                     data-testid="progressbar-box"
                     title="Done"
                   >
                     <div
-                      class="c26"
+                      background="low"
+                      class="c31"
                       data-testid="progress"
+                      progress="100"
                     />
                     <div
-                      class="c27"
+                      class="c32"
                     >
                       <span
-                        class="c28"
+                        class="c33"
                       >
                         Done
                       </span>
@@ -1010,13 +922,13 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c20"
+                class="c25"
               >
                 <div
-                  class="c13"
+                  class="c9"
                 >
                   <a
-                    class="c23"
+                    class="c28"
                     href="/reports?filter=task_id%3D1234%20sort-reverse%3Ddate"
                     title="View list of all reports for Task foo, including unfinished ones"
                   >
@@ -1027,11 +939,11 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c20"
+                class="c25"
               >
                 <span>
                   <a
-                    class="c23"
+                    class="c28"
                     data-testid="details-link"
                     href="/report/1234"
                   >
@@ -1042,19 +954,22 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c20"
+                class="c25"
               >
                 <div
-                  class="c25"
+                  boxbackground="#4C4C4C"
+                  class="c30"
                   data-testid="progressbar-box"
                   title="Medium"
                 >
                   <div
-                    class="c29"
+                    background="warn"
+                    class="c34"
                     data-testid="progress"
+                    progress="50"
                   />
                   <div
-                    class="c27"
+                    class="c32"
                   >
                     5.0 (Medium)
                   </div>
@@ -1063,24 +978,24 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c30"
+                class="c35"
               >
                 <span />
               </div>
             </td>
             <td>
               <div
-                class="c31"
+                class="c0"
               >
                 <div
-                  class="c32"
+                  class="c36 c10"
                 >
                   <div
-                    class="c33"
+                    class="c37 c11"
                     margin="5px"
                   >
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Start"
                     >
@@ -1092,7 +1007,7 @@ exports[`Tasks table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c8 c3"
+                      class="c3 c12 c5"
                       data-testid="svg-icon"
                       title="Task is not stopped"
                     >
@@ -1103,7 +1018,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Move Task to trashcan"
                     >
@@ -1114,7 +1029,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Edit Task"
                     >
@@ -1125,7 +1040,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Clone Task"
                     >
@@ -1136,7 +1051,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Export Task"
                     >
@@ -1154,27 +1069,27 @@ exports[`Tasks table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c20"
+                class="c25"
               >
                 <div
-                  class="c21"
+                  class="c26"
                 >
                   <span
-                    class="c22"
+                    class="c27"
                     name="12345"
                   >
                     lorem
                   </span>
                   <div
-                    class="c6"
+                    class="c9 c10"
                   >
                     <div
-                      class="c7"
+                      class="c9 c11"
                       margin="5px"
                     >
                       <span
                         alt="Task owned by user"
-                        class="c3"
+                        class="c3 c5"
                         data-testid="svg-icon"
                         title="Task owned by user"
                       >
@@ -1198,25 +1113,28 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c20"
+                class="c25"
               >
                 <span
-                  class="c23 c24"
+                  class="c28 c29"
                 >
                   <div
-                    class="c25"
+                    boxbackground="#4C4C4C"
+                    class="c30"
                     data-testid="progressbar-box"
                     title="New"
                   >
                     <div
-                      class="c34"
+                      background="new"
+                      class="c38"
                       data-testid="progress"
+                      progress="100"
                     />
                     <div
-                      class="c27"
+                      class="c32"
                     >
                       <span
-                        class="c28"
+                        class="c33"
                       >
                         New
                       </span>
@@ -1227,39 +1145,39 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c20"
+                class="c25"
               />
             </td>
             <td>
               <div
-                class="c20"
+                class="c25"
               />
             </td>
             <td>
               <div
-                class="c20"
+                class="c25"
               />
             </td>
             <td>
               <div
-                class="c30"
+                class="c35"
               >
                 <span />
               </div>
             </td>
             <td>
               <div
-                class="c31"
+                class="c0"
               >
                 <div
-                  class="c32"
+                  class="c36 c10"
                 >
                   <div
-                    class="c33"
+                    class="c37 c11"
                     margin="5px"
                   >
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Start"
                     >
@@ -1271,7 +1189,7 @@ exports[`Tasks table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c8 c3"
+                      class="c3 c12 c5"
                       data-testid="svg-icon"
                       title="Task is not stopped"
                     >
@@ -1282,7 +1200,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Move Task to trashcan"
                     >
@@ -1293,7 +1211,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Edit Task"
                     >
@@ -1304,7 +1222,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Clone Task"
                     >
@@ -1315,7 +1233,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Export Task"
                     >
@@ -1333,27 +1251,27 @@ exports[`Tasks table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c20"
+                class="c25"
               >
                 <div
-                  class="c21"
+                  class="c26"
                 >
                   <span
-                    class="c22"
+                    class="c27"
                     name="123456"
                   >
                     hello
                   </span>
                   <div
-                    class="c6"
+                    class="c9 c10"
                   >
                     <div
-                      class="c7"
+                      class="c9 c11"
                       margin="5px"
                     >
                       <span
                         alt="Task owned by user"
-                        class="c3"
+                        class="c3 c5"
                         data-testid="svg-icon"
                         title="Task owned by user"
                       >
@@ -1377,27 +1295,30 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c20"
+                class="c25"
               >
                 <a
-                  class="c23 c24"
+                  class="c28 c29"
                   data-testid="details-link"
                   href="/report/5678"
                 >
                   <div
-                    class="c25"
+                    boxbackground="#4C4C4C"
+                    class="c30"
                     data-testid="progressbar-box"
                     title="Running"
                   >
                     <div
-                      class="c35"
+                      background="run"
+                      class="c39"
                       data-testid="progress"
+                      progress="0"
                     />
                     <div
-                      class="c27"
+                      class="c32"
                     >
                       <span
-                        class="c28"
+                        class="c33"
                       >
                         0 %
                       </span>
@@ -1408,13 +1329,13 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c20"
+                class="c25"
               >
                 <div
-                  class="c13"
+                  class="c9"
                 >
                   <a
-                    class="c23"
+                    class="c28"
                     href="/reports?filter=task_id%3D123456%20sort-reverse%3Ddate"
                     title="View list of all reports for Task hello, including unfinished ones"
                   >
@@ -1425,11 +1346,11 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c20"
+                class="c25"
               >
                 <span>
                   <a
-                    class="c23"
+                    class="c28"
                     data-testid="details-link"
                     href="/report/1234"
                   >
@@ -1440,19 +1361,22 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c20"
+                class="c25"
               >
                 <div
-                  class="c25"
+                  boxbackground="#4C4C4C"
+                  class="c30"
                   data-testid="progressbar-box"
                   title="High"
                 >
                   <div
-                    class="c36"
+                    background="error"
+                    class="c40"
                     data-testid="progress"
+                    progress="100"
                   />
                   <div
-                    class="c27"
+                    class="c32"
                   >
                     10.0 (High)
                   </div>
@@ -1461,24 +1385,24 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c30"
+                class="c35"
               >
                 <span />
               </div>
             </td>
             <td>
               <div
-                class="c31"
+                class="c0"
               >
                 <div
-                  class="c32"
+                  class="c36 c10"
                 >
                   <div
-                    class="c33"
+                    class="c37 c11"
                     margin="5px"
                   >
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Stop"
                     >
@@ -1490,7 +1414,7 @@ exports[`Tasks table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c8 c3"
+                      class="c3 c12 c5"
                       data-testid="svg-icon"
                       title="Task is not stopped"
                     >
@@ -1501,7 +1425,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Move Task to trashcan"
                     >
@@ -1512,7 +1436,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Edit Task"
                     >
@@ -1523,7 +1447,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Clone Task"
                     >
@@ -1534,7 +1458,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c2 c3"
+                      class="c3 c4 c5"
                       data-testid="svg-icon"
                       title="Export Task"
                     >
@@ -1556,43 +1480,43 @@ exports[`Tasks table tests should render 1`] = `
               colspan="10"
             >
               <div
-                class="c37"
+                class="c7"
               >
                 <div
-                  class="c6"
+                  class="c9 c10"
                 >
                   <div
-                    class="c7"
+                    class="c9 c11"
                     margin="5px"
                   >
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-labelledby="downshift-0-label"
-                      class="c38"
+                      class="c41"
                       role="combobox"
                     >
                       <div
-                        class="c39"
+                        class="c42"
                         width="180px"
                       >
                         <div
                           aria-haspopup="true"
                           aria-label="open menu"
-                          class="c40"
+                          class="c43"
                           data-toggle="true"
                           role="button"
                           type="button"
                         >
                           <div
-                            class="c41"
+                            class="c44 c45"
                             data-testid="select-selected-value"
                           />
                           <div
-                            class="c42"
+                            class="c46"
                           >
                             <span
-                              class="c43 c44"
+                              class="c47 c48"
                               data-testid="select-open-button"
                             >
                               ▼
@@ -1601,21 +1525,21 @@ exports[`Tasks table tests should render 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c45"
+                        class="c49"
                         data-testid="error-marker"
                       >
                         ×
                       </div>
                     </div>
                     <div
-                      class="c6"
+                      class="c9 c10"
                     >
                       <div
-                        class="c7"
+                        class="c9 c11"
                         margin="5px"
                       >
                         <span
-                          class="c3"
+                          class="c3 c5"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1623,7 +1547,7 @@ exports[`Tasks table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3"
+                          class="c3 c5"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1631,7 +1555,7 @@ exports[`Tasks table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3"
+                          class="c3 c5"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1648,25 +1572,25 @@ exports[`Tasks table tests should render 1`] = `
         </tfoot>
       </table>
       <div
-        class="c21"
+        class="c26"
       >
         <div
-          class="c46"
+          class="c9 c50"
         >
           (Applied filter: rows=2)
         </div>
         <div
-          class="c5"
+          class="c7 c8"
         >
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -1677,7 +1601,7 @@ exports[`Tasks table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -1690,19 +1614,19 @@ exports[`Tasks table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c9"
+            class="c13"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c6"
+            class="c9 c10"
           >
             <div
-              class="c7"
+              class="c9 c11"
               margin="5px"
             >
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -1713,7 +1637,7 @@ exports[`Tasks table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c3"
+                class="c3 c12 c5"
                 data-testid="svg-icon"
                 title="Last"
               >

--- a/src/web/pages/tickets/__tests__/__snapshots__/createdialog.js.snap
+++ b/src/web/pages/tickets/__tests__/__snapshots__/createdialog.js.snap
@@ -1,7 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CreateTicketDialog component tests should render dialog 1`] = `
-.c8 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,8 +49,8 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -19,7 +58,25 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   align-items: stretch;
 }
 
-.c16 {
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -28,9 +85,30 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -62,7 +140,7 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -70,7 +148,7 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   height: 100%;
 }
 
-.c27 {
+.c33 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -79,13 +157,13 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c26 {
+.c32 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -104,7 +182,7 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -121,30 +199,30 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c23 {
+.c29 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -164,12 +242,12 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   z-index: 1;
 }
 
-.c23:focus,
-.c23:hover {
+.c29:focus,
+.c29:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c23:hover {
+.c29:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -177,26 +255,26 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   color: #fff;
 }
 
-.c23[disabled] {
+.c29[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c23 img {
+.c29 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c23:link {
+.c29:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c24 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -205,8 +283,8 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -214,63 +292,32 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c25 {
+.c31 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c25:hover {
+.c31 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c27 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c28 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -284,17 +331,15 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -302,31 +347,12 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -336,13 +362,13 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   max-width: 100%;
   font-weight: bold;
@@ -353,28 +379,13 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   margin-left: 0;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c17 {
+.c21 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -387,8 +398,8 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -399,18 +410,18 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   cursor: pointer;
 }
 
-.c18 {
+.c22 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c18 * {
+.c22 * {
   height: inherit;
   width: inherit;
 }
 
-.c14 {
+.c17 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -434,7 +445,7 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   font-weight: normal;
 }
 
-.c13 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -446,16 +457,7 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   width: 180px;
 }
 
-.c19 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c15 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -472,17 +474,29 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
+}
+
+.c23 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c19 {
   cursor: default;
 }
 
-.c12 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c20 {
+.c24 {
   display: block;
   height: auto;
   color: #4C4C4C;
@@ -493,7 +507,7 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   padding: 4px 8px;
 }
 
-.c21 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -506,8 +520,8 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -534,14 +548,14 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 Create new Ticket for Result
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -549,26 +563,29 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Assign To User
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
@@ -576,33 +593,33 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
                         aria-expanded="false"
                         aria-haspopup="listbox"
                         aria-labelledby="downshift-0-label"
-                        class="c12"
+                        class="c15"
                         role="combobox"
                       >
                         <div
-                          class="c13"
+                          class="c16"
                           width="180px"
                         >
                           <div
                             aria-haspopup="true"
                             aria-label="open menu"
-                            class="c14"
+                            class="c17"
                             data-toggle="true"
                             role="button"
                             type="button"
                           >
                             <div
-                              class="c15"
+                              class="c18 c19"
                               data-testid="select-selected-value"
                               title="foo"
                             >
                               foo
                             </div>
                             <div
-                              class="c16"
+                              class="c20"
                             >
                               <span
-                                class="c17 c18"
+                                class="c21 c22"
                                 data-testid="select-open-button"
                               >
                                 ▼
@@ -611,7 +628,7 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c19"
+                          class="c23"
                           data-testid="error-marker"
                         >
                           ×
@@ -620,26 +637,28 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Note
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <textarea
-                        class="c20 c21"
+                        class="c24 c25"
                         name="note"
                         rows="5"
                       />
                       <div
-                        class="c19"
+                        class="c23"
                         data-testid="error-marker"
                       >
                         ×
@@ -650,17 +669,17 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c22"
+              class="c26 c27 c28"
             >
               <button
-                class="c23 c24 c25"
+                class="c29 c30 c31"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c23 c24 c25"
+                class="c29 c30 c31"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -669,10 +688,10 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c32"
           >
             <div
-              class="c27"
+              class="c33"
             />
           </div>
         </div>

--- a/src/web/pages/tickets/__tests__/__snapshots__/editdialog.js.snap
+++ b/src/web/pages/tickets/__tests__/__snapshots__/editdialog.js.snap
@@ -1,7 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EditTicketDialog component tests should render dialog 1`] = `
-.c8 {
+.c3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,8 +49,8 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -19,7 +58,25 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   align-items: stretch;
 }
 
-.c16 {
+.c13 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -28,9 +85,30 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  -webkit-box-pack: end;
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -62,7 +140,7 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102,102,102,0.5);
+  background: rgba(102, 102, 102, 0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -70,7 +148,7 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   height: 100%;
 }
 
-.c27 {
+.c33 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -79,13 +157,13 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c26 {
+.c32 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
+  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
 }
 
 .c2 {
@@ -104,7 +182,7 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   border: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -121,30 +199,30 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c4:hover {
+.c5 :hover {
   border: 1px solid #074320;
 }
 
-.c5 {
+.c6 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c5 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c23 {
+.c29 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -164,12 +242,12 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   z-index: 1;
 }
 
-.c23:focus,
-.c23:hover {
+.c29:focus,
+.c29:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c23:hover {
+.c29:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -177,26 +255,26 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   color: #fff;
 }
 
-.c23[disabled] {
+.c29[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c23 img {
+.c29 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c23:link {
+.c29:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c24 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -205,8 +283,8 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -214,63 +292,32 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c25 {
+.c31 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c25:hover {
+.c31 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c27 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
   margin-top: 15px;
   padding: 10px 20px 10px 20px;
+}
+
+.c28 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c3 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c4 {
   padding: 5px 5px 5px 10px;
   margin-bottom: 15px;
   border-radius: 2px 2px 0 0;
@@ -284,17 +331,15 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
-  cursor: -moz-grab;
   cursor: grab;
 }
 
-.c7 {
+.c9 {
   overflow: auto;
   padding: 0 15px;
   width: 100%;
@@ -302,31 +347,12 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   max-height: 400px;
 }
 
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+.c8 {
   overflow: hidden;
   height: 100%;
 }
 
-.c9 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -336,13 +362,13 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   padding-bottom: 10px;
 }
 
-.c10 {
+.c12 {
   display: inline-block;
   max-width: 100%;
   font-weight: bold;
@@ -353,28 +379,13 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   margin-left: 0;
 }
 
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -webkit-justify-content: start;
-  -ms-flex-pack: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+.c14 {
   width: 83.33333333%;
   padding-left: 10px;
   padding-right: 10px;
 }
 
-.c17 {
+.c21 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -387,8 +398,8 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -webkit-justify-content: center;
   -ms-flex-pack: center;
+  -webkit-justify-content: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -399,18 +410,18 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   cursor: pointer;
 }
 
-.c18 {
+.c22 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c18 * {
+.c22 * {
   height: inherit;
   width: inherit;
 }
 
-.c14 {
+.c17 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -434,7 +445,7 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   font-weight: normal;
 }
 
-.c13 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -446,16 +457,7 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   width: 180px;
 }
 
-.c19 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
-.c15 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -472,17 +474,29 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   white-space: nowrap;
   overflow: hidden;
   cursor: pointer;
+}
+
+.c23 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
+.c19 {
   cursor: default;
 }
 
-.c12 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c20 {
+.c24 {
   display: block;
   height: auto;
   color: #4C4C4C;
@@ -493,7 +507,7 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   padding: 4px 8px;
 }
 
-.c21 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -506,8 +520,8 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -webkit-justify-content: start;
   -ms-flex-pack: start;
+  -webkit-justify-content: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -534,14 +548,14 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
             class="c2"
           >
             <div
-              class="c3"
+              class="c3 c4"
               data-testid="dialog-title-bar"
             >
               <span>
                 Edit Ticket
               </span>
               <div
-                class="c4 c5"
+                class="c5 c6"
                 data-testid="dialog-title-close-button"
                 title="Close"
               >
@@ -549,26 +563,29 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c6"
+              class="c7 c8"
             >
               <div
-                class="c7"
+                class="c9"
                 data-testid="save-dialog-content"
+                maxheight="400px"
               >
                 <div
-                  class="c8"
+                  class="c10"
                 >
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Status
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
@@ -576,33 +593,33 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
                         aria-expanded="false"
                         aria-haspopup="listbox"
                         aria-labelledby="downshift-0-label"
-                        class="c12"
+                        class="c15"
                         role="combobox"
                       >
                         <div
-                          class="c13"
+                          class="c16"
                           width="180px"
                         >
                           <div
                             aria-haspopup="true"
                             aria-label="open menu"
-                            class="c14"
+                            class="c17"
                             data-toggle="true"
                             role="button"
                             type="button"
                           >
                             <div
-                              class="c15"
+                              class="c18 c19"
                               data-testid="select-selected-value"
                               title="Open"
                             >
                               Open
                             </div>
                             <div
-                              class="c16"
+                              class="c20"
                             >
                               <span
-                                class="c17 c18"
+                                class="c21 c22"
                                 data-testid="select-open-button"
                               >
                                 ▼
@@ -611,7 +628,7 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c19"
+                          class="c23"
                           data-testid="error-marker"
                         >
                           ×
@@ -620,16 +637,18 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Assigned User
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
@@ -637,33 +656,33 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
                         aria-expanded="false"
                         aria-haspopup="listbox"
                         aria-labelledby="downshift-1-label"
-                        class="c12"
+                        class="c15"
                         role="combobox"
                       >
                         <div
-                          class="c13"
+                          class="c16"
                           width="180px"
                         >
                           <div
                             aria-haspopup="true"
                             aria-label="open menu"
-                            class="c14"
+                            class="c17"
                             data-toggle="true"
                             role="button"
                             type="button"
                           >
                             <div
-                              class="c15"
+                              class="c18 c19"
                               data-testid="select-selected-value"
                               title="foo"
                             >
                               foo
                             </div>
                             <div
-                              class="c16"
+                              class="c20"
                             >
                               <span
-                                class="c17 c18"
+                                class="c21 c22"
                                 data-testid="select-open-button"
                               >
                                 ▼
@@ -672,7 +691,7 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
                           </div>
                         </div>
                         <div
-                          class="c19"
+                          class="c23"
                           data-testid="error-marker"
                         >
                           ×
@@ -681,26 +700,28 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Note for Open
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <textarea
-                        class="c20 c21"
+                        class="c24 c25"
                         name="openNote"
                         rows="5"
                       />
                       <div
-                        class="c19"
+                        class="c23"
                         data-testid="error-marker"
                       >
                         ×
@@ -708,26 +729,28 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Note for Fixed
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <textarea
-                        class="c20 c21"
+                        class="c24 c25"
                         name="fixedNote"
                         rows="5"
                       />
                       <div
-                        class="c19"
+                        class="c23"
                         data-testid="error-marker"
                       >
                         ×
@@ -735,26 +758,28 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
                     </div>
                   </div>
                   <div
-                    class="c9"
+                    class="c11"
                   >
                     <label
-                      class="c10"
+                      class="c12"
                       data-testid="formgroup-title"
+                      titleoffset="0"
+                      titlesize="2"
                     >
                       Note for Closed
                     </label>
                     <div
-                      class="c11"
+                      class="c13 c14"
                       data-testid="formgroup-content"
                       size="10"
                     >
                       <textarea
-                        class="c20 c21"
+                        class="c24 c25"
                         name="closedNote"
                         rows="5"
                       />
                       <div
-                        class="c19"
+                        class="c23"
                         data-testid="error-marker"
                       >
                         ×
@@ -765,17 +790,17 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c22"
+              class="c26 c27 c28"
             >
               <button
-                class="c23 c24 c25"
+                class="c29 c30 c31"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c23 c24 c25"
+                class="c29 c30 c31"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -784,10 +809,10 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c32"
           >
             <div
-              class="c27"
+              class="c33"
             />
           </div>
         </div>

--- a/src/web/utils/testing.js
+++ b/src/web/utils/testing.js
@@ -46,6 +46,7 @@ import LicenseProvider from 'web/components/provider/licenseprovider';
 
 import {createQueryHistory} from 'web/routes';
 import configureStore from 'web/store';
+import {StyleSheetManager} from 'styled-components';
 
 export * from '@testing-library/react';
 
@@ -88,7 +89,9 @@ export const getByName = (container, name) => {
 };
 
 export const render = ui => {
-  const {container, baseElement, ...other} = reactTestingRender(ui);
+  const {container, baseElement, rerender, ...other} = reactTestingRender(
+    <StyleSheetManager enableVendorPrefixes>{ui}</StyleSheetManager>,
+  );
   return {
     baseElement,
     container,
@@ -97,6 +100,10 @@ export const render = ui => {
     getByName: name => getByName(baseElement, name),
     queryByName: name => queryByName(baseElement, name),
     queryAllByName: name => queryAllByName(baseElement, name),
+    rerender: ui =>
+      rerender(
+        <StyleSheetManager enableVendorPrefixes>{ui}</StyleSheetManager>,
+      ),
     ...other,
   };
 };

--- a/src/web/utils/testing.js
+++ b/src/web/utils/testing.js
@@ -100,9 +100,9 @@ export const render = ui => {
     getByName: name => getByName(baseElement, name),
     queryByName: name => queryByName(baseElement, name),
     queryAllByName: name => queryAllByName(baseElement, name),
-    rerender: ui =>
+    rerender: component =>
       rerender(
-        <StyleSheetManager enableVendorPrefixes>{ui}</StyleSheetManager>,
+        <StyleSheetManager enableVendorPrefixes>{component}</StyleSheetManager>,
       ),
     ...other,
   };


### PR DESCRIPTION
## What

Update styled-components to v6.0.8 and jest-styled-components to v7.1.1.

- styled-components v6.0.0 dropped automatic vendor prefixing. They have to be re-enabled with the prop `enableVendorPrefixes`. See [Breaking changes in v6](https://styled-components.com/releases#v6.0.0)
- snapshot tests are updated. Majority of the changes are about breaking down classes into multiple ones or re-ordering. Noticed a few additions to snapshots occasionally.
- .toHaveStyle does not seem to work after updating and has to be replaced with .toHaveStyleRule. Was only used in once in tests. See [toHaveStyle](https://stackoverflow.com/questions/76740922/after-upgrading-styled-components-to-6-0-tohavestyle-does-not-work)

## Why

To keep dependencies up to date.

## References

GEA-314


