### PR TITLE
Fix: Remove warning when running lint staged pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,8 +121,7 @@
   },
   "lint-staged": {
     "*.{js,json}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   }
 }


### PR DESCRIPTION
## What

Remove warning when running lint staged pre-commit hook

## Why
Running `git add` is obsolete with the lint-staged version in use.