### PR TITLE
Add: Add report config to report download composer

### DIFF
--- a/src/gmp/commands/reports.js
+++ b/src/gmp/commands/reports.js
@@ -86,13 +86,14 @@ export class ReportCommand extends EntityCommand {
     });
   }
 
-  download({id}, {reportFormatId, deltaReportId, filter}) {
+  download({id}, {reportFormatId, reportConfigId, deltaReportId, filter}) {
     return this.httpGet(
       {
         cmd: 'get_report',
         delta_report_id: deltaReportId,
         details: 1,
         report_id: id,
+        report_config_id: reportConfigId,
         report_format_id: reportFormatId,
         filter: isDefined(filter) ? filter.all() : ALL_FILTER,
       },

--- a/src/web/pages/reports/downloadreportdialog.js
+++ b/src/web/pages/reports/downloadreportdialog.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import React, {useState} from 'react';
 
 import styled from 'styled-components';
 
@@ -25,7 +25,7 @@ import _ from 'gmp/locale';
 import {NO_VALUE, YES_VALUE} from 'gmp/parser';
 
 import {selectSaveId} from 'gmp/utils/id';
-import {isString} from 'gmp/utils/identity';
+import {isDefined, isString} from 'gmp/utils/identity';
 import PropTypes from 'web/utils/proptypes';
 import {renderSelectItems} from 'web/utils/render';
 
@@ -48,10 +48,13 @@ const StyledDiv = styled.div`
 `;
 
 const DownloadReportDialog = ({
+  defaultReportConfigId,
   defaultReportFormatId,
   filter = {},
   includeNotes = COMPOSER_CONTENT_DEFAULTS.includeNotes,
   includeOverrides = COMPOSER_CONTENT_DEFAULTS.includeOverrides,
+  reportConfigId,
+  reportConfigs,
   reportFormatId,
   reportFormats,
   showThresholdMessage = false,
@@ -62,13 +65,38 @@ const DownloadReportDialog = ({
 }) => {
   const filterString = isString(filter) ? filter : filter.toFilterString();
 
-  reportFormatId = selectSaveId(reportFormats, defaultReportFormatId);
+  if (defaultReportConfigId === '' || !isDefined(defaultReportConfigId)) {
+    reportConfigId = '';
+  } else {
+    reportConfigId = selectSaveId(reportConfigs, defaultReportConfigId, '');
+  }
+
+  const [reportFormatIdInState, setReportFormatId] = useState(
+    selectSaveId(reportFormats, defaultReportFormatId),
+  );
+  const [reportConfigIdInState, setReportConfigId] = useState(reportConfigId);
 
   const unControlledValues = {
     includeNotes,
     includeOverrides,
-    reportFormatId,
     storeAsDefault,
+  };
+
+  const handleReportFormatIdChange = value => {
+    setReportConfigId('');
+    setReportFormatId(value);
+  };
+
+  const handleReportConfigIdChange = value => {
+    setReportConfigId(value);
+  };
+
+  const handleSave = values => {
+    onSave({
+      ...values,
+      reportConfigId: reportConfigIdInState,
+      reportFormatId: reportFormatIdInState,
+    });
   };
 
   return (
@@ -77,52 +105,72 @@ const DownloadReportDialog = ({
       title={_('Compose Content for Scan Report')}
       defaultValues={unControlledValues}
       onClose={onClose}
-      onSave={onSave}
+      onSave={handleSave}
     >
-      {({values, onValueChange}) => (
-        <Layout flex="column">
-          <ComposerContent
-            filterString={filterString}
-            includeNotes={values.includeNotes}
-            includeOverrides={values.includeOverrides}
-            onValueChange={onValueChange}
-          />
-          <FormGroup title={_('Report Format')} titleSize="3">
-            <Divider flex="column">
-              <Select
-                name="reportFormatId"
-                value={values.reportFormatId}
-                items={renderSelectItems(reportFormats)}
-                width="auto"
+      {({values, onValueChange}) => {
+        const filteredReportConfigs = reportConfigs.filter(
+          config => config.report_format.id === reportFormatIdInState,
+        );
+
+        return (
+          <Layout flex="column">
+            <ComposerContent
+              filterString={filterString}
+              includeNotes={values.includeNotes}
+              includeOverrides={values.includeOverrides}
+              onValueChange={onValueChange}
+            />
+            <FormGroup title={_('Report Format')} titleSize="3">
+              <Divider flex="column">
+                <Select
+                  name="reportFormatId"
+                  value={reportFormatIdInState}
+                  items={renderSelectItems(reportFormats)}
+                  width="auto"
+                  onChange={handleReportFormatIdChange}
+                />
+              </Divider>
+            </FormGroup>
+            <FormGroup title={_('Report Config')} titleSize="3">
+              <Divider flex="column">
+                <Select
+                  name="reportConfigId"
+                  value={reportConfigIdInState}
+                  items={renderSelectItems(filteredReportConfigs, '')}
+                  width="auto"
+                  onChange={handleReportConfigIdChange}
+                />
+              </Divider>
+            </FormGroup>
+            <StyledDiv>
+              <CheckBox
+                name="storeAsDefault"
+                checked={storeAsDefault}
+                checkedValue={YES_VALUE}
+                unCheckedValue={NO_VALUE}
+                title={_('Store as default')}
+                toolTipTitle={_(
+                  'Store indicated settings (without filter) as default',
+                )}
                 onChange={onValueChange}
               />
-            </Divider>
-          </FormGroup>
-          <StyledDiv>
-            <CheckBox
-              name="storeAsDefault"
-              checked={storeAsDefault}
-              checkedValue={YES_VALUE}
-              unCheckedValue={NO_VALUE}
-              title={_('Store as default')}
-              toolTipTitle={_(
-                'Store indicated settings (without filter) as default',
-              )}
-              onChange={onValueChange}
-            />
-          </StyledDiv>
-          {showThresholdMessage && <ThresholdMessage threshold={threshold} />}
-        </Layout>
-      )}
+            </StyledDiv>
+            {showThresholdMessage && <ThresholdMessage threshold={threshold} />}
+          </Layout>
+        );
+      }}
     </SaveDialog>
   );
 };
 
 DownloadReportDialog.propTypes = {
+  defaultReportConfigId: PropTypes.id,
   defaultReportFormatId: PropTypes.id,
   filter: PropTypes.filter.isRequired,
   includeNotes: PropTypes.number,
   includeOverrides: PropTypes.number,
+  reportConfigId: PropTypes.id,
+  reportConfigs: PropTypes.array,
   reportFormatId: PropTypes.id,
   reportFormats: PropTypes.array,
   showThresholdMessage: PropTypes.bool,


### PR DESCRIPTION
## What
In the composer dialog for downloading a report it is now possible to select a report config to apply.

## Why
This is one of the main use cases for report configs.

## References
GEA-473

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


