### PR TITLE
Change: Disable start icon for tasks with duration limit

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -1918,6 +1918,7 @@
   "{{title}} {{filtered}} of {{all}}": "{{title}} {{filtered}} von {{all}}",
   "{{type}} owned by {{owner}}": "{{type}} gehört {{owner}}",
   "{{type}}:unnamed": "{{type}}:unbenannt",
+  "{{usageType}} cannot be started manually because the assigned schedule has a duration limit": "{{usageType}} kann nicht manuell gestartet werden, da ein Zeitplan mit Laufzeitbegrenzung zugewiesen ist",
   "{{usageType}} is a container": "{{usageType}} ist Container-{{usageType}}",
   "{{usageType}} is already active": "{{usageType}} ist bereits aktiv",
   "{{usageType}} is not stopped": "{{usageType}} ist nicht gestoppt",

--- a/src/web/pages/tasks/icons/starticon.js
+++ b/src/web/pages/tasks/icons/starticon.js
@@ -20,6 +20,7 @@ import React from 'react';
 import _ from 'gmp/locale';
 
 import PropTypes from 'web/utils/proptypes';
+import {isDefined} from 'gmp/utils/identity';
 import {capitalizeFirstLetter} from 'gmp/utils/string';
 import withCapabilities from 'web/utils/withCapabilities';
 
@@ -43,6 +44,24 @@ const TaskStartIcon = ({
       <StartIcon
         active={false}
         title={_('Permission to start {{usageType}} denied', {usageType})}
+      />
+    );
+  }
+
+  if (
+    isDefined(task.schedule) &&
+    task.schedule?.event?.event?.duration?.toSeconds() > 0
+  ) {
+    return (
+      <StartIcon
+        active={false}
+        title={_(
+          '{{usageType}} cannot be started manually' +
+            ' because the assigned schedule has a duration limit',
+          {
+            usageType: capitalizeFirstLetter(usageType),
+          },
+        )}
       />
     );
   }


### PR DESCRIPTION
## What
If a task has a schedule with a duration limit assigned, the start icon will be disabled.

## Why
This is done because there is currently no distinction between a scheduled start and a manual one, so the schedule would often stop the task immediately.

## References
GEA-379

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


