### PR TITLE
Enable Dependabot update grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
     schedule:
       interval: monthly
       time: '04:00'
+    groups:
+      patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
     open-pull-requests-limit: 10
     versioning-strategy: increase
     ignore:


### PR DESCRIPTION
## What
Grouping of all Dependabot updates that only increase the patch level is enabled so they will be added in a single commit.

## Why
To simplify the update process.

