### PR TITLE
Change: Refactor DialogNotification into a function component

### DIFF
--- a/src/web/components/dialog/footer.js
+++ b/src/web/components/dialog/footer.js
@@ -36,8 +36,17 @@ export const DialogFooterLayout = styled(Layout)`
   padding: 10px 20px 10px 20px;
 `;
 
-const DialogFooter = ({title, onClick, loading = false}) => (
-  <DialogFooterLayout align={['end', 'center']} shrink="0">
+const DialogFooter = ({
+  title,
+  onClick,
+  loading = false,
+  'data-testid': dataTestId,
+}) => (
+  <DialogFooterLayout
+    align={['end', 'center']}
+    shrink="0"
+    data-testid={dataTestId}
+  >
     <Button onClick={onClick} title={title} loading={loading}>
       {title}
     </Button>
@@ -45,6 +54,7 @@ const DialogFooter = ({title, onClick, loading = false}) => (
 );
 
 DialogFooter.propTypes = {
+  'data-testid': PropTypes.string,
   loading: PropTypes.bool,
   title: PropTypes.string.isRequired,
   onClick: PropTypes.func,

--- a/src/web/components/notification/__tests__/dialognotification.js
+++ b/src/web/components/notification/__tests__/dialognotification.js
@@ -1,0 +1,171 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import React from 'react';
+
+import {rendererWith, screen, fireEvent} from 'web/utils/testing';
+
+import DialogNotification from '../dialognotification';
+import useDialogNotification from '../useDialogNotification';
+
+const TestComponent = () => {
+  const {
+    dialogState,
+    closeDialog,
+    showMessage,
+    showError,
+    showErrorMessage,
+    showSuccessMessage,
+  } = useDialogNotification();
+  return (
+    <div>
+      <button data-testid="show-message" onClick={() => showMessage('foo')} />
+      <button
+        data-testid="show-message-with-subject"
+        onClick={() => showMessage('foo', 'bar')}
+      />
+      <button
+        data-testid="show-error-message"
+        onClick={() => showErrorMessage('foo')}
+      />
+      <button
+        data-testid="show-success-message"
+        onClick={() => showSuccessMessage('foo')}
+      />
+      <button
+        data-testid="show-error"
+        onClick={() => showError(new Error('foo'))}
+      />
+      <DialogNotification {...dialogState} onCloseClick={closeDialog} />
+    </div>
+  );
+};
+
+describe('DialogNotification tests', () => {
+  test('should display a message', () => {
+    const {render} = rendererWith();
+
+    render(<TestComponent />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    const button = screen.getByTestId('show-message');
+
+    fireEvent.click(button);
+
+    const dialogTitleBar = screen.getByTestId('dialog-title-bar');
+
+    expect(dialogTitleBar).toHaveTextContent('Message');
+
+    const dialogContent = screen.getByTestId('dialog-notification-message');
+
+    expect(dialogContent).toHaveTextContent('foo');
+  });
+
+  test('should display a message with subject', () => {
+    const {render} = rendererWith();
+
+    render(<TestComponent />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    const button = screen.getByTestId('show-message-with-subject');
+
+    fireEvent.click(button);
+
+    const dialogTitleBar = screen.getByTestId('dialog-title-bar');
+
+    expect(dialogTitleBar).toHaveTextContent('bar');
+
+    const dialogContent = screen.getByTestId('dialog-notification-message');
+
+    expect(dialogContent).toHaveTextContent('foo');
+  });
+
+  test('should allow to close dialog', () => {
+    const {render} = rendererWith();
+
+    render(<TestComponent />);
+
+    const button = screen.getByTestId('show-message');
+
+    fireEvent.click(button);
+
+    const dialogTitleBar = screen.getByTestId('dialog-title-bar');
+
+    expect(dialogTitleBar).toHaveTextContent('Message');
+
+    const dialogContent = screen.getByTestId('dialog-notification-message');
+
+    expect(dialogContent).toHaveTextContent('foo');
+
+    const dialogFooter = screen.getByTestId('dialog-notification-footer');
+    const closeButton = dialogFooter.querySelector('button');
+
+    fireEvent.click(closeButton);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  test('should display an error message', () => {
+    const {render} = rendererWith();
+
+    render(<TestComponent />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    const button = screen.getByTestId('show-error-message');
+
+    fireEvent.click(button);
+
+    const dialogTitleBar = screen.getByTestId('dialog-title-bar');
+
+    expect(dialogTitleBar).toHaveTextContent('Error');
+
+    const dialogContent = screen.getByTestId('dialog-notification-message');
+
+    expect(dialogContent).toHaveTextContent('foo');
+  });
+
+  test('should display a success message', () => {
+    const {render} = rendererWith();
+
+    render(<TestComponent />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    const button = screen.getByTestId('show-success-message');
+
+    fireEvent.click(button);
+
+    const dialogTitleBar = screen.getByTestId('dialog-title-bar');
+
+    expect(dialogTitleBar).toHaveTextContent('Success');
+
+    const dialogContent = screen.getByTestId('dialog-notification-message');
+
+    expect(dialogContent).toHaveTextContent('foo');
+  });
+
+  test('should display an error', () => {
+    const {render} = rendererWith();
+
+    render(<TestComponent />);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    const button = screen.getByTestId('show-error');
+
+    fireEvent.click(button);
+
+    const dialogTitleBar = screen.getByTestId('dialog-title-bar');
+
+    expect(dialogTitleBar).toHaveTextContent('Error');
+
+    const dialogContent = screen.getByTestId('dialog-notification-message');
+
+    expect(dialogContent).toHaveTextContent('foo');
+  });
+});

--- a/src/web/components/notification/dialognotification.js
+++ b/src/web/components/notification/dialognotification.js
@@ -17,11 +17,11 @@
  */
 import React from 'react';
 
-import _ from 'gmp/locale';
-
-import {isDefined} from 'gmp/utils/identity';
+import {hasValue} from 'gmp/utils/identity';
 
 import PropTypes from 'web/utils/proptypes';
+
+import useTranslation from 'web/hooks/useTranslation';
 
 import Dialog from 'web/components/dialog/dialog';
 import DialogContent from 'web/components/dialog/content';
@@ -29,88 +29,38 @@ import DialogFooter from 'web/components/dialog/footer';
 import DialogTitle from 'web/components/dialog/title';
 import ScrollableContent from 'web/components/dialog/scrollablecontent';
 
-class DialogNotification extends React.Component {
-  constructor(...args) {
-    super(...args);
+const DialogNotification = ({title, message, onCloseClick}) => {
+  const [_] = useTranslation();
 
-    this.handleDialogClose = this.handleDialogClose.bind(this);
-    this.handleShowError = this.handleShowError.bind(this);
-    this.handleShowErrorMessage = this.handleShowErrorMessage.bind(this);
-    this.handleShowMessage = this.handleShowMessage.bind(this);
-    this.handleShowSuccessMessage = this.handleShowSuccessMessage.bind(this);
-
-    this.state = {};
+  if (!hasValue(message)) {
+    return null;
   }
-
-  handleShowError(error) {
-    this.handleShowErrorMessage(error.message);
-  }
-
-  handleShowErrorMessage(message) {
-    this.handleShowMessage(message, _('Error'));
-  }
-
-  handleShowSuccessMessage(message) {
-    this.handleShowMessage(message, _('Success'));
-  }
-
-  handleShowMessage(message, subject = _('Message')) {
-    this.setState({
-      message,
-      title: subject,
-    });
-  }
-
-  handleDialogClose() {
-    this.setState({message: undefined});
-  }
-
-  isDialogOpen() {
-    return isDefined(this.state.message);
-  }
-
-  render() {
-    const {children} = this.props;
-
-    if (!isDefined(children)) {
-      return null;
-    }
-
-    const {title, message} = this.state;
-    return (
-      <React.Fragment>
-        {children({
-          showError: this.handleShowError,
-          showErrorMessage: this.handleShowErrorMessage,
-          showMessage: this.handleShowMessage,
-          showSuccessMessage: this.handleShowSuccessMessage,
-        })}
-        {this.isDialogOpen() && (
-          <Dialog width="400px" onClose={this.handleDialogClose}>
-            {({close, moveProps, heightProps}) => (
-              <DialogContent>
-                <DialogTitle
-                  title={title}
-                  onCloseClick={close}
-                  {...moveProps}
-                />
-                <ScrollableContent {...heightProps}>
-                  {message}
-                </ScrollableContent>
-                <DialogFooter title={_('Close')} onClick={close} />
-              </DialogContent>
-            )}
-          </Dialog>
-        )}
-      </React.Fragment>
-    );
-  }
-}
+  return (
+    <Dialog width="400px" onClose={onCloseClick}>
+      {({close, moveProps, heightProps}) => (
+        <DialogContent>
+          <DialogTitle title={title} onCloseClick={close} {...moveProps} />
+          <ScrollableContent
+            {...heightProps}
+            data-testid="dialog-notification-message"
+          >
+            {message}
+          </ScrollableContent>
+          <DialogFooter
+            title={_('Close')}
+            onClick={close}
+            data-testid="dialog-notification-footer"
+          />
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+};
 
 DialogNotification.propTypes = {
-  children: PropTypes.func,
+  message: PropTypes.string,
+  title: PropTypes.string,
+  onCloseClick: PropTypes.func,
 };
 
 export default DialogNotification;
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/components/notification/useDialogNotification.js
+++ b/src/web/components/notification/useDialogNotification.js
@@ -1,0 +1,75 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {useCallback, useState} from 'react';
+
+import _ from 'gmp/locale';
+
+/**
+ * Hook to handle the state for showing different types of messages in a dialog
+ *
+ * Should be used in conjunction with a DialogNotification component
+ *
+ * @example
+ *
+ * const {
+ *   dialogState,
+ *   closeDialog,
+ *   showError,
+ *   showMessage,
+ * } = useDialogNotification();
+ *
+ * return (
+ *   <DialogNotification
+ *      {...dialogState}
+ *      onCloseClick={closeDialog}
+ *   />
+ * );
+ * @returns {Object} Object containing the dialog state and functions to show different types of messages
+ */
+const useDialogNotification = () => {
+  const [dialogState, setDialogState] = useState({});
+  const showMessage = useCallback((message, subject = _('Message')) => {
+    setDialogState(prevState => ({
+      message,
+      title: subject,
+    }));
+  }, []);
+
+  const showErrorMessage = useCallback(
+    message => {
+      showMessage(message, _('Error'));
+    },
+    [showMessage],
+  );
+
+  const showError = useCallback(
+    error => {
+      showErrorMessage(error.message);
+    },
+    [showErrorMessage],
+  );
+
+  const showSuccessMessage = useCallback(
+    message => {
+      showMessage(message, _('Success'));
+    },
+    [showMessage],
+  );
+
+  const handleDialogClose = useCallback(() => {
+    setDialogState(prevState => ({...prevState, message: undefined}));
+  }, []);
+  return {
+    closeDialog: handleDialogClose,
+    showError,
+    showErrorMessage,
+    showMessage,
+    showSuccessMessage,
+    dialogState,
+  };
+};
+
+export default useDialogNotification;

--- a/src/web/components/notification/withDialogNotifiaction.js
+++ b/src/web/components/notification/withDialogNotifiaction.js
@@ -18,17 +18,21 @@
 
 import React from 'react';
 
-import DialogNotifaction from './dialognotification.js';
+import DialogNotification from './dialognotification';
+import useDialogNotification from './useDialogNotification';
 
 const withDialogNotification = Component => {
-  const DialogNoticiationWrapper = props => {
+  const DialogNotificationWrapper = props => {
+    const {dialogState, closeDialog, ...notificationProps} =
+      useDialogNotification();
     return (
-      <DialogNotifaction>
-        {notificationProps => <Component {...props} {...notificationProps} />}
-      </DialogNotifaction>
+      <React.Fragment>
+        <Component {...props} {...notificationProps} />
+        <DialogNotification {...dialogState} onCloseClick={closeDialog} />
+      </React.Fragment>
     );
   };
-  return DialogNoticiationWrapper;
+  return DialogNotificationWrapper;
 };
 
 export default withDialogNotification;


### PR DESCRIPTION

## What

Refactor DialogNotification into a function component
## Why
The DialogNotification component is intended to show messages (for example errors) in a dialog easily. With this change it got refactored to a function component which is easier to understand. Also tests for the DialogNotification component are added.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


