### PR TITLE
Fix: Use correct oldest result date in vulns

### DIFF
--- a/src/gmp/models/vulnerability.js
+++ b/src/gmp/models/vulnerability.js
@@ -27,7 +27,7 @@ class Vulnerability extends Model {
 
     if (isDefined(ret.results)) {
       ret.results.newest = parseDate(ret.results.newest);
-      ret.results.oldest = parseDate(ret.results.newest);
+      ret.results.oldest = parseDate(ret.results.oldest);
     }
 
     return ret;


### PR DESCRIPTION
## What
When parsing the result dates for vulnerabilities, the correct field is now used for the oldest result.

## Why
When date parsing was added to the Vulnerability model class, the newest date was used accidentally.

## References
GEA-414

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


