### PR TITLE
Add: New multi_selection report format param type

### DIFF
--- a/src/gmp/commands/__tests__/reportconfig.js
+++ b/src/gmp/commands/__tests__/reportconfig.js
@@ -64,11 +64,19 @@ describe('ReportConfigCommand tests', () => {
           'param 1': 'value 1',
           'param 2': 'value 2',
           'param 3': ['report-format-1', 'report-format-2'],
+          'param 4': ['option-1', 'option-2'],
         },
         params_using_default: {
           'param 1': false,
           'param 2': true,
           'param 3': false,
+          'param 4': false,
+        },
+        param_types: {
+          'param 1': 'string',
+          'param 2': 'text',
+          'param 3': 'report_format_list',
+          'param 4': 'multi_selection',
         },
       })
       .then(resp => {
@@ -81,6 +89,7 @@ describe('ReportConfigCommand tests', () => {
             'param:param 1': 'value 1',
             'param:param 2': 'value 2',
             'param:param 3': 'report-format-1,report-format-2',
+            'param:param 4': '["option-1","option-2"]',
             'param_using_default:param 2': 1,
           },
         });
@@ -106,11 +115,19 @@ describe('ReportConfigCommand tests', () => {
           'param 1': 'value A',
           'param 2': 'value B',
           'param 3': ['report-format-A', 'report-format-B'],
+          'param 4': ['option-1', 'option-2'],
         },
         params_using_default: {
           'param 1': true,
           'param 2': false,
           'param 3': false,
+          'param 4': false,
+        },
+        param_types: {
+          'param 1': 'string',
+          'param 2': 'text',
+          'param 3': 'report_format_list',
+          'param 4': 'multi_selection',
         },
       })
       .then(resp => {
@@ -122,6 +139,7 @@ describe('ReportConfigCommand tests', () => {
             'param:param 1': 'value A',
             'param:param 2': 'value B',
             'param:param 3': 'report-format-A,report-format-B',
+            'param:param 4': '["option-1","option-2"]',
             'param_using_default:param 1': 1,
           },
         });

--- a/src/gmp/commands/reportconfigs.js
+++ b/src/gmp/commands/reportconfigs.js
@@ -41,6 +41,7 @@ export class ReportConfigCommand extends EntityCommand {
       report_format_id,
       params = {},
       params_using_default = {},
+      param_types = {},
     } = args;
 
     const data = {
@@ -52,8 +53,12 @@ export class ReportConfigCommand extends EntityCommand {
 
     for (const prefname in params) {
       let value = params[prefname];
-      if (isArray(params[prefname])) {
-        value = params[prefname].join(',');
+      if (isArray(value)) {
+        if (param_types[prefname] === 'report_format_list') {
+          value = params[prefname].join(',');
+        } else {
+          value = JSON.stringify(params[prefname]);
+        }
       }
       data['param:' + prefname] = value;
     }
@@ -71,7 +76,14 @@ export class ReportConfigCommand extends EntityCommand {
   }
 
   save(args) {
-    const {id, comment, name, params = {}, params_using_default = {}} = args;
+    const {
+      id,
+      comment,
+      name,
+      params = {},
+      params_using_default = {},
+      param_types = {},
+    } = args;
 
     const data = {
       cmd: 'save_report_config',
@@ -91,7 +103,11 @@ export class ReportConfigCommand extends EntityCommand {
     for (const prefname in params) {
       let value = params[prefname];
       if (isArray(params[prefname])) {
-        value = params[prefname].join(',');
+        if (param_types[prefname] === 'report_format_list') {
+          value = params[prefname].join(',');
+        } else {
+          value = JSON.stringify(params[prefname]);
+        }
       }
       data['param:' + prefname] = value;
     }

--- a/src/gmp/models/__tests__/reportformat.js
+++ b/src/gmp/models/__tests__/reportformat.js
@@ -231,6 +231,9 @@ describe('ReportFormat model tests', () => {
             value: {
               report_format: [{_id: '42'}, {_id: '21'}],
             },
+            default: {
+              report_format: [{_id: '43'}, {_id: '22'}],
+            },
           },
         ],
       };

--- a/src/gmp/models/reportconfig.js
+++ b/src/gmp/models/reportconfig.js
@@ -56,6 +56,9 @@ class Param {
       forEach(other.default.report_format, format => {
         this.default_labels[format._id] = format.name;
       });
+    } else if (this.type === 'multi_selection') {
+      this.value = JSON.parse(get_value(value));
+      this.default = JSON.parse(get_value(other.default));
     } else if (this.type === 'integer') {
       this.value = parseInt(get_value(value));
       this.default = parseInt(get_value(other.default));

--- a/src/gmp/models/reportformat.js
+++ b/src/gmp/models/reportformat.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 import {isDefined, isObject} from 'gmp/utils/identity';
-import {map} from 'gmp/utils/array';
+import {forEach, map} from 'gmp/utils/array';
 import {isEmpty} from 'gmp/utils/string';
 
 import {parseDate, parseYesNo, YES_VALUE, parseBoolean} from 'gmp/parser';
@@ -48,11 +48,27 @@ class Param {
 
     if (this.type === 'report_format_list') {
       this.value = map(value.report_format, format => format._id);
+      this.default = map(other.default.report_format, format => format._id);
+      this.value_labels = {};
+      this.default_labels = {};
+      forEach(value.report_format, format => {
+        this.value_labels[format._id] = format.name;
+      });
+      forEach(other.default.report_format, format => {
+        this.default_labels[format._id] = format.name;
+      });
     } else if (this.type === 'multi_selection') {
       this.value = JSON.parse(get_value(value));
       this.default = JSON.parse(get_value(other.default));
+    } else if (this.type === 'integer') {
+      this.value = parseInt(get_value(value));
+      this.default = parseInt(get_value(other.default));
+    } else if (this.type === 'boolean') {
+      this.value = parseBoolean(get_value(value));
+      this.default = parseBoolean(get_value(other.default));
     } else {
       this.value = get_value(value);
+      this.default = get_value(other.default);
     }
   }
 }

--- a/src/gmp/models/reportformat.js
+++ b/src/gmp/models/reportformat.js
@@ -48,6 +48,9 @@ class Param {
 
     if (this.type === 'report_format_list') {
       this.value = map(value.report_format, format => format._id);
+    } else if (this.type === 'multi_selection') {
+      this.value = JSON.parse(get_value(value));
+      this.default = JSON.parse(get_value(other.default));
     } else {
       this.value = get_value(value);
     }

--- a/src/gmp/parser.js
+++ b/src/gmp/parser.js
@@ -230,6 +230,7 @@ export const parseDuration = value => {
  */
 export const parseBoolean = value => {
   if (isString(value)) {
+    if (value.trim().toLowerCase() === 'true') return true;
     value = parseInt(value);
   }
   if (isNumber(value)) {

--- a/src/web/pages/reportconfigs/__tests__/__snapshots__/details.jsx.snap
+++ b/src/web/pages/reportconfigs/__tests__/__snapshots__/details.jsx.snap
@@ -167,7 +167,9 @@ exports[`Report Config Details tests > should render full Details 1`] = `
                   class=""
                 >
                   <tr>
-                    <td>
+                    <td
+                      class="c7"
+                    >
                       <div
                         class="c5"
                       >
@@ -183,7 +185,9 @@ exports[`Report Config Details tests > should render full Details 1`] = `
                     </td>
                   </tr>
                   <tr>
-                    <td>
+                    <td
+                      class="c7"
+                    >
                       <div
                         class="c5"
                       >
@@ -201,7 +205,9 @@ exports[`Report Config Details tests > should render full Details 1`] = `
                     </td>
                   </tr>
                   <tr>
-                    <td>
+                    <td
+                      class="c7"
+                    >
                       <div
                         class="c5"
                       >
@@ -217,7 +223,9 @@ exports[`Report Config Details tests > should render full Details 1`] = `
                     </td>
                   </tr>
                   <tr>
-                    <td>
+                    <td
+                      class="c7"
+                    >
                       <div
                         class="c5"
                       >
@@ -233,7 +241,9 @@ exports[`Report Config Details tests > should render full Details 1`] = `
                     </td>
                   </tr>
                   <tr>
-                    <td>
+                    <td
+                      class="c7"
+                    >
                       <div
                         class="c5"
                       >
@@ -249,7 +259,9 @@ exports[`Report Config Details tests > should render full Details 1`] = `
                     </td>
                   </tr>
                   <tr>
-                    <td>
+                    <td
+                      class="c7"
+                    >
                       <div
                         class="c5"
                       >

--- a/src/web/pages/reportconfigs/__tests__/__snapshots__/detailspage.jsx.snap
+++ b/src/web/pages/reportconfigs/__tests__/__snapshots__/detailspage.jsx.snap
@@ -876,7 +876,9 @@ exports[`Report Config Details Page tests > should render full Details page with
                           class=""
                         >
                           <tr>
-                            <td>
+                            <td
+                              class="c34"
+                            >
                               <div
                                 class="c29"
                               >
@@ -892,7 +894,9 @@ exports[`Report Config Details Page tests > should render full Details page with
                             </td>
                           </tr>
                           <tr>
-                            <td>
+                            <td
+                              class="c34"
+                            >
                               <div
                                 class="c29"
                               >
@@ -910,7 +914,9 @@ exports[`Report Config Details Page tests > should render full Details page with
                             </td>
                           </tr>
                           <tr>
-                            <td>
+                            <td
+                              class="c34"
+                            >
                               <div
                                 class="c29"
                               >
@@ -926,7 +932,9 @@ exports[`Report Config Details Page tests > should render full Details page with
                             </td>
                           </tr>
                           <tr>
-                            <td>
+                            <td
+                              class="c34"
+                            >
                               <div
                                 class="c29"
                               >
@@ -942,7 +950,9 @@ exports[`Report Config Details Page tests > should render full Details page with
                             </td>
                           </tr>
                           <tr>
-                            <td>
+                            <td
+                              class="c34"
+                            >
                               <div
                                 class="c29"
                               >
@@ -958,7 +968,9 @@ exports[`Report Config Details Page tests > should render full Details page with
                             </td>
                           </tr>
                           <tr>
-                            <td>
+                            <td
+                              class="c34"
+                            >
                               <div
                                 class="c29"
                               >

--- a/src/web/pages/reportconfigs/__tests__/__snapshots__/dialog.jsx.snap
+++ b/src/web/pages/reportconfigs/__tests__/__snapshots__/dialog.jsx.snap
@@ -1354,11 +1354,12 @@ exports[`Edit Report Config Dialog component tests > should render dialog with d
                                         class="c13 c34"
                                       >
                                         <input
+                                          checked=""
                                           class="c35 c44"
                                           data-testid="radio-input"
                                           name="BooleanParam"
                                           type="radio"
-                                          value="1"
+                                          value="true"
                                         />
                                         <span
                                           class="c45"
@@ -1383,7 +1384,7 @@ exports[`Edit Report Config Dialog component tests > should render dialog with d
                                           data-testid="radio-input"
                                           name="BooleanParam"
                                           type="radio"
-                                          value="0"
+                                          value="false"
                                         />
                                         <span
                                           class="c45"

--- a/src/web/pages/reportconfigs/__tests__/component.jsx
+++ b/src/web/pages/reportconfigs/__tests__/component.jsx
@@ -134,6 +134,9 @@ describe('Report Config Component tests', () => {
       entityType: 'reportconfig',
       id: 'rc123',
       name: 'test report config',
+      param_types: {
+        'test param': 'string',
+      },
       params: {
         'test param': 'ABC',
       },
@@ -224,6 +227,9 @@ describe('Report Config Component tests', () => {
     expect(createReportConfig).toHaveBeenCalledWith({
       name: 'Unnamed',
       comment: '',
+      param_types: {
+        'test param': 'string',
+      },
       params: {
         'test param': 'ABC',
       },

--- a/src/web/pages/reportconfigs/__tests__/dialog.jsx
+++ b/src/web/pages/reportconfigs/__tests__/dialog.jsx
@@ -94,6 +94,14 @@ describe('Edit Report Config Dialog component tests', () => {
 
     expect(handleSave).toHaveBeenCalledWith({
       ...config,
+      param_types: {
+        BooleanParam: 'boolean',
+        IntegerParam: 'integer',
+        ReportFormatListParam: 'report_format_list',
+        SelectionParam: 'selection',
+        StringParam: 'string',
+        TextParam: 'text',
+      },
       params: {
         BooleanParam: true,
         IntegerParam: 12,
@@ -210,6 +218,14 @@ describe('Edit Report Config Dialog component tests', () => {
       ...config,
       name: 'lorem',
       comment: 'ipsum',
+      param_types: {
+        BooleanParam: 'boolean',
+        IntegerParam: 'integer',
+        ReportFormatListParam: 'report_format_list',
+        SelectionParam: 'selection',
+        StringParam: 'string',
+        TextParam: 'text',
+      },
       params: {
         BooleanParam: false,
         IntegerParam: 7,
@@ -279,6 +295,14 @@ describe('Edit Report Config Dialog component tests', () => {
 
     expect(handleSave).toHaveBeenCalledWith({
       ...config,
+      param_types: {
+        BooleanParam: 'boolean',
+        IntegerParam: 'integer',
+        ReportFormatListParam: 'report_format_list',
+        SelectionParam: 'selection',
+        StringParam: 'string',
+        TextParam: 'text',
+      },
       params: {
         BooleanParam: true,
         IntegerParam: 12,
@@ -435,6 +459,11 @@ describe('New Report Config Dialog component tests', () => {
       name: 'lorem',
       comment: 'ipsum',
       report_format_id: '1234567',
+      param_types: {
+        Param1: 'string',
+        Param2: 'string',
+        ReportFormatListParam: 'report_format_list',
+      },
       params: {
         Param1: 'ABC',
         Param2: 'XYZ',

--- a/src/web/pages/reportconfigs/__tests__/dialog.jsx
+++ b/src/web/pages/reportconfigs/__tests__/dialog.jsx
@@ -381,7 +381,20 @@ describe('New Report Config Dialog component tests', () => {
         },
         {
           name: 'ReportFormatListParam',
-          value: 'DEF',
+          value: {
+            __text: 'RF01',
+            report_format: {
+              _id: 'RF01',
+              name: 'report format 1'
+            },
+          },
+          default: {
+            __text: 'RF01',
+            report_format: {
+              _id: 'RF01',
+              name: 'report format 1'
+            },
+          },
           type: {
             __text: 'report_format_list',
             min: 0,
@@ -467,7 +480,7 @@ describe('New Report Config Dialog component tests', () => {
       params: {
         Param1: 'ABC',
         Param2: 'XYZ',
-        ReportFormatListParam: ['654321'],
+        ReportFormatListParam: ['RF01', '654321'],
       },
       params_using_default: {
         Param1: true,

--- a/src/web/pages/reportconfigs/details.jsx
+++ b/src/web/pages/reportconfigs/details.jsx
@@ -67,7 +67,7 @@ export const ReportConfigParamValue = ({
     `;
     return (
       <OptionsList>
-        {param.value.map(option => (
+        {value.map(option => (
           <li key={param.name + '=' + option}>{option}</li>
         ))}
       </OptionsList>

--- a/src/web/pages/reportconfigs/details.jsx
+++ b/src/web/pages/reportconfigs/details.jsx
@@ -36,6 +36,8 @@ import {map} from 'gmp/utils/array';
 import {isDefined} from 'gmp/utils/identity';
 import {renderYesNo} from 'web/utils/render';
 
+import styled from 'styled-components';
+
 export const ReportConfigParamValue = ({
   param,
   value = param.value,
@@ -58,6 +60,18 @@ export const ReportConfigParamValue = ({
         </DetailsLink>
       );
     });
+  } else if (param.type === 'multi_selection') {
+    const OptionsList = styled.ul`
+      margin: 0;
+      padding-left: 1em;
+    `;
+    return (
+      <OptionsList>
+        {param.value.map(option => (
+          <li key={param.name + '=' + option}>{option}</li>
+        ))}
+      </OptionsList>
+    );
   } else if (param.type === 'text') {
     return <pre>{value}</pre>;
   } else if (param.type === 'boolean') {
@@ -94,7 +108,7 @@ const ReportConfigDetails = ({entity, links = true}) => {
     params.map(param => {
       return (
         <TableRow key={param.name}>
-          <TableData>{param.name}</TableData>
+          <TableDataAlignTop>{param.name}</TableDataAlignTop>
           <TableData>
             <ReportConfigParamValue param={param} links={links} />
           </TableData>

--- a/src/web/pages/reportconfigs/dialog.jsx
+++ b/src/web/pages/reportconfigs/dialog.jsx
@@ -68,6 +68,8 @@ const Param = ({
     field = (
       <YesNoRadio
         convert={parseBoolean}
+        yesValue={true}
+        noValue={false}
         name={name}
         value={field_value}
         onChange={onPrefChange}
@@ -80,6 +82,19 @@ const Param = ({
         name={name}
         min={min}
         max={max}
+        value={field_value}
+        onChange={onPrefChange}
+      />
+    );
+  } else if (type === 'multi_selection') {
+    const typeOptions = map(value.options, opt => ({
+      label: opt.name,
+      value: opt.value,
+    }));
+    field = (
+      <MultiSelect
+        name={name}
+        items={typeOptions}
         value={field_value}
         onChange={onPrefChange}
       />
@@ -222,11 +237,21 @@ class Dialog extends React.Component {
   handleSave(data) {
     const {onSave} = this.props;
     if (isDefined(onSave)) {
-      const {params, params_using_default, report_format_id} = this.state;
+      const {
+        params,
+        params_using_default,
+        report_format_id,
+        originalParamInfo,
+      } = this.state;
+      const param_types = {};
+      originalParamInfo.forEach(param_item => {
+        param_types[param_item.name] = param_item.type;
+      });
       onSave({
         ...data,
         params,
         params_using_default,
+        param_types,
         report_format_id,
       });
     }


### PR DESCRIPTION
## What
A new parameter type for report formats and report configs is added that allows selecting multiple predefined options.

Some small style changes have been made to make params with multi-line values more readable and to make the params in report formats and report configs more consistent.

## Why
The new param type can later be used to add new customization options to report formats like a column selection for CSV.

## References
GEA-403

## Checklist

- [x] Tests


