### PR TITLE
Fix opening report format dialog

### DIFF
--- a/src/web/pages/reportformats/component.js
+++ b/src/web/pages/reportformats/component.js
@@ -128,7 +128,7 @@ class ReportFormatComponent extends React.Component {
   render() {
     const {children, onDeleted, onDeleteError, onInteraction} = this.props;
 
-    const {dialogVisible, reportformat, title} = this.state;
+    const {dialogVisible, reportformat, title, preferences} = this.state;
 
     return (
       <EntityComponent
@@ -147,6 +147,7 @@ class ReportFormatComponent extends React.Component {
             {dialogVisible && (
               <ReportFormatDialog
                 reportformat={reportformat}
+                preferences={preferences}
                 title={title}
                 onClose={this.handleCloseReportFormatDialog}
                 onSave={this.handleSave}


### PR DESCRIPTION
## What

Fix opening report format dialog

## Why

Opening the report format dialog wasn't possible because a required prop was not passed. This wasn't spotted because currently there is no non predefined report format thus no report format is editable.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


