### PR TITLE
Fix: Fix typos in WHOLE_SELECTION_FAMILIES

### DIFF
--- a/src/web/pages/scanconfigs/nvtfamilies.js
+++ b/src/web/pages/scanconfigs/nvtfamilies.js
@@ -52,8 +52,8 @@ import Trend from './trend';
 
 const WHOLE_SELECTION_FAMILIES = [
   'AIX Local Security Checks',
-  'AlmaLinux Security Checks',
-  'Amazon Linux Security Checks',
+  'AlmaLinux Local Security Checks',
+  'Amazon Linux Local Security Checks',
   'CentOS Local Security Checks',
   'Debian Local Security Checks',
   'Fedora Local Security Checks',


### PR DESCRIPTION
## What
The word "Local" has been added to "AlmaLinux Local Security Checks" and "Amazon Linux Local Security Checks" where it was previously missing in the list of VT families that must be selected as a whole.

## Why

<!-- Describe why are these changes necessary? -->

## References
GEA-387
