### PR TITLE
Fix: Update the import of redux-thunk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,9 +47,9 @@
         "react-redux": "^8.1.3",
         "react-router-dom": "^5.2.0",
         "react-scripts": "^5.0.1",
-        "redux": "^4.2.1",
+        "redux": "^5.0.1",
         "redux-logger": "^3.0.6",
-        "redux-thunk": "^2.4.2",
+        "redux-thunk": "^3.1.0",
         "styled-components": "^6.1.1",
         "uuid": "^9.0.1",
         "whatwg-fetch": "^3.6.19"
@@ -5129,6 +5129,14 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
+      }
+    },
+    "node_modules/@types/react-redux/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -18529,6 +18537,14 @@
         }
       }
     },
+    "node_modules/react-beautiful-dnd/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
     "node_modules/react-datepicker": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-1.8.0.tgz",
@@ -20287,13 +20303,9 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "node_modules/redux-logger": {
       "version": "3.0.6",
@@ -20305,12 +20317,11 @@
       }
     },
     "node_modules/redux-thunk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
-      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
-      "license": "MIT",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
       "peerDependencies": {
-        "redux": "^4"
+        "redux": "^5.0.0"
       }
     },
     "node_modules/regenerate": {

--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
     "react-redux": "^8.1.3",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^5.0.1",
-    "redux": "^4.2.1",
+    "redux": "^5.0.1",
     "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.4.2",
+    "redux-thunk": "^3.1.0",
     "styled-components": "^6.1.1",
     "uuid": "^9.0.1",
     "whatwg-fetch": "^3.6.19"

--- a/src/web/store/index.js
+++ b/src/web/store/index.js
@@ -18,7 +18,7 @@
 
 import {createStore, applyMiddleware} from 'redux';
 
-import thunk from 'redux-thunk';
+import {thunk} from 'redux-thunk';
 
 import {createLogger} from 'redux-logger';
 


### PR DESCRIPTION
## What

Update the import of redux-thunk after dependabot update https://github.com/greenbone/gsa/pull/3939

## Why

 The default export has been removed as of v3.1.0 and now there are named exports. See [redux-thunk/releases/tag/v3.1.0](https://github.com/reduxjs/redux-thunk/releases/tag/v3.1.0).

## References
GEA-451


