### PR TITLE
Fix: Allow loading of locales like zh_TW

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
     [
       "i18next-extract",
       {
-        "locales": ["de"],
+        "locales": ["de", "zh_TW", "zh_CN"],
         "pluralSeparator": null,
         "contextSeparator": null,
         "nsSeparator": null,

--- a/scripts/cleanuptranslations.js
+++ b/scripts/cleanuptranslations.js
@@ -20,7 +20,7 @@
 const fs = require('fs');
 
 // all locales that are included in .babelrc
-const languages = ['de'];
+const languages = ['de', 'zh_TW', 'zh_CN'];
 
 for (const lang of languages) {
   const path = './public/locales/gsa-' + lang + '.json';

--- a/src/gmp/locale/lang.js
+++ b/src/gmp/locale/lang.js
@@ -54,7 +54,7 @@ const I18N_OPTIONS = {
     loadPath: '/locales/{{ns}}-{{lng}}.json', // e.g. /locales/gsa-en.json
   },
   supportedLngs: whitelist,
-  nonExplicitSupportedLngs: true,
+  nonExplicitSupportedLngs: false,
   interpolation: {
     skipOnVariables: false,
   },


### PR DESCRIPTION
## What

Allow loading of locales like zh_TW

## Why

Deactivate the `nonExplicitSupportedLngs` i18next setting (see https://www.i18next.com/overview/configuration-options#languages-namespaces-resources for more details) that caused our supported languages needed to contain only short codes of the languages to be a valid locale. Therefore locales like `zh_TW` were considered as not supported and the locale did fall back to `en`.

## References

#3842
#3894

GEA-294

