### PR TITLE
Change: Add missing apt-get install line to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ gpg --no-default-keyring --keyring "$KEYRING" --list-keys
 
 echo "deb [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRIBUTION main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 echo "deb-src [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRIBUTION main" | sudo tee -a /etc/apt/sources.list.d/nodesource.list
+
+sudo apt-get update && sudo apt-get install nodejs
 ```
 
 Change into the gsa source directory and delete the possible existing build output

--- a/README.md
+++ b/README.md
@@ -56,17 +56,16 @@ Prerequisites for GSA:
 To install nodejs the following commands can be used
 
 ```bash
-export VERSION=node_18.x
+export VERSION=18
 export KEYRING=/usr/share/keyrings/nodesource.gpg
-export DISTRIBUTION="$(lsb_release -s -c)"
 
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee "$KEYRING" >/dev/null
 gpg --no-default-keyring --keyring "$KEYRING" --list-keys
 
-echo "deb [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRIBUTION main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-echo "deb-src [signed-by=$KEYRING] https://deb.nodesource.com/$VERSION $DISTRIBUTION main" | sudo tee -a /etc/apt/sources.list.d/nodesource.list
+echo "deb [signed-by=$KEYRING] https://deb.nodesource.com/node_$VERSION.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+echo "deb-src [signed-by=$KEYRING] https://deb.nodesource.com/node_$VERSION.x nodistro main" | sudo tee -a /etc/apt/sources.list.d/nodesource.list
 
-sudo apt-get update && sudo apt-get install nodejs
+sudo apt update && sudo apt install nodejs
 ```
 
 Change into the gsa source directory and delete the possible existing build output


### PR DESCRIPTION
## What
If the nodejs package isn't installed it can't be used later.

Note: https://deb.nodesource.com/ is using different install instructions, we might want to adjust it completely to that:

```
~$ sudo apt-get update && sudo apt-get install -y ca-certificates curl gnupg
~$ curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
~$ NODE_MAJOR=20
~$ echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
~$ sudo apt-get update && sudo apt-get install nodejs -y
```

## Why
Better documentation

## References

None