### PR TITLE
Install npm in prod.Dockerfile

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -18,7 +18,7 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dear
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    nodejs && \
+    nodejs npm && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . /source


### PR DESCRIPTION
## What
Install npm in prod.Dockerfile

## Why
Container builds are currently failing because npm is missing.
