### PR TITLE
Change: Make use of GMP command get_resource_names to load tag

### DIFF
--- a/src/gmp/collection/parser.js
+++ b/src/gmp/collection/parser.js
@@ -37,6 +37,13 @@ export function parseInfoEntities(response, name, modelclass, filter_func) {
     .map(info => modelclass.fromElement(info));
 }
 
+export function parseResourceNamesEntities(response, name, modelclass) {
+  const type = isDefined(response.type) ? response.type : '';
+  return map(parseElements(response, name), element =>
+    modelclass.fromElement(element, type),
+  );
+}
+
 export function parseInfoCounts(response) {
   // this is really ugly and more of a kind of a hack
   //  we depend on the order of the array to be able to parse the counts

--- a/src/gmp/commands/__tests__/resourcenames.js
+++ b/src/gmp/commands/__tests__/resourcenames.js
@@ -1,0 +1,167 @@
+/* Copyright (C) 2023 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+import {createResponse, createHttp} from '../testing';
+
+import {ResourceNamesCommand} from '../resourcenames';
+
+describe('ResourceNamesCommand tests', () => {
+  test('should return resource names', () => {
+    const response = createResponse({
+      get_resource_names: {
+        get_resource_names_response: {
+          type: 'os',
+          resource: [
+            {
+              name: 'cpe:/o:canonical:ubuntu_linux:18.04',
+              _id: '5b6b6aef-b320-42ca-899f-3161ee2a4195',
+            },
+            {
+              name: 'cpe:/o:debian:debian_linux',
+              _id: 'f2fa6833-fe34-4e04-a60c-6c5dc1ed0fcf',
+            },
+            {
+              name: 'cpe:/o:microsoft:windows',
+              _id: '19c091f0-a687-4dc3-b482-7d191ead4bb3',
+            },
+          ],
+        },
+      },
+    });
+
+    const fakeHttp = createHttp(response);
+
+    const cmd = new ResourceNamesCommand(fakeHttp);
+    return cmd.getAll({resource_type: 'os'}).then(resp => {
+      expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+        args: {
+          cmd: 'get_resource_names',
+          filter: 'first=1 rows=-1',
+          resource_type: 'os',
+        },
+      });
+      const {data} = resp;
+      expect(data.length).toEqual(3);
+      expect(data[0].id).toEqual('5b6b6aef-b320-42ca-899f-3161ee2a4195');
+      expect(data[0].name).toEqual('cpe:/o:canonical:ubuntu_linux:18.04');
+      expect(data[0].type).toEqual('os');
+
+      expect(data[1].id).toEqual('f2fa6833-fe34-4e04-a60c-6c5dc1ed0fcf');
+      expect(data[1].name).toEqual('cpe:/o:debian:debian_linux');
+      expect(data[1].type).toEqual('os');
+
+      expect(data[2].id).toEqual('19c091f0-a687-4dc3-b482-7d191ead4bb3');
+      expect(data[2].name).toEqual('cpe:/o:microsoft:windows');
+      expect(data[2].type).toEqual('os');
+    });
+  });
+
+  test('should return names from one resource', () => {
+    const response = createResponse({
+      get_resource_names: {
+        get_resource_names_response: {
+          type: 'filter',
+          resource: {
+            name: 'Filter_1',
+            _id: 'b0059c62-ce13-4ef0-adb7-75a04757668b',
+          },
+        },
+      },
+    });
+
+    const fakeHttp = createHttp(response);
+
+    const cmd = new ResourceNamesCommand(fakeHttp);
+    return cmd.getAll({resource_type: 'filter'}).then(resp => {
+      expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+        args: {
+          cmd: 'get_resource_names',
+          filter: 'first=1 rows=-1',
+          resource_type: 'filter',
+        },
+      });
+      const {data} = resp;
+      expect(data.length).toEqual(1);
+      expect(data[0].id).toEqual('b0059c62-ce13-4ef0-adb7-75a04757668b');
+      expect(data[0].name).toEqual('Filter_1');
+      expect(data[0].type).toEqual('filter');
+    });
+  });
+
+  test('should return no names', () => {
+    const response = createResponse({
+      get_resource_names: {
+        get_resource_names_response: {
+          type: 'note',
+        },
+      },
+    });
+
+    const fakeHttp = createHttp(response);
+
+    const cmd = new ResourceNamesCommand(fakeHttp);
+    return cmd.getAll({resource_type: 'note'}).then(resp => {
+      expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+        args: {
+          cmd: 'get_resource_names',
+          filter: 'first=1 rows=-1',
+          resource_type: 'note',
+        },
+      });
+      const {data} = resp;
+      expect(data.length).toEqual(0);
+    });
+  });
+
+  test('should throw not implemented exception', () => {
+    const response = createResponse({
+      get_resource_names: {
+        get_resource_names_response: {
+          type: 'note',
+        },
+      },
+    });
+
+    const fakeHttp = createHttp(response);
+
+    const cmd = new ResourceNamesCommand(fakeHttp);
+    expect(() => {
+      cmd.export();
+    }).toThrow();
+    expect(() => {
+      cmd.exportByIds();
+    }).toThrow();
+    expect(() => {
+      cmd.exportByFilter();
+    }).toThrow();
+    expect(() => {
+      cmd.delete();
+    }).toThrow();
+    expect(() => {
+      cmd.deleteByIds();
+    }).toThrow();
+    expect(() => {
+      cmd.deleteByFilter();
+    }).toThrow();
+    expect(() => {
+      cmd.transformAggregates();
+    }).toThrow();
+    expect(() => {
+      cmd.getAggregates();
+    }).toThrow();
+  });
+});

--- a/src/gmp/commands/resourcenames.js
+++ b/src/gmp/commands/resourcenames.js
@@ -21,6 +21,11 @@ import registerCommand from 'gmp/command';
 import ResourceName from 'gmp/models/resourcename';
 import EntitiesCommand from './entities';
 
+import {
+  parseCollectionList,
+  parseResourceNamesEntities,
+} from 'gmp/collection/parser';
+
 export class ResourceNamesCommand extends EntitiesCommand {
   constructor(http) {
     super(http, 'resource_name', ResourceName);
@@ -29,6 +34,18 @@ export class ResourceNamesCommand extends EntitiesCommand {
 
   getEntitiesResponse(root) {
     return root.get_resource_names.get_resource_names_response;
+  }
+
+  parseResourceNamesEntities(response, name, modelclass) {
+    return parseResourceNamesEntities(response, name, modelclass);
+  }
+
+  getCollectionListFromRoot(root, meta) {
+    const response = this.getEntitiesResponse(root);
+    const res = parseCollectionList(response, this.name, this.clazz, {
+      entities_parse_func: this.parseResourceNamesEntities,
+    });
+    return res;
   }
 
   export(entities) {

--- a/src/gmp/commands/resourcenames.js
+++ b/src/gmp/commands/resourcenames.js
@@ -1,0 +1,85 @@
+/* Copyright (C) 2023 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import registerCommand from 'gmp/command';
+
+import ResourceName from 'gmp/models/resourcename';
+import EntitiesCommand from './entities';
+
+export class ResourceNamesCommand extends EntitiesCommand {
+  constructor(http) {
+    super(http, 'resource_name', ResourceName);
+    this.name = 'resource';
+  }
+
+  getEntitiesResponse(root) {
+    return root.get_resource_names.get_resource_names_response;
+  }
+
+  export(entities) {
+    throw new Error('export not implemented in ' + this.constructor.name);
+  }
+
+  exportByIds(ids) {
+    throw new Error('exportByIds not implemented in ' + this.constructor.name);
+  }
+
+  exportByFilter(filter) {
+    throw new Error(
+      'exportByFilter not implemented in ' + this.constructor.name,
+    );
+  }
+
+  delete(entities, extraParams) {
+    throw new Error('delete not implemented in ' + this.constructor.name);
+  }
+
+  deleteByIds(ids, extraParams = {}) {
+    throw new Error('deleteByIds not implemented in ' + this.constructor.name);
+  }
+
+  deleteByFilter(filter, extraParams) {
+    throw new Error(
+      'deleteByFilter not implemented in ' + this.constructor.name,
+    );
+  }
+
+  transformAggregates(response) {
+    throw new Error(
+      'transformAggregates not implemented in ' + this.constructor.name,
+    );
+  }
+
+  getAggregates({
+    dataColumns = [],
+    textColumns = [],
+    sort = [],
+    aggregateMode,
+    maxGroups,
+    subgroupColumn,
+    ...params
+  } = {}) {
+    throw new Error(
+      'getAggregates not implemented in ' + this.constructor.name,
+    );
+  }
+}
+
+registerCommand('resourcenames', ResourceNamesCommand);
+
+// vim: set ts=2 sw=2 tw=80:

--- a/src/gmp/gmp.js
+++ b/src/gmp/gmp.js
@@ -36,6 +36,7 @@ import 'gmp/commands/filters';
 import 'gmp/commands/groups';
 import 'gmp/commands/hosts';
 import 'gmp/commands/license';
+import 'gmp/commands/resourcenames';
 import 'gmp/commands/notes';
 import 'gmp/commands/nvt';
 import 'gmp/commands/nvtfamilies';

--- a/src/gmp/models/__tests__/resourcename.js
+++ b/src/gmp/models/__tests__/resourcename.js
@@ -1,0 +1,55 @@
+/* Copyright (C) 2023 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {ResourceName} from '../resourcename';
+
+describe('ResourceName tests', () => {
+  test('should init ResourceName data via constructor', () => {
+    const resourceName = new ResourceName({
+      id: '19c091f0-a687-4dc3-b482-7d191ead4bb3',
+      name: 'Foo',
+      type: 'task',
+    });
+
+    expect(resourceName.id).toEqual('19c091f0-a687-4dc3-b482-7d191ead4bb3');
+    expect(resourceName.name).toEqual('Foo');
+    expect(resourceName.type).toEqual('task');
+  });
+
+  test('should parse ResourceName data from element', () => {
+    const resourceName = ResourceName.fromElement(
+      {
+        _id: '19c091f0-a687-4dc3-b482-7d191ead4bba',
+        name: 'Bar',
+      },
+      'report',
+    );
+
+    expect(resourceName.id).toEqual('19c091f0-a687-4dc3-b482-7d191ead4bba');
+    expect(resourceName.name).toEqual('Bar');
+    expect(resourceName.type).toEqual('report');
+  });
+
+  test('should parse empty name and id', () => {
+    const resourceName = ResourceName.fromElement({}, 'report');
+
+    expect(resourceName.id).toEqual('');
+    expect(resourceName.name).toEqual('');
+    expect(resourceName.type).toEqual('report');
+  });
+});

--- a/src/gmp/models/resourcename.js
+++ b/src/gmp/models/resourcename.js
@@ -1,0 +1,36 @@
+/* Copyright (C) 2023 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+import {isDefined} from 'gmp/utils/identity';
+
+export class ResourceName {
+  constructor({id, name}) {
+    this.id = id;
+    this.name = name;
+  }
+
+  static fromElement(element) {
+    const {_id, name} = element;
+
+    return new ResourceName({
+      id: isDefined(_id) ? _id : '',
+      name: isDefined(name) ? name : '',
+    });
+  }
+}
+
+export default ResourceName;

--- a/src/gmp/models/resourcename.js
+++ b/src/gmp/models/resourcename.js
@@ -18,17 +18,19 @@
 import {isDefined} from 'gmp/utils/identity';
 
 export class ResourceName {
-  constructor({id, name}) {
+  constructor({id, name, type}) {
     this.id = id;
     this.name = name;
+    this.type = type;
   }
 
-  static fromElement(element) {
+  static fromElement(element, type) {
     const {_id, name} = element;
 
     return new ResourceName({
       id: isDefined(_id) ? _id : '',
       name: isDefined(name) ? name : '',
+      type: type,
     });
   }
 }

--- a/src/web/pages/tags/dialog.js
+++ b/src/web/pages/tags/dialog.js
@@ -119,6 +119,10 @@ class TagDialog extends React.Component {
         this.setState({
           resourceOptions: data,
         });
+      })
+      .catch(err => {
+        this.isLoading = false;
+        throw err;
       });
   }
 

--- a/src/web/pages/tags/dialog.js
+++ b/src/web/pages/tags/dialog.js
@@ -76,13 +76,13 @@ class TagDialog extends React.Component {
     super(...args);
 
     const {resource_ids = []} = this.props;
-    this.isLoading = false;
 
     this.state = {
       resourceIdText: '',
       resourceIdsSelected: resource_ids,
       resourceOptions: [],
       resourceType: this.props.resource_type,
+      isLoading: false,
     };
   }
 
@@ -99,7 +99,9 @@ class TagDialog extends React.Component {
       return;
     }
     const {gmp} = this.props;
-    this.isLoading = true;
+    this.setState({
+      isLoading: true,
+    });
     gmp.resourcenames
       .getAll({resource_type: convertType(type)})
       .then(response => {
@@ -115,13 +117,15 @@ class TagDialog extends React.Component {
         if (isEmpty(id)) {
           id = undefined;
         }
-        this.isLoading = false;
         this.setState({
           resourceOptions: data,
+          isLoading: false,
         });
       })
       .catch(err => {
-        this.isLoading = false;
+        this.setState({
+          isLoading: false,
+        });
         throw err;
       });
   }
@@ -292,7 +296,7 @@ class TagDialog extends React.Component {
                         resourceTypesOptions.length === 0
                       }
                       isLoading={
-                        this.isLoading &&
+                        this.state.isLoading &&
                         this.state.resourceOptions.length === 0
                       }
                       onChange={ids => this.handleIdChange(ids, onValueChange)}


### PR DESCRIPTION
## What

Make use of the new GMP command get_resource_names to load tag resources.

Show a loading indicator to the user when data is being loaded.

## Why

To improve performance, the new GMP command only retrieves the names and ids of tag resources . The loading indicator is added to make it visible to the user that data is being loaded and some wait time is expected.

## References
GEA-380
requires https://github.com/greenbone/gvmd/pull/2116 and https://github.com/greenbone/gsad/pull/159

- [X] Tests 


