### PR TITLE
Change: Revert styled-components version to 5.3.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gsa",
-  "version": "22.8.2-dev1",
+  "version": "22.9.1-dev1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gsa",
-      "version": "22.8.2-dev1",
+      "version": "22.9.1-dev1",
       "license": "AGPL-3.0+",
       "dependencies": {
         "@babel/core": "7.23.2",
@@ -50,7 +50,7 @@
         "redux": "^4.2.1",
         "redux-logger": "^3.0.6",
         "redux-thunk": "^2.4.2",
-        "styled-components": "^6.1.0",
+        "styled-components": "^5.3.11",
         "uuid": "^9.0.1",
         "whatwg-fetch": "^3.6.19"
       },
@@ -2569,58 +2569,6 @@
         "prop-types": "^15",
         "react": "^16",
         "react-dom": "^16"
-      }
-    },
-    "node_modules/@greenbone/ui-components/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@greenbone/ui-components/node_modules/styled-components": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.6.tgz",
-      "integrity": "sha512-hGTZquGAaTqhGWldX7hhfzjnIYBZ0IXQXkCYdvF1Sq3DsUaLx6+NTHC5Jj1ooM2F68sBiVz3lvhfwQs/S3l6qg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^1.1.0",
-        "@emotion/stylis": "^0.8.4",
-        "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1.12.0",
-        "css-to-react-native": "^3.0.0",
-        "hoist-non-react-statics": "^3.0.0",
-        "shallowequal": "^1.1.0",
-        "supports-color": "^5.5.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0",
-        "react-is": ">= 16.8.0"
-      }
-    },
-    "node_modules/@greenbone/ui-components/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -5186,11 +5134,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
-    },
-    "node_modules/@types/stylis": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.1.tgz",
-      "integrity": "sha512-OSaMrXUKxVigGlKRrET39V2xdhzlztQ9Aqumn1WbCBKHOi9ry7jKSd7rkyj0GzmWaU960Rd+LpOFpLfx5bMQAg=="
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
@@ -21668,22 +21611,23 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.0.tgz",
-      "integrity": "sha512-VWNfYYBuXzuLS/QYEeoPgMErP26WL+dX9//rEh80B2mmlS1yRxRxuL5eax4m6ybYEUoHWlTy2XOU32767mlMkg==",
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
+      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
       "dependencies": {
-        "@emotion/is-prop-valid": "^1.2.1",
-        "@emotion/unitless": "^0.8.0",
-        "@types/stylis": "^4.0.2",
-        "css-to-react-native": "^3.2.0",
-        "csstype": "^3.1.2",
-        "postcss": "^8.4.31",
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/traverse": "^7.4.5",
+        "@emotion/is-prop-valid": "^1.1.0",
+        "@emotion/stylis": "^0.8.4",
+        "@emotion/unitless": "^0.7.4",
+        "babel-plugin-styled-components": ">= 1.12.0",
+        "css-to-react-native": "^3.0.0",
+        "hoist-non-react-statics": "^3.0.0",
         "shallowequal": "^1.1.0",
-        "stylis": "^4.3.0",
-        "tslib": "^2.5.0"
+        "supports-color": "^5.5.0"
       },
       "engines": {
-        "node": ">= 16"
+        "node": ">=10"
       },
       "funding": {
         "type": "opencollective",
@@ -21691,13 +21635,28 @@
       },
       "peerDependencies": {
         "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0"
+        "react-dom": ">= 16.8.0",
+        "react-is": ">= 16.8.0"
       }
     },
-    "node_modules/styled-components/node_modules/@emotion/unitless": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+    "node_modules/styled-components/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/styled-components/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/stylehacks": {
       "version": "5.1.1",
@@ -21714,11 +21673,6 @@
       "peerDependencies": {
         "postcss": "^8.2.15"
       }
-    },
-    "node_modules/stylis": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
-      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "https://github.com/greenbone/gsa/"
   },
-  "author": "Bj\u00f6rn Ricks <bjoern.ricks@greenbone.net>",
+  "author": "Björn Ricks <bjoern.ricks@greenbone.net>",
   "license": "AGPL-3.0+",
   "main": "src/index.js",
   "engines": {
@@ -64,7 +64,7 @@
     "redux": "^4.2.1",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.4.2",
-    "styled-components": "^6.1.0",
+    "styled-components": "^5.3.11",
     "uuid": "^9.0.1",
     "whatwg-fetch": "^3.6.19"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -27,8 +27,6 @@ import {isDefined} from 'gmp/utils/identity';
 
 import App from './web/app.js';
 
-import {StyleSheetManager} from 'styled-components';
-
 const config = isDefined(global.config) ? global.config : {};
 const {sentryDSN, sentryEnvironment} = config;
 
@@ -40,11 +38,6 @@ Sentry.init({
   release: GSA_VERSION,
 });
 
-ReactDOM.render(
-  <StyleSheetManager enableVendorPrefixes>
-    <App />
-  </StyleSheetManager>,
-  document.getElementById('app'),
-);
+ReactDOM.render(<App />, document.getElementById('app'));
 
 // vim: set ts=2 sw=2 tw=80:

--- a/src/web/components/badge/__tests__/__snapshots__/badge.js.snap
+++ b/src/web/components/badge/__tests__/__snapshots__/badge.js.snap
@@ -29,13 +29,12 @@ exports[`Badge tests should render badge 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -56,6 +55,10 @@ exports[`Badge tests should render badge 1`] = `
   color: #fff;
   bottom: -8px;
   right: 0px;
+}
+
+@media print {
+
 }
 
 <div

--- a/src/web/components/bar/__tests__/__snapshots__/titlebar.js.snap
+++ b/src/web/components/bar/__tests__/__snapshots__/titlebar.js.snap
@@ -10,8 +10,8 @@ exports[`Titlebar tests should not render content if user is logged out 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -40,6 +40,7 @@ exports[`Titlebar tests should not render content if user is logged out 1`] = `
   display: flex;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -102,8 +103,8 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -118,50 +119,50 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   display: inline-flex;
 }
 
-.c15 {
+.c16 {
   margin-left: -5px;
 }
 
-.c15>* {
+.c16 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c15>* {
+.c16 > * {
   margin-left: 5px;
 }
 
-.c14 {
+.c15 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c17 {
+.c18 {
   cursor: pointer;
 }
 
-.c9 {
+.c8 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c9 * {
+.c8 * {
   height: inherit;
   width: inherit;
 }
 
-.c16 {
+.c17 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c16 * {
+.c17 * {
   height: inherit;
   width: inherit;
 }
@@ -183,7 +184,7 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   animation: bNcXmX 0.1s ease-in;
 }
 
-.c6:hover .c11 {
+.c6:hover .c10 {
   display: block;
 }
 
@@ -199,7 +200,7 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   width: 300px;
 }
 
-.c13 {
+.c14 {
   height: 30px;
   width: 300px;
   border-left: 1px solid #7F7F7F;
@@ -216,13 +217,13 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   padding-left: 12px;
 }
 
-.c13:hover {
+.c14:hover {
   background: #11ab51;
   color: #fff;
   cursor: pointer;
 }
 
-.c13:first-child {
+.c14:first-child {
   border-top: 1px solid #7F7F7F;
   cursor: default;
 }
@@ -231,7 +232,7 @@ background-color:#f3f3f3 .c13:first-child:hover {
   color: #000;
 }
 
-.c13:nth-child(2) {
+.c14:nth-child(2) {
   cursor: default;
 }
 
@@ -239,25 +240,25 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
   color: #000;
 }
 
-.c13:last-child {
+.c14:last-child {
   border-top: 1px solid #7F7F7F;
   border-bottom: 1px solid #7F7F7F;
 }
 
-.c10 {
+.c9 {
   margin-right: 10px;
 }
 
-.c18 {
+.c19 {
   width: 100%;
   height: 100%;
 }
 
-.c18:link,
-.c18:hover,
-.c18:active,
-.c18:visited,
-.c18:hover {
+.c19:link,
+.c19:hover,
+.c19:active,
+.c19:visited,
+.c19:hover {
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -284,6 +285,7 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
   display: flex;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -304,7 +306,11 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
 }
 
 @media print {
-  .c8 {
+
+}
+
+@media print {
+  .c18 {
     display: none;
   }
 }
@@ -345,7 +351,7 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
         data-testid="usermenu"
       >
         <span
-          class="c8 c9 c10"
+          class="c8 c9"
           data-testid="svg-icon"
         >
           <svg>
@@ -353,23 +359,23 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
           </svg>
         </span>
         <div
-          class="c11"
+          class="c10 c11"
         >
           <ul
             class="c12"
           >
             <li
-              class="c13"
+              class="c13 c14"
               title="Logged in as: username"
             >
               <div
-                class="c3 c14"
+                class="c3 c15"
               >
                 <div
-                  class="c3 c15"
+                  class="c3 c16"
                 >
                   <span
-                    class="c8 c16"
+                    class="c17"
                     data-testid="svg-icon"
                   >
                     <svg>
@@ -383,16 +389,16 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
               </div>
             </li>
             <li
-              class="c13"
+              class="c13 c14"
             >
               <div
-                class="c3 c14"
+                class="c3 c15"
               >
                 <div
-                  class="c3 c15"
+                  class="c3 c16"
                 >
                   <span
-                    class="c8 c16"
+                    class="c17"
                     data-testid="svg-icon"
                   >
                     <svg>
@@ -403,7 +409,7 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
                     Session timeout: 
                   </span>
                   <span
-                    class="c8 c17 c16"
+                    class="c18 c17"
                     data-testid="svg-icon"
                     title="Renew session timeout"
                   >
@@ -417,21 +423,21 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
               </div>
             </li>
             <li
-              class="c13"
+              class="c13 c14"
             >
               <a
-                class="c2 c18"
+                class="c2 c19"
                 data-testid="usermenu-settings"
                 href="/usersettings"
               >
                 <div
-                  class="c3 c14"
+                  class="c3 c15"
                 >
                   <div
-                    class="c3 c15"
+                    class="c3 c16"
                   >
                     <span
-                      class="c8 c16"
+                      class="c17"
                       data-testid="svg-icon"
                     >
                       <svg>
@@ -446,17 +452,17 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
               </a>
             </li>
             <li
-              class="c13"
+              class="c13 c14"
               data-testid="usermenu-logout"
             >
               <div
-                class="c3 c14"
+                class="c3 c15"
               >
                 <div
-                  class="c3 c15"
+                  class="c3 c16"
                 >
                   <span
-                    class="c8 c16"
+                    class="c17"
                     data-testid="svg-icon"
                   >
                     <svg>

--- a/src/web/components/bar/__tests__/__snapshots__/toolbar.js.snap
+++ b/src/web/components/bar/__tests__/__snapshots__/toolbar.js.snap
@@ -11,6 +11,7 @@ exports[`Toolbar tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;

--- a/src/web/components/dialog/__tests__/__snapshots__/button.js.snap
+++ b/src/web/components/dialog/__tests__/__snapshots__/button.js.snap
@@ -62,8 +62,8 @@ exports[`Dialog Button tests should render button 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -77,7 +77,7 @@ exports[`Dialog Button tests should render button 1`] = `
   background: #11ab51;
 }
 
-.c2 :hover {
+.c2:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -149,8 +149,8 @@ exports[`Dialog Button tests should render button when loading 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -160,12 +160,12 @@ exports[`Dialog Button tests should render button when loading 1`] = `
 
 .c2 {
   border: 1px solid #7F7F7F;
-  color: rgba(0, 0, 0, 0.0);
+  color: rgba(0,0,0,0.0);
   background: #11ab51 url(/img/loading.gif) center center no-repeat;
 }
 
-.c2 :hover {
-  color: rgba(0, 0, 0, 0.0);
+.c2:hover {
+  color: rgba(0,0,0,0.0);
   background: #11ab51 url(/img/loading.gif) center center no-repeat;
 }
 

--- a/src/web/components/dialog/__tests__/__snapshots__/closebutton.js.snap
+++ b/src/web/components/dialog/__tests__/__snapshots__/closebutton.js.snap
@@ -18,15 +18,15 @@ exports[`Dialog CloseButton tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c0 :hover {
+.c0:hover {
   border: 1px solid #074320;
 }
 

--- a/src/web/components/dialog/__tests__/__snapshots__/confirmationdialog.js.snap
+++ b/src/web/components/dialog/__tests__/__snapshots__/confirmationdialog.js.snap
@@ -11,6 +11,7 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -31,8 +32,8 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -52,8 +53,8 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -86,7 +87,7 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -127,15 +128,15 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -211,8 +212,8 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -226,7 +227,7 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   background: #11ab51;
 }
 
-.c15 :hover {
+.c15:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -242,6 +243,7 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
 .c12 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -259,11 +261,13 @@ exports[`ConfirmationDialog component tests should render ConfirmationDialog wit
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 

--- a/src/web/components/dialog/__tests__/__snapshots__/dialog.js.snap
+++ b/src/web/components/dialog/__tests__/__snapshots__/dialog.js.snap
@@ -26,7 +26,7 @@ exports[`Dialog component tests should render a Dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -49,7 +49,7 @@ exports[`Dialog component tests should render a Dialog 1`] = `
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 <body>

--- a/src/web/components/dialog/__tests__/__snapshots__/errordialog.js.snap
+++ b/src/web/components/dialog/__tests__/__snapshots__/errordialog.js.snap
@@ -11,6 +11,7 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -31,8 +32,8 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -52,8 +53,8 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -86,7 +87,7 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -127,15 +128,15 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -211,8 +212,8 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -226,7 +227,7 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   background: #11ab51;
 }
 
-.c14 :hover {
+.c14:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -253,11 +254,13 @@ exports[`ErrorDialog component tests should render ErrorDialog with text and tit
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 

--- a/src/web/components/dialog/__tests__/__snapshots__/multistepfooter.js.snap
+++ b/src/web/components/dialog/__tests__/__snapshots__/multistepfooter.js.snap
@@ -13,8 +13,8 @@ exports[`MultiStepFooter tests should render 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -31,8 +31,8 @@ exports[`MultiStepFooter tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -44,14 +44,14 @@ exports[`MultiStepFooter tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c8>* {
+.c8 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c8>* {
+.c8 > * {
   margin-left: 5px;
 }
 
@@ -123,8 +123,8 @@ exports[`MultiStepFooter tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -138,7 +138,7 @@ exports[`MultiStepFooter tests should render 1`] = `
   background: #11ab51;
 }
 
-.c5 :hover {
+.c5:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -156,7 +156,7 @@ exports[`MultiStepFooter tests should render 1`] = `
   background: #fff;
 }
 
-.c9 :hover {
+.c9:hover {
   color: #fff;
   background: #11ab51;
 }
@@ -164,6 +164,7 @@ exports[`MultiStepFooter tests should render 1`] = `
 .c2 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -222,8 +223,8 @@ exports[`MultiStepFooter tests should render loading and disable cancel button 1
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -240,8 +241,8 @@ exports[`MultiStepFooter tests should render loading and disable cancel button 1
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -253,14 +254,14 @@ exports[`MultiStepFooter tests should render loading and disable cancel button 1
   margin-left: -5px;
 }
 
-.c8>* {
+.c8 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c8>* {
+.c8 > * {
   margin-left: 5px;
 }
 
@@ -332,8 +333,8 @@ exports[`MultiStepFooter tests should render loading and disable cancel button 1
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -347,19 +348,19 @@ exports[`MultiStepFooter tests should render loading and disable cancel button 1
   background: #11ab51;
 }
 
-.c5 :hover {
+.c5:hover {
   color: #074320;
   background: #A1DDBA;
 }
 
 .c10 {
   border: 1px solid #7F7F7F;
-  color: rgba(0, 0, 0, 0.0);
+  color: rgba(0,0,0,0.0);
   background: #11ab51 url(/img/loading.gif) center center no-repeat;
 }
 
-.c10 :hover {
-  color: rgba(0, 0, 0, 0.0);
+.c10:hover {
+  color: rgba(0,0,0,0.0);
   background: #11ab51 url(/img/loading.gif) center center no-repeat;
 }
 
@@ -376,7 +377,7 @@ exports[`MultiStepFooter tests should render loading and disable cancel button 1
   background: #fff;
 }
 
-.c9 :hover {
+.c9:hover {
   color: #fff;
   background: #11ab51;
 }
@@ -384,6 +385,7 @@ exports[`MultiStepFooter tests should render loading and disable cancel button 1
 .c2 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 

--- a/src/web/components/dialog/__tests__/__snapshots__/twobuttonfooter.js.snap
+++ b/src/web/components/dialog/__tests__/__snapshots__/twobuttonfooter.js.snap
@@ -13,8 +13,8 @@ exports[`DialogTwoButtonFooter tests should render 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -83,8 +83,8 @@ exports[`DialogTwoButtonFooter tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -98,7 +98,7 @@ exports[`DialogTwoButtonFooter tests should render 1`] = `
   background: #11ab51;
 }
 
-.c5 :hover {
+.c5:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -114,6 +114,7 @@ exports[`DialogTwoButtonFooter tests should render 1`] = `
 .c2 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -150,8 +151,8 @@ exports[`DialogTwoButtonFooter tests should render loading and disable cancel bu
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -220,8 +221,8 @@ exports[`DialogTwoButtonFooter tests should render loading and disable cancel bu
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -235,19 +236,19 @@ exports[`DialogTwoButtonFooter tests should render loading and disable cancel bu
   background: #11ab51;
 }
 
-.c5 :hover {
+.c5:hover {
   color: #074320;
   background: #A1DDBA;
 }
 
 .c6 {
   border: 1px solid #7F7F7F;
-  color: rgba(0, 0, 0, 0.0);
+  color: rgba(0,0,0,0.0);
   background: #11ab51 url(/img/loading.gif) center center no-repeat;
 }
 
-.c6 :hover {
-  color: rgba(0, 0, 0, 0.0);
+.c6:hover {
+  color: rgba(0,0,0,0.0);
   background: #11ab51 url(/img/loading.gif) center center no-repeat;
 }
 
@@ -262,6 +263,7 @@ exports[`DialogTwoButtonFooter tests should render loading and disable cancel bu
 .c2 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 

--- a/src/web/components/error/__tests__/__snapshots__/errorcontainer.js.snap
+++ b/src/web/components/error/__tests__/__snapshots__/errorcontainer.js.snap
@@ -10,8 +10,8 @@ exports[`ErrorContainer tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/error/__tests__/__snapshots__/errormessage.js.snap
+++ b/src/web/components/error/__tests__/__snapshots__/errormessage.js.snap
@@ -10,8 +10,8 @@ exports[`ErrorMessage tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -28,8 +28,8 @@ exports[`ErrorMessage tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -41,14 +41,14 @@ exports[`ErrorMessage tests should render 1`] = `
   margin-left: -15px;
 }
 
-.c4>* {
+.c4 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4>* {
+.c4 > * {
   margin-left: 15px;
 }
 
@@ -56,14 +56,14 @@ exports[`ErrorMessage tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c6>* {
+.c6 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c6>* {
+.c6 > * {
   margin-left: 5px;
 }
 
@@ -91,6 +91,10 @@ exports[`ErrorMessage tests should render 1`] = `
   border: 1px solid #f4b1b2;
   color: #c12c30;
   background-color: #fbddde;
+}
+
+@media print {
+
 }
 
 <div

--- a/src/web/components/footnote/__tests__/__snapshots__/footnote.js.snap
+++ b/src/web/components/footnote/__tests__/__snapshots__/footnote.js.snap
@@ -10,8 +10,8 @@ exports[`Footnote tests should render footnote 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/form/__tests__/__snapshots__/button.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/button.js.snap
@@ -62,8 +62,8 @@ exports[`Button tests should render button 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/form/__tests__/__snapshots__/checkbox.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/checkbox.js.snap
@@ -10,8 +10,8 @@ exports[`CheckBox component tests should render with children 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23,14 +23,14 @@ exports[`CheckBox component tests should render with children 1`] = `
   margin-left: -5px;
 }
 
-.c3>* {
+.c3 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c3>* {
+.c3 > * {
   margin-left: 5px;
 }
 
@@ -77,8 +77,8 @@ exports[`CheckBox component tests should render with children 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/form/__tests__/__snapshots__/field.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/field.js.snap
@@ -28,8 +28,8 @@ exports[`Field tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -39,6 +39,7 @@ exports[`Field tests should render 1`] = `
 
 <input
   class="c0 c1"
+  value=""
 />
 `;
 
@@ -73,8 +74,8 @@ exports[`Field tests should render in disabled state 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -85,5 +86,6 @@ exports[`Field tests should render in disabled state 1`] = `
 <input
   class="c0 c1"
   disabled=""
+  value=""
 />
 `;

--- a/src/web/components/form/__tests__/__snapshots__/filefield.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/filefield.js.snap
@@ -10,8 +10,8 @@ exports[`FileField tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -35,8 +35,8 @@ exports[`FileField tests should render in disabled state 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/form/__tests__/__snapshots__/formgroup.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/formgroup.js.snap
@@ -10,8 +10,8 @@ exports[`FormGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -29,8 +29,8 @@ exports[`FormGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -55,8 +55,8 @@ exports[`FormGroup tests should render with title 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -74,8 +74,8 @@ exports[`FormGroup tests should render with title 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }

--- a/src/web/components/form/__tests__/__snapshots__/loadingbutton.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/loadingbutton.js.snap
@@ -62,8 +62,8 @@ exports[`LoadingButton tests should render loading 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -72,12 +72,12 @@ exports[`LoadingButton tests should render loading 1`] = `
 }
 
 .c2 {
-  color: rgba(0, 0, 0, 0.0);
+  color: rgba(0,0,0,0.0);
   background: #A1DDBA url(/img/loading.gif) center center no-repeat;
 }
 
-.c2 :hover {
-  color: rgba(0, 0, 0, 0.0);
+.c2:hover {
+  color: rgba(0,0,0,0.0);
   background: #11ab51 url(/img/loading.gif) center center no-repeat;
 }
 
@@ -148,8 +148,8 @@ exports[`LoadingButton tests should render non loading 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -162,7 +162,7 @@ exports[`LoadingButton tests should render non loading 1`] = `
   background: #fff;
 }
 
-.c2 :hover {
+.c2:hover {
   color: #fff;
   background: #11ab51;
 }

--- a/src/web/components/form/__tests__/__snapshots__/multiselect.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/multiselect.js.snap
@@ -13,13 +13,12 @@ exports[`MultiSelect component tests should render 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -36,8 +35,8 @@ exports[`MultiSelect component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -58,8 +57,8 @@ exports[`MultiSelect component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;

--- a/src/web/components/form/__tests__/__snapshots__/passwordfield.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/passwordfield.js.snap
@@ -28,8 +28,8 @@ exports[`PasswordField tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -40,6 +40,7 @@ exports[`PasswordField tests should render 1`] = `
 <input
   class="c0 c1"
   type="password"
+  value=""
 />
 `;
 
@@ -74,8 +75,8 @@ exports[`PasswordField tests should render in disabled state 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -87,5 +88,6 @@ exports[`PasswordField tests should render in disabled state 1`] = `
   class="c0 c1"
   disabled=""
   type="password"
+  value=""
 />
 `;

--- a/src/web/components/form/__tests__/__snapshots__/radio.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/radio.js.snap
@@ -10,8 +10,8 @@ exports[`Radio tests should render radio 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23,14 +23,14 @@ exports[`Radio tests should render radio 1`] = `
   margin-left: -5px;
 }
 
-.c3>* {
+.c3 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c3>* {
+.c3 > * {
   margin-left: 5px;
 }
 
@@ -77,8 +77,8 @@ exports[`Radio tests should render radio 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -99,6 +99,7 @@ exports[`Radio tests should render radio 1`] = `
         class="c4 c5"
         data-testid="radio-input"
         type="radio"
+        value=""
       />
     </div>
   </div>
@@ -115,8 +116,8 @@ exports[`Radio tests should render radio with children 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -128,14 +129,14 @@ exports[`Radio tests should render radio with children 1`] = `
   margin-left: -5px;
 }
 
-.c3>* {
+.c3 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c3>* {
+.c3 > * {
   margin-left: 5px;
 }
 
@@ -182,8 +183,8 @@ exports[`Radio tests should render radio with children 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -204,6 +205,7 @@ exports[`Radio tests should render radio with children 1`] = `
         class="c4 c5"
         data-testid="radio-input"
         type="radio"
+        value=""
       />
       <span>
         child1

--- a/src/web/components/form/__tests__/__snapshots__/select.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/select.js.snap
@@ -10,8 +10,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -32,8 +32,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;

--- a/src/web/components/form/__tests__/__snapshots__/selectelement.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/selectelement.js.snap
@@ -187,7 +187,7 @@ exports[`Menu tests should render 1`] = `
   border-radius: 0 0 4px 4px;
   -webkit-transition: opacity 0.1s ease;
   transition: opacity 0.1s ease;
-  box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
+  box-shadow: 0 2px 3px 0 rgba(34,36,38,0.15);
   border: 1px solid #bfbfbf;
   background-color: #fff;
   display: -webkit-box;
@@ -222,7 +222,7 @@ exports[`Menu tests should render with open direction downwards 1`] = `
   border-radius: 0 0 4px 4px;
   -webkit-transition: opacity 0.1s ease;
   transition: opacity 0.1s ease;
-  box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
+  box-shadow: 0 2px 3px 0 rgba(34,36,38,0.15);
   border: 1px solid #bfbfbf;
   background-color: #fff;
   display: -webkit-box;
@@ -257,7 +257,7 @@ exports[`Menu tests should render with open direction upwards 1`] = `
   border-radius: 0 0 4px 4px;
   -webkit-transition: opacity 0.1s ease;
   transition: opacity 0.1s ease;
-  box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
+  box-shadow: 0 2px 3px 0 rgba(34,36,38,0.15);
   border: 1px solid #bfbfbf;
   background-color: #fff;
   display: -webkit-box;
@@ -292,7 +292,7 @@ exports[`Menu tests should render with position adjust 1`] = `
   border-radius: 0 0 4px 4px;
   -webkit-transition: opacity 0.1s ease;
   transition: opacity 0.1s ease;
-  box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
+  box-shadow: 0 2px 3px 0 rgba(34,36,38,0.15);
   border: 1px solid #bfbfbf;
   background-color: #fff;
   display: -webkit-box;
@@ -327,7 +327,7 @@ exports[`Menu tests should render with position reference to parent element 1`] 
   border-radius: 0 0 4px 4px;
   -webkit-transition: opacity 0.1s ease;
   transition: opacity 0.1s ease;
-  box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
+  box-shadow: 0 2px 3px 0 rgba(34,36,38,0.15);
   border: 1px solid #bfbfbf;
   background-color: #fff;
   display: -webkit-box;
@@ -362,7 +362,7 @@ exports[`Menu tests should render with position right 1`] = `
   border-radius: 0 0 4px 4px;
   -webkit-transition: opacity 0.1s ease;
   transition: opacity 0.1s ease;
-  box-shadow: 0 2px 3px 0 rgba(34, 36, 38, 0.15);
+  box-shadow: 0 2px 3px 0 rgba(34,36,38,0.15);
   border: 1px solid #bfbfbf;
   background-color: #fff;
   display: -webkit-box;

--- a/src/web/components/form/__tests__/__snapshots__/textarea.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/textarea.js.snap
@@ -21,8 +21,8 @@ exports[`TextArea tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -59,8 +59,8 @@ exports[`TextArea tests should render in disabled state 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/form/__tests__/__snapshots__/textfield.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/textfield.js.snap
@@ -28,8 +28,8 @@ exports[`TextField tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -40,6 +40,7 @@ exports[`TextField tests should render 1`] = `
 <input
   class="c0 c1"
   type="text"
+  value=""
 />
 `;
 
@@ -74,8 +75,8 @@ exports[`TextField tests should render in disabled state 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -87,5 +88,6 @@ exports[`TextField tests should render in disabled state 1`] = `
   class="c0 c1"
   disabled=""
   type="text"
+  value=""
 />
 `;

--- a/src/web/components/form/__tests__/__snapshots__/timezoneselect.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/timezoneselect.js.snap
@@ -10,8 +10,8 @@ exports[`TimezoneSelect tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -32,8 +32,8 @@ exports[`TimezoneSelect tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;

--- a/src/web/components/form/__tests__/__snapshots__/yesnoradio.js.snap
+++ b/src/web/components/form/__tests__/__snapshots__/yesnoradio.js.snap
@@ -10,8 +10,8 @@ exports[`YesNoRadio tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23,14 +23,14 @@ exports[`YesNoRadio tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c2>* {
+.c2 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2>* {
+.c2 > * {
   margin-left: 5px;
 }
 
@@ -81,8 +81,8 @@ exports[`YesNoRadio tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/icon/__tests__/__snapshots__/arrowicon.js.snap
+++ b/src/web/components/icon/__tests__/__snapshots__/arrowicon.js.snap
@@ -14,8 +14,8 @@ exports[`ArrowIcon component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;

--- a/src/web/components/icon/__tests__/__snapshots__/solutiontypeicon.js.snap
+++ b/src/web/components/icon/__tests__/__snapshots__/solutiontypeicon.js.snap
@@ -12,6 +12,10 @@ exports[`SolutionTypeIcon component tests should render correct image 1`] = `
   width: inherit;
 }
 
+@media print {
+
+}
+
 <span
   alt="Workaround"
   class="c0"
@@ -26,7 +30,13 @@ exports[`SolutionTypeIcon component tests should render correct image 1`] = `
 </span>
 `;
 
-exports[`SolutionTypeIcon component tests should render correct image 2`] = `<span />`;
+exports[`SolutionTypeIcon component tests should render correct image 2`] = `
+@media print {
+
+}
+
+<span />
+`;
 
 exports[`SolutionTypeIcon component tests should render correct image 3`] = `
 .c0 {
@@ -38,6 +48,10 @@ exports[`SolutionTypeIcon component tests should render correct image 3`] = `
 .c0 * {
   height: inherit;
   width: inherit;
+}
+
+@media print {
+
 }
 
 <span
@@ -66,6 +80,10 @@ exports[`SolutionTypeIcon component tests should render correct image 4`] = `
   width: inherit;
 }
 
+@media print {
+
+}
+
 <span
   alt="Vendorfix"
   class="c0"
@@ -90,6 +108,10 @@ exports[`SolutionTypeIcon component tests should render correct image 5`] = `
 .c0 * {
   height: inherit;
   width: inherit;
+}
+
+@media print {
+
 }
 
 <span
@@ -118,6 +140,10 @@ exports[`SolutionTypeIcon component tests should render correct image 6`] = `
   width: inherit;
 }
 
+@media print {
+
+}
+
 <span
   alt="Workaround"
   class="c0"
@@ -144,6 +170,10 @@ exports[`SolutionTypeIcon component tests should render correct image 7`] = `
   width: inherit;
 }
 
+@media print {
+
+}
+
 <span
   alt=""
   class="c0"
@@ -158,4 +188,10 @@ exports[`SolutionTypeIcon component tests should render correct image 7`] = `
 </span>
 `;
 
-exports[`SolutionTypeIcon component tests should render correct image 8`] = `<span />`;
+exports[`SolutionTypeIcon component tests should render correct image 8`] = `
+@media print {
+
+}
+
+<span />
+`;

--- a/src/web/components/icon/__tests__/__snapshots__/svgicon.js.snap
+++ b/src/web/components/icon/__tests__/__snapshots__/svgicon.js.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SVG icon component tests should render icon 1`] = `
-.c1 {
+.c0 {
   cursor: pointer;
 }
 
-.c2 {
+.c1 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c2 * {
+.c1 * {
   height: inherit;
   width: inherit;
 }
@@ -23,7 +23,7 @@ exports[`SVG icon component tests should render icon 1`] = `
 }
 
 <span
-  class="c0 c1 c2"
+  class="c0 c1"
   data-testid="svg-icon"
   title="Clone Entity"
 >

--- a/src/web/components/layout/__tests__/__snapshots__/Layout.js.snap
+++ b/src/web/components/layout/__tests__/__snapshots__/Layout.js.snap
@@ -10,8 +10,8 @@ exports[`Layout tests should create Layout with align="start" 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
 }
 
@@ -30,8 +30,8 @@ exports[`Layout tests should create Layout with align=[start, end] 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -54,8 +54,8 @@ exports[`Layout tests should create Layout with align=[stretch, center] 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: stretch;
-  -ms-flex-pack: stretch;
   -webkit-justify-content: stretch;
+  -ms-flex-pack: stretch;
   justify-content: stretch;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -81,8 +81,8 @@ exports[`Layout tests should create Layout with basis="20%" 1`] = `
   -ms-flex-preferred-size: 20%;
   flex-basis: 20%;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -108,8 +108,8 @@ exports[`Layout tests should create Layout with basis="auto" 1`] = `
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -132,8 +132,8 @@ exports[`Layout tests should create Layout with flex="column" align=[stretch, ce
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: stretch;
-  -ms-flex-pack: stretch;
   -webkit-justify-content: stretch;
+  -ms-flex-pack: stretch;
   justify-content: stretch;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -156,8 +156,8 @@ exports[`Layout tests should create Layout with flex="column" and align="start" 
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
 }
 
@@ -180,8 +180,8 @@ exports[`Layout tests should create Layout with grow 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -208,8 +208,8 @@ exports[`Layout tests should create Layout with grow="1" 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -236,8 +236,8 @@ exports[`Layout tests should create Layout with grow="666" 1`] = `
   -ms-flex-positive: 666;
   flex-grow: 666;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -263,8 +263,8 @@ exports[`Layout tests should create Layout with shrink 1`] = `
   -ms-flex-negative: 1;
   flex-shrink: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -290,8 +290,8 @@ exports[`Layout tests should create Layout with shrink="1" 1`] = `
   -ms-flex-negative: 1;
   flex-shrink: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -317,8 +317,8 @@ exports[`Layout tests should create Layout with shrink="666" 1`] = `
   -ms-flex-negative: 666;
   flex-shrink: 666;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -340,13 +340,12 @@ exports[`Layout tests should create Layout with wrap 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -368,13 +367,12 @@ exports[`Layout tests should create Layout with wrap=nowrap 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -396,13 +394,12 @@ exports[`Layout tests should create Layout with wrap=wrap 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -425,8 +422,8 @@ exports[`Layout tests should render Layout 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -449,8 +446,8 @@ exports[`Layout tests should render Layout with flex 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -473,8 +470,8 @@ exports[`Layout tests should render Layout with flex="column" 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -497,8 +494,8 @@ exports[`Layout tests should render Layout with flex="row" 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/layout/__tests__/__snapshots__/horizontalsep.js.snap
+++ b/src/web/components/layout/__tests__/__snapshots__/horizontalsep.js.snap
@@ -10,8 +10,8 @@ exports[`HorizontalSep tests should allow to wrap 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23,14 +23,14 @@ exports[`HorizontalSep tests should allow to wrap 1`] = `
   margin-left: -5px;
 }
 
-.c2>* {
+.c2 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2>* {
+.c2 > * {
   margin-left: 5px;
 }
 
@@ -42,13 +42,12 @@ exports[`HorizontalSep tests should allow to wrap 1`] = `
 }
 
 .c3 {
-  -webkit-box-flex-wrap: true;
   -webkit-flex-wrap: true;
   -ms-flex-wrap: true;
   flex-wrap: true;
 }
 
-.c3>*:not(:last-child)::after {
+.c3 > *:not(:last-child)::after {
   content: '•';
   margin-left: 5px;
 }
@@ -72,8 +71,8 @@ exports[`HorizontalSep tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -85,14 +84,14 @@ exports[`HorizontalSep tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c2>* {
+.c2 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2>* {
+.c2 > * {
   margin-left: 5px;
 }
 
@@ -103,7 +102,7 @@ exports[`HorizontalSep tests should render 1`] = `
   display: inline-flex;
 }
 
-.c3>*:not(:last-child)::after {
+.c3 > *:not(:last-child)::after {
   content: '•';
   margin-left: 5px;
 }
@@ -127,8 +126,8 @@ exports[`HorizontalSep tests should render with separator option 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -140,14 +139,14 @@ exports[`HorizontalSep tests should render with separator option 1`] = `
   margin-left: -5px;
 }
 
-.c2>* {
+.c2 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2>* {
+.c2 > * {
   margin-left: 5px;
 }
 
@@ -158,7 +157,7 @@ exports[`HorizontalSep tests should render with separator option 1`] = `
   display: inline-flex;
 }
 
-.c3>*:not(:last-child)::after {
+.c3 > *:not(:last-child)::after {
   content: '|';
   margin-left: 5px;
 }
@@ -182,8 +181,8 @@ exports[`HorizontalSep tests should render with spacing 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -195,14 +194,14 @@ exports[`HorizontalSep tests should render with spacing 1`] = `
   margin-left: -5px;
 }
 
-.c2>* {
+.c2 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2>* {
+.c2 > * {
   margin-left: 5px;
 }
 
@@ -213,7 +212,7 @@ exports[`HorizontalSep tests should render with spacing 1`] = `
   display: inline-flex;
 }
 
-.c3>*:not(:last-child)::after {
+.c3 > *:not(:last-child)::after {
   content: '|';
   margin-left: 10px;
 }

--- a/src/web/components/layout/__tests__/__snapshots__/withLayout.js.snap
+++ b/src/web/components/layout/__tests__/__snapshots__/withLayout.js.snap
@@ -10,8 +10,8 @@ exports[`withLayout HOC tests should create a new component 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -34,8 +34,8 @@ exports[`withLayout HOC tests should create a new component with align: [center,
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -58,8 +58,8 @@ exports[`withLayout HOC tests should create a new component with align: [start, 
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -82,8 +82,8 @@ exports[`withLayout HOC tests should create a new component with align: start 1`
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
 }
 
@@ -105,8 +105,8 @@ exports[`withLayout HOC tests should create a new component with basis: 20% 1`] 
   -ms-flex-preferred-size: 20%;
   flex-basis: 20%;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -132,8 +132,8 @@ exports[`withLayout HOC tests should create a new component with basis: auto 1`]
   -ms-flex-preferred-size: auto;
   flex-basis: auto;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -156,8 +156,8 @@ exports[`withLayout HOC tests should create a new component with flex 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -180,8 +180,8 @@ exports[`withLayout HOC tests should create a new component with flex: column 1`
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -204,8 +204,8 @@ exports[`withLayout HOC tests should create a new component with flex: column, a
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -228,8 +228,8 @@ exports[`withLayout HOC tests should create a new component with flex: column, a
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
 }
 
@@ -248,8 +248,8 @@ exports[`withLayout HOC tests should create a new component with flex: row 1`] =
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -276,8 +276,8 @@ exports[`withLayout HOC tests should create a new component with grow 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -304,8 +304,8 @@ exports[`withLayout HOC tests should create a new component with grow: 1 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -332,8 +332,8 @@ exports[`withLayout HOC tests should create a new component with grow: 666 1`] =
   -ms-flex-positive: 666;
   flex-grow: 666;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -359,8 +359,8 @@ exports[`withLayout HOC tests should create a new component with shrink 1`] = `
   -ms-flex-negative: 1;
   flex-shrink: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -386,8 +386,8 @@ exports[`withLayout HOC tests should create a new component with shrink: 1 1`] =
   -ms-flex-negative: 1;
   flex-shrink: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -413,8 +413,8 @@ exports[`withLayout HOC tests should create a new component with shrink: 666 1`]
   -ms-flex-negative: 666;
   flex-shrink: 666;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -436,13 +436,12 @@ exports[`withLayout HOC tests should create a new component with wrap 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -464,13 +463,12 @@ exports[`withLayout HOC tests should create a new component with wrap: nowrap 1`
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-flex-wrap: nowrap;
   -webkit-flex-wrap: nowrap;
   -ms-flex-wrap: nowrap;
   flex-wrap: nowrap;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -492,13 +490,12 @@ exports[`withLayout HOC tests should create a new component with wrap: wrap 1`] 
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/loading/__tests__/__snapshots__/loading.js.snap
+++ b/src/web/components/loading/__tests__/__snapshots__/loading.js.snap
@@ -10,8 +10,8 @@ exports[`Loading component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -24,9 +24,7 @@ exports[`Loading component tests should render 1`] = `
   height: 80px;
   margin: 40px auto;
   background-image: url(greenbone.svg);
-  -webkit-background-size: 90%;
   background-size: 90%;
-  -webkit-background-position: center;
   background-position: center;
   background-repeat: no-repeat;
   -webkit-animation: hGzRiT 2s infinite ease-in-out;

--- a/src/web/components/menu/__tests__/__snapshots__/usermenu.js.snap
+++ b/src/web/components/menu/__tests__/__snapshots__/usermenu.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`UserMenu component tests should render UserMenu 1`] = `
-.c8 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -10,8 +10,8 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -19,57 +19,57 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   align-items: center;
 }
 
-.c13 {
+.c14 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c10 {
+.c11 {
   margin-left: -5px;
 }
 
-.c10>* {
+.c11 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c10>* {
+.c11 > * {
   margin-left: 5px;
 }
 
-.c9 {
+.c10 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c12 {
+.c13 {
   cursor: pointer;
 }
 
-.c3 {
+.c2 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c3 * {
+.c2 * {
   height: inherit;
   width: inherit;
 }
 
-.c11 {
+.c12 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c11 * {
+.c12 * {
   height: inherit;
   width: inherit;
 }
@@ -91,7 +91,7 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   animation: bNcXmX 0.1s ease-in;
 }
 
-.c0:hover .c5 {
+.c0:hover .c4 {
   display: block;
 }
 
@@ -107,7 +107,7 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   width: 300px;
 }
 
-.c7 {
+.c8 {
   height: 30px;
   width: 300px;
   border-left: 1px solid #7F7F7F;
@@ -124,13 +124,13 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   padding-left: 12px;
 }
 
-.c7:hover {
+.c8:hover {
   background: #11ab51;
   color: #fff;
   cursor: pointer;
 }
 
-.c7:first-child {
+.c8:first-child {
   border-top: 1px solid #7F7F7F;
   cursor: default;
 }
@@ -139,7 +139,7 @@ background-color:#f3f3f3 .c7:first-child:hover {
   color: #000;
 }
 
-.c7:nth-child(2) {
+.c8:nth-child(2) {
   cursor: default;
 }
 
@@ -147,32 +147,36 @@ background-color:#f3f3f3 .c7:nth-child(2):hover {
   color: #000;
 }
 
-.c7:last-child {
+.c8:last-child {
   border-top: 1px solid #7F7F7F;
   border-bottom: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c3 {
   margin-right: 10px;
 }
 
-.c14 {
+.c15 {
   width: 100%;
   height: 100%;
 }
 
-.c14:link,
-.c14:hover,
-.c14:active,
-.c14:visited,
-.c14:hover {
+.c15:link,
+.c15:hover,
+.c15:active,
+.c15:visited,
+.c15:hover {
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 @media print {
-  .c2 {
+
+}
+
+@media print {
+  .c13 {
     display: none;
   }
 }
@@ -182,7 +186,7 @@ background-color:#f3f3f3 .c7:nth-child(2):hover {
   data-testid="usermenu"
 >
   <span
-    class="c2 c3 c4"
+    class="c2 c3"
     data-testid="svg-icon"
   >
     <svg>
@@ -190,23 +194,23 @@ background-color:#f3f3f3 .c7:nth-child(2):hover {
     </svg>
   </span>
   <div
-    class="c5"
+    class="c4 c5"
   >
     <ul
       class="c6"
     >
       <li
-        class="c7"
+        class="c7 c8"
         title="Logged in as: "
       >
         <div
-          class="c8 c9"
+          class="c9 c10"
         >
           <div
-            class="c8 c10"
+            class="c9 c11"
           >
             <span
-              class="c2 c11"
+              class="c12"
               data-testid="svg-icon"
             >
               <svg>
@@ -218,16 +222,16 @@ background-color:#f3f3f3 .c7:nth-child(2):hover {
         </div>
       </li>
       <li
-        class="c7"
+        class="c7 c8"
       >
         <div
-          class="c8 c9"
+          class="c9 c10"
         >
           <div
-            class="c8 c10"
+            class="c9 c11"
           >
             <span
-              class="c2 c11"
+              class="c12"
               data-testid="svg-icon"
             >
               <svg>
@@ -238,7 +242,7 @@ background-color:#f3f3f3 .c7:nth-child(2):hover {
               Session timeout: 
             </span>
             <span
-              class="c2 c12 c11"
+              class="c13 c12"
               data-testid="svg-icon"
               title="Renew session timeout"
             >
@@ -252,21 +256,21 @@ background-color:#f3f3f3 .c7:nth-child(2):hover {
         </div>
       </li>
       <li
-        class="c7"
+        class="c7 c8"
       >
         <a
-          class="c13 c14"
+          class="c14 c15"
           data-testid="usermenu-settings"
           href="/usersettings"
         >
           <div
-            class="c8 c9"
+            class="c9 c10"
           >
             <div
-              class="c8 c10"
+              class="c9 c11"
             >
               <span
-                class="c2 c11"
+                class="c12"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -281,17 +285,17 @@ background-color:#f3f3f3 .c7:nth-child(2):hover {
         </a>
       </li>
       <li
-        class="c7"
+        class="c7 c8"
         data-testid="usermenu-logout"
       >
         <div
-          class="c8 c9"
+          class="c9 c10"
         >
           <div
-            class="c8 c10"
+            class="c9 c11"
           >
             <span
-              class="c2 c11"
+              class="c12"
               data-testid="svg-icon"
             >
               <svg>

--- a/src/web/components/panel/__tests__/__snapshots__/button.js.snap
+++ b/src/web/components/panel/__tests__/__snapshots__/button.js.snap
@@ -55,8 +55,8 @@ exports[`InfoPanel button tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/powerfilter/__tests__/__snapshots__/applyoverridesgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/applyoverridesgroup.js.snap
@@ -10,8 +10,8 @@ exports[`ApplyOverridesGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23,14 +23,14 @@ exports[`ApplyOverridesGroup tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c5>* {
+.c5 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5>* {
+.c5 > * {
   margin-left: 5px;
 }
 
@@ -51,8 +51,8 @@ exports[`ApplyOverridesGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -114,8 +114,8 @@ exports[`ApplyOverridesGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/powerfilter/__tests__/__snapshots__/booleanfiltergroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/booleanfiltergroup.js.snap
@@ -10,8 +10,8 @@ exports[`BooleanFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23,14 +23,14 @@ exports[`BooleanFilterGroup tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c5>* {
+.c5 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5>* {
+.c5 > * {
   margin-left: 5px;
 }
 
@@ -51,8 +51,8 @@ exports[`BooleanFilterGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -114,8 +114,8 @@ exports[`BooleanFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/powerfilter/__tests__/__snapshots__/createnamedfiltergroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/createnamedfiltergroup.js.snap
@@ -10,8 +10,8 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23,14 +23,14 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c3>* {
+.c3 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c3>* {
+.c3 > * {
   margin-left: 5px;
 }
 
@@ -80,8 +80,8 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -129,8 +129,8 @@ exports[`CreateNamedFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/powerfilter/__tests__/__snapshots__/filtersearchgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/filtersearchgroup.js.snap
@@ -10,8 +10,8 @@ exports[`FilterSearchGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -29,8 +29,8 @@ exports[`FilterSearchGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -71,8 +71,8 @@ exports[`FilterSearchGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/powerfilter/__tests__/__snapshots__/filterstringgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/filterstringgroup.js.snap
@@ -10,8 +10,8 @@ exports[`FilterStringGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -29,8 +29,8 @@ exports[`FilterStringGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -92,8 +92,8 @@ exports[`FilterStringGroup tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/powerfilter/__tests__/__snapshots__/firstresultgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/firstresultgroup.js.snap
@@ -10,8 +10,8 @@ exports[`FirstresultGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -29,8 +29,8 @@ exports[`FirstresultGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }

--- a/src/web/components/powerfilter/__tests__/__snapshots__/minqodgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/minqodgroup.js.snap
@@ -10,8 +10,8 @@ exports[`MinQodGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23,14 +23,14 @@ exports[`MinQodGroup tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c5>* {
+.c5 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5>* {
+.c5 > * {
   margin-left: 5px;
 }
 
@@ -51,8 +51,8 @@ exports[`MinQodGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }

--- a/src/web/components/powerfilter/__tests__/__snapshots__/relationselector.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/relationselector.js.snap
@@ -10,8 +10,8 @@ exports[`Relation Selector Tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -32,8 +32,8 @@ exports[`Relation Selector Tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -187,8 +187,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -209,8 +209,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;

--- a/src/web/components/powerfilter/__tests__/__snapshots__/resultsperpagegroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/resultsperpagegroup.js.snap
@@ -10,8 +10,8 @@ exports[`ResultsPerPageGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -29,8 +29,8 @@ exports[`ResultsPerPageGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }

--- a/src/web/components/powerfilter/__tests__/__snapshots__/severitylevelsgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/severitylevelsgroup.js.snap
@@ -10,8 +10,8 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23,14 +23,14 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c5>* {
+.c5 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5>* {
+.c5 > * {
   margin-left: 5px;
 }
 
@@ -51,8 +51,8 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -110,8 +110,8 @@ exports[`SeverityLevelsFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/powerfilter/__tests__/__snapshots__/severityvaluesgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/severityvaluesgroup.js.snap
@@ -10,8 +10,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -32,8 +32,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -187,8 +187,8 @@ exports[`Severity Values Group Tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -205,8 +205,8 @@ exports[`Severity Values Group Tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -218,14 +218,14 @@ exports[`Severity Values Group Tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c5>* {
+.c5 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5>* {
+.c5 > * {
   margin-left: 5px;
 }
 
@@ -246,8 +246,8 @@ exports[`Severity Values Group Tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -282,8 +282,8 @@ exports[`Severity Values Group Tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;

--- a/src/web/components/powerfilter/__tests__/__snapshots__/solutiontypegroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/solutiontypegroup.js.snap
@@ -10,8 +10,8 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -28,8 +28,8 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -41,14 +41,14 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c9>* {
+.c9 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c9>* {
+.c9 > * {
   margin-left: 5px;
 }
 
@@ -80,8 +80,8 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -148,8 +148,8 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -162,6 +162,10 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
   -webkit-flex-grow: 0;
   -ms-flex-positive: 0;
   flex-grow: 0;
+}
+
+@media print {
+
 }
 
 @media print {
@@ -212,6 +216,7 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
                         data-testid="radio-input"
                         name="All"
                         type="radio"
+                        value=""
                       />
                       <span>
                         All
@@ -239,6 +244,7 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
                         data-testid="radio-input"
                         name="Workaround"
                         type="radio"
+                        value=""
                       />
                       <span
                         alt="Workaround"
@@ -278,6 +284,7 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
                         data-testid="radio-input"
                         name="Mitigation"
                         type="radio"
+                        value=""
                       />
                       <span
                         alt="Mitigation"
@@ -319,6 +326,7 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
                         data-testid="radio-input"
                         name="VendorFix"
                         type="radio"
+                        value=""
                       />
                       <span
                         alt="Vendorfix"
@@ -358,6 +366,7 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
                         data-testid="radio-input"
                         name="NoneAvailable"
                         type="radio"
+                        value=""
                       />
                       <span
                         alt="None available"
@@ -397,6 +406,7 @@ exports[`SolutionTypesFilterGroup tests should render 1`] = `
                         data-testid="radio-input"
                         name="WillNotFix"
                         type="radio"
+                        value=""
                       />
                       <span
                         alt="Will not fix"

--- a/src/web/components/powerfilter/__tests__/__snapshots__/sortbygroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/sortbygroup.js.snap
@@ -10,8 +10,8 @@ exports[`SortByGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -28,8 +28,8 @@ exports[`SortByGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -41,14 +41,14 @@ exports[`SortByGroup tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c15>* {
+.c15 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c15>* {
+.c15 > * {
   margin-left: 5px;
 }
 
@@ -69,8 +69,8 @@ exports[`SortByGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -105,8 +105,8 @@ exports[`SortByGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -243,8 +243,8 @@ exports[`SortByGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/powerfilter/__tests__/__snapshots__/tasktrendgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/tasktrendgroup.js.snap
@@ -10,8 +10,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -32,8 +32,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -187,8 +187,8 @@ exports[`Task Trend Selector Tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -205,8 +205,8 @@ exports[`Task Trend Selector Tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -224,8 +224,8 @@ exports[`Task Trend Selector Tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -260,8 +260,8 @@ exports[`Task Trend Selector Tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;

--- a/src/web/components/powerfilter/__tests__/__snapshots__/ticketstatusgroup.js.snap
+++ b/src/web/components/powerfilter/__tests__/__snapshots__/ticketstatusgroup.js.snap
@@ -10,8 +10,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -32,8 +32,8 @@ exports[`Select component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -187,8 +187,8 @@ exports[`TicketStatusGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -205,8 +205,8 @@ exports[`TicketStatusGroup tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -224,8 +224,8 @@ exports[`TicketStatusGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -260,8 +260,8 @@ exports[`TicketStatusGroup tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;

--- a/src/web/components/snackbar/__tests__/__snapshots__/snackbar.js.snap
+++ b/src/web/components/snackbar/__tests__/__snapshots__/snackbar.js.snap
@@ -17,8 +17,8 @@ exports[`Snackbar tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: space-around;
-  -ms-flex-pack: space-around;
   -webkit-justify-content: space-around;
+  -ms-flex-pack: space-around;
   justify-content: space-around;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/structure/__tests__/__snapshots__/header.js.snap
+++ b/src/web/components/structure/__tests__/__snapshots__/header.js.snap
@@ -10,8 +10,8 @@ exports[`Header tests should render header 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -40,6 +40,7 @@ exports[`Header tests should render header 1`] = `
   display: flex;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/components/structure/__tests__/__snapshots__/main.js.snap
+++ b/src/web/components/structure/__tests__/__snapshots__/main.js.snap
@@ -16,8 +16,8 @@ exports[`Main tests should render main 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
 }
 

--- a/src/web/components/table/__tests__/__snapshots__/detailstable.js.snap
+++ b/src/web/components/table/__tests__/__snapshots__/detailstable.js.snap
@@ -10,8 +10,8 @@ exports[`DetailsTable tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;

--- a/src/web/entities/__tests__/__snapshots__/tagsdialog.js.snap
+++ b/src/web/entities/__tests__/__snapshots__/tagsdialog.js.snap
@@ -11,6 +11,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -31,8 +32,8 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -49,8 +50,8 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -67,8 +68,8 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -85,8 +86,8 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -94,7 +95,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   align-items: center;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -106,8 +107,8 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -119,14 +120,14 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   margin-left: -5px;
 }
 
-.c16>* {
+.c16 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c16>* {
+.c16 > * {
   margin-left: 5px;
 }
 
@@ -137,17 +138,17 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   display: inline-flex;
 }
 
-.c27 {
+.c26 {
   cursor: pointer;
 }
 
-.c28 {
+.c27 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c28 * {
+.c27 * {
   height: inherit;
   width: inherit;
 }
@@ -177,7 +178,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -185,7 +186,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   height: 100%;
 }
 
-.c36 {
+.c35 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -194,13 +195,13 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   border-top: 20px solid #fff;
 }
 
-.c35 {
+.c34 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -236,15 +237,15 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -259,7 +260,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   width: inherit;
 }
 
-.c32 {
+.c31 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -279,12 +280,12 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   z-index: 1;
 }
 
-.c32:focus,
-.c32:hover {
+.c31:focus,
+.c31:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c32:hover {
+.c31:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -292,26 +293,26 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   color: #fff;
 }
 
-.c32[disabled] {
+.c31[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c32 img {
+.c31 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c32:link {
+.c31:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c33 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -320,8 +321,8 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -329,18 +330,18 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   align-items: center;
 }
 
-.c34 {
+.c33 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c34 :hover {
+.c33:hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c30 {
+.c29 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
@@ -348,9 +349,10 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   padding: 10px 20px 10px 20px;
 }
 
-.c31 {
+.c30 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -368,11 +370,13 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 
@@ -399,8 +403,8 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -435,8 +439,8 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -647,7 +651,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
                             </div>
                           </div>
                           <span
-                            class="c26 c27 c28"
+                            class="c26 c27"
                             data-testid="svg-icon"
                             title="Create a new Tag"
                           >
@@ -693,17 +697,17 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
               </div>
             </div>
             <div
-              class="c29 c30 c31"
+              class="c28 c29 c30"
             >
               <button
-                class="c32 c33 c34"
+                class="c31 c32 c33"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c32 c33 c34"
+                class="c31 c32 c33"
                 data-testid="dialog-save-button"
                 title="Add Tag"
               >
@@ -712,10 +716,10 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
             </div>
           </div>
           <div
-            class="c35"
+            class="c34"
           >
             <div
-              class="c36"
+              class="c35"
             />
           </div>
         </div>
@@ -737,6 +741,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -757,8 +762,8 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -775,8 +780,8 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -793,8 +798,8 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -811,8 +816,8 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -820,7 +825,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -832,8 +837,8 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -845,14 +850,14 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   margin-left: -5px;
 }
 
-.c16>* {
+.c16 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c16>* {
+.c16 > * {
   margin-left: 5px;
 }
 
@@ -863,17 +868,17 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   display: inline-flex;
 }
 
-.c27 {
+.c26 {
   cursor: pointer;
 }
 
-.c28 {
+.c27 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c28 * {
+.c27 * {
   height: inherit;
   width: inherit;
 }
@@ -903,7 +908,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -911,7 +916,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   height: 100%;
 }
 
-.c36 {
+.c35 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -920,13 +925,13 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c35 {
+.c34 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -962,15 +967,15 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -985,7 +990,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   width: inherit;
 }
 
-.c32 {
+.c31 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -1005,12 +1010,12 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   z-index: 1;
 }
 
-.c32:focus,
-.c32:hover {
+.c31:focus,
+.c31:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c32:hover {
+.c31:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -1018,26 +1023,26 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   color: #fff;
 }
 
-.c32[disabled] {
+.c31[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c32 img {
+.c31 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c32:link {
+.c31:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c33 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1046,8 +1051,8 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1055,18 +1060,18 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c34 {
+.c33 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c34 :hover {
+.c33:hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c30 {
+.c29 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
@@ -1074,9 +1079,10 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   padding: 10px 20px 10px 20px;
 }
 
-.c31 {
+.c30 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -1094,11 +1100,13 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 
@@ -1125,8 +1133,8 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -1161,8 +1169,8 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -1370,7 +1378,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
                             </div>
                           </div>
                           <span
-                            class="c26 c27 c28"
+                            class="c26 c27"
                             data-testid="svg-icon"
                             title="Create a new Tag"
                           >
@@ -1416,17 +1424,17 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c29 c30 c31"
+              class="c28 c29 c30"
             >
               <button
-                class="c32 c33 c34"
+                class="c31 c32 c33"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c32 c33 c34"
+                class="c31 c32 c33"
                 data-testid="dialog-save-button"
                 title="Add Tag"
               >
@@ -1435,10 +1443,10 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
             </div>
           </div>
           <div
-            class="c35"
+            class="c34"
           >
             <div
-              class="c36"
+              class="c35"
             />
           </div>
         </div>

--- a/src/web/pages/audits/__tests__/__snapshots__/actions.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/actions.js.snap
@@ -14,8 +14,8 @@ exports[`Audit Actions tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -36,8 +36,8 @@ exports[`Audit Actions tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -58,8 +58,8 @@ exports[`Audit Actions tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -71,14 +71,14 @@ exports[`Audit Actions tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c4>* {
+.c4 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4>* {
+.c4 > * {
   margin-left: 5px;
 }
 
@@ -89,21 +89,21 @@ exports[`Audit Actions tests should render 1`] = `
   display: inline-flex;
 }
 
-.c6 {
+.c5 {
   cursor: pointer;
 }
 
-.c8 svg path {
+.c7 svg path {
   fill: #bfbfbf;
 }
 
-.c7 {
+.c6 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c7 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
@@ -112,6 +112,10 @@ exports[`Audit Actions tests should render 1`] = `
   .c5 {
     display: none;
   }
+}
+
+@media print {
+
 }
 
 <body>
@@ -130,7 +134,7 @@ exports[`Audit Actions tests should render 1`] = `
             class="c3 c4"
           >
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Start"
             >
@@ -142,7 +146,7 @@ exports[`Audit Actions tests should render 1`] = `
             </span>
             <span
               alt="Resume"
-              class="c5 c8 c7"
+              class="c7 c6"
               data-testid="svg-icon"
               title="Audit is not stopped"
             >
@@ -153,7 +157,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Move Audit to trashcan"
             >
@@ -164,7 +168,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Edit Audit"
             >
@@ -175,7 +179,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Clone Audit"
             >
@@ -186,7 +190,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Export Audit"
             >
@@ -197,7 +201,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Download Greenbone Compliance Report"
             >

--- a/src/web/pages/audits/__tests__/__snapshots__/details.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/details.js.snap
@@ -14,8 +14,8 @@ exports[`Audit Details tests should render full audit details 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -32,8 +32,8 @@ exports[`Audit Details tests should render full audit details 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -50,8 +50,8 @@ exports[`Audit Details tests should render full audit details 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -70,14 +70,14 @@ exports[`Audit Details tests should render full audit details 1`] = `
   margin-left: -5px;
 }
 
-.c5>* {
+.c5 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5>* {
+.c5 > * {
   margin-left: 5px;
 }
 
@@ -97,7 +97,7 @@ exports[`Audit Details tests should render full audit details 1`] = `
   width: 100%;
 }
 
-.c6>*:not(:last-child)::after {
+.c6 > *:not(:last-child)::after {
   content: '•';
   margin-left: 5px;
 }

--- a/src/web/pages/audits/__tests__/__snapshots__/detailspage.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/detailspage.js.snap
@@ -14,8 +14,8 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
 }
 
@@ -29,6 +29,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -45,8 +46,8 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -63,8 +64,8 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -72,7 +73,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   align-items: flex-start;
 }
 
-.c14 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -82,243 +83,12 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
   align-items: flex-end;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
-.c22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c23 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-}
-
-.c25 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c26 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
-.c28 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c31 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c33 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c9 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4 {
-  margin-left: -10px;
-}
-
-.c4>* {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4>* {
-  margin-left: 10px;
-}
-
-.c6 {
-  margin-left: -5px;
-}
-
-.c6>* {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c6>* {
-  margin-left: 5px;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c10 {
-  cursor: pointer;
-}
-
-.c11 svg path {
-  fill: #bfbfbf;
-}
-
-.c8 {
-  height: 16px;
-  width: 16px;
-  line-height: 16px;
-}
-
-.c8 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c20 {
-  height: 50px;
-  width: 50px;
-  line-height: 50px;
-}
-
-.c20 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c15 {
-  margin: 10px 0px;
-  padding-bottom: 1px;
-  border-bottom: 2px solid #e5e5e5;
-  position: relative;
-}
-
-.c16 {
-  margin: 0 0 1px 0;
 }
 
 .c17 {
@@ -330,8 +100,102 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c22 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c24 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c25 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c27 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -339,16 +203,155 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
+.c30 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c32 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4 {
+  margin-left: -10px;
+}
+
+.c4 > * {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4 > * {
+  margin-left: 10px;
+}
+
+.c6 {
+  margin-left: -5px;
+}
+
+.c6 > * {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c6 > * {
+  margin-left: 5px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c9 {
+  cursor: pointer;
+}
+
+.c10 svg path {
+  fill: #bfbfbf;
+}
+
+.c7 {
+  height: 16px;
+  width: 16px;
+  line-height: 16px;
+}
+
+.c7 * {
+  height: inherit;
+  width: inherit;
+}
+
 .c19 {
+  height: 50px;
+  width: 50px;
+  line-height: 50px;
+}
+
+.c19 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c14 {
+  margin: 10px 0px;
+  padding-bottom: 1px;
+  border-bottom: 2px solid #e5e5e5;
+  position: relative;
+}
+
+.c15 {
+  margin: 0 0 1px 0;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c18 {
   margin-right: 5px;
 }
 
-.c21 {
+.c20 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c29 {
+.c28 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -375,15 +378,15 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #11ab51;
 }
 
-.c29 :hover {
+.c28:hover {
   border-top: 2px solid #fff;
 }
 
-.c29 :first-child {
+.c28:first-child {
   border-left: 1px solid #e5e5e5;
 }
 
-.c30 {
+.c29 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -407,21 +410,21 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #fff;
 }
 
-.c30 :hover {
+.c29:hover {
   border-top: 2px solid #e5e5e5;
 }
 
-.c30 :first-child {
+.c29:first-child {
   border-left: 1px solid #fff;
 }
 
-.c27 {
+.c26 {
   border-bottom: 2px solid #11ab51;
   margin-top: 30px;
   margin-bottom: 15px;
 }
 
-.c34 {
+.c33 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -429,7 +432,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   table-layout: auto;
 }
 
-.c44 {
+.c43 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -438,46 +441,46 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   width: 100%;
 }
 
-.c43>*:not(:last-child)::after {
+.c42 > *:not(:last-child)::after {
   content: '•';
   margin-left: 5px;
 }
 
-.c35 td {
+.c34 td {
   padding: 4px 4px 4px 0;
 }
 
-.c35 tr td:first-child {
+.c34 tr td:first-child {
   padding-right: 5px;
 }
 
-.c24 {
+.c23 {
   border-spacing: 0px;
   color: #7F7F7F;
   font-size: 10px;
 }
 
-.c24 :nth-child(even) {
+.c23 :nth-child(even) {
   margin-left: 3px;
 }
 
-.c24 :nth-child(odd) {
+.c23 :nth-child(odd) {
   margin-left: 30px;
 }
 
-.c36 {
+.c35 {
   width: 10%;
 }
 
-.c37 {
+.c36 {
   width: 90%;
 }
 
-.c32 {
+.c31 {
   font-size: 0.7em;
 }
 
-.c39 {
+.c38 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -487,7 +490,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   text-align: center;
 }
 
-.c41 {
+.c40 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -498,22 +501,22 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   padding-top: 1px;
 }
 
-.c40 {
+.c39 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
 }
 
-.c42 {
+.c41 {
   white-space: nowrap;
 }
 
-.c38:hover {
+.c37:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c12 {
+.c11 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -522,7 +525,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   margin-right: 0px;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -530,13 +533,12 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -560,38 +562,46 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
 }
 
 @media print {
-  .c7 {
+
+}
+
+@media print {
+  .c9 {
     display: none;
   }
 }
 
 @media print {
-  .c34 {
+
+}
+
+@media print {
+  .c33 {
     border-collapse: collapse;
   }
 }
 
 @media print {
-  .c44 {
+  .c43 {
     border-collapse: collapse;
   }
 }
 
 @media print {
-  .c39 {
+  .c38 {
     background: none;
     border: 0;
   }
 }
 
 @media print {
-  .c41 {
+  .c40 {
     color: black;
   }
 }
 
 @media print {
-  .c40 {
+  .c39 {
     background: none;
   }
 }
@@ -620,7 +630,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               target="_blank"
             >
               <span
-                class="c7 c8"
+                class="c7"
                 data-testid="svg-icon"
                 title="Help: Audits"
               >
@@ -632,11 +642,11 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <a
-              class="c9"
+              class="c8"
               href="/audits"
             >
               <span
-                class="c7 c8"
+                class="c7"
                 data-testid="svg-icon"
                 title="Audit List"
               >
@@ -648,7 +658,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <span
-              class="c7 c8"
+              class="c7"
               data-testid="svg-icon"
               title="This is an Alterable Audit. Reports may not relate to current Policy or Target!"
             >
@@ -667,7 +677,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             class="c2 c6"
           >
             <span
-              class="c7 c10 c8"
+              class="c9 c7"
               data-testid="svg-icon"
               title="Clone Audit"
             >
@@ -678,7 +688,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c10 c8"
+              class="c9 c7"
               data-testid="svg-icon"
               title="Edit Audit"
             >
@@ -689,7 +699,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c10 c8"
+              class="c9 c7"
               data-testid="svg-icon"
               title="Move Audit to trashcan"
             >
@@ -700,7 +710,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c10 c8"
+              class="c9 c7"
               data-testid="svg-icon"
               title="Export Audit as XML"
             >
@@ -719,7 +729,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             class="c2 c6"
           >
             <span
-              class="c7 c10 c8"
+              class="c9 c7"
               data-testid="svg-icon"
               title="Start"
             >
@@ -731,7 +741,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </span>
             <span
               alt="Resume"
-              class="c7 c11 c8"
+              class="c10 c7"
               data-testid="svg-icon"
               title="Audit is not stopped"
             >
@@ -756,13 +766,13 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                 class="c2 c6"
               >
                 <a
-                  class="c9"
+                  class="c8"
                   data-testid="details-link"
                   href="/report/1234"
                   title="Last Report for Audit foo from 07/30/2019"
                 >
                   <span
-                    class="c7 c8"
+                    class="c7"
                     data-testid="svg-icon"
                   >
                     <svg>
@@ -771,15 +781,15 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   </span>
                 </a>
                 <a
-                  class="c9"
+                  class="c8"
                   href="/reports?filter=task_id%3D12345"
                   title="Total Reports for Audit foo"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span
-                      class="c7 c8"
+                      class="c7"
                       data-testid="svg-icon"
                     >
                       <svg>
@@ -787,7 +797,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c13"
+                      class="c12"
                       data-testid="badge-icon"
                     >
                       1
@@ -797,15 +807,15 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </div>
             </div>
             <a
-              class="c9"
+              class="c8"
               href="/results?filter=task_id%3D12345"
               title="Results for Audit foo"
             >
               <div
-                class="c12"
+                class="c11"
               >
                 <span
-                  class="c7 c8"
+                  class="c7"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -813,7 +823,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c13"
+                  class="c12"
                   data-testid="badge-icon"
                 >
                   1
@@ -829,16 +839,16 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
     class="entity-section"
   >
     <div
-      class="c14 c15 section-header"
+      class="c13 c14 section-header"
     >
       <h2
-        class="c16 c17"
+        class="c15 c16"
       >
         <div
-          class="c18 c19"
+          class="c17 c18"
         >
           <span
-            class="c7 c20"
+            class="c19"
             data-testid="svg-icon"
           >
             <svg>
@@ -847,19 +857,19 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
           </span>
         </div>
         <div
-          class="c18 c21"
+          class="c17 c20"
         >
           Audit: foo
         </div>
       </h2>
       <div
-        class="c22"
+        class="c21"
       >
         <div
-          class="c23"
+          class="c22"
         >
           <div
-            class="c2 c24"
+            class="c2 c23"
           >
             <div>
               ID:
@@ -890,30 +900,30 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
       </div>
     </div>
     <div
-      class="c25"
+      class="c24"
     >
       <div
-        class="c26 c27"
+        class="c25 c26"
       >
         <div
-          class="c28"
+          class="c27"
         >
           <div
-            class="c29"
+            class="c28"
           >
             Information
           </div>
           <div
-            class="c30"
+            class="c29"
           >
             <div
-              class="c31"
+              class="c30"
             >
               <span>
                 Permissions
               </span>
               <span
-                class="c32"
+                class="c31"
               >
                 (
                 <i>
@@ -926,18 +936,18 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
         </div>
       </div>
       <div
-        class="c33"
+        class="c32"
       >
         <table
-          class="c34 c35"
+          class="c33 c34"
         >
           <colgroup>
             <col
-              class="c36"
+              class="c35"
               width="10%"
             />
             <col
-              class="c37"
+              class="c36"
               width="90%"
             />
           </colgroup>
@@ -947,14 +957,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   Name
                 </div>
               </td>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   foo
                 </div>
@@ -963,14 +973,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   Comment
                 </div>
               </td>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   bar
                 </div>
@@ -979,14 +989,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   Alterable
                 </div>
               </td>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   Yes
                 </div>
@@ -995,35 +1005,35 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   Status
                 </div>
               </td>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   <a
-                    class="c9 c38"
+                    class="c8 c37"
                     data-testid="details-link"
                     href="/report/1234"
                   >
                     <div
-                      class="c39"
+                      class="c38"
                       data-testid="progressbar-box"
                       title="Done"
                     >
                       <div
                         background="low"
-                        class="c40"
+                        class="c39"
                         data-testid="progress"
                       />
                       <div
-                        class="c41"
+                        class="c40"
                       >
                         <span
-                          class="c42"
+                          class="c41"
                         >
                           Done
                         </span>
@@ -1036,17 +1046,17 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
           </tbody>
         </table>
         <div
-          class="c25"
+          class="c24"
         >
           <div
-            class="c33"
+            class="c32"
           >
             <h2>
               Target
             </h2>
             <div>
               <a
-                class="c9"
+                class="c8"
                 data-testid="details-link"
                 href="/target/5678"
               >
@@ -1055,7 +1065,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c33"
+            class="c32"
           >
             <h2>
               Alerts
@@ -1065,11 +1075,11 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                 class="c2 c3"
               >
                 <div
-                  class="c2 c6 c43"
+                  class="c2 c6 c42"
                 >
                   <span>
                     <a
-                      class="c9"
+                      class="c8"
                       data-testid="details-link"
                       href="/alert/91011"
                     >
@@ -1081,22 +1091,22 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c33"
+            class="c32"
           >
             <h2>
               Scanner
             </h2>
             <div>
               <table
-                class="c44 c35"
+                class="c43 c34"
               >
                 <colgroup>
                   <col
-                    class="c36"
+                    class="c35"
                     width="10%"
                   />
                   <col
-                    class="c37"
+                    class="c36"
                     width="90%"
                   />
                 </colgroup>
@@ -1106,18 +1116,18 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         Name
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         <span>
                           <a
-                            class="c9"
+                            class="c8"
                             data-testid="details-link"
                             href="/scanner/1516"
                           >
@@ -1130,14 +1140,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         Type
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         OpenVAS Scanner
                       </div>
@@ -1148,22 +1158,22 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c33"
+            class="c32"
           >
             <h2>
               Assets
             </h2>
             <div>
               <table
-                class="c44 c35"
+                class="c43 c34"
               >
                 <colgroup>
                   <col
-                    class="c36"
+                    class="c35"
                     width="10%"
                   />
                   <col
-                    class="c37"
+                    class="c36"
                     width="90%"
                   />
                 </colgroup>
@@ -1173,14 +1183,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         Add to Assets
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         Yes
                       </div>
@@ -1191,22 +1201,22 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c33"
+            class="c32"
           >
             <h2>
               Scan
             </h2>
             <div>
               <table
-                class="c44 c35"
+                class="c43 c34"
               >
                 <colgroup>
                   <col
-                    class="c36"
+                    class="c35"
                     width="10%"
                   />
                   <col
-                    class="c37"
+                    class="c36"
                     width="90%"
                   />
                 </colgroup>
@@ -1216,14 +1226,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         Duration of last Scan
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         2 minutes
                       </div>
@@ -1232,14 +1242,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         Auto delete Reports
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         Do not automatically delete reports
                       </div>
@@ -1266,8 +1276,8 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1284,8 +1294,8 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -1293,7 +1303,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
   align-items: flex-start;
 }
 
-.c7 {
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1304,14 +1314,14 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
   margin-left: -10px;
 }
 
-.c2>* {
+.c2 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2>* {
+.c2 > * {
   margin-left: 10px;
 }
 
@@ -1319,14 +1329,14 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c4>* {
+.c4 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4>* {
+.c4 > * {
   margin-left: 5px;
 }
 
@@ -1337,26 +1347,26 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
   display: inline-flex;
 }
 
-.c8 {
+.c7 {
   cursor: pointer;
 }
 
-.c9 svg path {
+.c8 svg path {
   fill: #bfbfbf;
 }
 
-.c6 {
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
-.c10 {
+.c9 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1365,7 +1375,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
   margin-right: 0px;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1373,13 +1383,12 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -1403,9 +1412,17 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
 }
 
 @media print {
-  .c5 {
+
+}
+
+@media print {
+  .c7 {
     display: none;
   }
+}
+
+@media print {
+
 }
 
 <div
@@ -1426,7 +1443,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           target="_blank"
         >
           <span
-            class="c5 c6"
+            class="c5"
             data-testid="svg-icon"
             title="Help: Audits"
           >
@@ -1438,11 +1455,11 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <a
-          class="c7"
+          class="c6"
           href="/audits"
         >
           <span
-            class="c5 c6"
+            class="c5"
             data-testid="svg-icon"
             title="Audit List"
           >
@@ -1454,7 +1471,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <span
-          class="c5 c6"
+          class="c5"
           data-testid="svg-icon"
           title="This is an Alterable Audit. Reports may not relate to current Policy or Target!"
         >
@@ -1473,7 +1490,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
         class="c0 c4"
       >
         <span
-          class="c5 c8 c6"
+          class="c7 c5"
           data-testid="svg-icon"
           title="Clone Audit"
         >
@@ -1484,7 +1501,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c8 c6"
+          class="c7 c5"
           data-testid="svg-icon"
           title="Edit Audit"
         >
@@ -1495,7 +1512,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c8 c6"
+          class="c7 c5"
           data-testid="svg-icon"
           title="Move Audit to trashcan"
         >
@@ -1506,7 +1523,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c8 c6"
+          class="c7 c5"
           data-testid="svg-icon"
           title="Export Audit as XML"
         >
@@ -1525,7 +1542,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
         class="c0 c4"
       >
         <span
-          class="c5 c8 c6"
+          class="c7 c5"
           data-testid="svg-icon"
           title="Start"
         >
@@ -1537,7 +1554,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
         </span>
         <span
           alt="Resume"
-          class="c5 c9 c6"
+          class="c8 c5"
           data-testid="svg-icon"
           title="Audit is not stopped"
         >
@@ -1562,13 +1579,13 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
             class="c0 c4"
           >
             <a
-              class="c7"
+              class="c6"
               data-testid="details-link"
               href="/report/1234"
               title="Last Report for Audit foo from 07/30/2019"
             >
               <span
-                class="c5 c6"
+                class="c5"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -1577,15 +1594,15 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
               </span>
             </a>
             <a
-              class="c7"
+              class="c6"
               href="/reports?filter=task_id%3D12345"
               title="Total Reports for Audit foo"
             >
               <div
-                class="c10"
+                class="c9"
               >
                 <span
-                  class="c5 c6"
+                  class="c5"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -1593,7 +1610,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c11"
+                  class="c10"
                   data-testid="badge-icon"
                 >
                   1
@@ -1603,15 +1620,15 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </div>
         </div>
         <a
-          class="c7"
+          class="c6"
           href="/results?filter=task_id%3D12345"
           title="Results for Audit foo"
         >
           <div
-            class="c10"
+            class="c9"
           >
             <span
-              class="c5 c6"
+              class="c5"
               data-testid="svg-icon"
             >
               <svg>
@@ -1619,7 +1636,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c11"
+              class="c10"
               data-testid="badge-icon"
             >
               1

--- a/src/web/pages/audits/__tests__/__snapshots__/listpage.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/listpage.js.snap
@@ -10,8 +10,8 @@ exports[`AuditPage ToolBarIcons test should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23,14 +23,14 @@ exports[`AuditPage ToolBarIcons test should render 1`] = `
   margin-left: -5px;
 }
 
-.c2>* {
+.c2 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2>* {
+.c2 > * {
   margin-left: 5px;
 }
 
@@ -41,23 +41,27 @@ exports[`AuditPage ToolBarIcons test should render 1`] = `
   display: inline-flex;
 }
 
-.c5 {
+.c4 {
   cursor: pointer;
 }
 
-.c4 {
+.c3 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c4 * {
+.c3 * {
   height: inherit;
   width: inherit;
 }
 
 @media print {
-  .c3 {
+
+}
+
+@media print {
+  .c4 {
     display: none;
   }
 }
@@ -74,7 +78,7 @@ exports[`AuditPage ToolBarIcons test should render 1`] = `
       target="_blank"
     >
       <span
-        class="c3 c4"
+        class="c3"
         data-testid="svg-icon"
         title="Help: Audits"
       >
@@ -86,7 +90,7 @@ exports[`AuditPage ToolBarIcons test should render 1`] = `
       </span>
     </a>
     <span
-      class="c3 c5 c4"
+      class="c4 c3"
       data-testid="svg-icon"
       title="New Audit"
     >
@@ -114,8 +118,8 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -133,6 +137,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -149,8 +154,8 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -158,7 +163,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -171,12 +176,12 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -185,13 +190,31 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: stetch;
   -webkit-box-align: stetch;
   -ms-flex-align: stetch;
   align-items: stetch;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c10 {
@@ -202,26 +225,9 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -229,7 +235,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -238,8 +244,8 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -247,7 +253,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c25 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -257,6 +263,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -264,7 +271,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: flex-end;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -273,8 +280,8 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -282,7 +289,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: flex-end;
 }
 
-.c34 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -296,10 +303,11 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   flex-grow: 1;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c36 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -308,8 +316,8 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -317,7 +325,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c49 {
+.c48 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -326,12 +334,12 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
 }
 
-.c50 {
+.c49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -340,8 +348,8 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -349,7 +357,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: stretch;
 }
 
-.c51 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -359,7 +367,30 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
+}
+
+.c60 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -webkit-justify-content: start;
+  -ms-flex-pack: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c61 {
@@ -374,31 +405,9 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c62 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -406,7 +415,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c53 {
+.c52 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -417,14 +426,14 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   margin-left: -5px;
 }
 
-.c4>* {
+.c4 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4>* {
+.c4 > * {
   margin-left: 5px;
 }
 
@@ -435,48 +444,48 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   display: inline-flex;
 }
 
-.c7 {
+.c6 {
   cursor: pointer;
 }
 
-.c38 svg path {
+.c37 svg path {
   fill: #bfbfbf;
 }
 
-.c6 {
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
-.c31 {
+.c30 {
   height: 50px;
   width: 50px;
   line-height: 50px;
 }
 
-.c31 * {
+.c30 * {
   height: inherit;
   width: inherit;
 }
 
-.c26 {
+.c25 {
   margin: 10px 0px;
   padding-bottom: 1px;
   border-bottom: 2px solid #e5e5e5;
   position: relative;
 }
 
-.c27 {
+.c26 {
   margin: 0 0 1px 0;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -485,8 +494,8 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -494,16 +503,16 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: stretch;
 }
 
-.c30 {
+.c29 {
   margin-right: 5px;
 }
 
-.c32 {
+.c31 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c23 {
+.c22 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -516,8 +525,8 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -528,18 +537,18 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   cursor: pointer;
 }
 
-.c24 {
+.c23 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c24 * {
+.c23 * {
   height: inherit;
   width: inherit;
 }
 
-.c19 {
+.c18 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -563,7 +572,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   font-weight: normal;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -575,7 +584,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 150px;
 }
 
-.c63 {
+.c62 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -587,7 +596,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 180px;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -606,7 +615,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   cursor: pointer;
 }
 
-.c16 {
+.c15 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -615,18 +624,18 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   display: none;
 }
 
-.c21 {
+.c20 {
   cursor: default;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c40 {
+.c39 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -635,37 +644,37 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 100%;
 }
 
-.c41 th,
-.c41 td {
+.c40 th,
+.c40 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c41 tfoot tr {
+.c40 tfoot tr {
   background: #fff;
 }
 
-.c41 tfoot tr td {
+.c40 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c43 a {
+.c42 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c43 a:hover {
+.c42 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c45 {
+.c44 {
   cursor: pointer;
 }
 
-.c44 {
+.c43 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -673,7 +682,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 52%;
 }
 
-.c46 {
+.c45 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -681,7 +690,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 8%;
 }
 
-.c47 {
+.c46 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -689,7 +698,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 24%;
 }
 
-.c48 {
+.c47 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -697,7 +706,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 10em;
 }
 
-.c14 {
+.c13 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -711,11 +720,11 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   padding: 1px 8px;
 }
 
-.c14:-webkit-autofill {
+.c13:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -724,8 +733,8 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -733,55 +742,55 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c13 {
-  margin-right: 5px;
-}
-
 .c12 {
   margin-right: 5px;
 }
 
-.c64 {
+.c11 {
+  margin-right: 5px;
+}
+
+.c63 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c39 {
+.c38 {
   margin: 0 3px;
 }
 
-.c37 {
+.c36 {
   margin: 2px 3px;
 }
 
-.c42 {
+.c41 {
   opacity: 1.0;
 }
 
-.c35 {
+.c34 {
   margin-top: 2px;
   margin-left: 2px;
 }
 
-.c33 {
+.c32 {
   margin-top: 20px;
 }
 
-.c52 {
+.c51 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c52 :hover {
+.c51:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
-.c55 {
+.c54 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -791,7 +800,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   text-align: center;
 }
 
-.c59 {
+.c58 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -801,7 +810,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   text-align: center;
 }
 
-.c57 {
+.c56 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -812,58 +821,66 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   padding-top: 1px;
 }
 
-.c56 {
+.c55 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
 }
 
-.c60 {
+.c59 {
   height: 13px;
   width: 50%;
   background: #70c000;
 }
 
-.c58 {
+.c57 {
   white-space: nowrap;
 }
 
-.c54:hover {
+.c53:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 @media print {
-  .c5 {
+
+}
+
+@media print {
+  .c6 {
     display: none;
   }
 }
 
 @media print {
-  .c40 {
+
+}
+
+@media print {
+  .c39 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c41>tbody:nth-of-type(even),
-  .c41>tbody:only-of-type>tr:nth-of-type(even) {
+  .c40 > tbody:nth-of-type(even),
+  .c40 > tbody:only-of-type > tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c41>tbody:not(:only-of-type):hover,
-  .c41>tbody:only-of-type>tr:hover {
+  .c40 > tbody:not(:only-of-type):hover,
+  .c40 > tbody:only-of-type > tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c43 {
+  .c42 {
     border-bottom: 1px solid black;
   }
 
-  .c43 a,
-  .c43 a:hover {
+  .c42 a,
+  .c42 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -871,7 +888,16 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
 }
 
 @media print {
-  .c44 {
+  .c43 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: transparent;
+    font-weight: bold;
+  }
+}
+
+@media print {
+  .c45 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -898,54 +924,45 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
 }
 
 @media print {
-  .c48 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: transparent;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c37 svg {
+  .c36 svg {
     display: none;
   }
 }
 
 @media print {
-  .c52 {
+  .c51 {
     color: #000;
+  }
+}
+
+@media print {
+  .c54 {
+    background: none;
+    border: 0;
+  }
+}
+
+@media print {
+  .c58 {
+    background: none;
+    border: 0;
+  }
+}
+
+@media print {
+  .c56 {
+    color: black;
   }
 }
 
 @media print {
   .c55 {
     background: none;
-    border: 0;
   }
 }
 
 @media print {
   .c59 {
-    background: none;
-    border: 0;
-  }
-}
-
-@media print {
-  .c57 {
-    color: black;
-  }
-}
-
-@media print {
-  .c56 {
-    background: none;
-  }
-}
-
-@media print {
-  .c60 {
     background: none;
   }
 }
@@ -973,7 +990,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               target="_blank"
             >
               <span
-                class="c5 c6"
+                class="c5"
                 data-testid="svg-icon"
                 title="Help: Audits"
               >
@@ -985,7 +1002,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               </span>
             </a>
             <span
-              class="c5 c7 c6"
+              class="c6 c5"
               data-testid="svg-icon"
               title="New Audit"
             >
@@ -998,32 +1015,32 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
           </div>
         </div>
         <div
-          class="c8"
+          class="c7"
         >
           <div
-            class="c9 powerfilter"
+            class="c8 powerfilter"
           >
             <div
-              class="c10"
+              class="c9"
             >
               <div
                 class="c2 c3"
               >
                 <div
-                  class="c11 c4 c12"
+                  class="c10 c4 c11"
                 >
                   <div
-                    class="c11"
+                    class="c10"
                   >
                     <label
-                      class="c13"
+                      class="c12"
                     >
                       <b>
                         Filter
                       </b>
                     </label>
                     <input
-                      class="c14 c15"
+                      class="c13 c14"
                       maxlength="1000"
                       name="userFilterString"
                       size="53"
@@ -1031,7 +1048,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       value=""
                     />
                     <div
-                      class="c16"
+                      class="c15"
                       data-testid="error-marker"
                     >
                       ×
@@ -1041,10 +1058,10 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     class="c2 c3"
                   >
                     <div
-                      class="c11 c4"
+                      class="c10 c4"
                     >
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Update Filter"
                       >
@@ -1055,7 +1072,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Remove Filter"
                       >
@@ -1066,7 +1083,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Reset to Default Filter"
                       >
@@ -1082,7 +1099,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                         target="_blank"
                       >
                         <span
-                          class="c5 c6"
+                          class="c5"
                           data-testid="svg-icon"
                           title="Help: Powerfilter"
                         >
@@ -1101,34 +1118,34 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="downshift-0-label"
-                class="c17"
+                class="c16"
                 role="combobox"
               >
                 <div
-                  class="c18"
+                  class="c17"
                   width="150px"
                 >
                   <div
                     aria-haspopup="true"
                     aria-label="open menu"
-                    class="c19"
+                    class="c18"
                     data-toggle="true"
                     role="button"
                     title="Loaded filter"
                     type="button"
                   >
                     <div
-                      class="c20 c21"
+                      class="c19 c20"
                       data-testid="select-selected-value"
                       title="Loaded filter"
                     >
                       --
                     </div>
                     <div
-                      class="c22"
+                      class="c21"
                     >
                       <span
-                        class="c23 c24"
+                        class="c22 c23"
                         data-testid="select-open-button"
                       >
                         ▼
@@ -1137,7 +1154,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                   data-testid="error-marker"
                 >
                   ×
@@ -1151,16 +1168,16 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
         class="entities-section"
       >
         <div
-          class="c25 c26 section-header"
+          class="c24 c25 section-header"
         >
           <h2
-            class="c27 c28"
+            class="c26 c27"
           >
             <div
-              class="c29 c30"
+              class="c28 c29"
             >
               <span
-                class="c5 c31"
+                class="c30"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -1169,26 +1186,26 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               </span>
             </div>
             <div
-              class="c29 c32"
+              class="c28 c31"
             >
               Audits 0 of 0
             </div>
           </h2>
           <div
-            class="c10"
+            class="c9"
           />
         </div>
         <div
           class="c0"
         >
           <div
-            class="c0 c33 entities-table"
+            class="c0 c32 entities-table"
           >
             <div
-              class="c34"
+              class="c33"
             >
               <span
-                class="c5 c7 c6 c35"
+                class="c6 c5 c34"
                 data-testid="svg-icon"
                 title="Unfold all details"
               >
@@ -1199,7 +1216,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                 </svg>
               </span>
               <div
-                class="c36 c37"
+                class="c35 c36"
               >
                 <div
                   class="c2 c3"
@@ -1208,7 +1225,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1219,7 +1236,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1232,7 +1249,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c39"
+                  class="c38"
                 >
                   0 - 0 of 0
                 </span>
@@ -1243,7 +1260,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1254,7 +1271,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Last"
                     >
@@ -1269,17 +1286,17 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               </div>
             </div>
             <table
-              class="c40 c41 c42"
+              class="c39 c40 c41"
             >
               <thead
-                class="c43"
+                class="c42"
               >
                 <tr>
                   <th
-                    class="c44"
+                    class="c43"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1289,10 +1306,10 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c46"
+                    class="c45"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1302,10 +1319,10 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c47"
+                    class="c46"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1315,7 +1332,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c46"
+                    class="c45"
                   >
                     <div
                       class="c2"
@@ -1324,10 +1341,10 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     </div>
                   </th>
                   <th
-                    class="c48"
+                    class="c47"
                   >
                     <div
-                      class="c49"
+                      class="c48"
                     >
                       Actions
                     </div>
@@ -1340,13 +1357,13 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                 <tr>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       <div
-                        class="c51"
+                        class="c50"
                       >
                         <span
-                          class="c52"
+                          class="c51"
                           name="1234"
                         >
                           foo
@@ -1370,28 +1387,28 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       <a
-                        class="c53 c54"
+                        class="c52 c53"
                         data-testid="details-link"
                         href="/report/1234"
                       >
                         <div
-                          class="c55"
+                          class="c54"
                           data-testid="progressbar-box"
                           title="Done"
                         >
                           <div
                             background="low"
-                            class="c56"
+                            class="c55"
                             data-testid="progress"
                           />
                           <div
-                            class="c57"
+                            class="c56"
                           >
                             <span
-                              class="c58"
+                              class="c57"
                             >
                               Done
                             </span>
@@ -1402,11 +1419,11 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       <span>
                         <a
-                          class="c53"
+                          class="c52"
                           data-testid="details-link"
                           href="/report/1234"
                         >
@@ -1417,20 +1434,20 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       <div
-                        class="c59"
+                        class="c58"
                         data-testid="progressbar-box"
                         title="50%"
                       >
                         <div
                           background="#70c000"
-                          class="c60"
+                          class="c59"
                           data-testid="progress"
                         />
                         <div
-                          class="c57"
+                          class="c56"
                         >
                           50%
                         </div>
@@ -1442,13 +1459,13 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       class="c0"
                     >
                       <div
-                        class="c61 c3"
+                        class="c60 c3"
                       >
                         <div
-                          class="c62 c4"
+                          class="c61 c4"
                         >
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Start"
                           >
@@ -1460,7 +1477,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                           </span>
                           <span
                             alt="Resume"
-                            class="c5 c38 c6"
+                            class="c37 c5"
                             data-testid="svg-icon"
                             title="Audit is not stopped"
                           >
@@ -1471,7 +1488,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Move Audit to trashcan"
                           >
@@ -1482,7 +1499,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Edit Audit"
                           >
@@ -1493,7 +1510,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Clone Audit"
                           >
@@ -1504,7 +1521,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Export Audit"
                           >
@@ -1515,7 +1532,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c38 c6"
+                            class="c37 c5"
                             data-testid="svg-icon"
                             title="Report download not available"
                           >
@@ -1537,7 +1554,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     colspan="5"
                   >
                     <div
-                      class="c36"
+                      class="c35"
                     >
                       <div
                         class="c2 c3"
@@ -1549,33 +1566,33 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="downshift-1-label"
-                            class="c17"
+                            class="c16"
                             role="combobox"
                           >
                             <div
-                              class="c63"
+                              class="c62"
                               width="180px"
                             >
                               <div
                                 aria-haspopup="true"
                                 aria-label="open menu"
-                                class="c19"
+                                class="c18"
                                 data-toggle="true"
                                 role="button"
                                 type="button"
                               >
                                 <div
-                                  class="c20 c21"
+                                  class="c19 c20"
                                   data-testid="select-selected-value"
                                   title="Apply to page contents"
                                 >
                                   Apply to page contents
                                 </div>
                                 <div
-                                  class="c22"
+                                  class="c21"
                                 >
                                   <span
-                                    class="c23 c24"
+                                    class="c22 c23"
                                     data-testid="select-open-button"
                                   >
                                     ▼
@@ -1584,7 +1601,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                               </div>
                             </div>
                             <div
-                              class="c16"
+                              class="c15"
                               data-testid="error-marker"
                             >
                               ×
@@ -1597,7 +1614,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                               class="c2 c4"
                             >
                               <span
-                                class="c5 c7 c6"
+                                class="c6 c5"
                                 data-testid="svg-icon"
                                 title="Move page contents to trashcan"
                               >
@@ -1608,7 +1625,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                                 </svg>
                               </span>
                               <span
-                                class="c5 c7 c6"
+                                class="c6 c5"
                                 data-testid="svg-icon"
                                 title="Export page contents"
                               >
@@ -1628,15 +1645,15 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               </tfoot>
             </table>
             <div
-              class="c51"
+              class="c50"
             >
               <div
-                class="c2 c64"
+                class="c2 c63"
               >
                 (Applied filter: )
               </div>
               <div
-                class="c36 c37"
+                class="c35 c36"
               >
                 <div
                   class="c2 c3"
@@ -1645,7 +1662,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1656,7 +1673,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1669,7 +1686,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c39"
+                  class="c38"
                 >
                   0 - 0 of 0
                 </span>
@@ -1680,7 +1697,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1691,7 +1708,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Last"
                     >

--- a/src/web/pages/audits/__tests__/__snapshots__/row.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/row.js.snap
@@ -10,8 +10,8 @@ exports[`Audit Row tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -29,6 +29,7 @@ exports[`Audit Row tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -41,8 +42,8 @@ exports[`Audit Row tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -63,8 +64,8 @@ exports[`Audit Row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -85,8 +86,8 @@ exports[`Audit Row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -107,8 +108,8 @@ exports[`Audit Row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -127,14 +128,14 @@ exports[`Audit Row tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c5>* {
+.c5 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5>* {
+.c5 > * {
   margin-left: 5px;
 }
 
@@ -145,21 +146,21 @@ exports[`Audit Row tests should render 1`] = `
   display: inline-flex;
 }
 
-.c18 {
+.c17 {
   cursor: pointer;
 }
 
-.c20 svg path {
+.c19 svg path {
   fill: #bfbfbf;
 }
 
-.c19 {
+.c18 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c19 * {
+.c18 * {
   height: inherit;
   width: inherit;
 }
@@ -171,7 +172,7 @@ exports[`Audit Row tests should render 1`] = `
   color: #0a53b8;
 }
 
-.c2 :hover {
+.c2:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
@@ -233,6 +234,10 @@ exports[`Audit Row tests should render 1`] = `
   .c17 {
     display: none;
   }
+}
+
+@media print {
+
 }
 
 @media print {
@@ -389,7 +394,7 @@ exports[`Audit Row tests should render 1`] = `
               class="c16 c5"
             >
               <span
-                class="c17 c18 c19"
+                class="c17 c18"
                 data-testid="svg-icon"
                 title="Start"
               >
@@ -401,7 +406,7 @@ exports[`Audit Row tests should render 1`] = `
               </span>
               <span
                 alt="Resume"
-                class="c17 c20 c19"
+                class="c19 c18"
                 data-testid="svg-icon"
                 title="Audit is not stopped"
               >
@@ -412,7 +417,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c17 c18 c19"
+                class="c17 c18"
                 data-testid="svg-icon"
                 title="Move Audit to trashcan"
               >
@@ -423,7 +428,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c17 c18 c19"
+                class="c17 c18"
                 data-testid="svg-icon"
                 title="Edit Audit"
               >
@@ -434,7 +439,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c17 c18 c19"
+                class="c17 c18"
                 data-testid="svg-icon"
                 title="Clone Audit"
               >
@@ -445,7 +450,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c17 c18 c19"
+                class="c17 c18"
                 data-testid="svg-icon"
                 title="Export Audit"
               >
@@ -456,7 +461,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c17 c18 c19"
+                class="c17 c18"
                 data-testid="svg-icon"
                 title="Download Greenbone Compliance Report"
               >

--- a/src/web/pages/audits/__tests__/__snapshots__/table.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/table.js.snap
@@ -14,8 +14,8 @@ exports[`Audits table tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -37,10 +37,11 @@ exports[`Audits table tests should render 1`] = `
   flex-grow: 1;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c7 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -49,8 +50,8 @@ exports[`Audits table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -58,7 +59,7 @@ exports[`Audits table tests should render 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -67,8 +68,8 @@ exports[`Audits table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -76,7 +77,7 @@ exports[`Audits table tests should render 1`] = `
   align-items: center;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -85,12 +86,12 @@ exports[`Audits table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
 }
 
-.c23 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -99,8 +100,8 @@ exports[`Audits table tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -108,7 +109,7 @@ exports[`Audits table tests should render 1`] = `
   align-items: stretch;
 }
 
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -118,7 +119,30 @@ exports[`Audits table tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
+}
+
+.c33 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -webkit-justify-content: start;
+  -ms-flex-pack: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c34 {
@@ -133,31 +157,9 @@ exports[`Audits table tests should render 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c35 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -165,7 +167,7 @@ exports[`Audits table tests should render 1`] = `
   align-items: center;
 }
 
-.c43 {
+.c42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -174,8 +176,8 @@ exports[`Audits table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -183,55 +185,55 @@ exports[`Audits table tests should render 1`] = `
   align-items: center;
 }
 
-.c26 {
+.c25 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-}
-
-.c11 {
-  margin-left: -5px;
-}
-
-.c11>* {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c11>* {
-  margin-left: 5px;
 }
 
 .c10 {
+  margin-left: -5px;
+}
+
+.c10 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4 {
+.c10 > * {
+  margin-left: 5px;
+}
+
+.c9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c3 {
   cursor: pointer;
 }
 
-.c12 svg path {
+.c11 svg path {
   fill: #bfbfbf;
 }
 
-.c5 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c5 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
 
-.c44 {
+.c43 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -244,8 +246,8 @@ exports[`Audits table tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -256,18 +258,18 @@ exports[`Audits table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c45 {
+.c44 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c45 * {
+.c44 * {
   height: inherit;
   width: inherit;
 }
 
-.c40 {
+.c39 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -291,7 +293,7 @@ exports[`Audits table tests should render 1`] = `
   font-weight: normal;
 }
 
-.c39 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -303,7 +305,7 @@ exports[`Audits table tests should render 1`] = `
   width: 180px;
 }
 
-.c41 {
+.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -322,7 +324,7 @@ exports[`Audits table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c46 {
+.c45 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -331,18 +333,18 @@ exports[`Audits table tests should render 1`] = `
   display: none;
 }
 
-.c42 {
+.c41 {
   cursor: default;
 }
 
-.c38 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
+.c13 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -351,33 +353,33 @@ exports[`Audits table tests should render 1`] = `
   width: 100%;
 }
 
-.c15 th,
-.c15 td {
+.c14 th,
+.c14 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c15 tfoot tr {
+.c14 tfoot tr {
   background: #fff;
 }
 
-.c15 tfoot tr td {
+.c14 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c17 a {
+.c16 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c17 a:hover {
+.c16 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c18 {
+.c17 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -385,7 +387,7 @@ exports[`Audits table tests should render 1`] = `
   width: 52%;
 }
 
-.c19 {
+.c18 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -393,7 +395,7 @@ exports[`Audits table tests should render 1`] = `
   width: 8%;
 }
 
-.c20 {
+.c19 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -401,7 +403,7 @@ exports[`Audits table tests should render 1`] = `
   width: 24%;
 }
 
-.c21 {
+.c20 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -409,25 +411,25 @@ exports[`Audits table tests should render 1`] = `
   width: 10em;
 }
 
-.c47 {
+.c46 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c13 {
+.c12 {
   margin: 0 3px;
 }
 
-.c8 {
+.c7 {
   margin: 2px 3px;
 }
 
-.c16 {
+.c15 {
   opacity: 1.0;
 }
 
-.c6 {
+.c5 {
   margin-top: 2px;
   margin-left: 2px;
 }
@@ -436,20 +438,20 @@ exports[`Audits table tests should render 1`] = `
   margin-top: 20px;
 }
 
-.c25 {
+.c24 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c25 :hover {
+.c24:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
-.c28 {
+.c27 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -459,7 +461,7 @@ exports[`Audits table tests should render 1`] = `
   text-align: center;
 }
 
-.c32 {
+.c31 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -469,7 +471,7 @@ exports[`Audits table tests should render 1`] = `
   text-align: center;
 }
 
-.c30 {
+.c29 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -480,35 +482,35 @@ exports[`Audits table tests should render 1`] = `
   padding-top: 1px;
 }
 
-.c29 {
+.c28 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
 }
 
-.c33 {
+.c32 {
   height: 13px;
   width: 50%;
   background: #70c000;
 }
 
-.c36 {
+.c35 {
   height: 13px;
   width: 100%;
   background: #99be48;
 }
 
-.c37 {
+.c36 {
   height: 13px;
   width: 0%;
   background: #70c000;
 }
 
-.c31 {
+.c30 {
   white-space: nowrap;
 }
 
-.c27:hover {
+.c26:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -520,33 +522,50 @@ exports[`Audits table tests should render 1`] = `
 }
 
 @media print {
-  .c14 {
+
+}
+
+@media print {
+
+}
+
+@media print {
+  .c13 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c15>tbody:nth-of-type(even),
-  .c15>tbody:only-of-type>tr:nth-of-type(even) {
+  .c14 > tbody:nth-of-type(even),
+  .c14 > tbody:only-of-type > tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c15>tbody:not(:only-of-type):hover,
-  .c15>tbody:only-of-type>tr:hover {
+  .c14 > tbody:not(:only-of-type):hover,
+  .c14 > tbody:only-of-type > tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c17 {
+  .c16 {
     border-bottom: 1px solid black;
   }
 
-  .c17 a,
-  .c17 a:hover {
+  .c16 a,
+  .c16 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
+  }
+}
+
+@media print {
+  .c17 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: transparent;
+    font-weight: bold;
   }
 }
 
@@ -578,66 +597,57 @@ exports[`Audits table tests should render 1`] = `
 }
 
 @media print {
-  .c21 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: transparent;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c8 svg {
+  .c7 svg {
     display: none;
   }
 }
 
 @media print {
-  .c25 {
+  .c24 {
     color: #000;
+  }
+}
+
+@media print {
+  .c27 {
+    background: none;
+    border: 0;
+  }
+}
+
+@media print {
+  .c31 {
+    background: none;
+    border: 0;
+  }
+}
+
+@media print {
+  .c29 {
+    color: black;
   }
 }
 
 @media print {
   .c28 {
     background: none;
-    border: 0;
   }
 }
 
 @media print {
   .c32 {
     background: none;
-    border: 0;
   }
 }
 
 @media print {
-  .c30 {
-    color: black;
-  }
-}
-
-@media print {
-  .c29 {
-    background: none;
-  }
-}
-
-@media print {
-  .c33 {
+  .c35 {
     background: none;
   }
 }
 
 @media print {
   .c36 {
-    background: none;
-  }
-}
-
-@media print {
-  .c37 {
     background: none;
   }
 }
@@ -654,7 +664,7 @@ exports[`Audits table tests should render 1`] = `
         class="c2"
       >
         <span
-          class="c3 c4 c5 c6"
+          class="c3 c4 c5"
           data-testid="svg-icon"
           title="Unfold all details"
         >
@@ -665,16 +675,16 @@ exports[`Audits table tests should render 1`] = `
           </svg>
         </span>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -685,7 +695,7 @@ exports[`Audits table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -698,18 +708,18 @@ exports[`Audits table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -720,7 +730,7 @@ exports[`Audits table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >
@@ -735,53 +745,53 @@ exports[`Audits table tests should render 1`] = `
         </div>
       </div>
       <table
-        class="c14 c15 c16"
+        class="c13 c14 c15"
       >
         <thead
-          class="c17"
+          class="c16"
         >
           <tr>
+            <th
+              class="c17"
+            >
+              <div
+                class="c8"
+              >
+                Name
+              </div>
+            </th>
             <th
               class="c18"
             >
               <div
-                class="c9"
+                class="c8"
               >
-                Name
+                Status
               </div>
             </th>
             <th
               class="c19"
             >
               <div
-                class="c9"
+                class="c8"
               >
-                Status
+                Report
+              </div>
+            </th>
+            <th
+              class="c18"
+            >
+              <div
+                class="c8"
+              >
+                Compliance Status
               </div>
             </th>
             <th
               class="c20"
             >
               <div
-                class="c9"
-              >
-                Report
-              </div>
-            </th>
-            <th
-              class="c19"
-            >
-              <div
-                class="c9"
-              >
-                Compliance Status
-              </div>
-            </th>
-            <th
-              class="c21"
-            >
-              <div
-                class="c22"
+                class="c21"
               >
                 Actions
               </div>
@@ -794,22 +804,22 @@ exports[`Audits table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c24"
+                  class="c23"
                 >
                   <span
-                    class="c25"
+                    class="c24"
                     name="1234"
                   >
                     foo
                   </span>
                   <div
-                    class="c9 c10"
+                    class="c8 c9"
                   >
                     <div
-                      class="c9 c11"
+                      class="c8 c10"
                     />
                   </div>
                 </div>
@@ -824,28 +834,28 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <a
-                  class="c26 c27"
+                  class="c25 c26"
                   data-testid="details-link"
                   href="/report/1234"
                 >
                   <div
-                    class="c28"
+                    class="c27"
                     data-testid="progressbar-box"
                     title="Done"
                   >
                     <div
                       background="low"
-                      class="c29"
+                      class="c28"
                       data-testid="progress"
                     />
                     <div
-                      class="c30"
+                      class="c29"
                     >
                       <span
-                        class="c31"
+                        class="c30"
                       >
                         Done
                       </span>
@@ -856,11 +866,11 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span>
                   <a
-                    class="c26"
+                    class="c25"
                     data-testid="details-link"
                     href="/report/1234"
                   >
@@ -871,20 +881,20 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c32"
+                  class="c31"
                   data-testid="progressbar-box"
                   title="50%"
                 >
                   <div
                     background="#70c000"
-                    class="c33"
+                    class="c32"
                     data-testid="progress"
                   />
                   <div
-                    class="c30"
+                    class="c29"
                   >
                     50%
                   </div>
@@ -896,13 +906,13 @@ exports[`Audits table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c34 c10"
+                  class="c33 c9"
                 >
                   <div
-                    class="c35 c11"
+                    class="c34 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Start"
                     >
@@ -914,7 +924,7 @@ exports[`Audits table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Audit is not stopped"
                     >
@@ -925,7 +935,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Audit to trashcan"
                     >
@@ -936,7 +946,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Audit"
                     >
@@ -947,7 +957,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Audit"
                     >
@@ -958,7 +968,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Audit"
                     >
@@ -969,7 +979,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Report download not available"
                     >
@@ -987,26 +997,26 @@ exports[`Audits table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c24"
+                  class="c23"
                 >
                   <span
-                    class="c25"
+                    class="c24"
                     name="12345"
                   >
                     lorem
                   </span>
                   <div
-                    class="c9 c10"
+                    class="c8 c9"
                   >
                     <div
-                      class="c9 c11"
+                      class="c8 c10"
                     >
                       <span
                         alt="Audit owned by user"
-                        class="c3 c5"
+                        class="c4"
                         data-testid="svg-icon"
                         title="Audit owned by user"
                       >
@@ -1030,26 +1040,26 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span
-                  class="c26 c27"
+                  class="c25 c26"
                 >
                   <div
-                    class="c28"
+                    class="c27"
                     data-testid="progressbar-box"
                     title="New"
                   >
                     <div
                       background="new"
-                      class="c36"
+                      class="c35"
                       data-testid="progress"
                     />
                     <div
-                      class="c30"
+                      class="c29"
                     >
                       <span
-                        class="c31"
+                        class="c30"
                       >
                         New
                       </span>
@@ -1060,12 +1070,12 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               />
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               />
             </td>
             <td>
@@ -1073,13 +1083,13 @@ exports[`Audits table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c34 c10"
+                  class="c33 c9"
                 >
                   <div
-                    class="c35 c11"
+                    class="c34 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Start"
                     >
@@ -1091,7 +1101,7 @@ exports[`Audits table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Audit is not stopped"
                     >
@@ -1102,7 +1112,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Audit to trashcan"
                     >
@@ -1113,7 +1123,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Audit"
                     >
@@ -1124,7 +1134,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Audit"
                     >
@@ -1135,7 +1145,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Audit"
                     >
@@ -1146,7 +1156,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Report download not available"
                     >
@@ -1164,26 +1174,26 @@ exports[`Audits table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c24"
+                  class="c23"
                 >
                   <span
-                    class="c25"
+                    class="c24"
                     name="123456"
                   >
                     hello
                   </span>
                   <div
-                    class="c9 c10"
+                    class="c8 c9"
                   >
                     <div
-                      class="c9 c11"
+                      class="c8 c10"
                     >
                       <span
                         alt="Audit owned by user"
-                        class="c3 c5"
+                        class="c4"
                         data-testid="svg-icon"
                         title="Audit owned by user"
                       >
@@ -1207,28 +1217,28 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <a
-                  class="c26 c27"
+                  class="c25 c26"
                   data-testid="details-link"
                   href="/report/5678"
                 >
                   <div
-                    class="c28"
+                    class="c27"
                     data-testid="progressbar-box"
                     title="Running"
                   >
                     <div
                       background="run"
-                      class="c37"
+                      class="c36"
                       data-testid="progress"
                     />
                     <div
-                      class="c30"
+                      class="c29"
                     >
                       <span
-                        class="c31"
+                        class="c30"
                       >
                         0 %
                       </span>
@@ -1239,11 +1249,11 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span>
                   <a
-                    class="c26"
+                    class="c25"
                     data-testid="details-link"
                     href="/report/1234"
                   >
@@ -1254,20 +1264,20 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c32"
+                  class="c31"
                   data-testid="progressbar-box"
                   title="50%"
                 >
                   <div
                     background="#70c000"
-                    class="c33"
+                    class="c32"
                     data-testid="progress"
                   />
                   <div
-                    class="c30"
+                    class="c29"
                   >
                     50%
                   </div>
@@ -1279,13 +1289,13 @@ exports[`Audits table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c34 c10"
+                  class="c33 c9"
                 >
                   <div
-                    class="c35 c11"
+                    class="c34 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Stop"
                     >
@@ -1297,7 +1307,7 @@ exports[`Audits table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Audit is not stopped"
                     >
@@ -1308,7 +1318,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Audit to trashcan"
                     >
@@ -1319,7 +1329,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Audit"
                     >
@@ -1330,7 +1340,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Audit"
                     >
@@ -1341,7 +1351,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Audit"
                     >
@@ -1352,7 +1362,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Report download not available"
                     >
@@ -1374,42 +1384,42 @@ exports[`Audits table tests should render 1`] = `
               colspan="5"
             >
               <div
-                class="c7"
+                class="c6"
               >
                 <div
-                  class="c9 c10"
+                  class="c8 c9"
                 >
                   <div
-                    class="c9 c11"
+                    class="c8 c10"
                   >
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-labelledby="downshift-0-label"
-                      class="c38"
+                      class="c37"
                       role="combobox"
                     >
                       <div
-                        class="c39"
+                        class="c38"
                         width="180px"
                       >
                         <div
                           aria-haspopup="true"
                           aria-label="open menu"
-                          class="c40"
+                          class="c39"
                           data-toggle="true"
                           role="button"
                           type="button"
                         >
                           <div
-                            class="c41 c42"
+                            class="c40 c41"
                             data-testid="select-selected-value"
                           />
                           <div
-                            class="c43"
+                            class="c42"
                           >
                             <span
-                              class="c44 c45"
+                              class="c43 c44"
                               data-testid="select-open-button"
                             >
                               ▼
@@ -1418,20 +1428,20 @@ exports[`Audits table tests should render 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c46"
+                        class="c45"
                         data-testid="error-marker"
                       >
                         ×
                       </div>
                     </div>
                     <div
-                      class="c9 c10"
+                      class="c8 c9"
                     >
                       <div
-                        class="c9 c11"
+                        class="c8 c10"
                       >
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1439,7 +1449,7 @@ exports[`Audits table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1456,24 +1466,24 @@ exports[`Audits table tests should render 1`] = `
         </tfoot>
       </table>
       <div
-        class="c24"
+        class="c23"
       >
         <div
-          class="c9 c47"
+          class="c8 c46"
         >
           (Applied filter: rows=2)
         </div>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -1484,7 +1494,7 @@ exports[`Audits table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -1497,18 +1507,18 @@ exports[`Audits table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -1519,7 +1529,7 @@ exports[`Audits table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >

--- a/src/web/pages/ldap/__tests__/__snapshots__/dialog.js.snap
+++ b/src/web/pages/ldap/__tests__/__snapshots__/dialog.js.snap
@@ -11,6 +11,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -31,8 +32,8 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -49,8 +50,8 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -67,8 +68,8 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -88,8 +89,8 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -101,14 +102,14 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   margin-left: -5px;
 }
 
-.c17>* {
+.c17 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c17>* {
+.c17 > * {
   margin-left: 5px;
 }
 
@@ -144,7 +145,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -167,7 +168,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -203,15 +204,15 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -287,8 +288,8 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -302,7 +303,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   background: #11ab51;
 }
 
-.c29 :hover {
+.c29:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -318,6 +319,7 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
 .c26 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -335,11 +337,13 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 
@@ -366,8 +370,8 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -425,8 +429,8 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -470,8 +474,8 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -488,8 +492,8 @@ exports[`Ldap dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/pages/performance/__tests__/__snapshots__/startendtimeselection.js.snap
+++ b/src/web/pages/performance/__tests__/__snapshots__/startendtimeselection.js.snap
@@ -10,8 +10,8 @@ exports[`StartTimeSelection tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -28,8 +28,8 @@ exports[`StartTimeSelection tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -41,14 +41,14 @@ exports[`StartTimeSelection tests should render 1`] = `
   margin-top: -5px;
 }
 
-.c6>* {
+.c6 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c6>* {
+.c6 > * {
   margin-top: 5px;
 }
 
@@ -56,14 +56,14 @@ exports[`StartTimeSelection tests should render 1`] = `
   margin-left: -20px;
 }
 
-.c10>* {
+.c10 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c10>* {
+.c10 > * {
   margin-left: 20px;
 }
 
@@ -146,8 +146,8 @@ exports[`StartTimeSelection tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -165,8 +165,8 @@ exports[`StartTimeSelection tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -270,7 +270,7 @@ exports[`StartTimeSelection tests should render 1`] = `
   margin-left: 5px;
 }
 
-.c9 :hover {
+.c9:hover {
   cursor: pointer;
 }
 
@@ -281,6 +281,10 @@ exports[`StartTimeSelection tests should render 1`] = `
   display: flex;
   margin-right: 5px;
   width: auto;
+}
+
+@media print {
+
 }
 
 <div

--- a/src/web/pages/policies/__tests__/__snapshots__/details.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/details.js.snap
@@ -14,8 +14,8 @@ exports[`Policy Details tests should render full Details 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -32,8 +32,8 @@ exports[`Policy Details tests should render full Details 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -50,8 +50,8 @@ exports[`Policy Details tests should render full Details 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -67,13 +67,12 @@ exports[`Policy Details tests should render full Details 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -92,14 +91,14 @@ exports[`Policy Details tests should render full Details 1`] = `
   margin-left: -5px;
 }
 
-.c9>* {
+.c9 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c9>* {
+.c9 > * {
   margin-left: 5px;
 }
 

--- a/src/web/pages/policies/__tests__/__snapshots__/detailspage.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/detailspage.js.snap
@@ -14,8 +14,8 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
 }
 
@@ -29,6 +29,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -45,280 +46,31 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-}
-
-.c21 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
-.c24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c34 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c8 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4 {
-  margin-left: -10px;
-}
-
-.c4>* {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4>* {
-  margin-left: 10px;
-}
-
-.c5 {
-  margin-left: -5px;
-}
-
-.c5>* {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c5>* {
-  margin-left: 5px;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
 .c9 {
-  cursor: pointer;
-}
-
-.c7 {
-  height: 16px;
-  width: 16px;
-  line-height: 16px;
-}
-
-.c7 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c16 {
-  height: 50px;
-  width: 50px;
-  line-height: 50px;
-}
-
-.c16 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c11 {
-  margin: 10px 0px;
-  padding-bottom: 1px;
-  border-bottom: 2px solid #e5e5e5;
-  position: relative;
-}
-
-.c12 {
-  margin: 0 0 1px 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
 .c13 {
@@ -330,8 +82,102 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -339,16 +185,172 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
+.c26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c28 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c33 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: start;
+  -ms-flex-pack: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4 {
+  margin-left: -10px;
+}
+
+.c4 > * {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4 > * {
+  margin-left: 10px;
+}
+
+.c5 {
+  margin-left: -5px;
+}
+
+.c5 > * {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c5 > * {
+  margin-left: 5px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c8 {
+  cursor: pointer;
+}
+
+.c6 {
+  height: 16px;
+  width: 16px;
+  line-height: 16px;
+}
+
+.c6 * {
+  height: inherit;
+  width: inherit;
+}
+
 .c15 {
+  height: 50px;
+  width: 50px;
+  line-height: 50px;
+}
+
+.c15 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c10 {
+  margin: 10px 0px;
+  padding-bottom: 1px;
+  border-bottom: 2px solid #e5e5e5;
+  position: relative;
+}
+
+.c11 {
+  margin: 0 0 1px 0;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c14 {
   margin-right: 5px;
 }
 
-.c17 {
+.c16 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c25 {
+.c24 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -375,15 +377,15 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #11ab51;
 }
 
-.c25 :hover {
+.c24:hover {
   border-top: 2px solid #fff;
 }
 
-.c25 :first-child {
+.c24:first-child {
   border-left: 1px solid #e5e5e5;
 }
 
-.c26 {
+.c25 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -407,21 +409,21 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #fff;
 }
 
-.c26 :hover {
+.c25:hover {
   border-top: 2px solid #e5e5e5;
 }
 
-.c26 :first-child {
+.c25:first-child {
   border-left: 1px solid #fff;
 }
 
-.c23 {
+.c22 {
   border-bottom: 2px solid #11ab51;
   margin-top: 30px;
   margin-bottom: 15px;
 }
 
-.c30 {
+.c29 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -429,48 +431,52 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   table-layout: auto;
 }
 
-.c31 td {
+.c30 td {
   padding: 4px 4px 4px 0;
 }
 
-.c31 tr td:first-child {
+.c30 tr td:first-child {
   padding-right: 5px;
 }
 
-.c20 {
+.c19 {
   border-spacing: 0px;
   color: #7F7F7F;
   font-size: 10px;
 }
 
-.c20 :nth-child(even) {
+.c19 :nth-child(even) {
   margin-left: 3px;
 }
 
-.c20 :nth-child(odd) {
+.c19 :nth-child(odd) {
   margin-left: 30px;
 }
 
-.c32 {
+.c31 {
   width: 10%;
 }
 
-.c33 {
+.c32 {
   width: 90%;
 }
 
-.c28 {
+.c27 {
   font-size: 0.7em;
 }
 
 @media print {
-  .c6 {
+
+}
+
+@media print {
+  .c8 {
     display: none;
   }
 }
 
 @media print {
-  .c30 {
+  .c29 {
     border-collapse: collapse;
   }
 }
@@ -499,7 +505,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               target="_blank"
             >
               <span
-                class="c6 c7"
+                class="c6"
                 data-testid="svg-icon"
                 title="Help: Policies"
               >
@@ -511,11 +517,11 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <a
-              class="c8"
+              class="c7"
               href="/policies"
             >
               <span
-                class="c6 c7"
+                class="c6"
                 data-testid="svg-icon"
                 title="Policies List"
               >
@@ -535,7 +541,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
             class="c2 c5"
           >
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Clone Policy"
             >
@@ -546,7 +552,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Edit Policy"
             >
@@ -557,7 +563,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Move Policy to trashcan"
             >
@@ -568,7 +574,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Export Policy as XML"
             >
@@ -587,16 +593,16 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
     class="entity-section"
   >
     <div
-      class="c10 c11 section-header"
+      class="c9 c10 section-header"
     >
       <h2
-        class="c12 c13"
+        class="c11 c12"
       >
         <div
-          class="c14 c15"
+          class="c13 c14"
         >
           <span
-            class="c6 c16"
+            class="c15"
             data-testid="svg-icon"
           >
             <svg>
@@ -605,19 +611,19 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
           </span>
         </div>
         <div
-          class="c14 c17"
+          class="c13 c16"
         >
           Policy: foo
         </div>
       </h2>
       <div
-        class="c18"
+        class="c17"
       >
         <div
-          class="c19"
+          class="c18"
         >
           <div
-            class="c2 c20"
+            class="c2 c19"
           >
             <div>
               ID:
@@ -648,30 +654,30 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
       </div>
     </div>
     <div
-      class="c21"
+      class="c20"
     >
       <div
-        class="c22 c23"
+        class="c21 c22"
       >
         <div
-          class="c24"
+          class="c23"
         >
           <div
-            class="c25"
+            class="c24"
           >
             Information
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 Scanner Preferences
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -682,16 +688,16 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 NVT Families
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -702,16 +708,16 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 NVT Preferences
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -722,16 +728,16 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 Permissions
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -744,21 +750,21 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
         </div>
       </div>
       <div
-        class="c29"
+        class="c28"
       >
         <div
-          class="c21"
+          class="c20"
         >
           <table
-            class="c30 c31"
+            class="c29 c30"
           >
             <colgroup>
               <col
-                class="c32"
+                class="c31"
                 width="10%"
               />
               <col
-                class="c33"
+                class="c32"
                 width="90%"
               />
             </colgroup>
@@ -768,14 +774,14 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               <tr>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     Comment
                   </div>
                 </td>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     bar
                   </div>
@@ -784,23 +790,23 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               <tr>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     Audits using this Policy
                   </div>
                 </td>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     <div
                       class="c2 c3"
                     >
                       <div
-                        class="c34 c5"
+                        class="c33 c5"
                       >
                         <a
-                          class="c8"
+                          class="c7"
                           data-testid="details-link"
                           href="/audit/1234"
                         >
@@ -808,7 +814,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
                         </a>
                         ,
                         <a
-                          class="c8"
+                          class="c7"
                           data-testid="details-link"
                           href="/audit/5678"
                         >
@@ -838,8 +844,8 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -847,7 +853,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c5 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -858,14 +864,14 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
   margin-left: -10px;
 }
 
-.c2>* {
+.c2 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2>* {
+.c2 > * {
   margin-left: 10px;
 }
 
@@ -873,14 +879,14 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c3>* {
+.c3 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c3>* {
+.c3 > * {
   margin-left: 5px;
 }
 
@@ -891,23 +897,27 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
   display: inline-flex;
 }
 
-.c7 {
+.c6 {
   cursor: pointer;
 }
 
-.c5 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c5 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
 
 @media print {
-  .c4 {
+
+}
+
+@media print {
+  .c6 {
     display: none;
   }
 }
@@ -930,7 +940,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           target="_blank"
         >
           <span
-            class="c4 c5"
+            class="c4"
             data-testid="svg-icon"
             title="Help: Policies"
           >
@@ -942,11 +952,11 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <a
-          class="c6"
+          class="c5"
           href="/policies"
         >
           <span
-            class="c4 c5"
+            class="c4"
             data-testid="svg-icon"
             title="Policies List"
           >
@@ -966,7 +976,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
         class="c0 c3"
       >
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Clone Policy"
         >
@@ -977,7 +987,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Edit Policy"
         >
@@ -988,7 +998,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Move Policy to trashcan"
         >
@@ -999,7 +1009,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Export Policy as XML"
         >

--- a/src/web/pages/policies/__tests__/__snapshots__/dialog.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/dialog.js.snap
@@ -11,6 +11,7 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -31,8 +32,8 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -49,8 +50,8 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -67,8 +68,8 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -88,8 +89,8 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -122,7 +123,7 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -145,7 +146,7 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -181,15 +182,15 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -265,8 +266,8 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -280,7 +281,7 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   background: #11ab51;
 }
 
-.c23 :hover {
+.c23:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -296,6 +297,7 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
 .c20 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -313,11 +315,13 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 
@@ -344,8 +348,8 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -407,8 +411,8 @@ exports[`CreatePolicyDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/pages/policies/__tests__/__snapshots__/listpage.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/listpage.js.snap
@@ -10,8 +10,8 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23,14 +23,14 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
   margin-left: -5px;
 }
 
-.c2>* {
+.c2 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2>* {
+.c2 > * {
   margin-left: 5px;
 }
 
@@ -41,23 +41,27 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
   display: inline-flex;
 }
 
-.c5 {
+.c4 {
   cursor: pointer;
 }
 
-.c4 {
+.c3 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c4 * {
+.c3 * {
   height: inherit;
   width: inherit;
 }
 
 @media print {
-  .c3 {
+
+}
+
+@media print {
+  .c4 {
     display: none;
   }
 }
@@ -74,7 +78,7 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
       target="_blank"
     >
       <span
-        class="c3 c4"
+        class="c3"
         data-testid="svg-icon"
         title="Help: Policies"
       >
@@ -86,7 +90,7 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
       </span>
     </a>
     <span
-      class="c3 c5 c4"
+      class="c4 c3"
       data-testid="svg-icon"
       title="New Policy"
     >
@@ -97,7 +101,7 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
       </svg>
     </span>
     <span
-      class="c3 c5 c4"
+      class="c4 c3"
       data-testid="svg-icon"
       title="Import Policy"
     >
@@ -125,8 +129,8 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -144,6 +148,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -160,8 +165,8 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -169,7 +174,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: center;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -182,12 +187,12 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -196,13 +201,31 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: stetch;
   -webkit-box-align: stetch;
   -ms-flex-align: stetch;
   align-items: stetch;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c10 {
@@ -213,26 +236,9 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -240,7 +246,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: center;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -249,8 +255,8 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -258,7 +264,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: center;
 }
 
-.c25 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -268,6 +274,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -275,7 +282,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: flex-end;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -284,8 +291,8 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -293,7 +300,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: flex-end;
 }
 
-.c34 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -307,10 +314,11 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   flex-grow: 1;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c36 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -319,8 +327,8 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -328,7 +336,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: center;
 }
 
-.c47 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -337,12 +345,12 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
 }
 
-.c48 {
+.c47 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -351,8 +359,8 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -360,7 +368,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: stretch;
 }
 
-.c49 {
+.c48 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -370,7 +378,30 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
+}
+
+.c50 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -webkit-justify-content: start;
+  -ms-flex-pack: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c51 {
@@ -385,31 +416,9 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c52 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -421,14 +430,14 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   margin-left: -5px;
 }
 
-.c4>* {
+.c4 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4>* {
+.c4 > * {
   margin-left: 5px;
 }
 
@@ -439,48 +448,48 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   display: inline-flex;
 }
 
-.c7 {
+.c6 {
   cursor: pointer;
 }
 
-.c38 svg path {
+.c37 svg path {
   fill: #bfbfbf;
 }
 
-.c6 {
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
-.c31 {
+.c30 {
   height: 50px;
   width: 50px;
   line-height: 50px;
 }
 
-.c31 * {
+.c30 * {
   height: inherit;
   width: inherit;
 }
 
-.c26 {
+.c25 {
   margin: 10px 0px;
   padding-bottom: 1px;
   border-bottom: 2px solid #e5e5e5;
   position: relative;
 }
 
-.c27 {
+.c26 {
   margin: 0 0 1px 0;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -489,8 +498,8 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -498,16 +507,16 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: stretch;
 }
 
-.c30 {
+.c29 {
   margin-right: 5px;
 }
 
-.c32 {
+.c31 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c23 {
+.c22 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -520,8 +529,8 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -532,18 +541,18 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   cursor: pointer;
 }
 
-.c24 {
+.c23 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c24 * {
+.c23 * {
   height: inherit;
   width: inherit;
 }
 
-.c19 {
+.c18 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -567,7 +576,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   font-weight: normal;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -579,7 +588,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   width: 150px;
 }
 
-.c53 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -591,7 +600,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   width: 180px;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -610,7 +619,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   cursor: pointer;
 }
 
-.c16 {
+.c15 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -619,18 +628,18 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   display: none;
 }
 
-.c21 {
+.c20 {
   cursor: default;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c40 {
+.c39 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -639,37 +648,37 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   width: 100%;
 }
 
-.c41 th,
-.c41 td {
+.c40 th,
+.c40 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c41 tfoot tr {
+.c40 tfoot tr {
   background: #fff;
 }
 
-.c41 tfoot tr td {
+.c40 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c43 a {
+.c42 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c43 a:hover {
+.c42 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c45 {
+.c44 {
   cursor: pointer;
 }
 
-.c44 {
+.c43 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -677,7 +686,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   width: 92%;
 }
 
-.c46 {
+.c45 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -685,7 +694,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   width: 8%;
 }
 
-.c14 {
+.c13 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -699,11 +708,11 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   padding: 1px 8px;
 }
 
-.c14:-webkit-autofill {
+.c13:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -712,8 +721,8 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -721,85 +730,93 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: center;
 }
 
-.c13 {
-  margin-right: 5px;
-}
-
 .c12 {
   margin-right: 5px;
 }
 
-.c54 {
+.c11 {
+  margin-right: 5px;
+}
+
+.c53 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c39 {
+.c38 {
   margin: 0 3px;
 }
 
-.c37 {
+.c36 {
   margin: 2px 3px;
 }
 
-.c42 {
+.c41 {
   opacity: 1.0;
 }
 
-.c35 {
+.c34 {
   margin-top: 2px;
   margin-left: 2px;
 }
 
-.c33 {
+.c32 {
   margin-top: 20px;
 }
 
-.c50 {
+.c49 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c50 :hover {
+.c49:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
 @media print {
-  .c5 {
+
+}
+
+@media print {
+  .c6 {
     display: none;
   }
 }
 
 @media print {
-  .c40 {
+
+}
+
+@media print {
+  .c39 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c41>tbody:nth-of-type(even),
-  .c41>tbody:only-of-type>tr:nth-of-type(even) {
+  .c40 > tbody:nth-of-type(even),
+  .c40 > tbody:only-of-type > tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c41>tbody:not(:only-of-type):hover,
-  .c41>tbody:only-of-type>tr:hover {
+  .c40 > tbody:not(:only-of-type):hover,
+  .c40 > tbody:only-of-type > tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c43 {
+  .c42 {
     border-bottom: 1px solid black;
   }
 
-  .c43 a,
-  .c43 a:hover {
+  .c42 a,
+  .c42 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -807,7 +824,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
 }
 
 @media print {
-  .c44 {
+  .c43 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -816,7 +833,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
 }
 
 @media print {
-  .c46 {
+  .c45 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -825,13 +842,13 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
 }
 
 @media print {
-  .c37 svg {
+  .c36 svg {
     display: none;
   }
 }
 
 @media print {
-  .c50 {
+  .c49 {
     color: #000;
   }
 }
@@ -859,7 +876,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               target="_blank"
             >
               <span
-                class="c5 c6"
+                class="c5"
                 data-testid="svg-icon"
                 title="Help: Policies"
               >
@@ -871,7 +888,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </span>
             </a>
             <span
-              class="c5 c7 c6"
+              class="c6 c5"
               data-testid="svg-icon"
               title="New Policy"
             >
@@ -882,7 +899,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c7 c6"
+              class="c6 c5"
               data-testid="svg-icon"
               title="Import Policy"
             >
@@ -895,32 +912,32 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
           </div>
         </div>
         <div
-          class="c8"
+          class="c7"
         >
           <div
-            class="c9 powerfilter"
+            class="c8 powerfilter"
           >
             <div
-              class="c10"
+              class="c9"
             >
               <div
                 class="c2 c3"
               >
                 <div
-                  class="c11 c4 c12"
+                  class="c10 c4 c11"
                 >
                   <div
-                    class="c11"
+                    class="c10"
                   >
                     <label
-                      class="c13"
+                      class="c12"
                     >
                       <b>
                         Filter
                       </b>
                     </label>
                     <input
-                      class="c14 c15"
+                      class="c13 c14"
                       maxlength="1000"
                       name="userFilterString"
                       size="53"
@@ -928,7 +945,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       value=""
                     />
                     <div
-                      class="c16"
+                      class="c15"
                       data-testid="error-marker"
                     >
                       ×
@@ -938,10 +955,10 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     class="c2 c3"
                   >
                     <div
-                      class="c11 c4"
+                      class="c10 c4"
                     >
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Update Filter"
                       >
@@ -952,7 +969,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Remove Filter"
                       >
@@ -963,7 +980,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Reset to Default Filter"
                       >
@@ -979,7 +996,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                         target="_blank"
                       >
                         <span
-                          class="c5 c6"
+                          class="c5"
                           data-testid="svg-icon"
                           title="Help: Powerfilter"
                         >
@@ -998,34 +1015,34 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="downshift-0-label"
-                class="c17"
+                class="c16"
                 role="combobox"
               >
                 <div
-                  class="c18"
+                  class="c17"
                   width="150px"
                 >
                   <div
                     aria-haspopup="true"
                     aria-label="open menu"
-                    class="c19"
+                    class="c18"
                     data-toggle="true"
                     role="button"
                     title="Loaded filter"
                     type="button"
                   >
                     <div
-                      class="c20 c21"
+                      class="c19 c20"
                       data-testid="select-selected-value"
                       title="Loaded filter"
                     >
                       --
                     </div>
                     <div
-                      class="c22"
+                      class="c21"
                     >
                       <span
-                        class="c23 c24"
+                        class="c22 c23"
                         data-testid="select-open-button"
                       >
                         ▼
@@ -1034,7 +1051,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                   data-testid="error-marker"
                 >
                   ×
@@ -1048,16 +1065,16 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
         class="entities-section"
       >
         <div
-          class="c25 c26 section-header"
+          class="c24 c25 section-header"
         >
           <h2
-            class="c27 c28"
+            class="c26 c27"
           >
             <div
-              class="c29 c30"
+              class="c28 c29"
             >
               <span
-                class="c5 c31"
+                class="c30"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -1066,26 +1083,26 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </span>
             </div>
             <div
-              class="c29 c32"
+              class="c28 c31"
             >
               Policies 0 of 0
             </div>
           </h2>
           <div
-            class="c10"
+            class="c9"
           />
         </div>
         <div
           class="c0"
         >
           <div
-            class="c0 c33 entities-table"
+            class="c0 c32 entities-table"
           >
             <div
-              class="c34"
+              class="c33"
             >
               <span
-                class="c5 c7 c6 c35"
+                class="c6 c5 c34"
                 data-testid="svg-icon"
                 title="Unfold all details"
               >
@@ -1096,7 +1113,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                 </svg>
               </span>
               <div
-                class="c36 c37"
+                class="c35 c36"
               >
                 <div
                   class="c2 c3"
@@ -1105,7 +1122,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1116,7 +1133,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1129,7 +1146,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c39"
+                  class="c38"
                 >
                   0 - 0 of 0
                 </span>
@@ -1140,7 +1157,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1151,7 +1168,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Last"
                     >
@@ -1166,17 +1183,17 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </div>
             </div>
             <table
-              class="c40 c41 c42"
+              class="c39 c40 c41"
             >
               <thead
-                class="c43"
+                class="c42"
               >
                 <tr>
                   <th
-                    class="c44"
+                    class="c43"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1186,10 +1203,10 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c46"
+                    class="c45"
                   >
                     <div
-                      class="c47"
+                      class="c46"
                     >
                       Actions
                     </div>
@@ -1202,17 +1219,17 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                 <tr>
                   <td>
                     <div
-                      class="c48"
+                      class="c47"
                     >
                       <div
-                        class="c49"
+                        class="c48"
                       >
                         <div
-                          class="c48"
+                          class="c47"
                         >
                           <span>
                             <span
-                              class="c50"
+                              class="c49"
                               name="12345"
                             >
                               foo
@@ -1234,13 +1251,13 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       class="c0"
                     >
                       <div
-                        class="c51 c3"
+                        class="c50 c3"
                       >
                         <div
-                          class="c52 c4"
+                          class="c51 c4"
                         >
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Move Policy to trashcan"
                           >
@@ -1251,7 +1268,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Edit Policy"
                           >
@@ -1262,7 +1279,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Clone Policy"
                           >
@@ -1273,7 +1290,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Create Audit from Policy"
                           >
@@ -1284,7 +1301,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Export Policy"
                           >
@@ -1306,7 +1323,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     colspan="2"
                   >
                     <div
-                      class="c36"
+                      class="c35"
                     >
                       <div
                         class="c2 c3"
@@ -1318,33 +1335,33 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="downshift-1-label"
-                            class="c17"
+                            class="c16"
                             role="combobox"
                           >
                             <div
-                              class="c53"
+                              class="c52"
                               width="180px"
                             >
                               <div
                                 aria-haspopup="true"
                                 aria-label="open menu"
-                                class="c19"
+                                class="c18"
                                 data-toggle="true"
                                 role="button"
                                 type="button"
                               >
                                 <div
-                                  class="c20 c21"
+                                  class="c19 c20"
                                   data-testid="select-selected-value"
                                   title="Apply to page contents"
                                 >
                                   Apply to page contents
                                 </div>
                                 <div
-                                  class="c22"
+                                  class="c21"
                                 >
                                   <span
-                                    class="c23 c24"
+                                    class="c22 c23"
                                     data-testid="select-open-button"
                                   >
                                     ▼
@@ -1353,7 +1370,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                               </div>
                             </div>
                             <div
-                              class="c16"
+                              class="c15"
                               data-testid="error-marker"
                             >
                               ×
@@ -1366,7 +1383,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                               class="c2 c4"
                             >
                               <span
-                                class="c5 c7 c6"
+                                class="c6 c5"
                                 data-testid="svg-icon"
                                 title="Move page contents to trashcan"
                               >
@@ -1377,7 +1394,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                                 </svg>
                               </span>
                               <span
-                                class="c5 c7 c6"
+                                class="c6 c5"
                                 data-testid="svg-icon"
                                 title="Export page contents"
                               >
@@ -1397,15 +1414,15 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </tfoot>
             </table>
             <div
-              class="c49"
+              class="c48"
             >
               <div
-                class="c2 c54"
+                class="c2 c53"
               >
                 (Applied filter: )
               </div>
               <div
-                class="c36 c37"
+                class="c35 c36"
               >
                 <div
                   class="c2 c3"
@@ -1414,7 +1431,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1425,7 +1442,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1438,7 +1455,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c39"
+                  class="c38"
                 >
                   0 - 0 of 0
                 </span>
@@ -1449,7 +1466,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1460,7 +1477,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Last"
                     >

--- a/src/web/pages/policies/__tests__/__snapshots__/row.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/row.js.snap
@@ -10,8 +10,8 @@ exports[`Row tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -29,6 +29,7 @@ exports[`Row tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -45,8 +46,8 @@ exports[`Row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -67,8 +68,8 @@ exports[`Row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -89,8 +90,8 @@ exports[`Row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -102,14 +103,14 @@ exports[`Row tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c7>* {
+.c7 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c7>* {
+.c7 > * {
   margin-left: 5px;
 }
 
@@ -120,17 +121,17 @@ exports[`Row tests should render 1`] = `
   display: inline-flex;
 }
 
-.c9 {
+.c8 {
   cursor: pointer;
 }
 
-.c10 {
+.c9 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c10 * {
+.c9 * {
   height: inherit;
   width: inherit;
 }
@@ -142,7 +143,7 @@ exports[`Row tests should render 1`] = `
   color: #0a53b8;
 }
 
-.c2 :hover {
+.c2:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
@@ -206,7 +207,7 @@ exports[`Row tests should render 1`] = `
               class="c6 c7"
             >
               <span
-                class="c8 c9 c10"
+                class="c8 c9"
                 data-testid="svg-icon"
                 title="Move Policy to trashcan"
               >
@@ -217,7 +218,7 @@ exports[`Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c9 c10"
+                class="c8 c9"
                 data-testid="svg-icon"
                 title="Edit Policy"
               >
@@ -228,7 +229,7 @@ exports[`Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c9 c10"
+                class="c8 c9"
                 data-testid="svg-icon"
                 title="Clone Policy"
               >
@@ -239,7 +240,7 @@ exports[`Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c9 c10"
+                class="c8 c9"
                 data-testid="svg-icon"
                 title="Create Audit from Policy"
               >
@@ -250,7 +251,7 @@ exports[`Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c9 c10"
+                class="c8 c9"
                 data-testid="svg-icon"
                 title="Export Policy"
               >

--- a/src/web/pages/policies/__tests__/__snapshots__/table.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/table.js.snap
@@ -14,8 +14,8 @@ exports[`Policies table tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -37,10 +37,11 @@ exports[`Policies table tests should render 1`] = `
   flex-grow: 1;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c7 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -49,8 +50,8 @@ exports[`Policies table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -58,7 +59,7 @@ exports[`Policies table tests should render 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -67,8 +68,8 @@ exports[`Policies table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -76,7 +77,7 @@ exports[`Policies table tests should render 1`] = `
   align-items: center;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -85,12 +86,12 @@ exports[`Policies table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -99,8 +100,8 @@ exports[`Policies table tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -108,7 +109,7 @@ exports[`Policies table tests should render 1`] = `
   align-items: stretch;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -118,7 +119,30 @@ exports[`Policies table tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
+}
+
+.c23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -webkit-justify-content: start;
+  -ms-flex-pack: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c24 {
@@ -133,31 +157,9 @@ exports[`Policies table tests should render 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c25 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -165,7 +167,7 @@ exports[`Policies table tests should render 1`] = `
   align-items: center;
 }
 
-.c31 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -174,57 +176,57 @@ exports[`Policies table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.c11 {
-  margin-left: -5px;
-}
-
-.c11>* {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c11>* {
-  margin-left: 5px;
 }
 
 .c10 {
+  margin-left: -5px;
+}
+
+.c10 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4 {
+.c10 > * {
+  margin-left: 5px;
+}
+
+.c9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c3 {
   cursor: pointer;
 }
 
-.c12 svg path {
+.c11 svg path {
   fill: #bfbfbf;
 }
 
-.c5 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c5 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
 
-.c32 {
+.c31 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -237,8 +239,8 @@ exports[`Policies table tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -249,18 +251,18 @@ exports[`Policies table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c33 {
+.c32 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c33 * {
+.c32 * {
   height: inherit;
   width: inherit;
 }
 
-.c28 {
+.c27 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -284,7 +286,7 @@ exports[`Policies table tests should render 1`] = `
   font-weight: normal;
 }
 
-.c27 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -296,7 +298,7 @@ exports[`Policies table tests should render 1`] = `
   width: 180px;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -315,7 +317,7 @@ exports[`Policies table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c34 {
+.c33 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -324,18 +326,18 @@ exports[`Policies table tests should render 1`] = `
   display: none;
 }
 
-.c30 {
+.c29 {
   cursor: default;
 }
 
-.c26 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
+.c13 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -344,33 +346,33 @@ exports[`Policies table tests should render 1`] = `
   width: 100%;
 }
 
-.c15 th,
-.c15 td {
+.c14 th,
+.c14 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c15 tfoot tr {
+.c14 tfoot tr {
   background: #fff;
 }
 
-.c15 tfoot tr td {
+.c14 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c17 a {
+.c16 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c17 a:hover {
+.c16 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c18 {
+.c17 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -378,7 +380,7 @@ exports[`Policies table tests should render 1`] = `
   width: 92%;
 }
 
-.c19 {
+.c18 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -386,25 +388,25 @@ exports[`Policies table tests should render 1`] = `
   width: 8%;
 }
 
-.c35 {
+.c34 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c13 {
+.c12 {
   margin: 0 3px;
 }
 
-.c8 {
+.c7 {
   margin: 2px 3px;
 }
 
-.c16 {
+.c15 {
   opacity: 1.0;
 }
 
-.c6 {
+.c5 {
   margin-top: 2px;
   margin-left: 2px;
 }
@@ -413,14 +415,14 @@ exports[`Policies table tests should render 1`] = `
   margin-top: 20px;
 }
 
-.c23 {
+.c22 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c23 :hover {
+.c22:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
@@ -433,33 +435,50 @@ exports[`Policies table tests should render 1`] = `
 }
 
 @media print {
-  .c14 {
+
+}
+
+@media print {
+
+}
+
+@media print {
+  .c13 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c15>tbody:nth-of-type(even),
-  .c15>tbody:only-of-type>tr:nth-of-type(even) {
+  .c14 > tbody:nth-of-type(even),
+  .c14 > tbody:only-of-type > tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c15>tbody:not(:only-of-type):hover,
-  .c15>tbody:only-of-type>tr:hover {
+  .c14 > tbody:not(:only-of-type):hover,
+  .c14 > tbody:only-of-type > tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c17 {
+  .c16 {
     border-bottom: 1px solid black;
   }
 
-  .c17 a,
-  .c17 a:hover {
+  .c16 a,
+  .c16 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
+  }
+}
+
+@media print {
+  .c17 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: transparent;
+    font-weight: bold;
   }
 }
 
@@ -473,22 +492,13 @@ exports[`Policies table tests should render 1`] = `
 }
 
 @media print {
-  .c19 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: transparent;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c8 svg {
+  .c7 svg {
     display: none;
   }
 }
 
 @media print {
-  .c23 {
+  .c22 {
     color: #000;
   }
 }
@@ -505,7 +515,7 @@ exports[`Policies table tests should render 1`] = `
         class="c2"
       >
         <span
-          class="c3 c4 c5 c6"
+          class="c3 c4 c5"
           data-testid="svg-icon"
           title="Unfold all details"
         >
@@ -516,16 +526,16 @@ exports[`Policies table tests should render 1`] = `
           </svg>
         </span>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -536,7 +546,7 @@ exports[`Policies table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -549,18 +559,18 @@ exports[`Policies table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -571,7 +581,7 @@ exports[`Policies table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >
@@ -586,26 +596,26 @@ exports[`Policies table tests should render 1`] = `
         </div>
       </div>
       <table
-        class="c14 c15 c16"
+        class="c13 c14 c15"
       >
         <thead
-          class="c17"
+          class="c16"
         >
           <tr>
             <th
-              class="c18"
+              class="c17"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 Name
               </div>
             </th>
             <th
-              class="c19"
+              class="c18"
             >
               <div
-                class="c20"
+                class="c19"
               >
                 Actions
               </div>
@@ -618,17 +628,17 @@ exports[`Policies table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c21"
+                class="c20"
               >
                 <div
-                  class="c22"
+                  class="c21"
                 >
                   <div
-                    class="c21"
+                    class="c20"
                   >
                     <span>
                       <span
-                        class="c23"
+                        class="c22"
                         name="12345"
                       >
                         foo
@@ -650,13 +660,13 @@ exports[`Policies table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c24 c10"
+                  class="c23 c9"
                 >
                   <div
-                    class="c25 c11"
+                    class="c24 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Policy to trashcan"
                     >
@@ -667,7 +677,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Policy"
                     >
@@ -678,7 +688,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Policy"
                     >
@@ -689,7 +699,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Create Audit from Policy"
                     >
@@ -700,7 +710,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Policy"
                     >
@@ -718,17 +728,17 @@ exports[`Policies table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c21"
+                class="c20"
               >
                 <div
-                  class="c22"
+                  class="c21"
                 >
                   <div
-                    class="c21"
+                    class="c20"
                   >
                     <span>
                       <span
-                        class="c23"
+                        class="c22"
                         name="123456"
                       >
                         lorem
@@ -750,13 +760,13 @@ exports[`Policies table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c24 c10"
+                  class="c23 c9"
                 >
                   <div
-                    class="c25 c11"
+                    class="c24 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Policy to trashcan"
                     >
@@ -767,7 +777,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Policy"
                     >
@@ -778,7 +788,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Policy"
                     >
@@ -789,7 +799,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Create Audit from Policy"
                     >
@@ -800,7 +810,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Policy"
                     >
@@ -818,17 +828,17 @@ exports[`Policies table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c21"
+                class="c20"
               >
                 <div
-                  class="c22"
+                  class="c21"
                 >
                   <div
-                    class="c21"
+                    class="c20"
                   >
                     <span>
                       <span
-                        class="c23"
+                        class="c22"
                         name="1234567"
                       >
                         hello
@@ -850,13 +860,13 @@ exports[`Policies table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c24 c10"
+                  class="c23 c9"
                 >
                   <div
-                    class="c25 c11"
+                    class="c24 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Policy to trashcan"
                     >
@@ -867,7 +877,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Policy"
                     >
@@ -878,7 +888,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Policy"
                     >
@@ -889,7 +899,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Create Audit from Policy"
                     >
@@ -900,7 +910,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Policy"
                     >
@@ -922,42 +932,42 @@ exports[`Policies table tests should render 1`] = `
               colspan="2"
             >
               <div
-                class="c7"
+                class="c6"
               >
                 <div
-                  class="c9 c10"
+                  class="c8 c9"
                 >
                   <div
-                    class="c9 c11"
+                    class="c8 c10"
                   >
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-labelledby="downshift-0-label"
-                      class="c26"
+                      class="c25"
                       role="combobox"
                     >
                       <div
-                        class="c27"
+                        class="c26"
                         width="180px"
                       >
                         <div
                           aria-haspopup="true"
                           aria-label="open menu"
-                          class="c28"
+                          class="c27"
                           data-toggle="true"
                           role="button"
                           type="button"
                         >
                           <div
-                            class="c29 c30"
+                            class="c28 c29"
                             data-testid="select-selected-value"
                           />
                           <div
-                            class="c31"
+                            class="c30"
                           >
                             <span
-                              class="c32 c33"
+                              class="c31 c32"
                               data-testid="select-open-button"
                             >
                               ▼
@@ -966,20 +976,20 @@ exports[`Policies table tests should render 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c34"
+                        class="c33"
                         data-testid="error-marker"
                       >
                         ×
                       </div>
                     </div>
                     <div
-                      class="c9 c10"
+                      class="c8 c9"
                     >
                       <div
-                        class="c9 c11"
+                        class="c8 c10"
                       >
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -987,7 +997,7 @@ exports[`Policies table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1004,24 +1014,24 @@ exports[`Policies table tests should render 1`] = `
         </tfoot>
       </table>
       <div
-        class="c22"
+        class="c21"
       >
         <div
-          class="c9 c35"
+          class="c8 c34"
         >
           (Applied filter: rows=2)
         </div>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -1032,7 +1042,7 @@ exports[`Policies table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -1045,18 +1055,18 @@ exports[`Policies table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -1067,7 +1077,7 @@ exports[`Policies table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >

--- a/src/web/pages/radius/__tests__/__snapshots__/dialog.js.snap
+++ b/src/web/pages/radius/__tests__/__snapshots__/dialog.js.snap
@@ -11,6 +11,7 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -31,8 +32,8 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -49,8 +50,8 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -67,8 +68,8 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -88,8 +89,8 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -101,14 +102,14 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   margin-left: -5px;
 }
 
-.c17>* {
+.c17 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c17>* {
+.c17 > * {
   margin-left: 5px;
 }
 
@@ -144,7 +145,7 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -167,7 +168,7 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -203,15 +204,15 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -287,8 +288,8 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -302,7 +303,7 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   background: #11ab51;
 }
 
-.c28 :hover {
+.c28:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -318,6 +319,7 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
 .c25 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -335,11 +337,13 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 
@@ -366,8 +370,8 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -425,8 +429,8 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -470,8 +474,8 @@ exports[`RADIUS dialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/pages/results/__tests__/__snapshots__/diff.js.snap
+++ b/src/web/pages/results/__tests__/__snapshots__/diff.js.snap
@@ -16,7 +16,7 @@ exports[`Diff component tests should render 1`] = `
 }
 
 .c1 {
-  color: rgba(0, 0, 0, 0.3);
+  color: rgba(0,0,0,0.3);
 }
 
 <div>

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/details.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/details.js.snap
@@ -14,8 +14,8 @@ exports[`Scan Config Details tests should render full Details 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -32,8 +32,8 @@ exports[`Scan Config Details tests should render full Details 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -50,8 +50,8 @@ exports[`Scan Config Details tests should render full Details 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -67,13 +67,12 @@ exports[`Scan Config Details tests should render full Details 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -92,14 +91,14 @@ exports[`Scan Config Details tests should render full Details 1`] = `
   margin-left: -5px;
 }
 
-.c9>* {
+.c9 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c9>* {
+.c9 > * {
   margin-left: 5px;
 }
 

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/detailspage.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/detailspage.js.snap
@@ -14,8 +14,8 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
 }
 
@@ -29,6 +29,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -45,280 +46,31 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.c10 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
-.c14 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-}
-
-.c21 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c22 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  -webkit-align-items: flex-end;
-  -webkit-box-align: flex-end;
-  -ms-flex-align: flex-end;
-  align-items: flex-end;
-}
-
-.c24 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
-  -webkit-align-items: stretch;
-  -webkit-box-align: stretch;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-}
-
-.c34 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
-  -webkit-flex-wrap: wrap;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c8 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4 {
-  margin-left: -10px;
-}
-
-.c4>* {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c4>* {
-  margin-left: 10px;
-}
-
-.c5 {
-  margin-left: -5px;
-}
-
-.c5>* {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c5>* {
-  margin-left: 5px;
-}
-
-.c3 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
 }
 
 .c9 {
-  cursor: pointer;
-}
-
-.c7 {
-  height: 16px;
-  width: 16px;
-  line-height: 16px;
-}
-
-.c7 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c16 {
-  height: 50px;
-  width: 50px;
-  line-height: 50px;
-}
-
-.c16 * {
-  height: inherit;
-  width: inherit;
-}
-
-.c11 {
-  margin: 10px 0px;
-  padding-bottom: 1px;
-  border-bottom: 2px solid #e5e5e5;
-  position: relative;
-}
-
-.c12 {
-  margin: 0 0 1px 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
 }
 
 .c13 {
@@ -330,8 +82,102 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c18 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c20 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c23 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -339,16 +185,172 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
+.c26 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c28 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c33 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  -webkit-box-pack: start;
+  -webkit-justify-content: start;
+  -ms-flex-pack: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c7 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4 {
+  margin-left: -10px;
+}
+
+.c4 > * {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c4 > * {
+  margin-left: 10px;
+}
+
+.c5 {
+  margin-left: -5px;
+}
+
+.c5 > * {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c5 > * {
+  margin-left: 5px;
+}
+
+.c3 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c8 {
+  cursor: pointer;
+}
+
+.c6 {
+  height: 16px;
+  width: 16px;
+  line-height: 16px;
+}
+
+.c6 * {
+  height: inherit;
+  width: inherit;
+}
+
 .c15 {
+  height: 50px;
+  width: 50px;
+  line-height: 50px;
+}
+
+.c15 * {
+  height: inherit;
+  width: inherit;
+}
+
+.c10 {
+  margin: 10px 0px;
+  padding-bottom: 1px;
+  border-bottom: 2px solid #e5e5e5;
+  position: relative;
+}
+
+.c11 {
+  margin: 0 0 1px 0;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+}
+
+.c14 {
   margin-right: 5px;
 }
 
-.c17 {
+.c16 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c25 {
+.c24 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -375,15 +377,15 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #11ab51;
 }
 
-.c25 :hover {
+.c24:hover {
   border-top: 2px solid #fff;
 }
 
-.c25 :first-child {
+.c24:first-child {
   border-left: 1px solid #e5e5e5;
 }
 
-.c26 {
+.c25 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -407,21 +409,21 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #fff;
 }
 
-.c26 :hover {
+.c25:hover {
   border-top: 2px solid #e5e5e5;
 }
 
-.c26 :first-child {
+.c25:first-child {
   border-left: 1px solid #fff;
 }
 
-.c23 {
+.c22 {
   border-bottom: 2px solid #11ab51;
   margin-top: 30px;
   margin-bottom: 15px;
 }
 
-.c30 {
+.c29 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -429,48 +431,52 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   table-layout: auto;
 }
 
-.c31 td {
+.c30 td {
   padding: 4px 4px 4px 0;
 }
 
-.c31 tr td:first-child {
+.c30 tr td:first-child {
   padding-right: 5px;
 }
 
-.c20 {
+.c19 {
   border-spacing: 0px;
   color: #7F7F7F;
   font-size: 10px;
 }
 
-.c20 :nth-child(even) {
+.c19 :nth-child(even) {
   margin-left: 3px;
 }
 
-.c20 :nth-child(odd) {
+.c19 :nth-child(odd) {
   margin-left: 30px;
 }
 
-.c32 {
+.c31 {
   width: 10%;
 }
 
-.c33 {
+.c32 {
   width: 90%;
 }
 
-.c28 {
+.c27 {
   font-size: 0.7em;
 }
 
 @media print {
-  .c6 {
+
+}
+
+@media print {
+  .c8 {
     display: none;
   }
 }
 
 @media print {
-  .c30 {
+  .c29 {
     border-collapse: collapse;
   }
 }
@@ -499,7 +505,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               target="_blank"
             >
               <span
-                class="c6 c7"
+                class="c6"
                 data-testid="svg-icon"
                 title="Help: ScanConfigs"
               >
@@ -511,11 +517,11 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <a
-              class="c8"
+              class="c7"
               href="/scanconfigs"
             >
               <span
-                class="c6 c7"
+                class="c6"
                 data-testid="svg-icon"
                 title="ScanConfig List"
               >
@@ -535,7 +541,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
             class="c2 c5"
           >
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Create new Scan Config"
             >
@@ -546,7 +552,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Clone Scan Config"
             >
@@ -557,7 +563,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Edit Scan Config"
             >
@@ -568,7 +574,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Move Scan Config to trashcan"
             >
@@ -579,7 +585,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Export Scan Config as XML"
             >
@@ -590,7 +596,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Import Scan Config"
             >
@@ -609,16 +615,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
     class="entity-section"
   >
     <div
-      class="c10 c11 section-header"
+      class="c9 c10 section-header"
     >
       <h2
-        class="c12 c13"
+        class="c11 c12"
       >
         <div
-          class="c14 c15"
+          class="c13 c14"
         >
           <span
-            class="c6 c16"
+            class="c15"
             data-testid="svg-icon"
           >
             <svg>
@@ -627,19 +633,19 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
           </span>
         </div>
         <div
-          class="c14 c17"
+          class="c13 c16"
         >
           Scan Config: foo
         </div>
       </h2>
       <div
-        class="c18"
+        class="c17"
       >
         <div
-          class="c19"
+          class="c18"
         >
           <div
-            class="c2 c20"
+            class="c2 c19"
           >
             <div>
               ID:
@@ -670,30 +676,30 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
       </div>
     </div>
     <div
-      class="c21"
+      class="c20"
     >
       <div
-        class="c22 c23"
+        class="c21 c22"
       >
         <div
-          class="c24"
+          class="c23"
         >
           <div
-            class="c25"
+            class="c24"
           >
             Information
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 Scanner Preferences
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -704,16 +710,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 NVT Families
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -724,16 +730,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 NVT Preferences
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -744,16 +750,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 User Tags
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -764,16 +770,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 Permissions
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -786,21 +792,21 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
         </div>
       </div>
       <div
-        class="c29"
+        class="c28"
       >
         <div
-          class="c21"
+          class="c20"
         >
           <table
-            class="c30 c31"
+            class="c29 c30"
           >
             <colgroup>
               <col
-                class="c32"
+                class="c31"
                 width="10%"
               />
               <col
-                class="c33"
+                class="c32"
                 width="90%"
               />
             </colgroup>
@@ -810,14 +816,14 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               <tr>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     Comment
                   </div>
                 </td>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     bar
                   </div>
@@ -826,23 +832,23 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               <tr>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     Tasks using this Scan Config
                   </div>
                 </td>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     <div
                       class="c2 c3"
                     >
                       <div
-                        class="c34 c5"
+                        class="c33 c5"
                       >
                         <a
-                          class="c8"
+                          class="c7"
                           data-testid="details-link"
                           href="/task/1234"
                         >
@@ -850,7 +856,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
                         </a>
                         ,
                         <a
-                          class="c8"
+                          class="c7"
                           data-testid="details-link"
                           href="/task/5678"
                         >
@@ -880,8 +886,8 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -889,7 +895,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c5 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -900,14 +906,14 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
   margin-left: -10px;
 }
 
-.c2>* {
+.c2 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2>* {
+.c2 > * {
   margin-left: 10px;
 }
 
@@ -915,14 +921,14 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c3>* {
+.c3 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c3>* {
+.c3 > * {
   margin-left: 5px;
 }
 
@@ -933,23 +939,27 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
   display: inline-flex;
 }
 
-.c7 {
+.c6 {
   cursor: pointer;
 }
 
-.c5 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c5 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
 
 @media print {
-  .c4 {
+
+}
+
+@media print {
+  .c6 {
     display: none;
   }
 }
@@ -972,7 +982,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           target="_blank"
         >
           <span
-            class="c4 c5"
+            class="c4"
             data-testid="svg-icon"
             title="Help: ScanConfigs"
           >
@@ -984,11 +994,11 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <a
-          class="c6"
+          class="c5"
           href="/scanconfigs"
         >
           <span
-            class="c4 c5"
+            class="c4"
             data-testid="svg-icon"
             title="ScanConfig List"
           >
@@ -1008,7 +1018,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
         class="c0 c3"
       >
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Create new Scan Config"
         >
@@ -1019,7 +1029,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Clone Scan Config"
         >
@@ -1030,7 +1040,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Edit Scan Config"
         >
@@ -1041,7 +1051,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Move Scan Config to trashcan"
         >
@@ -1052,7 +1062,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Export Scan Config as XML"
         >
@@ -1063,7 +1073,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Import Scan Config"
         >

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/editconfigfamilydialog.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/editconfigfamilydialog.js.snap
@@ -11,6 +11,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -31,8 +32,8 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -49,8 +50,8 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -68,6 +69,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -84,8 +86,8 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -102,8 +104,8 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -120,8 +122,8 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
 }
 
@@ -134,8 +136,8 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
 }
 
@@ -148,8 +150,8 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -157,7 +159,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c39 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -169,8 +171,8 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -182,14 +184,14 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   margin-left: -5px;
 }
 
-.c31>* {
+.c31 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c31>* {
+.c31 > * {
   margin-left: 5px;
 }
 
@@ -200,17 +202,17 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   display: inline-flex;
 }
 
-.c36 {
+.c35 {
   cursor: pointer;
 }
 
-.c37 {
+.c36 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c37 * {
+.c36 * {
   height: inherit;
   width: inherit;
 }
@@ -235,8 +237,8 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -274,7 +276,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -282,7 +284,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   height: 100%;
 }
 
-.c46 {
+.c45 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -291,13 +293,13 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c45 {
+.c44 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -333,15 +335,15 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -356,7 +358,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   width: inherit;
 }
 
-.c42 {
+.c41 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -376,12 +378,12 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   z-index: 1;
 }
 
-.c42:focus,
-.c42:hover {
+.c41:focus,
+.c41:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c42:hover {
+.c41:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -389,26 +391,26 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   color: #fff;
 }
 
-.c42[disabled] {
+.c41[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c42 img {
+.c41 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c42:link {
+.c41:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c43 {
+.c42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -417,8 +419,8 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -426,18 +428,18 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c44 {
+.c43 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c44 :hover {
+.c43:hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c40 {
+.c39 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
@@ -445,9 +447,10 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   padding: 10px 20px 10px 20px;
 }
 
-.c41 {
+.c40 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -465,11 +468,13 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 
@@ -576,8 +581,8 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -612,7 +617,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   background: #4f91c7;
 }
 
-.c38 {
+.c37 {
   height: 13px;
   width: 100%;
   background: #c83814;
@@ -637,13 +642,13 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
 }
 
 @media screen {
-  .c19>tbody:nth-of-type(even),
-  .c19>tbody:only-of-type>tr:nth-of-type(even) {
+  .c19 > tbody:nth-of-type(even),
+  .c19 > tbody:only-of-type > tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c19>tbody:not(:only-of-type):hover,
-  .c19>tbody:only-of-type>tr:hover {
+  .c19 > tbody:not(:only-of-type):hover,
+  .c19 > tbody:only-of-type > tr:hover {
     background: #e5e5e5;
   }
 }
@@ -690,7 +695,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
 }
 
 @media print {
-  .c38 {
+  .c37 {
     background: none;
   }
 }
@@ -977,7 +982,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                               class="c34"
                             >
                               <span
-                                class="c35 c36 c37"
+                                class="c35 c36"
                                 data-testid="svg-icon"
                                 title="Select and edit NVT details"
                               >
@@ -1016,7 +1021,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                               >
                                 <div
                                   background="error"
-                                  class="c38"
+                                  class="c37"
                                   data-testid="progress"
                                 />
                                 <div
@@ -1072,7 +1077,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                               class="c34"
                             >
                               <span
-                                class="c35 c36 c37"
+                                class="c35 c36"
                                 data-testid="svg-icon"
                                 title="Select and edit NVT details"
                               >
@@ -1092,17 +1097,17 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c39 c40 c41"
+              class="c38 c39 c40"
             >
               <button
-                class="c42 c43 c44"
+                class="c41 c42 c43"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c42 c43 c44"
+                class="c41 c42 c43"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -1111,10 +1116,10 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
             </div>
           </div>
           <div
-            class="c45"
+            class="c44"
           >
             <div
-              class="c46"
+              class="c45"
             />
           </div>
         </div>
@@ -1136,6 +1141,7 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1156,8 +1162,8 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -1174,8 +1180,8 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1195,8 +1201,8 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1209,9 +1215,7 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   height: 80px;
   margin: 40px auto;
   background-image: url(greenbone.svg);
-  -webkit-background-size: 90%;
   background-size: 90%;
-  -webkit-background-position: center;
   background-position: center;
   background-repeat: no-repeat;
   -webkit-animation: hGzRiT 2s infinite ease-in-out;
@@ -1247,7 +1251,7 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -1270,7 +1274,7 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -1306,15 +1310,15 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -1390,8 +1394,8 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1405,7 +1409,7 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   background: #11ab51;
 }
 
-.c18 :hover {
+.c18:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -1421,6 +1425,7 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
 .c15 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -1438,11 +1443,13 @@ exports[`EditConfigFamilyDialog component tests should render loading indicator 
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/editdialog.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/editdialog.js.snap
@@ -11,6 +11,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -31,8 +32,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -49,8 +50,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -67,8 +68,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -86,6 +87,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -102,8 +104,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -111,7 +113,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: flex-end;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -124,8 +126,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -133,7 +135,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c35 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -142,9 +144,23 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
+}
+
+.c35 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
 }
 
 .c36 {
@@ -155,23 +171,9 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-}
-
-.c37 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -179,7 +181,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: flex-start;
 }
 
-.c43 {
+.c42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -188,8 +190,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -197,7 +199,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c45 {
+.c44 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -206,8 +208,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -215,7 +217,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c52 {
+.c51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -227,8 +229,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -236,50 +238,50 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c39 {
+.c38 {
   margin-left: -5px;
 }
 
-.c39>* {
+.c38 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c39>* {
+.c38 > * {
   margin-left: 5px;
 }
 
-.c38 {
+.c37 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c26 {
+.c25 {
   cursor: pointer;
 }
 
-.c27 {
+.c26 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c27 * {
+.c26 * {
   height: inherit;
   width: inherit;
 }
 
-.c28 {
+.c27 {
   overflow: hidden;
   -webkit-transition: 0.4s;
   transition: 0.4s;
 }
 
-.c46 {
+.c45 {
   overflow: hidden;
   -webkit-transition: 0.4s;
   transition: 0.4s;
@@ -307,8 +309,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -351,7 +353,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -359,7 +361,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   height: 100%;
 }
 
-.c59 {
+.c58 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -368,13 +370,13 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c58 {
+.c57 {
   position: absolute;
   bottom: 3px;
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -410,15 +412,15 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -433,7 +435,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   width: inherit;
 }
 
-.c55 {
+.c54 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -453,12 +455,12 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   z-index: 1;
 }
 
-.c55:focus,
-.c55:hover {
+.c54:focus,
+.c54:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c55:hover {
+.c54:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -466,26 +468,26 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   color: #fff;
 }
 
-.c55[disabled] {
+.c54[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c55 img {
+.c54 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c55:link {
+.c54:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c56 {
+.c55 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -494,8 +496,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -503,18 +505,18 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c57 {
+.c56 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c57 :hover {
+.c56:hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c53 {
+.c52 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
@@ -522,9 +524,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   padding: 10px 20px 10px 20px;
 }
 
-.c54 {
+.c53 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -542,11 +545,13 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 
@@ -573,8 +578,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -605,7 +610,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   display: none;
 }
 
-.c30 {
+.c29 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -614,7 +619,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   width: 100%;
 }
 
-.c48 {
+.c47 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -623,30 +628,37 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   width: 100%;
 }
 
-.c31 th,
-.c31 td {
+.c30 th,
+.c30 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c31 tfoot tr {
+.c30 tfoot tr {
   background: #fff;
 }
 
-.c31 tfoot tr td {
+.c30 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c32 a {
+.c31 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c32 a:hover {
+.c31 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
+}
+
+.c32 {
+  background-color: #fff;
+  color: #000;
+  border-top: 1px solid #e5e5e5;
+  font-weight: bold;
 }
 
 .c33 {
@@ -654,17 +666,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   color: #000;
   border-top: 1px solid #e5e5e5;
   font-weight: bold;
-}
-
-.c34 {
-  background-color: #fff;
-  color: #000;
-  border-top: 1px solid #e5e5e5;
-  font-weight: bold;
   width: 9em;
 }
 
-.c49 {
+.c48 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -672,7 +677,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   width: 30%;
 }
 
-.c50 {
+.c49 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -711,8 +716,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -720,7 +725,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c47 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -729,8 +734,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -738,7 +743,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c40 {
+.c39 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -754,7 +759,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   cursor: pointer;
 }
 
-.c41 {
+.c40 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -765,7 +770,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   height: auto;
 }
 
-.c42 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -774,8 +779,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -783,7 +788,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c44 {
+.c43 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -792,8 +797,8 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -801,7 +806,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c51 {
+.c50 {
   overflow-wrap: break-word;
 }
 
@@ -812,39 +817,52 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
 }
 
 @media print {
-  .c30 {
+
+}
+
+@media print {
+  .c29 {
     border-collapse: collapse;
   }
 }
 
 @media print {
-  .c48 {
+  .c47 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c31>tbody:nth-of-type(even),
-  .c31>tbody:only-of-type>tr:nth-of-type(even) {
+  .c30 > tbody:nth-of-type(even),
+  .c30 > tbody:only-of-type > tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c31>tbody:not(:only-of-type):hover,
-  .c31>tbody:only-of-type>tr:hover {
+  .c30 > tbody:not(:only-of-type):hover,
+  .c30 > tbody:only-of-type > tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c32 {
+  .c31 {
     border-bottom: 1px solid black;
   }
 
-  .c32 a,
-  .c32 a:hover {
+  .c31 a,
+  .c31 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
+  }
+}
+
+@media print {
+  .c32 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: transparent;
+    font-weight: bold;
   }
 }
 
@@ -858,7 +876,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
 }
 
 @media print {
-  .c34 {
+  .c48 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -868,15 +886,6 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
 
 @media print {
   .c49 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: transparent;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c50 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -1003,7 +1012,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                           class="c13 c24"
                         >
                           <span
-                            class="c25 c26 c27 section-fold-icon"
+                            class="c25 c26 section-fold-icon"
                             data-testid="svg-icon"
                             title="Fold"
                           >
@@ -1017,20 +1026,20 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c28"
+                      class="c27"
                     >
                       <div
-                        class="c29"
+                        class="c28"
                       >
                         <table
-                          class="c30 c31"
+                          class="c29 c30"
                         >
                           <thead
-                            class="c32"
+                            class="c31"
                           >
                             <tr>
                               <th
-                                class="c33"
+                                class="c32"
                               >
                                 <div
                                   class="c13"
@@ -1039,7 +1048,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c33"
+                                class="c32"
                               >
                                 <div
                                   class="c13"
@@ -1048,7 +1057,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c33"
+                                class="c32"
                               >
                                 <div
                                   class="c13"
@@ -1057,7 +1066,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c34"
+                                class="c33"
                               >
                                 <div
                                   class="c13"
@@ -1066,10 +1075,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c33"
+                                class="c32"
                               >
                                 <div
-                                  class="c35"
+                                  class="c34"
                                 >
                                   Actions
                                 </div>
@@ -1089,33 +1098,33 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c36"
+                                  class="c35"
                                 >
                                   1 of 1
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c37"
+                                  class="c36"
                                 >
                                   <div
-                                    class="c13 c38"
+                                    class="c13 c37"
                                   >
                                     <div
-                                      class="c13 c39"
+                                      class="c13 c38"
                                     >
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
                                               checked=""
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family1"
                                               type="radio"
@@ -1126,7 +1135,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Dynamic"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1134,16 +1143,16 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                         </svg>
                                       </span>
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family1"
                                               type="radio"
@@ -1154,7 +1163,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Static"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1167,20 +1176,20 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c43"
+                                  class="c42"
                                 >
                                   <label
-                                    class="c40"
+                                    class="c39"
                                   >
                                     <div
-                                      class="c13 c38"
+                                      class="c13 c37"
                                     >
                                       <div
-                                        class="c13 c39"
+                                        class="c13 c38"
                                       >
                                         <input
                                           checked=""
-                                          class="c41 c44"
+                                          class="c40 c43"
                                           name="family1"
                                           type="checkbox"
                                         />
@@ -1191,10 +1200,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c45"
+                                  class="c44"
                                 >
                                   <span
-                                    class="c25 c26 c27"
+                                    class="c25 c26"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config Family"
                                   >
@@ -1217,32 +1226,32 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c36"
+                                  class="c35"
                                 >
                                   2 of 4
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c37"
+                                  class="c36"
                                 >
                                   <div
-                                    class="c13 c38"
+                                    class="c13 c37"
                                   >
                                     <div
-                                      class="c13 c39"
+                                      class="c13 c38"
                                     >
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family2"
                                               type="radio"
@@ -1253,7 +1262,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Dynamic"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1261,17 +1270,17 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                         </svg>
                                       </span>
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
                                               checked=""
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family2"
                                               type="radio"
@@ -1282,7 +1291,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Static"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1295,19 +1304,19 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c43"
+                                  class="c42"
                                 >
                                   <label
-                                    class="c40"
+                                    class="c39"
                                   >
                                     <div
-                                      class="c13 c38"
+                                      class="c13 c37"
                                     >
                                       <div
-                                        class="c13 c39"
+                                        class="c13 c38"
                                       >
                                         <input
-                                          class="c41 c44"
+                                          class="c40 c43"
                                           name="family2"
                                           type="checkbox"
                                         />
@@ -1318,10 +1327,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c45"
+                                  class="c44"
                                 >
                                   <span
-                                    class="c25 c26 c27"
+                                    class="c25 c26"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config Family"
                                   >
@@ -1344,32 +1353,32 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c36"
+                                  class="c35"
                                 >
                                   0 of 2
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c37"
+                                  class="c36"
                                 >
                                   <div
-                                    class="c13 c38"
+                                    class="c13 c37"
                                   >
                                     <div
-                                      class="c13 c39"
+                                      class="c13 c38"
                                     >
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family3"
                                               type="radio"
@@ -1380,7 +1389,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Dynamic"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1388,17 +1397,17 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                         </svg>
                                       </span>
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
                                               checked=""
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family3"
                                               type="radio"
@@ -1409,7 +1418,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Static"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1422,19 +1431,19 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c43"
+                                  class="c42"
                                 >
                                   <label
-                                    class="c40"
+                                    class="c39"
                                   >
                                     <div
-                                      class="c13 c38"
+                                      class="c13 c37"
                                     >
                                       <div
-                                        class="c13 c39"
+                                        class="c13 c38"
                                       >
                                         <input
-                                          class="c41 c44"
+                                          class="c40 c43"
                                           name="family3"
                                           type="checkbox"
                                         />
@@ -1445,10 +1454,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c45"
+                                  class="c44"
                                 >
                                   <span
-                                    class="c25 c26 c27"
+                                    class="c25 c26"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config Family"
                                   >
@@ -1471,32 +1480,32 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c36"
+                                  class="c35"
                                 >
                                   0 of 6
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c37"
+                                  class="c36"
                                 >
                                   <div
-                                    class="c13 c38"
+                                    class="c13 c37"
                                   >
                                     <div
-                                      class="c13 c39"
+                                      class="c13 c38"
                                     >
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family4"
                                               type="radio"
@@ -1507,7 +1516,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Dynamic"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1515,17 +1524,17 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                         </svg>
                                       </span>
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
                                               checked=""
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family4"
                                               type="radio"
@@ -1536,7 +1545,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Static"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1549,19 +1558,19 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c43"
+                                  class="c42"
                                 >
                                   <label
-                                    class="c40"
+                                    class="c39"
                                   >
                                     <div
-                                      class="c13 c38"
+                                      class="c13 c37"
                                     >
                                       <div
-                                        class="c13 c39"
+                                        class="c13 c38"
                                       >
                                         <input
-                                          class="c41 c44"
+                                          class="c40 c43"
                                           name="family4"
                                           type="checkbox"
                                         />
@@ -1572,10 +1581,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c45"
+                                  class="c44"
                                 >
                                   <span
-                                    class="c25 c26 c27"
+                                    class="c25 c26"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config Family"
                                   >
@@ -1613,7 +1622,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                           class="c13 c24"
                         >
                           <span
-                            class="c25 c26 c27 section-fold-icon"
+                            class="c25 c26 section-fold-icon"
                             data-testid="svg-icon"
                             title="Unfold"
                           >
@@ -1627,20 +1636,20 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c46"
+                      class="c45"
                     >
                       <div
-                        class="c29"
+                        class="c28"
                       >
                         <table
-                          class="c30 c31"
+                          class="c29 c30"
                         >
                           <thead
-                            class="c32"
+                            class="c31"
                           >
                             <tr>
                               <th
-                                class="c33"
+                                class="c32"
                               >
                                 <div
                                   class="c13"
@@ -1649,7 +1658,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c33"
+                                class="c32"
                               >
                                 <div
                                   class="c13"
@@ -1658,7 +1667,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c33"
+                                class="c32"
                               >
                                 <div
                                   class="c13"
@@ -1684,7 +1693,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                   class="c10"
                                 >
                                   <input
-                                    class="c15 c47"
+                                    class="c15 c46"
                                     name="scannerpref0"
                                     type="text"
                                     value="0"
@@ -1728,7 +1737,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                           class="c13 c24"
                         >
                           <span
-                            class="c25 c26 c27 section-fold-icon"
+                            class="c25 c26 section-fold-icon"
                             data-testid="svg-icon"
                             title="Unfold"
                           >
@@ -1742,20 +1751,20 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c46"
+                      class="c45"
                     >
                       <div
-                        class="c29"
+                        class="c28"
                       >
                         <table
-                          class="c48 c31"
+                          class="c47 c30"
                         >
                           <thead
-                            class="c32"
+                            class="c31"
                           >
                             <tr>
                               <th
-                                class="c49"
+                                class="c48"
                               >
                                 <div
                                   class="c13"
@@ -1764,7 +1773,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c49"
+                                class="c48"
                               >
                                 <div
                                   class="c13"
@@ -1773,7 +1782,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c49"
+                                class="c48"
                               >
                                 <div
                                   class="c13"
@@ -1782,10 +1791,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c50"
+                                class="c49"
                               >
                                 <div
-                                  class="c35"
+                                  class="c34"
                                 >
                                   Actions
                                 </div>
@@ -1797,7 +1806,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                           >
                             <tr>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1806,7 +1815,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </td>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1815,7 +1824,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </td>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1825,10 +1834,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c45"
+                                  class="c44"
                                 >
                                   <span
-                                    class="c25 c26 c27"
+                                    class="c25 c26"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config NVT Details"
                                   >
@@ -1843,7 +1852,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                             </tr>
                             <tr>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1852,7 +1861,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </td>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1861,7 +1870,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </td>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1871,10 +1880,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c45"
+                                  class="c44"
                                 >
                                   <span
-                                    class="c25 c26 c27"
+                                    class="c25 c26"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config NVT Details"
                                   >
@@ -1889,7 +1898,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                             </tr>
                             <tr>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1898,7 +1907,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </td>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1907,7 +1916,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </td>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1917,10 +1926,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c45"
+                                  class="c44"
                                 >
                                   <span
-                                    class="c25 c26 c27"
+                                    class="c25 c26"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config NVT Details"
                                   >
@@ -1942,17 +1951,17 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c52 c53 c54"
+              class="c51 c52 c53"
             >
               <button
-                class="c55 c56 c57"
+                class="c54 c55 c56"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c55 c56 c57"
+                class="c54 c55 c56"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -1961,10 +1970,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
             </div>
           </div>
           <div
-            class="c58"
+            class="c57"
           >
             <div
-              class="c59"
+              class="c58"
             />
           </div>
         </div>
@@ -1986,6 +1995,7 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2006,8 +2016,8 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -2024,8 +2034,8 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -2042,8 +2052,8 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2063,8 +2073,8 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2097,7 +2107,7 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -2120,7 +2130,7 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -2156,15 +2166,15 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -2240,8 +2250,8 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2255,7 +2265,7 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   background: #11ab51;
 }
 
-.c24 :hover {
+.c24:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -2271,6 +2281,7 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
 .c21 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -2288,11 +2299,13 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 
@@ -2319,8 +2332,8 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -2382,8 +2395,8 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2399,8 +2412,8 @@ exports[`EditScanConfigDialog component tests should render dialog for config in
   display: -ms-flexbox;
   display: flex;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
 }
 
@@ -2557,6 +2570,7 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2577,8 +2591,8 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -2595,8 +2609,8 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -2613,8 +2627,8 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2634,8 +2648,8 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2668,7 +2682,7 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -2691,7 +2705,7 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -2727,15 +2741,15 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -2811,8 +2825,8 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2826,7 +2840,7 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   background: #11ab51;
 }
 
-.c24 :hover {
+.c24:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -2842,6 +2856,7 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
 .c21 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -2859,11 +2874,13 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 
@@ -2890,8 +2907,8 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -2953,8 +2970,8 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2970,8 +2987,8 @@ exports[`EditScanConfigDialog component tests should render dialog inline notifi
   display: -ms-flexbox;
   display: flex;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
 }
 

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/listpage.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/listpage.js.snap
@@ -10,8 +10,8 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -23,14 +23,14 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
   margin-left: -5px;
 }
 
-.c2>* {
+.c2 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2>* {
+.c2 > * {
   margin-left: 5px;
 }
 
@@ -41,23 +41,27 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
   display: inline-flex;
 }
 
-.c5 {
+.c4 {
   cursor: pointer;
 }
 
-.c4 {
+.c3 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c4 * {
+.c3 * {
   height: inherit;
   width: inherit;
 }
 
 @media print {
-  .c3 {
+
+}
+
+@media print {
+  .c4 {
     display: none;
   }
 }
@@ -74,7 +78,7 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
       target="_blank"
     >
       <span
-        class="c3 c4"
+        class="c3"
         data-testid="svg-icon"
         title="Help: Scan Configs"
       >
@@ -86,7 +90,7 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
       </span>
     </a>
     <span
-      class="c3 c5 c4"
+      class="c4 c3"
       data-testid="svg-icon"
       title="New Scan Config"
     >
@@ -97,7 +101,7 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
       </svg>
     </span>
     <span
-      class="c3 c5 c4"
+      class="c4 c3"
       data-testid="svg-icon"
       title="Import Scan Config"
     >
@@ -125,8 +129,8 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -144,6 +148,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -160,8 +165,8 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -169,7 +174,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: center;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -182,12 +187,12 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -196,13 +201,31 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: stetch;
   -webkit-box-align: stetch;
   -ms-flex-align: stetch;
   align-items: stetch;
+}
+
+.c9 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c10 {
@@ -213,26 +236,9 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c11 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -240,7 +246,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: center;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -249,8 +255,8 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -258,7 +264,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: center;
 }
 
-.c25 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -268,6 +274,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -275,7 +282,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: flex-end;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -284,8 +291,8 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -293,7 +300,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: flex-end;
 }
 
-.c34 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -307,10 +314,11 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   flex-grow: 1;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c36 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -319,8 +327,8 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -328,7 +336,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: center;
 }
 
-.c48 {
+.c47 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -337,12 +345,12 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
 }
 
-.c50 {
+.c49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -351,8 +359,8 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -360,7 +368,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: stretch;
 }
 
-.c51 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -370,7 +378,30 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
+}
+
+.c52 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -webkit-justify-content: start;
+  -ms-flex-pack: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c53 {
@@ -385,31 +416,9 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c54 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -421,14 +430,14 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   margin-left: -5px;
 }
 
-.c4>* {
+.c4 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4>* {
+.c4 > * {
   margin-left: 5px;
 }
 
@@ -439,48 +448,48 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   display: inline-flex;
 }
 
-.c7 {
+.c6 {
   cursor: pointer;
 }
 
-.c38 svg path {
+.c37 svg path {
   fill: #bfbfbf;
 }
 
-.c6 {
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
-.c31 {
+.c30 {
   height: 50px;
   width: 50px;
   line-height: 50px;
 }
 
-.c31 * {
+.c30 * {
   height: inherit;
   width: inherit;
 }
 
-.c26 {
+.c25 {
   margin: 10px 0px;
   padding-bottom: 1px;
   border-bottom: 2px solid #e5e5e5;
   position: relative;
 }
 
-.c27 {
+.c26 {
   margin: 0 0 1px 0;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -489,8 +498,8 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -498,16 +507,16 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: stretch;
 }
 
-.c30 {
+.c29 {
   margin-right: 5px;
 }
 
-.c32 {
+.c31 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c23 {
+.c22 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -520,8 +529,8 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -532,18 +541,18 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   cursor: pointer;
 }
 
-.c24 {
+.c23 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c24 * {
+.c23 * {
   height: inherit;
   width: inherit;
 }
 
-.c19 {
+.c18 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -567,7 +576,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   font-weight: normal;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -579,7 +588,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 150px;
 }
 
-.c55 {
+.c54 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -591,7 +600,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 180px;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -610,7 +619,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   cursor: pointer;
 }
 
-.c16 {
+.c15 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -619,18 +628,18 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   display: none;
 }
 
-.c21 {
+.c20 {
   cursor: default;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c40 {
+.c39 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -639,37 +648,37 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 100%;
 }
 
-.c41 th,
-.c41 td {
+.c40 th,
+.c40 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c41 tfoot tr {
+.c40 tfoot tr {
   background: #fff;
 }
 
-.c41 tfoot tr td {
+.c40 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c43 a {
+.c42 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c43 a:hover {
+.c42 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c45 {
+.c44 {
   cursor: pointer;
 }
 
-.c44 {
+.c43 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -677,7 +686,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 72%;
 }
 
-.c46 {
+.c45 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -685,7 +694,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 10%;
 }
 
-.c47 {
+.c46 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -693,7 +702,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 8%;
 }
 
-.c49 {
+.c48 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -701,7 +710,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 5%;
 }
 
-.c14 {
+.c13 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -715,11 +724,11 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   padding: 1px 8px;
 }
 
-.c14:-webkit-autofill {
+.c13:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -728,8 +737,8 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -737,85 +746,93 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: center;
 }
 
-.c13 {
-  margin-right: 5px;
-}
-
 .c12 {
   margin-right: 5px;
 }
 
-.c56 {
+.c11 {
+  margin-right: 5px;
+}
+
+.c55 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c39 {
+.c38 {
   margin: 0 3px;
 }
 
-.c37 {
+.c36 {
   margin: 2px 3px;
 }
 
-.c42 {
+.c41 {
   opacity: 1.0;
 }
 
-.c35 {
+.c34 {
   margin-top: 2px;
   margin-left: 2px;
 }
 
-.c33 {
+.c32 {
   margin-top: 20px;
 }
 
-.c52 {
+.c51 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c52 :hover {
+.c51:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
 @media print {
-  .c5 {
+
+}
+
+@media print {
+  .c6 {
     display: none;
   }
 }
 
 @media print {
-  .c40 {
+
+}
+
+@media print {
+  .c39 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c41>tbody:nth-of-type(even),
-  .c41>tbody:only-of-type>tr:nth-of-type(even) {
+  .c40 > tbody:nth-of-type(even),
+  .c40 > tbody:only-of-type > tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c41>tbody:not(:only-of-type):hover,
-  .c41>tbody:only-of-type>tr:hover {
+  .c40 > tbody:not(:only-of-type):hover,
+  .c40 > tbody:only-of-type > tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c43 {
+  .c42 {
     border-bottom: 1px solid black;
   }
 
-  .c43 a,
-  .c43 a:hover {
+  .c42 a,
+  .c42 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -823,7 +840,16 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
 }
 
 @media print {
-  .c44 {
+  .c43 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: transparent;
+    font-weight: bold;
+  }
+}
+
+@media print {
+  .c45 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -841,7 +867,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
 }
 
 @media print {
-  .c47 {
+  .c48 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -850,22 +876,13 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
 }
 
 @media print {
-  .c49 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: transparent;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c37 svg {
+  .c36 svg {
     display: none;
   }
 }
 
 @media print {
-  .c52 {
+  .c51 {
     color: #000;
   }
 }
@@ -893,7 +910,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               target="_blank"
             >
               <span
-                class="c5 c6"
+                class="c5"
                 data-testid="svg-icon"
                 title="Help: Scan Configs"
               >
@@ -905,7 +922,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </span>
             </a>
             <span
-              class="c5 c7 c6"
+              class="c6 c5"
               data-testid="svg-icon"
               title="New Scan Config"
             >
@@ -916,7 +933,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c7 c6"
+              class="c6 c5"
               data-testid="svg-icon"
               title="Import Scan Config"
             >
@@ -929,32 +946,32 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
           </div>
         </div>
         <div
-          class="c8"
+          class="c7"
         >
           <div
-            class="c9 powerfilter"
+            class="c8 powerfilter"
           >
             <div
-              class="c10"
+              class="c9"
             >
               <div
                 class="c2 c3"
               >
                 <div
-                  class="c11 c4 c12"
+                  class="c10 c4 c11"
                 >
                   <div
-                    class="c11"
+                    class="c10"
                   >
                     <label
-                      class="c13"
+                      class="c12"
                     >
                       <b>
                         Filter
                       </b>
                     </label>
                     <input
-                      class="c14 c15"
+                      class="c13 c14"
                       maxlength="1000"
                       name="userFilterString"
                       size="53"
@@ -962,7 +979,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       value=""
                     />
                     <div
-                      class="c16"
+                      class="c15"
                       data-testid="error-marker"
                     >
                       ×
@@ -972,10 +989,10 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     class="c2 c3"
                   >
                     <div
-                      class="c11 c4"
+                      class="c10 c4"
                     >
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Update Filter"
                       >
@@ -986,7 +1003,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Remove Filter"
                       >
@@ -997,7 +1014,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Reset to Default Filter"
                       >
@@ -1013,7 +1030,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                         target="_blank"
                       >
                         <span
-                          class="c5 c6"
+                          class="c5"
                           data-testid="svg-icon"
                           title="Help: Powerfilter"
                         >
@@ -1025,7 +1042,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                         </span>
                       </a>
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Edit Filter"
                       >
@@ -1043,34 +1060,34 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="downshift-0-label"
-                class="c17"
+                class="c16"
                 role="combobox"
               >
                 <div
-                  class="c18"
+                  class="c17"
                   width="150px"
                 >
                   <div
                     aria-haspopup="true"
                     aria-label="open menu"
-                    class="c19"
+                    class="c18"
                     data-toggle="true"
                     role="button"
                     title="Loaded filter"
                     type="button"
                   >
                     <div
-                      class="c20 c21"
+                      class="c19 c20"
                       data-testid="select-selected-value"
                       title="Loaded filter"
                     >
                       --
                     </div>
                     <div
-                      class="c22"
+                      class="c21"
                     >
                       <span
-                        class="c23 c24"
+                        class="c22 c23"
                         data-testid="select-open-button"
                       >
                         ▼
@@ -1079,7 +1096,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                   data-testid="error-marker"
                 >
                   ×
@@ -1093,16 +1110,16 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
         class="entities-section"
       >
         <div
-          class="c25 c26 section-header"
+          class="c24 c25 section-header"
         >
           <h2
-            class="c27 c28"
+            class="c26 c27"
           >
             <div
-              class="c29 c30"
+              class="c28 c29"
             >
               <span
-                class="c5 c31"
+                class="c30"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -1111,26 +1128,26 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </span>
             </div>
             <div
-              class="c29 c32"
+              class="c28 c31"
             >
               Scan Configs 0 of 0
             </div>
           </h2>
           <div
-            class="c10"
+            class="c9"
           />
         </div>
         <div
           class="c0"
         >
           <div
-            class="c0 c33 entities-table"
+            class="c0 c32 entities-table"
           >
             <div
-              class="c34"
+              class="c33"
             >
               <span
-                class="c5 c7 c6 c35"
+                class="c6 c5 c34"
                 data-testid="svg-icon"
                 title="Unfold all details"
               >
@@ -1141,7 +1158,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                 </svg>
               </span>
               <div
-                class="c36 c37"
+                class="c35 c36"
               >
                 <div
                   class="c2 c3"
@@ -1150,7 +1167,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1161,7 +1178,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1174,7 +1191,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c39"
+                  class="c38"
                 >
                   0 - 0 of 0
                 </span>
@@ -1185,7 +1202,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1196,7 +1213,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Last"
                     >
@@ -1211,18 +1228,18 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </div>
             </div>
             <table
-              class="c40 c41 c42"
+              class="c39 c40 c41"
             >
               <thead
-                class="c43"
+                class="c42"
               >
                 <tr>
                   <th
-                    class="c44"
+                    class="c43"
                     rowspan="2"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1232,7 +1249,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c46"
+                    class="c45"
                     colspan="2"
                   >
                     <div
@@ -1242,7 +1259,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </div>
                   </th>
                   <th
-                    class="c46"
+                    class="c45"
                     colspan="2"
                   >
                     <div
@@ -1252,11 +1269,11 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </div>
                   </th>
                   <th
-                    class="c47"
+                    class="c46"
                     rowspan="2"
                   >
                     <div
-                      class="c48"
+                      class="c47"
                     >
                       Actions
                     </div>
@@ -1264,10 +1281,10 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                 </tr>
                 <tr>
                   <th
-                    class="c49"
+                    class="c48"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1277,10 +1294,10 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c49"
+                    class="c48"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1290,10 +1307,10 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c49"
+                    class="c48"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1303,10 +1320,10 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c49"
+                    class="c48"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1323,17 +1340,17 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                 <tr>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       <div
-                        class="c51"
+                        class="c50"
                       >
                         <div
-                          class="c50"
+                          class="c49"
                         >
                           <span>
                             <span
-                              class="c52"
+                              class="c51"
                               name="12345"
                             >
                               foo
@@ -1352,18 +1369,18 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       2
                     </div>
                   </td>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       <span
                         alt="Static"
-                        class="c5 c6"
+                        class="c5"
                         data-testid="svg-icon"
                         title="The family selection is STATIC. New families will NOT automatically be added and considered."
                       >
@@ -1377,18 +1394,18 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       4
                     </div>
                   </td>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       <span
                         alt="Dynamic"
-                        class="c5 c6"
+                        class="c5"
                         data-testid="svg-icon"
                         title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
                       >
@@ -1405,13 +1422,13 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       class="c0"
                     >
                       <div
-                        class="c53 c3"
+                        class="c52 c3"
                       >
                         <div
-                          class="c54 c4"
+                          class="c53 c4"
                         >
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Move Scan Config to trashcan"
                           >
@@ -1422,7 +1439,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Edit Scan Config"
                           >
@@ -1433,7 +1450,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Clone Scan Config"
                           >
@@ -1444,7 +1461,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Export Scan Config"
                           >
@@ -1466,7 +1483,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     colspan="6"
                   >
                     <div
-                      class="c36"
+                      class="c35"
                     >
                       <div
                         class="c2 c3"
@@ -1478,33 +1495,33 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="downshift-1-label"
-                            class="c17"
+                            class="c16"
                             role="combobox"
                           >
                             <div
-                              class="c55"
+                              class="c54"
                               width="180px"
                             >
                               <div
                                 aria-haspopup="true"
                                 aria-label="open menu"
-                                class="c19"
+                                class="c18"
                                 data-toggle="true"
                                 role="button"
                                 type="button"
                               >
                                 <div
-                                  class="c20 c21"
+                                  class="c19 c20"
                                   data-testid="select-selected-value"
                                   title="Apply to page contents"
                                 >
                                   Apply to page contents
                                 </div>
                                 <div
-                                  class="c22"
+                                  class="c21"
                                 >
                                   <span
-                                    class="c23 c24"
+                                    class="c22 c23"
                                     data-testid="select-open-button"
                                   >
                                     ▼
@@ -1513,7 +1530,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                               </div>
                             </div>
                             <div
-                              class="c16"
+                              class="c15"
                               data-testid="error-marker"
                             >
                               ×
@@ -1526,7 +1543,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                               class="c2 c4"
                             >
                               <span
-                                class="c5 c7 c6"
+                                class="c6 c5"
                                 data-testid="svg-icon"
                                 title="Add tag to page contents"
                               >
@@ -1537,7 +1554,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                                 </svg>
                               </span>
                               <span
-                                class="c5 c7 c6"
+                                class="c6 c5"
                                 data-testid="svg-icon"
                                 title="Move page contents to trashcan"
                               >
@@ -1548,7 +1565,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                                 </svg>
                               </span>
                               <span
-                                class="c5 c7 c6"
+                                class="c6 c5"
                                 data-testid="svg-icon"
                                 title="Export page contents"
                               >
@@ -1568,15 +1585,15 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </tfoot>
             </table>
             <div
-              class="c51"
+              class="c50"
             >
               <div
-                class="c2 c56"
+                class="c2 c55"
               >
                 (Applied filter: )
               </div>
               <div
-                class="c36 c37"
+                class="c35 c36"
               >
                 <div
                   class="c2 c3"
@@ -1585,7 +1602,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1596,7 +1613,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1609,7 +1626,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c39"
+                  class="c38"
                 >
                   0 - 0 of 0
                 </span>
@@ -1620,7 +1637,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1631,7 +1648,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Last"
                     >

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/row.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/row.js.snap
@@ -10,8 +10,8 @@ exports[`Scan Config row tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -29,10 +29,11 @@ exports[`Scan Config row tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -45,8 +46,8 @@ exports[`Scan Config row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -54,7 +55,7 @@ exports[`Scan Config row tests should render 1`] = `
   align-items: stretch;
 }
 
-.c6 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -67,8 +68,8 @@ exports[`Scan Config row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -76,7 +77,7 @@ exports[`Scan Config row tests should render 1`] = `
   align-items: center;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -89,8 +90,8 @@ exports[`Scan Config row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -98,39 +99,39 @@ exports[`Scan Config row tests should render 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c8 {
   margin-left: -5px;
 }
 
-.c9>* {
+.c8 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c9>* {
+.c8 > * {
   margin-left: 5px;
 }
 
-.c7 {
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c10 {
+.c9 {
   cursor: pointer;
 }
 
-.c4 {
+.c3 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c4 * {
+.c3 * {
   height: inherit;
   width: inherit;
 }
@@ -142,14 +143,18 @@ exports[`Scan Config row tests should render 1`] = `
   color: #0a53b8;
 }
 
-.c2 :hover {
+.c2:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
 @media print {
-  .c3 {
+
+}
+
+@media print {
+  .c9 {
     display: none;
   }
 }
@@ -208,7 +213,7 @@ exports[`Scan Config row tests should render 1`] = `
         >
           <span
             alt="Static"
-            class="c3 c4"
+            class="c3"
             data-testid="svg-icon"
             title="The family selection is STATIC. New families will NOT automatically be added and considered."
           >
@@ -233,7 +238,7 @@ exports[`Scan Config row tests should render 1`] = `
         >
           <span
             alt="Dynamic"
-            class="c3 c4"
+            class="c3"
             data-testid="svg-icon"
             title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
           >
@@ -247,16 +252,16 @@ exports[`Scan Config row tests should render 1`] = `
       </td>
       <td>
         <div
-          class="c5"
+          class="c4"
         >
           <div
-            class="c6 c7"
+            class="c5 c6"
           >
             <div
-              class="c8 c9"
+              class="c7 c8"
             >
               <span
-                class="c3 c10 c4"
+                class="c9 c3"
                 data-testid="svg-icon"
                 title="Move Scan Config to trashcan"
               >
@@ -267,7 +272,7 @@ exports[`Scan Config row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c10 c4"
+                class="c9 c3"
                 data-testid="svg-icon"
                 title="Edit Scan Config"
               >
@@ -278,7 +283,7 @@ exports[`Scan Config row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c10 c4"
+                class="c9 c3"
                 data-testid="svg-icon"
                 title="Clone Scan Config"
               >
@@ -289,7 +294,7 @@ exports[`Scan Config row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c10 c4"
+                class="c9 c3"
                 data-testid="svg-icon"
                 title="Export Scan Config"
               >

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/table.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/table.js.snap
@@ -14,8 +14,8 @@ exports[`Scan Config table tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -37,10 +37,11 @@ exports[`Scan Config table tests should render 1`] = `
   flex-grow: 1;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c7 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -49,8 +50,8 @@ exports[`Scan Config table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -58,7 +59,7 @@ exports[`Scan Config table tests should render 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -67,8 +68,8 @@ exports[`Scan Config table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -76,7 +77,7 @@ exports[`Scan Config table tests should render 1`] = `
   align-items: center;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -85,12 +86,12 @@ exports[`Scan Config table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
 }
 
-.c23 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -99,8 +100,8 @@ exports[`Scan Config table tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -108,7 +109,7 @@ exports[`Scan Config table tests should render 1`] = `
   align-items: stretch;
 }
 
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -118,7 +119,30 @@ exports[`Scan Config table tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
+}
+
+.c25 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -webkit-justify-content: start;
+  -ms-flex-pack: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c26 {
@@ -133,31 +157,9 @@ exports[`Scan Config table tests should render 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c27 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -165,7 +167,7 @@ exports[`Scan Config table tests should render 1`] = `
   align-items: center;
 }
 
-.c33 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -174,57 +176,57 @@ exports[`Scan Config table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-}
-
-.c11 {
-  margin-left: -5px;
-}
-
-.c11>* {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c11>* {
-  margin-left: 5px;
 }
 
 .c10 {
+  margin-left: -5px;
+}
+
+.c10 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4 {
+.c10 > * {
+  margin-left: 5px;
+}
+
+.c9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c3 {
   cursor: pointer;
 }
 
-.c12 svg path {
+.c11 svg path {
   fill: #bfbfbf;
 }
 
-.c5 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c5 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
 
-.c34 {
+.c33 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -237,8 +239,8 @@ exports[`Scan Config table tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -249,18 +251,18 @@ exports[`Scan Config table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c35 {
+.c34 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c35 * {
+.c34 * {
   height: inherit;
   width: inherit;
 }
 
-.c30 {
+.c29 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -284,7 +286,7 @@ exports[`Scan Config table tests should render 1`] = `
   font-weight: normal;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -296,7 +298,7 @@ exports[`Scan Config table tests should render 1`] = `
   width: 180px;
 }
 
-.c31 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -315,7 +317,7 @@ exports[`Scan Config table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c36 {
+.c35 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -324,18 +326,18 @@ exports[`Scan Config table tests should render 1`] = `
   display: none;
 }
 
-.c32 {
+.c31 {
   cursor: default;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
+.c13 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -344,33 +346,33 @@ exports[`Scan Config table tests should render 1`] = `
   width: 100%;
 }
 
-.c15 th,
-.c15 td {
+.c14 th,
+.c14 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c15 tfoot tr {
+.c14 tfoot tr {
   background: #fff;
 }
 
-.c15 tfoot tr td {
+.c14 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c17 a {
+.c16 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c17 a:hover {
+.c16 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c18 {
+.c17 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -378,7 +380,7 @@ exports[`Scan Config table tests should render 1`] = `
   width: 72%;
 }
 
-.c19 {
+.c18 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -386,7 +388,7 @@ exports[`Scan Config table tests should render 1`] = `
   width: 10%;
 }
 
-.c20 {
+.c19 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -394,7 +396,7 @@ exports[`Scan Config table tests should render 1`] = `
   width: 8%;
 }
 
-.c22 {
+.c21 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -402,25 +404,25 @@ exports[`Scan Config table tests should render 1`] = `
   width: 5%;
 }
 
-.c37 {
+.c36 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c13 {
+.c12 {
   margin: 0 3px;
 }
 
-.c8 {
+.c7 {
   margin: 2px 3px;
 }
 
-.c16 {
+.c15 {
   opacity: 1.0;
 }
 
-.c6 {
+.c5 {
   margin-top: 2px;
   margin-left: 2px;
 }
@@ -429,14 +431,14 @@ exports[`Scan Config table tests should render 1`] = `
   margin-top: 20px;
 }
 
-.c25 {
+.c24 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c25 :hover {
+.c24:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
@@ -449,33 +451,50 @@ exports[`Scan Config table tests should render 1`] = `
 }
 
 @media print {
-  .c14 {
+
+}
+
+@media print {
+
+}
+
+@media print {
+  .c13 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c15>tbody:nth-of-type(even),
-  .c15>tbody:only-of-type>tr:nth-of-type(even) {
+  .c14 > tbody:nth-of-type(even),
+  .c14 > tbody:only-of-type > tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c15>tbody:not(:only-of-type):hover,
-  .c15>tbody:only-of-type>tr:hover {
+  .c14 > tbody:not(:only-of-type):hover,
+  .c14 > tbody:only-of-type > tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c17 {
+  .c16 {
     border-bottom: 1px solid black;
   }
 
-  .c17 a,
-  .c17 a:hover {
+  .c16 a,
+  .c16 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
+  }
+}
+
+@media print {
+  .c17 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: transparent;
+    font-weight: bold;
   }
 }
 
@@ -498,7 +517,7 @@ exports[`Scan Config table tests should render 1`] = `
 }
 
 @media print {
-  .c20 {
+  .c21 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -507,22 +526,13 @@ exports[`Scan Config table tests should render 1`] = `
 }
 
 @media print {
-  .c22 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: transparent;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c8 svg {
+  .c7 svg {
     display: none;
   }
 }
 
 @media print {
-  .c25 {
+  .c24 {
     color: #000;
   }
 }
@@ -539,7 +549,7 @@ exports[`Scan Config table tests should render 1`] = `
         class="c2"
       >
         <span
-          class="c3 c4 c5 c6"
+          class="c3 c4 c5"
           data-testid="svg-icon"
           title="Unfold all details"
         >
@@ -550,16 +560,16 @@ exports[`Scan Config table tests should render 1`] = `
           </svg>
         </span>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -570,7 +580,7 @@ exports[`Scan Config table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -583,18 +593,18 @@ exports[`Scan Config table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -605,7 +615,7 @@ exports[`Scan Config table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >
@@ -620,48 +630,48 @@ exports[`Scan Config table tests should render 1`] = `
         </div>
       </div>
       <table
-        class="c14 c15 c16"
+        class="c13 c14 c15"
       >
         <thead
-          class="c17"
+          class="c16"
         >
           <tr>
             <th
-              class="c18"
+              class="c17"
               rowspan="2"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 Name
               </div>
             </th>
             <th
-              class="c19"
+              class="c18"
               colspan="2"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 Family
               </div>
             </th>
             <th
-              class="c19"
+              class="c18"
               colspan="2"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 NVTs
               </div>
             </th>
             <th
-              class="c20"
+              class="c19"
               rowspan="2"
             >
               <div
-                class="c21"
+                class="c20"
               >
                 Actions
               </div>
@@ -669,37 +679,37 @@ exports[`Scan Config table tests should render 1`] = `
           </tr>
           <tr>
             <th
-              class="c22"
+              class="c21"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 Total
               </div>
             </th>
             <th
-              class="c22"
+              class="c21"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 Trend
               </div>
             </th>
             <th
-              class="c22"
+              class="c21"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 Total
               </div>
             </th>
             <th
-              class="c22"
+              class="c21"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 Trend
               </div>
@@ -712,17 +722,17 @@ exports[`Scan Config table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c24"
+                  class="c23"
                 >
                   <div
-                    class="c23"
+                    class="c22"
                   >
                     <span>
                       <span
-                        class="c25"
+                        class="c24"
                         name="12345"
                       >
                         foo
@@ -741,18 +751,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 2
               </div>
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span
                   alt="Static"
-                  class="c3 c5"
+                  class="c4"
                   data-testid="svg-icon"
                   title="The family selection is STATIC. New families will NOT automatically be added and considered."
                 >
@@ -766,18 +776,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 4
               </div>
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span
                   alt="Dynamic"
-                  class="c3 c5"
+                  class="c4"
                   data-testid="svg-icon"
                   title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
                 >
@@ -794,13 +804,13 @@ exports[`Scan Config table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c26 c10"
+                  class="c25 c9"
                 >
                   <div
-                    class="c27 c11"
+                    class="c26 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Scan Config to trashcan"
                     >
@@ -811,7 +821,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Scan Config"
                     >
@@ -822,7 +832,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Scan Config"
                     >
@@ -833,7 +843,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Scan Config"
                     >
@@ -851,17 +861,17 @@ exports[`Scan Config table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c24"
+                  class="c23"
                 >
                   <div
-                    class="c23"
+                    class="c22"
                   >
                     <span>
                       <span
-                        class="c25"
+                        class="c24"
                         name="123456"
                       >
                         lorem
@@ -880,18 +890,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 3
               </div>
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span
                   alt="Static"
-                  class="c3 c5"
+                  class="c4"
                   data-testid="svg-icon"
                   title="The family selection is STATIC. New families will NOT automatically be added and considered."
                 >
@@ -905,18 +915,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 5
               </div>
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span
                   alt="Dynamic"
-                  class="c3 c5"
+                  class="c4"
                   data-testid="svg-icon"
                   title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
                 >
@@ -933,13 +943,13 @@ exports[`Scan Config table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c26 c10"
+                  class="c25 c9"
                 >
                   <div
-                    class="c27 c11"
+                    class="c26 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Scan Config to trashcan"
                     >
@@ -950,7 +960,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Scan Config"
                     >
@@ -961,7 +971,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Scan Config"
                     >
@@ -972,7 +982,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Scan Config"
                     >
@@ -990,17 +1000,17 @@ exports[`Scan Config table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c24"
+                  class="c23"
                 >
                   <div
-                    class="c23"
+                    class="c22"
                   >
                     <span>
                       <span
-                        class="c25"
+                        class="c24"
                         name="1234567"
                       >
                         hello
@@ -1019,18 +1029,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 1
               </div>
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span
                   alt="Static"
-                  class="c3 c5"
+                  class="c4"
                   data-testid="svg-icon"
                   title="The family selection is STATIC. New families will NOT automatically be added and considered."
                 >
@@ -1044,18 +1054,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 1
               </div>
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span
                   alt="Dynamic"
-                  class="c3 c5"
+                  class="c4"
                   data-testid="svg-icon"
                   title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
                 >
@@ -1072,13 +1082,13 @@ exports[`Scan Config table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c26 c10"
+                  class="c25 c9"
                 >
                   <div
-                    class="c27 c11"
+                    class="c26 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Scan Config to trashcan"
                     >
@@ -1089,7 +1099,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Scan Config"
                     >
@@ -1100,7 +1110,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Scan Config"
                     >
@@ -1111,7 +1121,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Scan Config"
                     >
@@ -1133,42 +1143,42 @@ exports[`Scan Config table tests should render 1`] = `
               colspan="6"
             >
               <div
-                class="c7"
+                class="c6"
               >
                 <div
-                  class="c9 c10"
+                  class="c8 c9"
                 >
                   <div
-                    class="c9 c11"
+                    class="c8 c10"
                   >
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-labelledby="downshift-0-label"
-                      class="c28"
+                      class="c27"
                       role="combobox"
                     >
                       <div
-                        class="c29"
+                        class="c28"
                         width="180px"
                       >
                         <div
                           aria-haspopup="true"
                           aria-label="open menu"
-                          class="c30"
+                          class="c29"
                           data-toggle="true"
                           role="button"
                           type="button"
                         >
                           <div
-                            class="c31 c32"
+                            class="c30 c31"
                             data-testid="select-selected-value"
                           />
                           <div
-                            class="c33"
+                            class="c32"
                           >
                             <span
-                              class="c34 c35"
+                              class="c33 c34"
                               data-testid="select-open-button"
                             >
                               ▼
@@ -1177,20 +1187,20 @@ exports[`Scan Config table tests should render 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c36"
+                        class="c35"
                         data-testid="error-marker"
                       >
                         ×
                       </div>
                     </div>
                     <div
-                      class="c9 c10"
+                      class="c8 c9"
                     >
                       <div
-                        class="c9 c11"
+                        class="c8 c10"
                       >
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1198,7 +1208,7 @@ exports[`Scan Config table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1206,7 +1216,7 @@ exports[`Scan Config table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1223,24 +1233,24 @@ exports[`Scan Config table tests should render 1`] = `
         </tfoot>
       </table>
       <div
-        class="c24"
+        class="c23"
       >
         <div
-          class="c9 c37"
+          class="c8 c36"
         >
           (Applied filter: rows=2)
         </div>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -1251,7 +1261,7 @@ exports[`Scan Config table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -1264,18 +1274,18 @@ exports[`Scan Config table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -1286,7 +1296,7 @@ exports[`Scan Config table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/trend.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/trend.js.snap
@@ -12,6 +12,10 @@ exports[`Scan Config Trend tests should render 1`] = `
   width: inherit;
 }
 
+@media print {
+
+}
+
 <span
   alt="Dynamic"
   class="c0"

--- a/src/web/pages/scanners/__tests__/__snapshots__/dialog.js.snap
+++ b/src/web/pages/scanners/__tests__/__snapshots__/dialog.js.snap
@@ -11,6 +11,7 @@ exports[`ScannerDialog component tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -31,8 +32,8 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -49,8 +50,8 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -67,8 +68,8 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -85,8 +86,8 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -106,8 +107,8 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -140,7 +141,7 @@ exports[`ScannerDialog component tests should render 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -163,7 +164,7 @@ exports[`ScannerDialog component tests should render 1`] = `
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -199,15 +200,15 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -283,8 +284,8 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -298,7 +299,7 @@ exports[`ScannerDialog component tests should render 1`] = `
   background: #11ab51;
 }
 
-.c31 :hover {
+.c31:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -314,6 +315,7 @@ exports[`ScannerDialog component tests should render 1`] = `
 .c28 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -331,11 +333,13 @@ exports[`ScannerDialog component tests should render 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 
@@ -362,8 +366,8 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -398,8 +402,8 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -527,8 +531,8 @@ exports[`ScannerDialog component tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/pages/tasks/__tests__/__snapshots__/actions.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/actions.js.snap
@@ -14,8 +14,8 @@ exports[`Task Actions tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -36,8 +36,8 @@ exports[`Task Actions tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -58,8 +58,8 @@ exports[`Task Actions tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -71,14 +71,14 @@ exports[`Task Actions tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c4>* {
+.c4 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4>* {
+.c4 > * {
   margin-left: 5px;
 }
 
@@ -89,21 +89,21 @@ exports[`Task Actions tests should render 1`] = `
   display: inline-flex;
 }
 
-.c6 {
+.c5 {
   cursor: pointer;
 }
 
-.c8 svg path {
+.c7 svg path {
   fill: #bfbfbf;
 }
 
-.c7 {
+.c6 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c7 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
@@ -112,6 +112,10 @@ exports[`Task Actions tests should render 1`] = `
   .c5 {
     display: none;
   }
+}
+
+@media print {
+
 }
 
 <body>
@@ -130,7 +134,7 @@ exports[`Task Actions tests should render 1`] = `
             class="c3 c4"
           >
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Start"
             >
@@ -142,7 +146,7 @@ exports[`Task Actions tests should render 1`] = `
             </span>
             <span
               alt="Resume"
-              class="c5 c8 c7"
+              class="c7 c6"
               data-testid="svg-icon"
               title="Task is not stopped"
             >
@@ -153,7 +157,7 @@ exports[`Task Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Move Task to trashcan"
             >
@@ -164,7 +168,7 @@ exports[`Task Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Edit Task"
             >
@@ -175,7 +179,7 @@ exports[`Task Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Clone Task"
             >
@@ -186,7 +190,7 @@ exports[`Task Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Export Task"
             >

--- a/src/web/pages/tasks/__tests__/__snapshots__/autodeletereportsgroup.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/autodeletereportsgroup.js.snap
@@ -10,8 +10,8 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -28,8 +28,8 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -41,14 +41,14 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   margin-left: -5px;
 }
 
-.c7>* {
+.c7 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c7>* {
+.c7 > * {
   margin-left: 5px;
 }
 
@@ -69,8 +69,8 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -132,8 +132,8 @@ exports[`AutoDeleteReportsGroup tests should render dialog group 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/pages/tasks/__tests__/__snapshots__/containerdialog.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/containerdialog.js.snap
@@ -11,6 +11,7 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -31,8 +32,8 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -49,8 +50,8 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -67,8 +68,8 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -88,8 +89,8 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -122,7 +123,7 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -145,7 +146,7 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -181,15 +182,15 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -265,8 +266,8 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -280,7 +281,7 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   background: #11ab51;
 }
 
-.c23 :hover {
+.c23:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -296,6 +297,7 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
 .c20 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -313,11 +315,13 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 
@@ -344,8 +348,8 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -407,8 +411,8 @@ exports[`ContainerDialog tests should render create dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -563,6 +567,7 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -583,8 +588,8 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -601,8 +606,8 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -619,8 +624,8 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -640,8 +645,8 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -653,14 +658,14 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   margin-left: -5px;
 }
 
-.c19>* {
+.c19 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c19>* {
+.c19 > * {
   margin-left: 5px;
 }
 
@@ -696,7 +701,7 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -719,7 +724,7 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -755,15 +760,15 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -839,8 +844,8 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -854,7 +859,7 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   background: #11ab51;
 }
 
-.c29 :hover {
+.c29:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -870,6 +875,7 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
 .c26 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -887,11 +893,13 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 
@@ -918,8 +926,8 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -981,8 +989,8 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1030,8 +1038,8 @@ exports[`ContainerDialog tests should render edit dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/pages/tasks/__tests__/__snapshots__/details.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/details.js.snap
@@ -14,8 +14,8 @@ exports[`Task Details tests should render full task details 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -32,8 +32,8 @@ exports[`Task Details tests should render full task details 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -50,8 +50,8 @@ exports[`Task Details tests should render full task details 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -70,14 +70,14 @@ exports[`Task Details tests should render full task details 1`] = `
   margin-left: -5px;
 }
 
-.c5>* {
+.c5 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5>* {
+.c5 > * {
   margin-left: 5px;
 }
 
@@ -97,7 +97,7 @@ exports[`Task Details tests should render full task details 1`] = `
   width: 100%;
 }
 
-.c6>*:not(:last-child)::after {
+.c6 > *:not(:last-child)::after {
   content: '•';
   margin-left: 5px;
 }

--- a/src/web/pages/tasks/__tests__/__snapshots__/detailspage.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/detailspage.js.snap
@@ -14,8 +14,8 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
 }
 
@@ -29,6 +29,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -45,8 +46,8 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -63,8 +64,8 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -85,8 +86,8 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -104,6 +105,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -120,8 +122,8 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -139,6 +141,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -155,8 +158,8 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
 }
 
@@ -173,8 +176,8 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -195,8 +198,8 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-end;
   -webkit-box-align: flex-end;
@@ -213,8 +216,8 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -231,8 +234,8 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -249,8 +252,8 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -258,7 +261,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c9 {
+.c8 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -269,14 +272,14 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   margin-left: -10px;
 }
 
-.c4>* {
+.c4 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4>* {
+.c4 > * {
   margin-left: 10px;
 }
 
@@ -284,14 +287,14 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   margin-left: -5px;
 }
 
-.c6>* {
+.c6 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c6>* {
+.c6 > * {
   margin-left: 5px;
 }
 
@@ -310,13 +313,13 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   fill: #bfbfbf;
 }
 
-.c8 {
+.c7 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c8 * {
+.c7 * {
   height: inherit;
   width: inherit;
 }
@@ -352,8 +355,8 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -397,11 +400,11 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #11ab51;
 }
 
-.c35 :hover {
+.c35:hover {
   border-top: 2px solid #fff;
 }
 
-.c35 :first-child {
+.c35:first-child {
   border-left: 1px solid #e5e5e5;
 }
 
@@ -429,11 +432,11 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #fff;
 }
 
-.c36 :hover {
+.c36:hover {
   border-top: 2px solid #e5e5e5;
 }
 
-.c36 :first-child {
+.c36:first-child {
   border-left: 1px solid #fff;
 }
 
@@ -460,7 +463,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   width: 100%;
 }
 
-.c49>*:not(:last-child)::after {
+.c49 > *:not(:last-child)::after {
   content: '•';
   margin-left: 5px;
 }
@@ -535,7 +538,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   text-decoration: none;
 }
 
-.c11 {
+.c10 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -550,7 +553,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   display: none;
 }
 
-.c10:hover .c12 {
+.c9:hover .c11 {
   display: block;
 }
 
@@ -631,13 +634,12 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -661,9 +663,17 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
 }
 
 @media print {
-  .c7 {
+
+}
+
+@media print {
+  .c16 {
     display: none;
   }
+}
+
+@media print {
+
 }
 
 @media print {
@@ -721,7 +731,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               target="_blank"
             >
               <span
-                class="c7 c8"
+                class="c7"
                 data-testid="svg-icon"
                 title="Help: Tasks"
               >
@@ -733,11 +743,11 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <a
-              class="c9"
+              class="c8"
               href="/tasks"
             >
               <span
-                class="c7 c8"
+                class="c7"
                 data-testid="svg-icon"
                 title="Task List"
               >
@@ -749,7 +759,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <span
-              class="c7 c8"
+              class="c7"
               data-testid="svg-icon"
               title="This is an Alterable Task. Reports may not relate to current Scan Config or Target!"
             >
@@ -768,10 +778,10 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             class="c2 c6"
           >
             <span
-              class="c10 c11"
+              class="c9 c10"
             >
               <span
-                class="c7 c8"
+                class="c7"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -779,7 +789,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                 </svg>
               </span>
               <div
-                class="c12"
+                class="c11 c12"
               >
                 <ul
                   class="c13"
@@ -806,7 +816,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               </div>
             </span>
             <span
-              class="c7 c16 c8"
+              class="c16 c7"
               data-testid="svg-icon"
               title="Clone Task"
             >
@@ -817,7 +827,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c16 c8"
+              class="c16 c7"
               data-testid="svg-icon"
               title="Edit Task"
             >
@@ -828,7 +838,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c16 c8"
+              class="c16 c7"
               data-testid="svg-icon"
               title="Move Task to trashcan"
             >
@@ -839,7 +849,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c16 c8"
+              class="c16 c7"
               data-testid="svg-icon"
               title="Export Task as XML"
             >
@@ -858,7 +868,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             class="c2 c6"
           >
             <span
-              class="c7 c16 c8"
+              class="c16 c7"
               data-testid="svg-icon"
               title="Start"
             >
@@ -870,7 +880,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             </span>
             <span
               alt="Resume"
-              class="c7 c17 c8"
+              class="c17 c7"
               data-testid="svg-icon"
               title="Task is not stopped"
             >
@@ -895,13 +905,13 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                 class="c2 c6"
               >
                 <a
-                  class="c9"
+                  class="c8"
                   data-testid="details-link"
                   href="/report/1234"
                   title="Last Report for Task foo from 07/30/2019"
                 >
                   <span
-                    class="c7 c8"
+                    class="c7"
                     data-testid="svg-icon"
                   >
                     <svg>
@@ -910,7 +920,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                   </span>
                 </a>
                 <a
-                  class="c9"
+                  class="c8"
                   href="/reports?filter=task_id%3D12345"
                   title="Total Reports for Task foo"
                 >
@@ -918,7 +928,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                     class="c18"
                   >
                     <span
-                      class="c7 c8"
+                      class="c7"
                       data-testid="svg-icon"
                     >
                       <svg>
@@ -936,7 +946,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               </div>
             </div>
             <a
-              class="c9"
+              class="c8"
               href="/results?filter=task_id%3D12345"
               title="Results for Task foo"
             >
@@ -944,7 +954,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                 class="c18"
               >
                 <span
-                  class="c7 c8"
+                  class="c7"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -966,7 +976,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                 class="c2 c6"
               >
                 <a
-                  class="c9"
+                  class="c8"
                   href="/notes?filter=task_id%3D12345"
                   title="Notes for Task foo"
                 >
@@ -974,7 +984,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                     class="c18"
                   >
                     <span
-                      class="c7 c8"
+                      class="c7"
                       data-testid="svg-icon"
                     >
                       <svg>
@@ -990,7 +1000,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                   </div>
                 </a>
                 <a
-                  class="c9"
+                  class="c8"
                   href="/overrides?filter=task_id%3D12345"
                   title="Overrides for Task foo"
                 >
@@ -998,7 +1008,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                     class="c18"
                   >
                     <span
-                      class="c7 c8"
+                      class="c7"
                       data-testid="svg-icon"
                     >
                       <svg>
@@ -1033,7 +1043,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
           class="c24 c25"
         >
           <span
-            class="c7 c26"
+            class="c26"
             data-testid="svg-icon"
           >
             <svg>
@@ -1220,7 +1230,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                   class="c39"
                 >
                   <a
-                    class="c9 c44"
+                    class="c8 c44"
                     data-testid="details-link"
                     href="/report/1234"
                   >
@@ -1261,7 +1271,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             </h2>
             <div>
               <a
-                class="c9"
+                class="c8"
                 data-testid="details-link"
                 href="/target/5678"
               >
@@ -1284,7 +1294,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                 >
                   <span>
                     <a
-                      class="c9"
+                      class="c8"
                       data-testid="details-link"
                       href="/alert/91011"
                     >
@@ -1332,7 +1342,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                       >
                         <span>
                           <a
-                            class="c9"
+                            class="c8"
                             data-testid="details-link"
                             href="/scanner/1516"
                           >
@@ -1513,8 +1523,8 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1531,8 +1541,8 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -1553,8 +1563,8 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -1562,7 +1572,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   align-items: center;
 }
 
-.c7 {
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1573,14 +1583,14 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   margin-left: -10px;
 }
 
-.c2>* {
+.c2 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2>* {
+.c2 > * {
   margin-left: 10px;
 }
 
@@ -1588,14 +1598,14 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c4>* {
+.c4 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4>* {
+.c4 > * {
   margin-left: 5px;
 }
 
@@ -1614,18 +1624,18 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   fill: #bfbfbf;
 }
 
-.c6 {
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
-.c9 {
+.c8 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1640,7 +1650,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   display: none;
 }
 
-.c8:hover .c10 {
+.c7:hover .c9 {
   display: block;
 }
 
@@ -1721,13 +1731,12 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-flex-wrap: wrap;
   -webkit-flex-wrap: wrap;
   -ms-flex-wrap: wrap;
   flex-wrap: wrap;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-content: center;
   -ms-flex-line-pack: center;
@@ -1751,9 +1760,17 @@ exports[`Task ToolBarIcons tests should render 1`] = `
 }
 
 @media print {
-  .c5 {
+
+}
+
+@media print {
+  .c14 {
     display: none;
   }
+}
+
+@media print {
+
 }
 
 <div
@@ -1774,7 +1791,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           target="_blank"
         >
           <span
-            class="c5 c6"
+            class="c5"
             data-testid="svg-icon"
             title="Help: Tasks"
           >
@@ -1786,11 +1803,11 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <a
-          class="c7"
+          class="c6"
           href="/tasks"
         >
           <span
-            class="c5 c6"
+            class="c5"
             data-testid="svg-icon"
             title="Task List"
           >
@@ -1802,7 +1819,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <span
-          class="c5 c6"
+          class="c5"
           data-testid="svg-icon"
           title="This is an Alterable Task. Reports may not relate to current Scan Config or Target!"
         >
@@ -1821,10 +1838,10 @@ exports[`Task ToolBarIcons tests should render 1`] = `
         class="c0 c4"
       >
         <span
-          class="c8 c9"
+          class="c7 c8"
         >
           <span
-            class="c5 c6"
+            class="c5"
             data-testid="svg-icon"
           >
             <svg>
@@ -1832,7 +1849,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
             </svg>
           </span>
           <div
-            class="c10"
+            class="c9 c10"
           >
             <ul
               class="c11"
@@ -1859,7 +1876,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </div>
         </span>
         <span
-          class="c5 c14 c6"
+          class="c14 c5"
           data-testid="svg-icon"
           title="Clone Task"
         >
@@ -1870,7 +1887,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c14 c6"
+          class="c14 c5"
           data-testid="svg-icon"
           title="Edit Task"
         >
@@ -1881,7 +1898,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c14 c6"
+          class="c14 c5"
           data-testid="svg-icon"
           title="Move Task to trashcan"
         >
@@ -1892,7 +1909,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c14 c6"
+          class="c14 c5"
           data-testid="svg-icon"
           title="Export Task as XML"
         >
@@ -1911,7 +1928,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
         class="c0 c4"
       >
         <span
-          class="c5 c14 c6"
+          class="c14 c5"
           data-testid="svg-icon"
           title="Start"
         >
@@ -1923,7 +1940,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
         </span>
         <span
           alt="Resume"
-          class="c5 c15 c6"
+          class="c15 c5"
           data-testid="svg-icon"
           title="Task is not stopped"
         >
@@ -1948,13 +1965,13 @@ exports[`Task ToolBarIcons tests should render 1`] = `
             class="c0 c4"
           >
             <a
-              class="c7"
+              class="c6"
               data-testid="details-link"
               href="/report/1234"
               title="Last Report for Task foo from 07/30/2019"
             >
               <span
-                class="c5 c6"
+                class="c5"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -1963,7 +1980,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
               </span>
             </a>
             <a
-              class="c7"
+              class="c6"
               href="/reports?filter=task_id%3D12345"
               title="Total Reports for Task foo"
             >
@@ -1971,7 +1988,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
                 class="c16"
               >
                 <span
-                  class="c5 c6"
+                  class="c5"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -1989,7 +2006,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </div>
         </div>
         <a
-          class="c7"
+          class="c6"
           href="/results?filter=task_id%3D12345"
           title="Results for Task foo"
         >
@@ -1997,7 +2014,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
             class="c16"
           >
             <span
-              class="c5 c6"
+              class="c5"
               data-testid="svg-icon"
             >
               <svg>
@@ -2019,7 +2036,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
             class="c0 c4"
           >
             <a
-              class="c7"
+              class="c6"
               href="/notes?filter=task_id%3D12345"
               title="Notes for Task foo"
             >
@@ -2027,7 +2044,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
                 class="c16"
               >
                 <span
-                  class="c5 c6"
+                  class="c5"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -2043,7 +2060,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
               </div>
             </a>
             <a
-              class="c7"
+              class="c6"
               href="/overrides?filter=task_id%3D12345"
               title="Overrides for Task foo"
             >
@@ -2051,7 +2068,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
                 class="c16"
               >
                 <span
-                  class="c5 c6"
+                  class="c5"
                   data-testid="svg-icon"
                 >
                   <svg>

--- a/src/web/pages/tasks/__tests__/__snapshots__/listpage.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/listpage.js.snap
@@ -10,8 +10,8 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -19,7 +19,7 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -32,8 +32,8 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
   justify-content: flex-start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -45,14 +45,14 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
   margin-left: -5px;
 }
 
-.c2>* {
+.c2 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c2>* {
+.c2 > * {
   margin-left: 5px;
 }
 
@@ -84,7 +84,7 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
   flex-direction: column;
 }
 
-.c6 {
+.c7 {
   position: relative;
   display: none;
 }
@@ -93,7 +93,7 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
   display: block;
 }
 
-.c7 {
+.c8 {
   position: absolute;
   margin: 0;
   padding: 0;
@@ -105,7 +105,7 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
   width: 255px;
 }
 
-.c8 {
+.c9 {
   height: 22px;
   width: 255px;
   border-left: 1px solid #7F7F7F;
@@ -124,20 +124,20 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
   text-align: left;
 }
 
-.c8:first-child {
+.c9:first-child {
   border-top: 1px solid #7F7F7F;
 }
 
-.c8:last-child {
+.c9:last-child {
   border-bottom: 1px solid #7F7F7F;
 }
 
-.c8:hover {
+.c9:hover {
   background: #11ab51;
   color: #fff;
 }
 
-.c8 div {
+.c9 div {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -151,6 +151,10 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   cursor: pointer;
+}
+
+@media print {
+
 }
 
 <div
@@ -188,34 +192,34 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
         </svg>
       </span>
       <div
-        class="c6"
+        class="c6 c7"
       >
         <ul
-          class="c7"
+          class="c8"
         >
           <li
-            class="c8"
+            class="c9"
           >
             <div
-              class="c9"
+              class="c10"
             >
               Task Wizard
             </div>
           </li>
           <li
-            class="c8"
+            class="c9"
           >
             <div
-              class="c9"
+              class="c10"
             >
               Advanced Task Wizard
             </div>
           </li>
           <li
-            class="c8"
+            class="c9"
           >
             <div
-              class="c9"
+              class="c10"
             >
               Modify Task Wizard
             </div>
@@ -235,25 +239,25 @@ exports[`TaskPage ToolBarIcons test should render 1`] = `
         </svg>
       </span>
       <div
-        class="c6"
+        class="c6 c7"
       >
         <ul
-          class="c7"
+          class="c8"
         >
           <li
-            class="c8"
+            class="c9"
           >
             <div
-              class="c9"
+              class="c10"
             >
               New Task
             </div>
           </li>
           <li
-            class="c8"
+            class="c9"
           >
             <div
-              class="c9"
+              class="c10"
             >
               New Container Task
             </div>

--- a/src/web/pages/tasks/__tests__/__snapshots__/row.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/row.js.snap
@@ -10,8 +10,8 @@ exports[`Task Row tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -29,6 +29,7 @@ exports[`Task Row tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -41,8 +42,8 @@ exports[`Task Row tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -59,12 +60,12 @@ exports[`Task Row tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -77,13 +78,35 @@ exports[`Task Row tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
   -ms-flex-align: stretch;
   align-items: stretch;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -webkit-justify-content: start;
+  -ms-flex-pack: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c17 {
@@ -98,31 +121,9 @@ exports[`Task Row tests should render 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c18 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -141,14 +142,14 @@ exports[`Task Row tests should render 1`] = `
   margin-left: -5px;
 }
 
-.c5>* {
+.c5 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c5>* {
+.c5 > * {
   margin-left: 5px;
 }
 
@@ -159,21 +160,21 @@ exports[`Task Row tests should render 1`] = `
   display: inline-flex;
 }
 
-.c19 {
+.c18 {
   cursor: pointer;
 }
 
-.c20 svg path {
+.c19 svg path {
   fill: #bfbfbf;
 }
 
-.c15 {
+.c14 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c15 * {
+.c14 * {
   height: inherit;
   width: inherit;
 }
@@ -185,7 +186,7 @@ exports[`Task Row tests should render 1`] = `
   color: #0a53b8;
 }
 
-.c2 :hover {
+.c2:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
@@ -234,9 +235,17 @@ exports[`Task Row tests should render 1`] = `
 }
 
 @media print {
-  .c14 {
+
+}
+
+@media print {
+  .c18 {
     display: none;
   }
+}
+
+@media print {
+
 }
 
 @media print {
@@ -398,7 +407,7 @@ exports[`Task Row tests should render 1`] = `
         >
           <span
             alt="Severity increased"
-            class="c14 c15"
+            class="c14"
             data-testid="svg-icon"
             title="Severity increased"
           >
@@ -412,16 +421,16 @@ exports[`Task Row tests should render 1`] = `
       </td>
       <td>
         <div
-          class="c16"
+          class="c15"
         >
           <div
-            class="c17 c4"
+            class="c16 c4"
           >
             <div
-              class="c18 c5"
+              class="c17 c5"
             >
               <span
-                class="c14 c19 c15"
+                class="c18 c14"
                 data-testid="svg-icon"
                 title="Start"
               >
@@ -433,7 +442,7 @@ exports[`Task Row tests should render 1`] = `
               </span>
               <span
                 alt="Resume"
-                class="c14 c20 c15"
+                class="c19 c14"
                 data-testid="svg-icon"
                 title="Task is not stopped"
               >
@@ -444,7 +453,7 @@ exports[`Task Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c14 c19 c15"
+                class="c18 c14"
                 data-testid="svg-icon"
                 title="Move Task to trashcan"
               >
@@ -455,7 +464,7 @@ exports[`Task Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c14 c19 c15"
+                class="c18 c14"
                 data-testid="svg-icon"
                 title="Edit Task"
               >
@@ -466,7 +475,7 @@ exports[`Task Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c14 c19 c15"
+                class="c18 c14"
                 data-testid="svg-icon"
                 title="Clone Task"
               >
@@ -477,7 +486,7 @@ exports[`Task Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c14 c19 c15"
+                class="c18 c14"
                 data-testid="svg-icon"
                 title="Export Task"
               >

--- a/src/web/pages/tasks/__tests__/__snapshots__/table.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/table.js.snap
@@ -14,8 +14,8 @@ exports[`Tasks table tests should render 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -37,10 +37,11 @@ exports[`Tasks table tests should render 1`] = `
   flex-grow: 1;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c7 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -49,8 +50,8 @@ exports[`Tasks table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -58,7 +59,7 @@ exports[`Tasks table tests should render 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -67,8 +68,8 @@ exports[`Tasks table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -76,7 +77,7 @@ exports[`Tasks table tests should render 1`] = `
   align-items: center;
 }
 
-.c23 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -85,12 +86,12 @@ exports[`Tasks table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
 }
 
-.c25 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -99,8 +100,8 @@ exports[`Tasks table tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -108,7 +109,7 @@ exports[`Tasks table tests should render 1`] = `
   align-items: stretch;
 }
 
-.c26 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -118,10 +119,11 @@ exports[`Tasks table tests should render 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
-.c35 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -130,9 +132,31 @@ exports[`Tasks table tests should render 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
+}
+
+.c35 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -webkit-justify-content: start;
+  -ms-flex-pack: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c36 {
@@ -147,31 +171,9 @@ exports[`Tasks table tests should render 1`] = `
   -webkit-flex-grow: 1;
   -ms-flex-positive: 1;
   flex-grow: 1;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c37 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -179,7 +181,7 @@ exports[`Tasks table tests should render 1`] = `
   align-items: center;
 }
 
-.c46 {
+.c45 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -188,8 +190,8 @@ exports[`Tasks table tests should render 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -197,55 +199,55 @@ exports[`Tasks table tests should render 1`] = `
   align-items: center;
 }
 
-.c28 {
+.c27 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-}
-
-.c11 {
-  margin-left: -5px;
-}
-
-.c11>* {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c11>* {
-  margin-left: 5px;
 }
 
 .c10 {
+  margin-left: -5px;
+}
+
+.c10 > * {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4 {
+.c10 > * {
+  margin-left: 5px;
+}
+
+.c9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c3 {
   cursor: pointer;
 }
 
-.c12 svg path {
+.c11 svg path {
   fill: #bfbfbf;
 }
 
-.c5 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c5 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
 
-.c47 {
+.c46 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -258,8 +260,8 @@ exports[`Tasks table tests should render 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -270,18 +272,18 @@ exports[`Tasks table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c48 {
+.c47 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c48 * {
+.c47 * {
   height: inherit;
   width: inherit;
 }
 
-.c43 {
+.c42 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -305,7 +307,7 @@ exports[`Tasks table tests should render 1`] = `
   font-weight: normal;
 }
 
-.c42 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -317,7 +319,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 180px;
 }
 
-.c44 {
+.c43 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -336,7 +338,7 @@ exports[`Tasks table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c49 {
+.c48 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -345,18 +347,18 @@ exports[`Tasks table tests should render 1`] = `
   display: none;
 }
 
-.c45 {
+.c44 {
   cursor: default;
 }
 
-.c41 {
+.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
+.c13 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -365,33 +367,33 @@ exports[`Tasks table tests should render 1`] = `
   width: 100%;
 }
 
-.c15 th,
-.c15 td {
+.c14 th,
+.c14 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c15 tfoot tr {
+.c14 tfoot tr {
   background: #fff;
 }
 
-.c15 tfoot tr td {
+.c14 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c17 a {
+.c16 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c17 a:hover {
+.c16 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c18 {
+.c17 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -399,7 +401,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 41%;
 }
 
-.c19 {
+.c18 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -407,7 +409,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 8%;
 }
 
-.c20 {
+.c19 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -415,7 +417,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 6%;
 }
 
-.c21 {
+.c20 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -423,7 +425,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 24%;
 }
 
-.c22 {
+.c21 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -431,7 +433,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 5%;
 }
 
-.c24 {
+.c23 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -439,25 +441,25 @@ exports[`Tasks table tests should render 1`] = `
   width: 10em;
 }
 
-.c50 {
+.c49 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c13 {
+.c12 {
   margin: 0 3px;
 }
 
-.c8 {
+.c7 {
   margin: 2px 3px;
 }
 
-.c16 {
+.c15 {
   opacity: 1.0;
 }
 
-.c6 {
+.c5 {
   margin-top: 2px;
   margin-left: 2px;
 }
@@ -466,20 +468,20 @@ exports[`Tasks table tests should render 1`] = `
   margin-top: 20px;
 }
 
-.c27 {
+.c26 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c27 :hover {
+.c26:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
-.c30 {
+.c29 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -489,7 +491,7 @@ exports[`Tasks table tests should render 1`] = `
   text-align: center;
 }
 
-.c32 {
+.c31 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -500,41 +502,41 @@ exports[`Tasks table tests should render 1`] = `
   padding-top: 1px;
 }
 
-.c31 {
+.c30 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
 }
 
-.c34 {
+.c33 {
   height: 13px;
   width: 50%;
   background: #f0a519;
 }
 
-.c38 {
+.c37 {
   height: 13px;
   width: 100%;
   background: #99be48;
 }
 
-.c39 {
+.c38 {
   height: 13px;
   width: 0%;
   background: #70c000;
 }
 
-.c40 {
+.c39 {
   height: 13px;
   width: 100%;
   background: #c83814;
 }
 
-.c33 {
+.c32 {
   white-space: nowrap;
 }
 
-.c29:hover {
+.c28:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -546,33 +548,50 @@ exports[`Tasks table tests should render 1`] = `
 }
 
 @media print {
-  .c14 {
+
+}
+
+@media print {
+
+}
+
+@media print {
+  .c13 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c15>tbody:nth-of-type(even),
-  .c15>tbody:only-of-type>tr:nth-of-type(even) {
+  .c14 > tbody:nth-of-type(even),
+  .c14 > tbody:only-of-type > tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c15>tbody:not(:only-of-type):hover,
-  .c15>tbody:only-of-type>tr:hover {
+  .c14 > tbody:not(:only-of-type):hover,
+  .c14 > tbody:only-of-type > tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c17 {
+  .c16 {
     border-bottom: 1px solid black;
   }
 
-  .c17 a,
-  .c17 a:hover {
+  .c16 a,
+  .c16 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
+  }
+}
+
+@media print {
+  .c17 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: transparent;
+    font-weight: bold;
   }
 }
 
@@ -613,7 +632,7 @@ exports[`Tasks table tests should render 1`] = `
 }
 
 @media print {
-  .c22 {
+  .c23 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -622,47 +641,44 @@ exports[`Tasks table tests should render 1`] = `
 }
 
 @media print {
-  .c24 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: transparent;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c8 svg {
+  .c7 svg {
     display: none;
   }
 }
 
 @media print {
-  .c27 {
+  .c26 {
     color: #000;
   }
 }
 
 @media print {
-  .c30 {
+  .c29 {
     background: none;
     border: 0;
   }
 }
 
 @media print {
-  .c32 {
+  .c31 {
     color: black;
   }
 }
 
 @media print {
-  .c31 {
+  .c30 {
     background: none;
   }
 }
 
 @media print {
-  .c34 {
+  .c33 {
+    background: none;
+  }
+}
+
+@media print {
+  .c37 {
     background: none;
   }
 }
@@ -679,12 +695,6 @@ exports[`Tasks table tests should render 1`] = `
   }
 }
 
-@media print {
-  .c40 {
-    background: none;
-  }
-}
-
 <body>
   <div
     id="portals"
@@ -697,7 +707,7 @@ exports[`Tasks table tests should render 1`] = `
         class="c2"
       >
         <span
-          class="c3 c4 c5 c6"
+          class="c3 c4 c5"
           data-testid="svg-icon"
           title="Unfold all details"
         >
@@ -708,16 +718,16 @@ exports[`Tasks table tests should render 1`] = `
           </svg>
         </span>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -728,7 +738,7 @@ exports[`Tasks table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -741,18 +751,18 @@ exports[`Tasks table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -763,7 +773,7 @@ exports[`Tasks table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >
@@ -778,71 +788,71 @@ exports[`Tasks table tests should render 1`] = `
         </div>
       </div>
       <table
-        class="c14 c15 c16"
+        class="c13 c14 c15"
       >
         <thead
-          class="c17"
+          class="c16"
         >
           <tr>
+            <th
+              class="c17"
+            >
+              <div
+                class="c8"
+              >
+                Name
+              </div>
+            </th>
             <th
               class="c18"
             >
               <div
-                class="c9"
+                class="c8"
               >
-                Name
+                Status
               </div>
             </th>
             <th
               class="c19"
             >
               <div
-                class="c9"
+                class="c8"
               >
-                Status
+                Reports
               </div>
             </th>
             <th
               class="c20"
             >
               <div
-                class="c9"
+                class="c8"
               >
-                Reports
+                Last Report
+              </div>
+            </th>
+            <th
+              class="c18"
+            >
+              <div
+                class="c8"
+              >
+                Severity
               </div>
             </th>
             <th
               class="c21"
             >
               <div
-                class="c9"
-              >
-                Last Report
-              </div>
-            </th>
-            <th
-              class="c19"
-            >
-              <div
-                class="c9"
-              >
-                Severity
-              </div>
-            </th>
-            <th
-              class="c22"
-            >
-              <div
-                class="c23"
+                class="c22"
               >
                 Trend
               </div>
             </th>
             <th
-              class="c24"
+              class="c23"
             >
               <div
-                class="c23"
+                class="c22"
               >
                 Actions
               </div>
@@ -855,22 +865,22 @@ exports[`Tasks table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <div
-                  class="c26"
+                  class="c25"
                 >
                   <span
-                    class="c27"
+                    class="c26"
                     name="1234"
                   >
                     foo
                   </span>
                   <div
-                    class="c9 c10"
+                    class="c8 c9"
                   >
                     <div
-                      class="c9 c11"
+                      class="c8 c10"
                     />
                   </div>
                 </div>
@@ -885,28 +895,28 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <a
-                  class="c28 c29"
+                  class="c27 c28"
                   data-testid="details-link"
                   href="/report/1234"
                 >
                   <div
-                    class="c30"
+                    class="c29"
                     data-testid="progressbar-box"
                     title="Done"
                   >
                     <div
                       background="low"
-                      class="c31"
+                      class="c30"
                       data-testid="progress"
                     />
                     <div
-                      class="c32"
+                      class="c31"
                     >
                       <span
-                        class="c33"
+                        class="c32"
                       >
                         Done
                       </span>
@@ -917,13 +927,13 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <div
-                  class="c9"
+                  class="c8"
                 >
                   <a
-                    class="c28"
+                    class="c27"
                     href="/reports?filter=task_id%3D1234%20sort-reverse%3Ddate"
                     title="View list of all reports for Task foo, including unfinished ones"
                   >
@@ -934,11 +944,11 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <span>
                   <a
-                    class="c28"
+                    class="c27"
                     data-testid="details-link"
                     href="/report/1234"
                   >
@@ -949,20 +959,20 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <div
-                  class="c30"
+                  class="c29"
                   data-testid="progressbar-box"
                   title="Medium"
                 >
                   <div
                     background="warn"
-                    class="c34"
+                    class="c33"
                     data-testid="progress"
                   />
                   <div
-                    class="c32"
+                    class="c31"
                   >
                     5.0 (Medium)
                   </div>
@@ -971,7 +981,7 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c35"
+                class="c34"
               >
                 <span />
               </div>
@@ -981,13 +991,13 @@ exports[`Tasks table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c36 c10"
+                  class="c35 c9"
                 >
                   <div
-                    class="c37 c11"
+                    class="c36 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Start"
                     >
@@ -999,7 +1009,7 @@ exports[`Tasks table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Task is not stopped"
                     >
@@ -1010,7 +1020,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Task to trashcan"
                     >
@@ -1021,7 +1031,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Task"
                     >
@@ -1032,7 +1042,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Task"
                     >
@@ -1043,7 +1053,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Task"
                     >
@@ -1061,26 +1071,26 @@ exports[`Tasks table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <div
-                  class="c26"
+                  class="c25"
                 >
                   <span
-                    class="c27"
+                    class="c26"
                     name="12345"
                   >
                     lorem
                   </span>
                   <div
-                    class="c9 c10"
+                    class="c8 c9"
                   >
                     <div
-                      class="c9 c11"
+                      class="c8 c10"
                     >
                       <span
                         alt="Task owned by user"
-                        class="c3 c5"
+                        class="c4"
                         data-testid="svg-icon"
                         title="Task owned by user"
                       >
@@ -1104,26 +1114,26 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <span
-                  class="c28 c29"
+                  class="c27 c28"
                 >
                   <div
-                    class="c30"
+                    class="c29"
                     data-testid="progressbar-box"
                     title="New"
                   >
                     <div
                       background="new"
-                      class="c38"
+                      class="c37"
                       data-testid="progress"
                     />
                     <div
-                      class="c32"
+                      class="c31"
                     >
                       <span
-                        class="c33"
+                        class="c32"
                       >
                         New
                       </span>
@@ -1134,22 +1144,22 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               />
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               />
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               />
             </td>
             <td>
               <div
-                class="c35"
+                class="c34"
               >
                 <span />
               </div>
@@ -1159,13 +1169,13 @@ exports[`Tasks table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c36 c10"
+                  class="c35 c9"
                 >
                   <div
-                    class="c37 c11"
+                    class="c36 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Start"
                     >
@@ -1177,7 +1187,7 @@ exports[`Tasks table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Task is not stopped"
                     >
@@ -1188,7 +1198,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Task to trashcan"
                     >
@@ -1199,7 +1209,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Task"
                     >
@@ -1210,7 +1220,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Task"
                     >
@@ -1221,7 +1231,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Task"
                     >
@@ -1239,26 +1249,26 @@ exports[`Tasks table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <div
-                  class="c26"
+                  class="c25"
                 >
                   <span
-                    class="c27"
+                    class="c26"
                     name="123456"
                   >
                     hello
                   </span>
                   <div
-                    class="c9 c10"
+                    class="c8 c9"
                   >
                     <div
-                      class="c9 c11"
+                      class="c8 c10"
                     >
                       <span
                         alt="Task owned by user"
-                        class="c3 c5"
+                        class="c4"
                         data-testid="svg-icon"
                         title="Task owned by user"
                       >
@@ -1282,28 +1292,28 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <a
-                  class="c28 c29"
+                  class="c27 c28"
                   data-testid="details-link"
                   href="/report/5678"
                 >
                   <div
-                    class="c30"
+                    class="c29"
                     data-testid="progressbar-box"
                     title="Running"
                   >
                     <div
                       background="run"
-                      class="c39"
+                      class="c38"
                       data-testid="progress"
                     />
                     <div
-                      class="c32"
+                      class="c31"
                     >
                       <span
-                        class="c33"
+                        class="c32"
                       >
                         0 %
                       </span>
@@ -1314,13 +1324,13 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <div
-                  class="c9"
+                  class="c8"
                 >
                   <a
-                    class="c28"
+                    class="c27"
                     href="/reports?filter=task_id%3D123456%20sort-reverse%3Ddate"
                     title="View list of all reports for Task hello, including unfinished ones"
                   >
@@ -1331,11 +1341,11 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <span>
                   <a
-                    class="c28"
+                    class="c27"
                     data-testid="details-link"
                     href="/report/1234"
                   >
@@ -1346,20 +1356,20 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <div
-                  class="c30"
+                  class="c29"
                   data-testid="progressbar-box"
                   title="High"
                 >
                   <div
                     background="error"
-                    class="c40"
+                    class="c39"
                     data-testid="progress"
                   />
                   <div
-                    class="c32"
+                    class="c31"
                   >
                     10.0 (High)
                   </div>
@@ -1368,7 +1378,7 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c35"
+                class="c34"
               >
                 <span />
               </div>
@@ -1378,13 +1388,13 @@ exports[`Tasks table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c36 c10"
+                  class="c35 c9"
                 >
                   <div
-                    class="c37 c11"
+                    class="c36 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Stop"
                     >
@@ -1396,7 +1406,7 @@ exports[`Tasks table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Task is not stopped"
                     >
@@ -1407,7 +1417,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Task to trashcan"
                     >
@@ -1418,7 +1428,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Task"
                     >
@@ -1429,7 +1439,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Task"
                     >
@@ -1440,7 +1450,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Task"
                     >
@@ -1462,42 +1472,42 @@ exports[`Tasks table tests should render 1`] = `
               colspan="10"
             >
               <div
-                class="c7"
+                class="c6"
               >
                 <div
-                  class="c9 c10"
+                  class="c8 c9"
                 >
                   <div
-                    class="c9 c11"
+                    class="c8 c10"
                   >
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-labelledby="downshift-0-label"
-                      class="c41"
+                      class="c40"
                       role="combobox"
                     >
                       <div
-                        class="c42"
+                        class="c41"
                         width="180px"
                       >
                         <div
                           aria-haspopup="true"
                           aria-label="open menu"
-                          class="c43"
+                          class="c42"
                           data-toggle="true"
                           role="button"
                           type="button"
                         >
                           <div
-                            class="c44 c45"
+                            class="c43 c44"
                             data-testid="select-selected-value"
                           />
                           <div
-                            class="c46"
+                            class="c45"
                           >
                             <span
-                              class="c47 c48"
+                              class="c46 c47"
                               data-testid="select-open-button"
                             >
                               ▼
@@ -1506,20 +1516,20 @@ exports[`Tasks table tests should render 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c49"
+                        class="c48"
                         data-testid="error-marker"
                       >
                         ×
                       </div>
                     </div>
                     <div
-                      class="c9 c10"
+                      class="c8 c9"
                     >
                       <div
-                        class="c9 c11"
+                        class="c8 c10"
                       >
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1527,7 +1537,7 @@ exports[`Tasks table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1535,7 +1545,7 @@ exports[`Tasks table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1552,24 +1562,24 @@ exports[`Tasks table tests should render 1`] = `
         </tfoot>
       </table>
       <div
-        class="c26"
+        class="c25"
       >
         <div
-          class="c9 c50"
+          class="c8 c49"
         >
           (Applied filter: rows=2)
         </div>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -1580,7 +1590,7 @@ exports[`Tasks table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -1593,18 +1603,18 @@ exports[`Tasks table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -1615,7 +1625,7 @@ exports[`Tasks table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >

--- a/src/web/pages/tasks/__tests__/__snapshots__/trend.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/trend.js.snap
@@ -12,6 +12,10 @@ exports[`Task Trend tests should render 1`] = `
   width: inherit;
 }
 
+@media print {
+
+}
+
 <span
   alt="Severity increased"
   class="c0"

--- a/src/web/pages/tickets/__tests__/__snapshots__/createdialog.js.snap
+++ b/src/web/pages/tickets/__tests__/__snapshots__/createdialog.js.snap
@@ -11,6 +11,7 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -31,8 +32,8 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -49,8 +50,8 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -67,8 +68,8 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -85,8 +86,8 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -106,8 +107,8 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -140,7 +141,7 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -163,7 +164,7 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -199,15 +200,15 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -283,8 +284,8 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -298,7 +299,7 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   background: #11ab51;
 }
 
-.c31 :hover {
+.c31:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -314,6 +315,7 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
 .c28 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -331,11 +333,13 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 
@@ -362,8 +366,8 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -398,8 +402,8 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -520,8 +524,8 @@ exports[`CreateTicketDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;

--- a/src/web/pages/tickets/__tests__/__snapshots__/editdialog.js.snap
+++ b/src/web/pages/tickets/__tests__/__snapshots__/editdialog.js.snap
@@ -11,6 +11,7 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   flex-direction: row;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -31,8 +32,8 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: flex-start;
   -webkit-box-align: flex-start;
@@ -49,8 +50,8 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-direction: column;
   flex-direction: column;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: stretch;
   -webkit-box-align: stretch;
@@ -67,8 +68,8 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -85,8 +86,8 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -106,8 +107,8 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-negative: 0;
   flex-shrink: 0;
   -webkit-box-pack: end;
-  -ms-flex-pack: end;
   -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
   justify-content: flex-end;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -140,7 +141,7 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   bottom: 0;
   left: 0;
   margin: 0;
-  background: rgba(102, 102, 102, 0.5);
+  background: rgba(102,102,102,0.5);
   z-index: 600;
   -webkit-transition: opacity 1s ease-in;
   transition: opacity 1s ease-in;
@@ -163,7 +164,7 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   right: 3px;
   width: 20px;
   height: 20px;
-  background: repeating-linear-gradient(     -45deg,     transparent,     transparent 2px,     #000 2px,     #000 3px   );
+  background: repeating-linear-gradient( -45deg, transparent, transparent 2px, #000 2px, #000 3px );
 }
 
 .c2 {
@@ -199,15 +200,15 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
 }
 
-.c5 :hover {
+.c5:hover {
   border: 1px solid #074320;
 }
 
@@ -283,8 +284,8 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -298,7 +299,7 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   background: #11ab51;
 }
 
-.c31 :hover {
+.c31:hover {
   color: #074320;
   background: #A1DDBA;
 }
@@ -314,6 +315,7 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
 .c28 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
 }
 
@@ -331,11 +333,13 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   align-items: center;
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
   justify-content: space-between;
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
   cursor: -webkit-grab;
+  cursor: -moz-grab;
   cursor: grab;
 }
 
@@ -362,8 +366,8 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   padding-bottom: 10px;
 }
@@ -398,8 +402,8 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-align: center;
   align-items: center;
   -webkit-box-pack: center;
-  -ms-flex-pack: center;
   -webkit-justify-content: center;
+  -ms-flex-pack: center;
   justify-content: center;
   outline: none;
   margin: 1px;
@@ -520,8 +524,8 @@ exports[`EditTicketDialog component tests should render dialog 1`] = `
   -ms-flex-positive: 1;
   flex-grow: 1;
   -webkit-box-pack: start;
-  -ms-flex-pack: start;
   -webkit-justify-content: start;
+  -ms-flex-pack: start;
   justify-content: start;
   -webkit-align-items: center;
   -webkit-box-align: center;


### PR DESCRIPTION


## What
Revert styled-components version from 6.1.0 to 5.3.11. 
Undo manually enabling vendor prefixes since this was only needed from styled-components v6.0.0 onward.
Test snapshots are updated due to version change.

## Why

Hovering on the tabs of an open report causes jumping behavior after updating styled-components from v4.4.1 to v6.1.0. Same happens with the tabs of alerts.

## References

GEA-382



