### PR TITLE
Fix: Avoid re-render when user settings haven't changed for FilterProvider

### DIFF
--- a/src/web/entities/filterprovider.js
+++ b/src/web/entities/filterprovider.js
@@ -18,7 +18,7 @@
 
 import React, {useEffect, useState} from 'react';
 
-import {useSelector, useDispatch} from 'react-redux';
+import {useSelector, useDispatch, shallowEqual} from 'react-redux';
 
 import {ROWS_PER_PAGE_SETTING_ID} from 'gmp/commands/users';
 
@@ -84,7 +84,7 @@ const FilterProvider = ({
       userSettingDefaultSel.getValueByName('rowsperpage'),
       userSettingDefaultSel.getError(),
     ];
-  });
+  }, shallowEqual);
 
   useEffect(() => {
     if (!isDefined(rowsPerPage)) {


### PR DESCRIPTION


## What

Avoid unnecessary re-renders in FilterProvider when getting the rowsPerPage settings from the redux store.

## Why

The behavior of `useSelector` hook and "old" `connect` function is differently. `useSelector` uses identity comparison `===` for detecting if the returned object has changed and a re-render is necessary. In contrast `connect` uses shallow comparison. See https://react-redux.js.org/api/hooks#equality-comparisons-and-updates for all details.

Therefore to avoid re-renders in the FilterProvider we need to compare the contents of returned array from the user settings selector via `shallowEqual` because with every call a new array is created and the identity changes.


