### PR TITLE
Allow to rebuild a specific container image

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      ref-name:
+        type: string
+        description: "The ref to build a container image from. For example a tag v23.0.0."
+        required: true
 
 jobs:
   images:
@@ -19,19 +24,24 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ inputs.ref-name || '' }}
       - uses: greenbone/actions/is-latest-tag@v3
         id: latest
+        with:
+          tag-name: ${{ inputs.ref-name || github.ref_name }}
       - name: Setup container meta information
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ github.repository }}
+          context: git
           labels: |
             org.opencontainers.image.vendor=Greenbone
             org.opencontainers.image.base.name=greenbone/gsad
           flavor: latest=false # no latest container tag for git tags
           tags: |
-            # use version, major.minor and major  for tags
+            # use version, major.minor and major for tags
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION


## What

Allow to rebuild a specific container image

## Why

Use workflow dispatch event to trigger a re-build of a specific container image. Therefore the passed tag will be checked out. The git tag and sha from the checkout will be used to determine the container image labels instead of deriving them from the github workflow context.

## References

https://forum.greenbone.net/t/update-path-for-community-containers-to-version-23/16594/4


