### PR TITLE
Fix: Pass missing timezone to DatePicker component

### DIFF
--- a/src/web/pages/schedules/dialog.js
+++ b/src/web/pages/schedules/dialog.js
@@ -141,10 +141,7 @@ class ScheduleDialog extends React.Component {
     const {
       duration,
       timezone = 'UTC',
-      startDate = date()
-        .tz(timezone)
-        .startOf('hour')
-        .add(1, 'hour'),
+      startDate = date().tz(timezone).startOf('hour').add(1, 'hour'),
     } = props;
     let {freq, interval = 1, weekdays, monthdays} = this.props;
 
@@ -469,6 +466,7 @@ class ScheduleDialog extends React.Component {
             <FormGroup title={_('Run Until')}>
               <DatePicker
                 disabled={state.endOpen}
+                timezone={timezone}
                 name="endDate"
                 value={state.endDate}
                 onChange={this.handleValueChange}


### PR DESCRIPTION
## What
Pass missing timezone to DatePicker component.

## Why
Timezone was not passed to DatePicker for the "Run Until".

## References
GEA-523


