### PR TITLE
Add: New marking of deprecated data objects

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -450,6 +450,7 @@
   "Deny all": "Alle verweigern",
   "Deny all and allow": "Verweigere alle und erlaube",
   "Deny all and allow from {{addresses}}": "Alle verweigern und von {{addresses}} erlauben",
+  "Deprecated": "Veraltet",
   "Deprecated By": "Veraltet ab",
   "Descending": "Absteigend",
   "Description": "Beschreibung",

--- a/src/web/entities/entitynametabledata.js
+++ b/src/web/entities/entitynametabledata.js
@@ -55,12 +55,14 @@ const EntityNameTableData = ({
             <RowDetailsToggle name={entity.id} onClick={onToggleDetailsClick}>
               {entity.name}
             </RowDetailsToggle>
+            {entity.deprecated && <b> ({_('Deprecated')})</b>}
           </span>
         ) : (
           <span>
             <DetailsLink type={type} id={entity.id} textOnly={!links}>
               {entity.name}
             </DetailsLink>
+            {entity.deprecated && <b> ({_('Deprecated')})</b>}
           </span>
         )}
       </Layout>

--- a/src/web/pages/portlists/details.js
+++ b/src/web/pages/portlists/details.js
@@ -35,6 +35,7 @@ import {Col} from 'web/entity/page';
 const PortListDetails = ({entity, ...props}) => {
   const {
     comment,
+    deprecated,
     port_count = {
       all: 0,
       tcp: 0,
@@ -50,6 +51,13 @@ const PortListDetails = ({entity, ...props}) => {
           <Col width="90%" />
         </colgroup>
         <TableBody>
+          {deprecated && (
+            <TableRow>
+              <TableData>{_('Deprecated')}</TableData>
+              <TableData>{_('yes')}</TableData>
+            </TableRow>
+          )}
+
           <TableRow>
             <TableData>{_('Comment')}</TableData>
             <TableData>{comment}</TableData>

--- a/src/web/pages/reportformats/details.js
+++ b/src/web/pages/reportformats/details.js
@@ -40,6 +40,7 @@ import {Col} from 'web/entity/page';
 
 const ReportFormatDetails = ({entity, links = true}) => {
   const {
+    deprecated,
     extension,
     content_type,
     trust = {},
@@ -55,6 +56,13 @@ const ReportFormatDetails = ({entity, links = true}) => {
           <Col width="90%" />
         </colgroup>
         <TableBody>
+          {deprecated && (
+            <TableRow>
+              <TableData>{_('Deprecated')}</TableData>
+              <TableData>{_('yes')}</TableData>
+            </TableRow>
+          )}
+
           <TableRow>
             <TableData>{_('Extension')}</TableData>
             <TableData>{extension}</TableData>

--- a/src/web/pages/scanconfigs/__tests__/details.js
+++ b/src/web/pages/scanconfigs/__tests__/details.js
@@ -59,4 +59,25 @@ describe('Scan Config Details tests', () => {
 
     expect(element).not.toHaveTextContent('scanner');
   });
+
+  test('should mark deprecated', () => {
+    const config = ScanConfig.fromElement({
+      name: 'foo',
+      comment: 'bar',
+      deprecated: '1',
+      scanner: {name: 'scanner1', id: '42', type: OPENVAS_SCANNER_TYPE},
+      tasks: {
+        task: [
+          {id: '1234', name: 'task1'},
+          {id: '5678', name: 'task2'},
+        ],
+      },
+    });
+    const caps = new Capabilities(['everything']);
+
+    const {render} = rendererWith({capabilities: caps, router: true});
+
+    const {element} = render(<Details entity={config} />);
+    expect(element).toHaveTextContent('Deprecatedyes');
+  });
 });

--- a/src/web/pages/scanconfigs/__tests__/row.js
+++ b/src/web/pages/scanconfigs/__tests__/row.js
@@ -97,6 +97,54 @@ describe('Scan Config row tests', () => {
     );
   });
 
+  test('should mark deprecated config', () => {
+    const config = ScanConfig.fromElement({
+      _id: '1234',
+      name: 'foo',
+      comment: 'bar',
+      in_use: '0',
+      writable: '1',
+      deprecated: '1',
+      owner: {
+        name: 'user',
+      },
+      permissions: {permission: [{name: 'everything'}]},
+      family_count: {
+        __text: 2,
+        growing: SCANCONFIG_TREND_STATIC,
+      },
+      nvt_count: {
+        __text: 4,
+        growing: SCANCONFIG_TREND_DYNAMIC,
+      },
+    });
+
+    const handleToggleDetailsClick = jest.fn();
+    const handleScanConfigClone = jest.fn();
+    const handleScanConfigDelete = jest.fn();
+    const handleScanConfigDownload = jest.fn();
+    const handleScanConfigEdit = jest.fn();
+
+    const {render} = rendererWith({
+      gmp,
+      capabilities: caps,
+      store: true,
+    });
+
+    const {baseElement, getAllByTestId} = render(
+      <Row
+        entity={config}
+        onToggleDetailsClick={handleToggleDetailsClick}
+        onScanConfigCloneClick={handleScanConfigClone}
+        onScanConfigDeleteClick={handleScanConfigDelete}
+        onScanConfigDownloadClick={handleScanConfigDownload}
+        onScanConfigEditClick={handleScanConfigEdit}
+      />,
+    );
+
+    expect(baseElement).toHaveTextContent('(Deprecated)');
+  });
+
   test('should render observer icon', () => {
     const config = ScanConfig.fromElement({
       _id: '1234',

--- a/src/web/pages/scanconfigs/details.js
+++ b/src/web/pages/scanconfigs/details.js
@@ -36,7 +36,7 @@ import TableRow from 'web/components/table/row';
 import {Col} from 'web/entity/page';
 
 const ScanConfigDetails = ({entity}) => {
-  const {comment, tasks = []} = entity;
+  const {comment, deprecated, tasks = []} = entity;
   return (
     <Layout flex="column" grow>
       <InfoTable>
@@ -45,6 +45,12 @@ const ScanConfigDetails = ({entity}) => {
           <Col width="90%" />
         </colgroup>
         <TableBody>
+          {deprecated && (
+            <TableRow>
+              <TableData>{_('Deprecated')}</TableData>
+              <TableData>{_('yes')}</TableData>
+            </TableRow>
+          )}
           {isDefined(comment) && (
             <TableRow>
               <TableData>{_('Comment')}</TableData>

--- a/src/web/utils/__tests__/render.js
+++ b/src/web/utils/__tests__/render.js
@@ -37,6 +37,31 @@ describe('render_select_items test', () => {
     expect(items[1]).toEqual({label: 'B Task', value: '2'});
   });
 
+  test('should mark deprecated items', () => {
+    const entities = [
+      {
+        name: 'A Config',
+        id: '1',
+      },
+      {
+        name: 'B Config',
+        deprecated: '1',
+        id: '2',
+      },
+      {
+        name: 'C Config',
+        id: '3',
+      },
+    ];
+
+    const items = renderSelectItems(entities);
+
+    expect(items.length).toBe(3);
+    expect(items[0]).toEqual({label: 'A Config', value: '1'});
+    expect(items[1]).toEqual({label: <s>B Config (Deprecated)</s>, value: '2'});
+    expect(items[2]).toEqual({label: 'C Config', value: '3'});
+  });
+
   test('should add default item', () => {
     const entities = [
       {

--- a/src/web/utils/render.js
+++ b/src/web/utils/render.js
@@ -30,6 +30,13 @@ import {typeName, getEntityType} from 'gmp/utils/entitytype';
 export const UNSET_VALUE = '0';
 export const UNSET_LABEL = '--';
 
+function selectItemLabel(item) {
+  if (item.deprecated) {
+    return <s>{item.name + ' (' + _('Deprecated') + ')'}</s>;
+  }
+  return item.name;
+}
+
 /**
  * Render a entities list as items array
  *
@@ -45,7 +52,7 @@ export const renderSelectItems = (
   default_item_label = UNSET_LABEL,
 ) => {
   const items = isDefined(list)
-    ? list.map(item => ({label: item.name, value: item.id}))
+    ? list.map(item => ({label: selectItemLabel(item), value: item.id}))
     : undefined;
 
   if (!isDefined(default_item_value)) {


### PR DESCRIPTION
## What
Data objects like configs, port lists and report formats that are deprecated are marked as such on the list and details pages as well as in dialog dropdowns.

## Why
To make the deprecation visible to users.

## References
GEA-6

## Checklist

- [x] Tests


