### PR TITLE
Test: Update snapshots after dependency update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "23.0.1-dev1",
       "license": "AGPL-3.0+",
       "dependencies": {
-        "@babel/core": "7.23.5",
-        "@babel/runtime": "^7.23.5",
+        "@babel/core": "7.23.7",
+        "@babel/runtime": "^7.23.8",
         "@greenbone/ui-components": "2021.1.2",
         "@sentry/react": "^7.93.0",
         "@vx/axis": "^0.0.199",
@@ -31,12 +31,12 @@
         "fast-xml-parser": "^4.2.5",
         "history": "^4.10.1",
         "hoist-non-react-statics": "^3.3.2",
-        "i18next": "^23.7.7",
+        "i18next": "^23.7.16",
         "i18next-xhr-backend": "3.2.2",
         "ical.js": "^1.5.0",
         "memoize-one": "^6.0.0",
         "moment": "^2.30.1",
-        "moment-timezone": "^0.5.43",
+        "moment-timezone": "^0.5.44",
         "prop-types": "^15.8.1",
         "qhistory": "^1.1.0",
         "qs": "^6.11.2",
@@ -50,16 +50,16 @@
         "redux": "^4.2.1",
         "redux-logger": "^3.0.6",
         "redux-thunk": "^2.4.2",
-        "styled-components": "^6.1.1",
+        "styled-components": "^6.1.8",
         "uuid": "^9.0.1",
-        "whatwg-fetch": "^3.6.19"
+        "whatwg-fetch": "^3.6.20"
       },
       "devDependencies": {
         "@babel/cli": "^7.23.4",
         "@testing-library/jest-dom": "^6.1.5",
         "@testing-library/react": "^12.1.5",
         "@testing-library/user-event": "^13.5.0",
-        "@types/jest": "^29.5.10",
+        "@types/jest": "^29.5.11",
         "babel-plugin-i18next-extract": "^0.10.0",
         "eslint-config-prettier": "^9.1.0",
         "husky": "^2.7.0",
@@ -251,28 +251,28 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
-      "integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.5.tgz",
-      "integrity": "sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
+      "integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.5",
-        "@babel/helper-compilation-targets": "^7.22.15",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-compilation-targets": "^7.23.6",
         "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.23.5",
-        "@babel/parser": "^7.23.5",
+        "@babel/helpers": "^7.23.7",
+        "@babel/parser": "^7.23.6",
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.5",
-        "@babel/types": "^7.23.5",
+        "@babel/traverse": "^7.23.7",
+        "@babel/types": "^7.23.6",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -320,11 +320,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
-      "integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
       "dependencies": {
-        "@babel/types": "^7.23.5",
+        "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -358,13 +358,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-      "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
       "dependencies": {
-        "@babel/compat-data": "^7.22.9",
-        "@babel/helper-validator-option": "^7.22.15",
-        "browserslist": "^4.21.9",
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "browserslist": "^4.22.2",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -615,9 +615,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-      "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -638,13 +638,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.5.tgz",
-      "integrity": "sha512-oO7us8FzTEsG3U6ag9MfdF1iA/7Z6dz+MtFhifZk8C8o453rGJFFWUP1t+ULM9TUIAzC9uxXEiXjOiVMyd7QPg==",
+      "version": "7.23.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
+      "integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
       "dependencies": {
         "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.5",
-        "@babel/types": "^7.23.5"
+        "@babel/traverse": "^7.23.7",
+        "@babel/types": "^7.23.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -728,9 +728,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
-      "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -2101,9 +2101,9 @@
       "license": "MIT"
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
-      "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
+      "version": "7.23.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
+      "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2130,19 +2130,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
-      "integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
       "dependencies": {
         "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.5",
+        "@babel/generator": "^7.23.6",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.5",
-        "@babel/types": "^7.23.5",
-        "debug": "^4.1.0",
+        "@babel/parser": "^7.23.6",
+        "@babel/types": "^7.23.6",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -2479,9 +2479,9 @@
       "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
     },
     "node_modules/@emotion/unitless": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz",
+      "integrity": "sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.4.1",
@@ -4971,9 +4971,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.10",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.10.tgz",
-      "integrity": "sha512-tE4yxKEphEyxj9s4inideLHktW/x6DwesIwWZ9NN1FKf9zbJYsnhBoA9vrHA/IuIOKwPa5PcFBNV4lpMIOEzyQ==",
+      "version": "29.5.11",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.11.tgz",
+      "integrity": "sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -5201,9 +5201,9 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
     },
     "node_modules/@types/stylis": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.4.tgz",
-      "integrity": "sha512-36ZrGJ8fgtBr6nwNnuJ9jXIj+bn/pF6UoqmrQT7+Y99+tFFeHHsoR54+194dHdyhPjgbeoNz3Qru0oRt0l6ASQ=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw=="
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
@@ -6893,9 +6893,9 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "node_modules/browserslist": {
-      "version": "4.21.10",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
+      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
       "funding": [
         {
           "type": "opencollective",
@@ -6911,10 +6911,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001517",
-        "electron-to-chromium": "^1.4.477",
-        "node-releases": "^2.0.13",
-        "update-browserslist-db": "^1.0.11"
+        "caniuse-lite": "^1.0.30001565",
+        "electron-to-chromium": "^1.4.601",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -7070,9 +7070,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001532",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001532.tgz",
-      "integrity": "sha512-FbDFnNat3nMnrROzqrsg314zhqN5LGQ1kyyMk2opcrwGbVGpHRhgCWtAgD5YJUqNAiQ+dklreil/c3Qf1dfCTw==",
+      "version": "1.0.30001579",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
+      "integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
       "funding": [
         {
           "type": "opencollective",
@@ -8815,9 +8815,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.513",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.513.tgz",
-      "integrity": "sha512-cOB0xcInjm+E5qIssHeXJ29BaUyWpMyFKT5RB3bsLENDheCja0wMkHJyiPl0NBE/VzDI7JDuNEQWhe6RitEUcw=="
+      "version": "1.4.639",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.639.tgz",
+      "integrity": "sha512-CkKf3ZUVZchr+zDpAlNLEEy2NJJ9T64ULWaDgy3THXXlPVPkLu3VOs9Bac44nebVtdwl2geSj6AxTtGDOxoXhg=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -11334,9 +11334,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/i18next": {
-      "version": "23.7.7",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.7.7.tgz",
-      "integrity": "sha512-peTvdT+Lma+o0LfLFD7IC2M37N9DJ04dH0IJYOyOHRhDfLo6nK36v7LkrQH35C2l8NHiiXZqGirhKESlEb/5PA==",
+      "version": "23.7.16",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.7.16.tgz",
+      "integrity": "sha512-SrqFkMn9W6Wb43ZJ9qrO6U2U4S80RsFMA7VYFSqp7oc7RllQOYDCdRfsse6A7Cq/V8MnpxKvJCYgM8++27n4Fw==",
       "funding": [
         {
           "type": "individual",
@@ -16015,10 +16015,9 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.43",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
-      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
-      "license": "MIT",
+      "version": "0.5.44",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.44.tgz",
+      "integrity": "sha512-nv3YpzI/8lkQn0U6RkLd+f0W/zy/JnoR5/EyPz/dNkPTBjA2jNLCVxaiQ8QpeLymhSZvX0wCL5s27NQWdOPwAw==",
       "dependencies": {
         "moment": "^2.29.4"
       },
@@ -16122,9 +16121,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -21631,19 +21630,19 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.1.tgz",
-      "integrity": "sha512-cpZZP5RrKRIClBW5Eby4JM1wElLVP4NQrJbJ0h10TidTyJf4SIIwa3zLXOoPb4gJi8MsJ8mjq5mu2IrEhZIAcQ==",
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.8.tgz",
+      "integrity": "sha512-PQ6Dn+QxlWyEGCKDS71NGsXoVLKfE1c3vApkvDYS5KAK+V8fNWGhbSUEo9Gg2iaID2tjLXegEW3bZDUGpofRWw==",
       "dependencies": {
-        "@emotion/is-prop-valid": "^1.2.1",
-        "@emotion/unitless": "^0.8.0",
-        "@types/stylis": "^4.0.2",
-        "css-to-react-native": "^3.2.0",
-        "csstype": "^3.1.2",
-        "postcss": "^8.4.31",
-        "shallowequal": "^1.1.0",
-        "stylis": "^4.3.0",
-        "tslib": "^2.5.0"
+        "@emotion/is-prop-valid": "1.2.1",
+        "@emotion/unitless": "0.8.0",
+        "@types/stylis": "4.2.0",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.1.2",
+        "postcss": "8.4.31",
+        "shallowequal": "1.1.0",
+        "stylis": "4.3.1",
+        "tslib": "2.5.0"
       },
       "engines": {
         "node": ">= 16"
@@ -21656,6 +21655,11 @@
         "react": ">= 16.8.0",
         "react-dom": ">= 16.8.0"
       }
+    },
+    "node_modules/styled-components/node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/stylehacks": {
       "version": "5.1.1",
@@ -21674,9 +21678,9 @@
       }
     },
     "node_modules/stylis": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
-      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.1.tgz",
+      "integrity": "sha512-EQepAV+wMsIaGVGX1RECzgrcqRRU/0sYOHkeLsZ3fzHaHXZy4DaOOX0vOlGQdlsjkh3mFHAIlVimpwAs4dslyQ=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -22487,9 +22491,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
       "funding": [
         {
           "type": "opencollective",
@@ -22953,9 +22957,9 @@
       }
     },
     "node_modules/whatwg-fetch": {
-      "version": "3.6.19",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.19.tgz",
-      "integrity": "sha512-d67JP4dHSbm2TrpFj8AbO8DnL1JXL5J9u0Kq2xW6d0TFDbCA3Muhdt8orXC22utleTVj7Prqt82baN6RBvnEgw=="
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
     },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "extends": "react-app"
   },
   "dependencies": {
-    "@babel/core": "7.23.5",
-    "@babel/runtime": "^7.23.5",
+    "@babel/core": "7.23.7",
+    "@babel/runtime": "^7.23.8",
     "@greenbone/ui-components": "2021.1.2",
     "@sentry/react": "^7.93.0",
     "@vx/axis": "^0.0.199",
@@ -45,12 +45,12 @@
     "fast-xml-parser": "^4.2.5",
     "history": "^4.10.1",
     "hoist-non-react-statics": "^3.3.2",
-    "i18next": "^23.7.7",
+    "i18next": "^23.7.16",
     "i18next-xhr-backend": "3.2.2",
     "ical.js": "^1.5.0",
     "memoize-one": "^6.0.0",
     "moment": "^2.30.1",
-    "moment-timezone": "^0.5.43",
+    "moment-timezone": "^0.5.44",
     "prop-types": "^15.8.1",
     "qhistory": "^1.1.0",
     "qs": "^6.11.2",
@@ -64,9 +64,9 @@
     "redux": "^4.2.1",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.4.2",
-    "styled-components": "^6.1.1",
+    "styled-components": "^6.1.8",
     "uuid": "^9.0.1",
-    "whatwg-fetch": "^3.6.19"
+    "whatwg-fetch": "^3.6.20"
   },
   "scripts": {
     "test": "react-scripts test --env=jest-environment-jsdom",
@@ -83,7 +83,7 @@
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^13.5.0",
-    "@types/jest": "^29.5.10",
+    "@types/jest": "^29.5.11",
     "babel-plugin-i18next-extract": "^0.10.0",
     "eslint-config-prettier": "^9.1.0",
     "husky": "^2.7.0",

--- a/src/web/components/bar/__tests__/__snapshots__/titlebar.js.snap
+++ b/src/web/components/bar/__tests__/__snapshots__/titlebar.js.snap
@@ -118,50 +118,50 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   display: inline-flex;
 }
 
-.c15 {
+.c14 {
   margin-left: -5px;
 }
 
-.c15>* {
+.c14>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c15>* {
+.c14>* {
   margin-left: 5px;
 }
 
-.c14 {
+.c13 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c17 {
+.c16 {
   cursor: pointer;
 }
 
-.c9 {
+.c8 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c9 * {
+.c8 * {
   height: inherit;
   width: inherit;
 }
 
-.c16 {
+.c15 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c16 * {
+.c15 * {
   height: inherit;
   width: inherit;
 }
@@ -176,18 +176,18 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   flex-direction: column;
 }
 
-.c11 {
+.c10 {
   position: relative;
   display: none;
   -webkit-animation: bNcXmX 0.1s ease-in;
   animation: bNcXmX 0.1s ease-in;
 }
 
-.c6:hover .c11 {
+.c6:hover .c10 {
   display: block;
 }
 
-.c12 {
+.c11 {
   position: absolute;
   margin: 0;
   padding: 0;
@@ -199,7 +199,7 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   width: 300px;
 }
 
-.c13 {
+.c12 {
   height: 30px;
   width: 300px;
   border-left: 1px solid #7F7F7F;
@@ -216,48 +216,48 @@ exports[`Titlebar tests should render content if user is logged in 1`] = `
   padding-left: 12px;
 }
 
-.c13:hover {
+.c12:hover {
   background: #11ab51;
   color: #fff;
   cursor: pointer;
 }
 
-.c13:first-child {
+.c12:first-child {
   border-top: 1px solid #7F7F7F;
   cursor: default;
 }
 
-background-color:#f3f3f3 .c13:first-child:hover {
+background-color:#f3f3f3 .c12:first-child:hover {
   color: #000;
 }
 
-.c13:nth-child(2) {
+.c12:nth-child(2) {
   cursor: default;
 }
 
-background-color:#f3f3f3 .c13:nth-child(2):hover {
+background-color:#f3f3f3 .c12:nth-child(2):hover {
   color: #000;
 }
 
-.c13:last-child {
+.c12:last-child {
   border-top: 1px solid #7F7F7F;
   border-bottom: 1px solid #7F7F7F;
 }
 
-.c10 {
+.c9 {
   margin-right: 10px;
 }
 
-.c18 {
+.c17 {
   width: 100%;
   height: 100%;
 }
 
-.c18:link,
-.c18:hover,
-.c18:active,
-.c18:visited,
-.c18:hover {
+.c17:link,
+.c17:hover,
+.c17:active,
+.c17:visited,
+.c17:hover {
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -304,7 +304,7 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
 }
 
 @media print {
-  .c8 {
+  .c16 {
     display: none;
   }
 }
@@ -345,7 +345,7 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
         data-testid="usermenu"
       >
         <span
-          class="c8 c9 c10"
+          class="c8 c9"
           data-testid="svg-icon"
         >
           <svg>
@@ -353,23 +353,23 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
           </svg>
         </span>
         <div
-          class="c11"
+          class="c10"
         >
           <ul
-            class="c12"
+            class="c11"
           >
             <li
-              class="c13"
+              class="c12"
               title="Logged in as: username"
             >
               <div
-                class="c3 c14"
+                class="c3 c13"
               >
                 <div
-                  class="c3 c15"
+                  class="c3 c14"
                 >
                   <span
-                    class="c8 c16"
+                    class="c15"
                     data-testid="svg-icon"
                   >
                     <svg>
@@ -383,16 +383,16 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
               </div>
             </li>
             <li
-              class="c13"
+              class="c12"
             >
               <div
-                class="c3 c14"
+                class="c3 c13"
               >
                 <div
-                  class="c3 c15"
+                  class="c3 c14"
                 >
                   <span
-                    class="c8 c16"
+                    class="c15"
                     data-testid="svg-icon"
                   >
                     <svg>
@@ -403,7 +403,7 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
                     Session timeout: 
                   </span>
                   <span
-                    class="c8 c17 c16"
+                    class="c16 c15"
                     data-testid="svg-icon"
                     title="Renew session timeout"
                   >
@@ -417,21 +417,21 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
               </div>
             </li>
             <li
-              class="c13"
+              class="c12"
             >
               <a
-                class="c2 c18"
+                class="c2 c17"
                 data-testid="usermenu-settings"
                 href="/usersettings"
               >
                 <div
-                  class="c3 c14"
+                  class="c3 c13"
                 >
                   <div
-                    class="c3 c15"
+                    class="c3 c14"
                   >
                     <span
-                      class="c8 c16"
+                      class="c15"
                       data-testid="svg-icon"
                     >
                       <svg>
@@ -446,17 +446,17 @@ background-color:#f3f3f3 .c13:nth-child(2):hover {
               </a>
             </li>
             <li
-              class="c13"
+              class="c12"
               data-testid="usermenu-logout"
             >
               <div
-                class="c3 c14"
+                class="c3 c13"
               >
                 <div
-                  class="c3 c15"
+                  class="c3 c14"
                 >
                   <span
-                    class="c8 c16"
+                    class="c15"
                     data-testid="svg-icon"
                   >
                     <svg>

--- a/src/web/components/icon/__tests__/__snapshots__/svgicon.js.snap
+++ b/src/web/components/icon/__tests__/__snapshots__/svgicon.js.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SVG icon component tests should render icon 1`] = `
-.c1 {
+.c0 {
   cursor: pointer;
 }
 
-.c2 {
+.c1 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c2 * {
+.c1 * {
   height: inherit;
   width: inherit;
 }
@@ -23,7 +23,7 @@ exports[`SVG icon component tests should render icon 1`] = `
 }
 
 <span
-  class="c0 c1 c2"
+  class="c0 c1"
   data-testid="svg-icon"
   title="Clone Entity"
 >

--- a/src/web/components/menu/__tests__/__snapshots__/usermenu.js.snap
+++ b/src/web/components/menu/__tests__/__snapshots__/usermenu.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`UserMenu component tests should render UserMenu 1`] = `
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -19,57 +19,57 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   align-items: center;
 }
 
-.c13 {
+.c12 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-}
-
-.c10 {
-  margin-left: -5px;
-}
-
-.c10>* {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c10>* {
-  margin-left: 5px;
 }
 
 .c9 {
+  margin-left: -5px;
+}
+
+.c9>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c12 {
+.c9>* {
+  margin-left: 5px;
+}
+
+.c8 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c11 {
   cursor: pointer;
 }
 
-.c3 {
+.c2 {
   height: 24px;
   width: 24px;
   line-height: 24px;
 }
 
-.c3 * {
+.c2 * {
   height: inherit;
   width: inherit;
 }
 
-.c11 {
+.c10 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c11 * {
+.c10 * {
   height: inherit;
   width: inherit;
 }
@@ -84,18 +84,18 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   flex-direction: column;
 }
 
-.c5 {
+.c4 {
   position: relative;
   display: none;
   -webkit-animation: bNcXmX 0.1s ease-in;
   animation: bNcXmX 0.1s ease-in;
 }
 
-.c0:hover .c5 {
+.c0:hover .c4 {
   display: block;
 }
 
-.c6 {
+.c5 {
   position: absolute;
   margin: 0;
   padding: 0;
@@ -107,7 +107,7 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   width: 300px;
 }
 
-.c7 {
+.c6 {
   height: 30px;
   width: 300px;
   border-left: 1px solid #7F7F7F;
@@ -124,55 +124,55 @@ exports[`UserMenu component tests should render UserMenu 1`] = `
   padding-left: 12px;
 }
 
-.c7:hover {
+.c6:hover {
   background: #11ab51;
   color: #fff;
   cursor: pointer;
 }
 
-.c7:first-child {
+.c6:first-child {
   border-top: 1px solid #7F7F7F;
   cursor: default;
 }
 
-background-color:#f3f3f3 .c7:first-child:hover {
+background-color:#f3f3f3 .c6:first-child:hover {
   color: #000;
 }
 
-.c7:nth-child(2) {
+.c6:nth-child(2) {
   cursor: default;
 }
 
-background-color:#f3f3f3 .c7:nth-child(2):hover {
+background-color:#f3f3f3 .c6:nth-child(2):hover {
   color: #000;
 }
 
-.c7:last-child {
+.c6:last-child {
   border-top: 1px solid #7F7F7F;
   border-bottom: 1px solid #7F7F7F;
 }
 
-.c4 {
+.c3 {
   margin-right: 10px;
 }
 
-.c14 {
+.c13 {
   width: 100%;
   height: 100%;
 }
 
-.c14:link,
-.c14:hover,
-.c14:active,
-.c14:visited,
-.c14:hover {
+.c13:link,
+.c13:hover,
+.c13:active,
+.c13:visited,
+.c13:hover {
   color: inherit;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 @media print {
-  .c2 {
+  .c11 {
     display: none;
   }
 }
@@ -182,7 +182,7 @@ background-color:#f3f3f3 .c7:nth-child(2):hover {
   data-testid="usermenu"
 >
   <span
-    class="c2 c3 c4"
+    class="c2 c3"
     data-testid="svg-icon"
   >
     <svg>
@@ -190,23 +190,23 @@ background-color:#f3f3f3 .c7:nth-child(2):hover {
     </svg>
   </span>
   <div
-    class="c5"
+    class="c4"
   >
     <ul
-      class="c6"
+      class="c5"
     >
       <li
-        class="c7"
+        class="c6"
         title="Logged in as: "
       >
         <div
-          class="c8 c9"
+          class="c7 c8"
         >
           <div
-            class="c8 c10"
+            class="c7 c9"
           >
             <span
-              class="c2 c11"
+              class="c10"
               data-testid="svg-icon"
             >
               <svg>
@@ -218,16 +218,16 @@ background-color:#f3f3f3 .c7:nth-child(2):hover {
         </div>
       </li>
       <li
-        class="c7"
+        class="c6"
       >
         <div
-          class="c8 c9"
+          class="c7 c8"
         >
           <div
-            class="c8 c10"
+            class="c7 c9"
           >
             <span
-              class="c2 c11"
+              class="c10"
               data-testid="svg-icon"
             >
               <svg>
@@ -238,7 +238,7 @@ background-color:#f3f3f3 .c7:nth-child(2):hover {
               Session timeout: 
             </span>
             <span
-              class="c2 c12 c11"
+              class="c11 c10"
               data-testid="svg-icon"
               title="Renew session timeout"
             >
@@ -252,21 +252,21 @@ background-color:#f3f3f3 .c7:nth-child(2):hover {
         </div>
       </li>
       <li
-        class="c7"
+        class="c6"
       >
         <a
-          class="c13 c14"
+          class="c12 c13"
           data-testid="usermenu-settings"
           href="/usersettings"
         >
           <div
-            class="c8 c9"
+            class="c7 c8"
           >
             <div
-              class="c8 c10"
+              class="c7 c9"
             >
               <span
-                class="c2 c11"
+                class="c10"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -281,17 +281,17 @@ background-color:#f3f3f3 .c7:nth-child(2):hover {
         </a>
       </li>
       <li
-        class="c7"
+        class="c6"
         data-testid="usermenu-logout"
       >
         <div
-          class="c8 c9"
+          class="c7 c8"
         >
           <div
-            class="c8 c10"
+            class="c7 c9"
           >
             <span
-              class="c2 c11"
+              class="c10"
               data-testid="svg-icon"
             >
               <svg>

--- a/src/web/entities/__tests__/__snapshots__/tagsdialog.js.snap
+++ b/src/web/entities/__tests__/__snapshots__/tagsdialog.js.snap
@@ -94,7 +94,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   align-items: center;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -137,17 +137,17 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   display: inline-flex;
 }
 
-.c27 {
+.c26 {
   cursor: pointer;
 }
 
-.c28 {
+.c27 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c28 * {
+.c27 * {
   height: inherit;
   width: inherit;
 }
@@ -185,7 +185,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   height: 100%;
 }
 
-.c36 {
+.c35 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -194,7 +194,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   border-top: 20px solid #fff;
 }
 
-.c35 {
+.c34 {
   position: absolute;
   bottom: 3px;
   right: 3px;
@@ -259,7 +259,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   width: inherit;
 }
 
-.c32 {
+.c31 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -279,12 +279,12 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   z-index: 1;
 }
 
-.c32:focus,
-.c32:hover {
+.c31:focus,
+.c31:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c32:hover {
+.c31:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -292,26 +292,26 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   color: #fff;
 }
 
-.c32[disabled] {
+.c31[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c32 img {
+.c31 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c32:link {
+.c31:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c33 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -329,18 +329,18 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   align-items: center;
 }
 
-.c34 {
+.c33 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c34 :hover {
+.c33 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c30 {
+.c29 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
@@ -348,7 +348,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
   padding: 10px 20px 10px 20px;
 }
 
-.c31 {
+.c30 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
@@ -647,7 +647,7 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
                             </div>
                           </div>
                           <span
-                            class="c26 c27 c28"
+                            class="c26 c27"
                             data-testid="svg-icon"
                             title="Create a new Tag"
                           >
@@ -693,17 +693,17 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
               </div>
             </div>
             <div
-              class="c29 c30 c31"
+              class="c28 c29 c30"
             >
               <button
-                class="c32 c33 c34"
+                class="c31 c32 c33"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c32 c33 c34"
+                class="c31 c32 c33"
                 data-testid="dialog-save-button"
                 title="Add Tag"
               >
@@ -712,10 +712,10 @@ exports[`TagsDialog dialog component tests should disable tag selection when no 
             </div>
           </div>
           <div
-            class="c35"
+            class="c34"
           >
             <div
-              class="c36"
+              class="c35"
             />
           </div>
         </div>
@@ -820,7 +820,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -863,17 +863,17 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   display: inline-flex;
 }
 
-.c27 {
+.c26 {
   cursor: pointer;
 }
 
-.c28 {
+.c27 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c28 * {
+.c27 * {
   height: inherit;
   width: inherit;
 }
@@ -911,7 +911,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   height: 100%;
 }
 
-.c36 {
+.c35 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -920,7 +920,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c35 {
+.c34 {
   position: absolute;
   bottom: 3px;
   right: 3px;
@@ -985,7 +985,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   width: inherit;
 }
 
-.c32 {
+.c31 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -1005,12 +1005,12 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   z-index: 1;
 }
 
-.c32:focus,
-.c32:hover {
+.c31:focus,
+.c31:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c32:hover {
+.c31:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -1018,26 +1018,26 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   color: #fff;
 }
 
-.c32[disabled] {
+.c31[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c32 img {
+.c31 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c32:link {
+.c31:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c33 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1055,18 +1055,18 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c34 {
+.c33 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c34 :hover {
+.c33 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c30 {
+.c29 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
@@ -1074,7 +1074,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
   padding: 10px 20px 10px 20px;
 }
 
-.c31 {
+.c30 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
@@ -1370,7 +1370,7 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
                             </div>
                           </div>
                           <span
-                            class="c26 c27 c28"
+                            class="c26 c27"
                             data-testid="svg-icon"
                             title="Create a new Tag"
                           >
@@ -1416,17 +1416,17 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c29 c30 c31"
+              class="c28 c29 c30"
             >
               <button
-                class="c32 c33 c34"
+                class="c31 c32 c33"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c32 c33 c34"
+                class="c31 c32 c33"
                 data-testid="dialog-save-button"
                 title="Add Tag"
               >
@@ -1435,10 +1435,10 @@ exports[`TagsDialog dialog component tests should render dialog 1`] = `
             </div>
           </div>
           <div
-            class="c35"
+            class="c34"
           >
             <div
-              class="c36"
+              class="c35"
             />
           </div>
         </div>

--- a/src/web/pages/audits/__tests__/__snapshots__/actions.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/actions.js.snap
@@ -89,21 +89,21 @@ exports[`Audit Actions tests should render 1`] = `
   display: inline-flex;
 }
 
-.c6 {
+.c5 {
   cursor: pointer;
 }
 
-.c8 svg path {
+.c7 svg path {
   fill: #bfbfbf;
 }
 
-.c7 {
+.c6 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c7 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
@@ -130,7 +130,7 @@ exports[`Audit Actions tests should render 1`] = `
             class="c3 c4"
           >
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Start"
             >
@@ -142,7 +142,7 @@ exports[`Audit Actions tests should render 1`] = `
             </span>
             <span
               alt="Resume"
-              class="c5 c8 c7"
+              class="c7 c6"
               data-testid="svg-icon"
               title="Audit is not stopped"
             >
@@ -153,7 +153,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Move Audit to trashcan"
             >
@@ -164,7 +164,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Edit Audit"
             >
@@ -175,7 +175,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Clone Audit"
             >
@@ -186,7 +186,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Export Audit"
             >
@@ -197,7 +197,7 @@ exports[`Audit Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Download Greenbone Compliance Report"
             >

--- a/src/web/pages/audits/__tests__/__snapshots__/detailspage.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/detailspage.js.snap
@@ -72,7 +72,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   align-items: flex-start;
 }
 
-.c14 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -89,7 +89,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   align-items: flex-end;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -105,6 +105,23 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
   align-items: flex-end;
+}
+
+.c21 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c22 {
@@ -115,30 +132,13 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c23 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-pack: start;
   -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
-.c25 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -160,7 +160,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c26 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -182,7 +182,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   align-items: flex-end;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -200,7 +200,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c31 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -218,7 +218,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   align-items: center;
 }
 
-.c33 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -236,7 +236,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c9 {
+.c8 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -280,48 +280,48 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   display: inline-flex;
 }
 
-.c10 {
+.c9 {
   cursor: pointer;
 }
 
-.c11 svg path {
+.c10 svg path {
   fill: #bfbfbf;
 }
 
-.c8 {
+.c7 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c8 * {
+.c7 * {
   height: inherit;
   width: inherit;
 }
 
-.c20 {
+.c19 {
   height: 50px;
   width: 50px;
   line-height: 50px;
 }
 
-.c20 * {
+.c19 * {
   height: inherit;
   width: inherit;
 }
 
-.c15 {
+.c14 {
   margin: 10px 0px;
   padding-bottom: 1px;
   border-bottom: 2px solid #e5e5e5;
   position: relative;
 }
 
-.c16 {
+.c15 {
   margin: 0 0 1px 0;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -339,16 +339,16 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c19 {
+.c18 {
   margin-right: 5px;
 }
 
-.c21 {
+.c20 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c29 {
+.c28 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -375,15 +375,15 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #11ab51;
 }
 
-.c29:hover {
+.c28:hover {
   border-top: 2px solid #11ab51;
 }
 
-.c29:first-child {
+.c28:first-child {
   border-left: 1px solid #e5e5e5;
 }
 
-.c30 {
+.c29 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -407,21 +407,21 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #fff;
 }
 
-.c30:hover {
+.c29:hover {
   border-top: 2px solid #e5e5e5;
 }
 
-.c30:first-child {
+.c29:first-child {
   border-left: 1px solid #fff;
 }
 
-.c27 {
+.c26 {
   border-bottom: 2px solid #11ab51;
   margin-top: 30px;
   margin-bottom: 15px;
 }
 
-.c34 {
+.c33 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -429,7 +429,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   table-layout: auto;
 }
 
-.c44 {
+.c43 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -438,46 +438,46 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   width: 100%;
 }
 
-.c43>*:not(:last-child)::after {
+.c42>*:not(:last-child)::after {
   content: '•';
   margin-left: 5px;
 }
 
-.c35 td {
+.c34 td {
   padding: 4px 4px 4px 0;
 }
 
-.c35 tr td:first-child {
+.c34 tr td:first-child {
   padding-right: 5px;
 }
 
-.c24 {
+.c23 {
   border-spacing: 0px;
   color: #7F7F7F;
   font-size: 10px;
 }
 
-.c24 :nth-child(even) {
+.c23 :nth-child(even) {
   margin-left: 3px;
 }
 
-.c24 :nth-child(odd) {
+.c23 :nth-child(odd) {
   margin-left: 30px;
 }
 
-.c36 {
+.c35 {
   width: 10%;
 }
 
-.c37 {
+.c36 {
   width: 90%;
 }
 
-.c32 {
+.c31 {
   font-size: 0.7em;
 }
 
-.c39 {
+.c38 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -487,7 +487,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   text-align: center;
 }
 
-.c41 {
+.c40 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -498,22 +498,22 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   padding-top: 1px;
 }
 
-.c40 {
+.c39 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
 }
 
-.c42 {
+.c41 {
   white-space: nowrap;
 }
 
-.c38:hover {
+.c37:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c12 {
+.c11 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -522,7 +522,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
   margin-right: 0px;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -560,38 +560,38 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
 }
 
 @media print {
-  .c7 {
+  .c9 {
     display: none;
   }
 }
 
 @media print {
-  .c34 {
+  .c33 {
     border-collapse: collapse;
   }
 }
 
 @media print {
-  .c44 {
+  .c43 {
     border-collapse: collapse;
   }
 }
 
 @media print {
-  .c39 {
+  .c38 {
     background: none;
     border: 0;
   }
 }
 
 @media print {
-  .c41 {
+  .c40 {
     color: black;
   }
 }
 
 @media print {
-  .c40 {
+  .c39 {
     background: none;
   }
 }
@@ -620,7 +620,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               target="_blank"
             >
               <span
-                class="c7 c8"
+                class="c7"
                 data-testid="svg-icon"
                 title="Help: Audits"
               >
@@ -632,11 +632,11 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <a
-              class="c9"
+              class="c8"
               href="/audits"
             >
               <span
-                class="c7 c8"
+                class="c7"
                 data-testid="svg-icon"
                 title="Audit List"
               >
@@ -648,7 +648,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <span
-              class="c7 c8"
+              class="c7"
               data-testid="svg-icon"
               title="This is an Alterable Audit. Reports may not relate to current Policy or Target!"
             >
@@ -667,7 +667,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             class="c2 c6"
           >
             <span
-              class="c7 c10 c8"
+              class="c9 c7"
               data-testid="svg-icon"
               title="Clone Audit"
             >
@@ -678,7 +678,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c10 c8"
+              class="c9 c7"
               data-testid="svg-icon"
               title="Edit Audit"
             >
@@ -689,7 +689,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c10 c8"
+              class="c9 c7"
               data-testid="svg-icon"
               title="Move Audit to trashcan"
             >
@@ -700,7 +700,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c10 c8"
+              class="c9 c7"
               data-testid="svg-icon"
               title="Export Audit as XML"
             >
@@ -719,7 +719,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             class="c2 c6"
           >
             <span
-              class="c7 c10 c8"
+              class="c9 c7"
               data-testid="svg-icon"
               title="Start"
             >
@@ -731,7 +731,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </span>
             <span
               alt="Resume"
-              class="c7 c11 c8"
+              class="c10 c7"
               data-testid="svg-icon"
               title="Audit is not stopped"
             >
@@ -756,13 +756,13 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                 class="c2 c6"
               >
                 <a
-                  class="c9"
+                  class="c8"
                   data-testid="details-link"
                   href="/report/1234"
                   title="Last Report for Audit foo from 07/30/2019"
                 >
                   <span
-                    class="c7 c8"
+                    class="c7"
                     data-testid="svg-icon"
                   >
                     <svg>
@@ -771,15 +771,15 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   </span>
                 </a>
                 <a
-                  class="c9"
+                  class="c8"
                   href="/reports?filter=task_id%3D12345"
                   title="Total Reports for Audit foo"
                 >
                   <div
-                    class="c12"
+                    class="c11"
                   >
                     <span
-                      class="c7 c8"
+                      class="c7"
                       data-testid="svg-icon"
                     >
                       <svg>
@@ -787,7 +787,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c13"
+                      class="c12"
                       data-testid="badge-icon"
                     >
                       1
@@ -797,15 +797,15 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
               </div>
             </div>
             <a
-              class="c9"
+              class="c8"
               href="/results?filter=task_id%3D12345"
               title="Results for Audit foo"
             >
               <div
-                class="c12"
+                class="c11"
               >
                 <span
-                  class="c7 c8"
+                  class="c7"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -813,7 +813,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c13"
+                  class="c12"
                   data-testid="badge-icon"
                 >
                   1
@@ -829,16 +829,16 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
     class="entity-section"
   >
     <div
-      class="c14 c15 section-header"
+      class="c13 c14 section-header"
     >
       <h2
-        class="c16 c17"
+        class="c15 c16"
       >
         <div
-          class="c18 c19"
+          class="c17 c18"
         >
           <span
-            class="c7 c20"
+            class="c19"
             data-testid="svg-icon"
           >
             <svg>
@@ -847,19 +847,19 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
           </span>
         </div>
         <div
-          class="c18 c21"
+          class="c17 c20"
         >
           Audit: foo
         </div>
       </h2>
       <div
-        class="c22"
+        class="c21"
       >
         <div
-          class="c23"
+          class="c22"
         >
           <div
-            class="c2 c24"
+            class="c2 c23"
           >
             <div>
               ID:
@@ -890,30 +890,30 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
       </div>
     </div>
     <div
-      class="c25"
+      class="c24"
     >
       <div
-        class="c26 c27"
+        class="c25 c26"
       >
         <div
-          class="c28"
+          class="c27"
         >
           <div
-            class="c29"
+            class="c28"
           >
             Information
           </div>
           <div
-            class="c30"
+            class="c29"
           >
             <div
-              class="c31"
+              class="c30"
             >
               <span>
                 Permissions
               </span>
               <span
-                class="c32"
+                class="c31"
               >
                 (
                 <i>
@@ -926,18 +926,18 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
         </div>
       </div>
       <div
-        class="c33"
+        class="c32"
       >
         <table
-          class="c34 c35"
+          class="c33 c34"
         >
           <colgroup>
             <col
-              class="c36"
+              class="c35"
               width="10%"
             />
             <col
-              class="c37"
+              class="c36"
               width="90%"
             />
           </colgroup>
@@ -947,14 +947,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   Name
                 </div>
               </td>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   foo
                 </div>
@@ -963,14 +963,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   Comment
                 </div>
               </td>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   bar
                 </div>
@@ -979,14 +979,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   Alterable
                 </div>
               </td>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   Yes
                 </div>
@@ -995,35 +995,35 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   Status
                 </div>
               </td>
               <td>
                 <div
-                  class="c33"
+                  class="c32"
                 >
                   <a
-                    class="c9 c38"
+                    class="c8 c37"
                     data-testid="details-link"
                     href="/report/1234"
                   >
                     <div
-                      class="c39"
+                      class="c38"
                       data-testid="progressbar-box"
                       title="Done"
                     >
                       <div
                         background="low"
-                        class="c40"
+                        class="c39"
                         data-testid="progress"
                       />
                       <div
-                        class="c41"
+                        class="c40"
                       >
                         <span
-                          class="c42"
+                          class="c41"
                         >
                           Done
                         </span>
@@ -1036,17 +1036,17 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
           </tbody>
         </table>
         <div
-          class="c25"
+          class="c24"
         >
           <div
-            class="c33"
+            class="c32"
           >
             <h2>
               Target
             </h2>
             <div>
               <a
-                class="c9"
+                class="c8"
                 data-testid="details-link"
                 href="/target/5678"
               >
@@ -1055,7 +1055,7 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c33"
+            class="c32"
           >
             <h2>
               Alerts
@@ -1065,11 +1065,11 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                 class="c2 c3"
               >
                 <div
-                  class="c2 c6 c43"
+                  class="c2 c6 c42"
                 >
                   <span>
                     <a
-                      class="c9"
+                      class="c8"
                       data-testid="details-link"
                       href="/alert/91011"
                     >
@@ -1081,22 +1081,22 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c33"
+            class="c32"
           >
             <h2>
               Scanner
             </h2>
             <div>
               <table
-                class="c44 c35"
+                class="c43 c34"
               >
                 <colgroup>
                   <col
-                    class="c36"
+                    class="c35"
                     width="10%"
                   />
                   <col
-                    class="c37"
+                    class="c36"
                     width="90%"
                   />
                 </colgroup>
@@ -1106,18 +1106,18 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         Name
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         <span>
                           <a
-                            class="c9"
+                            class="c8"
                             data-testid="details-link"
                             href="/scanner/1516"
                           >
@@ -1130,14 +1130,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         Type
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         OpenVAS Scanner
                       </div>
@@ -1148,22 +1148,22 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c33"
+            class="c32"
           >
             <h2>
               Assets
             </h2>
             <div>
               <table
-                class="c44 c35"
+                class="c43 c34"
               >
                 <colgroup>
                   <col
-                    class="c36"
+                    class="c35"
                     width="10%"
                   />
                   <col
-                    class="c37"
+                    class="c36"
                     width="90%"
                   />
                 </colgroup>
@@ -1173,14 +1173,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         Add to Assets
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         Yes
                       </div>
@@ -1191,22 +1191,22 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c33"
+            class="c32"
           >
             <h2>
               Scan
             </h2>
             <div>
               <table
-                class="c44 c35"
+                class="c43 c34"
               >
                 <colgroup>
                   <col
-                    class="c36"
+                    class="c35"
                     width="10%"
                   />
                   <col
-                    class="c37"
+                    class="c36"
                     width="90%"
                   />
                 </colgroup>
@@ -1216,14 +1216,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         Duration of last Scan
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         2 minutes
                       </div>
@@ -1232,14 +1232,14 @@ exports[`Audit Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         Auto delete Reports
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c33"
+                        class="c32"
                       >
                         Do not automatically delete reports
                       </div>
@@ -1293,7 +1293,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
   align-items: flex-start;
 }
 
-.c7 {
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1337,26 +1337,26 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
   display: inline-flex;
 }
 
-.c8 {
+.c7 {
   cursor: pointer;
 }
 
-.c9 svg path {
+.c8 svg path {
   fill: #bfbfbf;
 }
 
-.c6 {
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
-.c10 {
+.c9 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1365,7 +1365,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
   margin-right: 0px;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1403,7 +1403,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
 }
 
 @media print {
-  .c5 {
+  .c7 {
     display: none;
   }
 }
@@ -1426,7 +1426,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           target="_blank"
         >
           <span
-            class="c5 c6"
+            class="c5"
             data-testid="svg-icon"
             title="Help: Audits"
           >
@@ -1438,11 +1438,11 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <a
-          class="c7"
+          class="c6"
           href="/audits"
         >
           <span
-            class="c5 c6"
+            class="c5"
             data-testid="svg-icon"
             title="Audit List"
           >
@@ -1454,7 +1454,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <span
-          class="c5 c6"
+          class="c5"
           data-testid="svg-icon"
           title="This is an Alterable Audit. Reports may not relate to current Policy or Target!"
         >
@@ -1473,7 +1473,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
         class="c0 c4"
       >
         <span
-          class="c5 c8 c6"
+          class="c7 c5"
           data-testid="svg-icon"
           title="Clone Audit"
         >
@@ -1484,7 +1484,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c8 c6"
+          class="c7 c5"
           data-testid="svg-icon"
           title="Edit Audit"
         >
@@ -1495,7 +1495,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c8 c6"
+          class="c7 c5"
           data-testid="svg-icon"
           title="Move Audit to trashcan"
         >
@@ -1506,7 +1506,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c8 c6"
+          class="c7 c5"
           data-testid="svg-icon"
           title="Export Audit as XML"
         >
@@ -1525,7 +1525,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
         class="c0 c4"
       >
         <span
-          class="c5 c8 c6"
+          class="c7 c5"
           data-testid="svg-icon"
           title="Start"
         >
@@ -1537,7 +1537,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
         </span>
         <span
           alt="Resume"
-          class="c5 c9 c6"
+          class="c8 c5"
           data-testid="svg-icon"
           title="Audit is not stopped"
         >
@@ -1562,13 +1562,13 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
             class="c0 c4"
           >
             <a
-              class="c7"
+              class="c6"
               data-testid="details-link"
               href="/report/1234"
               title="Last Report for Audit foo from 07/30/2019"
             >
               <span
-                class="c5 c6"
+                class="c5"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -1577,15 +1577,15 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
               </span>
             </a>
             <a
-              class="c7"
+              class="c6"
               href="/reports?filter=task_id%3D12345"
               title="Total Reports for Audit foo"
             >
               <div
-                class="c10"
+                class="c9"
               >
                 <span
-                  class="c5 c6"
+                  class="c5"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -1593,7 +1593,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c11"
+                  class="c10"
                   data-testid="badge-icon"
                 >
                   1
@@ -1603,15 +1603,15 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
           </div>
         </div>
         <a
-          class="c7"
+          class="c6"
           href="/results?filter=task_id%3D12345"
           title="Results for Audit foo"
         >
           <div
-            class="c10"
+            class="c9"
           >
             <span
-              class="c5 c6"
+              class="c5"
               data-testid="svg-icon"
             >
               <svg>
@@ -1619,7 +1619,7 @@ exports[`Audit ToolBarIcons tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c11"
+              class="c10"
               data-testid="badge-icon"
             >
               1

--- a/src/web/pages/audits/__tests__/__snapshots__/listpage.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/listpage.js.snap
@@ -41,23 +41,23 @@ exports[`AuditPage ToolBarIcons test should render 1`] = `
   display: inline-flex;
 }
 
-.c5 {
+.c4 {
   cursor: pointer;
 }
 
-.c4 {
+.c3 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c4 * {
+.c3 * {
   height: inherit;
   width: inherit;
 }
 
 @media print {
-  .c3 {
+  .c4 {
     display: none;
   }
 }
@@ -74,7 +74,7 @@ exports[`AuditPage ToolBarIcons test should render 1`] = `
       target="_blank"
     >
       <span
-        class="c3 c4"
+        class="c3"
         data-testid="svg-icon"
         title="Help: Audits"
       >
@@ -86,7 +86,7 @@ exports[`AuditPage ToolBarIcons test should render 1`] = `
       </span>
     </a>
     <span
-      class="c3 c5 c4"
+      class="c4 c3"
       data-testid="svg-icon"
       title="New Audit"
     >
@@ -158,7 +158,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -176,7 +176,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   justify-content: flex-end;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -194,7 +194,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: stetch;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -211,7 +211,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -229,7 +229,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -247,7 +247,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c25 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -264,7 +264,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: flex-end;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -282,7 +282,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: flex-end;
 }
 
-.c34 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -299,7 +299,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   justify-content: space-between;
 }
 
-.c36 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -317,7 +317,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c49 {
+.c48 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -331,7 +331,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   justify-content: center;
 }
 
-.c50 {
+.c49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -349,7 +349,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: stretch;
 }
 
-.c51 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -362,7 +362,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   justify-content: space-between;
 }
 
-.c61 {
+.c60 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -384,7 +384,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c62 {
+.c61 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -406,7 +406,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c53 {
+.c52 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -435,48 +435,48 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   display: inline-flex;
 }
 
-.c7 {
+.c6 {
   cursor: pointer;
 }
 
-.c38 svg path {
+.c37 svg path {
   fill: #bfbfbf;
 }
 
-.c6 {
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
-.c31 {
+.c30 {
   height: 50px;
   width: 50px;
   line-height: 50px;
 }
 
-.c31 * {
+.c30 * {
   height: inherit;
   width: inherit;
 }
 
-.c26 {
+.c25 {
   margin: 10px 0px;
   padding-bottom: 1px;
   border-bottom: 2px solid #e5e5e5;
   position: relative;
 }
 
-.c27 {
+.c26 {
   margin: 0 0 1px 0;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -494,16 +494,16 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: stretch;
 }
 
-.c30 {
+.c29 {
   margin-right: 5px;
 }
 
-.c32 {
+.c31 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c23 {
+.c22 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -528,18 +528,18 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   cursor: pointer;
 }
 
-.c24 {
+.c23 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c24 * {
+.c23 * {
   height: inherit;
   width: inherit;
 }
 
-.c19 {
+.c18 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -563,7 +563,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   font-weight: normal;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -575,7 +575,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 150px;
 }
 
-.c63 {
+.c62 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -587,7 +587,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 180px;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -606,7 +606,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   cursor: pointer;
 }
 
-.c16 {
+.c15 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -615,18 +615,18 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   display: none;
 }
 
-.c21 {
+.c20 {
   cursor: default;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c40 {
+.c39 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -635,37 +635,37 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 100%;
 }
 
-.c41 th,
-.c41 td {
+.c40 th,
+.c40 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c41 tfoot tr {
+.c40 tfoot tr {
   background: #fff;
 }
 
-.c41 tfoot tr td {
+.c40 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c43 a {
+.c42 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c43 a:hover {
+.c42 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c45 {
+.c44 {
   cursor: pointer;
 }
 
-.c44 {
+.c43 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -673,7 +673,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 52%;
 }
 
-.c46 {
+.c45 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -681,7 +681,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 8%;
 }
 
-.c47 {
+.c46 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -689,7 +689,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 24%;
 }
 
-.c48 {
+.c47 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -697,7 +697,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   width: 10em;
 }
 
-.c14 {
+.c13 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -711,11 +711,11 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   padding: 1px 8px;
 }
 
-.c14:-webkit-autofill {
+.c13:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -733,55 +733,55 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   align-items: center;
 }
 
-.c13 {
-  margin-right: 5px;
-}
-
 .c12 {
   margin-right: 5px;
 }
 
-.c64 {
+.c11 {
+  margin-right: 5px;
+}
+
+.c63 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c39 {
+.c38 {
   margin: 0 3px;
 }
 
-.c37 {
+.c36 {
   margin: 2px 3px;
 }
 
-.c42 {
+.c41 {
   opacity: 1.0;
 }
 
-.c35 {
+.c34 {
   margin-top: 2px;
   margin-left: 2px;
 }
 
-.c33 {
+.c32 {
   margin-top: 20px;
 }
 
-.c52 {
+.c51 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c52 :hover {
+.c51 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
-.c55 {
+.c54 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -791,7 +791,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   text-align: center;
 }
 
-.c59 {
+.c58 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -801,7 +801,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   text-align: center;
 }
 
-.c57 {
+.c56 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -812,58 +812,58 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
   padding-top: 1px;
 }
 
-.c56 {
+.c55 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
 }
 
-.c60 {
+.c59 {
   height: 13px;
   width: 50%;
   background: #70c000;
 }
 
-.c58 {
+.c57 {
   white-space: nowrap;
 }
 
-.c54:hover {
+.c53:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
 @media print {
-  .c5 {
+  .c6 {
     display: none;
   }
 }
 
 @media print {
-  .c40 {
+  .c39 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c41>tbody:nth-of-type(even),
-  .c41>tbody:only-of-type>tr:nth-of-type(even) {
+  .c40>tbody:nth-of-type(even),
+  .c40>tbody:only-of-type>tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c41>tbody:not(:only-of-type):hover,
-  .c41>tbody:only-of-type>tr:hover {
+  .c40>tbody:not(:only-of-type):hover,
+  .c40>tbody:only-of-type>tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c43 {
+  .c42 {
     border-bottom: 1px solid black;
   }
 
-  .c43 a,
-  .c43 a:hover {
+  .c42 a,
+  .c42 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -871,7 +871,16 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
 }
 
 @media print {
-  .c44 {
+  .c43 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: transparent;
+    font-weight: bold;
+  }
+}
+
+@media print {
+  .c45 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -898,54 +907,45 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
 }
 
 @media print {
-  .c48 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: transparent;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c37 svg {
+  .c36 svg {
     display: none;
   }
 }
 
 @media print {
-  .c52 {
+  .c51 {
     color: #000;
+  }
+}
+
+@media print {
+  .c54 {
+    background: none;
+    border: 0;
+  }
+}
+
+@media print {
+  .c58 {
+    background: none;
+    border: 0;
+  }
+}
+
+@media print {
+  .c56 {
+    color: black;
   }
 }
 
 @media print {
   .c55 {
     background: none;
-    border: 0;
   }
 }
 
 @media print {
   .c59 {
-    background: none;
-    border: 0;
-  }
-}
-
-@media print {
-  .c57 {
-    color: black;
-  }
-}
-
-@media print {
-  .c56 {
-    background: none;
-  }
-}
-
-@media print {
-  .c60 {
     background: none;
   }
 }
@@ -973,7 +973,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               target="_blank"
             >
               <span
-                class="c5 c6"
+                class="c5"
                 data-testid="svg-icon"
                 title="Help: Audits"
               >
@@ -985,7 +985,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               </span>
             </a>
             <span
-              class="c5 c7 c6"
+              class="c6 c5"
               data-testid="svg-icon"
               title="New Audit"
             >
@@ -998,32 +998,32 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
           </div>
         </div>
         <div
-          class="c8"
+          class="c7"
         >
           <div
-            class="c9 powerfilter"
+            class="c8 powerfilter"
           >
             <div
-              class="c10"
+              class="c9"
             >
               <div
                 class="c2 c3"
               >
                 <div
-                  class="c11 c4 c12"
+                  class="c10 c4 c11"
                 >
                   <div
-                    class="c11"
+                    class="c10"
                   >
                     <label
-                      class="c13"
+                      class="c12"
                     >
                       <b>
                         Filter
                       </b>
                     </label>
                     <input
-                      class="c14 c15"
+                      class="c13 c14"
                       maxlength="1000"
                       name="userFilterString"
                       size="53"
@@ -1031,7 +1031,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       value=""
                     />
                     <div
-                      class="c16"
+                      class="c15"
                       data-testid="error-marker"
                     >
                       ×
@@ -1041,10 +1041,10 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     class="c2 c3"
                   >
                     <div
-                      class="c11 c4"
+                      class="c10 c4"
                     >
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Update Filter"
                       >
@@ -1055,7 +1055,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Remove Filter"
                       >
@@ -1066,7 +1066,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Reset to Default Filter"
                       >
@@ -1082,7 +1082,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                         target="_blank"
                       >
                         <span
-                          class="c5 c6"
+                          class="c5"
                           data-testid="svg-icon"
                           title="Help: Powerfilter"
                         >
@@ -1101,34 +1101,34 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="downshift-0-label"
-                class="c17"
+                class="c16"
                 role="combobox"
               >
                 <div
-                  class="c18"
+                  class="c17"
                   width="150px"
                 >
                   <div
                     aria-haspopup="true"
                     aria-label="open menu"
-                    class="c19"
+                    class="c18"
                     data-toggle="true"
                     role="button"
                     title="Loaded filter"
                     type="button"
                   >
                     <div
-                      class="c20 c21"
+                      class="c19 c20"
                       data-testid="select-selected-value"
                       title="Loaded filter"
                     >
                       --
                     </div>
                     <div
-                      class="c22"
+                      class="c21"
                     >
                       <span
-                        class="c23 c24"
+                        class="c22 c23"
                         data-testid="select-open-button"
                       >
                         ▼
@@ -1137,7 +1137,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                   data-testid="error-marker"
                 >
                   ×
@@ -1151,16 +1151,16 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
         class="entities-section"
       >
         <div
-          class="c25 c26 section-header"
+          class="c24 c25 section-header"
         >
           <h2
-            class="c27 c28"
+            class="c26 c27"
           >
             <div
-              class="c29 c30"
+              class="c28 c29"
             >
               <span
-                class="c5 c31"
+                class="c30"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -1169,26 +1169,26 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               </span>
             </div>
             <div
-              class="c29 c32"
+              class="c28 c31"
             >
               Audits 0 of 0
             </div>
           </h2>
           <div
-            class="c10"
+            class="c9"
           />
         </div>
         <div
           class="c0"
         >
           <div
-            class="c0 c33 entities-table"
+            class="c0 c32 entities-table"
           >
             <div
-              class="c34"
+              class="c33"
             >
               <span
-                class="c5 c7 c6 c35"
+                class="c6 c5 c34"
                 data-testid="svg-icon"
                 title="Unfold all details"
               >
@@ -1199,7 +1199,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                 </svg>
               </span>
               <div
-                class="c36 c37"
+                class="c35 c36"
               >
                 <div
                   class="c2 c3"
@@ -1208,7 +1208,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1219,7 +1219,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1232,7 +1232,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c39"
+                  class="c38"
                 >
                   0 - 0 of 0
                 </span>
@@ -1243,7 +1243,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1254,7 +1254,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Last"
                     >
@@ -1269,17 +1269,17 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               </div>
             </div>
             <table
-              class="c40 c41 c42"
+              class="c39 c40 c41"
             >
               <thead
-                class="c43"
+                class="c42"
               >
                 <tr>
                   <th
-                    class="c44"
+                    class="c43"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1289,10 +1289,10 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c46"
+                    class="c45"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1302,10 +1302,10 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c47"
+                    class="c46"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1315,7 +1315,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c46"
+                    class="c45"
                   >
                     <div
                       class="c2"
@@ -1324,10 +1324,10 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     </div>
                   </th>
                   <th
-                    class="c48"
+                    class="c47"
                   >
                     <div
-                      class="c49"
+                      class="c48"
                     >
                       Actions
                     </div>
@@ -1340,13 +1340,13 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                 <tr>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       <div
-                        class="c51"
+                        class="c50"
                       >
                         <span
-                          class="c52"
+                          class="c51"
                           name="1234"
                         >
                           foo
@@ -1370,28 +1370,28 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       <a
-                        class="c53 c54"
+                        class="c52 c53"
                         data-testid="details-link"
                         href="/report/1234"
                       >
                         <div
-                          class="c55"
+                          class="c54"
                           data-testid="progressbar-box"
                           title="Done"
                         >
                           <div
                             background="low"
-                            class="c56"
+                            class="c55"
                             data-testid="progress"
                           />
                           <div
-                            class="c57"
+                            class="c56"
                           >
                             <span
-                              class="c58"
+                              class="c57"
                             >
                               Done
                             </span>
@@ -1402,11 +1402,11 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       <span>
                         <a
-                          class="c53"
+                          class="c52"
                           data-testid="details-link"
                           href="/report/1234"
                         >
@@ -1417,20 +1417,20 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       <div
-                        class="c59"
+                        class="c58"
                         data-testid="progressbar-box"
                         title="50%"
                       >
                         <div
                           background="#70c000"
-                          class="c60"
+                          class="c59"
                           data-testid="progress"
                         />
                         <div
-                          class="c57"
+                          class="c56"
                         >
                           50%
                         </div>
@@ -1442,13 +1442,13 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       class="c0"
                     >
                       <div
-                        class="c61 c3"
+                        class="c60 c3"
                       >
                         <div
-                          class="c62 c4"
+                          class="c61 c4"
                         >
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Start"
                           >
@@ -1460,7 +1460,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                           </span>
                           <span
                             alt="Resume"
-                            class="c5 c38 c6"
+                            class="c37 c5"
                             data-testid="svg-icon"
                             title="Audit is not stopped"
                           >
@@ -1471,7 +1471,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Move Audit to trashcan"
                           >
@@ -1482,7 +1482,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Edit Audit"
                           >
@@ -1493,7 +1493,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Clone Audit"
                           >
@@ -1504,7 +1504,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Export Audit"
                           >
@@ -1515,7 +1515,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c38 c6"
+                            class="c37 c5"
                             data-testid="svg-icon"
                             title="Report download not available"
                           >
@@ -1537,7 +1537,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     colspan="5"
                   >
                     <div
-                      class="c36"
+                      class="c35"
                     >
                       <div
                         class="c2 c3"
@@ -1549,33 +1549,33 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="downshift-1-label"
-                            class="c17"
+                            class="c16"
                             role="combobox"
                           >
                             <div
-                              class="c63"
+                              class="c62"
                               width="180px"
                             >
                               <div
                                 aria-haspopup="true"
                                 aria-label="open menu"
-                                class="c19"
+                                class="c18"
                                 data-toggle="true"
                                 role="button"
                                 type="button"
                               >
                                 <div
-                                  class="c20 c21"
+                                  class="c19 c20"
                                   data-testid="select-selected-value"
                                   title="Apply to page contents"
                                 >
                                   Apply to page contents
                                 </div>
                                 <div
-                                  class="c22"
+                                  class="c21"
                                 >
                                   <span
-                                    class="c23 c24"
+                                    class="c22 c23"
                                     data-testid="select-open-button"
                                   >
                                     ▼
@@ -1584,7 +1584,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                               </div>
                             </div>
                             <div
-                              class="c16"
+                              class="c15"
                               data-testid="error-marker"
                             >
                               ×
@@ -1597,7 +1597,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                               class="c2 c4"
                             >
                               <span
-                                class="c5 c7 c6"
+                                class="c6 c5"
                                 data-testid="svg-icon"
                                 title="Move page contents to trashcan"
                               >
@@ -1608,7 +1608,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                                 </svg>
                               </span>
                               <span
-                                class="c5 c7 c6"
+                                class="c6 c5"
                                 data-testid="svg-icon"
                                 title="Export page contents"
                               >
@@ -1628,15 +1628,15 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
               </tfoot>
             </table>
             <div
-              class="c51"
+              class="c50"
             >
               <div
-                class="c2 c64"
+                class="c2 c63"
               >
                 (Applied filter: )
               </div>
               <div
-                class="c36 c37"
+                class="c35 c36"
               >
                 <div
                   class="c2 c3"
@@ -1645,7 +1645,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1656,7 +1656,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1669,7 +1669,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c39"
+                  class="c38"
                 >
                   0 - 0 of 0
                 </span>
@@ -1680,7 +1680,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1691,7 +1691,7 @@ exports[`AuditPage tests should render full AuditPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Last"
                     >

--- a/src/web/pages/audits/__tests__/__snapshots__/row.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/row.js.snap
@@ -145,21 +145,21 @@ exports[`Audit Row tests should render 1`] = `
   display: inline-flex;
 }
 
-.c18 {
+.c17 {
   cursor: pointer;
 }
 
-.c20 svg path {
+.c19 svg path {
   fill: #bfbfbf;
 }
 
-.c19 {
+.c18 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c19 * {
+.c18 * {
   height: inherit;
   width: inherit;
 }
@@ -389,7 +389,7 @@ exports[`Audit Row tests should render 1`] = `
               class="c16 c5"
             >
               <span
-                class="c17 c18 c19"
+                class="c17 c18"
                 data-testid="svg-icon"
                 title="Start"
               >
@@ -401,7 +401,7 @@ exports[`Audit Row tests should render 1`] = `
               </span>
               <span
                 alt="Resume"
-                class="c17 c20 c19"
+                class="c19 c18"
                 data-testid="svg-icon"
                 title="Audit is not stopped"
               >
@@ -412,7 +412,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c17 c18 c19"
+                class="c17 c18"
                 data-testid="svg-icon"
                 title="Move Audit to trashcan"
               >
@@ -423,7 +423,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c17 c18 c19"
+                class="c17 c18"
                 data-testid="svg-icon"
                 title="Edit Audit"
               >
@@ -434,7 +434,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c17 c18 c19"
+                class="c17 c18"
                 data-testid="svg-icon"
                 title="Clone Audit"
               >
@@ -445,7 +445,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c17 c18 c19"
+                class="c17 c18"
                 data-testid="svg-icon"
                 title="Export Audit"
               >
@@ -456,7 +456,7 @@ exports[`Audit Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c17 c18 c19"
+                class="c17 c18"
                 data-testid="svg-icon"
                 title="Download Greenbone Compliance Report"
               >

--- a/src/web/pages/audits/__tests__/__snapshots__/table.js.snap
+++ b/src/web/pages/audits/__tests__/__snapshots__/table.js.snap
@@ -40,7 +40,7 @@ exports[`Audits table tests should render 1`] = `
   justify-content: space-between;
 }
 
-.c7 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -58,7 +58,7 @@ exports[`Audits table tests should render 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -76,7 +76,7 @@ exports[`Audits table tests should render 1`] = `
   align-items: center;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -90,7 +90,7 @@ exports[`Audits table tests should render 1`] = `
   justify-content: center;
 }
 
-.c23 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -108,7 +108,7 @@ exports[`Audits table tests should render 1`] = `
   align-items: stretch;
 }
 
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -121,7 +121,7 @@ exports[`Audits table tests should render 1`] = `
   justify-content: space-between;
 }
 
-.c34 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -143,7 +143,7 @@ exports[`Audits table tests should render 1`] = `
   align-items: center;
 }
 
-.c35 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -165,7 +165,7 @@ exports[`Audits table tests should render 1`] = `
   align-items: center;
 }
 
-.c43 {
+.c42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -183,55 +183,55 @@ exports[`Audits table tests should render 1`] = `
   align-items: center;
 }
 
-.c26 {
+.c25 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-}
-
-.c11 {
-  margin-left: -5px;
-}
-
-.c11>* {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c11>* {
-  margin-left: 5px;
 }
 
 .c10 {
+  margin-left: -5px;
+}
+
+.c10>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4 {
+.c10>* {
+  margin-left: 5px;
+}
+
+.c9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c3 {
   cursor: pointer;
 }
 
-.c12 svg path {
+.c11 svg path {
   fill: #bfbfbf;
 }
 
-.c5 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c5 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
 
-.c44 {
+.c43 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -256,18 +256,18 @@ exports[`Audits table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c45 {
+.c44 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c45 * {
+.c44 * {
   height: inherit;
   width: inherit;
 }
 
-.c40 {
+.c39 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -291,7 +291,7 @@ exports[`Audits table tests should render 1`] = `
   font-weight: normal;
 }
 
-.c39 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -303,7 +303,7 @@ exports[`Audits table tests should render 1`] = `
   width: 180px;
 }
 
-.c41 {
+.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -322,7 +322,7 @@ exports[`Audits table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c46 {
+.c45 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -331,18 +331,18 @@ exports[`Audits table tests should render 1`] = `
   display: none;
 }
 
-.c42 {
+.c41 {
   cursor: default;
 }
 
-.c38 {
+.c37 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
+.c13 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -351,33 +351,33 @@ exports[`Audits table tests should render 1`] = `
   width: 100%;
 }
 
-.c15 th,
-.c15 td {
+.c14 th,
+.c14 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c15 tfoot tr {
+.c14 tfoot tr {
   background: #fff;
 }
 
-.c15 tfoot tr td {
+.c14 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c17 a {
+.c16 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c17 a:hover {
+.c16 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c18 {
+.c17 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -385,7 +385,7 @@ exports[`Audits table tests should render 1`] = `
   width: 52%;
 }
 
-.c19 {
+.c18 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -393,7 +393,7 @@ exports[`Audits table tests should render 1`] = `
   width: 8%;
 }
 
-.c20 {
+.c19 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -401,7 +401,7 @@ exports[`Audits table tests should render 1`] = `
   width: 24%;
 }
 
-.c21 {
+.c20 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -409,25 +409,25 @@ exports[`Audits table tests should render 1`] = `
   width: 10em;
 }
 
-.c47 {
+.c46 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c13 {
+.c12 {
   margin: 0 3px;
 }
 
-.c8 {
+.c7 {
   margin: 2px 3px;
 }
 
-.c16 {
+.c15 {
   opacity: 1.0;
 }
 
-.c6 {
+.c5 {
   margin-top: 2px;
   margin-left: 2px;
 }
@@ -436,20 +436,20 @@ exports[`Audits table tests should render 1`] = `
   margin-top: 20px;
 }
 
-.c25 {
+.c24 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c25 :hover {
+.c24 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
-.c28 {
+.c27 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -459,7 +459,7 @@ exports[`Audits table tests should render 1`] = `
   text-align: center;
 }
 
-.c32 {
+.c31 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -469,7 +469,7 @@ exports[`Audits table tests should render 1`] = `
   text-align: center;
 }
 
-.c30 {
+.c29 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -480,35 +480,35 @@ exports[`Audits table tests should render 1`] = `
   padding-top: 1px;
 }
 
-.c29 {
+.c28 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
 }
 
-.c33 {
+.c32 {
   height: 13px;
   width: 50%;
   background: #70c000;
 }
 
-.c36 {
+.c35 {
   height: 13px;
   width: 100%;
   background: #99be48;
 }
 
-.c37 {
+.c36 {
   height: 13px;
   width: 0%;
   background: #70c000;
 }
 
-.c31 {
+.c30 {
   white-space: nowrap;
 }
 
-.c27:hover {
+.c26:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -520,33 +520,42 @@ exports[`Audits table tests should render 1`] = `
 }
 
 @media print {
-  .c14 {
+  .c13 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c15>tbody:nth-of-type(even),
-  .c15>tbody:only-of-type>tr:nth-of-type(even) {
+  .c14>tbody:nth-of-type(even),
+  .c14>tbody:only-of-type>tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c15>tbody:not(:only-of-type):hover,
-  .c15>tbody:only-of-type>tr:hover {
+  .c14>tbody:not(:only-of-type):hover,
+  .c14>tbody:only-of-type>tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c17 {
+  .c16 {
     border-bottom: 1px solid black;
   }
 
-  .c17 a,
-  .c17 a:hover {
+  .c16 a,
+  .c16 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
+  }
+}
+
+@media print {
+  .c17 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: transparent;
+    font-weight: bold;
   }
 }
 
@@ -578,66 +587,57 @@ exports[`Audits table tests should render 1`] = `
 }
 
 @media print {
-  .c21 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: transparent;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c8 svg {
+  .c7 svg {
     display: none;
   }
 }
 
 @media print {
-  .c25 {
+  .c24 {
     color: #000;
+  }
+}
+
+@media print {
+  .c27 {
+    background: none;
+    border: 0;
+  }
+}
+
+@media print {
+  .c31 {
+    background: none;
+    border: 0;
+  }
+}
+
+@media print {
+  .c29 {
+    color: black;
   }
 }
 
 @media print {
   .c28 {
     background: none;
-    border: 0;
   }
 }
 
 @media print {
   .c32 {
     background: none;
-    border: 0;
   }
 }
 
 @media print {
-  .c30 {
-    color: black;
-  }
-}
-
-@media print {
-  .c29 {
-    background: none;
-  }
-}
-
-@media print {
-  .c33 {
+  .c35 {
     background: none;
   }
 }
 
 @media print {
   .c36 {
-    background: none;
-  }
-}
-
-@media print {
-  .c37 {
     background: none;
   }
 }
@@ -654,7 +654,7 @@ exports[`Audits table tests should render 1`] = `
         class="c2"
       >
         <span
-          class="c3 c4 c5 c6"
+          class="c3 c4 c5"
           data-testid="svg-icon"
           title="Unfold all details"
         >
@@ -665,16 +665,16 @@ exports[`Audits table tests should render 1`] = `
           </svg>
         </span>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -685,7 +685,7 @@ exports[`Audits table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -698,18 +698,18 @@ exports[`Audits table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -720,7 +720,7 @@ exports[`Audits table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >
@@ -735,53 +735,53 @@ exports[`Audits table tests should render 1`] = `
         </div>
       </div>
       <table
-        class="c14 c15 c16"
+        class="c13 c14 c15"
       >
         <thead
-          class="c17"
+          class="c16"
         >
           <tr>
+            <th
+              class="c17"
+            >
+              <div
+                class="c8"
+              >
+                Name
+              </div>
+            </th>
             <th
               class="c18"
             >
               <div
-                class="c9"
+                class="c8"
               >
-                Name
+                Status
               </div>
             </th>
             <th
               class="c19"
             >
               <div
-                class="c9"
+                class="c8"
               >
-                Status
+                Report
+              </div>
+            </th>
+            <th
+              class="c18"
+            >
+              <div
+                class="c8"
+              >
+                Compliance Status
               </div>
             </th>
             <th
               class="c20"
             >
               <div
-                class="c9"
-              >
-                Report
-              </div>
-            </th>
-            <th
-              class="c19"
-            >
-              <div
-                class="c9"
-              >
-                Compliance Status
-              </div>
-            </th>
-            <th
-              class="c21"
-            >
-              <div
-                class="c22"
+                class="c21"
               >
                 Actions
               </div>
@@ -794,22 +794,22 @@ exports[`Audits table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c24"
+                  class="c23"
                 >
                   <span
-                    class="c25"
+                    class="c24"
                     name="1234"
                   >
                     foo
                   </span>
                   <div
-                    class="c9 c10"
+                    class="c8 c9"
                   >
                     <div
-                      class="c9 c11"
+                      class="c8 c10"
                     />
                   </div>
                 </div>
@@ -824,28 +824,28 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <a
-                  class="c26 c27"
+                  class="c25 c26"
                   data-testid="details-link"
                   href="/report/1234"
                 >
                   <div
-                    class="c28"
+                    class="c27"
                     data-testid="progressbar-box"
                     title="Done"
                   >
                     <div
                       background="low"
-                      class="c29"
+                      class="c28"
                       data-testid="progress"
                     />
                     <div
-                      class="c30"
+                      class="c29"
                     >
                       <span
-                        class="c31"
+                        class="c30"
                       >
                         Done
                       </span>
@@ -856,11 +856,11 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span>
                   <a
-                    class="c26"
+                    class="c25"
                     data-testid="details-link"
                     href="/report/1234"
                   >
@@ -871,20 +871,20 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c32"
+                  class="c31"
                   data-testid="progressbar-box"
                   title="50%"
                 >
                   <div
                     background="#70c000"
-                    class="c33"
+                    class="c32"
                     data-testid="progress"
                   />
                   <div
-                    class="c30"
+                    class="c29"
                   >
                     50%
                   </div>
@@ -896,13 +896,13 @@ exports[`Audits table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c34 c10"
+                  class="c33 c9"
                 >
                   <div
-                    class="c35 c11"
+                    class="c34 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Start"
                     >
@@ -914,7 +914,7 @@ exports[`Audits table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Audit is not stopped"
                     >
@@ -925,7 +925,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Audit to trashcan"
                     >
@@ -936,7 +936,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Audit"
                     >
@@ -947,7 +947,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Audit"
                     >
@@ -958,7 +958,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Audit"
                     >
@@ -969,7 +969,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Report download not available"
                     >
@@ -987,26 +987,26 @@ exports[`Audits table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c24"
+                  class="c23"
                 >
                   <span
-                    class="c25"
+                    class="c24"
                     name="12345"
                   >
                     lorem
                   </span>
                   <div
-                    class="c9 c10"
+                    class="c8 c9"
                   >
                     <div
-                      class="c9 c11"
+                      class="c8 c10"
                     >
                       <span
                         alt="Audit owned by user"
-                        class="c3 c5"
+                        class="c4"
                         data-testid="svg-icon"
                         title="Audit owned by user"
                       >
@@ -1030,26 +1030,26 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span
-                  class="c26 c27"
+                  class="c25 c26"
                 >
                   <div
-                    class="c28"
+                    class="c27"
                     data-testid="progressbar-box"
                     title="New"
                   >
                     <div
                       background="new"
-                      class="c36"
+                      class="c35"
                       data-testid="progress"
                     />
                     <div
-                      class="c30"
+                      class="c29"
                     >
                       <span
-                        class="c31"
+                        class="c30"
                       >
                         New
                       </span>
@@ -1060,12 +1060,12 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               />
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               />
             </td>
             <td>
@@ -1073,13 +1073,13 @@ exports[`Audits table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c34 c10"
+                  class="c33 c9"
                 >
                   <div
-                    class="c35 c11"
+                    class="c34 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Start"
                     >
@@ -1091,7 +1091,7 @@ exports[`Audits table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Audit is not stopped"
                     >
@@ -1102,7 +1102,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Audit to trashcan"
                     >
@@ -1113,7 +1113,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Audit"
                     >
@@ -1124,7 +1124,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Audit"
                     >
@@ -1135,7 +1135,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Audit"
                     >
@@ -1146,7 +1146,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Report download not available"
                     >
@@ -1164,26 +1164,26 @@ exports[`Audits table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c24"
+                  class="c23"
                 >
                   <span
-                    class="c25"
+                    class="c24"
                     name="123456"
                   >
                     hello
                   </span>
                   <div
-                    class="c9 c10"
+                    class="c8 c9"
                   >
                     <div
-                      class="c9 c11"
+                      class="c8 c10"
                     >
                       <span
                         alt="Audit owned by user"
-                        class="c3 c5"
+                        class="c4"
                         data-testid="svg-icon"
                         title="Audit owned by user"
                       >
@@ -1207,28 +1207,28 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <a
-                  class="c26 c27"
+                  class="c25 c26"
                   data-testid="details-link"
                   href="/report/5678"
                 >
                   <div
-                    class="c28"
+                    class="c27"
                     data-testid="progressbar-box"
                     title="Running"
                   >
                     <div
                       background="run"
-                      class="c37"
+                      class="c36"
                       data-testid="progress"
                     />
                     <div
-                      class="c30"
+                      class="c29"
                     >
                       <span
-                        class="c31"
+                        class="c30"
                       >
                         0 %
                       </span>
@@ -1239,11 +1239,11 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span>
                   <a
-                    class="c26"
+                    class="c25"
                     data-testid="details-link"
                     href="/report/1234"
                   >
@@ -1254,20 +1254,20 @@ exports[`Audits table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c32"
+                  class="c31"
                   data-testid="progressbar-box"
                   title="50%"
                 >
                   <div
                     background="#70c000"
-                    class="c33"
+                    class="c32"
                     data-testid="progress"
                   />
                   <div
-                    class="c30"
+                    class="c29"
                   >
                     50%
                   </div>
@@ -1279,13 +1279,13 @@ exports[`Audits table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c34 c10"
+                  class="c33 c9"
                 >
                   <div
-                    class="c35 c11"
+                    class="c34 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Stop"
                     >
@@ -1297,7 +1297,7 @@ exports[`Audits table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Audit is not stopped"
                     >
@@ -1308,7 +1308,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Audit to trashcan"
                     >
@@ -1319,7 +1319,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Audit"
                     >
@@ -1330,7 +1330,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Audit"
                     >
@@ -1341,7 +1341,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Audit"
                     >
@@ -1352,7 +1352,7 @@ exports[`Audits table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Report download not available"
                     >
@@ -1374,42 +1374,42 @@ exports[`Audits table tests should render 1`] = `
               colspan="5"
             >
               <div
-                class="c7"
+                class="c6"
               >
                 <div
-                  class="c9 c10"
+                  class="c8 c9"
                 >
                   <div
-                    class="c9 c11"
+                    class="c8 c10"
                   >
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-labelledby="downshift-0-label"
-                      class="c38"
+                      class="c37"
                       role="combobox"
                     >
                       <div
-                        class="c39"
+                        class="c38"
                         width="180px"
                       >
                         <div
                           aria-haspopup="true"
                           aria-label="open menu"
-                          class="c40"
+                          class="c39"
                           data-toggle="true"
                           role="button"
                           type="button"
                         >
                           <div
-                            class="c41 c42"
+                            class="c40 c41"
                             data-testid="select-selected-value"
                           />
                           <div
-                            class="c43"
+                            class="c42"
                           >
                             <span
-                              class="c44 c45"
+                              class="c43 c44"
                               data-testid="select-open-button"
                             >
                               ▼
@@ -1418,20 +1418,20 @@ exports[`Audits table tests should render 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c46"
+                        class="c45"
                         data-testid="error-marker"
                       >
                         ×
                       </div>
                     </div>
                     <div
-                      class="c9 c10"
+                      class="c8 c9"
                     >
                       <div
-                        class="c9 c11"
+                        class="c8 c10"
                       >
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1439,7 +1439,7 @@ exports[`Audits table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1456,24 +1456,24 @@ exports[`Audits table tests should render 1`] = `
         </tfoot>
       </table>
       <div
-        class="c24"
+        class="c23"
       >
         <div
-          class="c9 c47"
+          class="c8 c46"
         >
           (Applied filter: rows=2)
         </div>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -1484,7 +1484,7 @@ exports[`Audits table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -1497,18 +1497,18 @@ exports[`Audits table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -1519,7 +1519,7 @@ exports[`Audits table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >

--- a/src/web/pages/policies/__tests__/__snapshots__/detailspage.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/detailspage.js.snap
@@ -54,7 +54,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   align-items: center;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -71,7 +71,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   align-items: flex-end;
 }
 
-.c14 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -87,6 +87,23 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
   align-items: flex-end;
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c18 {
@@ -97,30 +114,13 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-pack: start;
   -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -142,7 +142,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -164,7 +164,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   align-items: flex-end;
 }
 
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -182,7 +182,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c27 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -200,7 +200,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   align-items: center;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -218,7 +218,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c34 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -240,7 +240,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   align-items: center;
 }
 
-.c8 {
+.c7 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -284,44 +284,44 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   display: inline-flex;
 }
 
-.c9 {
+.c8 {
   cursor: pointer;
 }
 
-.c7 {
+.c6 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c7 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c16 {
+.c15 {
   height: 50px;
   width: 50px;
   line-height: 50px;
 }
 
-.c16 * {
+.c15 * {
   height: inherit;
   width: inherit;
 }
 
-.c11 {
+.c10 {
   margin: 10px 0px;
   padding-bottom: 1px;
   border-bottom: 2px solid #e5e5e5;
   position: relative;
 }
 
-.c12 {
+.c11 {
   margin: 0 0 1px 0;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -339,16 +339,16 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c15 {
+.c14 {
   margin-right: 5px;
 }
 
-.c17 {
+.c16 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c25 {
+.c24 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -375,15 +375,15 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #11ab51;
 }
 
-.c25:hover {
+.c24:hover {
   border-top: 2px solid #11ab51;
 }
 
-.c25:first-child {
+.c24:first-child {
   border-left: 1px solid #e5e5e5;
 }
 
-.c26 {
+.c25 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -407,21 +407,21 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #fff;
 }
 
-.c26:hover {
+.c25:hover {
   border-top: 2px solid #e5e5e5;
 }
 
-.c26:first-child {
+.c25:first-child {
   border-left: 1px solid #fff;
 }
 
-.c23 {
+.c22 {
   border-bottom: 2px solid #11ab51;
   margin-top: 30px;
   margin-bottom: 15px;
 }
 
-.c30 {
+.c29 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -429,48 +429,48 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
   table-layout: auto;
 }
 
-.c31 td {
+.c30 td {
   padding: 4px 4px 4px 0;
 }
 
-.c31 tr td:first-child {
+.c30 tr td:first-child {
   padding-right: 5px;
 }
 
-.c20 {
+.c19 {
   border-spacing: 0px;
   color: #7F7F7F;
   font-size: 10px;
 }
 
-.c20 :nth-child(even) {
+.c19 :nth-child(even) {
   margin-left: 3px;
 }
 
-.c20 :nth-child(odd) {
+.c19 :nth-child(odd) {
   margin-left: 30px;
 }
 
-.c32 {
+.c31 {
   width: 10%;
 }
 
-.c33 {
+.c32 {
   width: 90%;
 }
 
-.c28 {
+.c27 {
   font-size: 0.7em;
 }
 
 @media print {
-  .c6 {
+  .c8 {
     display: none;
   }
 }
 
 @media print {
-  .c30 {
+  .c29 {
     border-collapse: collapse;
   }
 }
@@ -499,7 +499,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               target="_blank"
             >
               <span
-                class="c6 c7"
+                class="c6"
                 data-testid="svg-icon"
                 title="Help: Policies"
               >
@@ -511,11 +511,11 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <a
-              class="c8"
+              class="c7"
               href="/policies"
             >
               <span
-                class="c6 c7"
+                class="c6"
                 data-testid="svg-icon"
                 title="Policies List"
               >
@@ -535,7 +535,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
             class="c2 c5"
           >
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Clone Policy"
             >
@@ -546,7 +546,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Edit Policy"
             >
@@ -557,7 +557,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Move Policy to trashcan"
             >
@@ -568,7 +568,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Export Policy as XML"
             >
@@ -587,16 +587,16 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
     class="entity-section"
   >
     <div
-      class="c10 c11 section-header"
+      class="c9 c10 section-header"
     >
       <h2
-        class="c12 c13"
+        class="c11 c12"
       >
         <div
-          class="c14 c15"
+          class="c13 c14"
         >
           <span
-            class="c6 c16"
+            class="c15"
             data-testid="svg-icon"
           >
             <svg>
@@ -605,19 +605,19 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
           </span>
         </div>
         <div
-          class="c14 c17"
+          class="c13 c16"
         >
           Policy: foo
         </div>
       </h2>
       <div
-        class="c18"
+        class="c17"
       >
         <div
-          class="c19"
+          class="c18"
         >
           <div
-            class="c2 c20"
+            class="c2 c19"
           >
             <div>
               ID:
@@ -648,30 +648,30 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
       </div>
     </div>
     <div
-      class="c21"
+      class="c20"
     >
       <div
-        class="c22 c23"
+        class="c21 c22"
       >
         <div
-          class="c24"
+          class="c23"
         >
           <div
-            class="c25"
+            class="c24"
           >
             Information
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 Scanner Preferences
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -682,16 +682,16 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 NVT Families
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -702,16 +702,16 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 NVT Preferences
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -722,16 +722,16 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 Permissions
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -744,21 +744,21 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
         </div>
       </div>
       <div
-        class="c29"
+        class="c28"
       >
         <div
-          class="c21"
+          class="c20"
         >
           <table
-            class="c30 c31"
+            class="c29 c30"
           >
             <colgroup>
               <col
-                class="c32"
+                class="c31"
                 width="10%"
               />
               <col
-                class="c33"
+                class="c32"
                 width="90%"
               />
             </colgroup>
@@ -768,14 +768,14 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               <tr>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     Comment
                   </div>
                 </td>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     bar
                   </div>
@@ -784,23 +784,23 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
               <tr>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     Audits using this Policy
                   </div>
                 </td>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     <div
                       class="c2 c3"
                     >
                       <div
-                        class="c34 c5"
+                        class="c33 c5"
                       >
                         <a
-                          class="c8"
+                          class="c7"
                           data-testid="details-link"
                           href="/audit/1234"
                         >
@@ -808,7 +808,7 @@ exports[`Policy Detailspage tests should render full Detailspage 1`] = `
                         </a>
                         ,
                         <a
-                          class="c8"
+                          class="c7"
                           data-testid="details-link"
                           href="/audit/5678"
                         >
@@ -847,7 +847,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c5 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -891,23 +891,23 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
   display: inline-flex;
 }
 
-.c7 {
+.c6 {
   cursor: pointer;
 }
 
-.c5 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c5 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
 
 @media print {
-  .c4 {
+  .c6 {
     display: none;
   }
 }
@@ -930,7 +930,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           target="_blank"
         >
           <span
-            class="c4 c5"
+            class="c4"
             data-testid="svg-icon"
             title="Help: Policies"
           >
@@ -942,11 +942,11 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <a
-          class="c6"
+          class="c5"
           href="/policies"
         >
           <span
-            class="c4 c5"
+            class="c4"
             data-testid="svg-icon"
             title="Policies List"
           >
@@ -966,7 +966,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
         class="c0 c3"
       >
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Clone Policy"
         >
@@ -977,7 +977,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Edit Policy"
         >
@@ -988,7 +988,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Move Policy to trashcan"
         >
@@ -999,7 +999,7 @@ exports[`Policy ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Export Policy as XML"
         >

--- a/src/web/pages/policies/__tests__/__snapshots__/listpage.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/listpage.js.snap
@@ -41,23 +41,23 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
   display: inline-flex;
 }
 
-.c5 {
+.c4 {
   cursor: pointer;
 }
 
-.c4 {
+.c3 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c4 * {
+.c3 * {
   height: inherit;
   width: inherit;
 }
 
 @media print {
-  .c3 {
+  .c4 {
     display: none;
   }
 }
@@ -74,7 +74,7 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
       target="_blank"
     >
       <span
-        class="c3 c4"
+        class="c3"
         data-testid="svg-icon"
         title="Help: Policies"
       >
@@ -86,7 +86,7 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
       </span>
     </a>
     <span
-      class="c3 c5 c4"
+      class="c4 c3"
       data-testid="svg-icon"
       title="New Policy"
     >
@@ -97,7 +97,7 @@ exports[`PoliciesPage ToolBarIcons test should render 1`] = `
       </svg>
     </span>
     <span
-      class="c3 c5 c4"
+      class="c4 c3"
       data-testid="svg-icon"
       title="Import Policy"
     >
@@ -169,7 +169,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: center;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -187,7 +187,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   justify-content: flex-end;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -205,7 +205,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: stetch;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -222,7 +222,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: center;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -240,7 +240,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: center;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -258,7 +258,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: center;
 }
 
-.c25 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -275,7 +275,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: flex-end;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -293,7 +293,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: flex-end;
 }
 
-.c34 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -310,7 +310,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   justify-content: space-between;
 }
 
-.c36 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -328,7 +328,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: center;
 }
 
-.c47 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -342,7 +342,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   justify-content: center;
 }
 
-.c48 {
+.c47 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -360,7 +360,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: stretch;
 }
 
-.c49 {
+.c48 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -373,7 +373,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   justify-content: space-between;
 }
 
-.c51 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -395,7 +395,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: center;
 }
 
-.c52 {
+.c51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -439,48 +439,48 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   display: inline-flex;
 }
 
-.c7 {
+.c6 {
   cursor: pointer;
 }
 
-.c38 svg path {
+.c37 svg path {
   fill: #bfbfbf;
 }
 
-.c6 {
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
-.c31 {
+.c30 {
   height: 50px;
   width: 50px;
   line-height: 50px;
 }
 
-.c31 * {
+.c30 * {
   height: inherit;
   width: inherit;
 }
 
-.c26 {
+.c25 {
   margin: 10px 0px;
   padding-bottom: 1px;
   border-bottom: 2px solid #e5e5e5;
   position: relative;
 }
 
-.c27 {
+.c26 {
   margin: 0 0 1px 0;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -498,16 +498,16 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: stretch;
 }
 
-.c30 {
+.c29 {
   margin-right: 5px;
 }
 
-.c32 {
+.c31 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c23 {
+.c22 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -532,18 +532,18 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   cursor: pointer;
 }
 
-.c24 {
+.c23 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c24 * {
+.c23 * {
   height: inherit;
   width: inherit;
 }
 
-.c19 {
+.c18 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -567,7 +567,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   font-weight: normal;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -579,7 +579,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   width: 150px;
 }
 
-.c53 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -591,7 +591,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   width: 180px;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -610,7 +610,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   cursor: pointer;
 }
 
-.c16 {
+.c15 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -619,18 +619,18 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   display: none;
 }
 
-.c21 {
+.c20 {
   cursor: default;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c40 {
+.c39 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -639,37 +639,37 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   width: 100%;
 }
 
-.c41 th,
-.c41 td {
+.c40 th,
+.c40 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c41 tfoot tr {
+.c40 tfoot tr {
   background: #fff;
 }
 
-.c41 tfoot tr td {
+.c40 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c43 a {
+.c42 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c43 a:hover {
+.c42 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c45 {
+.c44 {
   cursor: pointer;
 }
 
-.c44 {
+.c43 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -677,7 +677,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   width: 92%;
 }
 
-.c46 {
+.c45 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -685,7 +685,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   width: 8%;
 }
 
-.c14 {
+.c13 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -699,11 +699,11 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   padding: 1px 8px;
 }
 
-.c14:-webkit-autofill {
+.c13:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -721,85 +721,85 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
   align-items: center;
 }
 
-.c13 {
-  margin-right: 5px;
-}
-
 .c12 {
   margin-right: 5px;
 }
 
-.c54 {
+.c11 {
+  margin-right: 5px;
+}
+
+.c53 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c39 {
+.c38 {
   margin: 0 3px;
 }
 
-.c37 {
+.c36 {
   margin: 2px 3px;
 }
 
-.c42 {
+.c41 {
   opacity: 1.0;
 }
 
-.c35 {
+.c34 {
   margin-top: 2px;
   margin-left: 2px;
 }
 
-.c33 {
+.c32 {
   margin-top: 20px;
 }
 
-.c50 {
+.c49 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c50 :hover {
+.c49 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
 @media print {
-  .c5 {
+  .c6 {
     display: none;
   }
 }
 
 @media print {
-  .c40 {
+  .c39 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c41>tbody:nth-of-type(even),
-  .c41>tbody:only-of-type>tr:nth-of-type(even) {
+  .c40>tbody:nth-of-type(even),
+  .c40>tbody:only-of-type>tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c41>tbody:not(:only-of-type):hover,
-  .c41>tbody:only-of-type>tr:hover {
+  .c40>tbody:not(:only-of-type):hover,
+  .c40>tbody:only-of-type>tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c43 {
+  .c42 {
     border-bottom: 1px solid black;
   }
 
-  .c43 a,
-  .c43 a:hover {
+  .c42 a,
+  .c42 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -807,7 +807,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
 }
 
 @media print {
-  .c44 {
+  .c43 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -816,7 +816,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
 }
 
 @media print {
-  .c46 {
+  .c45 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -825,13 +825,13 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
 }
 
 @media print {
-  .c37 svg {
+  .c36 svg {
     display: none;
   }
 }
 
 @media print {
-  .c50 {
+  .c49 {
     color: #000;
   }
 }
@@ -859,7 +859,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               target="_blank"
             >
               <span
-                class="c5 c6"
+                class="c5"
                 data-testid="svg-icon"
                 title="Help: Policies"
               >
@@ -871,7 +871,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </span>
             </a>
             <span
-              class="c5 c7 c6"
+              class="c6 c5"
               data-testid="svg-icon"
               title="New Policy"
             >
@@ -882,7 +882,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c7 c6"
+              class="c6 c5"
               data-testid="svg-icon"
               title="Import Policy"
             >
@@ -895,32 +895,32 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
           </div>
         </div>
         <div
-          class="c8"
+          class="c7"
         >
           <div
-            class="c9 powerfilter"
+            class="c8 powerfilter"
           >
             <div
-              class="c10"
+              class="c9"
             >
               <div
                 class="c2 c3"
               >
                 <div
-                  class="c11 c4 c12"
+                  class="c10 c4 c11"
                 >
                   <div
-                    class="c11"
+                    class="c10"
                   >
                     <label
-                      class="c13"
+                      class="c12"
                     >
                       <b>
                         Filter
                       </b>
                     </label>
                     <input
-                      class="c14 c15"
+                      class="c13 c14"
                       maxlength="1000"
                       name="userFilterString"
                       size="53"
@@ -928,7 +928,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       value=""
                     />
                     <div
-                      class="c16"
+                      class="c15"
                       data-testid="error-marker"
                     >
                       ×
@@ -938,10 +938,10 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     class="c2 c3"
                   >
                     <div
-                      class="c11 c4"
+                      class="c10 c4"
                     >
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Update Filter"
                       >
@@ -952,7 +952,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Remove Filter"
                       >
@@ -963,7 +963,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Reset to Default Filter"
                       >
@@ -979,7 +979,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                         target="_blank"
                       >
                         <span
-                          class="c5 c6"
+                          class="c5"
                           data-testid="svg-icon"
                           title="Help: Powerfilter"
                         >
@@ -998,34 +998,34 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="downshift-0-label"
-                class="c17"
+                class="c16"
                 role="combobox"
               >
                 <div
-                  class="c18"
+                  class="c17"
                   width="150px"
                 >
                   <div
                     aria-haspopup="true"
                     aria-label="open menu"
-                    class="c19"
+                    class="c18"
                     data-toggle="true"
                     role="button"
                     title="Loaded filter"
                     type="button"
                   >
                     <div
-                      class="c20 c21"
+                      class="c19 c20"
                       data-testid="select-selected-value"
                       title="Loaded filter"
                     >
                       --
                     </div>
                     <div
-                      class="c22"
+                      class="c21"
                     >
                       <span
-                        class="c23 c24"
+                        class="c22 c23"
                         data-testid="select-open-button"
                       >
                         ▼
@@ -1034,7 +1034,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                   data-testid="error-marker"
                 >
                   ×
@@ -1048,16 +1048,16 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
         class="entities-section"
       >
         <div
-          class="c25 c26 section-header"
+          class="c24 c25 section-header"
         >
           <h2
-            class="c27 c28"
+            class="c26 c27"
           >
             <div
-              class="c29 c30"
+              class="c28 c29"
             >
               <span
-                class="c5 c31"
+                class="c30"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -1066,26 +1066,26 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </span>
             </div>
             <div
-              class="c29 c32"
+              class="c28 c31"
             >
               Policies 0 of 0
             </div>
           </h2>
           <div
-            class="c10"
+            class="c9"
           />
         </div>
         <div
           class="c0"
         >
           <div
-            class="c0 c33 entities-table"
+            class="c0 c32 entities-table"
           >
             <div
-              class="c34"
+              class="c33"
             >
               <span
-                class="c5 c7 c6 c35"
+                class="c6 c5 c34"
                 data-testid="svg-icon"
                 title="Unfold all details"
               >
@@ -1096,7 +1096,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                 </svg>
               </span>
               <div
-                class="c36 c37"
+                class="c35 c36"
               >
                 <div
                   class="c2 c3"
@@ -1105,7 +1105,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1116,7 +1116,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1129,7 +1129,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c39"
+                  class="c38"
                 >
                   0 - 0 of 0
                 </span>
@@ -1140,7 +1140,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1151,7 +1151,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Last"
                     >
@@ -1166,17 +1166,17 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </div>
             </div>
             <table
-              class="c40 c41 c42"
+              class="c39 c40 c41"
             >
               <thead
-                class="c43"
+                class="c42"
               >
                 <tr>
                   <th
-                    class="c44"
+                    class="c43"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1186,10 +1186,10 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c46"
+                    class="c45"
                   >
                     <div
-                      class="c47"
+                      class="c46"
                     >
                       Actions
                     </div>
@@ -1202,17 +1202,17 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                 <tr>
                   <td>
                     <div
-                      class="c48"
+                      class="c47"
                     >
                       <div
-                        class="c49"
+                        class="c48"
                       >
                         <div
-                          class="c48"
+                          class="c47"
                         >
                           <span>
                             <span
-                              class="c50"
+                              class="c49"
                               name="12345"
                             >
                               foo
@@ -1234,13 +1234,13 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       class="c0"
                     >
                       <div
-                        class="c51 c3"
+                        class="c50 c3"
                       >
                         <div
-                          class="c52 c4"
+                          class="c51 c4"
                         >
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Move Policy to trashcan"
                           >
@@ -1251,7 +1251,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Edit Policy"
                           >
@@ -1262,7 +1262,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Clone Policy"
                           >
@@ -1273,7 +1273,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Create Audit from Policy"
                           >
@@ -1284,7 +1284,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Export Policy"
                           >
@@ -1306,7 +1306,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     colspan="2"
                   >
                     <div
-                      class="c36"
+                      class="c35"
                     >
                       <div
                         class="c2 c3"
@@ -1318,33 +1318,33 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="downshift-1-label"
-                            class="c17"
+                            class="c16"
                             role="combobox"
                           >
                             <div
-                              class="c53"
+                              class="c52"
                               width="180px"
                             >
                               <div
                                 aria-haspopup="true"
                                 aria-label="open menu"
-                                class="c19"
+                                class="c18"
                                 data-toggle="true"
                                 role="button"
                                 type="button"
                               >
                                 <div
-                                  class="c20 c21"
+                                  class="c19 c20"
                                   data-testid="select-selected-value"
                                   title="Apply to page contents"
                                 >
                                   Apply to page contents
                                 </div>
                                 <div
-                                  class="c22"
+                                  class="c21"
                                 >
                                   <span
-                                    class="c23 c24"
+                                    class="c22 c23"
                                     data-testid="select-open-button"
                                   >
                                     ▼
@@ -1353,7 +1353,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                               </div>
                             </div>
                             <div
-                              class="c16"
+                              class="c15"
                               data-testid="error-marker"
                             >
                               ×
@@ -1366,7 +1366,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                               class="c2 c4"
                             >
                               <span
-                                class="c5 c7 c6"
+                                class="c6 c5"
                                 data-testid="svg-icon"
                                 title="Move page contents to trashcan"
                               >
@@ -1377,7 +1377,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                                 </svg>
                               </span>
                               <span
-                                class="c5 c7 c6"
+                                class="c6 c5"
                                 data-testid="svg-icon"
                                 title="Export page contents"
                               >
@@ -1397,15 +1397,15 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
               </tfoot>
             </table>
             <div
-              class="c49"
+              class="c48"
             >
               <div
-                class="c2 c54"
+                class="c2 c53"
               >
                 (Applied filter: )
               </div>
               <div
-                class="c36 c37"
+                class="c35 c36"
               >
                 <div
                   class="c2 c3"
@@ -1414,7 +1414,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1425,7 +1425,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1438,7 +1438,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c39"
+                  class="c38"
                 >
                   0 - 0 of 0
                 </span>
@@ -1449,7 +1449,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1460,7 +1460,7 @@ exports[`PoliciesPage tests should render full PoliciesPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Last"
                     >

--- a/src/web/pages/policies/__tests__/__snapshots__/row.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/row.js.snap
@@ -120,17 +120,17 @@ exports[`Row tests should render 1`] = `
   display: inline-flex;
 }
 
-.c9 {
+.c8 {
   cursor: pointer;
 }
 
-.c10 {
+.c9 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c10 * {
+.c9 * {
   height: inherit;
   width: inherit;
 }
@@ -206,7 +206,7 @@ exports[`Row tests should render 1`] = `
               class="c6 c7"
             >
               <span
-                class="c8 c9 c10"
+                class="c8 c9"
                 data-testid="svg-icon"
                 title="Move Policy to trashcan"
               >
@@ -217,7 +217,7 @@ exports[`Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c9 c10"
+                class="c8 c9"
                 data-testid="svg-icon"
                 title="Edit Policy"
               >
@@ -228,7 +228,7 @@ exports[`Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c9 c10"
+                class="c8 c9"
                 data-testid="svg-icon"
                 title="Clone Policy"
               >
@@ -239,7 +239,7 @@ exports[`Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c9 c10"
+                class="c8 c9"
                 data-testid="svg-icon"
                 title="Create Audit from Policy"
               >
@@ -250,7 +250,7 @@ exports[`Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c8 c9 c10"
+                class="c8 c9"
                 data-testid="svg-icon"
                 title="Export Policy"
               >

--- a/src/web/pages/policies/__tests__/__snapshots__/table.js.snap
+++ b/src/web/pages/policies/__tests__/__snapshots__/table.js.snap
@@ -40,7 +40,7 @@ exports[`Policies table tests should render 1`] = `
   justify-content: space-between;
 }
 
-.c7 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -58,7 +58,7 @@ exports[`Policies table tests should render 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -76,7 +76,7 @@ exports[`Policies table tests should render 1`] = `
   align-items: center;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -90,7 +90,7 @@ exports[`Policies table tests should render 1`] = `
   justify-content: center;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -108,7 +108,7 @@ exports[`Policies table tests should render 1`] = `
   align-items: stretch;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -121,7 +121,7 @@ exports[`Policies table tests should render 1`] = `
   justify-content: space-between;
 }
 
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -143,7 +143,7 @@ exports[`Policies table tests should render 1`] = `
   align-items: center;
 }
 
-.c25 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -165,7 +165,7 @@ exports[`Policies table tests should render 1`] = `
   align-items: center;
 }
 
-.c31 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -183,48 +183,48 @@ exports[`Policies table tests should render 1`] = `
   align-items: center;
 }
 
-.c11 {
+.c10 {
   margin-left: -5px;
 }
 
-.c11>* {
+.c10>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c11>* {
+.c10>* {
   margin-left: 5px;
 }
 
-.c10 {
+.c9 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4 {
+.c3 {
   cursor: pointer;
 }
 
-.c12 svg path {
+.c11 svg path {
   fill: #bfbfbf;
 }
 
-.c5 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c5 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
 
-.c32 {
+.c31 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -249,18 +249,18 @@ exports[`Policies table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c33 {
+.c32 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c33 * {
+.c32 * {
   height: inherit;
   width: inherit;
 }
 
-.c28 {
+.c27 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -284,7 +284,7 @@ exports[`Policies table tests should render 1`] = `
   font-weight: normal;
 }
 
-.c27 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -296,7 +296,7 @@ exports[`Policies table tests should render 1`] = `
   width: 180px;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -315,7 +315,7 @@ exports[`Policies table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c34 {
+.c33 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -324,18 +324,18 @@ exports[`Policies table tests should render 1`] = `
   display: none;
 }
 
-.c30 {
+.c29 {
   cursor: default;
 }
 
-.c26 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
+.c13 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -344,33 +344,33 @@ exports[`Policies table tests should render 1`] = `
   width: 100%;
 }
 
-.c15 th,
-.c15 td {
+.c14 th,
+.c14 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c15 tfoot tr {
+.c14 tfoot tr {
   background: #fff;
 }
 
-.c15 tfoot tr td {
+.c14 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c17 a {
+.c16 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c17 a:hover {
+.c16 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c18 {
+.c17 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -378,7 +378,7 @@ exports[`Policies table tests should render 1`] = `
   width: 92%;
 }
 
-.c19 {
+.c18 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -386,25 +386,25 @@ exports[`Policies table tests should render 1`] = `
   width: 8%;
 }
 
-.c35 {
+.c34 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c13 {
+.c12 {
   margin: 0 3px;
 }
 
-.c8 {
+.c7 {
   margin: 2px 3px;
 }
 
-.c16 {
+.c15 {
   opacity: 1.0;
 }
 
-.c6 {
+.c5 {
   margin-top: 2px;
   margin-left: 2px;
 }
@@ -413,14 +413,14 @@ exports[`Policies table tests should render 1`] = `
   margin-top: 20px;
 }
 
-.c23 {
+.c22 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c23 :hover {
+.c22 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
@@ -433,33 +433,42 @@ exports[`Policies table tests should render 1`] = `
 }
 
 @media print {
-  .c14 {
+  .c13 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c15>tbody:nth-of-type(even),
-  .c15>tbody:only-of-type>tr:nth-of-type(even) {
+  .c14>tbody:nth-of-type(even),
+  .c14>tbody:only-of-type>tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c15>tbody:not(:only-of-type):hover,
-  .c15>tbody:only-of-type>tr:hover {
+  .c14>tbody:not(:only-of-type):hover,
+  .c14>tbody:only-of-type>tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c17 {
+  .c16 {
     border-bottom: 1px solid black;
   }
 
-  .c17 a,
-  .c17 a:hover {
+  .c16 a,
+  .c16 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
+  }
+}
+
+@media print {
+  .c17 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: transparent;
+    font-weight: bold;
   }
 }
 
@@ -473,22 +482,13 @@ exports[`Policies table tests should render 1`] = `
 }
 
 @media print {
-  .c19 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: transparent;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c8 svg {
+  .c7 svg {
     display: none;
   }
 }
 
 @media print {
-  .c23 {
+  .c22 {
     color: #000;
   }
 }
@@ -505,7 +505,7 @@ exports[`Policies table tests should render 1`] = `
         class="c2"
       >
         <span
-          class="c3 c4 c5 c6"
+          class="c3 c4 c5"
           data-testid="svg-icon"
           title="Unfold all details"
         >
@@ -516,16 +516,16 @@ exports[`Policies table tests should render 1`] = `
           </svg>
         </span>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -536,7 +536,7 @@ exports[`Policies table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -549,18 +549,18 @@ exports[`Policies table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -571,7 +571,7 @@ exports[`Policies table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >
@@ -586,26 +586,26 @@ exports[`Policies table tests should render 1`] = `
         </div>
       </div>
       <table
-        class="c14 c15 c16"
+        class="c13 c14 c15"
       >
         <thead
-          class="c17"
+          class="c16"
         >
           <tr>
             <th
-              class="c18"
+              class="c17"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 Name
               </div>
             </th>
             <th
-              class="c19"
+              class="c18"
             >
               <div
-                class="c20"
+                class="c19"
               >
                 Actions
               </div>
@@ -618,17 +618,17 @@ exports[`Policies table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c21"
+                class="c20"
               >
                 <div
-                  class="c22"
+                  class="c21"
                 >
                   <div
-                    class="c21"
+                    class="c20"
                   >
                     <span>
                       <span
-                        class="c23"
+                        class="c22"
                         name="12345"
                       >
                         foo
@@ -650,13 +650,13 @@ exports[`Policies table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c24 c10"
+                  class="c23 c9"
                 >
                   <div
-                    class="c25 c11"
+                    class="c24 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Policy to trashcan"
                     >
@@ -667,7 +667,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Policy"
                     >
@@ -678,7 +678,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Policy"
                     >
@@ -689,7 +689,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Create Audit from Policy"
                     >
@@ -700,7 +700,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Policy"
                     >
@@ -718,17 +718,17 @@ exports[`Policies table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c21"
+                class="c20"
               >
                 <div
-                  class="c22"
+                  class="c21"
                 >
                   <div
-                    class="c21"
+                    class="c20"
                   >
                     <span>
                       <span
-                        class="c23"
+                        class="c22"
                         name="123456"
                       >
                         lorem
@@ -750,13 +750,13 @@ exports[`Policies table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c24 c10"
+                  class="c23 c9"
                 >
                   <div
-                    class="c25 c11"
+                    class="c24 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Policy to trashcan"
                     >
@@ -767,7 +767,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Policy"
                     >
@@ -778,7 +778,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Policy"
                     >
@@ -789,7 +789,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Create Audit from Policy"
                     >
@@ -800,7 +800,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Policy"
                     >
@@ -818,17 +818,17 @@ exports[`Policies table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c21"
+                class="c20"
               >
                 <div
-                  class="c22"
+                  class="c21"
                 >
                   <div
-                    class="c21"
+                    class="c20"
                   >
                     <span>
                       <span
-                        class="c23"
+                        class="c22"
                         name="1234567"
                       >
                         hello
@@ -850,13 +850,13 @@ exports[`Policies table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c24 c10"
+                  class="c23 c9"
                 >
                   <div
-                    class="c25 c11"
+                    class="c24 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Policy to trashcan"
                     >
@@ -867,7 +867,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Policy"
                     >
@@ -878,7 +878,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Policy"
                     >
@@ -889,7 +889,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Create Audit from Policy"
                     >
@@ -900,7 +900,7 @@ exports[`Policies table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Policy"
                     >
@@ -922,42 +922,42 @@ exports[`Policies table tests should render 1`] = `
               colspan="2"
             >
               <div
-                class="c7"
+                class="c6"
               >
                 <div
-                  class="c9 c10"
+                  class="c8 c9"
                 >
                   <div
-                    class="c9 c11"
+                    class="c8 c10"
                   >
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-labelledby="downshift-0-label"
-                      class="c26"
+                      class="c25"
                       role="combobox"
                     >
                       <div
-                        class="c27"
+                        class="c26"
                         width="180px"
                       >
                         <div
                           aria-haspopup="true"
                           aria-label="open menu"
-                          class="c28"
+                          class="c27"
                           data-toggle="true"
                           role="button"
                           type="button"
                         >
                           <div
-                            class="c29 c30"
+                            class="c28 c29"
                             data-testid="select-selected-value"
                           />
                           <div
-                            class="c31"
+                            class="c30"
                           >
                             <span
-                              class="c32 c33"
+                              class="c31 c32"
                               data-testid="select-open-button"
                             >
                               ▼
@@ -966,20 +966,20 @@ exports[`Policies table tests should render 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c34"
+                        class="c33"
                         data-testid="error-marker"
                       >
                         ×
                       </div>
                     </div>
                     <div
-                      class="c9 c10"
+                      class="c8 c9"
                     >
                       <div
-                        class="c9 c11"
+                        class="c8 c10"
                       >
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -987,7 +987,7 @@ exports[`Policies table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1004,24 +1004,24 @@ exports[`Policies table tests should render 1`] = `
         </tfoot>
       </table>
       <div
-        class="c22"
+        class="c21"
       >
         <div
-          class="c9 c35"
+          class="c8 c34"
         >
           (Applied filter: rows=2)
         </div>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -1032,7 +1032,7 @@ exports[`Policies table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -1045,18 +1045,18 @@ exports[`Policies table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -1067,7 +1067,7 @@ exports[`Policies table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/detailspage.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/detailspage.js.snap
@@ -54,7 +54,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   align-items: center;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -71,7 +71,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   align-items: flex-end;
 }
 
-.c14 {
+.c13 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -87,6 +87,23 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
   align-items: flex-end;
+}
+
+.c17 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c18 {
@@ -97,30 +114,13 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c19 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-pack: start;
   -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -142,7 +142,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -164,7 +164,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   align-items: flex-end;
 }
 
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -182,7 +182,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c27 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -200,7 +200,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   align-items: center;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -218,7 +218,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c34 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -240,7 +240,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   align-items: center;
 }
 
-.c8 {
+.c7 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -284,44 +284,44 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   display: inline-flex;
 }
 
-.c9 {
+.c8 {
   cursor: pointer;
 }
 
-.c7 {
+.c6 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c7 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
 
-.c16 {
+.c15 {
   height: 50px;
   width: 50px;
   line-height: 50px;
 }
 
-.c16 * {
+.c15 * {
   height: inherit;
   width: inherit;
 }
 
-.c11 {
+.c10 {
   margin: 10px 0px;
   padding-bottom: 1px;
   border-bottom: 2px solid #e5e5e5;
   position: relative;
 }
 
-.c12 {
+.c11 {
   margin: 0 0 1px 0;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -339,16 +339,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c15 {
+.c14 {
   margin-right: 5px;
 }
 
-.c17 {
+.c16 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c25 {
+.c24 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -375,15 +375,15 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #11ab51;
 }
 
-.c25:hover {
+.c24:hover {
   border-top: 2px solid #11ab51;
 }
 
-.c25:first-child {
+.c24:first-child {
   border-left: 1px solid #e5e5e5;
 }
 
-.c26 {
+.c25 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -407,21 +407,21 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #fff;
 }
 
-.c26:hover {
+.c25:hover {
   border-top: 2px solid #e5e5e5;
 }
 
-.c26:first-child {
+.c25:first-child {
   border-left: 1px solid #fff;
 }
 
-.c23 {
+.c22 {
   border-bottom: 2px solid #11ab51;
   margin-top: 30px;
   margin-bottom: 15px;
 }
 
-.c30 {
+.c29 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -429,48 +429,48 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
   table-layout: auto;
 }
 
-.c31 td {
+.c30 td {
   padding: 4px 4px 4px 0;
 }
 
-.c31 tr td:first-child {
+.c30 tr td:first-child {
   padding-right: 5px;
 }
 
-.c20 {
+.c19 {
   border-spacing: 0px;
   color: #7F7F7F;
   font-size: 10px;
 }
 
-.c20 :nth-child(even) {
+.c19 :nth-child(even) {
   margin-left: 3px;
 }
 
-.c20 :nth-child(odd) {
+.c19 :nth-child(odd) {
   margin-left: 30px;
 }
 
-.c32 {
+.c31 {
   width: 10%;
 }
 
-.c33 {
+.c32 {
   width: 90%;
 }
 
-.c28 {
+.c27 {
   font-size: 0.7em;
 }
 
 @media print {
-  .c6 {
+  .c8 {
     display: none;
   }
 }
 
 @media print {
-  .c30 {
+  .c29 {
     border-collapse: collapse;
   }
 }
@@ -499,7 +499,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               target="_blank"
             >
               <span
-                class="c6 c7"
+                class="c6"
                 data-testid="svg-icon"
                 title="Help: ScanConfigs"
               >
@@ -511,11 +511,11 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <a
-              class="c8"
+              class="c7"
               href="/scanconfigs"
             >
               <span
-                class="c6 c7"
+                class="c6"
                 data-testid="svg-icon"
                 title="ScanConfig List"
               >
@@ -535,7 +535,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
             class="c2 c5"
           >
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Create new Scan Config"
             >
@@ -546,7 +546,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Clone Scan Config"
             >
@@ -557,7 +557,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Edit Scan Config"
             >
@@ -568,7 +568,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Move Scan Config to trashcan"
             >
@@ -579,7 +579,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Export Scan Config as XML"
             >
@@ -590,7 +590,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c6 c9 c7"
+              class="c8 c6"
               data-testid="svg-icon"
               title="Import Scan Config"
             >
@@ -609,16 +609,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
     class="entity-section"
   >
     <div
-      class="c10 c11 section-header"
+      class="c9 c10 section-header"
     >
       <h2
-        class="c12 c13"
+        class="c11 c12"
       >
         <div
-          class="c14 c15"
+          class="c13 c14"
         >
           <span
-            class="c6 c16"
+            class="c15"
             data-testid="svg-icon"
           >
             <svg>
@@ -627,19 +627,19 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
           </span>
         </div>
         <div
-          class="c14 c17"
+          class="c13 c16"
         >
           Scan Config: foo
         </div>
       </h2>
       <div
-        class="c18"
+        class="c17"
       >
         <div
-          class="c19"
+          class="c18"
         >
           <div
-            class="c2 c20"
+            class="c2 c19"
           >
             <div>
               ID:
@@ -670,30 +670,30 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
       </div>
     </div>
     <div
-      class="c21"
+      class="c20"
     >
       <div
-        class="c22 c23"
+        class="c21 c22"
       >
         <div
-          class="c24"
+          class="c23"
         >
           <div
-            class="c25"
+            class="c24"
           >
             Information
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 Scanner Preferences
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -704,16 +704,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 NVT Families
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -724,16 +724,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 NVT Preferences
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -744,16 +744,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 User Tags
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -764,16 +764,16 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c26"
+            class="c25"
           >
             <div
-              class="c27"
+              class="c26"
             >
               <span>
                 Permissions
               </span>
               <span
-                class="c28"
+                class="c27"
               >
                 (
                 <i>
@@ -786,21 +786,21 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
         </div>
       </div>
       <div
-        class="c29"
+        class="c28"
       >
         <div
-          class="c21"
+          class="c20"
         >
           <table
-            class="c30 c31"
+            class="c29 c30"
           >
             <colgroup>
               <col
-                class="c32"
+                class="c31"
                 width="10%"
               />
               <col
-                class="c33"
+                class="c32"
                 width="90%"
               />
             </colgroup>
@@ -810,14 +810,14 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               <tr>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     Comment
                   </div>
                 </td>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     bar
                   </div>
@@ -826,23 +826,23 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
               <tr>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     Tasks using this Scan Config
                   </div>
                 </td>
                 <td>
                   <div
-                    class="c29"
+                    class="c28"
                   >
                     <div
                       class="c2 c3"
                     >
                       <div
-                        class="c34 c5"
+                        class="c33 c5"
                       >
                         <a
-                          class="c8"
+                          class="c7"
                           data-testid="details-link"
                           href="/task/1234"
                         >
@@ -850,7 +850,7 @@ exports[`Scan Config Detailspage tests should render full Detailspage 1`] = `
                         </a>
                         ,
                         <a
-                          class="c8"
+                          class="c7"
                           data-testid="details-link"
                           href="/task/5678"
                         >
@@ -889,7 +889,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
   align-items: center;
 }
 
-.c6 {
+.c5 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -933,23 +933,23 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
   display: inline-flex;
 }
 
-.c7 {
+.c6 {
   cursor: pointer;
 }
 
-.c5 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c5 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
 
 @media print {
-  .c4 {
+  .c6 {
     display: none;
   }
 }
@@ -972,7 +972,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           target="_blank"
         >
           <span
-            class="c4 c5"
+            class="c4"
             data-testid="svg-icon"
             title="Help: ScanConfigs"
           >
@@ -984,11 +984,11 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <a
-          class="c6"
+          class="c5"
           href="/scanconfigs"
         >
           <span
-            class="c4 c5"
+            class="c4"
             data-testid="svg-icon"
             title="ScanConfig List"
           >
@@ -1008,7 +1008,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
         class="c0 c3"
       >
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Create new Scan Config"
         >
@@ -1019,7 +1019,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Clone Scan Config"
         >
@@ -1030,7 +1030,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Edit Scan Config"
         >
@@ -1041,7 +1041,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Move Scan Config to trashcan"
         >
@@ -1052,7 +1052,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Export Scan Config as XML"
         >
@@ -1063,7 +1063,7 @@ exports[`Scan Config ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c4 c7 c5"
+          class="c6 c4"
           data-testid="svg-icon"
           title="Import Scan Config"
         >

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/editconfigfamilydialog.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/editconfigfamilydialog.js.snap
@@ -157,7 +157,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c39 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -200,17 +200,17 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   display: inline-flex;
 }
 
-.c36 {
+.c35 {
   cursor: pointer;
 }
 
-.c37 {
+.c36 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c37 * {
+.c36 * {
   height: inherit;
   width: inherit;
 }
@@ -282,7 +282,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   height: 100%;
 }
 
-.c46 {
+.c45 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -291,7 +291,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c45 {
+.c44 {
   position: absolute;
   bottom: 3px;
   right: 3px;
@@ -356,7 +356,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   width: inherit;
 }
 
-.c42 {
+.c41 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -376,12 +376,12 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   z-index: 1;
 }
 
-.c42:focus,
-.c42:hover {
+.c41:focus,
+.c41:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c42:hover {
+.c41:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -389,26 +389,26 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   color: #fff;
 }
 
-.c42[disabled] {
+.c41[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c42 img {
+.c41 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c42:link {
+.c41:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c43 {
+.c42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -426,18 +426,18 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c44 {
+.c43 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c44 :hover {
+.c43 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c40 {
+.c39 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
@@ -445,7 +445,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   padding: 10px 20px 10px 20px;
 }
 
-.c41 {
+.c40 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
@@ -612,7 +612,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
   background: #4f91c7;
 }
 
-.c38 {
+.c37 {
   height: 13px;
   width: 100%;
   background: #c83814;
@@ -690,7 +690,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
 }
 
 @media print {
-  .c38 {
+  .c37 {
     background: none;
   }
 }
@@ -977,7 +977,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                               class="c34"
                             >
                               <span
-                                class="c35 c36 c37"
+                                class="c35 c36"
                                 data-testid="svg-icon"
                                 title="Select and edit NVT details"
                               >
@@ -1016,7 +1016,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                               >
                                 <div
                                   background="error"
-                                  class="c38"
+                                  class="c37"
                                   data-testid="progress"
                                 />
                                 <div
@@ -1072,7 +1072,7 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
                               class="c34"
                             >
                               <span
-                                class="c35 c36 c37"
+                                class="c35 c36"
                                 data-testid="svg-icon"
                                 title="Select and edit NVT details"
                               >
@@ -1092,17 +1092,17 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c39 c40 c41"
+              class="c38 c39 c40"
             >
               <button
-                class="c42 c43 c44"
+                class="c41 c42 c43"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c42 c43 c44"
+                class="c41 c42 c43"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -1111,10 +1111,10 @@ exports[`EditConfigFamilyDialog component tests should render dialog 1`] = `
             </div>
           </div>
           <div
-            class="c45"
+            class="c44"
           >
             <div
-              class="c46"
+              class="c45"
             />
           </div>
         </div>

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/editdialog.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/editdialog.js.snap
@@ -111,7 +111,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: flex-end;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -133,7 +133,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c35 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -147,7 +147,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   justify-content: center;
 }
 
-.c36 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -161,7 +161,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   justify-content: flex-start;
 }
 
-.c37 {
+.c36 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -179,7 +179,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: flex-start;
 }
 
-.c43 {
+.c42 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -197,7 +197,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c45 {
+.c44 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -215,7 +215,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c52 {
+.c51 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -236,50 +236,50 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c39 {
+.c38 {
   margin-left: -5px;
 }
 
-.c39>* {
+.c38>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c39>* {
+.c38>* {
   margin-left: 5px;
 }
 
-.c38 {
+.c37 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c26 {
+.c25 {
   cursor: pointer;
 }
 
-.c27 {
+.c26 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c27 * {
+.c26 * {
   height: inherit;
   width: inherit;
 }
 
-.c28 {
+.c27 {
   overflow: hidden;
   -webkit-transition: 0.4s;
   transition: 0.4s;
 }
 
-.c46 {
+.c45 {
   overflow: hidden;
   -webkit-transition: 0.4s;
   transition: 0.4s;
@@ -359,7 +359,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   height: 100%;
 }
 
-.c59 {
+.c58 {
   width: 0;
   height: 0;
   cursor: nwse-resize;
@@ -368,7 +368,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   border-top: 20px solid #fff;
 }
 
-.c58 {
+.c57 {
   position: absolute;
   bottom: 3px;
   right: 3px;
@@ -433,7 +433,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   width: inherit;
 }
 
-.c55 {
+.c54 {
   display: inline-block;
   padding: 0 15px;
   color: #4C4C4C;
@@ -453,12 +453,12 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   z-index: 1;
 }
 
-.c55:focus,
-.c55:hover {
+.c54:focus,
+.c54:hover {
   border: 1px solid #4C4C4C;
 }
 
-.c55:hover {
+.c54:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
   background: #11ab51;
@@ -466,26 +466,26 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   color: #fff;
 }
 
-.c55[disabled] {
+.c54[disabled] {
   cursor: not-allowed;
   opacity: 0.65;
   box-shadow: none;
 }
 
-.c55 img {
+.c54 img {
   height: 32px;
   width: 32px;
   margin-top: 5px 10px 5px -10px;
   vertical-align: middle;
 }
 
-.c55:link {
+.c54:link {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #4C4C4C;
 }
 
-.c56 {
+.c55 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -503,18 +503,18 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c57 {
+.c56 {
   border: 1px solid #7F7F7F;
   color: #fff;
   background: #11ab51;
 }
 
-.c57 :hover {
+.c56 :hover {
   color: #074320;
   background: #A1DDBA;
 }
 
-.c53 {
+.c52 {
   border-width: 1px 0 0 0;
   border-style: solid;
   border-color: #e5e5e5;
@@ -522,7 +522,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   padding: 10px 20px 10px 20px;
 }
 
-.c54 {
+.c53 {
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   justify-content: space-between;
@@ -605,7 +605,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   display: none;
 }
 
-.c30 {
+.c29 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -614,7 +614,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   width: 100%;
 }
 
-.c48 {
+.c47 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -623,30 +623,37 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   width: 100%;
 }
 
-.c31 th,
-.c31 td {
+.c30 th,
+.c30 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c31 tfoot tr {
+.c30 tfoot tr {
   background: #fff;
 }
 
-.c31 tfoot tr td {
+.c30 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c32 a {
+.c31 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c32 a:hover {
+.c31 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
+}
+
+.c32 {
+  background-color: #fff;
+  color: #000;
+  border-top: 1px solid #e5e5e5;
+  font-weight: bold;
 }
 
 .c33 {
@@ -654,17 +661,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   color: #000;
   border-top: 1px solid #e5e5e5;
   font-weight: bold;
-}
-
-.c34 {
-  background-color: #fff;
-  color: #000;
-  border-top: 1px solid #e5e5e5;
-  font-weight: bold;
   width: 9em;
 }
 
-.c49 {
+.c48 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -672,7 +672,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   width: 30%;
 }
 
-.c50 {
+.c49 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -720,7 +720,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c47 {
+.c46 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -738,7 +738,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c40 {
+.c39 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -754,7 +754,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   cursor: pointer;
 }
 
-.c41 {
+.c40 {
   font-family: inherit;
   font-size: inherit;
   padding: 0;
@@ -765,7 +765,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   height: auto;
 }
 
-.c42 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -783,7 +783,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c44 {
+.c43 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -801,7 +801,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
   align-items: center;
 }
 
-.c51 {
+.c50 {
   overflow-wrap: break-word;
 }
 
@@ -812,39 +812,48 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
 }
 
 @media print {
-  .c30 {
+  .c29 {
     border-collapse: collapse;
   }
 }
 
 @media print {
-  .c48 {
+  .c47 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c31>tbody:nth-of-type(even),
-  .c31>tbody:only-of-type>tr:nth-of-type(even) {
+  .c30>tbody:nth-of-type(even),
+  .c30>tbody:only-of-type>tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c31>tbody:not(:only-of-type):hover,
-  .c31>tbody:only-of-type>tr:hover {
+  .c30>tbody:not(:only-of-type):hover,
+  .c30>tbody:only-of-type>tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c32 {
+  .c31 {
     border-bottom: 1px solid black;
   }
 
-  .c32 a,
-  .c32 a:hover {
+  .c31 a,
+  .c31 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
+  }
+}
+
+@media print {
+  .c32 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: transparent;
+    font-weight: bold;
   }
 }
 
@@ -858,7 +867,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
 }
 
 @media print {
-  .c34 {
+  .c48 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -868,15 +877,6 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
 
 @media print {
   .c49 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: transparent;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c50 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -1003,7 +1003,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                           class="c13 c24"
                         >
                           <span
-                            class="c25 c26 c27 section-fold-icon"
+                            class="c25 c26 section-fold-icon"
                             data-testid="svg-icon"
                             title="Fold"
                           >
@@ -1017,20 +1017,20 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c28"
+                      class="c27"
                     >
                       <div
-                        class="c29"
+                        class="c28"
                       >
                         <table
-                          class="c30 c31"
+                          class="c29 c30"
                         >
                           <thead
-                            class="c32"
+                            class="c31"
                           >
                             <tr>
                               <th
-                                class="c33"
+                                class="c32"
                               >
                                 <div
                                   class="c13"
@@ -1039,7 +1039,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c33"
+                                class="c32"
                               >
                                 <div
                                   class="c13"
@@ -1048,7 +1048,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c33"
+                                class="c32"
                               >
                                 <div
                                   class="c13"
@@ -1057,7 +1057,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c34"
+                                class="c33"
                               >
                                 <div
                                   class="c13"
@@ -1066,10 +1066,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c33"
+                                class="c32"
                               >
                                 <div
-                                  class="c35"
+                                  class="c34"
                                 >
                                   Actions
                                 </div>
@@ -1089,33 +1089,33 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c36"
+                                  class="c35"
                                 >
                                   1 of 1
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c37"
+                                  class="c36"
                                 >
                                   <div
-                                    class="c13 c38"
+                                    class="c13 c37"
                                   >
                                     <div
-                                      class="c13 c39"
+                                      class="c13 c38"
                                     >
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
                                               checked=""
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family1"
                                               type="radio"
@@ -1126,7 +1126,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Dynamic"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1134,16 +1134,16 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                         </svg>
                                       </span>
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family1"
                                               type="radio"
@@ -1154,7 +1154,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Static"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1167,20 +1167,20 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c43"
+                                  class="c42"
                                 >
                                   <label
-                                    class="c40"
+                                    class="c39"
                                   >
                                     <div
-                                      class="c13 c38"
+                                      class="c13 c37"
                                     >
                                       <div
-                                        class="c13 c39"
+                                        class="c13 c38"
                                       >
                                         <input
                                           checked=""
-                                          class="c41 c44"
+                                          class="c40 c43"
                                           name="family1"
                                           type="checkbox"
                                         />
@@ -1191,10 +1191,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c45"
+                                  class="c44"
                                 >
                                   <span
-                                    class="c25 c26 c27"
+                                    class="c25 c26"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config Family"
                                   >
@@ -1217,32 +1217,32 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c36"
+                                  class="c35"
                                 >
                                   2 of 4
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c37"
+                                  class="c36"
                                 >
                                   <div
-                                    class="c13 c38"
+                                    class="c13 c37"
                                   >
                                     <div
-                                      class="c13 c39"
+                                      class="c13 c38"
                                     >
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family2"
                                               type="radio"
@@ -1253,7 +1253,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Dynamic"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1261,17 +1261,17 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                         </svg>
                                       </span>
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
                                               checked=""
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family2"
                                               type="radio"
@@ -1282,7 +1282,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Static"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1295,19 +1295,19 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c43"
+                                  class="c42"
                                 >
                                   <label
-                                    class="c40"
+                                    class="c39"
                                   >
                                     <div
-                                      class="c13 c38"
+                                      class="c13 c37"
                                     >
                                       <div
-                                        class="c13 c39"
+                                        class="c13 c38"
                                       >
                                         <input
-                                          class="c41 c44"
+                                          class="c40 c43"
                                           name="family2"
                                           type="checkbox"
                                         />
@@ -1318,10 +1318,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c45"
+                                  class="c44"
                                 >
                                   <span
-                                    class="c25 c26 c27"
+                                    class="c25 c26"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config Family"
                                   >
@@ -1344,32 +1344,32 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c36"
+                                  class="c35"
                                 >
                                   0 of 2
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c37"
+                                  class="c36"
                                 >
                                   <div
-                                    class="c13 c38"
+                                    class="c13 c37"
                                   >
                                     <div
-                                      class="c13 c39"
+                                      class="c13 c38"
                                     >
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family3"
                                               type="radio"
@@ -1380,7 +1380,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Dynamic"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1388,17 +1388,17 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                         </svg>
                                       </span>
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
                                               checked=""
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family3"
                                               type="radio"
@@ -1409,7 +1409,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Static"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1422,19 +1422,19 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c43"
+                                  class="c42"
                                 >
                                   <label
-                                    class="c40"
+                                    class="c39"
                                   >
                                     <div
-                                      class="c13 c38"
+                                      class="c13 c37"
                                     >
                                       <div
-                                        class="c13 c39"
+                                        class="c13 c38"
                                       >
                                         <input
-                                          class="c41 c44"
+                                          class="c40 c43"
                                           name="family3"
                                           type="checkbox"
                                         />
@@ -1445,10 +1445,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c45"
+                                  class="c44"
                                 >
                                   <span
-                                    class="c25 c26 c27"
+                                    class="c25 c26"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config Family"
                                   >
@@ -1471,32 +1471,32 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c36"
+                                  class="c35"
                                 >
                                   0 of 6
                                 </div>
                               </td>
                               <td>
                                 <div
-                                  class="c37"
+                                  class="c36"
                                 >
                                   <div
-                                    class="c13 c38"
+                                    class="c13 c37"
                                   >
                                     <div
-                                      class="c13 c39"
+                                      class="c13 c38"
                                     >
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family4"
                                               type="radio"
@@ -1507,7 +1507,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Dynamic"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1515,17 +1515,17 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                         </svg>
                                       </span>
                                       <label
-                                        class="c40"
+                                        class="c39"
                                       >
                                         <div
-                                          class="c13 c38"
+                                          class="c13 c37"
                                         >
                                           <div
-                                            class="c13 c39"
+                                            class="c13 c38"
                                           >
                                             <input
                                               checked=""
-                                              class="c41 c42"
+                                              class="c40 c41"
                                               data-testid="radio-input"
                                               name="family4"
                                               type="radio"
@@ -1536,7 +1536,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                       </label>
                                       <span
                                         alt="Static"
-                                        class="c25 c27"
+                                        class="c26"
                                         data-testid="svg-icon"
                                       >
                                         <svg>
@@ -1549,19 +1549,19 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c43"
+                                  class="c42"
                                 >
                                   <label
-                                    class="c40"
+                                    class="c39"
                                   >
                                     <div
-                                      class="c13 c38"
+                                      class="c13 c37"
                                     >
                                       <div
-                                        class="c13 c39"
+                                        class="c13 c38"
                                       >
                                         <input
-                                          class="c41 c44"
+                                          class="c40 c43"
                                           name="family4"
                                           type="checkbox"
                                         />
@@ -1572,10 +1572,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c45"
+                                  class="c44"
                                 >
                                   <span
-                                    class="c25 c26 c27"
+                                    class="c25 c26"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config Family"
                                   >
@@ -1613,7 +1613,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                           class="c13 c24"
                         >
                           <span
-                            class="c25 c26 c27 section-fold-icon"
+                            class="c25 c26 section-fold-icon"
                             data-testid="svg-icon"
                             title="Unfold"
                           >
@@ -1627,20 +1627,20 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c46"
+                      class="c45"
                     >
                       <div
-                        class="c29"
+                        class="c28"
                       >
                         <table
-                          class="c30 c31"
+                          class="c29 c30"
                         >
                           <thead
-                            class="c32"
+                            class="c31"
                           >
                             <tr>
                               <th
-                                class="c33"
+                                class="c32"
                               >
                                 <div
                                   class="c13"
@@ -1649,7 +1649,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c33"
+                                class="c32"
                               >
                                 <div
                                   class="c13"
@@ -1658,7 +1658,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c33"
+                                class="c32"
                               >
                                 <div
                                   class="c13"
@@ -1684,7 +1684,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                   class="c10"
                                 >
                                   <input
-                                    class="c15 c47"
+                                    class="c15 c46"
                                     name="scannerpref0"
                                     type="text"
                                     value="0"
@@ -1728,7 +1728,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                           class="c13 c24"
                         >
                           <span
-                            class="c25 c26 c27 section-fold-icon"
+                            class="c25 c26 section-fold-icon"
                             data-testid="svg-icon"
                             title="Unfold"
                           >
@@ -1742,20 +1742,20 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                       </div>
                     </div>
                     <div
-                      class="c46"
+                      class="c45"
                     >
                       <div
-                        class="c29"
+                        class="c28"
                       >
                         <table
-                          class="c48 c31"
+                          class="c47 c30"
                         >
                           <thead
-                            class="c32"
+                            class="c31"
                           >
                             <tr>
                               <th
-                                class="c49"
+                                class="c48"
                               >
                                 <div
                                   class="c13"
@@ -1764,7 +1764,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c49"
+                                class="c48"
                               >
                                 <div
                                   class="c13"
@@ -1773,7 +1773,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c49"
+                                class="c48"
                               >
                                 <div
                                   class="c13"
@@ -1782,10 +1782,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </th>
                               <th
-                                class="c50"
+                                class="c49"
                               >
                                 <div
-                                  class="c35"
+                                  class="c34"
                                 >
                                   Actions
                                 </div>
@@ -1797,7 +1797,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                           >
                             <tr>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1806,7 +1806,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </td>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1815,7 +1815,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </td>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1825,10 +1825,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c45"
+                                  class="c44"
                                 >
                                   <span
-                                    class="c25 c26 c27"
+                                    class="c25 c26"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config NVT Details"
                                   >
@@ -1843,7 +1843,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                             </tr>
                             <tr>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1852,7 +1852,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </td>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1861,7 +1861,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </td>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1871,10 +1871,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c45"
+                                  class="c44"
                                 >
                                   <span
-                                    class="c25 c26 c27"
+                                    class="c25 c26"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config NVT Details"
                                   >
@@ -1889,7 +1889,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                             </tr>
                             <tr>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1898,7 +1898,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </td>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1907,7 +1907,7 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                                 </div>
                               </td>
                               <td
-                                class="c51"
+                                class="c50"
                               >
                                 <div
                                   class="c10"
@@ -1917,10 +1917,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
                               </td>
                               <td>
                                 <div
-                                  class="c45"
+                                  class="c44"
                                 >
                                   <span
-                                    class="c25 c26 c27"
+                                    class="c25 c26"
                                     data-testid="svg-icon"
                                     title="Edit Scan Config NVT Details"
                                   >
@@ -1942,17 +1942,17 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
               </div>
             </div>
             <div
-              class="c52 c53 c54"
+              class="c51 c52 c53"
             >
               <button
-                class="c55 c56 c57"
+                class="c54 c55 c56"
                 data-testid="dialog-close-button"
                 title="Cancel"
               >
                 Cancel
               </button>
               <button
-                class="c55 c56 c57"
+                class="c54 c55 c56"
                 data-testid="dialog-save-button"
                 title="Save"
               >
@@ -1961,10 +1961,10 @@ exports[`EditScanConfigDialog component tests should render dialog 1`] = `
             </div>
           </div>
           <div
-            class="c58"
+            class="c57"
           >
             <div
-              class="c59"
+              class="c58"
             />
           </div>
         </div>

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/listpage.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/listpage.js.snap
@@ -41,23 +41,23 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
   display: inline-flex;
 }
 
-.c5 {
+.c4 {
   cursor: pointer;
 }
 
-.c4 {
+.c3 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c4 * {
+.c3 * {
   height: inherit;
   width: inherit;
 }
 
 @media print {
-  .c3 {
+  .c4 {
     display: none;
   }
 }
@@ -74,7 +74,7 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
       target="_blank"
     >
       <span
-        class="c3 c4"
+        class="c3"
         data-testid="svg-icon"
         title="Help: Scan Configs"
       >
@@ -86,7 +86,7 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
       </span>
     </a>
     <span
-      class="c3 c5 c4"
+      class="c4 c3"
       data-testid="svg-icon"
       title="New Scan Config"
     >
@@ -97,7 +97,7 @@ exports[`ScanConfigsPage ToolBarIcons test should render 1`] = `
       </svg>
     </span>
     <span
-      class="c3 c5 c4"
+      class="c4 c3"
       data-testid="svg-icon"
       title="Import Scan Config"
     >
@@ -169,7 +169,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: center;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -187,7 +187,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   justify-content: flex-end;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -205,7 +205,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: stetch;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -222,7 +222,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: center;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -240,7 +240,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: center;
 }
 
-.c22 {
+.c21 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -258,7 +258,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: center;
 }
 
-.c25 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -275,7 +275,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: flex-end;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -293,7 +293,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: flex-end;
 }
 
-.c34 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -310,7 +310,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   justify-content: space-between;
 }
 
-.c36 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -328,7 +328,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: center;
 }
 
-.c48 {
+.c47 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -342,7 +342,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   justify-content: center;
 }
 
-.c50 {
+.c49 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -360,7 +360,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: stretch;
 }
 
-.c51 {
+.c50 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -373,7 +373,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   justify-content: space-between;
 }
 
-.c53 {
+.c52 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -395,7 +395,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: center;
 }
 
-.c54 {
+.c53 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -439,48 +439,48 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   display: inline-flex;
 }
 
-.c7 {
+.c6 {
   cursor: pointer;
 }
 
-.c38 svg path {
+.c37 svg path {
   fill: #bfbfbf;
 }
 
-.c6 {
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
-.c31 {
+.c30 {
   height: 50px;
   width: 50px;
   line-height: 50px;
 }
 
-.c31 * {
+.c30 * {
   height: inherit;
   width: inherit;
 }
 
-.c26 {
+.c25 {
   margin: 10px 0px;
   padding-bottom: 1px;
   border-bottom: 2px solid #e5e5e5;
   position: relative;
 }
 
-.c27 {
+.c26 {
   margin: 0 0 1px 0;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -498,16 +498,16 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: stretch;
 }
 
-.c30 {
+.c29 {
   margin-right: 5px;
 }
 
-.c32 {
+.c31 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c23 {
+.c22 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -532,18 +532,18 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   cursor: pointer;
 }
 
-.c24 {
+.c23 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c24 * {
+.c23 * {
   height: inherit;
   width: inherit;
 }
 
-.c19 {
+.c18 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -567,7 +567,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   font-weight: normal;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -579,7 +579,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 150px;
 }
 
-.c55 {
+.c54 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -591,7 +591,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 180px;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -610,7 +610,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   cursor: pointer;
 }
 
-.c16 {
+.c15 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -619,18 +619,18 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   display: none;
 }
 
-.c21 {
+.c20 {
   cursor: default;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c40 {
+.c39 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -639,37 +639,37 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 100%;
 }
 
-.c41 th,
-.c41 td {
+.c40 th,
+.c40 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c41 tfoot tr {
+.c40 tfoot tr {
   background: #fff;
 }
 
-.c41 tfoot tr td {
+.c40 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c43 a {
+.c42 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c43 a:hover {
+.c42 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c45 {
+.c44 {
   cursor: pointer;
 }
 
-.c44 {
+.c43 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -677,7 +677,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 72%;
 }
 
-.c46 {
+.c45 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -685,7 +685,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 10%;
 }
 
-.c47 {
+.c46 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -693,7 +693,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 8%;
 }
 
-.c49 {
+.c48 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -701,7 +701,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   width: 5%;
 }
 
-.c14 {
+.c13 {
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
@@ -715,11 +715,11 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   padding: 1px 8px;
 }
 
-.c14:-webkit-autofill {
+.c13:-webkit-autofill {
   box-shadow: 0 0 0 1000px white inset;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -737,85 +737,85 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
   align-items: center;
 }
 
-.c13 {
-  margin-right: 5px;
-}
-
 .c12 {
   margin-right: 5px;
 }
 
-.c56 {
+.c11 {
+  margin-right: 5px;
+}
+
+.c55 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c39 {
+.c38 {
   margin: 0 3px;
 }
 
-.c37 {
+.c36 {
   margin: 2px 3px;
 }
 
-.c42 {
+.c41 {
   opacity: 1.0;
 }
 
-.c35 {
+.c34 {
   margin-top: 2px;
   margin-left: 2px;
 }
 
-.c33 {
+.c32 {
   margin-top: 20px;
 }
 
-.c52 {
+.c51 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c52 :hover {
+.c51 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
 @media print {
-  .c5 {
+  .c6 {
     display: none;
   }
 }
 
 @media print {
-  .c40 {
+  .c39 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c41>tbody:nth-of-type(even),
-  .c41>tbody:only-of-type>tr:nth-of-type(even) {
+  .c40>tbody:nth-of-type(even),
+  .c40>tbody:only-of-type>tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c41>tbody:not(:only-of-type):hover,
-  .c41>tbody:only-of-type>tr:hover {
+  .c40>tbody:not(:only-of-type):hover,
+  .c40>tbody:only-of-type>tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c43 {
+  .c42 {
     border-bottom: 1px solid black;
   }
 
-  .c43 a,
-  .c43 a:hover {
+  .c42 a,
+  .c42 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
@@ -823,7 +823,16 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
 }
 
 @media print {
-  .c44 {
+  .c43 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: transparent;
+    font-weight: bold;
+  }
+}
+
+@media print {
+  .c45 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -841,7 +850,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
 }
 
 @media print {
-  .c47 {
+  .c48 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -850,22 +859,13 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
 }
 
 @media print {
-  .c49 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: transparent;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c37 svg {
+  .c36 svg {
     display: none;
   }
 }
 
 @media print {
-  .c52 {
+  .c51 {
     color: #000;
   }
 }
@@ -893,7 +893,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               target="_blank"
             >
               <span
-                class="c5 c6"
+                class="c5"
                 data-testid="svg-icon"
                 title="Help: Scan Configs"
               >
@@ -905,7 +905,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </span>
             </a>
             <span
-              class="c5 c7 c6"
+              class="c6 c5"
               data-testid="svg-icon"
               title="New Scan Config"
             >
@@ -916,7 +916,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c7 c6"
+              class="c6 c5"
               data-testid="svg-icon"
               title="Import Scan Config"
             >
@@ -929,32 +929,32 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
           </div>
         </div>
         <div
-          class="c8"
+          class="c7"
         >
           <div
-            class="c9 powerfilter"
+            class="c8 powerfilter"
           >
             <div
-              class="c10"
+              class="c9"
             >
               <div
                 class="c2 c3"
               >
                 <div
-                  class="c11 c4 c12"
+                  class="c10 c4 c11"
                 >
                   <div
-                    class="c11"
+                    class="c10"
                   >
                     <label
-                      class="c13"
+                      class="c12"
                     >
                       <b>
                         Filter
                       </b>
                     </label>
                     <input
-                      class="c14 c15"
+                      class="c13 c14"
                       maxlength="1000"
                       name="userFilterString"
                       size="53"
@@ -962,7 +962,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       value=""
                     />
                     <div
-                      class="c16"
+                      class="c15"
                       data-testid="error-marker"
                     >
                       ×
@@ -972,10 +972,10 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     class="c2 c3"
                   >
                     <div
-                      class="c11 c4"
+                      class="c10 c4"
                     >
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Update Filter"
                       >
@@ -986,7 +986,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Remove Filter"
                       >
@@ -997,7 +997,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                         </svg>
                       </span>
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Reset to Default Filter"
                       >
@@ -1013,7 +1013,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                         target="_blank"
                       >
                         <span
-                          class="c5 c6"
+                          class="c5"
                           data-testid="svg-icon"
                           title="Help: Powerfilter"
                         >
@@ -1025,7 +1025,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                         </span>
                       </a>
                       <span
-                        class="c5 c7 c6"
+                        class="c6 c5"
                         data-testid="svg-icon"
                         title="Edit Filter"
                       >
@@ -1043,34 +1043,34 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-labelledby="downshift-0-label"
-                class="c17"
+                class="c16"
                 role="combobox"
               >
                 <div
-                  class="c18"
+                  class="c17"
                   width="150px"
                 >
                   <div
                     aria-haspopup="true"
                     aria-label="open menu"
-                    class="c19"
+                    class="c18"
                     data-toggle="true"
                     role="button"
                     title="Loaded filter"
                     type="button"
                   >
                     <div
-                      class="c20 c21"
+                      class="c19 c20"
                       data-testid="select-selected-value"
                       title="Loaded filter"
                     >
                       --
                     </div>
                     <div
-                      class="c22"
+                      class="c21"
                     >
                       <span
-                        class="c23 c24"
+                        class="c22 c23"
                         data-testid="select-open-button"
                       >
                         ▼
@@ -1079,7 +1079,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </div>
                 </div>
                 <div
-                  class="c16"
+                  class="c15"
                   data-testid="error-marker"
                 >
                   ×
@@ -1093,16 +1093,16 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
         class="entities-section"
       >
         <div
-          class="c25 c26 section-header"
+          class="c24 c25 section-header"
         >
           <h2
-            class="c27 c28"
+            class="c26 c27"
           >
             <div
-              class="c29 c30"
+              class="c28 c29"
             >
               <span
-                class="c5 c31"
+                class="c30"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -1111,26 +1111,26 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </span>
             </div>
             <div
-              class="c29 c32"
+              class="c28 c31"
             >
               Scan Configs 0 of 0
             </div>
           </h2>
           <div
-            class="c10"
+            class="c9"
           />
         </div>
         <div
           class="c0"
         >
           <div
-            class="c0 c33 entities-table"
+            class="c0 c32 entities-table"
           >
             <div
-              class="c34"
+              class="c33"
             >
               <span
-                class="c5 c7 c6 c35"
+                class="c6 c5 c34"
                 data-testid="svg-icon"
                 title="Unfold all details"
               >
@@ -1141,7 +1141,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                 </svg>
               </span>
               <div
-                class="c36 c37"
+                class="c35 c36"
               >
                 <div
                   class="c2 c3"
@@ -1150,7 +1150,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1161,7 +1161,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1174,7 +1174,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c39"
+                  class="c38"
                 >
                   0 - 0 of 0
                 </span>
@@ -1185,7 +1185,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1196,7 +1196,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Last"
                     >
@@ -1211,18 +1211,18 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </div>
             </div>
             <table
-              class="c40 c41 c42"
+              class="c39 c40 c41"
             >
               <thead
-                class="c43"
+                class="c42"
               >
                 <tr>
                   <th
-                    class="c44"
+                    class="c43"
                     rowspan="2"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1232,7 +1232,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c46"
+                    class="c45"
                     colspan="2"
                   >
                     <div
@@ -1242,7 +1242,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </div>
                   </th>
                   <th
-                    class="c46"
+                    class="c45"
                     colspan="2"
                   >
                     <div
@@ -1252,11 +1252,11 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </div>
                   </th>
                   <th
-                    class="c47"
+                    class="c46"
                     rowspan="2"
                   >
                     <div
-                      class="c48"
+                      class="c47"
                     >
                       Actions
                     </div>
@@ -1264,10 +1264,10 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                 </tr>
                 <tr>
                   <th
-                    class="c49"
+                    class="c48"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1277,10 +1277,10 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c49"
+                    class="c48"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1290,10 +1290,10 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c49"
+                    class="c48"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1303,10 +1303,10 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     </a>
                   </th>
                   <th
-                    class="c49"
+                    class="c48"
                   >
                     <a
-                      class="c45"
+                      class="c44"
                     >
                       <div
                         class="c2"
@@ -1323,17 +1323,17 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                 <tr>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       <div
-                        class="c51"
+                        class="c50"
                       >
                         <div
-                          class="c50"
+                          class="c49"
                         >
                           <span>
                             <span
-                              class="c52"
+                              class="c51"
                               name="12345"
                             >
                               foo
@@ -1352,18 +1352,18 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       2
                     </div>
                   </td>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       <span
                         alt="Static"
-                        class="c5 c6"
+                        class="c5"
                         data-testid="svg-icon"
                         title="The family selection is STATIC. New families will NOT automatically be added and considered."
                       >
@@ -1377,18 +1377,18 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </td>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       4
                     </div>
                   </td>
                   <td>
                     <div
-                      class="c50"
+                      class="c49"
                     >
                       <span
                         alt="Dynamic"
-                        class="c5 c6"
+                        class="c5"
                         data-testid="svg-icon"
                         title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
                       >
@@ -1405,13 +1405,13 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       class="c0"
                     >
                       <div
-                        class="c53 c3"
+                        class="c52 c3"
                       >
                         <div
-                          class="c54 c4"
+                          class="c53 c4"
                         >
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Move Scan Config to trashcan"
                           >
@@ -1422,7 +1422,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Edit Scan Config"
                           >
@@ -1433,7 +1433,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Clone Scan Config"
                           >
@@ -1444,7 +1444,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                             </svg>
                           </span>
                           <span
-                            class="c5 c7 c6"
+                            class="c6 c5"
                             data-testid="svg-icon"
                             title="Export Scan Config"
                           >
@@ -1466,7 +1466,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     colspan="6"
                   >
                     <div
-                      class="c36"
+                      class="c35"
                     >
                       <div
                         class="c2 c3"
@@ -1478,33 +1478,33 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                             aria-expanded="false"
                             aria-haspopup="listbox"
                             aria-labelledby="downshift-1-label"
-                            class="c17"
+                            class="c16"
                             role="combobox"
                           >
                             <div
-                              class="c55"
+                              class="c54"
                               width="180px"
                             >
                               <div
                                 aria-haspopup="true"
                                 aria-label="open menu"
-                                class="c19"
+                                class="c18"
                                 data-toggle="true"
                                 role="button"
                                 type="button"
                               >
                                 <div
-                                  class="c20 c21"
+                                  class="c19 c20"
                                   data-testid="select-selected-value"
                                   title="Apply to page contents"
                                 >
                                   Apply to page contents
                                 </div>
                                 <div
-                                  class="c22"
+                                  class="c21"
                                 >
                                   <span
-                                    class="c23 c24"
+                                    class="c22 c23"
                                     data-testid="select-open-button"
                                   >
                                     ▼
@@ -1513,7 +1513,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                               </div>
                             </div>
                             <div
-                              class="c16"
+                              class="c15"
                               data-testid="error-marker"
                             >
                               ×
@@ -1526,7 +1526,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                               class="c2 c4"
                             >
                               <span
-                                class="c5 c7 c6"
+                                class="c6 c5"
                                 data-testid="svg-icon"
                                 title="Add tag to page contents"
                               >
@@ -1537,7 +1537,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                                 </svg>
                               </span>
                               <span
-                                class="c5 c7 c6"
+                                class="c6 c5"
                                 data-testid="svg-icon"
                                 title="Move page contents to trashcan"
                               >
@@ -1548,7 +1548,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                                 </svg>
                               </span>
                               <span
-                                class="c5 c7 c6"
+                                class="c6 c5"
                                 data-testid="svg-icon"
                                 title="Export page contents"
                               >
@@ -1568,15 +1568,15 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
               </tfoot>
             </table>
             <div
-              class="c51"
+              class="c50"
             >
               <div
-                class="c2 c56"
+                class="c2 c55"
               >
                 (Applied filter: )
               </div>
               <div
-                class="c36 c37"
+                class="c35 c36"
               >
                 <div
                   class="c2 c3"
@@ -1585,7 +1585,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="First"
                     >
@@ -1596,7 +1596,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Previous"
                     >
@@ -1609,7 +1609,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                   </div>
                 </div>
                 <span
-                  class="c39"
+                  class="c38"
                 >
                   0 - 0 of 0
                 </span>
@@ -1620,7 +1620,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                     class="c2 c4"
                   >
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Next"
                     >
@@ -1631,7 +1631,7 @@ exports[`ScanConfigsPage tests should render full ScanConfigsPage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c5 c38 c6"
+                      class="c37 c5"
                       data-testid="svg-icon"
                       title="Last"
                     >

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/row.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/row.js.snap
@@ -32,7 +32,7 @@ exports[`Scan Config row tests should render 1`] = `
   justify-content: space-between;
 }
 
-.c5 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -54,7 +54,7 @@ exports[`Scan Config row tests should render 1`] = `
   align-items: stretch;
 }
 
-.c6 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -76,7 +76,7 @@ exports[`Scan Config row tests should render 1`] = `
   align-items: center;
 }
 
-.c8 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -98,39 +98,39 @@ exports[`Scan Config row tests should render 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c8 {
   margin-left: -5px;
 }
 
-.c9>* {
+.c8>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c9>* {
+.c8>* {
   margin-left: 5px;
 }
 
-.c7 {
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c10 {
+.c9 {
   cursor: pointer;
 }
 
-.c4 {
+.c3 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c4 * {
+.c3 * {
   height: inherit;
   width: inherit;
 }
@@ -149,7 +149,7 @@ exports[`Scan Config row tests should render 1`] = `
 }
 
 @media print {
-  .c3 {
+  .c9 {
     display: none;
   }
 }
@@ -208,7 +208,7 @@ exports[`Scan Config row tests should render 1`] = `
         >
           <span
             alt="Static"
-            class="c3 c4"
+            class="c3"
             data-testid="svg-icon"
             title="The family selection is STATIC. New families will NOT automatically be added and considered."
           >
@@ -233,7 +233,7 @@ exports[`Scan Config row tests should render 1`] = `
         >
           <span
             alt="Dynamic"
-            class="c3 c4"
+            class="c3"
             data-testid="svg-icon"
             title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
           >
@@ -247,16 +247,16 @@ exports[`Scan Config row tests should render 1`] = `
       </td>
       <td>
         <div
-          class="c5"
+          class="c4"
         >
           <div
-            class="c6 c7"
+            class="c5 c6"
           >
             <div
-              class="c8 c9"
+              class="c7 c8"
             >
               <span
-                class="c3 c10 c4"
+                class="c9 c3"
                 data-testid="svg-icon"
                 title="Move Scan Config to trashcan"
               >
@@ -267,7 +267,7 @@ exports[`Scan Config row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c10 c4"
+                class="c9 c3"
                 data-testid="svg-icon"
                 title="Edit Scan Config"
               >
@@ -278,7 +278,7 @@ exports[`Scan Config row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c10 c4"
+                class="c9 c3"
                 data-testid="svg-icon"
                 title="Clone Scan Config"
               >
@@ -289,7 +289,7 @@ exports[`Scan Config row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c10 c4"
+                class="c9 c3"
                 data-testid="svg-icon"
                 title="Export Scan Config"
               >

--- a/src/web/pages/scanconfigs/__tests__/__snapshots__/table.js.snap
+++ b/src/web/pages/scanconfigs/__tests__/__snapshots__/table.js.snap
@@ -40,7 +40,7 @@ exports[`Scan Config table tests should render 1`] = `
   justify-content: space-between;
 }
 
-.c7 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -58,7 +58,7 @@ exports[`Scan Config table tests should render 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -76,7 +76,7 @@ exports[`Scan Config table tests should render 1`] = `
   align-items: center;
 }
 
-.c21 {
+.c20 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -90,7 +90,7 @@ exports[`Scan Config table tests should render 1`] = `
   justify-content: center;
 }
 
-.c23 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -108,7 +108,7 @@ exports[`Scan Config table tests should render 1`] = `
   align-items: stretch;
 }
 
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -121,7 +121,7 @@ exports[`Scan Config table tests should render 1`] = `
   justify-content: space-between;
 }
 
-.c26 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -143,7 +143,7 @@ exports[`Scan Config table tests should render 1`] = `
   align-items: center;
 }
 
-.c27 {
+.c26 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -165,7 +165,7 @@ exports[`Scan Config table tests should render 1`] = `
   align-items: center;
 }
 
-.c33 {
+.c32 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -183,48 +183,48 @@ exports[`Scan Config table tests should render 1`] = `
   align-items: center;
 }
 
-.c11 {
+.c10 {
   margin-left: -5px;
 }
 
-.c11>* {
+.c10>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c11>* {
+.c10>* {
   margin-left: 5px;
 }
 
-.c10 {
+.c9 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4 {
+.c3 {
   cursor: pointer;
 }
 
-.c12 svg path {
+.c11 svg path {
   fill: #bfbfbf;
 }
 
-.c5 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c5 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
 
-.c34 {
+.c33 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -249,18 +249,18 @@ exports[`Scan Config table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c35 {
+.c34 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c35 * {
+.c34 * {
   height: inherit;
   width: inherit;
 }
 
-.c30 {
+.c29 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -284,7 +284,7 @@ exports[`Scan Config table tests should render 1`] = `
   font-weight: normal;
 }
 
-.c29 {
+.c28 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -296,7 +296,7 @@ exports[`Scan Config table tests should render 1`] = `
   width: 180px;
 }
 
-.c31 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -315,7 +315,7 @@ exports[`Scan Config table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c36 {
+.c35 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -324,18 +324,18 @@ exports[`Scan Config table tests should render 1`] = `
   display: none;
 }
 
-.c32 {
+.c31 {
   cursor: default;
 }
 
-.c28 {
+.c27 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
+.c13 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -344,33 +344,33 @@ exports[`Scan Config table tests should render 1`] = `
   width: 100%;
 }
 
-.c15 th,
-.c15 td {
+.c14 th,
+.c14 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c15 tfoot tr {
+.c14 tfoot tr {
   background: #fff;
 }
 
-.c15 tfoot tr td {
+.c14 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c17 a {
+.c16 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c17 a:hover {
+.c16 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c18 {
+.c17 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -378,7 +378,7 @@ exports[`Scan Config table tests should render 1`] = `
   width: 72%;
 }
 
-.c19 {
+.c18 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -386,7 +386,7 @@ exports[`Scan Config table tests should render 1`] = `
   width: 10%;
 }
 
-.c20 {
+.c19 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -394,7 +394,7 @@ exports[`Scan Config table tests should render 1`] = `
   width: 8%;
 }
 
-.c22 {
+.c21 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -402,25 +402,25 @@ exports[`Scan Config table tests should render 1`] = `
   width: 5%;
 }
 
-.c37 {
+.c36 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c13 {
+.c12 {
   margin: 0 3px;
 }
 
-.c8 {
+.c7 {
   margin: 2px 3px;
 }
 
-.c16 {
+.c15 {
   opacity: 1.0;
 }
 
-.c6 {
+.c5 {
   margin-top: 2px;
   margin-left: 2px;
 }
@@ -429,14 +429,14 @@ exports[`Scan Config table tests should render 1`] = `
   margin-top: 20px;
 }
 
-.c25 {
+.c24 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c25 :hover {
+.c24 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
@@ -449,33 +449,42 @@ exports[`Scan Config table tests should render 1`] = `
 }
 
 @media print {
-  .c14 {
+  .c13 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c15>tbody:nth-of-type(even),
-  .c15>tbody:only-of-type>tr:nth-of-type(even) {
+  .c14>tbody:nth-of-type(even),
+  .c14>tbody:only-of-type>tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c15>tbody:not(:only-of-type):hover,
-  .c15>tbody:only-of-type>tr:hover {
+  .c14>tbody:not(:only-of-type):hover,
+  .c14>tbody:only-of-type>tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c17 {
+  .c16 {
     border-bottom: 1px solid black;
   }
 
-  .c17 a,
-  .c17 a:hover {
+  .c16 a,
+  .c16 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
+  }
+}
+
+@media print {
+  .c17 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: transparent;
+    font-weight: bold;
   }
 }
 
@@ -498,7 +507,7 @@ exports[`Scan Config table tests should render 1`] = `
 }
 
 @media print {
-  .c20 {
+  .c21 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -507,22 +516,13 @@ exports[`Scan Config table tests should render 1`] = `
 }
 
 @media print {
-  .c22 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: transparent;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c8 svg {
+  .c7 svg {
     display: none;
   }
 }
 
 @media print {
-  .c25 {
+  .c24 {
     color: #000;
   }
 }
@@ -539,7 +539,7 @@ exports[`Scan Config table tests should render 1`] = `
         class="c2"
       >
         <span
-          class="c3 c4 c5 c6"
+          class="c3 c4 c5"
           data-testid="svg-icon"
           title="Unfold all details"
         >
@@ -550,16 +550,16 @@ exports[`Scan Config table tests should render 1`] = `
           </svg>
         </span>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -570,7 +570,7 @@ exports[`Scan Config table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -583,18 +583,18 @@ exports[`Scan Config table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -605,7 +605,7 @@ exports[`Scan Config table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >
@@ -620,48 +620,48 @@ exports[`Scan Config table tests should render 1`] = `
         </div>
       </div>
       <table
-        class="c14 c15 c16"
+        class="c13 c14 c15"
       >
         <thead
-          class="c17"
+          class="c16"
         >
           <tr>
             <th
-              class="c18"
+              class="c17"
               rowspan="2"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 Name
               </div>
             </th>
             <th
-              class="c19"
+              class="c18"
               colspan="2"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 Family
               </div>
             </th>
             <th
-              class="c19"
+              class="c18"
               colspan="2"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 NVTs
               </div>
             </th>
             <th
-              class="c20"
+              class="c19"
               rowspan="2"
             >
               <div
-                class="c21"
+                class="c20"
               >
                 Actions
               </div>
@@ -669,37 +669,37 @@ exports[`Scan Config table tests should render 1`] = `
           </tr>
           <tr>
             <th
-              class="c22"
+              class="c21"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 Total
               </div>
             </th>
             <th
-              class="c22"
+              class="c21"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 Trend
               </div>
             </th>
             <th
-              class="c22"
+              class="c21"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 Total
               </div>
             </th>
             <th
-              class="c22"
+              class="c21"
             >
               <div
-                class="c9"
+                class="c8"
               >
                 Trend
               </div>
@@ -712,17 +712,17 @@ exports[`Scan Config table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c24"
+                  class="c23"
                 >
                   <div
-                    class="c23"
+                    class="c22"
                   >
                     <span>
                       <span
-                        class="c25"
+                        class="c24"
                         name="12345"
                       >
                         foo
@@ -741,18 +741,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 2
               </div>
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span
                   alt="Static"
-                  class="c3 c5"
+                  class="c4"
                   data-testid="svg-icon"
                   title="The family selection is STATIC. New families will NOT automatically be added and considered."
                 >
@@ -766,18 +766,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 4
               </div>
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span
                   alt="Dynamic"
-                  class="c3 c5"
+                  class="c4"
                   data-testid="svg-icon"
                   title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
                 >
@@ -794,13 +794,13 @@ exports[`Scan Config table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c26 c10"
+                  class="c25 c9"
                 >
                   <div
-                    class="c27 c11"
+                    class="c26 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Scan Config to trashcan"
                     >
@@ -811,7 +811,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Scan Config"
                     >
@@ -822,7 +822,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Scan Config"
                     >
@@ -833,7 +833,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Scan Config"
                     >
@@ -851,17 +851,17 @@ exports[`Scan Config table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c24"
+                  class="c23"
                 >
                   <div
-                    class="c23"
+                    class="c22"
                   >
                     <span>
                       <span
-                        class="c25"
+                        class="c24"
                         name="123456"
                       >
                         lorem
@@ -880,18 +880,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 3
               </div>
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span
                   alt="Static"
-                  class="c3 c5"
+                  class="c4"
                   data-testid="svg-icon"
                   title="The family selection is STATIC. New families will NOT automatically be added and considered."
                 >
@@ -905,18 +905,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 5
               </div>
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span
                   alt="Dynamic"
-                  class="c3 c5"
+                  class="c4"
                   data-testid="svg-icon"
                   title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
                 >
@@ -933,13 +933,13 @@ exports[`Scan Config table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c26 c10"
+                  class="c25 c9"
                 >
                   <div
-                    class="c27 c11"
+                    class="c26 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Scan Config to trashcan"
                     >
@@ -950,7 +950,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Scan Config"
                     >
@@ -961,7 +961,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Scan Config"
                     >
@@ -972,7 +972,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Scan Config"
                     >
@@ -990,17 +990,17 @@ exports[`Scan Config table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <div
-                  class="c24"
+                  class="c23"
                 >
                   <div
-                    class="c23"
+                    class="c22"
                   >
                     <span>
                       <span
-                        class="c25"
+                        class="c24"
                         name="1234567"
                       >
                         hello
@@ -1019,18 +1019,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 1
               </div>
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span
                   alt="Static"
-                  class="c3 c5"
+                  class="c4"
                   data-testid="svg-icon"
                   title="The family selection is STATIC. New families will NOT automatically be added and considered."
                 >
@@ -1044,18 +1044,18 @@ exports[`Scan Config table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 1
               </div>
             </td>
             <td>
               <div
-                class="c23"
+                class="c22"
               >
                 <span
                   alt="Dynamic"
-                  class="c3 c5"
+                  class="c4"
                   data-testid="svg-icon"
                   title="The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered."
                 >
@@ -1072,13 +1072,13 @@ exports[`Scan Config table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c26 c10"
+                  class="c25 c9"
                 >
                   <div
-                    class="c27 c11"
+                    class="c26 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Scan Config to trashcan"
                     >
@@ -1089,7 +1089,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Scan Config"
                     >
@@ -1100,7 +1100,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Scan Config"
                     >
@@ -1111,7 +1111,7 @@ exports[`Scan Config table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Scan Config"
                     >
@@ -1133,42 +1133,42 @@ exports[`Scan Config table tests should render 1`] = `
               colspan="6"
             >
               <div
-                class="c7"
+                class="c6"
               >
                 <div
-                  class="c9 c10"
+                  class="c8 c9"
                 >
                   <div
-                    class="c9 c11"
+                    class="c8 c10"
                   >
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-labelledby="downshift-0-label"
-                      class="c28"
+                      class="c27"
                       role="combobox"
                     >
                       <div
-                        class="c29"
+                        class="c28"
                         width="180px"
                       >
                         <div
                           aria-haspopup="true"
                           aria-label="open menu"
-                          class="c30"
+                          class="c29"
                           data-toggle="true"
                           role="button"
                           type="button"
                         >
                           <div
-                            class="c31 c32"
+                            class="c30 c31"
                             data-testid="select-selected-value"
                           />
                           <div
-                            class="c33"
+                            class="c32"
                           >
                             <span
-                              class="c34 c35"
+                              class="c33 c34"
                               data-testid="select-open-button"
                             >
                               ▼
@@ -1177,20 +1177,20 @@ exports[`Scan Config table tests should render 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c36"
+                        class="c35"
                         data-testid="error-marker"
                       >
                         ×
                       </div>
                     </div>
                     <div
-                      class="c9 c10"
+                      class="c8 c9"
                     >
                       <div
-                        class="c9 c11"
+                        class="c8 c10"
                       >
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1198,7 +1198,7 @@ exports[`Scan Config table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1206,7 +1206,7 @@ exports[`Scan Config table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1223,24 +1223,24 @@ exports[`Scan Config table tests should render 1`] = `
         </tfoot>
       </table>
       <div
-        class="c24"
+        class="c23"
       >
         <div
-          class="c9 c37"
+          class="c8 c36"
         >
           (Applied filter: rows=2)
         </div>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -1251,7 +1251,7 @@ exports[`Scan Config table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -1264,18 +1264,18 @@ exports[`Scan Config table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -1286,7 +1286,7 @@ exports[`Scan Config table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >

--- a/src/web/pages/tasks/__tests__/__snapshots__/actions.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/actions.js.snap
@@ -89,21 +89,21 @@ exports[`Task Actions tests should render 1`] = `
   display: inline-flex;
 }
 
-.c6 {
+.c5 {
   cursor: pointer;
 }
 
-.c8 svg path {
+.c7 svg path {
   fill: #bfbfbf;
 }
 
-.c7 {
+.c6 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c7 * {
+.c6 * {
   height: inherit;
   width: inherit;
 }
@@ -130,7 +130,7 @@ exports[`Task Actions tests should render 1`] = `
             class="c3 c4"
           >
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Start"
             >
@@ -142,7 +142,7 @@ exports[`Task Actions tests should render 1`] = `
             </span>
             <span
               alt="Resume"
-              class="c5 c8 c7"
+              class="c7 c6"
               data-testid="svg-icon"
               title="Task is not stopped"
             >
@@ -153,7 +153,7 @@ exports[`Task Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Move Task to trashcan"
             >
@@ -164,7 +164,7 @@ exports[`Task Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Edit Task"
             >
@@ -175,7 +175,7 @@ exports[`Task Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Clone Task"
             >
@@ -186,7 +186,7 @@ exports[`Task Actions tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c5 c6 c7"
+              class="c5 c6"
               data-testid="svg-icon"
               title="Export Task"
             >

--- a/src/web/pages/tasks/__tests__/__snapshots__/detailspage.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/detailspage.js.snap
@@ -72,7 +72,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   align-items: flex-start;
 }
 
-.c15 {
+.c14 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -94,7 +94,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   align-items: center;
 }
 
-.c20 {
+.c19 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -111,7 +111,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   align-items: flex-end;
 }
 
-.c24 {
+.c23 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -127,6 +127,23 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -webkit-box-align: flex-end;
   -ms-flex-align: flex-end;
   align-items: flex-end;
+}
+
+.c27 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 .c28 {
@@ -137,30 +154,13 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  justify-content: space-between;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c29 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
   -webkit-box-pack: start;
   -ms-flex-pack: start;
   -webkit-justify-content: flex-start;
   justify-content: flex-start;
 }
 
-.c31 {
+.c30 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -182,7 +182,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c32 {
+.c31 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -204,7 +204,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   align-items: flex-end;
 }
 
-.c34 {
+.c33 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -222,7 +222,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c37 {
+.c36 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -240,7 +240,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   align-items: center;
 }
 
-.c39 {
+.c38 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -258,7 +258,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c9 {
+.c8 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -302,48 +302,48 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   display: inline-flex;
 }
 
-.c16 {
+.c15 {
   cursor: pointer;
 }
 
-.c17 svg path {
+.c16 svg path {
   fill: #bfbfbf;
 }
 
-.c8 {
+.c7 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c8 * {
+.c7 * {
   height: inherit;
   width: inherit;
 }
 
-.c26 {
+.c25 {
   height: 50px;
   width: 50px;
   line-height: 50px;
 }
 
-.c26 * {
+.c25 * {
   height: inherit;
   width: inherit;
 }
 
-.c21 {
+.c20 {
   margin: 10px 0px;
   padding-bottom: 1px;
   border-bottom: 2px solid #e5e5e5;
   position: relative;
 }
 
-.c22 {
+.c21 {
   margin: 0 0 1px 0;
 }
 
-.c23 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -361,16 +361,16 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   align-items: stretch;
 }
 
-.c25 {
+.c24 {
   margin-right: 5px;
 }
 
-.c27 {
+.c26 {
   word-break: break-all;
   min-width: 100px;
 }
 
-.c35 {
+.c34 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -397,15 +397,15 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #11ab51;
 }
 
-.c35:hover {
+.c34:hover {
   border-top: 2px solid #11ab51;
 }
 
-.c35:first-child {
+.c34:first-child {
   border-left: 1px solid #e5e5e5;
 }
 
-.c36 {
+.c35 {
   font-size: 16px;
   display: -webkit-box;
   display: -webkit-flex;
@@ -429,21 +429,21 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   border-top: 2px solid #fff;
 }
 
-.c36:hover {
+.c35:hover {
   border-top: 2px solid #e5e5e5;
 }
 
-.c36:first-child {
+.c35:first-child {
   border-left: 1px solid #fff;
 }
 
-.c33 {
+.c32 {
   border-bottom: 2px solid #11ab51;
   margin-top: 30px;
   margin-bottom: 15px;
 }
 
-.c40 {
+.c39 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -451,7 +451,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   table-layout: auto;
 }
 
-.c50 {
+.c49 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -460,46 +460,46 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   width: 100%;
 }
 
-.c49>*:not(:last-child)::after {
+.c48>*:not(:last-child)::after {
   content: '•';
   margin-left: 5px;
 }
 
-.c41 td {
+.c40 td {
   padding: 4px 4px 4px 0;
 }
 
-.c41 tr td:first-child {
+.c40 tr td:first-child {
   padding-right: 5px;
 }
 
-.c30 {
+.c29 {
   border-spacing: 0px;
   color: #7F7F7F;
   font-size: 10px;
 }
 
-.c30 :nth-child(even) {
+.c29 :nth-child(even) {
   margin-left: 3px;
 }
 
-.c30 :nth-child(odd) {
+.c29 :nth-child(odd) {
   margin-left: 30px;
 }
 
-.c42 {
+.c41 {
   width: 10%;
 }
 
-.c43 {
+.c42 {
   width: 90%;
 }
 
-.c38 {
+.c37 {
   font-size: 0.7em;
 }
 
-.c45 {
+.c44 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -509,7 +509,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   text-align: center;
 }
 
-.c47 {
+.c46 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -520,22 +520,22 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   padding-top: 1px;
 }
 
-.c46 {
+.c45 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
 }
 
-.c48 {
+.c47 {
   white-space: nowrap;
 }
 
-.c44:hover {
+.c43:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c11 {
+.c10 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -545,16 +545,16 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   flex-direction: column;
 }
 
-.c12 {
+.c11 {
   position: relative;
   display: none;
 }
 
-.c10:hover .c12 {
+.c9:hover .c11 {
   display: block;
 }
 
-.c13 {
+.c12 {
   position: absolute;
   margin: 0;
   padding: 0;
@@ -566,7 +566,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   width: 255px;
 }
 
-.c14 {
+.c13 {
   height: 22px;
   width: 255px;
   border-left: 1px solid #7F7F7F;
@@ -585,20 +585,20 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   text-align: left;
 }
 
-.c14:first-child {
+.c13:first-child {
   border-top: 1px solid #7F7F7F;
 }
 
-.c14:last-child {
+.c13:last-child {
   border-bottom: 1px solid #7F7F7F;
 }
 
-.c14:hover {
+.c13:hover {
   background: #11ab51;
   color: #fff;
 }
 
-.c14 div {
+.c13 div {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -614,7 +614,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   cursor: pointer;
 }
 
-.c18 {
+.c17 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -623,7 +623,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
   margin-right: 0px;
 }
 
-.c19 {
+.c18 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -661,38 +661,38 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
 }
 
 @media print {
-  .c7 {
+  .c15 {
     display: none;
   }
 }
 
 @media print {
-  .c40 {
+  .c39 {
     border-collapse: collapse;
   }
 }
 
 @media print {
-  .c50 {
+  .c49 {
     border-collapse: collapse;
   }
 }
 
 @media print {
-  .c45 {
+  .c44 {
     background: none;
     border: 0;
   }
 }
 
 @media print {
-  .c47 {
+  .c46 {
     color: black;
   }
 }
 
 @media print {
-  .c46 {
+  .c45 {
     background: none;
   }
 }
@@ -721,7 +721,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               target="_blank"
             >
               <span
-                class="c7 c8"
+                class="c7"
                 data-testid="svg-icon"
                 title="Help: Tasks"
               >
@@ -733,11 +733,11 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <a
-              class="c9"
+              class="c8"
               href="/tasks"
             >
               <span
-                class="c7 c8"
+                class="c7"
                 data-testid="svg-icon"
                 title="Task List"
               >
@@ -749,7 +749,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               </span>
             </a>
             <span
-              class="c7 c8"
+              class="c7"
               data-testid="svg-icon"
               title="This is an Alterable Task. Reports may not relate to current Scan Config or Target!"
             >
@@ -768,10 +768,10 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             class="c2 c6"
           >
             <span
-              class="c10 c11"
+              class="c9 c10"
             >
               <span
-                class="c7 c8"
+                class="c7"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -779,25 +779,25 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                 </svg>
               </span>
               <div
-                class="c12"
+                class="c11"
               >
                 <ul
-                  class="c13"
+                  class="c12"
                 >
                   <li
-                    class="c14"
+                    class="c13"
                   >
                     <div
-                      class="c15"
+                      class="c14"
                     >
                       New Task
                     </div>
                   </li>
                   <li
-                    class="c14"
+                    class="c13"
                   >
                     <div
-                      class="c15"
+                      class="c14"
                     >
                       New Container Task
                     </div>
@@ -806,7 +806,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               </div>
             </span>
             <span
-              class="c7 c16 c8"
+              class="c15 c7"
               data-testid="svg-icon"
               title="Clone Task"
             >
@@ -817,7 +817,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c16 c8"
+              class="c15 c7"
               data-testid="svg-icon"
               title="Edit Task"
             >
@@ -828,7 +828,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c16 c8"
+              class="c15 c7"
               data-testid="svg-icon"
               title="Move Task to trashcan"
             >
@@ -839,7 +839,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               </svg>
             </span>
             <span
-              class="c7 c16 c8"
+              class="c15 c7"
               data-testid="svg-icon"
               title="Export Task as XML"
             >
@@ -858,7 +858,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             class="c2 c6"
           >
             <span
-              class="c7 c16 c8"
+              class="c15 c7"
               data-testid="svg-icon"
               title="Start"
             >
@@ -870,7 +870,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             </span>
             <span
               alt="Resume"
-              class="c7 c17 c8"
+              class="c16 c7"
               data-testid="svg-icon"
               title="Task is not stopped"
             >
@@ -895,13 +895,13 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                 class="c2 c6"
               >
                 <a
-                  class="c9"
+                  class="c8"
                   data-testid="details-link"
                   href="/report/1234"
                   title="Last Report for Task foo from 07/30/2019"
                 >
                   <span
-                    class="c7 c8"
+                    class="c7"
                     data-testid="svg-icon"
                   >
                     <svg>
@@ -910,15 +910,15 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                   </span>
                 </a>
                 <a
-                  class="c9"
+                  class="c8"
                   href="/reports?filter=task_id%3D12345"
                   title="Total Reports for Task foo"
                 >
                   <div
-                    class="c18"
+                    class="c17"
                   >
                     <span
-                      class="c7 c8"
+                      class="c7"
                       data-testid="svg-icon"
                     >
                       <svg>
@@ -926,7 +926,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c19"
+                      class="c18"
                       data-testid="badge-icon"
                     >
                       1
@@ -936,15 +936,15 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
               </div>
             </div>
             <a
-              class="c9"
+              class="c8"
               href="/results?filter=task_id%3D12345"
               title="Results for Task foo"
             >
               <div
-                class="c18"
+                class="c17"
               >
                 <span
-                  class="c7 c8"
+                  class="c7"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -952,7 +952,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c19"
+                  class="c18"
                   data-testid="badge-icon"
                 >
                   1
@@ -966,15 +966,15 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                 class="c2 c6"
               >
                 <a
-                  class="c9"
+                  class="c8"
                   href="/notes?filter=task_id%3D12345"
                   title="Notes for Task foo"
                 >
                   <div
-                    class="c18"
+                    class="c17"
                   >
                     <span
-                      class="c7 c8"
+                      class="c7"
                       data-testid="svg-icon"
                     >
                       <svg>
@@ -982,7 +982,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c19"
+                      class="c18"
                       data-testid="badge-icon"
                     >
                       0
@@ -990,15 +990,15 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                   </div>
                 </a>
                 <a
-                  class="c9"
+                  class="c8"
                   href="/overrides?filter=task_id%3D12345"
                   title="Overrides for Task foo"
                 >
                   <div
-                    class="c18"
+                    class="c17"
                   >
                     <span
-                      class="c7 c8"
+                      class="c7"
                       data-testid="svg-icon"
                     >
                       <svg>
@@ -1006,7 +1006,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c19"
+                      class="c18"
                       data-testid="badge-icon"
                     >
                       0
@@ -1024,16 +1024,16 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
     class="entity-section"
   >
     <div
-      class="c20 c21 section-header"
+      class="c19 c20 section-header"
     >
       <h2
-        class="c22 c23"
+        class="c21 c22"
       >
         <div
-          class="c24 c25"
+          class="c23 c24"
         >
           <span
-            class="c7 c26"
+            class="c25"
             data-testid="svg-icon"
           >
             <svg>
@@ -1042,19 +1042,19 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
           </span>
         </div>
         <div
-          class="c24 c27"
+          class="c23 c26"
         >
           Task: foo
         </div>
       </h2>
       <div
-        class="c28"
+        class="c27"
       >
         <div
-          class="c29"
+          class="c28"
         >
           <div
-            class="c2 c30"
+            class="c2 c29"
           >
             <div>
               ID:
@@ -1085,30 +1085,30 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
       </div>
     </div>
     <div
-      class="c31"
+      class="c30"
     >
       <div
-        class="c32 c33"
+        class="c31 c32"
       >
         <div
-          class="c34"
+          class="c33"
         >
           <div
-            class="c35"
+            class="c34"
           >
             Information
           </div>
           <div
-            class="c36"
+            class="c35"
           >
             <div
-              class="c37"
+              class="c36"
             >
               <span>
                 User Tags
               </span>
               <span
-                class="c38"
+                class="c37"
               >
                 (
                 <i>
@@ -1119,16 +1119,16 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c36"
+            class="c35"
           >
             <div
-              class="c37"
+              class="c36"
             >
               <span>
                 Permissions
               </span>
               <span
-                class="c38"
+                class="c37"
               >
                 (
                 <i>
@@ -1141,18 +1141,18 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
         </div>
       </div>
       <div
-        class="c39"
+        class="c38"
       >
         <table
-          class="c40 c41"
+          class="c39 c40"
         >
           <colgroup>
             <col
-              class="c42"
+              class="c41"
               width="10%"
             />
             <col
-              class="c43"
+              class="c42"
               width="90%"
             />
           </colgroup>
@@ -1162,14 +1162,14 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   Name
                 </div>
               </td>
               <td>
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   foo
                 </div>
@@ -1178,14 +1178,14 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   Comment
                 </div>
               </td>
               <td>
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   bar
                 </div>
@@ -1194,14 +1194,14 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   Alterable
                 </div>
               </td>
               <td>
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   Yes
                 </div>
@@ -1210,35 +1210,35 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             <tr>
               <td>
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   Status
                 </div>
               </td>
               <td>
                 <div
-                  class="c39"
+                  class="c38"
                 >
                   <a
-                    class="c9 c44"
+                    class="c8 c43"
                     data-testid="details-link"
                     href="/report/1234"
                   >
                     <div
-                      class="c45"
+                      class="c44"
                       data-testid="progressbar-box"
                       title="Done"
                     >
                       <div
                         background="low"
-                        class="c46"
+                        class="c45"
                         data-testid="progress"
                       />
                       <div
-                        class="c47"
+                        class="c46"
                       >
                         <span
-                          class="c48"
+                          class="c47"
                         >
                           Done
                         </span>
@@ -1251,17 +1251,17 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
           </tbody>
         </table>
         <div
-          class="c31"
+          class="c30"
         >
           <div
-            class="c39"
+            class="c38"
           >
             <h2>
               Target
             </h2>
             <div>
               <a
-                class="c9"
+                class="c8"
                 data-testid="details-link"
                 href="/target/5678"
               >
@@ -1270,7 +1270,7 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c39"
+            class="c38"
           >
             <h2>
               Alerts
@@ -1280,11 +1280,11 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                 class="c2 c3"
               >
                 <div
-                  class="c2 c6 c49"
+                  class="c2 c6 c48"
                 >
                   <span>
                     <a
-                      class="c9"
+                      class="c8"
                       data-testid="details-link"
                       href="/alert/91011"
                     >
@@ -1296,22 +1296,22 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c39"
+            class="c38"
           >
             <h2>
               Scanner
             </h2>
             <div>
               <table
-                class="c50 c41"
+                class="c49 c40"
               >
                 <colgroup>
                   <col
-                    class="c42"
+                    class="c41"
                     width="10%"
                   />
                   <col
-                    class="c43"
+                    class="c42"
                     width="90%"
                   />
                 </colgroup>
@@ -1321,18 +1321,18 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c39"
+                        class="c38"
                       >
                         Name
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c39"
+                        class="c38"
                       >
                         <span>
                           <a
-                            class="c9"
+                            class="c8"
                             data-testid="details-link"
                             href="/scanner/1516"
                           >
@@ -1345,14 +1345,14 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c39"
+                        class="c38"
                       >
                         Type
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c39"
+                        class="c38"
                       >
                         OpenVAS Scanner
                       </div>
@@ -1363,22 +1363,22 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c39"
+            class="c38"
           >
             <h2>
               Assets
             </h2>
             <div>
               <table
-                class="c50 c41"
+                class="c49 c40"
               >
                 <colgroup>
                   <col
-                    class="c42"
+                    class="c41"
                     width="10%"
                   />
                   <col
-                    class="c43"
+                    class="c42"
                     width="90%"
                   />
                 </colgroup>
@@ -1388,14 +1388,14 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c39"
+                        class="c38"
                       >
                         Add to Assets
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c39"
+                        class="c38"
                       >
                         Yes
                       </div>
@@ -1404,14 +1404,14 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c39"
+                        class="c38"
                       >
                         Apply Overrides
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c39"
+                        class="c38"
                       >
                         Yes
                       </div>
@@ -1420,14 +1420,14 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c39"
+                        class="c38"
                       >
                         Min QoD
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c39"
+                        class="c38"
                       >
                         70 %
                       </div>
@@ -1438,22 +1438,22 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
             </div>
           </div>
           <div
-            class="c39"
+            class="c38"
           >
             <h2>
               Scan
             </h2>
             <div>
               <table
-                class="c50 c41"
+                class="c49 c40"
               >
                 <colgroup>
                   <col
-                    class="c42"
+                    class="c41"
                     width="10%"
                   />
                   <col
-                    class="c43"
+                    class="c42"
                     width="90%"
                   />
                 </colgroup>
@@ -1463,14 +1463,14 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c39"
+                        class="c38"
                       >
                         Duration of last Scan
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c39"
+                        class="c38"
                       >
                         2 minutes
                       </div>
@@ -1479,14 +1479,14 @@ exports[`Task Detailspage tests should render full Detailspage 1`] = `
                   <tr>
                     <td>
                       <div
-                        class="c39"
+                        class="c38"
                       >
                         Auto delete Reports
                       </div>
                     </td>
                     <td>
                       <div
-                        class="c39"
+                        class="c38"
                       >
                         Do not automatically delete reports
                       </div>
@@ -1540,7 +1540,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   align-items: flex-start;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1562,7 +1562,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   align-items: center;
 }
 
-.c7 {
+.c6 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1606,26 +1606,26 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   display: inline-flex;
 }
 
-.c14 {
+.c13 {
   cursor: pointer;
 }
 
-.c15 svg path {
+.c14 svg path {
   fill: #bfbfbf;
 }
 
-.c6 {
+.c5 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c6 * {
+.c5 * {
   height: inherit;
   width: inherit;
 }
 
-.c9 {
+.c8 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1635,16 +1635,16 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   flex-direction: column;
 }
 
-.c10 {
+.c9 {
   position: relative;
   display: none;
 }
 
-.c8:hover .c10 {
+.c7:hover .c9 {
   display: block;
 }
 
-.c11 {
+.c10 {
   position: absolute;
   margin: 0;
   padding: 0;
@@ -1656,7 +1656,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   width: 255px;
 }
 
-.c12 {
+.c11 {
   height: 22px;
   width: 255px;
   border-left: 1px solid #7F7F7F;
@@ -1675,20 +1675,20 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   text-align: left;
 }
 
-.c12:first-child {
+.c11:first-child {
   border-top: 1px solid #7F7F7F;
 }
 
-.c12:last-child {
+.c11:last-child {
   border-bottom: 1px solid #7F7F7F;
 }
 
-.c12:hover {
+.c11:hover {
   background: #11ab51;
   color: #fff;
 }
 
-.c12 div {
+.c11 div {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1704,7 +1704,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   cursor: pointer;
 }
 
-.c16 {
+.c15 {
   position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
@@ -1713,7 +1713,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
   margin-right: 0px;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1751,7 +1751,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
 }
 
 @media print {
-  .c5 {
+  .c13 {
     display: none;
   }
 }
@@ -1774,7 +1774,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           target="_blank"
         >
           <span
-            class="c5 c6"
+            class="c5"
             data-testid="svg-icon"
             title="Help: Tasks"
           >
@@ -1786,11 +1786,11 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <a
-          class="c7"
+          class="c6"
           href="/tasks"
         >
           <span
-            class="c5 c6"
+            class="c5"
             data-testid="svg-icon"
             title="Task List"
           >
@@ -1802,7 +1802,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </span>
         </a>
         <span
-          class="c5 c6"
+          class="c5"
           data-testid="svg-icon"
           title="This is an Alterable Task. Reports may not relate to current Scan Config or Target!"
         >
@@ -1821,10 +1821,10 @@ exports[`Task ToolBarIcons tests should render 1`] = `
         class="c0 c4"
       >
         <span
-          class="c8 c9"
+          class="c7 c8"
         >
           <span
-            class="c5 c6"
+            class="c5"
             data-testid="svg-icon"
           >
             <svg>
@@ -1832,25 +1832,25 @@ exports[`Task ToolBarIcons tests should render 1`] = `
             </svg>
           </span>
           <div
-            class="c10"
+            class="c9"
           >
             <ul
-              class="c11"
+              class="c10"
             >
               <li
-                class="c12"
+                class="c11"
               >
                 <div
-                  class="c13"
+                  class="c12"
                 >
                   New Task
                 </div>
               </li>
               <li
-                class="c12"
+                class="c11"
               >
                 <div
-                  class="c13"
+                  class="c12"
                 >
                   New Container Task
                 </div>
@@ -1859,7 +1859,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </div>
         </span>
         <span
-          class="c5 c14 c6"
+          class="c13 c5"
           data-testid="svg-icon"
           title="Clone Task"
         >
@@ -1870,7 +1870,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c14 c6"
+          class="c13 c5"
           data-testid="svg-icon"
           title="Edit Task"
         >
@@ -1881,7 +1881,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c14 c6"
+          class="c13 c5"
           data-testid="svg-icon"
           title="Move Task to trashcan"
         >
@@ -1892,7 +1892,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </svg>
         </span>
         <span
-          class="c5 c14 c6"
+          class="c13 c5"
           data-testid="svg-icon"
           title="Export Task as XML"
         >
@@ -1911,7 +1911,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
         class="c0 c4"
       >
         <span
-          class="c5 c14 c6"
+          class="c13 c5"
           data-testid="svg-icon"
           title="Start"
         >
@@ -1923,7 +1923,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
         </span>
         <span
           alt="Resume"
-          class="c5 c15 c6"
+          class="c14 c5"
           data-testid="svg-icon"
           title="Task is not stopped"
         >
@@ -1948,13 +1948,13 @@ exports[`Task ToolBarIcons tests should render 1`] = `
             class="c0 c4"
           >
             <a
-              class="c7"
+              class="c6"
               data-testid="details-link"
               href="/report/1234"
               title="Last Report for Task foo from 07/30/2019"
             >
               <span
-                class="c5 c6"
+                class="c5"
                 data-testid="svg-icon"
               >
                 <svg>
@@ -1963,15 +1963,15 @@ exports[`Task ToolBarIcons tests should render 1`] = `
               </span>
             </a>
             <a
-              class="c7"
+              class="c6"
               href="/reports?filter=task_id%3D12345"
               title="Total Reports for Task foo"
             >
               <div
-                class="c16"
+                class="c15"
               >
                 <span
-                  class="c5 c6"
+                  class="c5"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -1979,7 +1979,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c17"
+                  class="c16"
                   data-testid="badge-icon"
                 >
                   1
@@ -1989,15 +1989,15 @@ exports[`Task ToolBarIcons tests should render 1`] = `
           </div>
         </div>
         <a
-          class="c7"
+          class="c6"
           href="/results?filter=task_id%3D12345"
           title="Results for Task foo"
         >
           <div
-            class="c16"
+            class="c15"
           >
             <span
-              class="c5 c6"
+              class="c5"
               data-testid="svg-icon"
             >
               <svg>
@@ -2005,7 +2005,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
               </svg>
             </span>
             <span
-              class="c17"
+              class="c16"
               data-testid="badge-icon"
             >
               1
@@ -2019,15 +2019,15 @@ exports[`Task ToolBarIcons tests should render 1`] = `
             class="c0 c4"
           >
             <a
-              class="c7"
+              class="c6"
               href="/notes?filter=task_id%3D12345"
               title="Notes for Task foo"
             >
               <div
-                class="c16"
+                class="c15"
               >
                 <span
-                  class="c5 c6"
+                  class="c5"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -2035,7 +2035,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c17"
+                  class="c16"
                   data-testid="badge-icon"
                 >
                   2
@@ -2043,15 +2043,15 @@ exports[`Task ToolBarIcons tests should render 1`] = `
               </div>
             </a>
             <a
-              class="c7"
+              class="c6"
               href="/overrides?filter=task_id%3D12345"
               title="Overrides for Task foo"
             >
               <div
-                class="c16"
+                class="c15"
               >
                 <span
-                  class="c5 c6"
+                  class="c5"
                   data-testid="svg-icon"
                 >
                   <svg>
@@ -2059,7 +2059,7 @@ exports[`Task ToolBarIcons tests should render 1`] = `
                   </svg>
                 </span>
                 <span
-                  class="c17"
+                  class="c16"
                   data-testid="badge-icon"
                 >
                   3

--- a/src/web/pages/tasks/__tests__/__snapshots__/row.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/row.js.snap
@@ -64,7 +64,7 @@ exports[`Task Row tests should render 1`] = `
   justify-content: center;
 }
 
-.c16 {
+.c15 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -86,7 +86,7 @@ exports[`Task Row tests should render 1`] = `
   align-items: stretch;
 }
 
-.c17 {
+.c16 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -108,7 +108,7 @@ exports[`Task Row tests should render 1`] = `
   align-items: center;
 }
 
-.c18 {
+.c17 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -159,21 +159,21 @@ exports[`Task Row tests should render 1`] = `
   display: inline-flex;
 }
 
-.c19 {
+.c18 {
   cursor: pointer;
 }
 
-.c20 svg path {
+.c19 svg path {
   fill: #bfbfbf;
 }
 
-.c15 {
+.c14 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c15 * {
+.c14 * {
   height: inherit;
   width: inherit;
 }
@@ -234,7 +234,7 @@ exports[`Task Row tests should render 1`] = `
 }
 
 @media print {
-  .c14 {
+  .c18 {
     display: none;
   }
 }
@@ -398,7 +398,7 @@ exports[`Task Row tests should render 1`] = `
         >
           <span
             alt="Severity increased"
-            class="c14 c15"
+            class="c14"
             data-testid="svg-icon"
             title="Severity increased"
           >
@@ -412,16 +412,16 @@ exports[`Task Row tests should render 1`] = `
       </td>
       <td>
         <div
-          class="c16"
+          class="c15"
         >
           <div
-            class="c17 c4"
+            class="c16 c4"
           >
             <div
-              class="c18 c5"
+              class="c17 c5"
             >
               <span
-                class="c14 c19 c15"
+                class="c18 c14"
                 data-testid="svg-icon"
                 title="Start"
               >
@@ -433,7 +433,7 @@ exports[`Task Row tests should render 1`] = `
               </span>
               <span
                 alt="Resume"
-                class="c14 c20 c15"
+                class="c19 c14"
                 data-testid="svg-icon"
                 title="Task is not stopped"
               >
@@ -444,7 +444,7 @@ exports[`Task Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c14 c19 c15"
+                class="c18 c14"
                 data-testid="svg-icon"
                 title="Move Task to trashcan"
               >
@@ -455,7 +455,7 @@ exports[`Task Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c14 c19 c15"
+                class="c18 c14"
                 data-testid="svg-icon"
                 title="Edit Task"
               >
@@ -466,7 +466,7 @@ exports[`Task Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c14 c19 c15"
+                class="c18 c14"
                 data-testid="svg-icon"
                 title="Clone Task"
               >
@@ -477,7 +477,7 @@ exports[`Task Row tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c14 c19 c15"
+                class="c18 c14"
                 data-testid="svg-icon"
                 title="Export Task"
               >

--- a/src/web/pages/tasks/__tests__/__snapshots__/table.js.snap
+++ b/src/web/pages/tasks/__tests__/__snapshots__/table.js.snap
@@ -40,7 +40,7 @@ exports[`Tasks table tests should render 1`] = `
   justify-content: space-between;
 }
 
-.c7 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -58,7 +58,7 @@ exports[`Tasks table tests should render 1`] = `
   align-items: center;
 }
 
-.c9 {
+.c8 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -76,7 +76,7 @@ exports[`Tasks table tests should render 1`] = `
   align-items: center;
 }
 
-.c23 {
+.c22 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -90,7 +90,7 @@ exports[`Tasks table tests should render 1`] = `
   justify-content: center;
 }
 
-.c25 {
+.c24 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -108,7 +108,7 @@ exports[`Tasks table tests should render 1`] = `
   align-items: stretch;
 }
 
-.c26 {
+.c25 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -121,7 +121,7 @@ exports[`Tasks table tests should render 1`] = `
   justify-content: space-between;
 }
 
-.c35 {
+.c34 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -135,7 +135,7 @@ exports[`Tasks table tests should render 1`] = `
   justify-content: center;
 }
 
-.c36 {
+.c35 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -157,7 +157,7 @@ exports[`Tasks table tests should render 1`] = `
   align-items: center;
 }
 
-.c37 {
+.c36 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -179,7 +179,7 @@ exports[`Tasks table tests should render 1`] = `
   align-items: center;
 }
 
-.c46 {
+.c45 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -197,55 +197,55 @@ exports[`Tasks table tests should render 1`] = `
   align-items: center;
 }
 
-.c28 {
+.c27 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-}
-
-.c11 {
-  margin-left: -5px;
-}
-
-.c11>* {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-}
-
-.c11>* {
-  margin-left: 5px;
 }
 
 .c10 {
+  margin-left: -5px;
+}
+
+.c10>* {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
-.c4 {
+.c10>* {
+  margin-left: 5px;
+}
+
+.c9 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c3 {
   cursor: pointer;
 }
 
-.c12 svg path {
+.c11 svg path {
   fill: #bfbfbf;
 }
 
-.c5 {
+.c4 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c5 * {
+.c4 * {
   height: inherit;
   width: inherit;
 }
 
-.c47 {
+.c46 {
   background-color: transparent;
   border: none;
   cursor: pointer;
@@ -270,18 +270,18 @@ exports[`Tasks table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c48 {
+.c47 {
   height: 16px;
   width: 16px;
   line-height: 16px;
 }
 
-.c48 * {
+.c47 * {
   height: inherit;
   width: inherit;
 }
 
-.c43 {
+.c42 {
   border: 1px solid #bfbfbf;
   border-radius: 2px;
   display: -webkit-box;
@@ -305,7 +305,7 @@ exports[`Tasks table tests should render 1`] = `
   font-weight: normal;
 }
 
-.c42 {
+.c41 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -317,7 +317,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 180px;
 }
 
-.c44 {
+.c43 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -336,7 +336,7 @@ exports[`Tasks table tests should render 1`] = `
   cursor: pointer;
 }
 
-.c49 {
+.c48 {
   color: #c12c30;
   font-weight: bold;
   font-size: 19px;
@@ -345,18 +345,18 @@ exports[`Tasks table tests should render 1`] = `
   display: none;
 }
 
-.c45 {
+.c44 {
   cursor: default;
 }
 
-.c41 {
+.c40 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
 }
 
-.c14 {
+.c13 {
   border: 0;
   border-spacing: 0px;
   font-size: 12px;
@@ -365,33 +365,33 @@ exports[`Tasks table tests should render 1`] = `
   width: 100%;
 }
 
-.c15 th,
-.c15 td {
+.c14 th,
+.c14 td {
   padding: 4px 10px;
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c15 tfoot tr {
+.c14 tfoot tr {
   background: #fff;
 }
 
-.c15 tfoot tr td {
+.c14 tfoot tr td {
   border-bottom: 1px solid #e5e5e5;
 }
 
-.c17 a {
+.c16 a {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #000;
 }
 
-.c17 a:hover {
+.c16 a:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #000;
 }
 
-.c18 {
+.c17 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -399,7 +399,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 41%;
 }
 
-.c19 {
+.c18 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -407,7 +407,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 8%;
 }
 
-.c20 {
+.c19 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -415,7 +415,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 6%;
 }
 
-.c21 {
+.c20 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -423,7 +423,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 24%;
 }
 
-.c22 {
+.c21 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -431,7 +431,7 @@ exports[`Tasks table tests should render 1`] = `
   width: 5%;
 }
 
-.c24 {
+.c23 {
   background-color: #fff;
   color: #000;
   border-top: 1px solid #e5e5e5;
@@ -439,25 +439,25 @@ exports[`Tasks table tests should render 1`] = `
   width: 10em;
 }
 
-.c50 {
+.c49 {
   font-size: 10px;
   color: #7F7F7F;
   text-align: left;
 }
 
-.c13 {
+.c12 {
   margin: 0 3px;
 }
 
-.c8 {
+.c7 {
   margin: 2px 3px;
 }
 
-.c16 {
+.c15 {
   opacity: 1.0;
 }
 
-.c6 {
+.c5 {
   margin-top: 2px;
   margin-left: 2px;
 }
@@ -466,20 +466,20 @@ exports[`Tasks table tests should render 1`] = `
   margin-top: 20px;
 }
 
-.c27 {
+.c26 {
   cursor: pointer;
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #0a53b8;
 }
 
-.c27 :hover {
+.c26 :hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
   color: #0a53b8;
 }
 
-.c30 {
+.c29 {
   height: 13px;
   box-sizing: content-box;
   display: inline-block;
@@ -489,7 +489,7 @@ exports[`Tasks table tests should render 1`] = `
   text-align: center;
 }
 
-.c32 {
+.c31 {
   z-index: 1;
   font-weight: bold;
   color: #fff;
@@ -500,41 +500,41 @@ exports[`Tasks table tests should render 1`] = `
   padding-top: 1px;
 }
 
-.c31 {
+.c30 {
   height: 13px;
   width: 100%;
   background: #4f91c7;
 }
 
-.c34 {
+.c33 {
   height: 13px;
   width: 50%;
   background: #f0a519;
 }
 
-.c38 {
+.c37 {
   height: 13px;
   width: 100%;
   background: #99be48;
 }
 
-.c39 {
+.c38 {
   height: 13px;
   width: 0%;
   background: #70c000;
 }
 
-.c40 {
+.c39 {
   height: 13px;
   width: 100%;
   background: #c83814;
 }
 
-.c33 {
+.c32 {
   white-space: nowrap;
 }
 
-.c29:hover {
+.c28:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -546,33 +546,42 @@ exports[`Tasks table tests should render 1`] = `
 }
 
 @media print {
-  .c14 {
+  .c13 {
     border-collapse: collapse;
   }
 }
 
 @media screen {
-  .c15>tbody:nth-of-type(even),
-  .c15>tbody:only-of-type>tr:nth-of-type(even) {
+  .c14>tbody:nth-of-type(even),
+  .c14>tbody:only-of-type>tr:nth-of-type(even) {
     background: #f3f3f3;
   }
 
-  .c15>tbody:not(:only-of-type):hover,
-  .c15>tbody:only-of-type>tr:hover {
+  .c14>tbody:not(:only-of-type):hover,
+  .c14>tbody:only-of-type>tr:hover {
     background: #e5e5e5;
   }
 }
 
 @media print {
-  .c17 {
+  .c16 {
     border-bottom: 1px solid black;
   }
 
-  .c17 a,
-  .c17 a:hover {
+  .c16 a,
+  .c16 a:hover {
     -webkit-text-decoration: none;
     text-decoration: none;
     color: #000;
+  }
+}
+
+@media print {
+  .c17 {
+    color: #000;
+    font-size: 1.2em;
+    background-color: transparent;
+    font-weight: bold;
   }
 }
 
@@ -613,7 +622,7 @@ exports[`Tasks table tests should render 1`] = `
 }
 
 @media print {
-  .c22 {
+  .c23 {
     color: #000;
     font-size: 1.2em;
     background-color: transparent;
@@ -622,47 +631,44 @@ exports[`Tasks table tests should render 1`] = `
 }
 
 @media print {
-  .c24 {
-    color: #000;
-    font-size: 1.2em;
-    background-color: transparent;
-    font-weight: bold;
-  }
-}
-
-@media print {
-  .c8 svg {
+  .c7 svg {
     display: none;
   }
 }
 
 @media print {
-  .c27 {
+  .c26 {
     color: #000;
   }
 }
 
 @media print {
-  .c30 {
+  .c29 {
     background: none;
     border: 0;
   }
 }
 
 @media print {
-  .c32 {
+  .c31 {
     color: black;
   }
 }
 
 @media print {
-  .c31 {
+  .c30 {
     background: none;
   }
 }
 
 @media print {
-  .c34 {
+  .c33 {
+    background: none;
+  }
+}
+
+@media print {
+  .c37 {
     background: none;
   }
 }
@@ -679,12 +685,6 @@ exports[`Tasks table tests should render 1`] = `
   }
 }
 
-@media print {
-  .c40 {
-    background: none;
-  }
-}
-
 <body>
   <div
     id="portals"
@@ -697,7 +697,7 @@ exports[`Tasks table tests should render 1`] = `
         class="c2"
       >
         <span
-          class="c3 c4 c5 c6"
+          class="c3 c4 c5"
           data-testid="svg-icon"
           title="Unfold all details"
         >
@@ -708,16 +708,16 @@ exports[`Tasks table tests should render 1`] = `
           </svg>
         </span>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -728,7 +728,7 @@ exports[`Tasks table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -741,18 +741,18 @@ exports[`Tasks table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -763,7 +763,7 @@ exports[`Tasks table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >
@@ -778,71 +778,71 @@ exports[`Tasks table tests should render 1`] = `
         </div>
       </div>
       <table
-        class="c14 c15 c16"
+        class="c13 c14 c15"
       >
         <thead
-          class="c17"
+          class="c16"
         >
           <tr>
+            <th
+              class="c17"
+            >
+              <div
+                class="c8"
+              >
+                Name
+              </div>
+            </th>
             <th
               class="c18"
             >
               <div
-                class="c9"
+                class="c8"
               >
-                Name
+                Status
               </div>
             </th>
             <th
               class="c19"
             >
               <div
-                class="c9"
+                class="c8"
               >
-                Status
+                Reports
               </div>
             </th>
             <th
               class="c20"
             >
               <div
-                class="c9"
+                class="c8"
               >
-                Reports
+                Last Report
+              </div>
+            </th>
+            <th
+              class="c18"
+            >
+              <div
+                class="c8"
+              >
+                Severity
               </div>
             </th>
             <th
               class="c21"
             >
               <div
-                class="c9"
-              >
-                Last Report
-              </div>
-            </th>
-            <th
-              class="c19"
-            >
-              <div
-                class="c9"
-              >
-                Severity
-              </div>
-            </th>
-            <th
-              class="c22"
-            >
-              <div
-                class="c23"
+                class="c22"
               >
                 Trend
               </div>
             </th>
             <th
-              class="c24"
+              class="c23"
             >
               <div
-                class="c23"
+                class="c22"
               >
                 Actions
               </div>
@@ -855,22 +855,22 @@ exports[`Tasks table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <div
-                  class="c26"
+                  class="c25"
                 >
                   <span
-                    class="c27"
+                    class="c26"
                     name="1234"
                   >
                     foo
                   </span>
                   <div
-                    class="c9 c10"
+                    class="c8 c9"
                   >
                     <div
-                      class="c9 c11"
+                      class="c8 c10"
                     />
                   </div>
                 </div>
@@ -885,28 +885,28 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <a
-                  class="c28 c29"
+                  class="c27 c28"
                   data-testid="details-link"
                   href="/report/1234"
                 >
                   <div
-                    class="c30"
+                    class="c29"
                     data-testid="progressbar-box"
                     title="Done"
                   >
                     <div
                       background="low"
-                      class="c31"
+                      class="c30"
                       data-testid="progress"
                     />
                     <div
-                      class="c32"
+                      class="c31"
                     >
                       <span
-                        class="c33"
+                        class="c32"
                       >
                         Done
                       </span>
@@ -917,13 +917,13 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <div
-                  class="c9"
+                  class="c8"
                 >
                   <a
-                    class="c28"
+                    class="c27"
                     href="/reports?filter=task_id%3D1234%20sort-reverse%3Ddate"
                     title="View list of all reports for Task foo, including unfinished ones"
                   >
@@ -934,11 +934,11 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <span>
                   <a
-                    class="c28"
+                    class="c27"
                     data-testid="details-link"
                     href="/report/1234"
                   >
@@ -949,20 +949,20 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <div
-                  class="c30"
+                  class="c29"
                   data-testid="progressbar-box"
                   title="Medium"
                 >
                   <div
                     background="warn"
-                    class="c34"
+                    class="c33"
                     data-testid="progress"
                   />
                   <div
-                    class="c32"
+                    class="c31"
                   >
                     5.0 (Medium)
                   </div>
@@ -971,7 +971,7 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c35"
+                class="c34"
               >
                 <span />
               </div>
@@ -981,13 +981,13 @@ exports[`Tasks table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c36 c10"
+                  class="c35 c9"
                 >
                   <div
-                    class="c37 c11"
+                    class="c36 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Start"
                     >
@@ -999,7 +999,7 @@ exports[`Tasks table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Task is not stopped"
                     >
@@ -1010,7 +1010,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Task to trashcan"
                     >
@@ -1021,7 +1021,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Task"
                     >
@@ -1032,7 +1032,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Task"
                     >
@@ -1043,7 +1043,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Task"
                     >
@@ -1061,26 +1061,26 @@ exports[`Tasks table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <div
-                  class="c26"
+                  class="c25"
                 >
                   <span
-                    class="c27"
+                    class="c26"
                     name="12345"
                   >
                     lorem
                   </span>
                   <div
-                    class="c9 c10"
+                    class="c8 c9"
                   >
                     <div
-                      class="c9 c11"
+                      class="c8 c10"
                     >
                       <span
                         alt="Task owned by user"
-                        class="c3 c5"
+                        class="c4"
                         data-testid="svg-icon"
                         title="Task owned by user"
                       >
@@ -1104,26 +1104,26 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <span
-                  class="c28 c29"
+                  class="c27 c28"
                 >
                   <div
-                    class="c30"
+                    class="c29"
                     data-testid="progressbar-box"
                     title="New"
                   >
                     <div
                       background="new"
-                      class="c38"
+                      class="c37"
                       data-testid="progress"
                     />
                     <div
-                      class="c32"
+                      class="c31"
                     >
                       <span
-                        class="c33"
+                        class="c32"
                       >
                         New
                       </span>
@@ -1134,22 +1134,22 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               />
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               />
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               />
             </td>
             <td>
               <div
-                class="c35"
+                class="c34"
               >
                 <span />
               </div>
@@ -1159,13 +1159,13 @@ exports[`Tasks table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c36 c10"
+                  class="c35 c9"
                 >
                   <div
-                    class="c37 c11"
+                    class="c36 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Start"
                     >
@@ -1177,7 +1177,7 @@ exports[`Tasks table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Task is not stopped"
                     >
@@ -1188,7 +1188,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Task to trashcan"
                     >
@@ -1199,7 +1199,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Task"
                     >
@@ -1210,7 +1210,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Task"
                     >
@@ -1221,7 +1221,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Task"
                     >
@@ -1239,26 +1239,26 @@ exports[`Tasks table tests should render 1`] = `
           <tr>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <div
-                  class="c26"
+                  class="c25"
                 >
                   <span
-                    class="c27"
+                    class="c26"
                     name="123456"
                   >
                     hello
                   </span>
                   <div
-                    class="c9 c10"
+                    class="c8 c9"
                   >
                     <div
-                      class="c9 c11"
+                      class="c8 c10"
                     >
                       <span
                         alt="Task owned by user"
-                        class="c3 c5"
+                        class="c4"
                         data-testid="svg-icon"
                         title="Task owned by user"
                       >
@@ -1282,28 +1282,28 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <a
-                  class="c28 c29"
+                  class="c27 c28"
                   data-testid="details-link"
                   href="/report/5678"
                 >
                   <div
-                    class="c30"
+                    class="c29"
                     data-testid="progressbar-box"
                     title="Running"
                   >
                     <div
                       background="run"
-                      class="c39"
+                      class="c38"
                       data-testid="progress"
                     />
                     <div
-                      class="c32"
+                      class="c31"
                     >
                       <span
-                        class="c33"
+                        class="c32"
                       >
                         0 %
                       </span>
@@ -1314,13 +1314,13 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <div
-                  class="c9"
+                  class="c8"
                 >
                   <a
-                    class="c28"
+                    class="c27"
                     href="/reports?filter=task_id%3D123456%20sort-reverse%3Ddate"
                     title="View list of all reports for Task hello, including unfinished ones"
                   >
@@ -1331,11 +1331,11 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <span>
                   <a
-                    class="c28"
+                    class="c27"
                     data-testid="details-link"
                     href="/report/1234"
                   >
@@ -1346,20 +1346,20 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c25"
+                class="c24"
               >
                 <div
-                  class="c30"
+                  class="c29"
                   data-testid="progressbar-box"
                   title="High"
                 >
                   <div
                     background="error"
-                    class="c40"
+                    class="c39"
                     data-testid="progress"
                   />
                   <div
-                    class="c32"
+                    class="c31"
                   >
                     10.0 (High)
                   </div>
@@ -1368,7 +1368,7 @@ exports[`Tasks table tests should render 1`] = `
             </td>
             <td>
               <div
-                class="c35"
+                class="c34"
               >
                 <span />
               </div>
@@ -1378,13 +1378,13 @@ exports[`Tasks table tests should render 1`] = `
                 class="c0"
               >
                 <div
-                  class="c36 c10"
+                  class="c35 c9"
                 >
                   <div
-                    class="c37 c11"
+                    class="c36 c10"
                   >
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Stop"
                     >
@@ -1396,7 +1396,7 @@ exports[`Tasks table tests should render 1`] = `
                     </span>
                     <span
                       alt="Resume"
-                      class="c3 c12 c5"
+                      class="c11 c4"
                       data-testid="svg-icon"
                       title="Task is not stopped"
                     >
@@ -1407,7 +1407,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Move Task to trashcan"
                     >
@@ -1418,7 +1418,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Edit Task"
                     >
@@ -1429,7 +1429,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Clone Task"
                     >
@@ -1440,7 +1440,7 @@ exports[`Tasks table tests should render 1`] = `
                       </svg>
                     </span>
                     <span
-                      class="c3 c4 c5"
+                      class="c3 c4"
                       data-testid="svg-icon"
                       title="Export Task"
                     >
@@ -1462,42 +1462,42 @@ exports[`Tasks table tests should render 1`] = `
               colspan="10"
             >
               <div
-                class="c7"
+                class="c6"
               >
                 <div
-                  class="c9 c10"
+                  class="c8 c9"
                 >
                   <div
-                    class="c9 c11"
+                    class="c8 c10"
                   >
                     <div
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-labelledby="downshift-0-label"
-                      class="c41"
+                      class="c40"
                       role="combobox"
                     >
                       <div
-                        class="c42"
+                        class="c41"
                         width="180px"
                       >
                         <div
                           aria-haspopup="true"
                           aria-label="open menu"
-                          class="c43"
+                          class="c42"
                           data-toggle="true"
                           role="button"
                           type="button"
                         >
                           <div
-                            class="c44 c45"
+                            class="c43 c44"
                             data-testid="select-selected-value"
                           />
                           <div
-                            class="c46"
+                            class="c45"
                           >
                             <span
-                              class="c47 c48"
+                              class="c46 c47"
                               data-testid="select-open-button"
                             >
                               ▼
@@ -1506,20 +1506,20 @@ exports[`Tasks table tests should render 1`] = `
                         </div>
                       </div>
                       <div
-                        class="c49"
+                        class="c48"
                         data-testid="error-marker"
                       >
                         ×
                       </div>
                     </div>
                     <div
-                      class="c9 c10"
+                      class="c8 c9"
                     >
                       <div
-                        class="c9 c11"
+                        class="c8 c10"
                       >
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1527,7 +1527,7 @@ exports[`Tasks table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1535,7 +1535,7 @@ exports[`Tasks table tests should render 1`] = `
                           </svg>
                         </span>
                         <span
-                          class="c3 c5"
+                          class="c4"
                           data-testid="svg-icon"
                         >
                           <svg>
@@ -1552,24 +1552,24 @@ exports[`Tasks table tests should render 1`] = `
         </tfoot>
       </table>
       <div
-        class="c26"
+        class="c25"
       >
         <div
-          class="c9 c50"
+          class="c8 c49"
         >
           (Applied filter: rows=2)
         </div>
         <div
-          class="c7 c8"
+          class="c6 c7"
         >
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="First"
               >
@@ -1580,7 +1580,7 @@ exports[`Tasks table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Previous"
               >
@@ -1593,18 +1593,18 @@ exports[`Tasks table tests should render 1`] = `
             </div>
           </div>
           <span
-            class="c13"
+            class="c12"
           >
             1 - 1 of 1
           </span>
           <div
-            class="c9 c10"
+            class="c8 c9"
           >
             <div
-              class="c9 c11"
+              class="c8 c10"
             >
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Next"
               >
@@ -1615,7 +1615,7 @@ exports[`Tasks table tests should render 1`] = `
                 </svg>
               </span>
               <span
-                class="c3 c12 c5"
+                class="c11 c4"
                 data-testid="svg-icon"
                 title="Last"
               >


### PR DESCRIPTION
## What
Updating test snapshots after dependabot update https://github.com/greenbone/gsa/pull/3951 which bumps styled-components from v6.1.1 to v6.1.8.

## Why
Test cases were failing.

## References
GEA-451
