### PR TITLE
Fix: Also use edit_config_family_all for policies

### DIFF
--- a/src/gmp/commands/__tests__/policy.js
+++ b/src/gmp/commands/__tests__/policy.js
@@ -27,6 +27,7 @@ import {
   createActionResultResponse,
   createEntityResponse,
   createHttp,
+  createHttpMany,
   createResponse,
 } from '../testing';
 
@@ -215,27 +216,30 @@ describe('PolicyCommand tests', () => {
             },
           ],
         },
-        all: {
-          get_nvts_response: {
-            nvt: [
-              {
-                _oid: 1,
-                cvss_base: 1.1,
-              },
-              {
-                _oid: 2,
-                cvss_base: 2.2,
-              },
-              {
-                _oid: 3,
-                cvss_base: 3.3,
-              },
-            ],
-          },
+      },
+    });
+    const responseAll = createResponse({
+      get_config_family_response: {
+        get_nvts_response: {
+          nvt: [
+            {
+              _oid: 1,
+              cvss_base: 1.1,
+            },
+            {
+              _oid: 2,
+              cvss_base: 2.2,
+            },
+            {
+              _oid: 3,
+              cvss_base: 3.3,
+            },
+          ],
         },
       },
     });
-    const fakeHttp = createHttp(response);
+    const responses = [response, responseAll];
+    const fakeHttp = createHttpMany(responses);
 
     expect.hasAssertions();
 

--- a/src/gmp/commands/policies.js
+++ b/src/gmp/commands/policies.js
@@ -93,13 +93,21 @@ export class PolicyCommand extends EntityCommand {
   }
 
   editPolicyFamilySettings({id, familyName}) {
-    return this.httpGet({
+    const get = this.httpGet({
       cmd: 'edit_config_family',
       id,
       family: familyName,
-    }).then(response => {
+    });
+    const all = this.httpGet({
+      cmd: 'edit_config_family_all',
+      id,
+      family: familyName,
+    });
+    return Promise.all([get, all]).then(([response, response_all]) => {
       const {data} = response;
+      const data_all = response_all.data;
       const policy_resp = data.get_config_family_response;
+      const policy_resp_all = data_all.get_config_family_response;
       const settings = {};
 
       const nvts = {};
@@ -108,7 +116,7 @@ export class PolicyCommand extends EntityCommand {
         nvts[oid] = true;
       });
 
-      settings.nvts = map(policy_resp.all.get_nvts_response.nvt, nvt => {
+      settings.nvts = map(policy_resp_all.get_nvts_response.nvt, nvt => {
         nvt.oid = nvt._oid;
         delete nvt._oid;
 


### PR DESCRIPTION
## What
The config dialog now also uses edit_config_family_all alongside edit_config_family.

## Why
This fixes the dialog for editing a family in a compliance policy not loading correctly.

## References
GEA-415
Corresponding change for scan configs: #3857

## Checklist
- [x] Tests


