### PR TITLE
Change: Show extra details for report TLS certificates

### DIFF
--- a/src/gmp/models/__tests__/tlscertificate.js
+++ b/src/gmp/models/__tests__/tlscertificate.js
@@ -47,8 +47,8 @@ describe('TlsCertificate Model tests', () => {
     };
     const tlsCertificate = TlsCertificate.fromElement(element);
 
-    expect(tlsCertificate.issuer_dn).toEqual('CN=issuer');
-    expect(tlsCertificate.subject_dn).toEqual('CN=subject');
+    expect(tlsCertificate.issuerDn).toEqual('CN=issuer');
+    expect(tlsCertificate.subjectDn).toEqual('CN=subject');
   });
 
   test('should parse activation_time', () => {

--- a/src/gmp/models/report/__tests__/parser.js
+++ b/src/gmp/models/report/__tests__/parser.js
@@ -499,53 +499,124 @@ describe('report parser tests', () => {
         },
       ],
       ssl_certs: {count: '123'},
+      tls_certificates: {
+        tls_certificate: [
+          {
+            name: '57610B6A3C73866870678E638C7825743145B24',
+            certificate: {
+              __text: '66870678E638C7825743145B247554E0D92C94',
+              _format: 'DER',
+            },
+            sha256_fingerprint: '57610B6A3C73866870678E638C78',
+            md5_fingerprint: 'fa:a9:9d:f2:28:cc:2c:c0:80:16',
+            activation_time: '2019-08-10T12:51:27Z',
+            expiration_time: '2019-09-10T12:51:27Z',
+            valid: true,
+            subject_dn: 'CN=LoremIpsumSubject C=Dolor',
+            issuer_dn: 'CN=LoremIpsumIssuer C=Dolor',
+            serial: '00B49C541FF5A8E1D9',
+            host: {ip: '192.168.9.90', hostname: 'foo.bar'},
+            ports: {port: ['4021', '4023']},
+          },
+          {
+            name: 'C137E9D559CC95ED130011FE4012DE56CAE2F8',
+            certificate: {
+              __text: 'MIICGTCCAYICCQDDh8Msu4YfXDANBgkqhkiG9w0B',
+              _format: 'DER',
+            },
+            sha256_fingerprint: 'C137E9D559CC95ED130011FE4012',
+            md5_fingerprint: '63:70:d6:65:17:32:01:66:9e:7d:c4',
+            activation_time: 'unlimited',
+            expiration_time: 'undefined',
+            valid: false,
+            subject_dn: 'CN=LoremIpsumSubject2 C=Dolor',
+            issuer_dn: 'CN=LoremIpsumIssuer2 C=Dolor',
+            serial: '00C387C32CBB861F5C',
+            host: {ip: '191.164.9.93', hostname: ''},
+            ports: {port: ['8445', '5061']},
+          },
+          {
+            name: 'C137E9D559CC95ED130011FE4012DE56CAE2F8',
+            certificate: {},
+            sha256_fingerprint: 'C137E9D559CC95ED130011FE4012',
+            md5_fingerprint: '63:70:d6:65:17:32:01:66:9e:7d:c4',
+            activation_time: 'unlimited',
+            expiration_time: 'undefined',
+            valid: false,
+            subject_dn: 'CN=LoremIpsumSubject2 C=Dolor',
+            issuer_dn: 'CN=LoremIpsumIssuer2 C=Dolor',
+            serial: '00C387C32CBB861F5C',
+            host: {},
+            ports: {port: ['8441']},
+          },
+        ],
+      },
     };
     const counts = {
       first: 1,
       all: 123,
-      filtered: 4,
-      length: 4,
-      rows: 4,
-      last: 4,
+      filtered: 5,
+      length: 5,
+      rows: 5,
+      last: 5,
     };
     const tlsCerts = parseTlsCertificates(report, filterString);
 
-    expect(tlsCerts.entities.length).toEqual(4);
+    expect(tlsCerts.entities.length).toEqual(5);
     expect(tlsCerts.counts).toEqual(counts);
     expect(tlsCerts.filter).toEqual('foo=bar rows=5');
 
-    const [cert1, cert2, cert3, cert4] = tlsCerts.entities;
+    const [cert1, cert2, cert3, cert4, cert5] = tlsCerts.entities;
 
-    expect(cert1.fingerprint).toEqual('fingerprint1');
+    expect(cert1.fingerprint).toEqual(
+      '57610B6A3C73866870678E638C7825743145B24',
+    );
     expect(cert1.hostname).toEqual('foo.bar');
-    expect(cert1.ip).toEqual('1.1.1.1');
-    expect(cert1.data).toEqual('foobar');
-    expect(cert1._data).toEqual('x509:foobar');
+    expect(cert1.ip).toEqual('192.168.9.90');
+    expect(cert1.data).toEqual('66870678E638C7825743145B247554E0D92C94');
+    expect(cert1.valid).toEqual(true);
     expect(cert1.ports).toBeUndefined();
-    expect(cert1.port).toEqual(123);
+    expect(cert1.port).toEqual(4021);
 
-    expect(cert2.fingerprint).toEqual('fingerprint2');
-    expect(cert2.hostname).toBeUndefined();
-    expect(cert2.ip).toEqual('2.2.2.2');
-    expect(cert2.data).toBeUndefined();
-    expect(cert2._data).toBeUndefined();
+    expect(cert2.fingerprint).toEqual(
+      '57610B6A3C73866870678E638C7825743145B24',
+    );
+    expect(cert2.hostname).toEqual('foo.bar');
+    expect(cert2.ip).toEqual('192.168.9.90');
+    expect(cert2.data).toEqual('66870678E638C7825743145B247554E0D92C94');
+    expect(cert2.valid).toEqual(true);
     expect(cert2.ports).toBeUndefined();
-    expect(cert2.port).toEqual(123);
+    expect(cert2.port).toEqual(4023);
 
-    expect(cert3.fingerprint).toEqual('fingerprint2');
-    expect(cert3.hostname).toBeUndefined();
-    expect(cert3.ip).toEqual('2.2.2.2');
-    expect(cert3.data).toBeUndefined();
-    expect(cert3._data).toBeUndefined();
+    expect(cert3.fingerprint).toEqual('C137E9D559CC95ED130011FE4012DE56CAE2F8');
+    expect(cert3.hostname).toEqual('');
+    expect(cert3.ip).toEqual('191.164.9.93');
+    expect(cert3.data).toEqual('MIICGTCCAYICCQDDh8Msu4YfXDANBgkqhkiG9w0B');
+    expect(cert3.valid).toEqual(false);
+    expect(cert3.activationTime).toBeUndefined();
+    expect(cert3.expirationTime).toBeUndefined();
     expect(cert3.ports).toBeUndefined();
-    expect(cert3.port).toEqual(234);
+    expect(cert3.port).toEqual(8445);
 
-    expect(cert4.fingerprint).toEqual('fingerprint1');
-    expect(cert4.ip).toEqual('2.2.2.2');
-    expect(cert4.data).toBeUndefined();
-    expect(cert4._data).toBeUndefined();
+    expect(cert4.fingerprint).toEqual('C137E9D559CC95ED130011FE4012DE56CAE2F8');
+    expect(cert4.hostname).toEqual('');
+    expect(cert4.ip).toEqual('191.164.9.93');
+    expect(cert4.data).toEqual('MIICGTCCAYICCQDDh8Msu4YfXDANBgkqhkiG9w0B');
+    expect(cert4.valid).toEqual(false);
+    expect(cert4.activationTime).toBeUndefined();
+    expect(cert4.expirationTime).toBeUndefined();
     expect(cert4.ports).toBeUndefined();
-    expect(cert4.port).toEqual(234);
+    expect(cert4.port).toEqual(5061);
+
+    expect(cert5.fingerprint).toEqual('C137E9D559CC95ED130011FE4012DE56CAE2F8');
+    expect(cert5.hostname).toBeUndefined();
+    expect(cert5.ip).toBeUndefined();
+    expect(cert5.data).toBeUndefined();
+    expect(cert5.valid).toEqual(false);
+    expect(cert5.activationTime).toBeUndefined();
+    expect(cert5.expirationTime).toBeUndefined();
+    expect(cert5.ports).toBeUndefined();
+    expect(cert5.port).toEqual(8441);
   });
 
   test('should parse empty tls certificates', () => {

--- a/src/gmp/models/report/__tests__/parser.js
+++ b/src/gmp/models/report/__tests__/parser.js
@@ -543,8 +543,8 @@ describe('report parser tests', () => {
             activation_time: 'unlimited',
             expiration_time: 'undefined',
             valid: false,
-            subject_dn: 'CN=LoremIpsumSubject2 C=Dolor',
-            issuer_dn: 'CN=LoremIpsumIssuer2 C=Dolor',
+            subject_dn: 'CN=LoremIpsumSubject3 C=Dolor',
+            issuer_dn: 'CN=LoremIpsumIssuer3 C=Dolor',
             serial: '00C387C32CBB861F5C',
             host: {},
             ports: {port: ['8441']},
@@ -577,6 +577,8 @@ describe('report parser tests', () => {
     expect(cert1.valid).toEqual(true);
     expect(cert1.ports).toBeUndefined();
     expect(cert1.port).toEqual(4021);
+    expect(cert1.issuerDn).toEqual('CN=LoremIpsumIssuer C=Dolor');
+    expect(cert1.subjectDn).toEqual('CN=LoremIpsumSubject C=Dolor');
 
     expect(cert2.fingerprint).toEqual(
       '57610B6A3C73866870678E638C7825743145B24',
@@ -587,6 +589,8 @@ describe('report parser tests', () => {
     expect(cert2.valid).toEqual(true);
     expect(cert2.ports).toBeUndefined();
     expect(cert2.port).toEqual(4023);
+    expect(cert2.issuerDn).toEqual('CN=LoremIpsumIssuer C=Dolor');
+    expect(cert2.subjectDn).toEqual('CN=LoremIpsumSubject C=Dolor');
 
     expect(cert3.fingerprint).toEqual('C137E9D559CC95ED130011FE4012DE56CAE2F8');
     expect(cert3.hostname).toEqual('');
@@ -597,6 +601,8 @@ describe('report parser tests', () => {
     expect(cert3.expirationTime).toBeUndefined();
     expect(cert3.ports).toBeUndefined();
     expect(cert3.port).toEqual(8445);
+    expect(cert3.issuerDn).toEqual('CN=LoremIpsumIssuer2 C=Dolor');
+    expect(cert3.subjectDn).toEqual('CN=LoremIpsumSubject2 C=Dolor');
 
     expect(cert4.fingerprint).toEqual('C137E9D559CC95ED130011FE4012DE56CAE2F8');
     expect(cert4.hostname).toEqual('');
@@ -607,6 +613,8 @@ describe('report parser tests', () => {
     expect(cert4.expirationTime).toBeUndefined();
     expect(cert4.ports).toBeUndefined();
     expect(cert4.port).toEqual(5061);
+    expect(cert4.issuerDn).toEqual('CN=LoremIpsumIssuer2 C=Dolor');
+    expect(cert4.subjectDn).toEqual('CN=LoremIpsumSubject2 C=Dolor');
 
     expect(cert5.fingerprint).toEqual('C137E9D559CC95ED130011FE4012DE56CAE2F8');
     expect(cert5.hostname).toBeUndefined();
@@ -617,6 +625,8 @@ describe('report parser tests', () => {
     expect(cert5.expirationTime).toBeUndefined();
     expect(cert5.ports).toBeUndefined();
     expect(cert5.port).toEqual(8441);
+    expect(cert5.issuerDn).toEqual('CN=LoremIpsumIssuer3 C=Dolor');
+    expect(cert5.subjectDn).toEqual('CN=LoremIpsumSubject3 C=Dolor');
   });
 
   test('should parse empty tls certificates', () => {

--- a/src/gmp/models/report/parser.js
+++ b/src/gmp/models/report/parser.js
@@ -96,8 +96,8 @@ export const parseTlsCertificates = (report, filter) => {
         ? undefined
         : parseDate(expiration_time);
     cert.valid = parseBoolean(valid);
-    cert.subject_dn = subject_dn;
-    cert.issuer_dn = issuer_dn;
+    cert.subjectDn = subject_dn;
+    cert.issuerDn = issuer_dn;
     cert.serial = serial;
     cert.hostname = isDefined(host) ? host.hostname : '';
     cert.ip = isDefined(host) ? host.ip : undefined;

--- a/src/gmp/models/tlscertificate.js
+++ b/src/gmp/models/tlscertificate.js
@@ -54,6 +54,12 @@ class TlsCertificate extends Model {
     // Use subject DN as name
     ret.name = ret.subject_dn;
 
+    ret.subjectDn = element.subject_dn;
+    delete ret.subject_dn;
+
+    ret.issuerDn = element.issuer_dn;
+    delete ret.issuer_dn;
+
     ret.activationTime =
       element.activation_time === 'undefined' ||
       element.activation_time === 'unlimited'

--- a/src/web/entities/withRowDetails.js
+++ b/src/web/entities/withRowDetails.js
@@ -57,34 +57,38 @@ const StyledTableRow = styled(TableRow)`
   }
 `;
 
-const withRowDetails = (type, colSpan = '10') => Component => {
-  const RowDetailsWrapper = ({entity, links = true, ...props}) => (
-    <StyledTableRow>
-      <TableData colSpan={colSpan} flex align={['start', 'stretch']}>
-        {links && (
-          <Layout align={['start', 'start']}>
-            <DetailsLink
-              type={isFunction(type) ? type(entity) : type}
-              id={entity.id}
-            >
-              <DetailsIcon size="small" title={_('Open all details')} />
-            </DetailsLink>
+const withRowDetails =
+  (type, colSpan = '10', details = true) =>
+  Component => {
+    const RowDetailsWrapper = ({entity, links = true, ...props}) => (
+      <StyledTableRow>
+        <TableData colSpan={colSpan} flex align={['start', 'stretch']}>
+          {links && (
+            <Layout align={['start', 'start']}>
+              {details && (
+                <DetailsLink
+                  type={isFunction(type) ? type(entity) : type}
+                  id={entity.id}
+                >
+                  <DetailsIcon size="small" title={_('Open all details')} />
+                </DetailsLink>
+              )}
+            </Layout>
+          )}
+          <Indent />
+          <Layout flex="column" grow="1">
+            <Component {...props} links={links} entity={entity} />
           </Layout>
-        )}
-        <Indent />
-        <Layout flex="column" grow="1">
-          <Component {...props} links={links} entity={entity} />
-        </Layout>
-      </TableData>
-    </StyledTableRow>
-  );
+        </TableData>
+      </StyledTableRow>
+    );
 
-  RowDetailsWrapper.propTypes = {
-    entity: PropTypes.model.isRequired,
-    links: PropTypes.bool,
+    RowDetailsWrapper.propTypes = {
+      entity: PropTypes.model.isRequired,
+      links: PropTypes.bool,
+    };
+    return RowDetailsWrapper;
   };
-  return RowDetailsWrapper;
-};
 
 export default withRowDetails;
 

--- a/src/web/pages/reports/__mocks__/mockreport.js
+++ b/src/web/pages/reports/__mocks__/mockreport.js
@@ -236,6 +236,44 @@ const error2 = {
   },
 };
 
+// TLS certificates
+const tlsCertificate1 = {
+  name: '57610B6A3C73866870678E638C7825743145B24',
+  certificate: {
+    __text: '66870678E638C7825743145B247554E0D92C94',
+    _format: 'DER',
+  },
+  data: 'MIIDSzCCAjOgAwIBAgIJALScVB/zqOLZMA0GCSqGSIb3DQ',
+  sha256_fingerprint: '57610B6A3C73866870678E638C78',
+  md5_fingerprint: 'fa:a9:9d:f2:28:cc:2c:c0:80:16',
+  activation_time: '2019-08-10T12:51:27Z',
+  expiration_time: '2019-09-10T12:51:27Z',
+  valid: true,
+  subject_dn: 'CN=LoremIpsumSubject1 C=Dolor',
+  issuer_dn: 'CN=LoremIpsumIssuer1 C=Dolor',
+  serial: '00B49C541FF5A8E1D9',
+  host: {ip: '192.168.9.90', hostname: 'foo.bar'},
+  ports: {port: ['4021', '4023']},
+};
+
+const tlsCertificate2 = {
+  name: 'C137E9D559CC95ED130011FE4012DE56CAE2F8',
+  certificate: {
+    __text: 'MIICGTCCAYICCQDDh8Msu4YfXDANBgkqhkiG9w0B',
+    _format: 'DER',
+  },
+  sha256_fingerprint: 'C137E9D559CC95ED130011FE4012',
+  md5_fingerprint: '63:70:d6:65:17:32:01:66:9e:7d:c4',
+  activation_time: 'unlimited',
+  expiration_time: 'undefined',
+  valid: false,
+  subject_dn: 'CN=LoremIpsumSubject2 C=Dolor',
+  issuer_dn: 'CN=LoremIpsumIssuer2 C=Dolor',
+  serial: '00C387C32CBB861F5C',
+  host: {ip: '191.164.9.93', hostname: ''},
+  ports: {port: ['8445', '5061']},
+};
+
 export const getMockReport = () => {
   const report = {
     _id: '1234',
@@ -255,6 +293,9 @@ export const getMockReport = () => {
     results: {result: [result1, result2, result3]},
     hosts: {count: 2},
     host: [host1, host2],
+    tls_certificates: {
+      tls_certificate: [tlsCertificate1, tlsCertificate2],
+    },
     ports: {
       count: 2,
       port: [port1, port2],

--- a/src/web/pages/reports/details/__tests__/tlscertificatestab.js
+++ b/src/web/pages/reports/details/__tests__/tlscertificatestab.js
@@ -32,7 +32,7 @@ import TLSCertificatesTab from '../tlscertificatestab';
 setLocale('en');
 
 const filter = Filter.fromString(
-  'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
+  'apply_overrides=0 levels=hml rows=3 min_qod=70 first=1 sort-reverse=severity',
 );
 
 describe('Report TLS Certificates Tab tests', () => {
@@ -81,44 +81,59 @@ describe('Report TLS Certificates Tab tests', () => {
     expect(header[7]).toHaveTextContent('Actions');
 
     // Row 1
-    expect(rows[1]).toHaveTextContent('CN=foo');
-    expect(rows[1]).toHaveTextContent('abcd');
-    expect(rows[1]).toHaveTextContent('Wed, Jan 30, 2019');
-    expect(rows[1]).toHaveTextContent('Thu, Aug 1, 2019');
+    expect(rows[1]).toHaveTextContent('CN=LoremIpsumSubject1 C=Dolor');
+    expect(rows[1]).toHaveTextContent('00B49C541FF5A8E1D9');
+    expect(rows[1]).toHaveTextContent('Sat, Aug 10, 2019');
+    expect(rows[1]).toHaveTextContent('Tue, Sep 10, 2019');
     expect(links[7]).toHaveAttribute(
       'href',
-      '/hosts?filter=name%3D123.456.78.910',
+      '/hosts?filter=name%3D192.168.9.90',
     );
     expect(links[7]).toHaveAttribute(
       'title',
-      'Show all Hosts with IP 123.456.78.910',
+      'Show all Hosts with IP 192.168.9.90',
     );
-    expect(links[7]).toHaveTextContent('123.456.78.910');
+    expect(links[7]).toHaveTextContent('192.168.9.90');
     expect(rows[1]).toHaveTextContent('foo.bar');
-    expect(rows[1]).toHaveTextContent('1234');
+    expect(rows[1]).toHaveTextContent('4021');
     expect(icons[4]).toHaveTextContent('download.svg');
 
     // Row 2
-    expect(rows[2]).toHaveTextContent('CN=bar');
-    expect(rows[2]).toHaveTextContent('dcba');
-    expect(rows[2]).toHaveTextContent('Sat, Mar 30, 2019');
-    expect(rows[2]).toHaveTextContent('Tue, Oct 1, 2019');
+    expect(rows[2]).toHaveTextContent('CN=LoremIpsumSubject1 C=Dolor');
+    expect(rows[2]).toHaveTextContent('00B49C541FF5A8E1D9');
+    expect(rows[2]).toHaveTextContent('Sat, Aug 10, 2019');
+    expect(rows[2]).toHaveTextContent('Tue, Sep 10, 2019');
     expect(links[8]).toHaveAttribute(
       'href',
-      '/hosts?filter=name%3D109.876.54.321',
+      '/hosts?filter=name%3D192.168.9.90',
     );
     expect(links[8]).toHaveAttribute(
       'title',
-      'Show all Hosts with IP 109.876.54.321',
+      'Show all Hosts with IP 192.168.9.90',
     );
-    expect(links[8]).toHaveTextContent('109.876.54.321');
-    expect(rows[2]).toHaveTextContent('lorem.ipsum');
-    expect(rows[2]).toHaveTextContent('5678');
+    expect(links[8]).toHaveTextContent('192.168.9.90');
+    expect(rows[2]).toHaveTextContent('foo.bar');
+    expect(rows[2]).toHaveTextContent('4023');
     expect(icons[5]).toHaveTextContent('download.svg');
+
+    // Row 3
+    expect(rows[3]).toHaveTextContent('CN=LoremIpsumSubject2 C=Dolor');
+    expect(rows[3]).toHaveTextContent('00C387C32CBB861F5C');
+    expect(links[9]).toHaveAttribute(
+      'href',
+      '/hosts?filter=name%3D191.164.9.93',
+    );
+    expect(links[9]).toHaveAttribute(
+      'title',
+      'Show all Hosts with IP 191.164.9.93',
+    );
+    expect(links[9]).toHaveTextContent('191.164.9.93');
+    expect(rows[3]).toHaveTextContent('8445');
+    expect(icons[6]).toHaveTextContent('download.svg');
 
     // Filter
     expect(baseElement).toHaveTextContent(
-      '(Applied filter: apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity)',
+      '(Applied filter: apply_overrides=0 levels=hml rows=3 min_qod=70 first=1 sort-reverse=severity)',
     );
   });
 

--- a/src/web/pages/reports/details/tlscertificatestab.js
+++ b/src/web/pages/reports/details/tlscertificatestab.js
@@ -31,10 +31,10 @@ import {
 } from 'web/utils/sort';
 
 const tlsCertificatesSortFunctions = {
-  dn: makeCompareString('issuer'),
+  dn: makeCompareString('subject_dn'),
   serial: makeCompareString('serial'),
-  notvalidbefore: makeCompareDate('notbefore'),
-  notvalidafter: makeCompareDate('notafter'),
+  notvalidbefore: makeCompareDate('activationTime'),
+  notvalidafter: makeCompareDate('expirationTime'),
   ip: makeCompareIp('ip'),
   hostname: makeCompareString('hostname'),
   port: makeComparePort('port'),

--- a/src/web/pages/reports/details/tlscertificatestab.js
+++ b/src/web/pages/reports/details/tlscertificatestab.js
@@ -31,7 +31,7 @@ import {
 } from 'web/utils/sort';
 
 const tlsCertificatesSortFunctions = {
-  dn: makeCompareString('subject_dn'),
+  dn: makeCompareString('subjectDn'),
   serial: makeCompareString('serial'),
   notvalidbefore: makeCompareDate('activationTime'),
   notvalidafter: makeCompareDate('expirationTime'),

--- a/src/web/pages/reports/details/tlscertificatestable.js
+++ b/src/web/pages/reports/details/tlscertificatestable.js
@@ -129,7 +129,7 @@ const Row = ({
       <TableData>
         <StyledSpan>
           <RowDetailsToggle name={entity.id} onClick={onToggleDetailsClick}>
-            <Div>{entity.subject_dn}</Div>
+            <Div>{entity.subjectDn}</Div>
           </RowDetailsToggle>
         </StyledSpan>
       </TableData>

--- a/src/web/pages/reports/details/tlscertificatestable.js
+++ b/src/web/pages/reports/details/tlscertificatestable.js
@@ -36,6 +36,10 @@ import TableHead from 'web/components/table/head';
 import TableHeader from 'web/components/table/header';
 import TableRow from 'web/components/table/row';
 
+import TlsCertificateDetails from '../../tlscertificates/details';
+import withRowDetails from 'web/entities/withRowDetails';
+import {RowDetailsToggle} from 'web/entities/row';
+
 import {createEntitiesTable} from 'web/entities/table';
 
 const Header = ({
@@ -58,7 +62,7 @@ const Header = ({
           {...sortProps}
           sortBy="dn"
           width={actions ? '35%' : '40%'}
-          title={_('Issuer DN')}
+          title={_('Subject DN')}
         />
         <TableHead
           {...sortProps}
@@ -104,6 +108,10 @@ Header.propTypes = {
   onSortChange: PropTypes.func,
 };
 
+const Div = styled.div`
+  word-break: break-all;
+`;
+
 const StyledSpan = styled.span`
   word-break: break-all;
 `;
@@ -113,19 +121,24 @@ const Row = ({
   entity,
   links = true,
   onTlsCertificateDownloadClick,
+  onToggleDetailsClick,
 }) => {
-  const {issuer, serial, notafter, notbefore, hostname, ip, port} = entity;
+  const {serial, activationTime, expirationTime, hostname, ip, port} = entity;
   return (
     <TableRow>
       <TableData>
-        <StyledSpan>{issuer}</StyledSpan>
+        <StyledSpan>
+          <RowDetailsToggle name={entity.id} onClick={onToggleDetailsClick}>
+            <Div>{entity.subject_dn}</Div>
+          </RowDetailsToggle>
+        </StyledSpan>
       </TableData>
       <TableData>{serial}</TableData>
       <TableData>
-        <DateTime format={shortDate} date={notbefore} />
+        <DateTime format={shortDate} date={activationTime} />
       </TableData>
       <TableData>
-        <DateTime format={shortDate} date={notafter} />
+        <DateTime format={shortDate} date={expirationTime} />
       </TableData>
       <TableData>
         <Link
@@ -157,12 +170,14 @@ Row.propTypes = {
   entity: PropTypes.object.isRequired,
   links: PropTypes.bool,
   onTlsCertificateDownloadClick: PropTypes.func,
+  onToggleDetailsClick: PropTypes.func.isRequired,
 };
 
 export default createEntitiesTable({
   header: Header,
   emptyTitle: _l('No TLS Certificates available'),
   row: Row,
+  rowDetails: withRowDetails('tlscertificate', 6, false)(TlsCertificateDetails),
 });
 
 // vim: set ts=2 sw=2 tw=80:

--- a/src/web/pages/tlscertificates/details.js
+++ b/src/web/pages/tlscertificates/details.js
@@ -53,16 +53,16 @@ const TlsCertificateDetails = ({entity, links = true}) => {
           <Col width="90%" />
         </colgroup>
         <TableBody>
-          {isDefined(entity.subject_dn) && (
+          {isDefined(entity.subjectDn) && (
             <TableRow>
               <TableData>{_('Subject DN')}</TableData>
-              <TableData>{entity.subject_dn}</TableData>
+              <TableData>{entity.subjectDn}</TableData>
             </TableRow>
           )}
-          {isDefined(entity.issuer_dn) && (
+          {isDefined(entity.issuerDn) && (
             <TableRow>
               <TableData>{_('Issuer DN')}</TableData>
-              <TableData>{entity.issuer_dn}</TableData>
+              <TableData>{entity.issuerDn}</TableData>
             </TableRow>
           )}
           {isDefined(entity.valid) && (

--- a/src/web/pages/tlscertificates/row.js
+++ b/src/web/pages/tlscertificates/row.js
@@ -93,7 +93,7 @@ const Row = ({
       <TableData>
         <span>
           <RowDetailsToggle name={entity.id} onClick={onToggleDetailsClick}>
-            <Div>{entity.subject_dn}</Div>
+            <Div>{entity.subjectDn}</Div>
           </RowDetailsToggle>
         </span>
       </TableData>


### PR DESCRIPTION


## What

Show extra details for report TLS certificates. The first column now shows `subject_dn` instead of `issuer_dn` and the certificate entries are now expandable to show extra details including `issuer_dn`, `sha256_fingerprint`, `md5_fingerprint` and `valid`.

## Why

To make the behavior consistent with the TLS certificate assets page.

## References
GEA-308

## Checklist
- [x] Tests


