### PR TITLE
Fix: Fix filters for severity "N/A" and "1" in "CVES by CVSS" diagram

### DIFF
--- a/src/web/components/dashboard/display/cvss/cvssdisplay.js
+++ b/src/web/components/dashboard/display/cvss/cvssdisplay.js
@@ -25,7 +25,6 @@ import FilterTerm from 'gmp/models/filter/filterterm';
 import Filter from 'gmp/models/filter';
 
 import PropTypes from 'web/utils/proptypes';
-import {NA_VALUE} from 'web/utils/severity';
 
 import BarChart from 'web/components/chart/bar';
 
@@ -69,11 +68,9 @@ class CvssDisplay extends React.Component {
       let statusTerm;
 
       if (isDefined(start)) {
-        if (start === NA_VALUE) {
-          statusTerm = FilterTerm.fromString('severity=""');
-        } else {
-          statusTerm = FilterTerm.fromString(`severity=${start}`);
-        }
+        statusTerm = FilterTerm.fromString(`severity=${start}`);
+      } else {
+        statusTerm = FilterTerm.fromString('severity=""');
       }
 
       if (isDefined(filter) && filter.hasTerm(statusTerm)) {

--- a/src/web/components/dashboard/display/cvss/cvsstransform.js
+++ b/src/web/components/dashboard/display/cvss/cvsstransform.js
@@ -116,7 +116,7 @@ const transformCvssData = (data = {}) => {
           start: value,
         };
         toolTip = `10.0 (${label}): ${perc}% (${count})`;
-      } else if (value > 1) {
+      } else if (value >= 1) {
         filterValue = {
           start: format(value - 0.1),
           end: format(value + 1),

--- a/src/web/components/dashboard/display/severity/severityclassdisplay.js
+++ b/src/web/components/dashboard/display/severity/severityclassdisplay.js
@@ -22,8 +22,6 @@ import {isDefined} from 'gmp/utils/identity';
 import FilterTerm from 'gmp/models/filter/filterterm';
 import Filter from 'gmp/models/filter';
 
-import {NA_VALUE} from 'web/utils/severity';
-
 import PropTypes from 'web/utils/proptypes';
 
 import DonutChart from 'web/components/chart/donut';
@@ -67,8 +65,6 @@ class SeverityClassDisplay extends React.Component {
       let severityTerm;
       if (start > 0) {
         severityTerm = FilterTerm.fromString(`severity>${start}`);
-      } else if (start === NA_VALUE) {
-        severityTerm = FilterTerm.fromString('severity=""');
       } else {
         severityTerm = FilterTerm.fromString(`severity=${start}`);
       }


### PR DESCRIPTION
## What

Fix filters for severity "N/A" and "1" in "CVES by CVSS" diagram.

## Why

Column "1" of the diagram was incorrectly using the filter severity>0.9 and severity<1 and therefore showing no results.
Additionally, the filter used when clicking the column "N/A" was severity="", which shows zero results on the corresponding list page.

## References

GEA-370


