### PR TITLE
Change: Show status information for container tasks and reports

### DIFF
--- a/src/gmp/models/task.js
+++ b/src/gmp/models/task.js
@@ -64,6 +64,7 @@ export const TASK_STATUS = {
   interrupted: 'Interrupted',
   container: 'Container',
   uploading: 'Uploading',
+  uploadinginterrupted: 'Uploading Interrupted',
   processing: 'Processing',
   done: 'Done',
 };
@@ -84,6 +85,7 @@ const TASK_STATUS_TRANSLATIONS = {
   Done: _l('Done'),
   Queued: _l('Queued'),
   Processing: _l('Processing'),
+  'Uploading Interrupted': _l('Interrupted'),
 };
 /* eslint-disable quote-props */
 

--- a/src/web/pages/reports/row.js
+++ b/src/web/pages/reports/row.js
@@ -106,7 +106,9 @@ const Row = ({
   if (isDefined(task)) {
     if (task.isContainer() && status !== TASK_STATUS.processing) {
       status =
-        status === TASK_STATUS.running
+        status === TASK_STATUS.interrupted
+          ? TASK_STATUS.uploadinginterrupted
+          : status === TASK_STATUS.running || status === TASK_STATUS.processing
           ? TASK_STATUS.uploading
           : TASK_STATUS.container;
     }

--- a/src/web/pages/reports/row.js
+++ b/src/web/pages/reports/row.js
@@ -109,8 +109,8 @@ const Row = ({
         status === TASK_STATUS.interrupted
           ? TASK_STATUS.uploadinginterrupted
           : status === TASK_STATUS.running || status === TASK_STATUS.processing
-          ? TASK_STATUS.uploading
-          : TASK_STATUS.container;
+            ? TASK_STATUS.uploading
+            : TASK_STATUS.container;
     }
     progress = task.progress;
   }

--- a/src/web/pages/tasks/__tests__/status.js
+++ b/src/web/pages/tasks/__tests__/status.js
@@ -114,4 +114,46 @@ describe('Task Status tests', () => {
     expect(detailslink).toHaveTextContent('Container');
     expect(detailslink).toHaveAttribute('href', '/report/42');
   });
+
+  test('should render container with status interrupted', () => {
+    const task = Task.fromElement({
+      status: TASK_STATUS.interrupted,
+      permissions: {permission: [{name: 'everything'}]},
+    });
+
+    const {render} = rendererWith({capabilities: caps});
+    const {getByTestId} = render(<Status task={task} />);
+
+    const bar = getByTestId('progressbar-box');
+    expect(bar).toHaveAttribute('title', TASK_STATUS.interrupted);
+    expect(bar).toHaveTextContent(TASK_STATUS.interrupted);
+  });
+
+  test('should render running container task as processing', () => {
+    const task = Task.fromElement({
+      status: TASK_STATUS.running,
+      permissions: {permission: [{name: 'everything'}]},
+    });
+
+    const {render} = rendererWith({capabilities: caps});
+    const {getByTestId} = render(<Status task={task} />);
+
+    const bar = getByTestId('progressbar-box');
+    expect(bar).toHaveAttribute('title', TASK_STATUS.processing);
+    expect(bar).toHaveTextContent(TASK_STATUS.processing);
+  });
+
+  test('should render processing container task as processing', () => {
+    const task = Task.fromElement({
+      status: TASK_STATUS.processing,
+      permissions: {permission: [{name: 'everything'}]},
+    });
+
+    const {render} = rendererWith({capabilities: caps});
+    const {getByTestId} = render(<Status task={task} />);
+
+    const bar = getByTestId('progressbar-box');
+    expect(bar).toHaveAttribute('title', TASK_STATUS.processing);
+    expect(bar).toHaveTextContent(TASK_STATUS.processing);
+  });
 });

--- a/src/web/pages/tasks/status.js
+++ b/src/web/pages/tasks/status.js
@@ -49,7 +49,16 @@ const TaskStatus = ({task, links = true}) => {
   return (
     <StyledDetailsLink type="report" id={report_id} textOnly={!links}>
       <StatusBar
-        status={task.isContainer() ? TASK_STATUS.container : task.status}
+        status={
+          task.isContainer()
+            ? task.status === TASK_STATUS.interrupted
+              ? TASK_STATUS.uploadinginterrupted
+              : task.status === TASK_STATUS.running ||
+                task.status === TASK_STATUS.processing
+              ? TASK_STATUS.processing
+              : TASK_STATUS.container
+            : task.status
+        }
         progress={task.progress}
       />
     </StyledDetailsLink>


### PR DESCRIPTION
## What
Container tasks now show "Processing" when uploading reports or creating assets and show "Interrupted" when upload is interrupted. Reports show "Uploading" during upload  and "Interrupted" if upload is interrupted.

## Why
If a report is uploaded to a container task it will appear done (with the "Container" status in GSA) once it is in the phase of processing the assets. This can be misleading, especially if the processing takes a long time, as is the case for uploading multiple larger reports.

## References
GEA-353

