### PR TITLE
Add: Add new whole selection VT families

### DIFF
--- a/src/web/pages/scanconfigs/nvtfamilies.js
+++ b/src/web/pages/scanconfigs/nvtfamilies.js
@@ -51,12 +51,23 @@ import PropTypes from 'web/utils/proptypes';
 import Trend from './trend';
 
 const WHOLE_SELECTION_FAMILIES = [
+  'AIX Local Security Checks',
+  'AlmaLinux Security Checks',
+  'Amazon Linux Security Checks',
   'CentOS Local Security Checks',
   'Debian Local Security Checks',
   'Fedora Local Security Checks',
+  'FreeBSD Local Security Checks',
+  'Gentoo Local Security Checks',
+  'HP-UX Local Security Checks',
   'Huawei EulerOS Local Security Checks',
+  'Mageia Linux Local Security Checks',
+  'Mandrake Local Security Checks',
   'Oracle Linux Local Security Checks',
   'Red Hat Local Security Checks',
+  'Rocky Linux Local Security Checks',
+  'Slackware Local Security Checks',
+  'Solaris Local Security Checks',
   'SuSE Local Security Checks',
   'Ubuntu Local Security Checks',
 ];


### PR DESCRIPTION
## What
Various VT families that should be only selected as a whole have been added so editing individual VTs is disabled for them.

## Why
To make the dialogs consistent with the gvmd behavior introduced with updating the list there.

## References
GEA-331
greenbone/gvmd#2058
