### PR TITLE
Fix: Fix handling of missing delta result fields

### DIFF
--- a/src/web/pages/results/row.js
+++ b/src/web/pages/results/row.js
@@ -70,8 +70,8 @@ const Row = ({
     entity.overrides.filter(override => override.isActive()).length > 0;
   const hasTickets = entity.tickets.length > 0;
   const deltaSeverity = entity.delta?.result?.severity;
-  const deltaHostname = entity.delta?.result?.host.hostname;
-  const deltaQoD = entity.delta?.result?.qod.value;
+  const deltaHostname = entity.delta?.result?.host?.hostname;
+  const deltaQoD = entity.delta?.result?.qod?.value;
   return (
     <TableRow>
       {delta && (
@@ -105,20 +105,19 @@ const Row = ({
       <TableData>
         <IconDivider>
           <SeverityBar severity={entity.severity} />
-          {isDefined(entity.delta?.result) &&
-            entity.severity !== deltaSeverity && (
-              <DeltaDifferenceIcon
-                title={_('Severity is changed from {{deltaSeverity}}.', {
-                  deltaSeverity,
-                })}
-              />
-            )}
+          {isDefined(deltaSeverity) && entity.severity !== deltaSeverity && (
+            <DeltaDifferenceIcon
+              title={_('Severity is changed from {{deltaSeverity}}.', {
+                deltaSeverity,
+              })}
+            />
+          )}
         </IconDivider>
       </TableData>
       <TableData align="end">
         <IconDivider>
           <Qod value={entity.qod.value} />
-          {isDefined(entity.delta?.result) && entity.qod.value !== deltaQoD && (
+          {isDefined(deltaQoD) && entity.qod.value !== deltaQoD && (
             <DeltaDifferenceIcon
               title={_('QoD is changed from {{deltaQoD}}.', {deltaQoD})}
             />
@@ -141,7 +140,7 @@ const Row = ({
           {host.hostname.length > 0 && (
             <span title={host.hostname}>{shorten(host.hostname, 40)}</span>
           )}
-          {isDefined(entity.delta?.result) &&
+          {isDefined(deltaHostname) &&
             deltaHostname.length > 0 &&
             host.hostname !== deltaHostname && (
               <DeltaDifferenceIcon


### PR DESCRIPTION
## What
The delta icons for severity, QoD and hostname now handle missing values for the delta result correctly.

