### PR TITLE
Change: Allow to set a filter type to create in withFilterDialog

### DIFF
--- a/src/web/components/powerfilter/withFilterDialog.js
+++ b/src/web/components/powerfilter/withFilterDialog.js
@@ -19,11 +19,16 @@ import React from 'react';
 
 import FilterDialog from './filterdialog';
 
-const withFilterDialog = (options = {}) => FilterDialogComponent => props => (
-  <FilterDialog {...props}>
-    {dialogProps => <FilterDialogComponent {...options} {...dialogProps} />}
-  </FilterDialog>
-);
+const withFilterDialog =
+  ({createFilterType, ...options} = {}) =>
+  FilterDialogComponent =>
+  (
+    {createFilterType: createFilterTypeProp = createFilterType, ...props}, // eslint-disable-line react/prop-types
+  ) => (
+    <FilterDialog {...props} createFilterType={createFilterTypeProp}>
+      {dialogProps => <FilterDialogComponent {...options} {...dialogProps} />}
+    </FilterDialog>
+  );
 
 export default withFilterDialog;
 


### PR DESCRIPTION
## What

Allow to set a filter type to create in withFilterDialog

## Why

With this change it is possible to define the filter type to use when a new filter is created directly when writing a filter dialog component. Before it was required to pass it via a prop. Passing via a prop is still optional.

Example usage now (implicitly):
```
createFilterDialog({
  createFilterType: 'portlist',
  sortFields: SORT_FIELDS,
});
```

