### PR TITLE
Abstract differences of testing framework in a testing module

### DIFF
--- a/src/__tests__/version.js
+++ b/src/__tests__/version.js
@@ -16,6 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {describe, test, expect} from '@gsa/testing';
+
 import {RELEASE_VERSION} from '../version';
 
 describe('Version tests', () => {

--- a/src/gmp/__tests__/cancel.js
+++ b/src/gmp/__tests__/cancel.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import CancelToken from '../cancel.js';
 

--- a/src/gmp/__tests__/cvss.js
+++ b/src/gmp/__tests__/cvss.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import {
   parseCvssV2BaseFromVector,

--- a/src/gmp/__tests__/gmp.js
+++ b/src/gmp/__tests__/gmp.js
@@ -15,6 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  testing,
+} from '@gsa/testing';
+
 import DefaultTransform from '../http/transform/default';
 
 import Gmp from '../gmp';
@@ -50,7 +59,7 @@ describe('Gmp tests', () => {
 
   describe('login tests', () => {
     test('should login user', () => {
-      const request = vi.fn().mockResolvedValue({
+      const request = testing.fn().mockResolvedValue({
         data: {
           token: 'foo',
         },
@@ -76,7 +85,7 @@ describe('Gmp tests', () => {
     });
 
     test('should not login if request fails', () => {
-      const request = vi.fn().mockRejectedValue({
+      const request = testing.fn().mockRejectedValue({
         message: 'An error',
       });
       const settings = {};
@@ -131,7 +140,7 @@ describe('Gmp tests', () => {
     test('should call logout handlers if logged in', () => {
       const settings = {token: 'foo'};
       const gmp = new Gmp(settings);
-      const handler = vi.fn();
+      const handler = testing.fn();
       const unsub = gmp.subscribeToLogout(handler);
 
       expect(gmp.isLoggedIn()).toEqual(true);
@@ -147,7 +156,7 @@ describe('Gmp tests', () => {
     test('should call logout handlers if logged out', () => {
       const settings = {};
       const gmp = new Gmp(settings);
-      const handler = vi.fn();
+      const handler = testing.fn();
       const unsub = gmp.subscribeToLogout(handler);
 
       expect(gmp.isLoggedIn()).toEqual(false);
@@ -163,7 +172,7 @@ describe('Gmp tests', () => {
 
   describe('doLogout tests', () => {
     test('should logout user', () => {
-      const request = vi.fn().mockResolvedValue({
+      const request = testing.fn().mockResolvedValue({
         data: {
           token: 'foo',
         },
@@ -192,7 +201,7 @@ describe('Gmp tests', () => {
     });
 
     test('should notify handler on logout success', () => {
-      const request = vi.fn().mockResolvedValue({
+      const request = testing.fn().mockResolvedValue({
         data: {},
       });
       const settings = {token: 'foo', apiServer: 'localhost'};
@@ -201,7 +210,7 @@ describe('Gmp tests', () => {
         request,
       };
 
-      const handler = vi.fn();
+      const handler = testing.fn();
 
       const gmp = new Gmp(settings, http);
 
@@ -217,7 +226,7 @@ describe('Gmp tests', () => {
     });
 
     test('should ignore logout api call failure', () => {
-      const request = vi.fn().mockRejectedValue({
+      const request = testing.fn().mockRejectedValue({
         message: 'foo',
       });
       const settings = {
@@ -230,7 +239,7 @@ describe('Gmp tests', () => {
         request,
       };
 
-      const handler = vi.fn();
+      const handler = testing.fn();
 
       const gmp = new Gmp(settings, http);
 
@@ -246,7 +255,7 @@ describe('Gmp tests', () => {
     });
 
     test('should not do logout if not logged int', () => {
-      const request = vi.fn().mockResolvedValue({
+      const request = testing.fn().mockResolvedValue({
         data: {},
       });
       const settings = {apiServer: 'localhost'};
@@ -255,7 +264,7 @@ describe('Gmp tests', () => {
         request,
       };
 
-      const handler = vi.fn();
+      const handler = testing.fn();
 
       const gmp = new Gmp(settings, http);
 

--- a/src/gmp/__tests__/gmpsettings.js
+++ b/src/gmp/__tests__/gmpsettings.js
@@ -15,6 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  testing,
+} from '@gsa/testing';
+
 import GmpSettings, {
   DEFAULT_MANUAL_URL,
   DEFAULT_RELOAD_INTERVAL,
@@ -29,8 +38,8 @@ import GmpSettings, {
 const createStorage = state => {
   const store = {
     ...state,
-    setItem: vi.fn((name, value) => (store[name] = '' + value)),
-    removeItem: vi.fn(name => delete store[name]),
+    setItem: testing.fn((name, value) => (store[name] = '' + value)),
+    removeItem: testing.fn(name => delete store[name]),
   };
   return store;
 };

--- a/src/gmp/__tests__/log.js
+++ b/src/gmp/__tests__/log.js
@@ -15,6 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+  testing,
+} from '@gsa/testing';
+
 import {RootLogger, DEFAULT_LOG_LEVEL, LogLevels} from '../log.js';
 import {isFunction} from 'util';
 
@@ -27,11 +36,11 @@ describe('log tests', () => {
   beforeEach(() => {
     origConsole = global.console;
     testConsole = {
-      error: vi.fn(),
-      warn: vi.fn(),
-      info: vi.fn(),
-      debug: vi.fn(),
-      trace: vi.fn(),
+      error: testing.fn(),
+      warn: testing.fn(),
+      info: testing.fn(),
+      debug: testing.fn(),
+      trace: testing.fn(),
     };
 
     global.console = testConsole;

--- a/src/gmp/__tests__/model.js
+++ b/src/gmp/__tests__/model.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Model, {parseModelFromElement} from 'gmp/model';
 import {testModel} from 'gmp/models/testing';

--- a/src/gmp/__tests__/parser.js
+++ b/src/gmp/__tests__/parser.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import {isDate, isDuration} from 'gmp/models/date';
 

--- a/src/gmp/__tests__/timezones.js
+++ b/src/gmp/__tests__/timezones.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {isArray} from '../utils/identity';
 
 import timezones from '../timezones';

--- a/src/gmp/capabilities/__tests__/capabilities.js
+++ b/src/gmp/capabilities/__tests__/capabilities.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import Capabilities from '../capabilities';
 
 describe('Capabilities tests', () => {

--- a/src/gmp/capabilities/__tests__/everything.js
+++ b/src/gmp/capabilities/__tests__/everything.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import EverythingCapabilities from '../everything';
 
 describe('EverythingCapabilities tests', () => {

--- a/src/gmp/commands/__tests__/audit.js
+++ b/src/gmp/commands/__tests__/audit.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {ALL_FILTER} from 'gmp/models/filter';
 
 import {

--- a/src/gmp/commands/__tests__/auth.js
+++ b/src/gmp/commands/__tests__/auth.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {AuthenticationCommand} from '../auth';
 
 import {createActionResultResponse, createHttp} from '../testing';

--- a/src/gmp/commands/__tests__/convert.js
+++ b/src/gmp/commands/__tests__/convert.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import {convertBoolean} from '../convert';
 

--- a/src/gmp/commands/__tests__/dashboards.js
+++ b/src/gmp/commands/__tests__/dashboards.js
@@ -15,11 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import {DEFAULT_ROW_HEIGHT, createDisplay, createRow} from '../dashboards';
 
 describe('createRow tests', () => {
   test('should create row with default height', () => {
-    const uuid = vi.fn().mockReturnValue(1);
+    const uuid = testing.fn().mockReturnValue(1);
     expect(createRow(['foo', 'bar'], undefined, uuid)).toEqual({
       id: 1,
       items: ['foo', 'bar'],
@@ -29,7 +31,7 @@ describe('createRow tests', () => {
   });
 
   test('should create row with height', () => {
-    const uuid = vi.fn().mockReturnValue(1);
+    const uuid = testing.fn().mockReturnValue(1);
     expect(createRow(['foo', 'bar'], 100, uuid)).toEqual({
       id: 1,
       items: ['foo', 'bar'],
@@ -41,7 +43,7 @@ describe('createRow tests', () => {
 
 describe('createDisplay tests', () => {
   test('should create a new item with empty props', () => {
-    const uuid = vi.fn().mockReturnValue(1);
+    const uuid = testing.fn().mockReturnValue(1);
     expect(createDisplay('foo1', undefined, uuid)).toEqual({
       id: 1,
       displayId: 'foo1',
@@ -50,7 +52,7 @@ describe('createDisplay tests', () => {
   });
 
   test('should create a new item with props', () => {
-    const uuid = vi.fn().mockReturnValue(1);
+    const uuid = testing.fn().mockReturnValue(1);
     expect(createDisplay('foo1', {foo: 'bar'}, uuid)).toEqual({
       id: 1,
       displayId: 'foo1',

--- a/src/gmp/commands/__tests__/entities.js
+++ b/src/gmp/commands/__tests__/entities.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import Filter from 'gmp/models/filter';
 
 import {createEntitiesResponse, createHttp} from '../testing';

--- a/src/gmp/commands/__tests__/entity.js
+++ b/src/gmp/commands/__tests__/entity.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import Filter from 'gmp/models/filter';
 
 import {createEntityResponse, createHttp} from '../testing';

--- a/src/gmp/commands/__tests__/feedstatus.js
+++ b/src/gmp/commands/__tests__/feedstatus.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import {createResponse, createHttp} from '../testing';
 

--- a/src/gmp/commands/__tests__/http.js
+++ b/src/gmp/commands/__tests__/http.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import HttpCommand from '../http';
 
@@ -45,7 +46,7 @@ describe('HttpCommand tests', () => {
   test('should create http get request', () => {
     const retval = {};
     const http = {
-      request: vi.fn().mockReturnValue(retval),
+      request: testing.fn().mockReturnValue(retval),
     };
 
     const cmd = new HttpCommand(http);
@@ -58,7 +59,7 @@ describe('HttpCommand tests', () => {
   test('should create http get request with default params', () => {
     const retval = {};
     const http = {
-      request: vi.fn().mockReturnValue(retval),
+      request: testing.fn().mockReturnValue(retval),
     };
 
     const cmd = new HttpCommand(http, {bar: 1});
@@ -75,7 +76,7 @@ describe('HttpCommand tests', () => {
   test('should create http get request with overriding default params', () => {
     const retval = {};
     const http = {
-      request: vi.fn().mockReturnValue(retval),
+      request: testing.fn().mockReturnValue(retval),
     };
 
     const cmd = new HttpCommand(http, {bar: 1});
@@ -94,7 +95,7 @@ describe('HttpCommand tests', () => {
   test('should create http get request with extra params', () => {
     const retval = {};
     const http = {
-      request: vi.fn().mockReturnValue(retval),
+      request: testing.fn().mockReturnValue(retval),
     };
 
     const cmd = new HttpCommand(http, {bar: 1});
@@ -111,7 +112,7 @@ describe('HttpCommand tests', () => {
   test('should create http get request with extra params taking precedence', () => {
     const retval = {};
     const http = {
-      request: vi.fn().mockReturnValue(retval),
+      request: testing.fn().mockReturnValue(retval),
     };
 
     const cmd = new HttpCommand(http, {bar: 1, a: 1});
@@ -131,7 +132,7 @@ describe('HttpCommand tests', () => {
   test('should create http get request with ignoring default params', () => {
     const retval = {};
     const http = {
-      request: vi.fn().mockReturnValue(retval),
+      request: testing.fn().mockReturnValue(retval),
     };
 
     const cmd = new HttpCommand(http, {bar: 1});
@@ -156,7 +157,7 @@ describe('HttpCommand tests', () => {
   test('should create http post request with default params', () => {
     const retval = {};
     const http = {
-      request: vi.fn().mockReturnValue(retval),
+      request: testing.fn().mockReturnValue(retval),
     };
 
     const cmd = new HttpCommand(http, {bar: 1});
@@ -173,7 +174,7 @@ describe('HttpCommand tests', () => {
   test('should create http post request with overriding default params', () => {
     const retval = {};
     const http = {
-      request: vi.fn().mockReturnValue(retval),
+      request: testing.fn().mockReturnValue(retval),
     };
 
     const cmd = new HttpCommand(http, {bar: 1});
@@ -192,7 +193,7 @@ describe('HttpCommand tests', () => {
   test('should create http post request with extra params', () => {
     const retval = {};
     const http = {
-      request: vi.fn().mockReturnValue(retval),
+      request: testing.fn().mockReturnValue(retval),
     };
 
     const cmd = new HttpCommand(http, {bar: 1});
@@ -209,7 +210,7 @@ describe('HttpCommand tests', () => {
   test('should create http post request with extra params taking precedence', () => {
     const retval = {};
     const http = {
-      request: vi.fn().mockReturnValue(retval),
+      request: testing.fn().mockReturnValue(retval),
     };
 
     const cmd = new HttpCommand(http, {bar: 1, a: 1});
@@ -229,7 +230,7 @@ describe('HttpCommand tests', () => {
   test('should create http post request with ignoring default params', () => {
     const retval = {};
     const http = {
-      request: vi.fn().mockReturnValue(retval),
+      request: testing.fn().mockReturnValue(retval),
     };
 
     const cmd = new HttpCommand(http, {bar: 1});

--- a/src/gmp/commands/__tests__/license.js
+++ b/src/gmp/commands/__tests__/license.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {createResponse, createHttp} from '../testing';
 
 import {parseDate} from 'gmp/parser';

--- a/src/gmp/commands/__tests__/nvt.js
+++ b/src/gmp/commands/__tests__/nvt.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {createResponse, createHttp} from '../testing';
 
 import {NvtCommand} from '../nvt';

--- a/src/gmp/commands/__tests__/nvtfamilies.js
+++ b/src/gmp/commands/__tests__/nvtfamilies.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {NvtFamiliesCommand} from '../nvtfamilies';
 
 import {createResponse, createHttp} from '../testing';

--- a/src/gmp/commands/__tests__/policies.js
+++ b/src/gmp/commands/__tests__/policies.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {ALL_FILTER} from 'gmp/models/filter';
 
 import {createEntitiesResponse, createHttp} from '../testing';

--- a/src/gmp/commands/__tests__/policy.js
+++ b/src/gmp/commands/__tests__/policy.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {
   SCANCONFIG_TREND_DYNAMIC,
   SCANCONFIG_TREND_STATIC,

--- a/src/gmp/commands/__tests__/report.js
+++ b/src/gmp/commands/__tests__/report.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {createHttp, createEntityResponse} from '../testing';
 import {ReportCommand} from '../reports';
 

--- a/src/gmp/commands/__tests__/reportconfig.js
+++ b/src/gmp/commands/__tests__/reportconfig.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {
   createHttp,
   createEntityResponse,

--- a/src/gmp/commands/__tests__/reportconfigs.js
+++ b/src/gmp/commands/__tests__/reportconfigs.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {createHttp, createEntitiesResponse} from '../testing';
 import {ReportConfigsCommand} from '../reportconfigs';
 import {ALL_FILTER} from 'gmp/models/filter';

--- a/src/gmp/commands/__tests__/reports.js
+++ b/src/gmp/commands/__tests__/reports.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {ALL_FILTER} from 'gmp/models/filter';
 
 import {createHttp, createEntitiesResponse} from '../testing';

--- a/src/gmp/commands/__tests__/resourcenames.js
+++ b/src/gmp/commands/__tests__/resourcenames.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {createResponse, createHttp} from '../testing';
 
 import {ResourceNamesCommand} from '../resourcenames';

--- a/src/gmp/commands/__tests__/result.js
+++ b/src/gmp/commands/__tests__/result.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {ResultCommand} from '../results';
 
 import {createEntityResponse, createHttp} from '../testing';

--- a/src/gmp/commands/__tests__/results.js
+++ b/src/gmp/commands/__tests__/results.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {ALL_FILTER} from 'gmp/models/filter';
 
 import {

--- a/src/gmp/commands/__tests__/scanconfig.js
+++ b/src/gmp/commands/__tests__/scanconfig.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {
   createEntityResponse,
   createHttp,

--- a/src/gmp/commands/__tests__/tag.js
+++ b/src/gmp/commands/__tests__/tag.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {TagCommand} from '../tags';
 
 import {

--- a/src/gmp/commands/__tests__/target.js
+++ b/src/gmp/commands/__tests__/target.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {TargetCommand} from '../targets';
 
 import {createActionResultResponse, createHttp} from '../testing';

--- a/src/gmp/commands/__tests__/task.js
+++ b/src/gmp/commands/__tests__/task.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {TaskCommand} from '../tasks';
 
 import {createActionResultResponse, createHttp} from '../testing';

--- a/src/gmp/commands/__tests__/ticket.js
+++ b/src/gmp/commands/__tests__/ticket.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {TicketCommand} from '../tickets';
 
 import {

--- a/src/gmp/commands/__tests__/tickets.js
+++ b/src/gmp/commands/__tests__/tickets.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {ALL_FILTER} from 'gmp/models/filter';
 
 import {createHttp, createEntitiesResponse} from '../testing';

--- a/src/gmp/commands/__tests__/tlscertificates.js
+++ b/src/gmp/commands/__tests__/tlscertificates.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {ALL_FILTER} from 'gmp/models/filter';
 
 import defaults from 'gmp/http/transform/default';

--- a/src/gmp/commands/__tests__/user.js
+++ b/src/gmp/commands/__tests__/user.js
@@ -15,9 +15,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {UserCommand, transformSettingName} from '../users';
 
 import {createResponse, createHttp} from '../testing';
+
 describe('UserCommand tests', () => {
   test('should parse auth settinngs in currentAuthSettings', () => {
     const response = createResponse({

--- a/src/gmp/commands/testing.js
+++ b/src/gmp/commands/testing.js
@@ -15,6 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+
+import {testing} from '@gsa/testing';
+
 import Response from 'gmp/http/response';
 
 const entitiesRange = {
@@ -69,13 +72,15 @@ export const createAggregatesResponse = (data = {}) =>
   });
 
 export const createHttp = response => ({
-  request: vi.fn().mockReturnValue(Promise.resolve(response)),
+  request: testing.fn().mockReturnValue(Promise.resolve(response)),
 });
 
 export const createHttpMany = responses => {
   let i = 0;
   return {
-    request: vi.fn().mockImplementation(() => Promise.resolve(responses[i++])),
+    request: testing
+      .fn()
+      .mockImplementation(() => Promise.resolve(responses[i++])),
   };
 };
 

--- a/src/gmp/http/__tests__/rejection.js
+++ b/src/gmp/http/__tests__/rejection.js
@@ -15,11 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect} from '@gsa/testing';
 
 import Rejection from '../rejection';
-
-setLocale('en');
 
 describe('Rejection tests', () => {
   test('should create error rejection by default', () => {

--- a/src/gmp/http/__tests__/response.js
+++ b/src/gmp/http/__tests__/response.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import Response from '../response';
 
 describe('Response tests', () => {

--- a/src/gmp/http/transform/__tests__/fastxml.js
+++ b/src/gmp/http/transform/__tests__/fastxml.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import transform from '../fastxml';
 
 const createEnvelopedXml = xmlStr =>
@@ -44,8 +46,8 @@ describe('fastxml transform tests', () => {
     const xmlStr = createEnvelopedXml(
       '<foo>foo&quot;&lt;&gt;&amp;&apos;&#x2F;&#x5C;</foo>',
     );
-    const plainData = vi.fn().mockReturnValue(xmlStr);
-    const setData = vi.fn().mockReturnValue('foo');
+    const plainData = testing.fn().mockReturnValue(xmlStr);
+    const setData = testing.fn().mockReturnValue('foo');
     const response = {
       plainData,
       set: setData,
@@ -65,8 +67,8 @@ describe('fastxml transform tests', () => {
     const xmlStr = createEnvelopedXml(
       '<foo bar="foo&quot;&lt;&gt;&amp;&apos;&#x2F;&#x5C;"></foo>',
     );
-    const plainData = vi.fn().mockReturnValue(xmlStr);
-    const setData = vi.fn().mockReturnValue('foo');
+    const plainData = testing.fn().mockReturnValue(xmlStr);
+    const setData = testing.fn().mockReturnValue('foo');
     const response = {
       plainData,
       set: setData,
@@ -85,8 +87,8 @@ describe('fastxml transform tests', () => {
   });
 
   test('should create a rejection on parser errors', () => {
-    const plainData = vi.fn().mockReturnValue({foo: 'bar'});
-    const setData = vi.fn().mockReturnValue('foo');
+    const plainData = testing.fn().mockReturnValue({foo: 'bar'});
+    const setData = testing.fn().mockReturnValue('foo');
     const response = {
       plainData,
       set: setData,
@@ -100,9 +102,9 @@ describe('fastxml transform tests', () => {
   test('should transform rejection with action_result', () => {
     const xmlStr =
       '<envelope><action_result><message>foo</message></action_result></envelope>';
-    const isError = vi.fn().mockReturnValue(true);
-    const setMessage = vi.fn(() => errorRejection);
-    const plainData = vi.fn().mockReturnValue(xmlStr);
+    const isError = testing.fn().mockReturnValue(true);
+    const setMessage = testing.fn(() => errorRejection);
+    const plainData = testing.fn().mockReturnValue(xmlStr);
     const errorRejection = {
       isError,
       setMessage,
@@ -119,9 +121,9 @@ describe('fastxml transform tests', () => {
     const xmlStr =
       '<envelope><action_result><message>foo</message></action_result>' +
       '<gsad_response><message>bar</message></gsad_response></envelope>';
-    const isError = vi.fn().mockReturnValue(true);
-    const setMessage = vi.fn(() => errorRejection);
-    const plainData = vi.fn().mockReturnValue(xmlStr);
+    const isError = testing.fn().mockReturnValue(true);
+    const setMessage = testing.fn(() => errorRejection);
+    const plainData = testing.fn().mockReturnValue(xmlStr);
     const errorRejection = {
       isError,
       setMessage,

--- a/src/gmp/http/transform/__tests__/xml.js
+++ b/src/gmp/http/transform/__tests__/xml.js
@@ -15,15 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {success, rejection} from '../xml';
 
-setLocale('en');
-
 describe('xml base transform tests', () => {
   test('should call transform function', () => {
-    const fakeTransform = vi.fn().mockReturnValue('foo');
+    const fakeTransform = testing.fn().mockReturnValue('foo');
     const response = {};
     const options = {};
 
@@ -33,7 +31,7 @@ describe('xml base transform tests', () => {
   });
 
   test('should throw rejection in case of success transform errors', () => {
-    const fakeTransform = vi.fn(() => {
+    const fakeTransform = testing.fn(() => {
       throw new Error('foo');
     });
     const xhr = {};
@@ -50,9 +48,9 @@ describe('xml base transform tests', () => {
   });
 
   test('should not call rejection function for non error rejection', () => {
-    const fakeTransform = vi.fn().mockReturnValue('foo');
+    const fakeTransform = testing.fn().mockReturnValue('foo');
     const transform = rejection(fakeTransform);
-    const isError = vi.fn().mockReturnValue(false);
+    const isError = testing.fn().mockReturnValue(false);
     const errorRejection = {
       isError,
     };
@@ -63,7 +61,7 @@ describe('xml base transform tests', () => {
   });
 
   test('should transform rejection with action_result', () => {
-    const fakeTransform = vi.fn().mockReturnValue({
+    const fakeTransform = testing.fn().mockReturnValue({
       envelope: {
         action_result: {
           message: 'foo',
@@ -71,8 +69,8 @@ describe('xml base transform tests', () => {
       },
     });
     const transform = rejection(fakeTransform);
-    const isError = vi.fn().mockReturnValue(true);
-    const setMessage = vi.fn(() => errorRejection);
+    const isError = testing.fn().mockReturnValue(true);
+    const setMessage = testing.fn(() => errorRejection);
     const errorRejection = {
       isError,
       setMessage,
@@ -85,7 +83,7 @@ describe('xml base transform tests', () => {
   });
 
   test('should transform rejection with gsad_response', () => {
-    const fakeTransform = vi.fn().mockReturnValue({
+    const fakeTransform = testing.fn().mockReturnValue({
       envelope: {
         action_result: {
           message: 'foo',
@@ -96,8 +94,8 @@ describe('xml base transform tests', () => {
       },
     });
     const transform = rejection(fakeTransform);
-    const isError = vi.fn().mockReturnValue(true);
-    const setMessage = vi.fn(() => errorRejection);
+    const isError = testing.fn().mockReturnValue(true);
+    const setMessage = testing.fn(() => errorRejection);
     const errorRejection = {
       isError,
       setMessage,
@@ -110,11 +108,11 @@ describe('xml base transform tests', () => {
   });
 
   test('should transform rejection with unknown error', () => {
-    const fakeTransform = vi.fn().mockReturnValue({
+    const fakeTransform = testing.fn().mockReturnValue({
       envelope: {},
     });
     const transform = rejection(fakeTransform);
-    const isError = vi.fn().mockReturnValue(true);
+    const isError = testing.fn().mockReturnValue(true);
     const errorRejection = {
       isError,
     };

--- a/src/gmp/locale/__tests__/date.js
+++ b/src/gmp/locale/__tests__/date.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import date, {setLocale as locale} from '../../models/date';
 
 import {

--- a/src/gmp/locale/__tests__/detector.js
+++ b/src/gmp/locale/__tests__/detector.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import {isFunction} from '../../utils/identity';
 
 import LanguageDetector from '../detector';
@@ -31,11 +33,11 @@ describe('LanguageDetector tests', () => {
 
   test('should detect language from store', () => {
     const languageUtils = {
-      formatLanguageCode: vi.fn().mockReturnValue('foo'),
-      isSupportedCode: vi.fn().mockReturnValue(true),
+      formatLanguageCode: testing.fn().mockReturnValue('foo'),
+      isSupportedCode: testing.fn().mockReturnValue(true),
     };
     const storage = {};
-    const locale = vi.fn().mockReturnValue('foo');
+    const locale = testing.fn().mockReturnValue('foo');
     Object.defineProperty(storage, 'locale', {
       get: locale,
     });
@@ -52,11 +54,11 @@ describe('LanguageDetector tests', () => {
 
   test('should return fallback language', () => {
     const languageUtils = {
-      formatLanguageCode: vi.fn().mockReturnValue('foo'),
-      isSupportedCode: vi.fn().mockReturnValue(false),
+      formatLanguageCode: testing.fn().mockReturnValue('foo'),
+      isSupportedCode: testing.fn().mockReturnValue(false),
     };
     const storage = {};
-    const locale = vi.fn().mockReturnValue('foo');
+    const locale = testing.fn().mockReturnValue('foo');
     Object.defineProperty(storage, 'locale', {
       get: locale,
     });
@@ -76,8 +78,8 @@ describe('LanguageDetector tests', () => {
     global.navigator = {language: 'en-US'};
 
     const languageUtils = {
-      formatLanguageCode: vi.fn().mockImplementation(l => l),
-      isSupportedCode: vi.fn().mockReturnValue(true),
+      formatLanguageCode: testing.fn().mockImplementation(l => l),
+      isSupportedCode: testing.fn().mockReturnValue(true),
     };
 
     const detector = new LanguageDetector();
@@ -96,14 +98,14 @@ describe('LanguageDetector tests', () => {
   test('should return languages from fake navigator', () => {
     const storage = {};
     const languageUtils = {
-      formatLanguageCode: vi.fn().mockImplementation(l => l),
-      isSupportedCode: vi.fn().mockReturnValue(true),
+      formatLanguageCode: testing.fn().mockImplementation(l => l),
+      isSupportedCode: testing.fn().mockReturnValue(true),
     };
 
     const detector = new LanguageDetector();
 
     const navigator = {};
-    const languages = vi.fn().mockReturnValue(['lorem', 'ipsum']);
+    const languages = testing.fn().mockReturnValue(['lorem', 'ipsum']);
     Object.defineProperty(navigator, 'languages', {
       get: languages,
     });
@@ -121,14 +123,14 @@ describe('LanguageDetector tests', () => {
   test('should return language from fake navigator', () => {
     const storage = {};
     const languageUtils = {
-      formatLanguageCode: vi.fn().mockImplementation(l => l),
-      isSupportedCode: vi.fn().mockReturnValue(true),
+      formatLanguageCode: testing.fn().mockImplementation(l => l),
+      isSupportedCode: testing.fn().mockReturnValue(true),
     };
 
     const detector = new LanguageDetector();
 
     const navigator = {};
-    const language = vi.fn().mockReturnValue('lorem');
+    const language = testing.fn().mockReturnValue('lorem');
     Object.defineProperty(navigator, 'language', {
       get: language,
     });
@@ -146,14 +148,14 @@ describe('LanguageDetector tests', () => {
   test('should return userLanguage from fake navigator', () => {
     const storage = {};
     const languageUtils = {
-      formatLanguageCode: vi.fn().mockImplementation(l => l),
-      isSupportedCode: vi.fn().mockReturnValue(true),
+      formatLanguageCode: testing.fn().mockImplementation(l => l),
+      isSupportedCode: testing.fn().mockReturnValue(true),
     };
 
     const detector = new LanguageDetector();
 
     const navigator = {};
-    const userLanguage = vi.fn().mockReturnValue('lorem');
+    const userLanguage = testing.fn().mockReturnValue('lorem');
     Object.defineProperty(navigator, 'userLanguage', {
       get: userLanguage,
     });
@@ -171,8 +173,8 @@ describe('LanguageDetector tests', () => {
   test('should return fallback when navigator is not available', () => {
     const storage = {};
     const languageUtils = {
-      formatLanguageCode: vi.fn().mockImplementation(l => l),
-      isSupportedCode: vi.fn().mockReturnValue(true),
+      formatLanguageCode: testing.fn().mockImplementation(l => l),
+      isSupportedCode: testing.fn().mockReturnValue(true),
     };
 
     const detector = new LanguageDetector();

--- a/src/gmp/locale/__tests__/lang.js
+++ b/src/gmp/locale/__tests__/lang.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import {isFunction} from 'gmp/utils/identity';
 
 import {getLocale as getDateLocale} from '../date';
@@ -47,7 +49,7 @@ describe('setLocale tests', () => {
   });
 
   test('should notify language change listeners', () => {
-    const callback = vi.fn();
+    const callback = testing.fn();
 
     setLocale('en');
     expect(getLocale()).toEqual('en');
@@ -61,7 +63,7 @@ describe('setLocale tests', () => {
   });
 
   test('should not be notify when unsubscribed', () => {
-    const callback = vi.fn();
+    const callback = testing.fn();
 
     setLocale('en');
     expect(getLocale()).toEqual('en');

--- a/src/gmp/locale/__tests__/languages.js
+++ b/src/gmp/locale/__tests__/languages.js
@@ -16,6 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {describe, test, expect} from '@gsa/testing';
+
 import {isString} from 'gmp/utils/identity';
 
 import Languages, {getLanguageCodes} from '../languages';

--- a/src/gmp/models/__tests__/alert.js
+++ b/src/gmp/models/__tests__/alert.js
@@ -16,6 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {describe, test, expect} from '@gsa/testing';
+
 import Model from 'gmp/model';
 import Alert, {
   EVENT_TYPE_TASK_RUN_STATUS_CHANGED,

--- a/src/gmp/models/__tests__/audit.js
+++ b/src/gmp/models/__tests__/audit.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Audit, {
   HOSTS_ORDERING_RANDOM,

--- a/src/gmp/models/__tests__/certbund.js
+++ b/src/gmp/models/__tests__/certbund.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint-disable max-len */
+import {describe, test, expect} from '@gsa/testing';
 
 import CertBundAdv from 'gmp/models/certbund';
 import Info from 'gmp/models/info';

--- a/src/gmp/models/__tests__/cpe.js
+++ b/src/gmp/models/__tests__/cpe.js
@@ -16,6 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {describe, test, expect} from '@gsa/testing';
+
 import Cpe from 'gmp/models/cpe';
 import {isDate} from 'gmp/models/date';
 import {testModel} from 'gmp/models/testing';

--- a/src/gmp/models/__tests__/credential.js
+++ b/src/gmp/models/__tests__/credential.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint-disable max-len */
+import {describe, test, expect} from '@gsa/testing';
 
 import {setLocale} from 'gmp/locale/lang';
 

--- a/src/gmp/models/__tests__/cve.js
+++ b/src/gmp/models/__tests__/cve.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint-disable max-len */
+import {describe, test, expect} from '@gsa/testing';
 
 import Cve from 'gmp/models/cve';
 import {isDate} from 'gmp/models/date';

--- a/src/gmp/models/__tests__/dfncert.js
+++ b/src/gmp/models/__tests__/dfncert.js
@@ -16,6 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {describe, test, expect} from '@gsa/testing';
+
 import DfnCertAdv from 'gmp/models/dfncert';
 import Info from 'gmp/models/info';
 import {testModel} from 'gmp/models/testing';

--- a/src/gmp/models/__tests__/event.js
+++ b/src/gmp/models/__tests__/event.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import date from '../date';
 
 import Event from '../event';

--- a/src/gmp/models/__tests__/filter.js
+++ b/src/gmp/models/__tests__/filter.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {isArray} from '../../utils/identity';
 
 import Filter, {UNKNOWN_FILTER_ID} from '../filter';

--- a/src/gmp/models/__tests__/group.js
+++ b/src/gmp/models/__tests__/group.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Group from '../group';
 import {testModel} from 'gmp/models/testing';

--- a/src/gmp/models/__tests__/host.js
+++ b/src/gmp/models/__tests__/host.js
@@ -15,14 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Asset from 'gmp/models/asset';
 import Host from 'gmp/models/host';
 import {testModel} from 'gmp/models/testing';
 
 import {parseDate} from 'gmp/parser';
-
-/* eslint-disable max-len */
 
 testModel(Host, 'host');
 

--- a/src/gmp/models/__tests__/license.js
+++ b/src/gmp/models/__tests__/license.js
@@ -16,6 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {describe, test, expect} from '@gsa/testing';
+
 import {parseDate} from 'gmp/parser';
 
 import {License} from '../license';

--- a/src/gmp/models/__tests__/login.js
+++ b/src/gmp/models/__tests__/login.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import {isDate} from 'gmp/models/date';
 import Login from 'gmp/models/login';

--- a/src/gmp/models/__tests__/note.js
+++ b/src/gmp/models/__tests__/note.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Model from 'gmp/model';
 import Note from 'gmp/models/note';

--- a/src/gmp/models/__tests__/nvt.js
+++ b/src/gmp/models/__tests__/nvt.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint-disable max-len */
+import {describe, test, expect} from '@gsa/testing';
 
 import Nvt, {getRefs, hasRefType, getFilteredRefIds} from 'gmp/models/nvt';
 import Info from 'gmp/models/info';

--- a/src/gmp/models/__tests__/os.js
+++ b/src/gmp/models/__tests__/os.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Asset from 'gmp/models/asset';
 import OperatingSystem from 'gmp/models/os';

--- a/src/gmp/models/__tests__/override.js
+++ b/src/gmp/models/__tests__/override.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Model from 'gmp/model';
 import Nvt from 'gmp/models/nvt';

--- a/src/gmp/models/__tests__/permission.js
+++ b/src/gmp/models/__tests__/permission.js
@@ -15,8 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-/* eslint-disable max-len */
+import {describe, test, expect} from '@gsa/testing';
 
 import Model from 'gmp/model';
 import Permission from 'gmp/models/permission';

--- a/src/gmp/models/__tests__/policy.js
+++ b/src/gmp/models/__tests__/policy.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint-disable max-len */
+import {describe, test, expect} from '@gsa/testing';
 
 import Model from 'gmp/model';
 import Policy from 'gmp/models/policy';

--- a/src/gmp/models/__tests__/portlist.js
+++ b/src/gmp/models/__tests__/portlist.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Model from 'gmp/model';
 import PortList from 'gmp/models/portlist';

--- a/src/gmp/models/__tests__/reportconfig.js
+++ b/src/gmp/models/__tests__/reportconfig.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint-disable max-len */
+import {describe, test, expect} from '@gsa/testing';
 
 import ReportConfig from 'gmp/models/reportconfig';
 

--- a/src/gmp/models/__tests__/reportformat.js
+++ b/src/gmp/models/__tests__/reportformat.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint-disable max-len */
+import {describe, test, expect} from '@gsa/testing';
 
 import Model from 'gmp/model';
 

--- a/src/gmp/models/__tests__/resourcename.js
+++ b/src/gmp/models/__tests__/resourcename.js
@@ -16,6 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {describe, test, expect} from '@gsa/testing';
+
 import {ResourceName} from '../resourcename';
 
 describe('ResourceName tests', () => {

--- a/src/gmp/models/__tests__/result.js
+++ b/src/gmp/models/__tests__/result.js
@@ -16,6 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {describe, test, expect} from '@gsa/testing';
+
 import Model from 'gmp/model';
 import Note from 'gmp/models/note';
 import Nvt from 'gmp/models/nvt';

--- a/src/gmp/models/__tests__/role.js
+++ b/src/gmp/models/__tests__/role.js
@@ -16,6 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {describe, test, expect} from '@gsa/testing';
+
 import Role from '../role';
 import {testModel} from 'gmp/models/testing';
 

--- a/src/gmp/models/__tests__/scanconfig.js
+++ b/src/gmp/models/__tests__/scanconfig.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint-disable max-len */
+import {describe, test, expect} from '@gsa/testing';
 
 import Model from 'gmp/model';
 import ScanConfig, {

--- a/src/gmp/models/__tests__/scanner.js
+++ b/src/gmp/models/__tests__/scanner.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint-disable max-len */
+import {describe, test, expect} from '@gsa/testing';
 
 import Model from 'gmp/model';
 import {isDate} from 'gmp/models/date';

--- a/src/gmp/models/__tests__/schedule.js
+++ b/src/gmp/models/__tests__/schedule.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint-disable max-len */
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Model from 'gmp/model';
 import Schedule from 'gmp/models/schedule';
@@ -64,7 +64,7 @@ describe('Schedule model tests', () => {
   test('should handle invalid ical data safely', () => {
     /* eslint-disable no-console */
     const consoleError = console.log;
-    const errorLog = vi.fn();
+    const errorLog = testing.fn();
 
     console.error = errorLog;
 

--- a/src/gmp/models/__tests__/secinfo.js
+++ b/src/gmp/models/__tests__/secinfo.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Info from 'gmp/models/info';
 import SecInfo, {secInfoType, secInfoTypeName} from 'gmp/models/secinfo';

--- a/src/gmp/models/__tests__/setting.js
+++ b/src/gmp/models/__tests__/setting.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import Setting from '../setting';
 
 describe('Setting tests', () => {

--- a/src/gmp/models/__tests__/settings.js
+++ b/src/gmp/models/__tests__/settings.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Settings from 'gmp/models/settings';
 
@@ -34,7 +35,10 @@ describe('Settings model tests', () => {
     settings.set('foo', 'bar');
     settings.set('lorem', 'ipsum');
 
-    expect(settings.getEntries()).toEqual([['foo', 'bar'], ['lorem', 'ipsum']]);
+    expect(settings.getEntries()).toEqual([
+      ['foo', 'bar'],
+      ['lorem', 'ipsum'],
+    ]);
   });
 
   test('should not have non existing key', () => {

--- a/src/gmp/models/__tests__/tag.js
+++ b/src/gmp/models/__tests__/tag.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Tag from 'gmp/models/tag';
 

--- a/src/gmp/models/__tests__/target.js
+++ b/src/gmp/models/__tests__/target.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Model from 'gmp/model';
 import PortList from 'gmp/models/portlist';

--- a/src/gmp/models/__tests__/task.js
+++ b/src/gmp/models/__tests__/task.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Model from 'gmp/model';
 

--- a/src/gmp/models/__tests__/ticket.js
+++ b/src/gmp/models/__tests__/ticket.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import Ticket from '../ticket';
 import {isDate} from '../date';
 

--- a/src/gmp/models/__tests__/tlscertificate.js
+++ b/src/gmp/models/__tests__/tlscertificate.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import TlsCertificate, {TIME_STATUS} from '../tlscertificate';
 
 import {testModel} from 'gmp/models/testing';

--- a/src/gmp/models/__tests__/user.js
+++ b/src/gmp/models/__tests__/user.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Model from 'gmp/model';
 import User, {

--- a/src/gmp/models/filter/__tests__/convert.js
+++ b/src/gmp/models/filter/__tests__/convert.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import convert from '../convert';
 
 describe('convert tests', () => {

--- a/src/gmp/models/filter/__tests__/filterterm.js
+++ b/src/gmp/models/filter/__tests__/filterterm.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import FilterTerm from '../filterterm.js';
 

--- a/src/gmp/models/filter/__tests__/utils.js
+++ b/src/gmp/models/filter/__tests__/utils.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {filter_string} from '../utils';
 import Filter from '../../filter';
 

--- a/src/gmp/models/report/__tests__/app.js
+++ b/src/gmp/models/report/__tests__/app.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import App from '../app';
 
 describe('App tests', () => {

--- a/src/gmp/models/report/__tests__/cve.js
+++ b/src/gmp/models/report/__tests__/cve.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import ReportCve from '../cve';
 
 describe('ReportCve tests', () => {

--- a/src/gmp/models/report/__tests__/host.js
+++ b/src/gmp/models/report/__tests__/host.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import ReportHost from '../host';
 import {isDate} from 'gmp/models/date';
 

--- a/src/gmp/models/report/__tests__/os.js
+++ b/src/gmp/models/report/__tests__/os.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import ReportOperatingSystem from '../os';
 

--- a/src/gmp/models/report/__tests__/parser.js
+++ b/src/gmp/models/report/__tests__/parser.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import {
   parseHosts,

--- a/src/gmp/models/report/__tests__/port.js
+++ b/src/gmp/models/report/__tests__/port.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import ReportPort from '../port';
 
 describe('ReportPort tests', () => {

--- a/src/gmp/models/report/__tests__/task.js
+++ b/src/gmp/models/report/__tests__/task.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import ReportTask from '../task';
 
 describe('ReportTask tests', () => {

--- a/src/gmp/models/report/__tests__/tlscertificate.js
+++ b/src/gmp/models/report/__tests__/tlscertificate.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import ReportTlsCertificate from '../tlscertificate';
 
 describe('ReportTlsCertificate tests', () => {

--- a/src/gmp/models/testing.js
+++ b/src/gmp/models/testing.js
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint-disable max-len */
+import {test, expect} from '@gsa/testing';
 
 import {isDate} from 'gmp/models/date';
 import {parseDate, NO_VALUE, YES_VALUE} from 'gmp/parser';

--- a/src/gmp/utils/__tests__/array.js
+++ b/src/gmp/utils/__tests__/array.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import {arraysEqual, map, forEach, filter, first} from '../array';
 
 describe('arrayEquals function test', () => {
@@ -137,7 +139,7 @@ describe('for_each function tests', () => {
   });
 
   test('should iterate over array', () => {
-    const callback = vi.fn();
+    const callback = testing.fn();
     forEach([1, 2, 3], callback);
 
     expect(callback).toBeCalled();
@@ -148,7 +150,7 @@ describe('for_each function tests', () => {
   });
 
   test('should iterate over single item', () => {
-    const callback = vi.fn();
+    const callback = testing.fn();
     forEach(2, callback);
 
     expect(callback).toBeCalled();
@@ -157,7 +159,7 @@ describe('for_each function tests', () => {
   });
 
   test('should iterate over Set', () => {
-    const callback = vi.fn();
+    const callback = testing.fn();
     forEach(new Set([1, 2, 3]), callback);
 
     expect(callback).toBeCalled();

--- a/src/gmp/utils/__tests__/entitytype.js
+++ b/src/gmp/utils/__tests__/entitytype.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {parseModelFromElement} from 'gmp/model';
 import Nvt from 'gmp/models/nvt';
 import Host from 'gmp/models/host';

--- a/src/gmp/utils/__tests__/event.js
+++ b/src/gmp/utils/__tests__/event.js
@@ -15,22 +15,24 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import {debounce, throttleAnimation} from '../event';
 
 // @vitest-environment jsdom
 
 describe('debounce function tests', () => {
-  vi.useFakeTimers();
+  testing.useFakeTimers();
 
   test('should debounce function', () => {
-    const callback = vi.fn();
+    const callback = testing.fn();
     const func = debounce(callback);
 
     func(1);
     func(2);
     func(3);
 
-    vi.runAllTimers();
+    testing.runAllTimers();
 
     expect(callback).toBeCalled();
     expect(callback.mock.calls.length).toBe(1);
@@ -38,7 +40,7 @@ describe('debounce function tests', () => {
   });
 
   test('should run callback immediately', () => {
-    const callback = vi.fn();
+    const callback = testing.fn();
     const func = debounce(callback, 10000, true);
 
     func(1);
@@ -49,7 +51,7 @@ describe('debounce function tests', () => {
     expect(callback.mock.calls.length).toBe(1);
     expect(callback.mock.calls[0][0]).toBe(1);
 
-    vi.runAllTimers();
+    testing.runAllTimers();
 
     expect(callback.mock.calls.length).toBe(2);
     expect(callback.mock.calls[1][0]).toBe(3);
@@ -57,24 +59,22 @@ describe('debounce function tests', () => {
 });
 
 describe('throttleAnimation function tests', () => {
-  vi.useFakeTimers();
+  testing.useFakeTimers();
 
   test('should throttle running callback', () => {
     global.requestAnimationFrame = cb => setTimeout(cb, 0);
 
-    const callback = vi.fn();
+    const callback = testing.fn();
     const func = throttleAnimation(callback);
 
     func(1);
     func(2);
     func(3);
 
-    vi.runAllTimers();
+    testing.runAllTimers();
 
     expect(callback).toBeCalled();
     expect(callback.mock.calls.length).toBe(1);
     expect(callback.mock.calls[0][0]).toBe(1);
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/gmp/utils/__tests__/id.js
+++ b/src/gmp/utils/__tests__/id.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {includesId, selectSaveId, hasId} from '../id';
 
 describe('includesId function tests', () => {

--- a/src/gmp/utils/__tests__/identity.js
+++ b/src/gmp/utils/__tests__/identity.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {
   isDefined,
   hasValue,

--- a/src/gmp/utils/__tests__/number.js
+++ b/src/gmp/utils/__tests__/number.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {severityValue, fixedValue} from 'gmp/utils/number';
 
 describe('severityValue function tests', () => {

--- a/src/gmp/utils/__tests__/object.js
+++ b/src/gmp/utils/__tests__/object.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {exclude, excludeObjectProps} from '../object';
 
 describe('exclude function test', () => {

--- a/src/gmp/utils/__tests__/string.js
+++ b/src/gmp/utils/__tests__/string.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {split, capitalizeFirstLetter, shorten, isEmpty} from '../string';
 
 describe('split function tests', () => {

--- a/src/testing.js
+++ b/src/testing.js
@@ -1,0 +1,13 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {vi} from 'vitest';
+
+export * from 'vitest';
+
+// alternatively for jest
+// export * from '@jest/globals';
+
+export {vi as testing};

--- a/src/web/components/badge/__tests__/badge.jsx
+++ b/src/web/components/badge/__tests__/badge.jsx
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/bar/__tests__/compliancestatusbar.jsx
+++ b/src/web/components/bar/__tests__/compliancestatusbar.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 import Theme from 'web/utils/theme';

--- a/src/web/components/bar/__tests__/progressbar.jsx
+++ b/src/web/components/bar/__tests__/progressbar.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/bar/__tests__/severitybar.jsx
+++ b/src/web/components/bar/__tests__/severitybar.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/bar/__tests__/statusbar.jsx
+++ b/src/web/components/bar/__tests__/statusbar.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/bar/__tests__/titlebar.jsx
+++ b/src/web/components/bar/__tests__/titlebar.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {rendererWith} from 'web/utils/testing';
 

--- a/src/web/components/bar/__tests__/toolbar.jsx
+++ b/src/web/components/bar/__tests__/toolbar.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/chart/utils/__tests__/arc.jsx
+++ b/src/web/components/chart/utils/__tests__/arc.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import arc from '../arc';
 
 describe('arc class tests', () => {
@@ -26,9 +28,7 @@ describe('arc class tests', () => {
   });
 
   test('should calculate central position', () => {
-    const c = arc()
-      .outerRadiusX(100)
-      .centroid();
+    const c = arc().outerRadiusX(100).centroid();
 
     expect(c.x).toEqual(-50);
     expect(c.y).toBeCloseTo(0); // it can't be zero due to floating point numbers

--- a/src/web/components/chart/utils/__tests__/path.jsx
+++ b/src/web/components/chart/utils/__tests__/path.jsx
@@ -15,29 +15,21 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import path from '../path';
 
 describe('path tests', () => {
   test('should draw a move path', () => {
-    expect(
-      path()
-        .move(10, 10)
-        .toString(),
-    ).toEqual('M 10 10');
+    expect(path().move(10, 10).toString()).toEqual('M 10 10');
   });
 
   test('should draw a line path', () => {
-    expect(
-      path()
-        .line(10, 10)
-        .toString(),
-    ).toEqual('L 10 10');
+    expect(path().line(10, 10).toString()).toEqual('L 10 10');
   });
 
   test('should close a path', () => {
-    const p = path()
-      .move(10, 10)
-      .close();
+    const p = path().move(10, 10).close();
 
     expect(p.toString()).toEqual('M 10 10 Z');
   });
@@ -53,9 +45,7 @@ describe('path tests', () => {
   });
 
   test('should ignore calls after close', () => {
-    const p = path()
-      .move(10, 10)
-      .close();
+    const p = path().move(10, 10).close();
 
     expect(p.toString()).toEqual('M 10 10 Z');
 

--- a/src/web/components/chart/utils/__tests__/update.jsx
+++ b/src/web/components/chart/utils/__tests__/update.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {shouldUpdate} from '../update';
 
 describe('shouldUpdate tests', () => {

--- a/src/web/components/comment/__tests__/comment.jsx
+++ b/src/web/components/comment/__tests__/comment.jsx
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/dashboard/__tests__/utils.jsx
+++ b/src/web/components/dashboard/__tests__/utils.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import {DEFAULT_ROW_HEIGHT} from 'gmp/commands/dashboards';
 
 import {
@@ -77,7 +79,7 @@ describe('convertDefaultDisplays test', () => {
 
   test('should convert array to rows', () => {
     let i = 1;
-    const uuid = vi.fn().mockImplementation(() => i++);
+    const uuid = testing.fn().mockImplementation(() => i++);
 
     const rows = [['foo', 'bar'], ['lorem']];
 

--- a/src/web/components/date/__tests__/datetime.jsx
+++ b/src/web/components/date/__tests__/datetime.jsx
@@ -16,16 +16,15 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 /* eslint-disable no-console */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
-import Date, {setLocale} from 'gmp/models/date';
+import Date from 'gmp/models/date';
 
 import {rendererWith} from 'web/utils/testing';
 
-import DateTime from '../datetime';
 import {setTimezone} from 'web/store/usersettings/actions';
 
-setLocale('en');
+import DateTime from '../datetime';
 
 describe('DateTime render tests', () => {
   test('should render nothing if date is undefined', () => {
@@ -55,7 +54,7 @@ describe('DateTime render tests', () => {
   });
 
   test('should call formatter', () => {
-    const formatter = vi.fn().mockReturnValue('foo');
+    const formatter = testing.fn().mockReturnValue('foo');
     const {render, store} = rendererWith({store: true});
 
     const date = Date('2019-01-01T12:00:00Z');

--- a/src/web/components/dialog/__tests__/button.jsx
+++ b/src/web/components/dialog/__tests__/button.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 import Theme from 'web/utils/theme';
@@ -24,7 +24,7 @@ import Button from '../button';
 
 describe('Dialog Button tests', () => {
   test('should call click handler', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const {element} = render(<Button onClick={handler} />);
 

--- a/src/web/components/dialog/__tests__/closebutton.jsx
+++ b/src/web/components/dialog/__tests__/closebutton.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -27,8 +25,6 @@ import {
 } from 'web/components/icon/withIconSize';
 
 import CloseButton from '../closebutton';
-
-setLocale('en');
 
 describe('Dialog CloseButton tests', () => {
   test('should render', () => {
@@ -41,7 +37,7 @@ describe('Dialog CloseButton tests', () => {
   });
 
   test('should call close handler', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const {element} = render(<CloseButton onClick={handler} />);
 

--- a/src/web/components/dialog/__tests__/confirmationdialog.jsx
+++ b/src/web/components/dialog/__tests__/confirmationdialog.jsx
@@ -15,17 +15,18 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
+
+import {KeyCode} from 'gmp/utils/event';
 
 import {render, fireEvent} from 'web/utils/testing';
 
 import ConfirmationDialog from '../confirmationdialog';
-import {KeyCode} from 'gmp/utils/event';
 
 describe('ConfirmationDialog component tests', () => {
   test('should render ConfirmationDialog with text and title', () => {
-    const handleClose = vi.fn();
-    const handleResumeClick = vi.fn();
+    const handleClose = testing.fn();
+    const handleResumeClick = testing.fn();
 
     const {baseElement, getByTestId} = render(
       <ConfirmationDialog
@@ -44,8 +45,8 @@ describe('ConfirmationDialog component tests', () => {
   });
 
   test('should render ConfirmationDialog with element content and title', () => {
-    const handleClose = vi.fn();
-    const handleResumeClick = vi.fn();
+    const handleClose = testing.fn();
+    const handleResumeClick = testing.fn();
 
     const {getByTestId} = render(
       <ConfirmationDialog
@@ -63,8 +64,8 @@ describe('ConfirmationDialog component tests', () => {
   });
 
   test('should close ConfirmationDialog with close button', () => {
-    const handleClose = vi.fn();
-    const handleResumeClick = vi.fn();
+    const handleClose = testing.fn();
+    const handleResumeClick = testing.fn();
 
     const {getByTestId} = render(
       <ConfirmationDialog
@@ -80,8 +81,8 @@ describe('ConfirmationDialog component tests', () => {
   });
 
   test('should close ConfirmationDialog with cancel button', () => {
-    const handleClose = vi.fn();
-    const handleResumeClick = vi.fn();
+    const handleClose = testing.fn();
+    const handleResumeClick = testing.fn();
 
     const {baseElement} = render(
       <ConfirmationDialog
@@ -97,8 +98,8 @@ describe('ConfirmationDialog component tests', () => {
   });
 
   test('should resume ConfirmationDialog with resume button', () => {
-    const handleClose = vi.fn();
-    const handleResumeClick = vi.fn();
+    const handleClose = testing.fn();
+    const handleResumeClick = testing.fn();
 
     const {baseElement} = render(
       <ConfirmationDialog
@@ -114,8 +115,8 @@ describe('ConfirmationDialog component tests', () => {
   });
 
   test('should close ConfirmationDialog on escape key', () => {
-    const handleClose = vi.fn();
-    const handleResumeClick = vi.fn();
+    const handleClose = testing.fn();
+    const handleResumeClick = testing.fn();
 
     const {getByRole} = render(
       <ConfirmationDialog

--- a/src/web/components/dialog/__tests__/dialog.jsx
+++ b/src/web/components/dialog/__tests__/dialog.jsx
@@ -15,18 +15,19 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
+
+import {isFunction} from 'gmp/utils/identity';
+import {KeyCode} from 'gmp/utils/event';
 
 import {render, fireEvent} from 'web/utils/testing';
 
 import Dialog from '../dialog';
-import {isFunction} from 'gmp/utils/identity';
-import {KeyCode} from 'gmp/utils/event';
 
 describe('Dialog component tests', () => {
   test('should render a Dialog', () => {
-    const handleClose = vi.fn();
-    const renderFunc = vi.fn().mockReturnValue(<div />);
+    const handleClose = testing.fn();
+    const renderFunc = testing.fn().mockReturnValue(<div />);
 
     const {baseElement} = render(
       <Dialog onClose={handleClose}>{renderFunc}</Dialog>,
@@ -46,8 +47,8 @@ describe('Dialog component tests', () => {
   });
 
   test('should close Dialog', () => {
-    const handleClose = vi.fn();
-    const renderFunc = vi.fn().mockReturnValue(<div />);
+    const handleClose = testing.fn();
+    const renderFunc = testing.fn().mockReturnValue(<div />);
 
     render(<Dialog onClose={handleClose}>{renderFunc}</Dialog>);
 
@@ -62,8 +63,8 @@ describe('Dialog component tests', () => {
   });
 
   test('should close Dialog on escape key', () => {
-    const handleClose = vi.fn();
-    const renderFunc = vi.fn().mockReturnValue(<div />);
+    const handleClose = testing.fn();
+    const renderFunc = testing.fn().mockReturnValue(<div />);
 
     const {getByRole} = render(
       <Dialog onClose={handleClose}>{renderFunc}</Dialog>,

--- a/src/web/components/dialog/__tests__/error.jsx
+++ b/src/web/components/dialog/__tests__/error.jsx
@@ -15,16 +15,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent, screen} from 'web/utils/testing';
 import Theme from 'web/utils/theme';
 
 import DialogError from '../error';
-
-setLocale('en');
 
 describe('Dialog error tests', () => {
   test('should render with defined error', () => {
@@ -43,7 +39,7 @@ describe('Dialog error tests', () => {
   });
 
   test('should call close handler', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const {element} = render(
       <DialogError error="foo" onCloseClick={handler} />,

--- a/src/web/components/dialog/__tests__/errordialog.jsx
+++ b/src/web/components/dialog/__tests__/errordialog.jsx
@@ -15,16 +15,17 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
+
+import {KeyCode} from 'gmp/utils/event';
 
 import {render, fireEvent} from 'web/utils/testing';
 
 import ErrorDialog from '../errordialog';
-import {KeyCode} from 'gmp/utils/event';
 
 describe('ErrorDialog component tests', () => {
   test('should render ErrorDialog with text and title', () => {
-    const handleClose = vi.fn();
+    const handleClose = testing.fn();
 
     const {baseElement, getByTestId} = render(
       <ErrorDialog text="foo" title="bar" onClose={handleClose} />,
@@ -38,7 +39,7 @@ describe('ErrorDialog component tests', () => {
   });
 
   test('should close ErrorDialog with close button', () => {
-    const handleClose = vi.fn();
+    const handleClose = testing.fn();
 
     const {getByTestId} = render(
       <ErrorDialog title="bar" onClose={handleClose} />,
@@ -50,7 +51,7 @@ describe('ErrorDialog component tests', () => {
   });
 
   test('should close ErrorDialog with resume button', () => {
-    const handleClose = vi.fn();
+    const handleClose = testing.fn();
 
     const {baseElement} = render(
       <ErrorDialog title="bar" onClose={handleClose} />,
@@ -62,7 +63,7 @@ describe('ErrorDialog component tests', () => {
   });
 
   test('should close ErrorDialog on escape key', () => {
-    const handleClose = vi.fn();
+    const handleClose = testing.fn();
 
     const {getByRole} = render(
       <ErrorDialog title="bar" onClose={handleClose} />,

--- a/src/web/components/dialog/__tests__/multistepfooter.jsx
+++ b/src/web/components/dialog/__tests__/multistepfooter.jsx
@@ -15,16 +15,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 import Theme from 'web/utils/theme';
 
 import MultiStepFooter from 'web/components/dialog/multistepfooter';
-
-setLocale('en');
 
 describe('MultiStepFooter tests', () => {
   test('should render', () => {
@@ -100,10 +96,10 @@ describe('MultiStepFooter tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handler1 = vi.fn();
-    const handler2 = vi.fn();
-    const handler3 = vi.fn();
-    const handler4 = vi.fn();
+    const handler1 = testing.fn();
+    const handler2 = testing.fn();
+    const handler3 = testing.fn();
+    const handler4 = testing.fn();
 
     const {element} = render(
       <MultiStepFooter

--- a/src/web/components/dialog/__tests__/twobuttonfooter.jsx
+++ b/src/web/components/dialog/__tests__/twobuttonfooter.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 import Theme from 'web/utils/theme';
@@ -79,8 +79,8 @@ describe('DialogTwoButtonFooter tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handler1 = vi.fn();
-    const handler2 = vi.fn();
+    const handler1 = testing.fn();
+    const handler2 = testing.fn();
 
     const {element} = render(
       <DialogTwoButtonFooter

--- a/src/web/components/error/__tests__/errorboundary.jsx
+++ b/src/web/components/error/__tests__/errorboundary.jsx
@@ -18,7 +18,7 @@
 
 /* eslint-disable no-console */
 
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 import ErrorBoundary from '../errorboundary';

--- a/src/web/components/error/__tests__/errorcontainer.jsx
+++ b/src/web/components/error/__tests__/errorcontainer.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/error/__tests__/errormessage.jsx
+++ b/src/web/components/error/__tests__/errormessage.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/error/__tests__/errorpanel.jsx
+++ b/src/web/components/error/__tests__/errorpanel.jsx
@@ -18,15 +18,11 @@
 
 /* eslint-disable no-console */
 
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
 import ErrorPanel from '../errorpanel';
-
-setLocale('en');
 
 describe('ErrorPanel tests', () => {
   test('should render message', () => {

--- a/src/web/components/footnote/__tests__/footnote.jsx
+++ b/src/web/components/footnote/__tests__/footnote.jsx
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/form/__tests__/button.jsx
+++ b/src/web/components/form/__tests__/button.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -23,7 +23,7 @@ import Button from '../button';
 
 describe('Button tests', () => {
   test('should call click handler', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const {element} = render(<Button onClick={handler} />);
 
@@ -33,7 +33,7 @@ describe('Button tests', () => {
   });
 
   test('should call click handler with value', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const {element} = render(<Button onClick={handler} value="bar" />);
 
@@ -43,7 +43,7 @@ describe('Button tests', () => {
   });
 
   test('should call click handler with value and name', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const {element} = render(
       <Button name="foo" value="bar" onClick={handler} />,

--- a/src/web/components/form/__tests__/checkbox.jsx
+++ b/src/web/components/form/__tests__/checkbox.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -23,7 +23,7 @@ import CheckBox from '../checkbox';
 
 describe('CheckBox component tests', () => {
   test('should call change handler', () => {
-    const change = vi.fn();
+    const change = testing.fn();
     const {element} = render(
       <CheckBox name="foo" checked={false} onChange={change} />,
     );
@@ -36,7 +36,7 @@ describe('CheckBox component tests', () => {
   });
 
   test('should use checkedValue', () => {
-    const change = vi.fn();
+    const change = testing.fn();
     const {element} = render(
       <CheckBox
         name="foo"
@@ -55,7 +55,7 @@ describe('CheckBox component tests', () => {
   });
 
   test('should use unCheckedValue', () => {
-    const change = vi.fn();
+    const change = testing.fn();
     const {element} = render(
       <CheckBox
         name="foo"
@@ -74,7 +74,7 @@ describe('CheckBox component tests', () => {
   });
 
   test('should not call change handler if disabled', () => {
-    const change = vi.fn();
+    const change = testing.fn();
     const {element} = render(
       <CheckBox
         name="foo"

--- a/src/web/components/form/__tests__/download.jsx
+++ b/src/web/components/form/__tests__/download.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/form/__tests__/field.jsx
+++ b/src/web/components/form/__tests__/field.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Theme from 'web/utils/theme';
 import {render, fireEvent} from 'web/utils/testing';
@@ -44,7 +44,7 @@ describe('Field tests', () => {
   });
 
   test('should call change handler with value', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(<Field value="foo" onChange={onChange} />);
 
@@ -54,7 +54,7 @@ describe('Field tests', () => {
   });
 
   test('should call change handler with value and name', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(
       <Field name="foo" value="ipsum" onChange={onChange} />,
@@ -66,7 +66,7 @@ describe('Field tests', () => {
   });
 
   test('should not call change handler if disabled', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(
       <Field disabled={true} value="foo" onChange={onChange} />,

--- a/src/web/components/form/__tests__/filefield.jsx
+++ b/src/web/components/form/__tests__/filefield.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -33,7 +33,7 @@ describe('FileField tests', () => {
   });
 
   test('should call change handler with file', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(<FileField onChange={onChange} />);
 
@@ -43,7 +43,7 @@ describe('FileField tests', () => {
   });
 
   test('should call change handler with file and name', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(<FileField name="foo" onChange={onChange} />);
 
@@ -53,7 +53,7 @@ describe('FileField tests', () => {
   });
 
   test('should not call change handler if disabled', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(<FileField disabled={true} onChange={onChange} />);
 

--- a/src/web/components/form/__tests__/formgroup.jsx
+++ b/src/web/components/form/__tests__/formgroup.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/form/__tests__/loadingbutton.jsx
+++ b/src/web/components/form/__tests__/loadingbutton.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Theme from 'web/utils/theme';
 import {render, fireEvent} from 'web/utils/testing';
@@ -36,7 +36,7 @@ describe('LoadingButton tests', () => {
   });
 
   test('should call click handler', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const {element} = render(<LoadingButton onClick={handler} />);
 
@@ -46,7 +46,7 @@ describe('LoadingButton tests', () => {
   });
 
   test('should call click handler with value', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const {element} = render(<LoadingButton onClick={handler} value="bar" />);
 
@@ -56,7 +56,7 @@ describe('LoadingButton tests', () => {
   });
 
   test('should call click handler with value and name', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const {element} = render(
       <LoadingButton name="foo" value="bar" onClick={handler} />,

--- a/src/web/components/form/__tests__/multiselect.jsx
+++ b/src/web/components/form/__tests__/multiselect.jsx
@@ -15,15 +15,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
 
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
 import MultiSelect from '../multiselect';
-
-setLocale('en');
 
 const openInputElement = element => {
   const button = element.querySelector('[type="button"]');
@@ -116,7 +113,7 @@ describe('MultiSelect component tests', () => {
       },
     ];
 
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element, baseElement} = render(
       <MultiSelect items={items} onChange={onChange} />,
@@ -145,7 +142,7 @@ describe('MultiSelect component tests', () => {
       },
     ];
 
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element, baseElement} = render(
       <MultiSelect name="abc" items={items} onChange={onChange} />,
@@ -244,7 +241,7 @@ describe('MultiSelect component tests', () => {
       },
     ];
 
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {getAllByTestId} = render(
       <MultiSelect items={items} value={['bar', 'foo']} onChange={onChange} />,

--- a/src/web/components/form/__tests__/numberfield.jsx
+++ b/src/web/components/form/__tests__/numberfield.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {KeyCode} from 'gmp/utils/event';
 
@@ -32,7 +32,7 @@ describe('NumberField tests', () => {
   });
 
   test('should call change handler', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {element} = render(<NumberField value={1} onChange={onChange} />);
 
     fireEvent.change(element, {target: {value: '2'}});
@@ -42,7 +42,7 @@ describe('NumberField tests', () => {
   });
 
   test('should call change handler with value and name', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {element} = render(
       <NumberField name="foo" value={1} onChange={onChange} />,
     );
@@ -54,7 +54,7 @@ describe('NumberField tests', () => {
   });
 
   test('should not call change handler if disabled', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {element} = render(
       <NumberField disabled={true} value={1} onChange={onChange} />,
     );
@@ -66,7 +66,7 @@ describe('NumberField tests', () => {
   });
 
   test('should update value', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {element, rerender} = render(
       <NumberField value={1} onChange={onChange} />,
     );
@@ -86,7 +86,7 @@ describe('NumberField tests', () => {
   });
 
   test('should not call change handler if value > max', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {element} = render(
       <NumberField value={1} max={2} onChange={onChange} />,
     );
@@ -99,7 +99,7 @@ describe('NumberField tests', () => {
   });
 
   test('should reset to max', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {element} = render(
       <NumberField value={1} max={2} onChange={onChange} />,
     );
@@ -115,7 +115,7 @@ describe('NumberField tests', () => {
   });
 
   test('should not call change handler if value < min', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {element} = render(
       <NumberField value={1} min={1} onChange={onChange} />,
     );
@@ -128,7 +128,7 @@ describe('NumberField tests', () => {
   });
 
   test('should reset to min', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {element} = render(
       <NumberField value={2} min={1} onChange={onChange} />,
     );
@@ -146,7 +146,7 @@ describe('NumberField tests', () => {
   });
 
   test('should reset to last valid value', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {element} = render(
       <NumberField value={2} min={1} onChange={onChange} />,
     );
@@ -164,7 +164,7 @@ describe('NumberField tests', () => {
   });
 
   test('should not allow to add letters', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {element} = render(<NumberField value={1} onKeyDown={handler} />);
 
     fireEvent.keyDown(element, {key: 'a', keyCode: 65});
@@ -173,7 +173,7 @@ describe('NumberField tests', () => {
   });
 
   test('should allow to add numbers', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {element} = render(<NumberField value={1} onKeyDown={handler} />);
 
     fireEvent.keyDown(element, {key: '1', keyCode: 49});
@@ -183,7 +183,7 @@ describe('NumberField tests', () => {
   });
 
   test('should allow point key for float numbers', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {element} = render(
       <NumberField value={1} type="float" onKeyDown={handler} />,
     );
@@ -195,7 +195,7 @@ describe('NumberField tests', () => {
   });
 
   test('should not allow point key for int numbers', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {element} = render(
       <NumberField value={1} type="int" onKeyDown={handler} />,
     );
@@ -207,7 +207,7 @@ describe('NumberField tests', () => {
   });
 
   test('should call onDownKeyPressed handler', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {element} = render(
       <NumberField value={1} onDownKeyPressed={handler} />,
     );
@@ -222,7 +222,7 @@ describe('NumberField tests', () => {
   });
 
   test('should call onUpKeyPressed handler', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {element} = render(
       <NumberField value={1} onUpKeyPressed={handler} />,
     );

--- a/src/web/components/form/__tests__/passwordfield.jsx
+++ b/src/web/components/form/__tests__/passwordfield.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -37,7 +37,7 @@ describe('PasswordField tests', () => {
   });
 
   test('should call change handler with value', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(<PasswordField value="foo" onChange={onChange} />);
 
@@ -47,7 +47,7 @@ describe('PasswordField tests', () => {
   });
 
   test('should call change handler with value and name', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(
       <PasswordField name="foo" value="ipsum" onChange={onChange} />,
@@ -59,7 +59,7 @@ describe('PasswordField tests', () => {
   });
 
   test('should not call change handler if disabled', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(
       <PasswordField disabled={true} value="foo" onChange={onChange} />,

--- a/src/web/components/form/__tests__/radio.jsx
+++ b/src/web/components/form/__tests__/radio.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -78,7 +78,7 @@ describe('Radio tests', () => {
   });
 
   test('should call change handler', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(<Radio onChange={onChange} />);
 
@@ -88,7 +88,7 @@ describe('Radio tests', () => {
   });
 
   test('should call change handler with value', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(<Radio value="foo" onChange={onChange} />);
 
@@ -98,7 +98,7 @@ describe('Radio tests', () => {
   });
 
   test('should call change handler with value and name', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(
       <Radio name="bar" value="foo" onChange={onChange} />,
@@ -110,7 +110,7 @@ describe('Radio tests', () => {
   });
 
   test('should not call change handler if disabled', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(<Radio disabled={true} onChange={onChange} />);
 
@@ -127,7 +127,7 @@ describe('Radio tests', () => {
   });
 
   test('should not call change handler if already checked', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(
       <Radio checked={true} value="foo" onChange={onChange} />,

--- a/src/web/components/form/__tests__/select.jsx
+++ b/src/web/components/form/__tests__/select.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {
   render,
@@ -27,8 +25,6 @@ import {
 } from 'web/utils/testing';
 
 import Select from '../select';
-
-setLocale('en');
 
 export const openSelectElement = element => {
   const openButton = getByTestId(element, 'select-open-button');
@@ -127,7 +123,7 @@ describe('Select component tests', () => {
       },
     ];
 
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element, baseElement} = render(
       <Select items={items} onChange={onChange} />,
@@ -157,7 +153,7 @@ describe('Select component tests', () => {
       },
     ];
 
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element, baseElement} = render(
       <Select name="abc" items={items} onChange={onChange} />,
@@ -185,7 +181,7 @@ describe('Select component tests', () => {
       },
     ];
 
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     // eslint-disable-next-line no-shadow
     const {baseElement, element, getByTestId} = render(

--- a/src/web/components/form/__tests__/selectelement.jsx
+++ b/src/web/components/form/__tests__/selectelement.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import React from 'react';
 
 import {isFunction} from 'gmp/utils/identity';
@@ -211,7 +213,7 @@ class MenuTestComponent extends React.Component {
     const {mockBoundingClientRect, ...otherProps} = this.props;
     this.mockBoundingClientRect = mockBoundingClientRect;
     this.otherProps = otherProps;
-    this.notifyRefAssigned = vi.fn();
+    this.notifyRefAssigned = testing.fn();
   }
 
   render() {
@@ -219,7 +221,7 @@ class MenuTestComponent extends React.Component {
     if (hasTarget && this.mockBoundingClientRect) {
       const rect = this.target.current.closest('.multiselect-scroll');
       if (rect !== null) {
-        vi.spyOn(rect, 'getBoundingClientRect').mockImplementation(() => {
+        testing.spyOn(rect, 'getBoundingClientRect').mockImplementation(() => {
           return {
             top: 100,
             bottom: 50,
@@ -292,7 +294,7 @@ describe('Menu tests', () => {
   });
 
   test('should not render without target', () => {
-    const notifyRefAssigned = vi.fn();
+    const notifyRefAssigned = testing.fn();
     const {queryByTestId} = render(
       <Menu target={null} notifyRefAssigned={notifyRefAssigned} />,
     );
@@ -320,5 +322,3 @@ describe('Menu tests', () => {
     expect(menu).toMatchSnapshot();
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/components/form/__tests__/spinner.jsx
+++ b/src/web/components/form/__tests__/spinner.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {KeyCode} from 'gmp/utils/event';
 
@@ -34,7 +34,7 @@ describe('Spinner tests', () => {
   });
 
   test('should call change handler', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(<Spinner value={1} onChange={handler} />);
 
     const input = getByTestId('spinner-input');
@@ -44,7 +44,7 @@ describe('Spinner tests', () => {
   });
 
   test('should call change handler with name', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(
       <Spinner name="foo" value={1} onChange={handler} />,
     );
@@ -56,7 +56,7 @@ describe('Spinner tests', () => {
   });
 
   test('should increment value on button click', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(<Spinner value={1} onChange={handler} />);
 
     const button = getByTestId('spinner-up');
@@ -66,7 +66,7 @@ describe('Spinner tests', () => {
   });
 
   test('should decrement value on button click', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(<Spinner value={1} onChange={handler} />);
 
     const button = getByTestId('spinner-down');
@@ -76,7 +76,7 @@ describe('Spinner tests', () => {
   });
 
   test('should increment value on wheel up', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(<Spinner value={1} onChange={handler} />);
 
     const input = getByTestId('spinner-input');
@@ -86,7 +86,7 @@ describe('Spinner tests', () => {
   });
 
   test('should decrement value on wheel down', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(<Spinner value={1} onChange={handler} />);
 
     const input = getByTestId('spinner-input');
@@ -96,7 +96,7 @@ describe('Spinner tests', () => {
   });
 
   test('should increment on key up', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(<Spinner value={1} onChange={handler} />);
 
     const input = getByTestId('spinner-input');
@@ -106,7 +106,7 @@ describe('Spinner tests', () => {
   });
 
   test('should increment on key page up', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(<Spinner value={1} onChange={handler} />);
 
     const input = getByTestId('spinner-input');
@@ -116,7 +116,7 @@ describe('Spinner tests', () => {
   });
 
   test('should decrement on key down', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(<Spinner value={1} onChange={handler} />);
 
     const input = getByTestId('spinner-input');
@@ -126,7 +126,7 @@ describe('Spinner tests', () => {
   });
 
   test('should decrement on key page down', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(<Spinner value={1} onChange={handler} />);
 
     const input = getByTestId('spinner-input');
@@ -136,7 +136,7 @@ describe('Spinner tests', () => {
   });
 
   test('should not call event handler if disabled', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(
       <Spinner disabled={true} value={1} onChange={handler} />,
     );
@@ -159,9 +159,9 @@ describe('Spinner tests', () => {
   });
 
   test('should debounce notification', () => {
-    vi.useFakeTimers();
+    testing.useFakeTimers();
 
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(
       <Spinner debounce={200} value={1} onChange={handler} />,
     );
@@ -171,14 +171,14 @@ describe('Spinner tests', () => {
     fireEvent.click(ubutton);
     fireEvent.click(ubutton);
 
-    vi.runAllTimers();
+    testing.runAllTimers();
 
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenCalledWith(2, undefined);
   });
 
   test('should not increment value beyond max', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(
       <Spinner value={1} max={1} onChange={handler} />,
     );
@@ -190,7 +190,7 @@ describe('Spinner tests', () => {
   });
 
   test('should not decrement value below min', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(
       <Spinner value={1} min={1} onChange={handler} />,
     );
@@ -202,7 +202,7 @@ describe('Spinner tests', () => {
   });
 
   test('should increment float value', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(
       <Spinner type="float" value={1} onChange={handler} />,
     );
@@ -214,7 +214,7 @@ describe('Spinner tests', () => {
   });
 
   test('should increment value with step', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId} = render(
       <Spinner step={0.5} type="float" value={1} onChange={handler} />,
     );

--- a/src/web/components/form/__tests__/textarea.jsx
+++ b/src/web/components/form/__tests__/textarea.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Theme from 'web/utils/theme';
 import {render, fireEvent} from 'web/utils/testing';
@@ -51,7 +51,7 @@ describe('TextArea tests', () => {
   });
 
   test('should call change handler with value', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(<TextArea value="foo" onChange={onChange} />);
 
@@ -61,7 +61,7 @@ describe('TextArea tests', () => {
   });
 
   test('should call change handler with value and name', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(
       <TextArea name="foo" value="ipsum" onChange={onChange} />,
@@ -73,7 +73,7 @@ describe('TextArea tests', () => {
   });
 
   test('should not call change handler if disabled', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(
       <TextArea disabled={true} value="foo" onChange={onChange} />,

--- a/src/web/components/form/__tests__/textfield.jsx
+++ b/src/web/components/form/__tests__/textfield.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -39,7 +39,7 @@ describe('TextField tests', () => {
   });
 
   test('should call change handler with value', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(<TextField value="foo" onChange={onChange} />);
 
@@ -49,7 +49,7 @@ describe('TextField tests', () => {
   });
 
   test('should call change handler with value and name', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(
       <TextField name="foo" value="ipsum" onChange={onChange} />,
@@ -61,7 +61,7 @@ describe('TextField tests', () => {
   });
 
   test('should not call change handler if disabled', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(
       <TextField disabled={true} value="foo" onChange={onChange} />,

--- a/src/web/components/form/__tests__/timezoneselect.jsx
+++ b/src/web/components/form/__tests__/timezoneselect.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {setLocale} from 'gmp/locale/lang';
 import timezones from 'gmp/timezones';
@@ -47,7 +47,7 @@ describe('TimezoneSelect tests', () => {
   });
 
   test('should call onChange handler', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId, getAllByTestId} = render(
       <TimezoneSelect onChange={handler} />,
     );
@@ -62,7 +62,7 @@ describe('TimezoneSelect tests', () => {
   });
 
   test('should call onChange handler with name', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {getByTestId, getAllByTestId} = render(
       <TimezoneSelect name="foo" onChange={handler} />,
     );

--- a/src/web/components/form/__tests__/togglebutton.jsx
+++ b/src/web/components/form/__tests__/togglebutton.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Theme from 'web/utils/theme';
 import {render, fireEvent} from 'web/utils/testing';
@@ -50,7 +50,7 @@ describe('ToggleButton tests', () => {
   });
 
   test('should call onToggle handler', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {element} = render(<ToggleButton onToggle={handler} />);
 
     fireEvent.click(element);
@@ -59,7 +59,7 @@ describe('ToggleButton tests', () => {
   });
 
   test('should call onToggle handler with name', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {element} = render(<ToggleButton name="foo" onToggle={handler} />);
 
     fireEvent.click(element);
@@ -68,7 +68,7 @@ describe('ToggleButton tests', () => {
   });
 
   test('should toggle checked state', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {element} = render(
       <ToggleButton name="foo" checked={true} onToggle={handler} />,
     );
@@ -79,7 +79,7 @@ describe('ToggleButton tests', () => {
   });
 
   test('should not call handler if disabled', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {element} = render(
       <ToggleButton disabled={true} onToggle={handler} />,
     );

--- a/src/web/components/form/__tests__/useFormValidation.jsx
+++ b/src/web/components/form/__tests__/useFormValidation.jsx
@@ -19,6 +19,8 @@
 
 /* eslint-disable react/prop-types */
 
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import React, {useState} from 'react';
 
 import {rendererWith, fireEvent, screen} from 'web/utils/testing';
@@ -76,7 +78,7 @@ const UseFormValidationTestComponent = ({onSave}) => {
 describe('useFormValidation tests', () => {
   test('should validate form value successfully', async () => {
     const {render} = rendererWith();
-    const handleSave = vi.fn();
+    const handleSave = testing.fn();
 
     render(<UseFormValidationTestComponent onSave={handleSave} />);
 
@@ -90,7 +92,7 @@ describe('useFormValidation tests', () => {
 
   test('should show error if validation fails', async () => {
     const {render} = rendererWith();
-    const handleSave = vi.fn();
+    const handleSave = testing.fn();
 
     render(<UseFormValidationTestComponent onSave={handleSave} />);
 

--- a/src/web/components/form/__tests__/useFormValues.jsx
+++ b/src/web/components/form/__tests__/useFormValues.jsx
@@ -17,6 +17,8 @@
  */
 import React, {useRef} from 'react';
 
+import {describe, test, expect} from '@gsa/testing';
+
 import {fireEvent, rendererWith, wait, screen} from 'web/utils/testing';
 
 import TextField from '../textfield';

--- a/src/web/components/form/__tests__/withClickHandler.jsx
+++ b/src/web/components/form/__tests__/withClickHandler.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -29,7 +29,7 @@ describe('withClickHandler tests', () => {
   test('should call click handler with value', () => {
     const Component = withClickHandler()(TestInput);
 
-    const onClick = vi.fn();
+    const onClick = testing.fn();
     const {element} = render(<Component value="foo" onClick={onClick} />);
 
     fireEvent.click(element);
@@ -40,7 +40,7 @@ describe('withClickHandler tests', () => {
   test('should call click handler with value and name', () => {
     const Component = withClickHandler()(TestInput);
 
-    const onClick = vi.fn();
+    const onClick = testing.fn();
     const {element} = render(
       <Component name="bar" value="foo" onClick={onClick} />,
     );
@@ -53,7 +53,7 @@ describe('withClickHandler tests', () => {
   test('should call click handler with converted value', () => {
     const Component = withClickHandler()(TestInput);
 
-    const onClick = vi.fn();
+    const onClick = testing.fn();
     const {element} = render(
       <Component convert={v => v * 2} value={21} onClick={onClick} />,
     );
@@ -68,7 +68,7 @@ describe('withClickHandler tests', () => {
       convert_func: v => v * 2,
     })(TestInput);
 
-    const onClick = vi.fn();
+    const onClick = testing.fn();
     const {element} = render(<Component value={21} onClick={onClick} />);
 
     fireEvent.click(element);
@@ -81,7 +81,7 @@ describe('withClickHandler tests', () => {
       value_func: (event, props) => props.foo,
     })(TestInput);
 
-    const onClick = vi.fn();
+    const onClick = testing.fn();
     const {element} = render(
       <Component foo="bar" value={21} onClick={onClick} />,
     );

--- a/src/web/components/form/__tests__/withDownload.jsx
+++ b/src/web/components/form/__tests__/withDownload.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -25,9 +25,9 @@ const TestComponent = withDownload(({onDownload, filename, data}) => (
   <button data-testid="button" onClick={() => onDownload({filename, data})} />
 ));
 
-const createObjectURL = vi.fn().mockReturnValue('foo://bar');
+const createObjectURL = testing.fn().mockReturnValue('foo://bar');
 window.URL.createObjectURL = createObjectURL;
-window.URL.revokeObjectURL = vi.fn();
+window.URL.revokeObjectURL = testing.fn();
 
 describe('withDownload tests', () => {
   test('should render', () => {

--- a/src/web/components/form/__tests__/yesnoradio.jsx
+++ b/src/web/components/form/__tests__/yesnoradio.jsx
@@ -15,16 +15,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
 import YesNoRadio from '../yesnoradio';
 import {YES_VALUE, NO_VALUE} from 'gmp/parser';
-
-setLocale('en');
 
 describe('YesNoRadio tests', () => {
   test('should render', () => {
@@ -39,7 +35,7 @@ describe('YesNoRadio tests', () => {
   });
 
   test('should call change handler', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {getAllByTestId} = render(<YesNoRadio onChange={onChange} />);
 
     const inputs = getAllByTestId('radio-input');
@@ -55,7 +51,7 @@ describe('YesNoRadio tests', () => {
   });
 
   test('should call change handler with name', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {getAllByTestId} = render(
       <YesNoRadio name="foo" onChange={onChange} />,
     );
@@ -69,7 +65,7 @@ describe('YesNoRadio tests', () => {
   });
 
   test('should allow to set values for yes and no state', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {getAllByTestId} = render(
       <YesNoRadio
         convert={v => v}
@@ -93,7 +89,7 @@ describe('YesNoRadio tests', () => {
   });
 
   test('should call change handler only if checked state changes', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {getAllByTestId} = render(
       <YesNoRadio value={YES_VALUE} onChange={onChange} />,
     );
@@ -111,7 +107,7 @@ describe('YesNoRadio tests', () => {
   });
 
   test('should not call change handler if disabled', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {getAllByTestId} = render(
       <YesNoRadio disabled={true} value={YES_VALUE} onChange={onChange} />,
     );

--- a/src/web/components/icon/__tests__/addtoassetsicon.jsx
+++ b/src/web/components/icon/__tests__/addtoassetsicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import AddToAssetsIcon from '../addtoassetsicon';

--- a/src/web/components/icon/__tests__/alerticon.jsx
+++ b/src/web/components/icon/__tests__/alerticon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/alterableicon.jsx
+++ b/src/web/components/icon/__tests__/alterableicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/arrowicon.jsx
+++ b/src/web/components/icon/__tests__/arrowicon.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -46,7 +46,7 @@ describe('ArrowIcon component tests', () => {
   });
 
   test('should handle click', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {element} = render(<ArrowIcon onClick={handler} />);
 
     fireEvent.click(element);

--- a/src/web/components/icon/__tests__/auditicon.jsx
+++ b/src/web/components/icon/__tests__/auditicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/calendaricon.jsx
+++ b/src/web/components/icon/__tests__/calendaricon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/certbundadvicon.jsx
+++ b/src/web/components/icon/__tests__/certbundadvicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/cloneicon.jsx
+++ b/src/web/components/icon/__tests__/cloneicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/cpelogoicon.jsx
+++ b/src/web/components/icon/__tests__/cpelogoicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/credentialicon.jsx
+++ b/src/web/components/icon/__tests__/credentialicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/cveicon.jsx
+++ b/src/web/components/icon/__tests__/cveicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/cvssicon.jsx
+++ b/src/web/components/icon/__tests__/cvssicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/dashboardicon.jsx
+++ b/src/web/components/icon/__tests__/dashboardicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/deleteicon.jsx
+++ b/src/web/components/icon/__tests__/deleteicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import DeleteIcon from '../deleteicon';

--- a/src/web/components/icon/__tests__/deltaicon.jsx
+++ b/src/web/components/icon/__tests__/deltaicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/deltasecondicon.jsx
+++ b/src/web/components/icon/__tests__/deltasecondicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/dfncertadvicon.jsx
+++ b/src/web/components/icon/__tests__/dfncertadvicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/disableicon.jsx
+++ b/src/web/components/icon/__tests__/disableicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/downloadcsvicon.jsx
+++ b/src/web/components/icon/__tests__/downloadcsvicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import DownloadCsvIcon from '../downloadcsvicon';

--- a/src/web/components/icon/__tests__/downloaddebicon.jsx
+++ b/src/web/components/icon/__tests__/downloaddebicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import DownloadDebIcon from '../downloaddebicon';

--- a/src/web/components/icon/__tests__/downloadexeicon.jsx
+++ b/src/web/components/icon/__tests__/downloadexeicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import DownloadExeIcon from '../downloadexeicon';

--- a/src/web/components/icon/__tests__/downloadicon.jsx
+++ b/src/web/components/icon/__tests__/downloadicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/downloadkeyicon.jsx
+++ b/src/web/components/icon/__tests__/downloadkeyicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import DownloadKeyIcon from '../downloadkeyicon';

--- a/src/web/components/icon/__tests__/downloadrpmicon.jsx
+++ b/src/web/components/icon/__tests__/downloadrpmicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import DownloadRpmIcon from '../downloadrpmicon';

--- a/src/web/components/icon/__tests__/downloadsvgicon.jsx
+++ b/src/web/components/icon/__tests__/downloadsvgicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import DownloadSvgIcon from '../downloadsvgicon';

--- a/src/web/components/icon/__tests__/editicon.jsx
+++ b/src/web/components/icon/__tests__/editicon.jsx
@@ -16,6 +16,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import EditIcon from '../editicon';

--- a/src/web/components/icon/__tests__/enableicon.jsx
+++ b/src/web/components/icon/__tests__/enableicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/exporticon.jsx
+++ b/src/web/components/icon/__tests__/exporticon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import ExportIcon from '../exporticon';

--- a/src/web/components/icon/__tests__/feedicon.jsx
+++ b/src/web/components/icon/__tests__/feedicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import FeedIcon from '../feedicon';

--- a/src/web/components/icon/__tests__/filtericon.jsx
+++ b/src/web/components/icon/__tests__/filtericon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import FilterIcon from '../filtericon';

--- a/src/web/components/icon/__tests__/firsticon.jsx
+++ b/src/web/components/icon/__tests__/firsticon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import FirstIcon from '../firsticon';

--- a/src/web/components/icon/__tests__/foldicon.jsx
+++ b/src/web/components/icon/__tests__/foldicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/groupicon.jsx
+++ b/src/web/components/icon/__tests__/groupicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/helpicon.jsx
+++ b/src/web/components/icon/__tests__/helpicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import HelpIcon from '../helpicon';

--- a/src/web/components/icon/__tests__/hosticon.jsx
+++ b/src/web/components/icon/__tests__/hosticon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/importicon.jsx
+++ b/src/web/components/icon/__tests__/importicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/infoicon.jsx
+++ b/src/web/components/icon/__tests__/infoicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import InfoIcon from '../infoicon';

--- a/src/web/components/icon/__tests__/keyicon.jsx
+++ b/src/web/components/icon/__tests__/keyicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/lasticon.jsx
+++ b/src/web/components/icon/__tests__/lasticon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import LastIcon from '../lasticon';

--- a/src/web/components/icon/__tests__/ldapicon.jsx
+++ b/src/web/components/icon/__tests__/ldapicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/legendicon.jsx
+++ b/src/web/components/icon/__tests__/legendicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/licenseicon.jsx
+++ b/src/web/components/icon/__tests__/licenseicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import LicenseIcon from '../licenseicon';

--- a/src/web/components/icon/__tests__/listsvgicon.jsx
+++ b/src/web/components/icon/__tests__/listsvgicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/logouticon.jsx
+++ b/src/web/components/icon/__tests__/logouticon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/mysettingsicon.jsx
+++ b/src/web/components/icon/__tests__/mysettingsicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/newicon.jsx
+++ b/src/web/components/icon/__tests__/newicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/newnoteicon.jsx
+++ b/src/web/components/icon/__tests__/newnoteicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import NewNoteIcon from '../newnoteicon';

--- a/src/web/components/icon/__tests__/newoverrideicon.jsx
+++ b/src/web/components/icon/__tests__/newoverrideicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import NewOverrideIcon from '../newoverrideicon';

--- a/src/web/components/icon/__tests__/nexticon.jsx
+++ b/src/web/components/icon/__tests__/nexticon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import NextIcon from '../nexticon';

--- a/src/web/components/icon/__tests__/noteicon.jsx
+++ b/src/web/components/icon/__tests__/noteicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import NoteIcon from '../noteicon';

--- a/src/web/components/icon/__tests__/nvticon.jsx
+++ b/src/web/components/icon/__tests__/nvticon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import NvtIcon from '../nvticon';

--- a/src/web/components/icon/__tests__/ossvgicon.jsx
+++ b/src/web/components/icon/__tests__/ossvgicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/overrideicon.jsx
+++ b/src/web/components/icon/__tests__/overrideicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/performanceicon.jsx
+++ b/src/web/components/icon/__tests__/performanceicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import PerformanceIcon from '../performanceicon';

--- a/src/web/components/icon/__tests__/permissionicon.jsx
+++ b/src/web/components/icon/__tests__/permissionicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/policyicon.jsx
+++ b/src/web/components/icon/__tests__/policyicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/portlisticon.jsx
+++ b/src/web/components/icon/__tests__/portlisticon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import PortListIcon from '../portlisticon';

--- a/src/web/components/icon/__tests__/previousicon.jsx
+++ b/src/web/components/icon/__tests__/previousicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import PreviousIcon from '../previousicon';

--- a/src/web/components/icon/__tests__/provideviewicon.jsx
+++ b/src/web/components/icon/__tests__/provideviewicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import ProvideViewIcon from '../provideviewicon';

--- a/src/web/components/icon/__tests__/radiusicon.jsx
+++ b/src/web/components/icon/__tests__/radiusicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/refreshicon.jsx
+++ b/src/web/components/icon/__tests__/refreshicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import RefreshIcon from '../refreshicon';

--- a/src/web/components/icon/__tests__/removefromassetsicon.jsx
+++ b/src/web/components/icon/__tests__/removefromassetsicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import RemoveFromAssetsIcon from '../removefromassetsicon';

--- a/src/web/components/icon/__tests__/reportformaticon.jsx
+++ b/src/web/components/icon/__tests__/reportformaticon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/reporticon.jsx
+++ b/src/web/components/icon/__tests__/reporticon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/reseticon.jsx
+++ b/src/web/components/icon/__tests__/reseticon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import ResetIcon from '../reseticon';

--- a/src/web/components/icon/__tests__/restoreicon.jsx
+++ b/src/web/components/icon/__tests__/restoreicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import RestoreIcon from '../restoreicon';

--- a/src/web/components/icon/__tests__/resumeicon.jsx
+++ b/src/web/components/icon/__tests__/resumeicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/roleicon.jsx
+++ b/src/web/components/icon/__tests__/roleicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/scanconfigicon.jsx
+++ b/src/web/components/icon/__tests__/scanconfigicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/scannericon.jsx
+++ b/src/web/components/icon/__tests__/scannericon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/scheduleicon.jsx
+++ b/src/web/components/icon/__tests__/scheduleicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/sensoricon.jsx
+++ b/src/web/components/icon/__tests__/sensoricon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/solutiontypeicon.jsx
+++ b/src/web/components/icon/__tests__/solutiontypeicon.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/icon/__tests__/solutiontypesvgicon.jsx
+++ b/src/web/components/icon/__tests__/solutiontypesvgicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/starticon.jsx
+++ b/src/web/components/icon/__tests__/starticon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/stmitigateicon.jsx
+++ b/src/web/components/icon/__tests__/stmitigateicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/stnonavailableicon.jsx
+++ b/src/web/components/icon/__tests__/stnonavailableicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/stopicon.jsx
+++ b/src/web/components/icon/__tests__/stopicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/stunknownicon.jsx
+++ b/src/web/components/icon/__tests__/stunknownicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/stvendorfixicon.jsx
+++ b/src/web/components/icon/__tests__/stvendorfixicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/stwillnotfixicon.jsx
+++ b/src/web/components/icon/__tests__/stwillnotfixicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/stworkaroundicon.jsx
+++ b/src/web/components/icon/__tests__/stworkaroundicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/svgicon.jsx
+++ b/src/web/components/icon/__tests__/svgicon.jsx
@@ -16,9 +16,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 import React, {useEffect} from 'react';
-import {act} from 'react-dom/test-utils';
 
-import {render, fireEvent} from 'web/utils/testing';
+import {describe, test, expect, testing} from '@gsa/testing';
+
+import {render, fireEvent, act} from 'web/utils/testing';
 
 import CloneIcon from '../cloneicon';
 
@@ -28,7 +29,7 @@ const entity = {name: 'entity'};
 
 describe('SVG icon component tests', () => {
   test('should render icon', () => {
-    const handleClick = vi.fn();
+    const handleClick = testing.fn();
 
     const {element} = render(
       <CloneIcon
@@ -48,7 +49,7 @@ describe('SVG icon component tests', () => {
       res = resolve;
     });
 
-    const handleClick = vi.fn().mockReturnValue(promise);
+    const handleClick = testing.fn().mockReturnValue(promise);
 
     const {element} = render(
       <CloneIcon
@@ -94,7 +95,7 @@ describe('useStateWithMountCheck() hook tests', () => {
 });
 describe('useIsMountedRef() hook tests', () => {
   test('should return false after component is unmounted', () => {
-    const callback = vi.fn();
+    const callback = testing.fn();
 
     const MockComponent = () => {
       const isMountedRef = useIsMountedRef();
@@ -113,7 +114,7 @@ describe('useIsMountedRef() hook tests', () => {
   });
 
   test('should return true if component is mounted', () => {
-    const callback = vi.fn();
+    const callback = testing.fn();
 
     const MockComponent = () => {
       const isMountedRef = useIsMountedRef();

--- a/src/web/components/icon/__tests__/tagicon.jsx
+++ b/src/web/components/icon/__tests__/tagicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/tagssvgicon.jsx
+++ b/src/web/components/icon/__tests__/tagssvgicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/taskicon.jsx
+++ b/src/web/components/icon/__tests__/taskicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/tlscertificateicon.jsx
+++ b/src/web/components/icon/__tests__/tlscertificateicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/toggle3dicon.jsx
+++ b/src/web/components/icon/__tests__/toggle3dicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import Toggle3dIcon from '../toggle3dicon';

--- a/src/web/components/icon/__tests__/trashcanicon.jsx
+++ b/src/web/components/icon/__tests__/trashcanicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/trashdeleteicon.jsx
+++ b/src/web/components/icon/__tests__/trashdeleteicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import TrashDeleteIcon from '../trashdeleteicon';

--- a/src/web/components/icon/__tests__/trashicon.jsx
+++ b/src/web/components/icon/__tests__/trashicon.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
+
 import {testIcon} from 'web/components/icon/testing';
 
 import TrashIcon from '../trashicon';

--- a/src/web/components/icon/__tests__/trenddownicon.jsx
+++ b/src/web/components/icon/__tests__/trenddownicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/trendlessicon.jsx
+++ b/src/web/components/icon/__tests__/trendlessicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/trendmoreicon.jsx
+++ b/src/web/components/icon/__tests__/trendmoreicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/trendnochangeicon.jsx
+++ b/src/web/components/icon/__tests__/trendnochangeicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/trendupicon.jsx
+++ b/src/web/components/icon/__tests__/trendupicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/unfoldicon.jsx
+++ b/src/web/components/icon/__tests__/unfoldicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/uploadicon.jsx
+++ b/src/web/components/icon/__tests__/uploadicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/usericon.jsx
+++ b/src/web/components/icon/__tests__/usericon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/verifyicon.jsx
+++ b/src/web/components/icon/__tests__/verifyicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/verifynoicon.jsx
+++ b/src/web/components/icon/__tests__/verifynoicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/viewothericon.jsx
+++ b/src/web/components/icon/__tests__/viewothericon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/vulnerabilityicon.jsx
+++ b/src/web/components/icon/__tests__/vulnerabilityicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/__tests__/wizardicon.jsx
+++ b/src/web/components/icon/__tests__/wizardicon.jsx
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe} from '@gsa/testing';
 
 import {testIcon} from 'web/components/icon/testing';
 

--- a/src/web/components/icon/testing.jsx
+++ b/src/web/components/icon/testing.jsx
@@ -16,8 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* eslint-disable max-len */
-import React from 'react';
+import {test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent, act} from 'web/utils/testing';
 import Theme from 'web/utils/theme';
@@ -33,7 +32,7 @@ export const testIcon = Icon => {
   });
 
   test('should handle click', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {element} = render(<Icon onClick={handler} value="1" />);
 
     fireEvent.click(element);
@@ -58,7 +57,7 @@ export const testIcon = Icon => {
   });
 
   test('should not call clickhandler when disabled', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const {element} = render(<Icon disabled={true} onClick={handler} />);
 
     fireEvent.click(element);
@@ -72,7 +71,7 @@ export const testIcon = Icon => {
       resolve = res;
     });
 
-    const handler = vi.fn().mockReturnValue(promise);
+    const handler = testing.fn().mockReturnValue(promise);
 
     const {element} = render(
       <Icon title="foo" loadingTitle="bar" onClick={handler} />,

--- a/src/web/components/img/__tests__/greenbone.jsx
+++ b/src/web/components/img/__tests__/greenbone.jsx
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/img/__tests__/greenboneloginlogo.jsx
+++ b/src/web/components/img/__tests__/greenboneloginlogo.jsx
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/img/__tests__/img.jsx
+++ b/src/web/components/img/__tests__/img.jsx
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/img/__tests__/product.jsx
+++ b/src/web/components/img/__tests__/product.jsx
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {rendererWith} from 'web/utils/testing';
 

--- a/src/web/components/label/__tests__/severityclass.jsx
+++ b/src/web/components/label/__tests__/severityclass.jsx
@@ -15,16 +15,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 
 import SeverityClassLabel from '../severityclass';
-
-import {setLocale} from 'gmp/locale/lang';
-
-setLocale('en');
 
 describe('SeverityClassLabel tests', () => {
   test('should render', () => {

--- a/src/web/components/layout/__tests__/Layout.jsx
+++ b/src/web/components/layout/__tests__/Layout.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Layout from 'web/components/layout/layout';
 

--- a/src/web/components/layout/__tests__/horizontalsep.jsx
+++ b/src/web/components/layout/__tests__/horizontalsep.jsx
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import HorizontalSep from 'web/components/layout/horizontalsep';
 

--- a/src/web/components/layout/__tests__/pagetitle.jsx
+++ b/src/web/components/layout/__tests__/pagetitle.jsx
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import PageTitle from 'web/components/layout/pagetitle';
 

--- a/src/web/components/layout/__tests__/withLayout.jsx
+++ b/src/web/components/layout/__tests__/withLayout.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import withLayout from 'web/components/layout/withLayout';
 

--- a/src/web/components/link/__tests__/blanklink.jsx
+++ b/src/web/components/link/__tests__/blanklink.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/link/__tests__/certlink.jsx
+++ b/src/web/components/link/__tests__/certlink.jsx
@@ -15,15 +15,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect} from '@gsa/testing';
 
 import {fireEvent, rendererWith} from 'web/utils/testing';
 
 import CertLink from '../certlink';
-
-setLocale('en');
 
 describe('CertLink tests', () => {
   test('should render CertLink', () => {

--- a/src/web/components/link/__tests__/cvelink.jsx
+++ b/src/web/components/link/__tests__/cvelink.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {fireEvent, rendererWith} from 'web/utils/testing';
 

--- a/src/web/components/link/__tests__/detailslink.jsx
+++ b/src/web/components/link/__tests__/detailslink.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 

--- a/src/web/components/link/__tests__/externallink.jsx
+++ b/src/web/components/link/__tests__/externallink.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {
   fireEvent,
@@ -28,8 +26,6 @@ import {
 } from 'web/utils/testing';
 
 import ExternalLink from '../externallink';
-
-setLocale('en');
 
 describe('ExternalLink tests', () => {
   test('should render ExternalLink', () => {
@@ -65,7 +61,7 @@ describe('ExternalLink tests', () => {
   test('should close confirmation dialog on resume click', () => {
     const oldOpen = window.open;
 
-    window.open = vi.fn();
+    window.open = testing.fn();
 
     const {render} = rendererWith({capabilities: true, router: true});
     const {element, baseElement, getByTestId} = render(
@@ -96,7 +92,7 @@ describe('ExternalLink tests', () => {
   test('should open url in new window', () => {
     const oldOpen = window.open;
 
-    window.open = vi.fn();
+    window.open = testing.fn();
 
     const {render} = rendererWith({capabilities: true, router: true});
     const {element, baseElement} = render(
@@ -120,5 +116,3 @@ describe('ExternalLink tests', () => {
     window.open = oldOpen;
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/components/link/__tests__/innerlink.jsx
+++ b/src/web/components/link/__tests__/innerlink.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/link/__tests__/link.jsx
+++ b/src/web/components/link/__tests__/link.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {rendererWith, fireEvent} from 'web/utils/testing';
 

--- a/src/web/components/link/__tests__/manuallink.jsx
+++ b/src/web/components/link/__tests__/manuallink.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {setLocale} from 'gmp/locale/lang';
 

--- a/src/web/components/link/__tests__/protocoldoclink.jsx
+++ b/src/web/components/link/__tests__/protocoldoclink.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {rendererWith} from 'web/utils/testing';
 

--- a/src/web/components/link/__tests__/target.jsx
+++ b/src/web/components/link/__tests__/target.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/loading/__tests__/loading.jsx
+++ b/src/web/components/loading/__tests__/loading.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/loading/__tests__/reload.jsx
+++ b/src/web/components/loading/__tests__/reload.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {act, fireEvent, rendererWith} from 'web/utils/testing';
 
@@ -33,7 +33,7 @@ const TestComponent = ({reload, id, reloadOptions}) => (
 
 const runTimers = async () => {
   await act(async () => {
-    vi.runAllTimers();
+    testing.runAllTimers();
   });
 };
 
@@ -47,9 +47,9 @@ describe('Reload component tests', () => {
 
     const {render} = rendererWith({gmp});
 
-    const renderFunc = vi.fn().mockReturnValue(<div data-testid="foo" />);
-    const loadFunc = vi.fn().mockResolvedValue();
-    const reloadFunc = vi.fn().mockResolvedValue();
+    const renderFunc = testing.fn().mockReturnValue(<div data-testid="foo" />);
+    const loadFunc = testing.fn().mockResolvedValue();
+    const reloadFunc = testing.fn().mockResolvedValue();
 
     const {getByTestId} = render(
       <Reload load={loadFunc} reload={reloadFunc} name="foo">
@@ -73,8 +73,8 @@ describe('Reload component tests', () => {
 
     const {render} = rendererWith({gmp});
 
-    const renderFunc = vi.fn().mockReturnValue(<div data-testid="foo" />);
-    const reloadFunc = vi.fn().mockResolvedValue();
+    const renderFunc = testing.fn().mockReturnValue(<div data-testid="foo" />);
+    const reloadFunc = testing.fn().mockResolvedValue();
 
     const {getByTestId} = render(
       <Reload reload={reloadFunc} name="foo">
@@ -89,7 +89,7 @@ describe('Reload component tests', () => {
   });
 
   test('should reload when timer fires', async () => {
-    vi.useFakeTimers();
+    testing.useFakeTimers();
 
     const gmp = {
       settings: {
@@ -99,12 +99,12 @@ describe('Reload component tests', () => {
 
     const {render} = rendererWith({gmp});
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValueOnce(<div data-testid="one" />)
       .mockReturnValueOnce(<div data-testid="two" />);
-    const loadFunc = vi.fn().mockResolvedValue();
-    const reloadFunc = vi.fn().mockResolvedValue();
+    const loadFunc = testing.fn().mockResolvedValue();
+    const reloadFunc = testing.fn().mockResolvedValue();
 
     const {queryByTestId} = render(
       <Reload load={loadFunc} reload={reloadFunc} name="foo">
@@ -133,7 +133,7 @@ describe('Reload component tests', () => {
   });
 
   test('should not reload when initial loading fails', async () => {
-    vi.useFakeTimers();
+    testing.useFakeTimers();
 
     const gmp = {
       settings: {
@@ -143,12 +143,12 @@ describe('Reload component tests', () => {
 
     const {render} = rendererWith({gmp});
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValueOnce(<div data-testid="one" />)
       .mockReturnValueOnce(<div data-testid="two" />);
-    const loadFunc = vi.fn().mockRejectedValue();
-    const reloadFunc = vi.fn().mockResolvedValue();
+    const loadFunc = testing.fn().mockRejectedValue();
+    const reloadFunc = testing.fn().mockResolvedValue();
 
     const {queryByTestId} = render(
       <Reload load={loadFunc} reload={reloadFunc} name="foo">
@@ -177,7 +177,7 @@ describe('Reload component tests', () => {
   });
 
   test('should not reload when reloading fails', async () => {
-    vi.useFakeTimers();
+    testing.useFakeTimers();
 
     const gmp = {
       settings: {
@@ -187,12 +187,12 @@ describe('Reload component tests', () => {
 
     const {render} = rendererWith({gmp});
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValueOnce(<div data-testid="one" />)
       .mockReturnValueOnce(<div data-testid="two" />);
-    const loadFunc = vi.fn().mockResolvedValue();
-    const reloadFunc = vi.fn().mockRejectedValue();
+    const loadFunc = testing.fn().mockResolvedValue();
+    const reloadFunc = testing.fn().mockRejectedValue();
 
     const {queryByTestId} = render(
       <Reload load={loadFunc} reload={reloadFunc} name="foo">
@@ -229,15 +229,15 @@ describe('Reload component tests', () => {
   });
 
   test('should reload on demand after failed loading', async () => {
-    vi.useFakeTimers();
+    testing.useFakeTimers();
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockImplementationOnce(({reload}) => (
         <TestComponent reload={reload} id="one" />
       ));
-    const loadFunc = vi.fn().mockRejectedValue();
-    const reloadFunc = vi.fn().mockResolvedValue();
+    const loadFunc = testing.fn().mockRejectedValue();
+    const reloadFunc = testing.fn().mockResolvedValue();
 
     const gmp = {
       settings: {
@@ -272,15 +272,15 @@ describe('Reload component tests', () => {
   });
 
   test('should allow to reload on demand', async () => {
-    vi.useFakeTimers();
+    testing.useFakeTimers();
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockImplementationOnce(({reload}) => (
         <TestComponent reload={reload} id="one" />
       ));
-    const loadFunc = vi.fn().mockResolvedValue();
-    const reloadFunc = vi.fn().mockResolvedValue();
+    const loadFunc = testing.fn().mockResolvedValue();
+    const reloadFunc = testing.fn().mockResolvedValue();
 
     const gmp = {
       settings: {
@@ -325,16 +325,16 @@ describe('Reload component tests', () => {
   });
 
   test('should allow to calculate reload timer', async () => {
-    vi.useFakeTimers();
+    testing.useFakeTimers();
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValueOnce(<div data-testid="one" />)
       .mockReturnValueOnce(<div data-testid="two" />);
-    const loadFunc = vi.fn().mockResolvedValue();
-    const reloadFunc = vi.fn().mockResolvedValue();
+    const loadFunc = testing.fn().mockResolvedValue();
+    const reloadFunc = testing.fn().mockResolvedValue();
 
-    const reloadInterval = vi.fn().mockReturnValue(1000);
+    const reloadInterval = testing.fn().mockReturnValue(1000);
 
     const gmp = {
       settings: {
@@ -378,16 +378,16 @@ describe('Reload component tests', () => {
   });
 
   test('should not start reload timer if reloadInterval returns equal or less then zero', async () => {
-    vi.useFakeTimers();
+    testing.useFakeTimers();
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValueOnce(<div data-testid="one" />)
       .mockReturnValueOnce(<div data-testid="two" />);
-    const loadFunc = vi.fn().mockResolvedValue();
-    const reloadFunc = vi.fn().mockResolvedValue();
+    const loadFunc = testing.fn().mockResolvedValue();
+    const reloadFunc = testing.fn().mockResolvedValue();
 
-    const reloadInterval = vi.fn().mockReturnValue(0);
+    const reloadInterval = testing.fn().mockReturnValue(0);
 
     const gmp = {
       settings: {
@@ -434,16 +434,16 @@ describe('Reload component tests', () => {
     'should fall back to defaultReloadInterval if reloadInterval returns ' +
       'USE_DEFAULT_RELOAD_INTERVAL',
     async () => {
-      vi.useFakeTimers();
+      testing.useFakeTimers();
 
-      const renderFunc = vi
+      const renderFunc = testing
         .fn()
         .mockReturnValueOnce(<div data-testid="one" />)
         .mockReturnValueOnce(<div data-testid="two" />);
-      const loadFunc = vi.fn().mockResolvedValue();
-      const reloadFunc = vi.fn().mockResolvedValue();
+      const loadFunc = testing.fn().mockResolvedValue();
+      const reloadFunc = testing.fn().mockResolvedValue();
 
-      const reloadInterval = vi
+      const reloadInterval = testing
         .fn()
         .mockReturnValue(USE_DEFAULT_RELOAD_INTERVAL);
 
@@ -494,16 +494,16 @@ describe('Reload component tests', () => {
     'should fall back to defaultReloadIntervalActive if reloadInterval ' +
       'returns USE_DEFAULT_RELOAD_INTERVAL_ACTIVE',
     async () => {
-      vi.useFakeTimers();
+      testing.useFakeTimers();
 
-      const renderFunc = vi
+      const renderFunc = testing
         .fn()
         .mockReturnValueOnce(<div data-testid="one" />)
         .mockReturnValueOnce(<div data-testid="two" />);
-      const loadFunc = vi.fn().mockResolvedValue();
-      const reloadFunc = vi.fn().mockResolvedValue();
+      const loadFunc = testing.fn().mockResolvedValue();
+      const reloadFunc = testing.fn().mockResolvedValue();
 
-      const reloadInterval = vi
+      const reloadInterval = testing
         .fn()
         .mockReturnValue(USE_DEFAULT_RELOAD_INTERVAL_ACTIVE);
 
@@ -554,16 +554,16 @@ describe('Reload component tests', () => {
     'should fall back to defaultReloadIntervalInactive if reloadInterval ' +
       'returns USE_DEFAULT_RELOAD_INTERVAL_INACTIVE',
     async () => {
-      vi.useFakeTimers();
+      testing.useFakeTimers();
 
-      const renderFunc = vi
+      const renderFunc = testing
         .fn()
         .mockReturnValueOnce(<div data-testid="one" />)
         .mockReturnValueOnce(<div data-testid="two" />);
-      const loadFunc = vi.fn().mockResolvedValue();
-      const reloadFunc = vi.fn().mockResolvedValue();
+      const loadFunc = testing.fn().mockResolvedValue();
+      const reloadFunc = testing.fn().mockResolvedValue();
 
-      const reloadInterval = vi
+      const reloadInterval = testing
         .fn()
         .mockReturnValue(USE_DEFAULT_RELOAD_INTERVAL_INACTIVE);
 
@@ -610,14 +610,14 @@ describe('Reload component tests', () => {
   );
 
   test('should use reloadInterval from settings', async () => {
-    vi.useFakeTimers();
+    testing.useFakeTimers();
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValueOnce(<div data-testid="one" />)
       .mockReturnValueOnce(<div data-testid="two" />);
-    const loadFunc = vi.fn().mockResolvedValue();
-    const reloadFunc = vi.fn().mockResolvedValue();
+    const loadFunc = testing.fn().mockResolvedValue();
+    const reloadFunc = testing.fn().mockResolvedValue();
 
     const gmp = {
       settings: {
@@ -653,15 +653,15 @@ describe('Reload component tests', () => {
   });
 
   test('should use reloadIntervalActive from settings', async () => {
-    vi.useFakeTimers();
+    testing.useFakeTimers();
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValueOnce(<div data-testid="one" />)
       .mockReturnValueOnce(<div data-testid="two" />);
-    const loadFunc = vi.fn().mockResolvedValue();
-    const reloadFunc = vi.fn().mockResolvedValue();
-    const reloadIntervalFunc = vi
+    const loadFunc = testing.fn().mockResolvedValue();
+    const reloadFunc = testing.fn().mockResolvedValue();
+    const reloadIntervalFunc = testing
       .fn()
       .mockReturnValue(USE_DEFAULT_RELOAD_INTERVAL_ACTIVE);
 
@@ -706,15 +706,15 @@ describe('Reload component tests', () => {
   });
 
   test('should use reloadIntervalInactive from settings', async () => {
-    vi.useFakeTimers();
+    testing.useFakeTimers();
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValueOnce(<div data-testid="one" />)
       .mockReturnValueOnce(<div data-testid="two" />);
-    const loadFunc = vi.fn().mockResolvedValue();
-    const reloadFunc = vi.fn().mockResolvedValue();
-    const reloadIntervalFunc = vi
+    const loadFunc = testing.fn().mockResolvedValue();
+    const reloadFunc = testing.fn().mockResolvedValue();
+    const reloadIntervalFunc = testing
       .fn()
       .mockReturnValue(USE_DEFAULT_RELOAD_INTERVAL_INACTIVE);
 

--- a/src/web/components/menu/__tests__/usermenu.jsx
+++ b/src/web/components/menu/__tests__/usermenu.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import date from 'gmp/models/date';
 import {longDate} from 'gmp/locale/date';
@@ -48,7 +48,7 @@ describe('UserMenu component tests', () => {
     expect(element).toHaveTextContent('foo');
   });
 
-  test('should route to usersettings on click',() => {
+  test('should route to usersettings on click', () => {
     const {render, history} = rendererWith({
       gmp: {},
       store: true,
@@ -64,7 +64,7 @@ describe('UserMenu component tests', () => {
   });
 
   test('should logout user on click', async () => {
-    const doLogout = vi.fn().mockResolvedValue();
+    const doLogout = testing.fn().mockResolvedValue();
     const gmp = {
       doLogout,
     };
@@ -81,7 +81,7 @@ describe('UserMenu component tests', () => {
   });
 
   test('should renew session timeout on click', async () => {
-    const renewSession = vi
+    const renewSession = testing
       .fn()
       .mockResolvedValue({data: '2019-10-10T12:00:00Z'});
     const gmp = {
@@ -101,5 +101,3 @@ describe('UserMenu component tests', () => {
     expect(gmp.user.renewSession).toHaveBeenCalled();
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/components/notification/__tests__/dialognotification.jsx
+++ b/src/web/components/notification/__tests__/dialognotification.jsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {rendererWith, screen, fireEvent} from 'web/utils/testing';
 

--- a/src/web/components/notification/__tests__/licensenotification.jsx
+++ b/src/web/components/notification/__tests__/licensenotification.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -128,15 +128,15 @@ const capsAdmin = new Capabilities(['everything']);
 const capsUser = new Capabilities(['get_license']);
 
 beforeEach(() => {
-  vi.spyOn(global.Date, 'now').mockImplementation(() => mockDate);
+  testing.spyOn(global.Date, 'now').mockImplementation(() => mockDate);
 });
 
 describe('LicenseNotification tests', () => {
   test('should render if <=30 days active for Admin user', async () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const gmp = {
       license: {
-        getLicenseInformation: vi.fn().mockReturnValue(
+        getLicenseInformation: testing.fn().mockReturnValue(
           Promise.resolve({
             data: dataLessThan30days,
           }),
@@ -170,10 +170,10 @@ describe('LicenseNotification tests', () => {
   });
 
   test('should render if <=30 days active for User user', async () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const gmp = {
       license: {
-        getLicenseInformation: vi.fn().mockReturnValue(
+        getLicenseInformation: testing.fn().mockReturnValue(
           Promise.resolve({
             data: dataLessThan30days,
           }),
@@ -204,10 +204,10 @@ describe('LicenseNotification tests', () => {
   });
 
   test('should render if <=30 days active for Admin user Trial', async () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const gmp = {
       license: {
-        getLicenseInformation: vi.fn().mockReturnValue(
+        getLicenseInformation: testing.fn().mockReturnValue(
           Promise.resolve({
             data: dataLessThan30daysTrial,
           }),
@@ -241,10 +241,10 @@ describe('LicenseNotification tests', () => {
   });
 
   test('should render if <=30 days active for User user Trial', async () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
     const gmp = {
       license: {
-        getLicenseInformation: vi.fn().mockReturnValue(
+        getLicenseInformation: testing.fn().mockReturnValue(
           Promise.resolve({
             data: dataLessThan30daysTrial,
           }),
@@ -275,11 +275,11 @@ describe('LicenseNotification tests', () => {
   });
 
   test('should not render if >30 days and active for Admin user', async () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const gmp = {
       license: {
-        getLicenseInformation: vi.fn().mockReturnValue(
+        getLicenseInformation: testing.fn().mockReturnValue(
           Promise.resolve({
             data: dataMoreThan30days,
           }),
@@ -303,11 +303,11 @@ describe('LicenseNotification tests', () => {
   });
 
   test('should not render if >30 days and active for User user', async () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const gmp = {
       license: {
-        getLicenseInformation: vi.fn().mockReturnValue(
+        getLicenseInformation: testing.fn().mockReturnValue(
           Promise.resolve({
             data: dataMoreThan30days,
           }),
@@ -331,11 +331,11 @@ describe('LicenseNotification tests', () => {
   });
 
   test('should render warning if expired for Admin user', async () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const gmp = {
       license: {
-        getLicenseInformation: vi.fn().mockReturnValue(
+        getLicenseInformation: testing.fn().mockReturnValue(
           Promise.resolve({
             data: dataExpired,
           }),
@@ -371,11 +371,11 @@ describe('LicenseNotification tests', () => {
   });
 
   test('should render warning if expired for User user', async () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const gmp = {
       license: {
-        getLicenseInformation: vi.fn().mockReturnValue(
+        getLicenseInformation: testing.fn().mockReturnValue(
           Promise.resolve({
             data: dataExpired,
           }),
@@ -407,11 +407,11 @@ describe('LicenseNotification tests', () => {
   });
 
   test('should render warning if corrupt for Admin user', async () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const gmp = {
       license: {
-        getLicenseInformation: vi.fn().mockReturnValue(
+        getLicenseInformation: testing.fn().mockReturnValue(
           Promise.resolve({
             data: dataCorrupt,
           }),
@@ -450,11 +450,11 @@ describe('LicenseNotification tests', () => {
   });
 
   test('should render warning if corrupt for User user', async () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const gmp = {
       license: {
-        getLicenseInformation: vi.fn().mockReturnValue(
+        getLicenseInformation: testing.fn().mockReturnValue(
           Promise.resolve({
             data: dataCorrupt,
           }),
@@ -487,11 +487,11 @@ describe('LicenseNotification tests', () => {
   });
 
   test('should not render if status is no_license for Admin user', async () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const gmp = {
       license: {
-        getLicenseInformation: vi.fn().mockReturnValue(
+        getLicenseInformation: testing.fn().mockReturnValue(
           Promise.resolve({
             data: dataNoLicense,
           }),
@@ -515,11 +515,11 @@ describe('LicenseNotification tests', () => {
   });
 
   test('should not render if status is no_license for User user', async () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const gmp = {
       license: {
-        getLicenseInformation: vi.fn().mockReturnValue(
+        getLicenseInformation: testing.fn().mockReturnValue(
           Promise.resolve({
             data: dataNoLicense,
           }),

--- a/src/web/components/panel/__tests__/button.jsx
+++ b/src/web/components/panel/__tests__/button.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -29,7 +29,7 @@ describe('InfoPanel button tests', () => {
   });
 
   test('should call click handler', () => {
-    const handler = vi.fn();
+    const handler = testing.fn();
 
     const {element} = render(<Button onClick={handler} />);
 

--- a/src/web/components/panel/__tests__/infopanel.jsx
+++ b/src/web/components/panel/__tests__/infopanel.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, userEvent} from 'web/utils/testing';
 import Theme from 'web/utils/theme';
@@ -41,7 +41,7 @@ describe('InfoPanel tests', () => {
   });
 
   test('should show close button if handler is defined', () => {
-    const handleCloseClick = vi.fn();
+    const handleCloseClick = testing.fn();
     const {element, queryByRole} = render(
       <InfoPanel
         heading="heading text"
@@ -58,7 +58,7 @@ describe('InfoPanel tests', () => {
   });
 
   test('should render blue if info', () => {
-    const handleCloseClick = vi.fn();
+    const handleCloseClick = testing.fn();
     const {element, queryByRole, getByTestId} = render(
       <InfoPanel
         heading="heading text"
@@ -77,7 +77,7 @@ describe('InfoPanel tests', () => {
   });
 
   test('should render red if warning', () => {
-    const handleCloseClick = vi.fn();
+    const handleCloseClick = testing.fn();
     const {element, queryByRole, getByTestId} = render(
       <InfoPanel
         isWarning={true}
@@ -97,7 +97,7 @@ describe('InfoPanel tests', () => {
   });
 
   test('should call click handler', () => {
-    const handleCloseClick = vi.fn();
+    const handleCloseClick = testing.fn();
     const {queryByRole} = render(
       <InfoPanel
         heading="heading text"

--- a/src/web/components/portal/__tests__/portal.jsx
+++ b/src/web/components/portal/__tests__/portal.jsx
@@ -15,9 +15,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
+
 import Portal from '../portal';
 
 describe('Portal component tests', () => {

--- a/src/web/components/powerfilter/__tests__/applyoverridesgroup.jsx
+++ b/src/web/components/powerfilter/__tests__/applyoverridesgroup.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -26,7 +26,7 @@ import Filter from 'gmp/models/filter';
 describe('ApplyOverridesGroup tests', () => {
   test('should render', () => {
     const filter = Filter.fromString();
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <ApplyOverridesGroup
         filter={filter}
@@ -41,7 +41,7 @@ describe('ApplyOverridesGroup tests', () => {
 
   test('should call change handler', () => {
     const filter = Filter.fromString('apply_overrides=1');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {getAllByTestId} = render(
       <ApplyOverridesGroup
         filter={filter}
@@ -59,7 +59,7 @@ describe('ApplyOverridesGroup tests', () => {
 
   test('should check radio', () => {
     const filter = Filter.fromString('apply_overrides=1');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {getAllByTestId} = render(
       <ApplyOverridesGroup
         filter={filter}
@@ -77,7 +77,7 @@ describe('ApplyOverridesGroup tests', () => {
   test('should uncheck radio of previous choice', () => {
     const filter1 = Filter.fromString('apply_overrides=1');
     const filter2 = Filter.fromString('apply_overrides=0');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {getAllByTestId, rerender} = render(
       <ApplyOverridesGroup
         filter={filter1}
@@ -107,7 +107,7 @@ describe('ApplyOverridesGroup tests', () => {
 
   test('should use filter value by default', () => {
     const filter = Filter.fromString('apply_overrides=1');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {getAllByTestId} = render(
       <ApplyOverridesGroup
         filter={filter}
@@ -123,7 +123,7 @@ describe('ApplyOverridesGroup tests', () => {
   });
 
   test('should use overrides', () => {
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {getAllByTestId} = render(
       <ApplyOverridesGroup
         name="applyOverrides"

--- a/src/web/components/powerfilter/__tests__/booleanfiltergroup.jsx
+++ b/src/web/components/powerfilter/__tests__/booleanfiltergroup.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -28,7 +28,7 @@ describe('BooleanFilterGroup tests', () => {
     const filter = Filter.fromString();
     const title = 'foo';
     const name = 'active';
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <BooleanFilterGroup
         filter={filter}
@@ -45,7 +45,7 @@ describe('BooleanFilterGroup tests', () => {
     const filter = Filter.fromString('active=0');
     const title = 'foo';
     const name = 'active';
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {getAllByTestId} = render(
       <BooleanFilterGroup
         filter={filter}
@@ -65,7 +65,7 @@ describe('BooleanFilterGroup tests', () => {
     const filter = Filter.fromString('apply_overrides=0');
     const title = 'foo';
     const name = 'apply_overrides';
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {getAllByTestId} = render(
       <BooleanFilterGroup
         filter={filter}
@@ -85,7 +85,7 @@ describe('BooleanFilterGroup tests', () => {
     const name = 'apply_overrides';
     const filter1 = Filter.fromString('apply_overrides=1');
     const filter2 = Filter.fromString('apply_overrides=0');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {getAllByTestId, rerender} = render(
       <BooleanFilterGroup
         filter={filter1}
@@ -117,7 +117,7 @@ describe('BooleanFilterGroup tests', () => {
     const title = 'foo';
     const name = 'apply_overrides';
     const filter = Filter.fromString('apply_overrides=1');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {getAllByTestId} = render(
       <BooleanFilterGroup
         filter={filter}
@@ -136,7 +136,7 @@ describe('BooleanFilterGroup tests', () => {
     const title = 'foo';
     const name = 'apply_overrides';
     const filter = Filter.fromString('apply_overrides=1');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <BooleanFilterGroup
         name={name}

--- a/src/web/components/powerfilter/__tests__/createnamedfiltergroup.jsx
+++ b/src/web/components/powerfilter/__tests__/createnamedfiltergroup.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -23,7 +23,7 @@ import CreateNamedFilterGroup from '../createnamedfiltergroup';
 
 describe('CreateNamedFilterGroup tests', () => {
   test('should render', () => {
-    const handleChangeMock = vi.fn();
+    const handleChangeMock = testing.fn();
     const {element} = render(
       <CreateNamedFilterGroup onValueChange={handleChangeMock} />,
     );
@@ -34,7 +34,7 @@ describe('CreateNamedFilterGroup tests', () => {
   });
 
   test('should check checkbox and enable textfield correctly', () => {
-    const handleChangeMock = vi.fn();
+    const handleChangeMock = testing.fn();
     const {getByTestId} = render(
       <CreateNamedFilterGroup
         saveNamedFilter={true}
@@ -49,7 +49,7 @@ describe('CreateNamedFilterGroup tests', () => {
   });
 
   test('should uncheck checkbox and disable textfield correctly', () => {
-    const handleChangeMock = vi.fn();
+    const handleChangeMock = testing.fn();
     const {getByTestId} = render(
       <CreateNamedFilterGroup
         saveNamedFilter={false}
@@ -64,7 +64,7 @@ describe('CreateNamedFilterGroup tests', () => {
   });
 
   test('should uncheck checkbox if saveNamedFilter is undefined', () => {
-    const handleChangeMock = vi.fn();
+    const handleChangeMock = testing.fn();
     const {getByTestId} = render(
       <CreateNamedFilterGroup onValueChange={handleChangeMock} />,
     );
@@ -73,7 +73,7 @@ describe('CreateNamedFilterGroup tests', () => {
   });
 
   test('should call change handler of checkbox for "unchecking"', () => {
-    const handleChangeMock = vi.fn();
+    const handleChangeMock = testing.fn();
     const {getByTestId} = render(
       <CreateNamedFilterGroup
         saveNamedFilter={true}
@@ -88,7 +88,7 @@ describe('CreateNamedFilterGroup tests', () => {
   });
 
   test('should call change handler of checkbox for "checking"', () => {
-    const handleChangeMock = vi.fn();
+    const handleChangeMock = testing.fn();
     const {getByTestId} = render(
       <CreateNamedFilterGroup
         saveNamedFilter={false}
@@ -103,7 +103,7 @@ describe('CreateNamedFilterGroup tests', () => {
   });
 
   test('should call change handler of textfield with value and name', () => {
-    const handleChangeMock = vi.fn();
+    const handleChangeMock = testing.fn();
 
     const {getByTestId} = render(
       <CreateNamedFilterGroup
@@ -120,7 +120,7 @@ describe('CreateNamedFilterGroup tests', () => {
   });
 
   test('textfield should not change value when disabled', () => {
-    const handleChangeMock = vi.fn();
+    const handleChangeMock = testing.fn();
 
     const {getByTestId} = render(
       <CreateNamedFilterGroup

--- a/src/web/components/powerfilter/__tests__/filtersearchgroup.jsx
+++ b/src/web/components/powerfilter/__tests__/filtersearchgroup.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -26,7 +26,7 @@ import Filter from 'gmp/models/filter';
 describe('FilterSearchGroup tests', () => {
   test('should render', () => {
     const filter = Filter.fromString('location=tcp');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <FilterSearchGroup
         filter={filter}
@@ -40,7 +40,7 @@ describe('FilterSearchGroup tests', () => {
 
   test('should render value from filter', () => {
     const filter = Filter.fromString('location=tcp');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <FilterSearchGroup
         filter={filter}
@@ -54,7 +54,7 @@ describe('FilterSearchGroup tests', () => {
   });
   test('should call change handler', () => {
     const filter = Filter.fromString('location=tcp');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <FilterSearchGroup
         filter={filter}

--- a/src/web/components/powerfilter/__tests__/filterstringgroup.jsx
+++ b/src/web/components/powerfilter/__tests__/filterstringgroup.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -26,7 +26,7 @@ import Filter from 'gmp/models/filter';
 describe('FilterStringGroup tests', () => {
   test('should render', () => {
     const filter = Filter.fromString('');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <FilterStringGroup filter={filter} name="name" onChange={handleChange} />,
     );
@@ -36,7 +36,7 @@ describe('FilterStringGroup tests', () => {
 
   test('should render filterstring from string', () => {
     const filter = 'Test';
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <FilterStringGroup
         filter={filter}
@@ -52,7 +52,7 @@ describe('FilterStringGroup tests', () => {
 
   test('should render filterstring from filter', () => {
     const filter = Filter.fromString('Test');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <FilterStringGroup filter={filter} name="name" onChange={handleChange} />,
     );
@@ -64,7 +64,7 @@ describe('FilterStringGroup tests', () => {
 
   test('should return correct keyword name', () => {
     const filter = 'Test';
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <FilterStringGroup
         filter={filter}
@@ -80,7 +80,7 @@ describe('FilterStringGroup tests', () => {
 
   test('should call change handler', () => {
     const filter = Filter.fromString('');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <FilterStringGroup filter={filter} name="name" onChange={handleChange} />,
     );

--- a/src/web/components/powerfilter/__tests__/firstresultgroup.jsx
+++ b/src/web/components/powerfilter/__tests__/firstresultgroup.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -26,7 +26,7 @@ import Filter from 'gmp/models/filter';
 describe('FirstresultGroup tests', () => {
   test('should render', () => {
     const filter = Filter.fromString('first=1');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <FirstResultGroup
         filter={filter}
@@ -41,7 +41,7 @@ describe('FirstresultGroup tests', () => {
 
   test('should render value from filter by default', () => {
     const filter = Filter.fromString('first=1');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <FirstResultGroup
         filter={filter}
@@ -57,7 +57,7 @@ describe('FirstresultGroup tests', () => {
   });
 
   test('should render value from first', () => {
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <FirstResultGroup first={2} name="name" onChange={handleChange} />,
     );
@@ -69,7 +69,7 @@ describe('FirstresultGroup tests', () => {
 
   test('should call change handler', () => {
     const filter = Filter.fromString('first=1');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <FirstResultGroup
         filter={filter}

--- a/src/web/components/powerfilter/__tests__/minqodgroup.jsx
+++ b/src/web/components/powerfilter/__tests__/minqodgroup.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -26,7 +26,7 @@ import Filter from 'gmp/models/filter';
 describe('MinQodGroup tests', () => {
   test('should render', () => {
     const filter = Filter.fromString('min_qod=10');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <MinQodGroup
         filter={filter}
@@ -41,7 +41,7 @@ describe('MinQodGroup tests', () => {
 
   test('should render value from filter', () => {
     const filter = Filter.fromString('min_qod=10');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <MinQodGroup filter={filter} name="name" onChange={handleChange} />,
     );
@@ -53,7 +53,7 @@ describe('MinQodGroup tests', () => {
 
   test('should render value from qod by default', () => {
     const filter = Filter.fromString('min_qod=10');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <MinQodGroup
         filter={filter}
@@ -70,7 +70,7 @@ describe('MinQodGroup tests', () => {
 
   test('should call change handler', () => {
     const filter = Filter.fromString('min_qod=10');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <MinQodGroup
         filter={filter}

--- a/src/web/components/powerfilter/__tests__/relationselector.jsx
+++ b/src/web/components/powerfilter/__tests__/relationselector.jsx
@@ -15,8 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -30,7 +29,7 @@ import RelationSelector from 'web/components/powerfilter/relationselector';
 
 describe('Relation Selector Tests', () => {
   test('should render', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {element} = render(
       <RelationSelector relation="<" onChange={onChange} />,
     );
@@ -39,7 +38,7 @@ describe('Relation Selector Tests', () => {
   });
 
   test('should return items', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {element, baseElement} = render(
       <RelationSelector relation="<" onChange={onChange} />,
     );
@@ -60,7 +59,7 @@ describe('Relation Selector Tests', () => {
   });
 
   test('should call onChange handler', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element, baseElement} = render(
       <RelationSelector relation="<" onChange={onChange} />,
@@ -76,7 +75,7 @@ describe('Relation Selector Tests', () => {
     expect(onChange).toBeCalledWith('=', undefined);
   });
   test('should change value', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     // eslint-disable-next-line no-shadow
     const {baseElement, element, getByTestId} = render(
@@ -97,7 +96,7 @@ describe('Relation Selector Tests', () => {
   });
 
   test('should filter items', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const {element, baseElement} = render(
       <RelationSelector relation="=" onChange={onChange} />,
     );

--- a/src/web/components/powerfilter/__tests__/resultsperpagegroup.jsx
+++ b/src/web/components/powerfilter/__tests__/resultsperpagegroup.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -26,7 +26,7 @@ import Filter from 'gmp/models/filter';
 describe('ResultsPerPageGroup tests', () => {
   test('should render', () => {
     const filter = Filter.fromString('rows=10');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <ResultsPerPageGroup
         filter={filter}
@@ -41,7 +41,7 @@ describe('ResultsPerPageGroup tests', () => {
 
   test('should render value from filter by default', () => {
     const filter = Filter.fromString('rows=10');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <ResultsPerPageGroup
         filter={filter}
@@ -57,7 +57,7 @@ describe('ResultsPerPageGroup tests', () => {
   });
 
   test('should render value from rows', () => {
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <ResultsPerPageGroup name="name" rows={20} onChange={handleChange} />,
     );
@@ -69,7 +69,7 @@ describe('ResultsPerPageGroup tests', () => {
 
   test('should call change handler', () => {
     const filter = Filter.fromString('rows=10');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <ResultsPerPageGroup
         filter={filter}

--- a/src/web/components/powerfilter/__tests__/severitylevelsgroup.jsx
+++ b/src/web/components/powerfilter/__tests__/severitylevelsgroup.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -26,8 +26,8 @@ import Filter from 'gmp/models/filter';
 describe('SeverityLevelsFilterGroup tests', () => {
   test('should render', () => {
     const filter = Filter.fromString('levels=h');
-    const handleChange = vi.fn();
-    const handleRemove = vi.fn();
+    const handleChange = testing.fn();
+    const handleRemove = testing.fn();
     const {element} = render(
       <SeverityLevelsFilterGroup
         filter={filter}
@@ -41,8 +41,8 @@ describe('SeverityLevelsFilterGroup tests', () => {
 
   test('should call change handler', () => {
     const filter = Filter.fromString('levels=');
-    const handleChange = vi.fn();
-    const handleRemove = vi.fn();
+    const handleChange = testing.fn();
+    const handleRemove = testing.fn();
     const {element} = render(
       <SeverityLevelsFilterGroup
         filter={filter}
@@ -60,8 +60,8 @@ describe('SeverityLevelsFilterGroup tests', () => {
 
   test('should check checkbox', () => {
     const filter = Filter.fromString('levels=hm');
-    const handleChange = vi.fn();
-    const handleRemove = vi.fn();
+    const handleChange = testing.fn();
+    const handleRemove = testing.fn();
     const {element} = render(
       <SeverityLevelsFilterGroup
         filter={filter}
@@ -79,8 +79,8 @@ describe('SeverityLevelsFilterGroup tests', () => {
   test('should uncheck checkbox', () => {
     const filter1 = Filter.fromString('levels=hm');
     const filter2 = Filter.fromString('levels=m');
-    const handleChange = vi.fn();
-    const handleRemove = vi.fn();
+    const handleChange = testing.fn();
+    const handleRemove = testing.fn();
     const {element, rerender} = render(
       <SeverityLevelsFilterGroup
         filter={filter1}
@@ -108,8 +108,8 @@ describe('SeverityLevelsFilterGroup tests', () => {
 
   test('should be unchecked by default', () => {
     const filter = Filter.fromString();
-    const handleChange = vi.fn();
-    const handleRemove = vi.fn();
+    const handleChange = testing.fn();
+    const handleRemove = testing.fn();
     const {element} = render(
       <SeverityLevelsFilterGroup
         filter={filter}
@@ -129,8 +129,8 @@ describe('SeverityLevelsFilterGroup tests', () => {
 
   test('should call remove handler', () => {
     const filter = Filter.fromString('levels=h');
-    const handleChange = vi.fn();
-    const handleRemove = vi.fn();
+    const handleChange = testing.fn();
+    const handleRemove = testing.fn();
     const {element} = render(
       <SeverityLevelsFilterGroup
         filter={filter}

--- a/src/web/components/powerfilter/__tests__/severityvaluesgroup.jsx
+++ b/src/web/components/powerfilter/__tests__/severityvaluesgroup.jsx
@@ -15,8 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -33,7 +32,7 @@ describe('Severity Values Group Tests', () => {
   test('should render', () => {
     const filter = Filter.fromString('severity>3');
     const name = 'severity';
-    const onChange = vi.fn();
+    const onChange = testing.fn();
 
     const {element} = render(
       <SeverityValuesGroup
@@ -48,7 +47,7 @@ describe('Severity Values Group Tests', () => {
   });
 
   test('arguments are processed correctly', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const filter = Filter.fromString('severity=3');
     const name = 'severity';
 
@@ -70,7 +69,7 @@ describe('Severity Values Group Tests', () => {
   });
 
   test('should initialize value with 0 in case no filter value is given', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const filter = Filter.fromString('rows=10');
     const name = 'severity';
 
@@ -90,7 +89,7 @@ describe('Severity Values Group Tests', () => {
   });
 
   test('should change value', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const filter = Filter.fromString('severity=3');
     const name = 'severity';
 
@@ -111,7 +110,7 @@ describe('Severity Values Group Tests', () => {
   });
 
   test('should change relationship', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const filter = Filter.fromString('severity=3');
     const name = 'severity';
 

--- a/src/web/components/powerfilter/__tests__/solutiontypegroup.jsx
+++ b/src/web/components/powerfilter/__tests__/solutiontypegroup.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -26,7 +26,7 @@ import Filter from 'gmp/models/filter';
 describe('SolutionTypesFilterGroup tests', () => {
   test('should render', () => {
     const filter = Filter.fromString('solution_type=All');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <SolutionTypesFilterGroup filter={filter} onChange={handleChange} />,
     );
@@ -36,7 +36,7 @@ describe('SolutionTypesFilterGroup tests', () => {
 
   test('should call change handler', () => {
     const filter = Filter.fromString('solution_type=Mitigation');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {getAllByTestId} = render(
       <SolutionTypesFilterGroup filter={filter} onChange={handleChange} />,
     );
@@ -52,7 +52,7 @@ describe('SolutionTypesFilterGroup tests', () => {
 
   test('should check radio', () => {
     const filter = Filter.fromString('solution_type=Workaround');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {getAllByTestId} = render(
       <SolutionTypesFilterGroup filter={filter} onChange={handleChange} />,
     );
@@ -65,7 +65,7 @@ describe('SolutionTypesFilterGroup tests', () => {
   test('should uncheck radio of previous choice', () => {
     const filter1 = Filter.fromString('solution_type=Workaround');
     const filter2 = Filter.fromString('solution_type=Mitigation');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {getAllByTestId, rerender} = render(
       <SolutionTypesFilterGroup filter={filter1} onChange={handleChange} />,
     );
@@ -85,7 +85,7 @@ describe('SolutionTypesFilterGroup tests', () => {
 
   test('should check "All" by default', () => {
     const filter = Filter.fromString();
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {getAllByTestId} = render(
       <SolutionTypesFilterGroup filter={filter} onChange={handleChange} />,
     );

--- a/src/web/components/powerfilter/__tests__/sortbygroup.jsx
+++ b/src/web/components/powerfilter/__tests__/sortbygroup.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent, queryAllByTestId} from 'web/utils/testing';
 
@@ -26,8 +26,8 @@ import Filter from 'gmp/models/filter';
 describe('SortByGroup tests', () => {
   test('should render', () => {
     const filter = Filter.fromString('sort');
-    const handleSortByChange = vi.fn();
-    const handleSortOrderChange = vi.fn();
+    const handleSortByChange = testing.fn();
+    const handleSortOrderChange = testing.fn();
     const {element} = render(
       <SortByGroup
         by=""
@@ -44,8 +44,8 @@ describe('SortByGroup tests', () => {
 
   test('should render fields', () => {
     const filter1 = Filter.fromString('sort=severity');
-    const handleSortByChange = vi.fn();
-    const handleSortOrderChange = vi.fn();
+    const handleSortByChange = testing.fn();
+    const handleSortOrderChange = testing.fn();
     const {baseElement, getByTestId} = render(
       <SortByGroup
         by="solution"
@@ -73,8 +73,8 @@ describe('SortByGroup tests', () => {
   test('should use filter by default', () => {
     const filter1 = Filter.fromString('sort=severity');
     const filter2 = Filter.fromString('sort-reverse=severity');
-    const handleSortByChange = vi.fn();
-    const handleSortOrderChange = vi.fn();
+    const handleSortByChange = testing.fn();
+    const handleSortOrderChange = testing.fn();
     const {rerender, getAllByTestId, getByTestId} = render(
       <SortByGroup
         by="solution"
@@ -119,8 +119,8 @@ describe('SortByGroup tests', () => {
   });
 
   test('should use by and order', () => {
-    const handleSortByChange = vi.fn();
-    const handleSortOrderChange = vi.fn();
+    const handleSortByChange = testing.fn();
+    const handleSortOrderChange = testing.fn();
     const {getAllByTestId, getByTestId} = render(
       <SortByGroup
         by="solution_type"
@@ -146,8 +146,8 @@ describe('SortByGroup tests', () => {
 
   test('should call change handler of select', () => {
     const filter = Filter.fromString('sort');
-    const handleSortByChange = vi.fn();
-    const handleSortOrderChange = vi.fn();
+    const handleSortByChange = testing.fn();
+    const handleSortOrderChange = testing.fn();
     const {baseElement, getByTestId} = render(
       <SortByGroup
         by=""
@@ -175,8 +175,8 @@ describe('SortByGroup tests', () => {
 
   test('should call change handler of radio button', () => {
     const filter = Filter.fromString('sort');
-    const handleSortByChange = vi.fn();
-    const handleSortOrderChange = vi.fn();
+    const handleSortByChange = testing.fn();
+    const handleSortOrderChange = testing.fn();
     const {getAllByTestId} = render(
       <SortByGroup
         by=""

--- a/src/web/components/powerfilter/__tests__/tasktrendgroup.jsx
+++ b/src/web/components/powerfilter/__tests__/tasktrendgroup.jsx
@@ -15,8 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -29,7 +28,7 @@ import {
 
 describe('Task Trend Selector Tests', () => {
   test('should render', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const filter = Filter.fromString('trend=down');
     const {element} = render(
       <TaskTrendGroup filter={filter} onChange={onChange} />,
@@ -39,7 +38,7 @@ describe('Task Trend Selector Tests', () => {
   });
 
   test('should return items', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const filter = Filter.fromString('trend=down');
     const {element, baseElement} = render(
       <TaskTrendGroup filter={filter} onChange={onChange} />,
@@ -60,7 +59,7 @@ describe('Task Trend Selector Tests', () => {
   });
 
   test('should parse filter', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const filter = Filter.fromString('trend=same');
     // eslint-disable-next-line no-shadow
     const {getByTestId} = render(
@@ -72,7 +71,7 @@ describe('Task Trend Selector Tests', () => {
   });
 
   test('should call onChange handler', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const filter = Filter.fromString('trend=down');
     const {element, baseElement} = render(
       <TaskTrendGroup filter={filter} onChange={onChange} />,
@@ -88,7 +87,7 @@ describe('Task Trend Selector Tests', () => {
     expect(onChange).toBeCalledWith('up', 'trend');
   });
   test('should change value', () => {
-    const onChange = vi.fn();
+    const onChange = testing.fn();
     const filter = Filter.fromString('trend=down');
 
     // eslint-disable-next-line no-shadow

--- a/src/web/components/powerfilter/__tests__/ticketstatusgroup.jsx
+++ b/src/web/components/powerfilter/__tests__/ticketstatusgroup.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -31,7 +31,7 @@ import Filter from 'gmp/models/filter';
 describe('TicketStatusGroup tests', () => {
   test('should render', () => {
     const filter = Filter.fromString('status=Closed');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <TicketStatusGroup
         filter={filter}
@@ -45,7 +45,7 @@ describe('TicketStatusGroup tests', () => {
 
   test('should render value from filter and change it', () => {
     const filter = Filter.fromString('status=Closed');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
 
     // eslint-disable-next-line no-shadow
     const {baseElement, element, getByTestId} = render(
@@ -70,7 +70,7 @@ describe('TicketStatusGroup tests', () => {
   });
   test('should process title', () => {
     const filter = Filter.fromString('status=Open');
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
     const {element} = render(
       <TicketStatusGroup
         filter={filter}

--- a/src/web/components/qod/__tests__/qod.jsx
+++ b/src/web/components/qod/__tests__/qod.jsx
@@ -15,8 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Qod from 'web/components/qod/qod';
 

--- a/src/web/components/snackbar/__tests__/snackbar.jsx
+++ b/src/web/components/snackbar/__tests__/snackbar.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/structure/__tests__/footer.jsx
+++ b/src/web/components/structure/__tests__/footer.jsx
@@ -15,8 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import date from 'gmp/models/date';
 

--- a/src/web/components/structure/__tests__/header.jsx
+++ b/src/web/components/structure/__tests__/header.jsx
@@ -15,8 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {rendererWith} from 'web/utils/testing';
 
@@ -25,7 +24,7 @@ import {setUsername} from 'web/store/usersettings/actions';
 
 describe('Header tests', () => {
   test('should render header', () => {
-    const isLoggedIn = vi.fn().mockReturnValue(true);
+    const isLoggedIn = testing.fn().mockReturnValue(true);
     const gmp = {isLoggedIn, settings: {vendorVersion: ''}};
     const {render, store} = rendererWith({gmp, router: true, store: true});
     store.dispatch(setUsername('username'));

--- a/src/web/components/structure/__tests__/main.jsx
+++ b/src/web/components/structure/__tests__/main.jsx
@@ -15,8 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/components/table/__tests__/detailstable.jsx
+++ b/src/web/components/table/__tests__/detailstable.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 
@@ -40,5 +40,3 @@ describe('DetailsTable tests', () => {
     expect(element).toMatchSnapshot();
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/entities/__tests__/filterprovider.jsx
+++ b/src/web/entities/__tests__/filterprovider.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Filter, {DEFAULT_FALLBACK_FILTER} from 'gmp/models/filter';
 
@@ -35,7 +35,7 @@ describe('FilterProvider component tests', () => {
 
     const defaultSettingFilter = Filter.fromString('foo=bar');
 
-    const getSetting = vi.fn().mockResolvedValue({});
+    const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
       user: {
         getSetting,
@@ -53,7 +53,7 @@ describe('FilterProvider component tests', () => {
       defaultFilterLoadingActions.success('task', defaultSettingFilter),
     );
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValue(<span data-testid="awaiting-span" />);
 
@@ -77,7 +77,7 @@ describe('FilterProvider component tests', () => {
 
     const defaultSettingFilter = Filter.fromString('foo=bar');
 
-    const getSetting = vi.fn().mockResolvedValue({});
+    const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
       user: {
         getSetting,
@@ -96,7 +96,7 @@ describe('FilterProvider component tests', () => {
     );
     store.dispatch(pageFilter('task', pFilter));
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValue(<span data-testid="awaiting-span" />);
 
@@ -119,7 +119,7 @@ describe('FilterProvider component tests', () => {
 
     const defaultSettingFilter = Filter.fromString('foo=bar');
 
-    const getSetting = vi.fn().mockResolvedValue({});
+    const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
       user: {
         getSetting,
@@ -138,7 +138,7 @@ describe('FilterProvider component tests', () => {
     );
     store.dispatch(pageFilter(pageName, pFilter));
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValue(<span data-testid="awaiting-span" />);
 
@@ -161,7 +161,7 @@ describe('FilterProvider component tests', () => {
 
     const emptyFilter = Filter.fromString('rows=42');
 
-    const getSetting = vi.fn().mockResolvedValue({});
+    const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
       user: {
         getSetting,
@@ -179,7 +179,7 @@ describe('FilterProvider component tests', () => {
       defaultFilterLoadingActions.success('task', defaultSettingFilter),
     );
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValue(<span data-testid="awaiting-span" />);
 
@@ -198,7 +198,7 @@ describe('FilterProvider component tests', () => {
 
     const emptyFilter = Filter.fromString('rows=42');
 
-    const getSetting = vi.fn().mockResolvedValue({});
+    const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
       user: {
         getSetting,
@@ -216,7 +216,7 @@ describe('FilterProvider component tests', () => {
       defaultFilterLoadingActions.error('task', new Error('an error')),
     );
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValue(<span data-testid="awaiting-span" />);
 
@@ -238,8 +238,8 @@ describe('FilterProvider component tests', () => {
 
     const fallbackFilter = Filter.fromString('fall=back');
 
-    const getSetting = vi.fn().mockResolvedValue({});
-    const subscribe = vi.fn();
+    const getSetting = testing.fn().mockResolvedValue({});
+    const subscribe = testing.fn();
     const gmp = {
       user: {
         getSetting,
@@ -256,7 +256,7 @@ describe('FilterProvider component tests', () => {
 
     store.dispatch(loadingActions.success({rowsperpage: {value: '42'}}));
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValue(<span data-testid="awaiting-span" />);
 
@@ -274,8 +274,8 @@ describe('FilterProvider component tests', () => {
   test('should use default fallbackFilter as last resort', async () => {
     const resultingFilter = DEFAULT_FALLBACK_FILTER.copy().set('rows', 42);
 
-    const getSetting = vi.fn().mockResolvedValue({});
-    const subscribe = vi.fn();
+    const getSetting = testing.fn().mockResolvedValue({});
+    const subscribe = testing.fn();
     const gmp = {
       user: {
         getSetting,
@@ -292,7 +292,7 @@ describe('FilterProvider component tests', () => {
 
     store.dispatch(loadingActions.success({rowsperpage: {value: '42'}}));
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValue(<span data-testid="awaiting-span" />);
 
@@ -310,8 +310,8 @@ describe('FilterProvider component tests', () => {
     // use fallbackFilter as sample
     const fallbackFilter = Filter.fromString('fall=back rows=21');
 
-    const getSetting = vi.fn().mockResolvedValue({});
-    const subscribe = vi.fn();
+    const getSetting = testing.fn().mockResolvedValue({});
+    const subscribe = testing.fn();
     const gmp = {
       user: {
         getSetting,
@@ -328,7 +328,7 @@ describe('FilterProvider component tests', () => {
 
     store.dispatch(loadingActions.success({rowsperpage: {value: '42'}}));
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValue(<span data-testid="awaiting-span" />);
 
@@ -347,7 +347,7 @@ describe('FilterProvider component tests', () => {
     const resultingFilter = Filter.fromString('fall=back rows=50');
     const fallbackFilter = Filter.fromString('fall=back');
 
-    const getSetting = vi.fn().mockRejectedValue(new Error('an error'));
+    const getSetting = testing.fn().mockRejectedValue(new Error('an error'));
     const gmp = {
       user: {
         getSetting,
@@ -362,7 +362,7 @@ describe('FilterProvider component tests', () => {
 
     store.dispatch(loadingActions.error(new Error('an error')));
 
-    const renderFunc = vi
+    const renderFunc = testing
       .fn()
       .mockReturnValue(<span data-testid="awaiting-span" />);
 

--- a/src/web/entities/__tests__/tagsdialog.jsx
+++ b/src/web/entities/__tests__/tagsdialog.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -23,10 +23,10 @@ import Dialog from '../tagsdialog';
 
 describe('TagsDialog dialog component tests', () => {
   test('should render dialog', () => {
-    const handleClose = vi.fn();
-    const handleNewTagClick = vi.fn();
-    const handleSave = vi.fn();
-    const handleTagChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleNewTagClick = testing.fn();
+    const handleSave = testing.fn();
+    const handleTagChange = testing.fn();
 
     const {baseElement} = render(
       <Dialog
@@ -43,10 +43,10 @@ describe('TagsDialog dialog component tests', () => {
   });
 
   test('should disable tag selection when no options available', () => {
-    const handleClose = vi.fn();
-    const handleNewTagClick = vi.fn();
-    const handleSave = vi.fn();
-    const handleTagChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleNewTagClick = testing.fn();
+    const handleSave = testing.fn();
+    const handleTagChange = testing.fn();
 
     const {baseElement} = render(
       <Dialog
@@ -62,10 +62,10 @@ describe('TagsDialog dialog component tests', () => {
   });
 
   test('should save data', () => {
-    const handleClose = vi.fn();
-    const handleNewTagClick = vi.fn();
-    const handleSave = vi.fn();
-    const handleTagChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleNewTagClick = testing.fn();
+    const handleSave = testing.fn();
+    const handleTagChange = testing.fn();
 
     const {getByTestId} = render(
       <Dialog
@@ -93,10 +93,10 @@ describe('TagsDialog dialog component tests', () => {
   });
 
   test('should allow to close the dialog', () => {
-    const handleClose = vi.fn();
-    const handleNewTagClick = vi.fn();
-    const handleSave = vi.fn();
-    const handleTagChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleNewTagClick = testing.fn();
+    const handleSave = testing.fn();
+    const handleTagChange = testing.fn();
 
     const {getByTestId} = render(
       <Dialog

--- a/src/web/entity/__tests__/block.jsx
+++ b/src/web/entity/__tests__/block.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 
@@ -37,5 +37,3 @@ describe('Entity Block component tests', () => {
     expect(element).toHaveTextContent('child');
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/entity/__tests__/box.jsx
+++ b/src/web/entity/__tests__/box.jsx
@@ -15,16 +15,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
-import Date, {setLocale} from 'gmp/models/date';
+import Date from 'gmp/models/date';
 
 import {setTimezone} from 'web/store/usersettings/actions';
 import {rendererWith} from 'web/utils/testing';
 
 import EntityBox from '../box';
-
-setLocale('en');
 
 const date1 = Date('2019-01-01T12:00:00Z');
 const date2 = Date('2019-02-02T12:00:00Z');
@@ -71,5 +69,3 @@ describe('EntityBox component tests', () => {
     expect(element).toHaveStyleRule('width', '400px');
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/entity/__tests__/info.jsx
+++ b/src/web/entity/__tests__/info.jsx
@@ -15,19 +15,17 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Model from 'gmp/model';
 
-import Date, {setLocale} from 'gmp/models/date';
+import Date from 'gmp/models/date';
 
 import {setTimezone} from 'web/store/usersettings/actions';
 
 import {rendererWith} from 'web/utils/testing';
 
 import EntityInfo from '../info';
-
-setLocale('en');
 
 const date = Date('2019-01-01T12:00:00Z');
 const date2 = Date('2019-02-02T12:00:00Z');
@@ -86,5 +84,3 @@ describe('EntityInfo component tests', () => {
     expect(element).toHaveTextContent('Owner:(Global Object)');
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/entity/__tests__/link.jsx
+++ b/src/web/entity/__tests__/link.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -118,5 +118,3 @@ describe('EntityLink component tests', () => {
     expect(element).toHaveTextContent('Orphan');
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/entity/__tests__/note.jsx
+++ b/src/web/entity/__tests__/note.jsx
@@ -15,18 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/models/date';
 import Note from 'gmp/models/note';
 
 import {setTimezone} from 'web/store/usersettings/actions';
 import {rendererWith} from 'web/utils/testing';
 
 import NoteBox from '../note';
-
-setLocale('en');
 
 const caps = new Capabilities(['everything']);
 
@@ -91,5 +88,3 @@ describe('NoteBox component tests', () => {
     );
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/entity/__tests__/override.jsx
+++ b/src/web/entity/__tests__/override.jsx
@@ -15,18 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/models/date';
 import Override from 'gmp/models/override';
 
 import {setTimezone} from 'web/store/usersettings/actions';
 import {rendererWith} from 'web/utils/testing';
 
 import OverrideBox from '../override';
-
-setLocale('en');
 
 const caps = new Capabilities(['everything']);
 
@@ -91,5 +88,3 @@ describe('OverrideBox component tests', () => {
     );
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/entity/icon/__tests__/cloneicon.jsx
+++ b/src/web/entity/icon/__tests__/cloneicon.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -33,7 +33,7 @@ describe('Entity CloneIcon component tests', () => {
     const entity = Task.fromElement({
       permissions: {permission: [{name: 'get_tasks'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -56,7 +56,7 @@ describe('Entity CloneIcon component tests', () => {
     const entity = Task.fromElement({
       permissions: {permission: [{name: 'get_tasks'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -78,7 +78,7 @@ describe('Entity CloneIcon component tests', () => {
     const entity = Task.fromElement({
       permissions: {permission: [{name: 'get_schedule'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -96,5 +96,3 @@ describe('Entity CloneIcon component tests', () => {
     });
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/entity/icon/__tests__/createicon.jsx
+++ b/src/web/entity/icon/__tests__/createicon.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -31,7 +31,7 @@ describe('Entity CreateIcon component tests', () => {
   test('should render in active state with correct permissions', () => {
     const caps = new Capabilities(['everything']);
     const entity = Task.fromElement({});
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -61,5 +61,3 @@ describe('Entity CreateIcon component tests', () => {
     expect(caps.mayCreate('task')).toEqual(false);
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/entity/icon/__tests__/deleteicon.jsx
+++ b/src/web/entity/icon/__tests__/deleteicon.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -33,7 +33,7 @@ describe('Entity DeleteIcon component tests', () => {
     const entity = Task.fromElement({
       permissions: {permission: [{name: 'delete_task'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -57,7 +57,7 @@ describe('Entity DeleteIcon component tests', () => {
     const entity = Task.fromElement({
       permissions: {permission: [{name: 'delete_task'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -80,7 +80,7 @@ describe('Entity DeleteIcon component tests', () => {
     const entity = Task.fromElement({
       permissions: {permission: [{name: 'delete_schedule'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 

--- a/src/web/entity/icon/__tests__/editicon.jsx
+++ b/src/web/entity/icon/__tests__/editicon.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -33,7 +33,7 @@ describe('Entity EditIcon component tests', () => {
     const entity = Task.fromElement({
       permissions: {permission: [{name: 'modify_task'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -56,7 +56,7 @@ describe('Entity EditIcon component tests', () => {
     const entity = Task.fromElement({
       permissions: {permission: [{name: 'modify_task'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -78,7 +78,7 @@ describe('Entity EditIcon component tests', () => {
     const entity = Task.fromElement({
       permissions: {permission: [{name: 'modify_schedule'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -101,7 +101,7 @@ describe('Entity EditIcon component tests', () => {
     const entity = Task.fromElement({
       permissions: {permission: [{name: 'modify_schedule'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -119,5 +119,3 @@ describe('Entity EditIcon component tests', () => {
     });
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/entity/icon/__tests__/observericon.jsx
+++ b/src/web/entity/icon/__tests__/observericon.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Task from 'gmp/models/task';
 
@@ -40,5 +40,3 @@ describe('Entity ObserverIcon component tests', () => {
     expect(element).toEqual(null);
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/entity/icon/__tests__/trashicon.jsx
+++ b/src/web/entity/icon/__tests__/trashicon.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -33,7 +33,7 @@ describe('Entity TrashIcon component tests', () => {
     const entity = Task.fromElement({
       permissions: {permission: [{name: 'delete_task'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -57,7 +57,7 @@ describe('Entity TrashIcon component tests', () => {
     const entity = Task.fromElement({
       permissions: {permission: [{name: 'delete_task'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -80,7 +80,7 @@ describe('Entity TrashIcon component tests', () => {
     const entity = Task.fromElement({
       permissions: {permission: [{name: 'delete_schedule'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -99,5 +99,3 @@ describe('Entity TrashIcon component tests', () => {
     });
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/entity/icon/__tests__/verifyicon.jsx
+++ b/src/web/entity/icon/__tests__/verifyicon.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -33,7 +33,7 @@ describe('Entity VerifyIcon component tests', () => {
     const entity = ReportFormat.fromElement({
       permissions: {permission: [{name: 'verify_report_format'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -56,7 +56,7 @@ describe('Entity VerifyIcon component tests', () => {
     const entity = ReportFormat.fromElement({
       permissions: {permission: [{name: 'verify_report_format'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -83,7 +83,7 @@ describe('Entity VerifyIcon component tests', () => {
     const entity = ReportFormat.fromElement({
       permissions: {permission: [{name: 'verify_report_format'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -105,7 +105,7 @@ describe('Entity VerifyIcon component tests', () => {
     const entity = ReportFormat.fromElement({
       permissions: {permission: [{name: 'verify_scanner'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -125,5 +125,3 @@ describe('Entity VerifyIcon component tests', () => {
     });
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/hooks/__tests__/useLocale.jsx
+++ b/src/web/hooks/__tests__/useLocale.jsx
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import {describe, test, expect} from '@gsa/testing';
+
 import {setLocale} from 'web/store/usersettings/actions';
 
 import {rendererWith, screen, fireEvent} from 'web/utils/testing';

--- a/src/web/hooks/__tests__/useTranslation.jsx
+++ b/src/web/hooks/__tests__/useTranslation.jsx
@@ -2,6 +2,7 @@
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import {fireEvent, rendererWith, screen} from 'web/utils/testing';
 

--- a/src/web/pages/alerts/__tests__/detailspage.jsx
+++ b/src/web/pages/alerts/__tests__/detailspage.jsx
@@ -15,11 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
-
-import {isDefined} from 'gmp/utils/identity';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
@@ -33,13 +29,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import Detailspage, {ToolBarIcons} from '../detailspage';
-
-setLocale('en');
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
 
 const caps = new Capabilities(['everything']);
 
@@ -95,11 +84,11 @@ let currentSettings;
 let renewSession;
 
 beforeEach(() => {
-  getAlert = vi.fn().mockResolvedValue({
+  getAlert = testing.fn().mockResolvedValue({
     data: alert,
   });
 
-  getEntities = vi.fn().mockResolvedValue({
+  getEntities = testing.fn().mockResolvedValue({
     data: [],
     meta: {
       filter: Filter.fromString(),
@@ -107,11 +96,11 @@ beforeEach(() => {
     },
   });
 
-  currentSettings = vi.fn().mockResolvedValue({
+  currentSettings = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 
-  renewSession = vi.fn().mockResolvedValue({
+  renewSession = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 });
@@ -264,15 +253,15 @@ describe('Alert Detailspage tests', () => {
   });
 
   test('should call commands', async () => {
-    const clone = vi.fn().mockResolvedValue({
+    const clone = testing.fn().mockResolvedValue({
       data: {id: 'foo'},
     });
 
-    const deleteFunc = vi.fn().mockResolvedValue({
+    const deleteFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportFunc = vi.fn().mockResolvedValue({
+    const exportFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -337,11 +326,11 @@ describe('Alert Detailspage tests', () => {
 
 describe('Alert ToolBarIcons tests', () => {
   test('should render', () => {
-    const handleAlertCloneClick = vi.fn();
-    const handleAlertDeleteClick = vi.fn();
-    const handleAlertDownloadClick = vi.fn();
-    const handleAlertEditClick = vi.fn();
-    const handleAlertCreateClick = vi.fn();
+    const handleAlertCloneClick = testing.fn();
+    const handleAlertDeleteClick = testing.fn();
+    const handleAlertDownloadClick = testing.fn();
+    const handleAlertEditClick = testing.fn();
+    const handleAlertCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -376,11 +365,11 @@ describe('Alert ToolBarIcons tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleAlertCloneClick = vi.fn();
-    const handleAlertDeleteClick = vi.fn();
-    const handleAlertDownloadClick = vi.fn();
-    const handleAlertEditClick = vi.fn();
-    const handleAlertCreateClick = vi.fn();
+    const handleAlertCloneClick = testing.fn();
+    const handleAlertDeleteClick = testing.fn();
+    const handleAlertDownloadClick = testing.fn();
+    const handleAlertEditClick = testing.fn();
+    const handleAlertCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -421,11 +410,11 @@ describe('Alert ToolBarIcons tests', () => {
   });
 
   test('should not call click handlers without permission', () => {
-    const handleAlertCloneClick = vi.fn();
-    const handleAlertDeleteClick = vi.fn();
-    const handleAlertDownloadClick = vi.fn();
-    const handleAlertEditClick = vi.fn();
-    const handleAlertCreateClick = vi.fn();
+    const handleAlertCloneClick = testing.fn();
+    const handleAlertDeleteClick = testing.fn();
+    const handleAlertDownloadClick = testing.fn();
+    const handleAlertEditClick = testing.fn();
+    const handleAlertCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -473,11 +462,11 @@ describe('Alert ToolBarIcons tests', () => {
   });
 
   test('should (not) call click handlers for alert in use', () => {
-    const handleAlertCloneClick = vi.fn();
-    const handleAlertDeleteClick = vi.fn();
-    const handleAlertDownloadClick = vi.fn();
-    const handleAlertEditClick = vi.fn();
-    const handleAlertCreateClick = vi.fn();
+    const handleAlertCloneClick = testing.fn();
+    const handleAlertDeleteClick = testing.fn();
+    const handleAlertDownloadClick = testing.fn();
+    const handleAlertEditClick = testing.fn();
+    const handleAlertCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 

--- a/src/web/pages/alerts/__tests__/listpage.jsx
+++ b/src/web/pages/alerts/__tests__/listpage.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
@@ -34,10 +32,6 @@ import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import AlertPage, {ToolBarIcons} from '../listpage';
-
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
 
 const caps = new Capabilities(['everything']);
 const wrongCaps = new Capabilities(['get_config']);
@@ -76,7 +70,7 @@ let currentSettings;
 let renewSession;
 
 beforeEach(() => {
-  getAlerts = vi.fn().mockResolvedValue({
+  getAlerts = testing.fn().mockResolvedValue({
     data: [alert],
     meta: {
       filter: Filter.fromString(),
@@ -84,7 +78,7 @@ beforeEach(() => {
     },
   });
 
-  getFilters = vi.fn().mockReturnValue(
+  getFilters = testing.fn().mockReturnValue(
     Promise.resolve({
       data: [],
       meta: {
@@ -94,15 +88,15 @@ beforeEach(() => {
     }),
   );
 
-  getSetting = vi.fn().mockResolvedValue({
+  getSetting = testing.fn().mockResolvedValue({
     filter: null,
   });
 
-  currentSettings = vi.fn().mockResolvedValue({
+  currentSettings = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 
-  renewSession = vi.fn().mockResolvedValue({
+  renewSession = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 });
@@ -199,11 +193,11 @@ describe('Alert listpage tests', () => {
   });
 
   test('should allow to bulk action on page contents', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -276,11 +270,11 @@ describe('Alert listpage tests', () => {
   });
 
   test('should allow to bulk action on selected alerts', async () => {
-    const deleteByIds = vi.fn().mockResolvedValue({
+    const deleteByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByIds = vi.fn().mockResolvedValue({
+    const exportByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -365,11 +359,11 @@ describe('Alert listpage tests', () => {
   });
 
   test('should allow to bulk action on filtered alerts', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -452,7 +446,7 @@ describe('Alert listpage tests', () => {
 
 describe('Alert listpage ToolBarIcons test', () => {
   test('should render', () => {
-    const handleAlertCreateClick = vi.fn();
+    const handleAlertCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -483,7 +477,7 @@ describe('Alert listpage ToolBarIcons test', () => {
   });
 
   test('should call click handlers', () => {
-    const handleAlertCreateClick = vi.fn();
+    const handleAlertCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -505,7 +499,7 @@ describe('Alert listpage ToolBarIcons test', () => {
   });
 
   test('should not show icons if user does not have the right permissions', () => {
-    const handleAlertCreateClick = vi.fn();
+    const handleAlertCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},

--- a/src/web/pages/audits/__tests__/actions.jsx
+++ b/src/web/pages/audits/__tests__/actions.jsx
@@ -16,18 +16,15 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 /* eslint-disable no-console */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 
 import {rendererWith, fireEvent} from 'web/utils/testing';
 import Theme from 'web/utils/theme';
 
 import Actions from '../actions';
 import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
-
-setLocale('en');
 
 const caps = new Capabilities(['everything']);
 const wrongCaps = new Capabilities(['get_task']);
@@ -48,14 +45,14 @@ describe('Audit Actions tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
     const {baseElement} = render(
@@ -87,14 +84,14 @@ describe('Audit Actions tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
     const {getAllByTestId} = render(
@@ -157,14 +154,14 @@ describe('Audit Actions tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: wrongCaps});
     const {getAllByTestId} = render(
@@ -239,14 +236,14 @@ describe('Audit Actions tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: wrongCaps});
     const {getAllByTestId} = render(
@@ -324,14 +321,14 @@ describe('Audit Actions tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: wrongCaps});
     const {getAllByTestId} = render(
@@ -406,14 +403,14 @@ describe('Audit Actions tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
     const {getAllByTestId} = render(
@@ -474,14 +471,14 @@ describe('Audit Actions tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
     const {getAllByTestId} = render(
@@ -544,14 +541,14 @@ describe('Audit Actions tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
     const {getAllByTestId} = render(
@@ -595,14 +592,14 @@ describe('Audit Actions tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({
       capabilities: true,

--- a/src/web/pages/audits/__tests__/details.jsx
+++ b/src/web/pages/audits/__tests__/details.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -31,8 +29,6 @@ import {entityLoadingActions as scheduleActions} from 'web/store/entities/schedu
 import {rendererWith} from 'web/utils/testing';
 
 import Details from '../details';
-
-setLocale('en');
 
 const policy = Policy.fromElement({
   _id: '314',
@@ -74,13 +70,13 @@ const preferences = {
 
 const schedule = Schedule.fromElement({_id: '121314', name: 'schedule1'});
 
-const getPolicy = vi.fn().mockReturnValue(
+const getPolicy = testing.fn().mockReturnValue(
   Promise.resolve({
     data: policy,
   }),
 );
 
-const getSchedule = vi.fn().mockReturnValue(
+const getSchedule = testing.fn().mockReturnValue(
   Promise.resolve({
     data: schedule,
   }),

--- a/src/web/pages/audits/__tests__/detailspage.jsx
+++ b/src/web/pages/audits/__tests__/detailspage.jsx
@@ -15,12 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-import {act} from 'react-dom/test-utils';
-
-import {setLocale} from 'gmp/locale/lang';
-
-import {isDefined} from 'gmp/utils/identity';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
@@ -33,16 +28,9 @@ import Schedule from 'gmp/models/schedule';
 import {entityLoadingActions} from 'web/store/entities/audits';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 
-import {rendererWith, fireEvent} from 'web/utils/testing';
+import {rendererWith, fireEvent, act} from 'web/utils/testing';
 
 import Detailspage, {ToolBarIcons} from '../detailspage';
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
-
-setLocale('en');
 
 const policy = Policy.fromElement({
   _id: '314',
@@ -259,23 +247,23 @@ const caps = new Capabilities(['everything']);
 const reloadInterval = 1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getPolicy = vi.fn().mockResolvedValue({
+const getPolicy = testing.fn().mockResolvedValue({
   data: policy,
 });
 
-const getSchedule = vi.fn().mockResolvedValue({
+const getSchedule = testing.fn().mockResolvedValue({
   data: schedule,
 });
 
-const getEntities = vi.fn().mockResolvedValue({
+const getEntities = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -285,7 +273,7 @@ const getEntities = vi.fn().mockResolvedValue({
 
 describe('Audit Detailspage tests', () => {
   test('should render full Detailspage', () => {
-    const getAudit = vi.fn().mockResolvedValue({
+    const getAudit = testing.fn().mockResolvedValue({
       data: audit,
     });
 
@@ -380,7 +368,7 @@ describe('Audit Detailspage tests', () => {
   });
 
   test('should render permissions tab', () => {
-    const getAudit = vi.fn().mockResolvedValue({
+    const getAudit = testing.fn().mockResolvedValue({
       data: audit2,
     });
 
@@ -428,27 +416,27 @@ describe('Audit Detailspage tests', () => {
   });
 
   test('should call commands', async () => {
-    const getAudit = vi.fn().mockResolvedValue({
+    const getAudit = testing.fn().mockResolvedValue({
       data: audit5,
     });
 
-    const clone = vi.fn().mockResolvedValue({
+    const clone = testing.fn().mockResolvedValue({
       data: {id: 'foo'},
     });
 
-    const deleteFunc = vi.fn().mockResolvedValue({
+    const deleteFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportFunc = vi.fn().mockResolvedValue({
+    const exportFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const start = vi.fn().mockResolvedValue({
+    const start = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const resume = vi.fn().mockResolvedValue({
+    const resume = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -523,13 +511,13 @@ describe('Audit Detailspage tests', () => {
 
 describe('Audit ToolBarIcons tests', () => {
   test('should render', () => {
-    const handleAuditCloneClick = vi.fn();
-    const handleAuditDeleteClick = vi.fn();
-    const handleAuditDownloadClick = vi.fn();
-    const handleAuditEditClick = vi.fn();
-    const handleAuditResumeClick = vi.fn();
-    const handleAuditStartClick = vi.fn();
-    const handleAuditStopClick = vi.fn();
+    const handleAuditCloneClick = testing.fn();
+    const handleAuditDeleteClick = testing.fn();
+    const handleAuditDownloadClick = testing.fn();
+    const handleAuditEditClick = testing.fn();
+    const handleAuditResumeClick = testing.fn();
+    const handleAuditStartClick = testing.fn();
+    const handleAuditStopClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -568,13 +556,13 @@ describe('Audit ToolBarIcons tests', () => {
   });
 
   test('should call click handlers for new audit', () => {
-    const handleAuditCloneClick = vi.fn();
-    const handleAuditDeleteClick = vi.fn();
-    const handleAuditDownloadClick = vi.fn();
-    const handleAuditEditClick = vi.fn();
-    const handleAuditResumeClick = vi.fn();
-    const handleAuditStartClick = vi.fn();
-    const handleAuditStopClick = vi.fn();
+    const handleAuditCloneClick = testing.fn();
+    const handleAuditDeleteClick = testing.fn();
+    const handleAuditDownloadClick = testing.fn();
+    const handleAuditEditClick = testing.fn();
+    const handleAuditResumeClick = testing.fn();
+    const handleAuditStartClick = testing.fn();
+    const handleAuditStopClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -635,13 +623,13 @@ describe('Audit ToolBarIcons tests', () => {
   });
 
   test('should call click handlers for running audit', () => {
-    const handleAuditCloneClick = vi.fn();
-    const handleAuditDeleteClick = vi.fn();
-    const handleAuditDownloadClick = vi.fn();
-    const handleAuditEditClick = vi.fn();
-    const handleAuditResumeClick = vi.fn();
-    const handleAuditStartClick = vi.fn();
-    const handleAuditStopClick = vi.fn();
+    const handleAuditCloneClick = testing.fn();
+    const handleAuditDeleteClick = testing.fn();
+    const handleAuditDownloadClick = testing.fn();
+    const handleAuditEditClick = testing.fn();
+    const handleAuditResumeClick = testing.fn();
+    const handleAuditStartClick = testing.fn();
+    const handleAuditStopClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -709,13 +697,13 @@ describe('Audit ToolBarIcons tests', () => {
   });
 
   test('should call click handlers for stopped audit', () => {
-    const handleAuditCloneClick = vi.fn();
-    const handleAuditDeleteClick = vi.fn();
-    const handleAuditDownloadClick = vi.fn();
-    const handleAuditEditClick = vi.fn();
-    const handleAuditResumeClick = vi.fn();
-    const handleAuditStartClick = vi.fn();
-    const handleAuditStopClick = vi.fn();
+    const handleAuditCloneClick = testing.fn();
+    const handleAuditDeleteClick = testing.fn();
+    const handleAuditDownloadClick = testing.fn();
+    const handleAuditEditClick = testing.fn();
+    const handleAuditResumeClick = testing.fn();
+    const handleAuditStartClick = testing.fn();
+    const handleAuditStopClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -782,13 +770,13 @@ describe('Audit ToolBarIcons tests', () => {
   });
 
   test('should call click handlers for finished audit', () => {
-    const handleAuditCloneClick = vi.fn();
-    const handleAuditDeleteClick = vi.fn();
-    const handleAuditDownloadClick = vi.fn();
-    const handleAuditEditClick = vi.fn();
-    const handleAuditResumeClick = vi.fn();
-    const handleAuditStartClick = vi.fn();
-    const handleAuditStopClick = vi.fn();
+    const handleAuditCloneClick = testing.fn();
+    const handleAuditDeleteClick = testing.fn();
+    const handleAuditDownloadClick = testing.fn();
+    const handleAuditEditClick = testing.fn();
+    const handleAuditResumeClick = testing.fn();
+    const handleAuditStartClick = testing.fn();
+    const handleAuditStopClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -855,13 +843,13 @@ describe('Audit ToolBarIcons tests', () => {
   });
 
   test('should not call click handlers without permission', () => {
-    const handleAuditCloneClick = vi.fn();
-    const handleAuditDeleteClick = vi.fn();
-    const handleAuditDownloadClick = vi.fn();
-    const handleAuditEditClick = vi.fn();
-    const handleAuditResumeClick = vi.fn();
-    const handleAuditStartClick = vi.fn();
-    const handleAuditStopClick = vi.fn();
+    const handleAuditCloneClick = testing.fn();
+    const handleAuditDeleteClick = testing.fn();
+    const handleAuditDownloadClick = testing.fn();
+    const handleAuditEditClick = testing.fn();
+    const handleAuditResumeClick = testing.fn();
+    const handleAuditStartClick = testing.fn();
+    const handleAuditStopClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -937,13 +925,13 @@ describe('Audit ToolBarIcons tests', () => {
   });
 
   test('should render schedule icon if audit is scheduled', () => {
-    const handleAuditCloneClick = vi.fn();
-    const handleAuditDeleteClick = vi.fn();
-    const handleAuditDownloadClick = vi.fn();
-    const handleAuditEditClick = vi.fn();
-    const handleAuditResumeClick = vi.fn();
-    const handleAuditStartClick = vi.fn();
-    const handleAuditStopClick = vi.fn();
+    const handleAuditCloneClick = testing.fn();
+    const handleAuditDeleteClick = testing.fn();
+    const handleAuditDownloadClick = testing.fn();
+    const handleAuditEditClick = testing.fn();
+    const handleAuditResumeClick = testing.fn();
+    const handleAuditStartClick = testing.fn();
+    const handleAuditStopClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 

--- a/src/web/pages/audits/__tests__/listpage.jsx
+++ b/src/web/pages/audits/__tests__/listpage.jsx
@@ -15,10 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-import {act} from 'react-dom/test-utils';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
@@ -32,13 +29,9 @@ import {entitiesLoadingActions} from 'web/store/entities/audits';
 import {loadingActions} from 'web/store/usersettings/defaults/actions';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
 
-import {rendererWith, waitFor, fireEvent} from 'web/utils/testing';
+import {rendererWith, waitFor, fireEvent, act} from 'web/utils/testing';
 
 import AuditPage, {ToolBarIcons} from '../listpage';
-
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
 
 const lastReport = {
   report: {
@@ -66,15 +59,15 @@ const wrongCaps = new Capabilities(['get_config']);
 const reloadInterval = 1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getSetting = vi.fn().mockResolvedValue({
+const getSetting = testing.fn().mockResolvedValue({
   filter: null,
 });
 
-const getFilters = vi.fn().mockReturnValue(
+const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
     meta: {
@@ -84,7 +77,7 @@ const getFilters = vi.fn().mockReturnValue(
   }),
 );
 
-const getAudits = vi.fn().mockResolvedValue({
+const getAudits = testing.fn().mockResolvedValue({
   data: [audit],
   meta: {
     filter: Filter.fromString(),
@@ -92,7 +85,7 @@ const getAudits = vi.fn().mockResolvedValue({
   },
 });
 
-const getReportFormats = vi.fn().mockResolvedValue({
+const getReportFormats = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -100,7 +93,7 @@ const getReportFormats = vi.fn().mockResolvedValue({
   },
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
@@ -158,11 +151,11 @@ describe('AuditPage tests', () => {
   });
 
   test('should call commands for bulk actions', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -235,7 +228,7 @@ describe('AuditPage tests', () => {
 
 describe('AuditPage ToolBarIcons test', () => {
   test('should render', () => {
-    const handleAuditCreateClick = vi.fn();
+    const handleAuditCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -263,7 +256,7 @@ describe('AuditPage ToolBarIcons test', () => {
   });
 
   test('should call click handlers', () => {
-    const handleAuditCreateClick = vi.fn();
+    const handleAuditCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -287,7 +280,7 @@ describe('AuditPage ToolBarIcons test', () => {
   });
 
   test('should not show icons if user does not have the right permissions', () => {
-    const handleAuditCreateClick = vi.fn();
+    const handleAuditCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},

--- a/src/web/pages/audits/__tests__/row.jsx
+++ b/src/web/pages/audits/__tests__/row.jsx
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 /* eslint-disable no-console */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import {setLocale} from 'gmp/locale/lang';
@@ -70,15 +70,15 @@ describe('Audit Row tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -170,15 +170,15 @@ describe('Audit Row tests', () => {
       },
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -233,15 +233,15 @@ describe('Audit Row tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -336,15 +336,15 @@ describe('Audit Row tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -444,15 +444,15 @@ describe('Audit Row tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -554,15 +554,15 @@ describe('Audit Row tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -664,15 +664,15 @@ describe('Audit Row tests', () => {
       usage_type: 'audit',
     });
 
-    const handleAuditClone = vi.fn();
-    const handleAuditDelete = vi.fn();
-    const handleAuditDownload = vi.fn();
-    const handleAuditEdit = vi.fn();
-    const handleAuditResume = vi.fn();
-    const handleAuditStart = vi.fn();
-    const handleAuditStop = vi.fn();
-    const handleReportDownload = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleAuditClone = testing.fn();
+    const handleAuditDelete = testing.fn();
+    const handleAuditDownload = testing.fn();
+    const handleAuditEdit = testing.fn();
+    const handleAuditResume = testing.fn();
+    const handleAuditStart = testing.fn();
+    const handleAuditStop = testing.fn();
+    const handleReportDownload = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,

--- a/src/web/pages/audits/__tests__/table.jsx
+++ b/src/web/pages/audits/__tests__/table.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
@@ -105,14 +105,14 @@ const filter = Filter.fromString('rows=2');
 
 describe('Audits table tests', () => {
   test('should render', () => {
-    const handleAuditCloneClick = vi.fn();
-    const handleAuditDeleteClick = vi.fn();
-    const handleAuditDownloadClick = vi.fn();
-    const handleAuditEditClick = vi.fn();
-    const handleAuditStartClick = vi.fn();
-    const handleAuditStopClick = vi.fn();
-    const handleAuditResumeClick = vi.fn();
-    const handleReportDownloadClick = vi.fn();
+    const handleAuditCloneClick = testing.fn();
+    const handleAuditDeleteClick = testing.fn();
+    const handleAuditDownloadClick = testing.fn();
+    const handleAuditEditClick = testing.fn();
+    const handleAuditStartClick = testing.fn();
+    const handleAuditStopClick = testing.fn();
+    const handleAuditResumeClick = testing.fn();
+    const handleReportDownloadClick = testing.fn();
 
     const gmp = {
       settings: {},
@@ -154,14 +154,14 @@ describe('Audits table tests', () => {
   });
 
   test('should unfold all details', () => {
-    const handleAuditCloneClick = vi.fn();
-    const handleAuditDeleteClick = vi.fn();
-    const handleAuditDownloadClick = vi.fn();
-    const handleAuditEditClick = vi.fn();
-    const handleAuditStartClick = vi.fn();
-    const handleAuditStopClick = vi.fn();
-    const handleAuditResumeClick = vi.fn();
-    const handleReportDownloadClick = vi.fn();
+    const handleAuditCloneClick = testing.fn();
+    const handleAuditDeleteClick = testing.fn();
+    const handleAuditDownloadClick = testing.fn();
+    const handleAuditEditClick = testing.fn();
+    const handleAuditStartClick = testing.fn();
+    const handleAuditStopClick = testing.fn();
+    const handleAuditResumeClick = testing.fn();
+    const handleReportDownloadClick = testing.fn();
 
     const gmp = {
       settings: {},
@@ -203,14 +203,14 @@ describe('Audits table tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleAuditCloneClick = vi.fn();
-    const handleAuditDeleteClick = vi.fn();
-    const handleAuditDownloadClick = vi.fn();
-    const handleAuditEditClick = vi.fn();
-    const handleAuditStartClick = vi.fn();
-    const handleAuditStopClick = vi.fn();
-    const handleAuditResumeClick = vi.fn();
-    const handleReportDownloadClick = vi.fn();
+    const handleAuditCloneClick = testing.fn();
+    const handleAuditDeleteClick = testing.fn();
+    const handleAuditDownloadClick = testing.fn();
+    const handleAuditEditClick = testing.fn();
+    const handleAuditStartClick = testing.fn();
+    const handleAuditStopClick = testing.fn();
+    const handleAuditResumeClick = testing.fn();
+    const handleReportDownloadClick = testing.fn();
 
     const gmp = {
       settings: {},

--- a/src/web/pages/cpes/__tests__/detailspage.jsx
+++ b/src/web/pages/cpes/__tests__/detailspage.jsx
@@ -15,11 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
-
-import {isDefined} from 'gmp/utils/identity';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -34,13 +30,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, wait, fireEvent} from 'web/utils/testing';
 
 import CpePage, {ToolBarIcons} from '../detailspage';
-
-setLocale('en');
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
 
 const cpe = CPE.fromElement({
   _id: 'cpe:/a:foo',
@@ -71,18 +60,18 @@ let currentSettings;
 let renewSession;
 
 beforeEach(() => {
-  currentSettings = vi.fn().mockResolvedValue({
+  currentSettings = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 
-  renewSession = vi.fn().mockResolvedValue({
+  renewSession = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 });
 
 describe('CPE Detailspage tests', () => {
   test('should render full Detailspage', () => {
-    const getCpe = vi.fn().mockResolvedValue({
+    const getCpe = testing.fn().mockResolvedValue({
       data: cpe,
     });
 
@@ -164,11 +153,11 @@ describe('CPE Detailspage tests', () => {
   });
 
   test('should render user tags tab', async () => {
-    const getCpe = vi.fn().mockResolvedValue({
+    const getCpe = testing.fn().mockResolvedValue({
       data: cpe,
     });
 
-    const getTags = vi.fn().mockResolvedValue({
+    const getTags = testing.fn().mockResolvedValue({
       data: [],
       meta: {
         filter: Filter.fromString(),
@@ -212,11 +201,11 @@ describe('CPE Detailspage tests', () => {
   });
 
   test('should call commands', async () => {
-    const exportFunc = vi.fn().mockResolvedValue({
+    const exportFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const getCpe = vi.fn().mockReturnValue(
+    const getCpe = testing.fn().mockReturnValue(
       Promise.resolve({
         data: cpe,
       }),
@@ -262,7 +251,7 @@ describe('CPE Detailspage tests', () => {
 
 describe('CPEs ToolBarIcons tests', () => {
   test('should render', () => {
-    const handleCpeDownload = vi.fn();
+    const handleCpeDownload = testing.fn();
 
     const {render} = rendererWith({
       gmp: {settings: {manualUrl}},
@@ -288,7 +277,7 @@ describe('CPEs ToolBarIcons tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleCpeDownload = vi.fn();
+    const handleCpeDownload = testing.fn();
 
     const {render} = rendererWith({
       gmp: {settings: {manualUrl}},

--- a/src/web/pages/cpes/__tests__/listpage.jsx
+++ b/src/web/pages/cpes/__tests__/listpage.jsx
@@ -15,11 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import CollectionCounts from 'gmp/collection/collectioncounts';
-
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 import CPE from 'gmp/models/cpe';
@@ -33,10 +31,6 @@ import {loadingActions} from 'web/store/usersettings/defaults/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import CpesPage, {ToolBarIcons} from '../listpage';
-
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
 
 const cpe = CPE.fromElement({
   _id: 'cpe:/a:foo',
@@ -70,7 +64,7 @@ let currentSettings;
 let renewSession;
 
 beforeEach(() => {
-  getCpes = vi.fn().mockResolvedValue({
+  getCpes = testing.fn().mockResolvedValue({
     data: [cpe],
     meta: {
       filter: Filter.fromString(),
@@ -78,7 +72,7 @@ beforeEach(() => {
     },
   });
 
-  getFilters = vi.fn().mockReturnValue(
+  getFilters = testing.fn().mockReturnValue(
     Promise.resolve({
       data: [],
       meta: {
@@ -88,7 +82,7 @@ beforeEach(() => {
     }),
   );
 
-  getDashboardSetting = vi.fn().mockResolvedValue({
+  getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
       filter: Filter.fromString(),
@@ -96,7 +90,7 @@ beforeEach(() => {
     },
   });
 
-  getAggregates = vi.fn().mockResolvedValue({
+  getAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
       filter: Filter.fromString(),
@@ -104,15 +98,15 @@ beforeEach(() => {
     },
   });
 
-  getSetting = vi.fn().mockResolvedValue({
+  getSetting = testing.fn().mockResolvedValue({
     filter: null,
   });
 
-  currentSettings = vi.fn().mockResolvedValue({
+  currentSettings = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 
-  renewSession = vi.fn().mockResolvedValue({
+  renewSession = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 });
@@ -215,11 +209,11 @@ describe('CpesPage tests', () => {
   });
 
   test('should allow to bulk action on page contents', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -287,11 +281,11 @@ describe('CpesPage tests', () => {
   });
 
   test('should allow to bulk action on selected cpes', async () => {
-    const deleteByIds = vi.fn().mockResolvedValue({
+    const deleteByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByIds = vi.fn().mockResolvedValue({
+    const exportByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -374,11 +368,11 @@ describe('CpesPage tests', () => {
   });
 
   test('should allow to bulk action on filtered cpes', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 

--- a/src/web/pages/credentials/__tests__/detailspage.jsx
+++ b/src/web/pages/credentials/__tests__/detailspage.jsx
@@ -15,18 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
-import {setLocale} from 'gmp/locale/lang';
-
 import Credential from 'gmp/models/credential';
 import Filter from 'gmp/models/filter';
-
-import {isDefined} from 'gmp/utils/identity';
 
 import {entityLoadingActions} from 'web/store/entities/credentials';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
@@ -35,36 +30,29 @@ import {rendererWith, screen, fireEvent} from 'web/utils/testing';
 
 import Detailspage, {ToolBarIcons} from '../detailspage';
 
-setLocale('en');
-
 let getCredential;
 let getEntities;
 let currentSettings;
 let renewSession;
 
 beforeEach(() => {
-  getCredential = vi.fn().mockResolvedValue({
+  getCredential = testing.fn().mockResolvedValue({
     data: credential,
   });
-  getEntities = vi.fn().mockResolvedValue({
+  getEntities = testing.fn().mockResolvedValue({
     data: [],
     meta: {
       filter: Filter.fromString(),
       counts: new CollectionCounts(),
     },
   });
-  currentSettings = vi.fn().mockResolvedValue({
+  currentSettings = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
-  renewSession = vi.fn().mockResolvedValue({
+  renewSession = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 });
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
 
 const caps = new Capabilities(['everything']);
 
@@ -255,15 +243,15 @@ describe('Credential Detailspage tests', () => {
   });
 
   test('should call commands', () => {
-    const clone = vi.fn().mockResolvedValue({
+    const clone = testing.fn().mockResolvedValue({
       data: {id: 'foo'},
     });
 
-    const deleteFunc = vi.fn().mockResolvedValue({
+    const deleteFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportFunc = vi.fn().mockResolvedValue({
+    const exportFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -320,12 +308,12 @@ describe('Credential Detailspage tests', () => {
 
 describe('Credential ToolBarIcons tests', () => {
   test('should render', () => {
-    const handleCredentialCloneClick = vi.fn();
-    const handleCredentialDeleteClick = vi.fn();
-    const handleCredentialDownloadClick = vi.fn();
-    const handleCredentialEditClick = vi.fn();
-    const handleCredentialCreateClick = vi.fn();
-    const handleCredentialInstallerDownloadClick = vi.fn();
+    const handleCredentialCloneClick = testing.fn();
+    const handleCredentialDeleteClick = testing.fn();
+    const handleCredentialDownloadClick = testing.fn();
+    const handleCredentialEditClick = testing.fn();
+    const handleCredentialCreateClick = testing.fn();
+    const handleCredentialInstallerDownloadClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -362,12 +350,12 @@ describe('Credential ToolBarIcons tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleCredentialCloneClick = vi.fn();
-    const handleCredentialDeleteClick = vi.fn();
-    const handleCredentialDownloadClick = vi.fn();
-    const handleCredentialEditClick = vi.fn();
-    const handleCredentialCreateClick = vi.fn();
-    const handleCredentialInstallerDownloadClick = vi.fn();
+    const handleCredentialCloneClick = testing.fn();
+    const handleCredentialDeleteClick = testing.fn();
+    const handleCredentialDownloadClick = testing.fn();
+    const handleCredentialEditClick = testing.fn();
+    const handleCredentialCreateClick = testing.fn();
+    const handleCredentialInstallerDownloadClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -422,12 +410,12 @@ describe('Credential ToolBarIcons tests', () => {
   });
 
   test('should not call click handlers without permission', () => {
-    const handleCredentialCloneClick = vi.fn();
-    const handleCredentialDeleteClick = vi.fn();
-    const handleCredentialDownloadClick = vi.fn();
-    const handleCredentialEditClick = vi.fn();
-    const handleCredentialCreateClick = vi.fn();
-    const handleCredentialInstallerDownloadClick = vi.fn();
+    const handleCredentialCloneClick = testing.fn();
+    const handleCredentialDeleteClick = testing.fn();
+    const handleCredentialDownloadClick = testing.fn();
+    const handleCredentialEditClick = testing.fn();
+    const handleCredentialCreateClick = testing.fn();
+    const handleCredentialInstallerDownloadClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -484,12 +472,12 @@ describe('Credential ToolBarIcons tests', () => {
   });
 
   test('should (not) call click handlers for credential in use', () => {
-    const handleCredentialCloneClick = vi.fn();
-    const handleCredentialDeleteClick = vi.fn();
-    const handleCredentialDownloadClick = vi.fn();
-    const handleCredentialEditClick = vi.fn();
-    const handleCredentialCreateClick = vi.fn();
-    const handleCredentialInstallerDownloadClick = vi.fn();
+    const handleCredentialCloneClick = testing.fn();
+    const handleCredentialDeleteClick = testing.fn();
+    const handleCredentialDownloadClick = testing.fn();
+    const handleCredentialEditClick = testing.fn();
+    const handleCredentialCreateClick = testing.fn();
+    const handleCredentialInstallerDownloadClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 

--- a/src/web/pages/credentials/__tests__/dialog.jsx
+++ b/src/web/pages/credentials/__tests__/dialog.jsx
@@ -15,25 +15,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
-import {setLocale} from 'gmp/locale/lang';
 import Credential, {ALL_CREDENTIAL_TYPES} from 'gmp/models/credential';
 
 import {rendererWith, fireEvent} from 'web/utils/testing';
 
 import CredentialsDialog from '../dialog';
 
-setLocale('en');
-
 let handleSave;
 let handleClose;
 let handleErrorClose;
 
 beforeEach(() => {
-  handleSave = vi.fn();
-  handleClose = vi.fn();
-  handleErrorClose = vi.fn();
+  handleSave = testing.fn();
+  handleClose = testing.fn();
+  handleErrorClose = testing.fn();
 });
 
 const credential = Credential.fromElement({

--- a/src/web/pages/credentials/__tests__/listpage.jsx
+++ b/src/web/pages/credentials/__tests__/listpage.jsx
@@ -15,12 +15,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
-
-import {setLocale} from 'gmp/locale/lang';
 
 import Credential from 'gmp/models/credential';
 import Filter from 'gmp/models/filter';
@@ -32,10 +30,6 @@ import {loadingActions} from 'web/store/usersettings/defaults/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import CredentialPage, {ToolBarIcons} from '../listpage';
-
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
 
 const credential = Credential.fromElement({
   _id: '6575',
@@ -73,13 +67,13 @@ let getCredentials;
 let renewSession;
 
 beforeEach(() => {
-  currentSettings = vi.fn().mockResolvedValue({
+  currentSettings = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
-  getSetting = vi.fn().mockResolvedValue({
+  getSetting = testing.fn().mockResolvedValue({
     filter: null,
   });
-  getFilters = vi.fn().mockReturnValue(
+  getFilters = testing.fn().mockReturnValue(
     Promise.resolve({
       data: [],
       meta: {
@@ -89,14 +83,14 @@ beforeEach(() => {
     }),
   );
 
-  getCredentials = vi.fn().mockResolvedValue({
+  getCredentials = testing.fn().mockResolvedValue({
     data: [credential],
     meta: {
       filter: Filter.fromString(),
       counts: new CollectionCounts(),
     },
   });
-  renewSession = vi.fn().mockResolvedValue({
+  renewSession = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 });
@@ -179,11 +173,11 @@ describe('CredentialPage tests', () => {
   });
 
   test('should allow to bulk action on page contents', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -243,11 +237,11 @@ describe('CredentialPage tests', () => {
 
   test('should allow to bulk action on selected credentials', async () => {
     // mock cache issues will cause these tests to randomly fail. Will fix later.
-    const deleteByIds = vi.fn().mockResolvedValue({
+    const deleteByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByIds = vi.fn().mockResolvedValue({
+    const exportByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -326,11 +320,11 @@ describe('CredentialPage tests', () => {
 
   test('should allow to bulk action on filtered credentials', async () => {
     // mock cache issues will cause these tests to randomly fail. Will fix later.
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -404,7 +398,7 @@ describe('CredentialPage tests', () => {
 
 describe('CredentialPage ToolBarIcons test', () => {
   test('should render', () => {
-    const handleCredentialCreateClick = vi.fn();
+    const handleCredentialCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -430,7 +424,7 @@ describe('CredentialPage ToolBarIcons test', () => {
   });
 
   test('should call click handlers', () => {
-    const handleCredentialCreateClick = vi.fn();
+    const handleCredentialCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -455,7 +449,7 @@ describe('CredentialPage ToolBarIcons test', () => {
   });
 
   test('should not show icons if user does not have the right permissions', () => {
-    const handleCredentialCreateClick = vi.fn();
+    const handleCredentialCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},

--- a/src/web/pages/cves/__tests__/detailspage.jsx
+++ b/src/web/pages/cves/__tests__/detailspage.jsx
@@ -15,11 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
-
-import {isDefined} from 'gmp/utils/identity';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -31,13 +27,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith} from 'web/utils/testing';
 
 import CvePage from '../detailspage';
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
-
-setLocale('en');
 
 const entity_v2 = Cve.fromElement({
   _id: 'CVE-2020-9997',
@@ -136,11 +125,11 @@ const entity_v2 = Cve.fromElement({
 
 const caps = new Capabilities(['everything']);
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
@@ -149,7 +138,7 @@ const manualUrl = 'test/';
 
 describe('CVE Detailspage tests', () => {
   test('should render full Detailspage', () => {
-    const getCve = vi.fn().mockResolvedValue({
+    const getCve = testing.fn().mockResolvedValue({
       data: entity_v2,
     });
 

--- a/src/web/pages/cves/__tests__/listpage.jsx
+++ b/src/web/pages/cves/__tests__/listpage.jsx
@@ -15,11 +15,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
-import {setLocale} from 'gmp/locale/lang';
 import {parseDate} from 'gmp/parser';
 
 import Filter from 'gmp/models/filter';
@@ -34,10 +33,6 @@ import {loadingActions} from 'web/store/usersettings/defaults/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import CvesPage, {ToolBarIcons} from '../listpage';
-
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
 
 const cve = Cve.fromElement({
   _id: 'CVE-2020-9992',
@@ -61,7 +56,7 @@ let currentSettings;
 let renewSession;
 
 beforeEach(() => {
-  getCves = vi.fn().mockResolvedValue({
+  getCves = testing.fn().mockResolvedValue({
     data: [cve],
     meta: {
       filter: Filter.fromString(),
@@ -69,7 +64,7 @@ beforeEach(() => {
     },
   });
 
-  getFilters = vi.fn().mockReturnValue(
+  getFilters = testing.fn().mockReturnValue(
     Promise.resolve({
       data: [],
       meta: {
@@ -79,7 +74,7 @@ beforeEach(() => {
     }),
   );
 
-  getDashboardSetting = vi.fn().mockResolvedValue({
+  getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
       filter: Filter.fromString(),
@@ -87,7 +82,7 @@ beforeEach(() => {
     },
   });
 
-  getAggregates = vi.fn().mockResolvedValue({
+  getAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
       filter: Filter.fromString(),
@@ -95,15 +90,15 @@ beforeEach(() => {
     },
   });
 
-  getSetting = vi.fn().mockResolvedValue({
+  getSetting = testing.fn().mockResolvedValue({
     filter: null,
   });
 
-  currentSettings = vi.fn().mockResolvedValue({
+  currentSettings = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 
-  renewSession = vi.fn().mockResolvedValue({
+  renewSession = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 });
@@ -206,11 +201,11 @@ describe('CvesPage tests', () => {
   });
 
   test('should allow to bulk action on page contents', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -278,11 +273,11 @@ describe('CvesPage tests', () => {
   });
 
   test('should allow to bulk action on selected cves', async () => {
-    const deleteByIds = vi.fn().mockResolvedValue({
+    const deleteByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByIds = vi.fn().mockResolvedValue({
+    const exportByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -365,11 +360,11 @@ describe('CvesPage tests', () => {
   });
 
   test('should allow to bulk action on filtered cves', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 

--- a/src/web/pages/cves/__tests__/row.jsx
+++ b/src/web/pages/cves/__tests__/row.jsx
@@ -16,10 +16,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 /* eslint-disable no-console */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 import {parseDate} from 'gmp/parser';
 
 import Cve from 'gmp/models/cve';
@@ -29,8 +28,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent} from 'web/utils/testing';
 
 import CveRow from '../row';
-
-setLocale('en');
 
 const gmp = {settings: {}};
 const caps = new Capabilities(['everything']);
@@ -52,7 +49,7 @@ describe('CVEv2 Row tests', () => {
   console.error = () => {};
 
   test('should render', () => {
-    const handleToggleDetailsClick = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -96,7 +93,7 @@ describe('CVEv2 Row tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleToggleDetailsClick = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render} = rendererWith({
       gmp,
@@ -140,7 +137,7 @@ describe('CVEv3 Row tests', () => {
   console.error = () => {};
 
   test('should render', () => {
-    const handleToggleDetailsClick = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -186,7 +183,7 @@ describe('CVEv3 Row tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleToggleDetailsClick = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render} = rendererWith({
       gmp,

--- a/src/web/pages/cves/__tests__/table.jsx
+++ b/src/web/pages/cves/__tests__/table.jsx
@@ -15,11 +15,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
-import {setLocale} from 'gmp/locale/lang';
 import {parseDate} from 'gmp/parser';
 
 import Filter from 'gmp/models/filter';
@@ -30,8 +29,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent} from 'web/utils/testing';
 
 import CveTable from '../table';
-
-setLocale('en');
 
 const caps = new Capabilities(['everything']);
 

--- a/src/web/pages/extras/__tests__/cvsscalculatorpage.jsx
+++ b/src/web/pages/extras/__tests__/cvsscalculatorpage.jsx
@@ -16,13 +16,13 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {fireEvent, rendererWith, waitFor, wait} from 'web/utils/testing';
 
 import CvssCalculator from 'web/pages/extras/cvsscalculatorpage';
 
-const calculateScoreFromVector = vi.fn().mockReturnValue(
+const calculateScoreFromVector = testing.fn().mockReturnValue(
   Promise.resolve({
     data: 7.5,
   }),
@@ -36,7 +36,7 @@ const gmp = {
     manualUrl: 'http://docs.greenbone.net/GSM-Manual/gos-5/',
   },
   user: {
-    renewSession: vi.fn().mockReturnValue(
+    renewSession: testing.fn().mockReturnValue(
       Promise.resolve({
         data: 'foo',
       }),

--- a/src/web/pages/extras/__tests__/feedstatuspage.jsx
+++ b/src/web/pages/extras/__tests__/feedstatuspage.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {rendererWith, waitFor} from 'web/utils/testing';
 
@@ -30,7 +30,7 @@ const mockDate = new Date(1595660400000); // Saturday July 25 090000
 const _now = global.Date.now;
 
 // set mockDate so the feed ages don't keep changing
-global.Date.now = vi.fn(() => mockDate);
+global.Date.now = testing.fn(() => mockDate);
 
 const nvtFeed = new Feed({
   name: 'Greenbone Community Feed',
@@ -69,7 +69,7 @@ const response = new Response(xhr, data);
 
 const gmp = {
   feedstatus: {
-    readFeedInformation: vi.fn(() => Promise.resolve(response)),
+    readFeedInformation: testing.fn(() => Promise.resolve(response)),
   },
   settings: {
     manualUrl: 'http://foo.bar',

--- a/src/web/pages/help/__tests__/about.jsx
+++ b/src/web/pages/help/__tests__/about.jsx
@@ -15,15 +15,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect} from '@gsa/testing';
 
 import {rendererWith, waitFor, fireEvent} from 'web/utils/testing';
 
 import AboutPage from '../about';
-
-setLocale('en');
 
 describe('AboutPage tests', () => {
   test('should render about page', async () => {

--- a/src/web/pages/hosts/__tests__/detailspage.jsx
+++ b/src/web/pages/hosts/__tests__/detailspage.jsx
@@ -15,16 +15,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
-import {setLocale} from 'gmp/locale/lang';
-
 import Filter from 'gmp/models/filter';
 import Host from 'gmp/models/host';
-
-import {isDefined} from 'gmp/utils/identity';
 
 import {entityLoadingActions} from 'web/store/entities/hosts';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
@@ -34,13 +30,6 @@ import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 import Detailspage, {ToolBarIcons} from '../detailspage';
 
 // setup
-
-setLocale('en');
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
 
 const reloadInterval = -1;
 const manualUrl = 'test/';
@@ -175,11 +164,11 @@ let currentSettings;
 let renewSession;
 
 beforeEach(() => {
-  getHost = vi.fn().mockResolvedValue({
+  getHost = testing.fn().mockResolvedValue({
     data: host,
   });
 
-  getPermissions = vi.fn().mockResolvedValue({
+  getPermissions = testing.fn().mockResolvedValue({
     data: [],
     meta: {
       filter: Filter.fromString(),
@@ -187,11 +176,11 @@ beforeEach(() => {
     },
   });
 
-  currentSettings = vi.fn().mockResolvedValue({
+  currentSettings = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 
-  renewSession = vi.fn().mockResolvedValue({
+  renewSession = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 });
@@ -384,13 +373,13 @@ describe('Host Detailspage tests', () => {
   });
 
   test('should call commands', async () => {
-    const deleteIdentifier = vi.fn().mockResolvedValue({
+    const deleteIdentifier = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
-    const deleteFunc = vi.fn().mockResolvedValue({
+    const deleteFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
-    const exportFunc = vi.fn().mockResolvedValue({
+    const exportFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -455,10 +444,10 @@ describe('Host Detailspage tests', () => {
 
 describe('Host ToolBarIcons tests', () => {
   test('should render', () => {
-    const handleHostCreateClick = vi.fn();
-    const handleHostDeleteClick = vi.fn();
-    const handleHostDownloadClick = vi.fn();
-    const handleHostEditClick = vi.fn();
+    const handleHostCreateClick = testing.fn();
+    const handleHostDeleteClick = testing.fn();
+    const handleHostDownloadClick = testing.fn();
+    const handleHostEditClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -505,10 +494,10 @@ describe('Host ToolBarIcons tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleHostCreateClick = vi.fn();
-    const handleHostDeleteClick = vi.fn();
-    const handleHostDownloadClick = vi.fn();
-    const handleHostEditClick = vi.fn();
+    const handleHostCreateClick = testing.fn();
+    const handleHostDeleteClick = testing.fn();
+    const handleHostDownloadClick = testing.fn();
+    const handleHostEditClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -542,10 +531,10 @@ describe('Host ToolBarIcons tests', () => {
   });
 
   test('should not call click handlers without permission', () => {
-    const handleHostCreateClick = vi.fn();
-    const handleHostDeleteClick = vi.fn();
-    const handleHostDownloadClick = vi.fn();
-    const handleHostEditClick = vi.fn();
+    const handleHostCreateClick = testing.fn();
+    const handleHostDeleteClick = testing.fn();
+    const handleHostDownloadClick = testing.fn();
+    const handleHostEditClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 

--- a/src/web/pages/hosts/__tests__/listpage.jsx
+++ b/src/web/pages/hosts/__tests__/listpage.jsx
@@ -15,12 +15,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
-
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 import Host from 'gmp/models/host';
@@ -36,10 +34,6 @@ import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 import HostPage, {ToolBarIcons} from '../listpage';
 
 // setup
-
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
 
 const capabilities = new Capabilities(['everything']);
 const wrongCapabilities = new Capabilities(['get_host']);
@@ -100,7 +94,7 @@ let currentSettings;
 let renewSession;
 
 beforeEach(() => {
-  getHosts = vi.fn().mockResolvedValue({
+  getHosts = testing.fn().mockResolvedValue({
     data: [host],
     meta: {
       filter: Filter.fromString(),
@@ -108,7 +102,7 @@ beforeEach(() => {
     },
   });
 
-  getFilters = vi.fn().mockReturnValue(
+  getFilters = testing.fn().mockReturnValue(
     Promise.resolve({
       data: [],
       meta: {
@@ -118,7 +112,7 @@ beforeEach(() => {
     }),
   );
 
-  getDashboardSetting = vi.fn().mockResolvedValue({
+  getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
       filter: Filter.fromString(),
@@ -126,7 +120,7 @@ beforeEach(() => {
     },
   });
 
-  getAggregates = vi.fn().mockResolvedValue({
+  getAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
       filter: Filter.fromString(),
@@ -134,15 +128,15 @@ beforeEach(() => {
     },
   });
 
-  getSetting = vi.fn().mockResolvedValue({
+  getSetting = testing.fn().mockResolvedValue({
     filter: null,
   });
 
-  currentSettings = vi.fn().mockResolvedValue({
+  currentSettings = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 
-  renewSession = vi.fn().mockResolvedValue({
+  renewSession = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 });
@@ -273,11 +267,11 @@ describe('Host listpage tests', () => {
   });
 
   test('should allow to bulk action on page contents', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -348,11 +342,11 @@ describe('Host listpage tests', () => {
   });
 
   test('should allow to bulk action on selected hosts', async () => {
-    const deleteByIds = vi.fn().mockResolvedValue({
+    const deleteByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByIds = vi.fn().mockResolvedValue({
+    const exportByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -440,11 +434,11 @@ describe('Host listpage tests', () => {
   });
 
   test('should allow to bulk action on filtered hosts', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -530,7 +524,7 @@ describe('Host listpage tests', () => {
 
 describe('Host listpage ToolBarIcons test', () => {
   test('should render', () => {
-    const handleCreateHostClick = vi.fn();
+    const handleCreateHostClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -561,7 +555,7 @@ describe('Host listpage ToolBarIcons test', () => {
   });
 
   test('should call click handlers', () => {
-    const handleCreateHostClick = vi.fn();
+    const handleCreateHostClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -580,7 +574,7 @@ describe('Host listpage ToolBarIcons test', () => {
   });
 
   test('should not show icons if user does not have the right permissions', () => {
-    const handleCreateHostClick = vi.fn();
+    const handleCreateHostClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},

--- a/src/web/pages/ldap/__tests__/dialog.jsx
+++ b/src/web/pages/ldap/__tests__/dialog.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -23,9 +23,9 @@ import Dialog from '../dialog';
 
 describe('Ldap dialog component tests', () => {
   test('should render dialog', () => {
-    const handleChange = vi.fn();
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleChange = testing.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {baseElement} = render(
       <Dialog
@@ -43,9 +43,9 @@ describe('Ldap dialog component tests', () => {
   });
 
   test('should save data', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleValueChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleValueChange = testing.fn();
 
     const {getByTestId} = render(
       <Dialog
@@ -70,8 +70,8 @@ describe('Ldap dialog component tests', () => {
   });
 
   test('should allow to close the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByTestId} = render(
       <Dialog
@@ -91,8 +91,8 @@ describe('Ldap dialog component tests', () => {
   });
 
   test('should allow to change data', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByTestId} = render(
       <Dialog

--- a/src/web/pages/login/__tests__/loginform.jsx
+++ b/src/web/pages/login/__tests__/loginform.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {rendererWith, fireEvent, screen} from 'web/utils/testing';
 
@@ -25,8 +25,8 @@ const gmp = {settings: {}};
 
 describe('LoginForm tests', () => {
   test('should render full LoginForm', () => {
-    const handleSubmit = vi.fn();
-    const handleClick = vi.fn();
+    const handleSubmit = testing.fn();
+    const handleClick = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -46,8 +46,8 @@ describe('LoginForm tests', () => {
   });
 
   test('should display error', () => {
-    const handleSubmit = vi.fn();
-    const handleClick = vi.fn();
+    const handleSubmit = testing.fn();
+    const handleClick = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -63,8 +63,8 @@ describe('LoginForm tests', () => {
   });
 
   test('should not display error by default', () => {
-    const handleSubmit = vi.fn();
-    const handleClick = vi.fn();
+    const handleSubmit = testing.fn();
+    const handleClick = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -76,8 +76,8 @@ describe('LoginForm tests', () => {
   });
 
   test('should display insecure protocol message', () => {
-    const handleSubmit = vi.fn();
-    const handleClick = vi.fn();
+    const handleSubmit = testing.fn();
+    const handleClick = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -93,8 +93,8 @@ describe('LoginForm tests', () => {
   });
 
   test('should not display insecure protocol message by default', () => {
-    const handleSubmit = vi.fn();
-    const handleClick = vi.fn();
+    const handleSubmit = testing.fn();
+    const handleClick = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -106,8 +106,8 @@ describe('LoginForm tests', () => {
   });
 
   test('should display IE11 message', () => {
-    const handleSubmit = vi.fn();
-    const handleClick = vi.fn();
+    const handleSubmit = testing.fn();
+    const handleClick = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -123,8 +123,8 @@ describe('LoginForm tests', () => {
   });
 
   test('should not display IE11 message by default', () => {
-    const handleSubmit = vi.fn();
-    const handleClick = vi.fn();
+    const handleSubmit = testing.fn();
+    const handleClick = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -136,8 +136,8 @@ describe('LoginForm tests', () => {
   });
 
   test('should display login fields by default', () => {
-    const handleSubmit = vi.fn();
-    const handleClick = vi.fn();
+    const handleSubmit = testing.fn();
+    const handleClick = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -150,8 +150,8 @@ describe('LoginForm tests', () => {
   });
 
   test('should allow to disable login fields', () => {
-    const handleSubmit = vi.fn();
-    const handleClick = vi.fn();
+    const handleSubmit = testing.fn();
+    const handleClick = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -168,8 +168,8 @@ describe('LoginForm tests', () => {
   });
 
   test('should allow to login with username and password', () => {
-    const handleSubmit = vi.fn();
-    const handleClick = vi.fn();
+    const handleSubmit = testing.fn();
+    const handleClick = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -190,8 +190,8 @@ describe('LoginForm tests', () => {
   });
 
   test('should not display guest login by default', () => {
-    const handleSubmit = vi.fn();
-    const handleClick = vi.fn();
+    const handleSubmit = testing.fn();
+    const handleClick = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -204,8 +204,8 @@ describe('LoginForm tests', () => {
   });
 
   test('should allow to display guest login', () => {
-    const handleSubmit = vi.fn();
-    const handleClick = vi.fn();
+    const handleSubmit = testing.fn();
+    const handleClick = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -222,8 +222,8 @@ describe('LoginForm tests', () => {
   });
 
   test('should allow to login as guest', () => {
-    const handleSubmit = vi.fn();
-    const handleClick = vi.fn();
+    const handleSubmit = testing.fn();
+    const handleClick = testing.fn();
 
     const {render} = rendererWith({gmp});
 

--- a/src/web/pages/login/__tests__/loginpage.jsx
+++ b/src/web/pages/login/__tests__/loginpage.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Logger from 'gmp/log';
 
@@ -27,8 +27,8 @@ Logger.setDefaultLevel('silent');
 
 describe('LoginPage tests', () => {
   test('should render Loginpage', () => {
-    const isLoggedIn = vi.fn().mockReturnValue(false);
-    const clearToken = vi.fn();
+    const isLoggedIn = testing.fn().mockReturnValue(false);
+    const clearToken = testing.fn();
     const gmp = {isLoggedIn, clearToken, settings: {}};
 
     const {render} = rendererWith({gmp, router: true, store: true});
@@ -37,16 +37,16 @@ describe('LoginPage tests', () => {
   });
 
   test('should allow to login with username and password', () => {
-    const login = vi.fn().mockResolvedValue({
+    const login = testing.fn().mockResolvedValue({
       locale: 'locale',
       username: 'username',
       token: 'token',
       timezone: 'timezone',
     });
-    const isLoggedIn = vi.fn().mockReturnValue(false);
-    const clearToken = vi.fn();
-    const setLocale = vi.fn();
-    const setTimezone = vi.fn();
+    const isLoggedIn = testing.fn().mockReturnValue(false);
+    const clearToken = testing.fn();
+    const setLocale = testing.fn();
+    const setTimezone = testing.fn();
     const gmp = {
       setTimezone,
       setLocale,
@@ -72,8 +72,8 @@ describe('LoginPage tests', () => {
   });
 
   test('should not display guest login by default', () => {
-    const isLoggedIn = vi.fn().mockReturnValue(false);
-    const clearToken = vi.fn();
+    const isLoggedIn = testing.fn().mockReturnValue(false);
+    const clearToken = testing.fn();
     const gmp = {
       isLoggedIn,
       clearToken,
@@ -88,16 +88,16 @@ describe('LoginPage tests', () => {
   });
 
   test('should allow to login as guest', () => {
-    const login = vi.fn().mockResolvedValue({
+    const login = testing.fn().mockResolvedValue({
       locale: 'locale',
       username: 'username',
       token: 'token',
       timezone: 'timezone',
     });
-    const isLoggedIn = vi.fn().mockReturnValue(false);
-    const clearToken = vi.fn();
-    const setLocale = vi.fn();
-    const setTimezone = vi.fn();
+    const isLoggedIn = testing.fn().mockReturnValue(false);
+    const clearToken = testing.fn();
+    const setLocale = testing.fn();
+    const setTimezone = testing.fn();
     const gmp = {
       setTimezone,
       setLocale,
@@ -117,11 +117,11 @@ describe('LoginPage tests', () => {
   });
 
   test('should display error message', async () => {
-    const login = vi.fn().mockRejectedValue({message: 'Just a test'});
-    const isLoggedIn = vi.fn().mockReturnValue(false);
-    const clearToken = vi.fn();
-    const setLocale = vi.fn();
-    const setTimezone = vi.fn();
+    const login = testing.fn().mockRejectedValue({message: 'Just a test'});
+    const isLoggedIn = testing.fn().mockReturnValue(false);
+    const clearToken = testing.fn();
+    const setLocale = testing.fn();
+    const setTimezone = testing.fn();
     const gmp = {
       setTimezone,
       setLocale,
@@ -149,16 +149,16 @@ describe('LoginPage tests', () => {
   });
 
   test('should redirect to main page if already logged in', () => {
-    const login = vi.fn().mockResolvedValue({
+    const login = testing.fn().mockResolvedValue({
       locale: 'locale',
       username: 'username',
       token: 'token',
       timezone: 'timezone',
     });
-    const isLoggedIn = vi.fn().mockReturnValue(true);
-    const clearToken = vi.fn();
-    const setLocale = vi.fn();
-    const setTimezone = vi.fn();
+    const isLoggedIn = testing.fn().mockReturnValue(true);
+    const clearToken = testing.fn();
+    const setLocale = testing.fn();
+    const setTimezone = testing.fn();
     const gmp = {
       setTimezone,
       setLocale,

--- a/src/web/pages/notes/__tests__/detailspage.jsx
+++ b/src/web/pages/notes/__tests__/detailspage.jsx
@@ -15,17 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
-import {setLocale} from 'gmp/locale/lang';
-
 import Filter from 'gmp/models/filter';
 import Note from 'gmp/models/note';
-
-import {isDefined} from 'gmp/utils/identity';
 
 import {entityLoadingActions} from 'web/store/entities/notes';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
@@ -33,13 +29,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import Detailspage, {ToolBarIcons} from '../detailspage';
-
-setLocale('en');
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
 
 const caps = new Capabilities(['everything']);
 
@@ -111,11 +100,11 @@ const noPermNote = Note.fromElement({
   writable: 1,
 });
 
-const getNote = vi.fn().mockResolvedValue({
+const getNote = testing.fn().mockResolvedValue({
   data: note,
 });
 
-const getEntities = vi.fn().mockResolvedValue({
+const getEntities = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -123,11 +112,11 @@ const getEntities = vi.fn().mockResolvedValue({
   },
 });
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
@@ -309,15 +298,15 @@ describe('Note detailspage tests', () => {
   });
 
   test('should call commands', async () => {
-    const clone = vi.fn().mockResolvedValue({
+    const clone = testing.fn().mockResolvedValue({
       data: {id: 'foo'},
     });
 
-    const deleteFunc = vi.fn().mockResolvedValue({
+    const deleteFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportFunc = vi.fn().mockResolvedValue({
+    const exportFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -390,11 +379,11 @@ describe('Note detailspage tests', () => {
 
 describe('Note ToolBarIcons tests', () => {
   test('should render', () => {
-    const handleNoteCloneClick = vi.fn();
-    const handleNoteDeleteClick = vi.fn();
-    const handleNoteDownloadClick = vi.fn();
-    const handleNoteEditClick = vi.fn();
-    const handleNoteCreateClick = vi.fn();
+    const handleNoteCloneClick = testing.fn();
+    const handleNoteDeleteClick = testing.fn();
+    const handleNoteDownloadClick = testing.fn();
+    const handleNoteEditClick = testing.fn();
+    const handleNoteCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -428,11 +417,11 @@ describe('Note ToolBarIcons tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleNoteCloneClick = vi.fn();
-    const handleNoteDeleteClick = vi.fn();
-    const handleNoteDownloadClick = vi.fn();
-    const handleNoteEditClick = vi.fn();
-    const handleNoteCreateClick = vi.fn();
+    const handleNoteCloneClick = testing.fn();
+    const handleNoteDeleteClick = testing.fn();
+    const handleNoteDownloadClick = testing.fn();
+    const handleNoteEditClick = testing.fn();
+    const handleNoteCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -476,11 +465,11 @@ describe('Note ToolBarIcons tests', () => {
   });
 
   test('should not call click handlers without permission', () => {
-    const handleNoteCloneClick = vi.fn();
-    const handleNoteDeleteClick = vi.fn();
-    const handleNoteDownloadClick = vi.fn();
-    const handleNoteEditClick = vi.fn();
-    const handleNoteCreateClick = vi.fn();
+    const handleNoteCloneClick = testing.fn();
+    const handleNoteDeleteClick = testing.fn();
+    const handleNoteDownloadClick = testing.fn();
+    const handleNoteEditClick = testing.fn();
+    const handleNoteCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -530,11 +519,11 @@ describe('Note ToolBarIcons tests', () => {
   });
 
   test('should call correct click handlers for note in use', () => {
-    const handleNoteCloneClick = vi.fn();
-    const handleNoteDeleteClick = vi.fn();
-    const handleNoteDownloadClick = vi.fn();
-    const handleNoteEditClick = vi.fn();
-    const handleNoteCreateClick = vi.fn();
+    const handleNoteCloneClick = testing.fn();
+    const handleNoteDeleteClick = testing.fn();
+    const handleNoteDownloadClick = testing.fn();
+    const handleNoteEditClick = testing.fn();
+    const handleNoteCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 

--- a/src/web/pages/notes/__tests__/listpage.jsx
+++ b/src/web/pages/notes/__tests__/listpage.jsx
@@ -15,12 +15,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
-
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 import Note from 'gmp/models/note';
@@ -34,10 +32,6 @@ import {loadingActions} from 'web/store/usersettings/defaults/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import NotesPage, {ToolBarIcons} from '../listpage';
-
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
 
 const note = Note.fromElement({
   _id: '6d00d22f-551b-4fbe-8215-d8615eff73ea',
@@ -64,15 +58,15 @@ const wrongCaps = new Capabilities(['get_config']);
 const reloadInterval = -1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getSetting = vi.fn().mockResolvedValue({
+const getSetting = testing.fn().mockResolvedValue({
   filter: null,
 });
 
-const getDashboardSetting = vi.fn().mockResolvedValue({
+const getDashboardSetting = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -80,7 +74,7 @@ const getDashboardSetting = vi.fn().mockResolvedValue({
   },
 });
 
-const getAggregates = vi.fn().mockResolvedValue({
+const getAggregates = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -88,7 +82,7 @@ const getAggregates = vi.fn().mockResolvedValue({
   },
 });
 
-const getFilters = vi.fn().mockReturnValue(
+const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
     meta: {
@@ -98,7 +92,7 @@ const getFilters = vi.fn().mockReturnValue(
   }),
 );
 
-const getNotes = vi.fn().mockResolvedValue({
+const getNotes = testing.fn().mockResolvedValue({
   data: [note],
   meta: {
     filter: Filter.fromString(),
@@ -106,7 +100,7 @@ const getNotes = vi.fn().mockResolvedValue({
   },
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
@@ -218,11 +212,11 @@ describe('NotesPage tests', () => {
   });
 
   test('should allow to bulk action on page contents', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -300,11 +294,11 @@ describe('NotesPage tests', () => {
   });
 
   test('should allow to bulk action on selected notes', async () => {
-    const deleteByIds = vi.fn().mockResolvedValue({
+    const deleteByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByIds = vi.fn().mockResolvedValue({
+    const exportByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -397,11 +391,11 @@ describe('NotesPage tests', () => {
   });
 
   test('should allow to bulk action on filtered notes', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -492,7 +486,7 @@ describe('NotesPage tests', () => {
 
 describe('NotesPage ToolBarIcons test', () => {
   test('should render', () => {
-    const handleNoteCreateClick = vi.fn();
+    const handleNoteCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -518,7 +512,7 @@ describe('NotesPage ToolBarIcons test', () => {
   });
 
   test('should call click handlers', () => {
-    const handleNoteCreateClick = vi.fn();
+    const handleNoteCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -541,7 +535,7 @@ describe('NotesPage ToolBarIcons test', () => {
   });
 
   test('should not show icons if user does not have the right permissions', () => {
-    const handleNoteCreateClick = vi.fn();
+    const handleNoteCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},

--- a/src/web/pages/nvts/__tests__/detailspage.jsx
+++ b/src/web/pages/nvts/__tests__/detailspage.jsx
@@ -15,19 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
-
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 import NVT from 'gmp/models/nvt';
 import Note from 'gmp/models/note';
 import Override from 'gmp/models/override';
-
-import {isDefined} from 'gmp/utils/identity';
 
 import {entityLoadingActions} from 'web/store/entities/nvts';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
@@ -35,13 +31,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import Detailspage, {ToolBarIcons} from '../detailspage';
-
-setLocale('en');
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
 
 const caps = new Capabilities(['everything']);
 
@@ -73,8 +62,7 @@ const nvt = NVT.fromElement({
       value: 80,
       type: 'remote_banner',
     },
-    tags:
-      'cvss_base_vector=AV:N/AC:M/Au:S/C:P/I:N/A:P|summary=This is a description|solution_type=VendorFix|insight=Foo|impact=Bar|vuldetect=Baz|affected=foo',
+    tags: 'cvss_base_vector=AV:N/AC:M/Au:S/C:P/I:N/A:P|summary=This is a description|solution_type=VendorFix|insight=Foo|impact=Bar|vuldetect=Baz|affected=foo',
     solution: {
       _type: 'VendorFix',
       __text: 'This is a description',
@@ -217,11 +205,11 @@ let currentSettings;
 let renewSession;
 
 beforeEach(() => {
-  getNvt = vi.fn().mockResolvedValue({
+  getNvt = testing.fn().mockResolvedValue({
     data: nvt,
   });
 
-  getNotes = vi.fn().mockResolvedValue({
+  getNotes = testing.fn().mockResolvedValue({
     data: [note1],
     meta: {
       filter: Filter.fromString(),
@@ -229,7 +217,7 @@ beforeEach(() => {
     },
   });
 
-  getOverrides = vi.fn().mockResolvedValue({
+  getOverrides = testing.fn().mockResolvedValue({
     data: [override1, override2],
     meta: {
       filter: Filter.fromString(),
@@ -237,7 +225,7 @@ beforeEach(() => {
     },
   });
 
-  getEntities = vi.fn().mockResolvedValue({
+  getEntities = testing.fn().mockResolvedValue({
     data: [],
     meta: {
       filter: Filter.fromString(),
@@ -245,11 +233,11 @@ beforeEach(() => {
     },
   });
 
-  currentSettings = vi.fn().mockResolvedValue({
+  currentSettings = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 
-  renewSession = vi.fn().mockResolvedValue({
+  renewSession = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 });
@@ -450,9 +438,9 @@ describe('Nvt Detailspage tests', () => {
 
 describe('Nvt ToolBarIcons tests', () => {
   test('should render', () => {
-    const handleNvtDownloadClick = vi.fn();
-    const handleOnNoteCreateClick = vi.fn();
-    const handleOnOverrideCreateClick = vi.fn();
+    const handleNvtDownloadClick = testing.fn();
+    const handleOnNoteCreateClick = testing.fn();
+    const handleOnOverrideCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -497,9 +485,9 @@ describe('Nvt ToolBarIcons tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleNvtDownloadClick = vi.fn();
-    const handleOnNoteCreateClick = vi.fn();
-    const handleOnOverrideCreateClick = vi.fn();
+    const handleNvtDownloadClick = testing.fn();
+    const handleOnNoteCreateClick = testing.fn();
+    const handleOnOverrideCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 

--- a/src/web/pages/nvts/__tests__/listpage.jsx
+++ b/src/web/pages/nvts/__tests__/listpage.jsx
@@ -15,11 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import CollectionCounts from 'gmp/collection/collectioncounts';
-
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 import NVT from 'gmp/models/nvt';
@@ -33,10 +31,6 @@ import {loadingActions} from 'web/store/usersettings/defaults/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import NvtsPage, {ToolBarIcons} from '../listpage';
-
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
 
 const nvt = NVT.fromElement({
   _oid: '1.3.6.1.4.1.25623.1.0',
@@ -62,15 +56,15 @@ const nvt = NVT.fromElement({
 const reloadInterval = -1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getSetting = vi.fn().mockResolvedValue({
+const getSetting = testing.fn().mockResolvedValue({
   filter: null,
 });
 
-const getDashboardSetting = vi.fn().mockResolvedValue({
+const getDashboardSetting = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -78,7 +72,7 @@ const getDashboardSetting = vi.fn().mockResolvedValue({
   },
 });
 
-const getAggregates = vi.fn().mockResolvedValue({
+const getAggregates = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -86,7 +80,7 @@ const getAggregates = vi.fn().mockResolvedValue({
   },
 });
 
-const getFilters = vi.fn().mockReturnValue(
+const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
     meta: {
@@ -96,7 +90,7 @@ const getFilters = vi.fn().mockReturnValue(
   }),
 );
 
-const getNvts = vi.fn().mockResolvedValue({
+const getNvts = testing.fn().mockResolvedValue({
   data: [nvt],
   meta: {
     filter: Filter.fromString(),
@@ -104,7 +98,7 @@ const getNvts = vi.fn().mockResolvedValue({
   },
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
@@ -211,11 +205,11 @@ describe('NvtsPage tests', () => {
   });
 
   test('should allow to bulk action on page contents', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -283,11 +277,11 @@ describe('NvtsPage tests', () => {
   });
 
   test('should allow to bulk action on selected nvts', async () => {
-    const deleteByIds = vi.fn().mockResolvedValue({
+    const deleteByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByIds = vi.fn().mockResolvedValue({
+    const exportByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -370,11 +364,11 @@ describe('NvtsPage tests', () => {
   });
 
   test('should allow to bulk action on filtered nvts', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 

--- a/src/web/pages/nvts/__tests__/row.jsx
+++ b/src/web/pages/nvts/__tests__/row.jsx
@@ -18,7 +18,7 @@
  */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-console */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import {setLocale} from 'gmp/locale/lang';
@@ -31,8 +31,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent} from 'web/utils/testing';
 
 import Row from '../row';
-
-setLocale('en');
 
 const gmp = {settings: {}};
 const caps = new Capabilities(['everything']);
@@ -65,8 +63,8 @@ describe('NVT row tests', () => {
   console.error = () => {};
 
   test('should render', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleFilterChanged = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleFilterChanged = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -110,8 +108,8 @@ describe('NVT row tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleFilterChanged = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleFilterChanged = testing.fn();
 
     const filter = Filter.fromString('family="bar"');
 

--- a/src/web/pages/overrides/__tests__/detailspage.jsx
+++ b/src/web/pages/overrides/__tests__/detailspage.jsx
@@ -15,17 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
-import {setLocale} from 'gmp/locale/lang';
-
 import Filter from 'gmp/models/filter';
 import Override from 'gmp/models/override';
-
-import {isDefined} from 'gmp/utils/identity';
 
 import {entityLoadingActions} from 'web/store/entities/overrides';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
@@ -33,13 +29,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import Detailspage, {ToolBarIcons} from '../detailspage';
-
-setLocale('en');
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
 
 const caps = new Capabilities(['everything']);
 
@@ -113,11 +102,11 @@ const noPermOverride = Override.fromElement({
   writable: 1,
 });
 
-const getOverride = vi.fn().mockResolvedValue({
+const getOverride = testing.fn().mockResolvedValue({
   data: override,
 });
 
-const getEntities = vi.fn().mockResolvedValue({
+const getEntities = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -125,11 +114,11 @@ const getEntities = vi.fn().mockResolvedValue({
   },
 });
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
@@ -317,15 +306,15 @@ describe('Override detailspage tests', () => {
   });
 
   test('should call commands', async () => {
-    const clone = vi.fn().mockResolvedValue({
+    const clone = testing.fn().mockResolvedValue({
       data: {id: 'foo'},
     });
 
-    const deleteFunc = vi.fn().mockResolvedValue({
+    const deleteFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportFunc = vi.fn().mockResolvedValue({
+    const exportFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -398,11 +387,11 @@ describe('Override detailspage tests', () => {
 
 describe('Override ToolBarIcons tests', () => {
   test('should render', () => {
-    const handleOverrideCloneClick = vi.fn();
-    const handleOverrideDeleteClick = vi.fn();
-    const handleOverrideDownloadClick = vi.fn();
-    const handleOverrideEditClick = vi.fn();
-    const handleOverrideCreateClick = vi.fn();
+    const handleOverrideCloneClick = testing.fn();
+    const handleOverrideDeleteClick = testing.fn();
+    const handleOverrideDownloadClick = testing.fn();
+    const handleOverrideEditClick = testing.fn();
+    const handleOverrideCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -436,11 +425,11 @@ describe('Override ToolBarIcons tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleOverrideCloneClick = vi.fn();
-    const handleOverrideDeleteClick = vi.fn();
-    const handleOverrideDownloadClick = vi.fn();
-    const handleOverrideEditClick = vi.fn();
-    const handleOverrideCreateClick = vi.fn();
+    const handleOverrideCloneClick = testing.fn();
+    const handleOverrideDeleteClick = testing.fn();
+    const handleOverrideDownloadClick = testing.fn();
+    const handleOverrideEditClick = testing.fn();
+    const handleOverrideCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -484,11 +473,11 @@ describe('Override ToolBarIcons tests', () => {
   });
 
   test('should not call click handlers without permission', () => {
-    const handleOverrideCloneClick = vi.fn();
-    const handleOverrideDeleteClick = vi.fn();
-    const handleOverrideDownloadClick = vi.fn();
-    const handleOverrideEditClick = vi.fn();
-    const handleOverrideCreateClick = vi.fn();
+    const handleOverrideCloneClick = testing.fn();
+    const handleOverrideDeleteClick = testing.fn();
+    const handleOverrideDownloadClick = testing.fn();
+    const handleOverrideEditClick = testing.fn();
+    const handleOverrideCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -538,11 +527,11 @@ describe('Override ToolBarIcons tests', () => {
   });
 
   test('should call correct click handlers for override in use', () => {
-    const handleOverrideCloneClick = vi.fn();
-    const handleOverrideDeleteClick = vi.fn();
-    const handleOverrideDownloadClick = vi.fn();
-    const handleOverrideEditClick = vi.fn();
-    const handleOverrideCreateClick = vi.fn();
+    const handleOverrideCloneClick = testing.fn();
+    const handleOverrideDeleteClick = testing.fn();
+    const handleOverrideDownloadClick = testing.fn();
+    const handleOverrideEditClick = testing.fn();
+    const handleOverrideCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 

--- a/src/web/pages/overrides/__tests__/listpage.jsx
+++ b/src/web/pages/overrides/__tests__/listpage.jsx
@@ -15,12 +15,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
-
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 import Override from 'gmp/models/override';
@@ -34,10 +32,6 @@ import {loadingActions} from 'web/store/usersettings/defaults/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import OverridesPage, {ToolBarIcons} from '../listpage';
-
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
 
 const override = Override.fromElement({
   _id: '6d00d22f-551b-4fbe-8215-d8615eff73ea',
@@ -66,15 +60,15 @@ const wrongCaps = new Capabilities(['get_config']);
 const reloadInterval = -1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getSetting = vi.fn().mockResolvedValue({
+const getSetting = testing.fn().mockResolvedValue({
   filter: null,
 });
 
-const getDashboardSetting = vi.fn().mockResolvedValue({
+const getDashboardSetting = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -82,7 +76,7 @@ const getDashboardSetting = vi.fn().mockResolvedValue({
   },
 });
 
-const getAggregates = vi.fn().mockResolvedValue({
+const getAggregates = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -90,7 +84,7 @@ const getAggregates = vi.fn().mockResolvedValue({
   },
 });
 
-const getFilters = vi.fn().mockReturnValue(
+const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
     meta: {
@@ -100,7 +94,7 @@ const getFilters = vi.fn().mockReturnValue(
   }),
 );
 
-const getOverrides = vi.fn().mockResolvedValue({
+const getOverrides = testing.fn().mockResolvedValue({
   data: [override],
   meta: {
     filter: Filter.fromString(),
@@ -108,7 +102,7 @@ const getOverrides = vi.fn().mockResolvedValue({
   },
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
@@ -224,11 +218,11 @@ describe('OverridesPage tests', () => {
   });
 
   test('should allow to bulk action on page contents', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -306,11 +300,11 @@ describe('OverridesPage tests', () => {
   });
 
   test('should allow to bulk action on selected overrides', async () => {
-    const deleteByIds = vi.fn().mockResolvedValue({
+    const deleteByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByIds = vi.fn().mockResolvedValue({
+    const exportByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -403,11 +397,11 @@ describe('OverridesPage tests', () => {
   });
 
   test('should allow to bulk action on filtered overrides', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -498,7 +492,7 @@ describe('OverridesPage tests', () => {
 
 describe('OverridesPage ToolBarIcons test', () => {
   test('should render', () => {
-    const handleOverrideCreateClick = vi.fn();
+    const handleOverrideCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -524,7 +518,7 @@ describe('OverridesPage ToolBarIcons test', () => {
   });
 
   test('should call click handlers', () => {
-    const handleOverrideCreateClick = vi.fn();
+    const handleOverrideCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -547,7 +541,7 @@ describe('OverridesPage ToolBarIcons test', () => {
   });
 
   test('should not show icons if user does not have the right permissions', () => {
-    const handleOverrideCreateClick = vi.fn();
+    const handleOverrideCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},

--- a/src/web/pages/performance/__tests__/startendtimeselection.jsx
+++ b/src/web/pages/performance/__tests__/startendtimeselection.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/date';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Date from 'gmp/models/date';
 
@@ -25,15 +23,13 @@ import {render, fireEvent} from 'web/utils/testing';
 
 import StartTimeSelection from '../startendtimeselection';
 
-setLocale('en');
-
 describe('StartTimeSelection tests', () => {
   test('should render', () => {
     const timezone = 'CET';
     const startDate = Date('2019-01-01T12:00Z').tz(timezone);
     const endDate = Date('2019-01-01T13:00Z').tz(timezone);
 
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
 
     const {element} = render(
       <StartTimeSelection
@@ -52,7 +48,7 @@ describe('StartTimeSelection tests', () => {
     const startDate = Date('2019-01-01T12:00Z').tz(timezone);
     const endDate = Date('2019-01-01T13:00Z').tz(timezone);
 
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
 
     const {getByTestId} = render(
       <StartTimeSelection
@@ -74,7 +70,7 @@ describe('StartTimeSelection tests', () => {
     const newStartDate = Date('2019-01-01T01:00Z').tz(timezone);
     const endDate = Date('2019-01-01T13:00Z').tz(timezone);
 
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
 
     const {getByName, getByTestId} = render(
       <StartTimeSelection
@@ -105,7 +101,7 @@ describe('StartTimeSelection tests', () => {
     const newStartDate = Date('2019-01-01T12:10Z').tz(timezone);
     const endDate = Date('2019-01-01T13:00Z').tz(timezone);
 
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
 
     const {getByName, getByTestId} = render(
       <StartTimeSelection
@@ -136,7 +132,7 @@ describe('StartTimeSelection tests', () => {
     const endDate = Date('2019-01-01T13:00Z').tz(timezone);
     const newEndDate = Date('2019-01-01T14:00Z').tz(timezone);
 
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
 
     const {getByName, getByTestId} = render(
       <StartTimeSelection
@@ -167,7 +163,7 @@ describe('StartTimeSelection tests', () => {
     const endDate = Date('2019-01-01T13:00Z').tz(timezone);
     const newEndDate = Date('2019-01-01T13:15Z').tz(timezone);
 
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
 
     const {getByName, getByTestId} = render(
       <StartTimeSelection

--- a/src/web/pages/policies/__tests__/details.jsx
+++ b/src/web/pages/policies/__tests__/details.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 

--- a/src/web/pages/policies/__tests__/detailspage.jsx
+++ b/src/web/pages/policies/__tests__/detailspage.jsx
@@ -15,12 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-import {act} from 'react-dom/test-utils';
-
-import {setLocale} from 'gmp/locale/lang';
-
-import {isDefined} from 'gmp/utils/identity';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
@@ -31,16 +26,9 @@ import Policy from 'gmp/models/policy';
 import {entityLoadingActions} from 'web/store/entities/policies';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 
-import {rendererWith, fireEvent} from 'web/utils/testing';
+import {rendererWith, fireEvent, act} from 'web/utils/testing';
 
 import Detailspage, {ToolBarIcons} from '../detailspage';
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
-
-setLocale('en');
 
 const families = [
   {
@@ -216,15 +204,15 @@ const entityType = 'policy';
 const reloadInterval = 1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getPermissions = vi.fn().mockResolvedValue({
+const getPermissions = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -234,7 +222,7 @@ const getPermissions = vi.fn().mockResolvedValue({
 
 describe('Policy Detailspage tests', () => {
   test('should render full Detailspage', () => {
-    const getPolicy = vi.fn().mockResolvedValue({
+    const getPolicy = testing.fn().mockResolvedValue({
       data: policy,
     });
 
@@ -300,7 +288,7 @@ describe('Policy Detailspage tests', () => {
   });
 
   test('should render nvt families tab', () => {
-    const getPolicy = vi.fn().mockResolvedValue({
+    const getPolicy = testing.fn().mockResolvedValue({
       data: policy,
     });
 
@@ -386,7 +374,7 @@ describe('Policy Detailspage tests', () => {
   });
 
   test('should render nvt preferences tab', () => {
-    const getPolicy = vi.fn().mockResolvedValue({
+    const getPolicy = testing.fn().mockResolvedValue({
       data: policy,
     });
 
@@ -443,7 +431,7 @@ describe('Policy Detailspage tests', () => {
   });
 
   test('should render permissions tab', () => {
-    const getPolicy = vi.fn().mockResolvedValue({
+    const getPolicy = testing.fn().mockResolvedValue({
       data: policy,
     });
 
@@ -483,32 +471,32 @@ describe('Policy Detailspage tests', () => {
   });
 
   test('should call commands', async () => {
-    const getPolicy = vi.fn().mockReturnValue(
+    const getPolicy = testing.fn().mockReturnValue(
       Promise.resolve({
         data: policy,
       }),
     );
-    const clone = vi.fn().mockReturnValue(
+    const clone = testing.fn().mockReturnValue(
       Promise.resolve({
         data: {id: 'foo'},
       }),
     );
-    const getNvtFamilies = vi.fn().mockReturnValue(
+    const getNvtFamilies = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const getAllScanners = vi.fn().mockReturnValue(
+    const getAllScanners = testing.fn().mockReturnValue(
       Promise.resolve({
         data: scanners,
       }),
     );
-    const deleteFunc = vi.fn().mockReturnValue(
+    const deleteFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const exportFunc = vi.fn().mockReturnValue(
+    const exportFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
@@ -576,33 +564,33 @@ describe('Policy Detailspage tests', () => {
   });
 
   test('should not call commands without permission', async () => {
-    const getPolicy = vi.fn().mockReturnValue(
+    const getPolicy = testing.fn().mockReturnValue(
       Promise.resolve({
         data: policy2,
       }),
     );
 
-    const clone = vi.fn().mockReturnValue(
+    const clone = testing.fn().mockReturnValue(
       Promise.resolve({
         data: {id: 'foo'},
       }),
     );
-    const getNvtFamilies = vi.fn().mockReturnValue(
+    const getNvtFamilies = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const getAllScanners = vi.fn().mockReturnValue(
+    const getAllScanners = testing.fn().mockReturnValue(
       Promise.resolve({
         data: scanners,
       }),
     );
-    const deleteFunc = vi.fn().mockReturnValue(
+    const deleteFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const exportFunc = vi.fn().mockReturnValue(
+    const exportFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
@@ -679,33 +667,33 @@ describe('Policy Detailspage tests', () => {
   });
 
   test('should (not) call commands if policy is in use', async () => {
-    const getPolicy = vi.fn().mockReturnValue(
+    const getPolicy = testing.fn().mockReturnValue(
       Promise.resolve({
         data: policy3,
       }),
     );
 
-    const clone = vi.fn().mockReturnValue(
+    const clone = testing.fn().mockReturnValue(
       Promise.resolve({
         data: {id: 'foo'},
       }),
     );
-    const getNvtFamilies = vi.fn().mockReturnValue(
+    const getNvtFamilies = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const getAllScanners = vi.fn().mockReturnValue(
+    const getAllScanners = testing.fn().mockReturnValue(
       Promise.resolve({
         data: scanners,
       }),
     );
-    const deleteFunc = vi.fn().mockReturnValue(
+    const deleteFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const exportFunc = vi.fn().mockReturnValue(
+    const exportFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
@@ -773,33 +761,33 @@ describe('Policy Detailspage tests', () => {
   });
 
   test('should (not) call commands if policy is not writable', async () => {
-    const getPolicy = vi.fn().mockReturnValue(
+    const getPolicy = testing.fn().mockReturnValue(
       Promise.resolve({
         data: policy4,
       }),
     );
 
-    const clone = vi.fn().mockReturnValue(
+    const clone = testing.fn().mockReturnValue(
       Promise.resolve({
         data: {id: 'foo'},
       }),
     );
-    const getNvtFamilies = vi.fn().mockReturnValue(
+    const getNvtFamilies = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const getAllScanners = vi.fn().mockReturnValue(
+    const getAllScanners = testing.fn().mockReturnValue(
       Promise.resolve({
         data: scanners,
       }),
     );
-    const deleteFunc = vi.fn().mockReturnValue(
+    const deleteFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const exportFunc = vi.fn().mockReturnValue(
+    const exportFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
@@ -871,10 +859,10 @@ describe('Policy Detailspage tests', () => {
 
 describe('Policy ToolBarIcons tests', () => {
   test('should render', () => {
-    const handlePolicyCloneClick = vi.fn();
-    const handlePolicyDeleteClick = vi.fn();
-    const handlePolicyDownloadClick = vi.fn();
-    const handlePolicyEditClick = vi.fn();
+    const handlePolicyCloneClick = testing.fn();
+    const handlePolicyDeleteClick = testing.fn();
+    const handlePolicyDownloadClick = testing.fn();
+    const handlePolicyEditClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -910,10 +898,10 @@ describe('Policy ToolBarIcons tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handlePolicyCloneClick = vi.fn();
-    const handlePolicyDeleteClick = vi.fn();
-    const handlePolicyDownloadClick = vi.fn();
-    const handlePolicyEditClick = vi.fn();
+    const handlePolicyCloneClick = testing.fn();
+    const handlePolicyDeleteClick = testing.fn();
+    const handlePolicyDownloadClick = testing.fn();
+    const handlePolicyEditClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -953,10 +941,10 @@ describe('Policy ToolBarIcons tests', () => {
   });
 
   test('should not call click handlers without permission', () => {
-    const handlePolicyCloneClick = vi.fn();
-    const handlePolicyDeleteClick = vi.fn();
-    const handlePolicyDownloadClick = vi.fn();
-    const handlePolicyEditClick = vi.fn();
+    const handlePolicyCloneClick = testing.fn();
+    const handlePolicyDeleteClick = testing.fn();
+    const handlePolicyDownloadClick = testing.fn();
+    const handlePolicyEditClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -1005,10 +993,10 @@ describe('Policy ToolBarIcons tests', () => {
   });
 
   test('should (not) call click handlers if policy is in use', () => {
-    const handlePolicyCloneClick = vi.fn();
-    const handlePolicyDeleteClick = vi.fn();
-    const handlePolicyDownloadClick = vi.fn();
-    const handlePolicyEditClick = vi.fn();
+    const handlePolicyCloneClick = testing.fn();
+    const handlePolicyDeleteClick = testing.fn();
+    const handlePolicyDownloadClick = testing.fn();
+    const handlePolicyEditClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -1048,10 +1036,10 @@ describe('Policy ToolBarIcons tests', () => {
   });
 
   test('should (not) call click handlers if policy is not writable', () => {
-    const handlePolicyCloneClick = vi.fn();
-    const handlePolicyDeleteClick = vi.fn();
-    const handlePolicyDownloadClick = vi.fn();
-    const handlePolicyEditClick = vi.fn();
+    const handlePolicyCloneClick = testing.fn();
+    const handlePolicyDeleteClick = testing.fn();
+    const handlePolicyDownloadClick = testing.fn();
+    const handlePolicyEditClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 

--- a/src/web/pages/policies/__tests__/dialog.jsx
+++ b/src/web/pages/policies/__tests__/dialog.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -23,8 +23,8 @@ import CreatePolicyDialog from '../dialog';
 
 describe('CreatePolicyDialog component tests', () => {
   test('should render dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {baseElement} = render(
       <CreatePolicyDialog
@@ -38,8 +38,8 @@ describe('CreatePolicyDialog component tests', () => {
   });
 
   test('should allow to close the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByTestId} = render(
       <CreatePolicyDialog
@@ -57,8 +57,8 @@ describe('CreatePolicyDialog component tests', () => {
   });
 
   test('should allow to cancel the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByTestId} = render(
       <CreatePolicyDialog
@@ -76,8 +76,8 @@ describe('CreatePolicyDialog component tests', () => {
   });
 
   test('should allow to save the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByName, getByTestId} = render(
       <CreatePolicyDialog

--- a/src/web/pages/policies/__tests__/listpage.jsx
+++ b/src/web/pages/policies/__tests__/listpage.jsx
@@ -15,10 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-import {act} from 'react-dom/test-utils';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
@@ -32,13 +29,9 @@ import {entitiesLoadingActions} from 'web/store/entities/audits';
 import {loadingActions} from 'web/store/usersettings/defaults/actions';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
 
-import {rendererWith, waitFor, fireEvent} from 'web/utils/testing';
+import {rendererWith, waitFor, fireEvent, act} from 'web/utils/testing';
 
 import PoliciesPage, {ToolBarIcons} from '../listpage';
-
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
 
 const policy = Policy.fromElement({
   _id: '12345',
@@ -66,11 +59,11 @@ const wrongCaps = new Capabilities(['get_config']);
 const reloadInterval = 1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({foo: 'bar'});
+const currentSettings = testing.fn().mockResolvedValue({foo: 'bar'});
 
-const getSetting = vi.fn().mockResolvedValue({filter: null});
+const getSetting = testing.fn().mockResolvedValue({filter: null});
 
-const getFilters = vi.fn().mockReturnValue(
+const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
     meta: {
@@ -80,7 +73,7 @@ const getFilters = vi.fn().mockReturnValue(
   }),
 );
 
-const getPolicies = vi.fn().mockResolvedValue({
+const getPolicies = testing.fn().mockResolvedValue({
   data: [policy],
   meta: {
     filter: Filter.fromString(),
@@ -138,15 +131,15 @@ describe('PoliciesPage tests', () => {
   });
 
   test('should call commands for bulk actions', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const renewSession = vi.fn().mockResolvedValue({data: {}});
+    const renewSession = testing.fn().mockResolvedValue({data: {}});
 
     const gmp = {
       policies: {
@@ -213,9 +206,9 @@ describe('PoliciesPage tests', () => {
 
 describe('PoliciesPage ToolBarIcons test', () => {
   test('should render', () => {
-    const handlePolicyCreateClick = vi.fn();
-    const handlePolicyImportClick = vi.fn();
-    const renewSession = vi.fn().mockResolvedValue({data: {}});
+    const handlePolicyCreateClick = testing.fn();
+    const handlePolicyImportClick = testing.fn();
+    const renewSession = testing.fn().mockResolvedValue({data: {}});
 
     const gmp = {settings: {manualUrl}, user: {renewSession}};
 
@@ -244,10 +237,10 @@ describe('PoliciesPage ToolBarIcons test', () => {
   });
 
   test('should call click handlers', () => {
-    const handlePolicyCreateClick = vi.fn();
-    const handlePolicyImportClick = vi.fn();
+    const handlePolicyCreateClick = testing.fn();
+    const handlePolicyImportClick = testing.fn();
 
-    const renewSession = vi.fn().mockResolvedValue({data: {}});
+    const renewSession = testing.fn().mockResolvedValue({data: {}});
 
     const gmp = {settings: {manualUrl}, user: {renewSession}};
 
@@ -276,8 +269,8 @@ describe('PoliciesPage ToolBarIcons test', () => {
   });
 
   test('should not show icons if user does not have the right permissions', () => {
-    const handlePolicyCreateClick = vi.fn();
-    const handlePolicyImportClick = vi.fn();
+    const handlePolicyCreateClick = testing.fn();
+    const handlePolicyImportClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 

--- a/src/web/pages/policies/__tests__/row.jsx
+++ b/src/web/pages/policies/__tests__/row.jsx
@@ -17,7 +17,7 @@
  */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-console */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -48,12 +48,12 @@ describe('Row tests', () => {
   console.error = () => {};
 
   test('should render', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handlePolicyClone = vi.fn();
-    const handlePolicyDelete = vi.fn();
-    const handlePolicyDownload = vi.fn();
-    const handlePolicyEdit = vi.fn();
-    const handleCreateAudit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handlePolicyClone = testing.fn();
+    const handlePolicyDelete = testing.fn();
+    const handlePolicyDownload = testing.fn();
+    const handlePolicyEdit = testing.fn();
+    const handleCreateAudit = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -89,12 +89,12 @@ describe('Row tests', () => {
       permissions: {permission: [{name: 'everything'}]},
     });
 
-    const handleToggleDetailsClick = vi.fn();
-    const handlePolicyClone = vi.fn();
-    const handlePolicyDelete = vi.fn();
-    const handlePolicyDownload = vi.fn();
-    const handlePolicyEdit = vi.fn();
-    const handleCreateAudit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handlePolicyClone = testing.fn();
+    const handlePolicyDelete = testing.fn();
+    const handlePolicyDownload = testing.fn();
+    const handlePolicyEdit = testing.fn();
+    const handleCreateAudit = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -121,12 +121,12 @@ describe('Row tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handlePolicyClone = vi.fn();
-    const handlePolicyDelete = vi.fn();
-    const handlePolicyDownload = vi.fn();
-    const handlePolicyEdit = vi.fn();
-    const handleCreateAudit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handlePolicyClone = testing.fn();
+    const handlePolicyDelete = testing.fn();
+    const handlePolicyDownload = testing.fn();
+    const handlePolicyEdit = testing.fn();
+    const handleCreateAudit = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -174,12 +174,12 @@ describe('Row tests', () => {
   });
 
   test('should not call click handlers without permissions', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handlePolicyClone = vi.fn();
-    const handlePolicyDelete = vi.fn();
-    const handlePolicyDownload = vi.fn();
-    const handlePolicyEdit = vi.fn();
-    const handleCreateAudit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handlePolicyClone = testing.fn();
+    const handlePolicyDelete = testing.fn();
+    const handlePolicyDownload = testing.fn();
+    const handlePolicyEdit = testing.fn();
+    const handleCreateAudit = testing.fn();
 
     const policy = Policy.fromElement({
       _id: '1234',
@@ -245,12 +245,12 @@ describe('Row tests', () => {
   });
 
   test('should (not) call click handlers if policy is in use', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handlePolicyClone = vi.fn();
-    const handlePolicyDelete = vi.fn();
-    const handlePolicyDownload = vi.fn();
-    const handlePolicyEdit = vi.fn();
-    const handleCreateAudit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handlePolicyClone = testing.fn();
+    const handlePolicyDelete = testing.fn();
+    const handlePolicyDownload = testing.fn();
+    const handlePolicyEdit = testing.fn();
+    const handleCreateAudit = testing.fn();
 
     const policy = Policy.fromElement({
       _id: '1234',
@@ -307,12 +307,12 @@ describe('Row tests', () => {
   });
 
   test('should (not) call click handlers if policy is not writable', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handlePolicyClone = vi.fn();
-    const handlePolicyDelete = vi.fn();
-    const handlePolicyDownload = vi.fn();
-    const handlePolicyEdit = vi.fn();
-    const handleCreateAudit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handlePolicyClone = testing.fn();
+    const handlePolicyDelete = testing.fn();
+    const handlePolicyDownload = testing.fn();
+    const handlePolicyEdit = testing.fn();
+    const handleCreateAudit = testing.fn();
 
     const policy = Policy.fromElement({
       _id: '1234',

--- a/src/web/pages/policies/__tests__/table.jsx
+++ b/src/web/pages/policies/__tests__/table.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
@@ -64,11 +64,11 @@ const filter = Filter.fromString('rows=2');
 
 describe('Policies table tests', () => {
   test('should render', () => {
-    const handlePolicyCloneClick = vi.fn();
-    const handleCreateAuditClick = vi.fn();
-    const handlePolicyDeleteClick = vi.fn();
-    const handlePolicyDownloadClick = vi.fn();
-    const handlePolicyEditClick = vi.fn();
+    const handlePolicyCloneClick = testing.fn();
+    const handleCreateAuditClick = testing.fn();
+    const handlePolicyDeleteClick = testing.fn();
+    const handlePolicyDownloadClick = testing.fn();
+    const handlePolicyEditClick = testing.fn();
 
     const gmp = {
       settings: {},
@@ -102,11 +102,11 @@ describe('Policies table tests', () => {
   });
 
   test('should unfold all details', () => {
-    const handlePolicyCloneClick = vi.fn();
-    const handleCreateAuditClick = vi.fn();
-    const handlePolicyDeleteClick = vi.fn();
-    const handlePolicyDownloadClick = vi.fn();
-    const handlePolicyEditClick = vi.fn();
+    const handlePolicyCloneClick = testing.fn();
+    const handleCreateAuditClick = testing.fn();
+    const handlePolicyDeleteClick = testing.fn();
+    const handlePolicyDownloadClick = testing.fn();
+    const handlePolicyEditClick = testing.fn();
 
     const gmp = {
       settings: {},
@@ -143,11 +143,11 @@ describe('Policies table tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handlePolicyCloneClick = vi.fn();
-    const handleCreateAuditClick = vi.fn();
-    const handlePolicyDeleteClick = vi.fn();
-    const handlePolicyDownloadClick = vi.fn();
-    const handlePolicyEditClick = vi.fn();
+    const handlePolicyCloneClick = testing.fn();
+    const handleCreateAuditClick = testing.fn();
+    const handlePolicyDeleteClick = testing.fn();
+    const handlePolicyDownloadClick = testing.fn();
+    const handlePolicyEditClick = testing.fn();
 
     const gmp = {
       settings: {},

--- a/src/web/pages/radius/__tests__/dialog.jsx
+++ b/src/web/pages/radius/__tests__/dialog.jsx
@@ -15,16 +15,16 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-import userEvent from '@testing-library/user-event';
-import {render, fireEvent} from 'web/utils/testing';
+import {describe, test, expect, testing} from '@gsa/testing';
+
+import {render, fireEvent, userEvent} from 'web/utils/testing';
 
 import Dialog from '../dialog';
 
 describe('RADIUS dialog component tests', () => {
   test('should render dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {baseElement} = render(
       <Dialog
@@ -39,8 +39,8 @@ describe('RADIUS dialog component tests', () => {
   });
 
   test('should save data', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByTestId} = render(
       <Dialog
@@ -61,8 +61,8 @@ describe('RADIUS dialog component tests', () => {
   });
 
   test('should allow to close the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByTestId} = render(
       <Dialog
@@ -81,8 +81,8 @@ describe('RADIUS dialog component tests', () => {
   });
 
   test('should allow to change data', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByTestId} = render(
       <Dialog

--- a/src/web/pages/radius/__tests__/radiuspage.jsx
+++ b/src/web/pages/radius/__tests__/radiuspage.jsx
@@ -15,8 +15,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import Settings from 'gmp/models/settings';
+
 import {rendererWith, wait} from 'web/utils/testing';
 
 import RadiusAuthentication from '../radiuspage';
@@ -30,7 +32,7 @@ describe('RADIUS page renders', () => {
     });
     const gmp = {
       user: {
-        currentAuthSettings: vi.fn().mockReturnValue(
+        currentAuthSettings: testing.fn().mockReturnValue(
           Promise.resolve({
             data: settings,
           }),
@@ -58,7 +60,7 @@ describe('RADIUS page renders', () => {
     });
     const gmp = {
       user: {
-        currentAuthSettings: vi.fn().mockReturnValue(
+        currentAuthSettings: testing.fn().mockReturnValue(
           Promise.resolve({
             data: settings,
           }),

--- a/src/web/pages/reportconfigs/__tests__/__snapshots__/component.jsx.snap
+++ b/src/web/pages/reportconfigs/__tests__/__snapshots__/component.jsx.snap
@@ -385,55 +385,6 @@ exports[`Report Config Component tests > should open create dialog and call GMP 
   padding-right: 10px;
 }
 
-.c15 {
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-  display: block;
-  height: 22px;
-  color: #4C4C4C;
-  background-color: #fff;
-  background-image: none;
-  border: 1px solid #bfbfbf;
-  border-radius: 2px;
-  padding: 1px 8px;
-}
-
-.c15:-webkit-autofill {
-  box-shadow: 0 0 0 1000px white inset;
-}
-
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c17 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
 .c24 {
   background-color: transparent;
   border: none;
@@ -525,6 +476,15 @@ exports[`Report Config Component tests > should open create dialog and call GMP 
   cursor: pointer;
 }
 
+.c17 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
 .c22 {
   cursor: default;
 }
@@ -534,6 +494,46 @@ exports[`Report Config Component tests > should open create dialog and call GMP 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.c15 {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  display: block;
+  height: 22px;
+  color: #4C4C4C;
+  background-color: #fff;
+  background-image: none;
+  border: 1px solid #bfbfbf;
+  border-radius: 2px;
+  padding: 1px 8px;
+}
+
+.c15:-webkit-autofill {
+  box-shadow: 0 0 0 1000px white inset;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
 }
 
 <body>
@@ -1134,73 +1134,6 @@ exports[`Report Config Component tests > should open edit dialog and call GMP sa
   padding-right: 10px;
 }
 
-.c15 {
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-  display: block;
-  height: 22px;
-  color: #4C4C4C;
-  background-color: #fff;
-  background-image: none;
-  border: 1px solid #bfbfbf;
-  border-radius: 2px;
-  padding: 1px 8px;
-}
-
-.c15:-webkit-autofill {
-  box-shadow: 0 0 0 1000px white inset;
-}
-
-.c16 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c31 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-box-pack: start;
-  -ms-flex-pack: start;
-  -webkit-justify-content: start;
-  justify-content: start;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-.c17 {
-  color: #c12c30;
-  font-weight: bold;
-  font-size: 19px;
-  padding-bottom: 1px;
-  padding-left: 4px;
-  display: none;
-}
-
 .c24 {
   background-color: transparent;
   border: none;
@@ -1293,6 +1226,15 @@ exports[`Report Config Component tests > should open edit dialog and call GMP sa
   cursor: default;
 }
 
+.c17 {
+  color: #c12c30;
+  font-weight: bold;
+  font-size: 19px;
+  padding-bottom: 1px;
+  padding-left: 4px;
+  display: none;
+}
+
 .c22 {
   cursor: default;
 }
@@ -1302,33 +1244,6 @@ exports[`Report Config Component tests > should open edit dialog and call GMP sa
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-}
-
-.c32 {
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  font-weight: normal;
-  cursor: pointer;
-}
-
-.c35 {
-  font-family: inherit;
-  font-size: inherit;
-  padding: 0;
-  margin: 0;
-  margin-left: 10px;
-  line-height: normal;
-  width: auto;
-  height: auto;
 }
 
 .c26 {
@@ -1374,6 +1289,91 @@ exports[`Report Config Component tests > should open edit dialog and call GMP sa
   border-top: 1px solid #e5e5e5;
   font-weight: bold;
   width: 10%;
+}
+
+.c15 {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  display: block;
+  height: 22px;
+  color: #4C4C4C;
+  background-color: #fff;
+  background-image: none;
+  border: 1px solid #bfbfbf;
+  border-radius: 2px;
+  padding: 1px 8px;
+}
+
+.c15:-webkit-autofill {
+  box-shadow: 0 0 0 1000px white inset;
+}
+
+.c16 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c31 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: start;
+  justify-content: start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c32 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-weight: normal;
+  cursor: pointer;
+}
+
+.c35 {
+  font-family: inherit;
+  font-size: inherit;
+  padding: 0;
+  margin: 0;
+  margin-left: 10px;
+  line-height: normal;
+  width: auto;
+  height: auto;
 }
 
 .c36 {

--- a/src/web/pages/reportconfigs/__tests__/component.jsx
+++ b/src/web/pages/reportconfigs/__tests__/component.jsx
@@ -16,16 +16,21 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import ReportFormatComponent from '../component';
-import {rendererWith, wait} from 'web/utils/testing';
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import ReportConfig from 'gmp/models/reportconfig';
+import Capabilities from 'gmp/capabilities/capabilities';
+
 import {
   fireEvent,
   getAllByRole,
   getAllByTestId,
   getByTestId,
-} from '@testing-library/react';
-import Capabilities from 'gmp/capabilities/capabilities';
+  rendererWith,
+  wait,
+} from 'web/utils/testing';
+
+import ReportFormatComponent from '../component';
 
 describe('Report Config Component tests', () => {
   const mockReportConfig = ReportConfig.fromElement({
@@ -63,24 +68,24 @@ describe('Report Config Component tests', () => {
 
   test('should open edit dialog and call GMP save', async () => {
     let editClick;
-    const children = vi.fn(({edit}) => {
+    const children = testing.fn(({edit}) => {
       editClick = edit;
     });
 
-    const handleInteraction = vi.fn();
-    const getReportConfig = vi.fn().mockResolvedValue({
+    const handleInteraction = testing.fn();
+    const getReportConfig = testing.fn().mockResolvedValue({
       data: mockReportConfig,
     });
-    const getAllReportFormats = vi.fn().mockResolvedValue({
+    const getAllReportFormats = testing.fn().mockResolvedValue({
       data: [mockReportFormat],
     });
-    const saveReportConfig = vi.fn().mockResolvedValue({
+    const saveReportConfig = testing.fn().mockResolvedValue({
       data: {},
     });
 
     const gmp = {
       user: {
-        currentSettings: vi.fn().mockResolvedValue({
+        currentSettings: testing.fn().mockResolvedValue({
           data: {},
         }),
       },
@@ -144,23 +149,23 @@ describe('Report Config Component tests', () => {
 
   test('should open create dialog and call GMP create', async () => {
     let createClick;
-    const children = vi.fn(({edit, create}) => {
+    const children = testing.fn(({edit, create}) => {
       createClick = create;
     });
-    const handleInteraction = vi.fn();
-    const getAllReportFormats = vi.fn().mockResolvedValue({
+    const handleInteraction = testing.fn();
+    const getAllReportFormats = testing.fn().mockResolvedValue({
       data: [mockReportFormat],
     });
-    const getReportFormat = vi.fn().mockResolvedValue({
+    const getReportFormat = testing.fn().mockResolvedValue({
       data: mockReportFormat,
     });
-    const createReportConfig = vi.fn().mockResolvedValue({
+    const createReportConfig = testing.fn().mockResolvedValue({
       data: {},
     });
 
     const gmp = {
       user: {
-        currentSettings: vi.fn().mockResolvedValue({
+        currentSettings: testing.fn().mockResolvedValue({
           data: {},
         }),
       },
@@ -231,17 +236,17 @@ describe('Report Config Component tests', () => {
 
   test('should open and close create dialog', async () => {
     let createClick;
-    const children = vi.fn(({edit, create}) => {
+    const children = testing.fn(({edit, create}) => {
       createClick = create;
     });
-    const handleInteraction = vi.fn();
-    const getAllReportFormats = vi.fn().mockResolvedValue({
+    const handleInteraction = testing.fn();
+    const getAllReportFormats = testing.fn().mockResolvedValue({
       data: [mockReportFormat],
     });
 
     const gmp = {
       user: {
-        currentSettings: vi.fn().mockResolvedValue({
+        currentSettings: testing.fn().mockResolvedValue({
           data: {},
         }),
       },

--- a/src/web/pages/reportconfigs/__tests__/details.jsx
+++ b/src/web/pages/reportconfigs/__tests__/details.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import ReportConfig from 'gmp/models/reportconfig';

--- a/src/web/pages/reportconfigs/__tests__/detailspage.jsx
+++ b/src/web/pages/reportconfigs/__tests__/detailspage.jsx
@@ -15,38 +15,35 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import ReportConfig from 'gmp/models/reportconfig';
+
+import Filter from 'gmp/models/filter';
+import CollectionCounts from 'gmp/collection/collectioncounts';
+import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 
 import {entityLoadingActions} from 'web/store/entities/reportconfigs';
 
 import {rendererWith, fireEvent} from 'web/utils/testing';
 
 import DetailsPage from '../detailspage';
-import Filter from 'gmp/models/filter';
-import CollectionCounts from 'gmp/collection/collectioncounts';
-import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {setLocale} from 'gmp/locale/date';
-
 import {mockReportConfig} from '../__mocks__/mockreportconfig';
-
-setLocale('en');
 
 const entityType = 'reportconfig';
 const reloadInterval = 1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getPermissions = vi.fn().mockResolvedValue({
+const getPermissions = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -57,7 +54,7 @@ const getPermissions = vi.fn().mockResolvedValue({
 const config = ReportConfig.fromElement(mockReportConfig);
 describe('Report Config Details Page tests', () => {
   test('should render full Details page with param details', () => {
-    const getReportConfig = vi.fn().mockResolvedValue({
+    const getReportConfig = testing.fn().mockResolvedValue({
       data: config,
     });
 

--- a/src/web/pages/reportconfigs/__tests__/dialog.jsx
+++ b/src/web/pages/reportconfigs/__tests__/dialog.jsx
@@ -15,27 +15,32 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
-import {setLocale} from 'gmp/locale/lang';
 import ReportConfig from 'gmp/models/reportconfig';
+import ReportFormat from 'gmp/models/reportformat';
 
-import {rendererWith, fireEvent, getAllByTestId, wait} from 'web/utils/testing';
-
-import ReportConfigDialog from '../dialog';
+import {
+  rendererWith,
+  fireEvent,
+  getAllByTestId,
+  wait,
+  getAllByRole,
+  getByRole,
+  getByTestId,
+} from 'web/utils/testing';
 
 import {mockReportConfig} from 'web/pages/reportconfigs/__mocks__/mockreportconfig';
 import {mockReportFormats} from '../__mocks__/mockreportformats';
-import {getAllByRole, getByRole, getByTestId} from '@testing-library/react';
-import ReportFormat from 'gmp/models/reportformat';
 
-setLocale('en');
+import ReportConfigDialog from '../dialog';
 
 const config = ReportConfig.fromElement(mockReportConfig);
+
 describe('Edit Report Config Dialog component tests', () => {
   test('should render dialog with disabled report format selection', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const gmp = {};
     const formats = mockReportFormats;
@@ -67,8 +72,8 @@ describe('Edit Report Config Dialog component tests', () => {
   });
 
   test('should save data', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const gmp = {};
     const formats = mockReportFormats;
@@ -111,8 +116,8 @@ describe('Edit Report Config Dialog component tests', () => {
   });
 
   test('should allow to close the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const gmp = {};
     const formats = mockReportFormats;
@@ -137,9 +142,9 @@ describe('Edit Report Config Dialog component tests', () => {
   });
 
   test('should allow to change name, comment and params', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleValueChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleValueChange = testing.fn();
 
     const gmp = {};
     const formats = mockReportFormats;
@@ -227,9 +232,9 @@ describe('Edit Report Config Dialog component tests', () => {
   });
 
   test('should be able to toggle which params use default value', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleValueChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleValueChange = testing.fn();
 
     const gmp = {};
     const formats = mockReportFormats;
@@ -299,8 +304,8 @@ describe('Edit Report Config Dialog component tests', () => {
 
 describe('New Report Config Dialog component tests', () => {
   test('should render dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const gmp = {};
     const formats = mockReportFormats;
@@ -325,8 +330,8 @@ describe('New Report Config Dialog component tests', () => {
   });
 
   test('should allow to change name, comment, report_format and params', async () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
     const mockReportFormatDetails = ReportFormat.fromElement({
       _id: '1234567',
       name: 'example-configurable-2',
@@ -362,7 +367,7 @@ describe('New Report Config Dialog component tests', () => {
       ],
     });
 
-    const getReportFormat = vi.fn().mockResolvedValue({
+    const getReportFormat = testing.fn().mockResolvedValue({
       data: mockReportFormatDetails,
     });
 
@@ -375,7 +380,7 @@ describe('New Report Config Dialog component tests', () => {
 
     const {render} = rendererWith({capabilities: true, router: true, gmp});
 
-    const handleValueChange = vi.fn();
+    const handleValueChange = testing.fn();
 
     const {baseElement} = render(
       <ReportConfigDialog

--- a/src/web/pages/reportconfigs/__tests__/listpage.jsx
+++ b/src/web/pages/reportconfigs/__tests__/listpage.jsx
@@ -15,8 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-import {act} from 'react-dom/test-utils';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
@@ -30,11 +29,9 @@ import {entitiesLoadingActions} from 'web/store/entities/scanconfigs';
 import {loadingActions} from 'web/store/usersettings/defaults/actions';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
 
-import {rendererWith, waitFor, fireEvent} from 'web/utils/testing';
+import {rendererWith, waitFor, fireEvent, act} from 'web/utils/testing';
 
 import ReportConfigsPage, {ToolBarIcons} from '../listpage';
-
-window.URL.createObjectURL = vi.fn();
 
 const config = ReportConfig.fromElement({
   _id: '12345',
@@ -57,9 +54,9 @@ const wrongCaps = new Capabilities(['get_config']);
 const reloadInterval = 1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({foo: 'bar'});
+const currentSettings = testing.fn().mockResolvedValue({foo: 'bar'});
 
-const getFilters = vi.fn().mockReturnValue(
+const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
     meta: {
@@ -69,7 +66,7 @@ const getFilters = vi.fn().mockReturnValue(
   }),
 );
 
-const getReportConfigs = vi.fn().mockResolvedValue({
+const getReportConfigs = testing.fn().mockResolvedValue({
   data: [config],
   meta: {
     filter: Filter.fromString(),
@@ -77,7 +74,7 @@ const getReportConfigs = vi.fn().mockResolvedValue({
   },
 });
 
-const getSetting = vi.fn().mockResolvedValue({filter: null});
+const getSetting = testing.fn().mockResolvedValue({filter: null});
 
 describe('ReportConfigsPage tests', () => {
   test('should render full ReportConfigsPage', async () => {
@@ -129,15 +126,15 @@ describe('ReportConfigsPage tests', () => {
   });
 
   test('should call commands for bulk actions', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const addTagByFilter = vi.fn().mockResolvedValue({
+    const addTagByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const renewSession = vi.fn().mockResolvedValue({data: {}});
+    const renewSession = testing.fn().mockResolvedValue({data: {}});
 
     const gmp = {
       reportconfigs: {
@@ -201,7 +198,7 @@ describe('ReportConfigsPage tests', () => {
 
   describe('ReportConfigsPage ToolBarIcons test', () => {
     test('should render', () => {
-      const handleReportConfigCreateClick = vi.fn();
+      const handleReportConfigCreateClick = testing.fn();
 
       const gmp = {
         settings: {manualUrl},
@@ -231,7 +228,7 @@ describe('ReportConfigsPage tests', () => {
     });
 
     test('should call click handlers', () => {
-      const handleReportConfigCreateClick = vi.fn();
+      const handleReportConfigCreateClick = testing.fn();
 
       const gmp = {
         settings: {manualUrl},
@@ -257,7 +254,7 @@ describe('ReportConfigsPage tests', () => {
     });
 
     test('should not show icons if user does not have the right permissions', () => {
-      const handleReportConfigCreateClick = vi.fn();
+      const handleReportConfigCreateClick = testing.fn();
 
       const gmp = {settings: {manualUrl}};
 

--- a/src/web/pages/reportconfigs/__tests__/row.jsx
+++ b/src/web/pages/reportconfigs/__tests__/row.jsx
@@ -17,7 +17,7 @@
  */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-console */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -63,11 +63,11 @@ describe('Report Config row tests', () => {
   console.error = () => {};
 
   test('should render', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleReportConfigClone = vi.fn();
-    const handleReportConfigDelete = vi.fn();
-    const handleReportConfigDownload = vi.fn();
-    const handleReportConfigEdit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleReportConfigClone = testing.fn();
+    const handleReportConfigDelete = testing.fn();
+    const handleReportConfigDownload = testing.fn();
+    const handleReportConfigEdit = testing.fn();
 
     const {render} = rendererWith({
       gmp,
@@ -94,11 +94,11 @@ describe('Report Config row tests', () => {
   });
 
   test('should render orphan', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleReportConfigClone = vi.fn();
-    const handleReportConfigDelete = vi.fn();
-    const handleReportConfigDownload = vi.fn();
-    const handleReportConfigEdit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleReportConfigClone = testing.fn();
+    const handleReportConfigDelete = testing.fn();
+    const handleReportConfigDownload = testing.fn();
+    const handleReportConfigEdit = testing.fn();
 
     const {render} = rendererWith({
       gmp,
@@ -142,11 +142,11 @@ describe('Report Config row tests', () => {
       },
     });
 
-    const handleToggleDetailsClick = vi.fn();
-    const handleReportConfigClone = vi.fn();
-    const handleReportConfigDelete = vi.fn();
-    const handleReportConfigDownload = vi.fn();
-    const handleReportConfigEdit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleReportConfigClone = testing.fn();
+    const handleReportConfigDelete = testing.fn();
+    const handleReportConfigDownload = testing.fn();
+    const handleReportConfigEdit = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -173,11 +173,11 @@ describe('Report Config row tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleReportConfigClone = vi.fn();
-    const handleReportConfigDelete = vi.fn();
-    const handleReportConfigDownload = vi.fn();
-    const handleReportConfigEdit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleReportConfigClone = testing.fn();
+    const handleReportConfigDelete = testing.fn();
+    const handleReportConfigDownload = testing.fn();
+    const handleReportConfigEdit = testing.fn();
 
     const {render} = rendererWith({
       gmp,
@@ -221,11 +221,11 @@ describe('Report Config row tests', () => {
   });
 
   test('should not call click handlers without permissions', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleReportConfigClone = vi.fn();
-    const handleReportConfigDelete = vi.fn();
-    const handleReportConfigDownload = vi.fn();
-    const handleReportConfigEdit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleReportConfigClone = testing.fn();
+    const handleReportConfigDelete = testing.fn();
+    const handleReportConfigDownload = testing.fn();
+    const handleReportConfigEdit = testing.fn();
 
     const config = ReportConfig.fromElement({
       _id: '1234',
@@ -290,11 +290,11 @@ describe('Report Config row tests', () => {
   });
 
   test('should (not) call click handlers if scan config is in use', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleReportConfigClone = vi.fn();
-    const handleReportConfigDelete = vi.fn();
-    const handleReportConfigDownload = vi.fn();
-    const handleReportConfigEdit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleReportConfigClone = testing.fn();
+    const handleReportConfigDelete = testing.fn();
+    const handleReportConfigDownload = testing.fn();
+    const handleReportConfigEdit = testing.fn();
 
     const config = ReportConfig.fromElement({
       _id: '1234',
@@ -351,11 +351,11 @@ describe('Report Config row tests', () => {
   });
 
   test('should (not) call click handlers if scan config is not writable', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleReportConfigClone = vi.fn();
-    const handleReportConfigDelete = vi.fn();
-    const handleReportConfigDownload = vi.fn();
-    const handleReportConfigEdit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleReportConfigClone = testing.fn();
+    const handleReportConfigDelete = testing.fn();
+    const handleReportConfigDownload = testing.fn();
+    const handleReportConfigEdit = testing.fn();
 
     const config = ReportConfig.fromElement({
       _id: '1234',

--- a/src/web/pages/reportconfigs/__tests__/table.jsx
+++ b/src/web/pages/reportconfigs/__tests__/table.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
@@ -76,10 +76,10 @@ const filter = Filter.fromString('rows=2');
 
 describe('Scan Config table tests', () => {
   test('should render', () => {
-    const handleReportConfigClone = vi.fn();
-    const handleReportConfigDelete = vi.fn();
-    const handleReportConfigDownload = vi.fn();
-    const handleReportConfigEdit = vi.fn();
+    const handleReportConfigClone = testing.fn();
+    const handleReportConfigDelete = testing.fn();
+    const handleReportConfigDownload = testing.fn();
+    const handleReportConfigEdit = testing.fn();
 
     const gmp = {
       settings: {},
@@ -114,10 +114,10 @@ describe('Scan Config table tests', () => {
   });
 
   test('should unfold all details', () => {
-    const handleReportConfigClone = vi.fn();
-    const handleReportConfigDelete = vi.fn();
-    const handleReportConfigDownload = vi.fn();
-    const handleReportConfigEdit = vi.fn();
+    const handleReportConfigClone = testing.fn();
+    const handleReportConfigDelete = testing.fn();
+    const handleReportConfigDownload = testing.fn();
+    const handleReportConfigEdit = testing.fn();
 
     const gmp = {
       settings: {},
@@ -153,10 +153,10 @@ describe('Scan Config table tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleReportConfigClone = vi.fn();
-    const handleReportConfigDelete = vi.fn();
-    const handleReportConfigDownload = vi.fn();
-    const handleReportConfigEdit = vi.fn();
+    const handleReportConfigClone = testing.fn();
+    const handleReportConfigDelete = testing.fn();
+    const handleReportConfigDownload = testing.fn();
+    const handleReportConfigEdit = testing.fn();
 
     const gmp = {
       settings: {},

--- a/src/web/pages/reports/__tests__/deltadetailscontent.jsx
+++ b/src/web/pages/reports/__tests__/deltadetailscontent.jsx
@@ -15,10 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 
@@ -30,15 +29,12 @@ import {getMockDeltaReport} from 'web/pages/reports/__mocks__/mockdeltareport';
 
 import DeltaDetailsContent from '../deltadetailscontent';
 
-setLocale('en');
-
 const filter = Filter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 
 const filterWithName = Filter.fromElement({
-  term:
-    'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
+  term: 'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
   name: 'foo',
   id: '123',
 });
@@ -47,37 +43,37 @@ const caps = new Capabilities(['everything']);
 
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getReportComposerDefaults = vi.fn().mockResolvedValue({
+const getReportComposerDefaults = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
 describe('Delta Report Details Content tests', () => {
   test('should render Delta Report Details Content', () => {
-    const onActivateTab = vi.fn();
-    const onAddToAssetsClick = vi.fn();
-    const onError = vi.fn();
-    const onFilterAddLogLevelClick = vi.fn();
-    const onFilterDecreaseMinQoDClick = vi.fn();
-    const onFilterChanged = vi.fn();
-    const onFilterCreated = vi.fn();
-    const onFilterEditClick = vi.fn();
-    const onFilterRemoveSeverityClick = vi.fn();
-    const onFilterResetClick = vi.fn();
-    const onFilterRemoveClick = vi.fn();
-    const onInteraction = vi.fn();
-    const onRemoveFromAssetsClick = vi.fn();
-    const onReportDownloadClick = vi.fn();
-    const showError = vi.fn();
-    const showErrorMessage = vi.fn();
-    const showSuccessMessage = vi.fn();
-    const onSortChange = vi.fn();
-    const onTagSuccess = vi.fn();
-    const onTargetEditClick = vi.fn();
-    const onTlsCertificateDownloadClick = vi.fn();
+    const onActivateTab = testing.fn();
+    const onAddToAssetsClick = testing.fn();
+    const onError = testing.fn();
+    const onFilterAddLogLevelClick = testing.fn();
+    const onFilterDecreaseMinQoDClick = testing.fn();
+    const onFilterChanged = testing.fn();
+    const onFilterCreated = testing.fn();
+    const onFilterEditClick = testing.fn();
+    const onFilterRemoveSeverityClick = testing.fn();
+    const onFilterResetClick = testing.fn();
+    const onFilterRemoveClick = testing.fn();
+    const onInteraction = testing.fn();
+    const onRemoveFromAssetsClick = testing.fn();
+    const onReportDownloadClick = testing.fn();
+    const showError = testing.fn();
+    const showErrorMessage = testing.fn();
+    const showSuccessMessage = testing.fn();
+    const onSortChange = testing.fn();
+    const onTagSuccess = testing.fn();
+    const onTargetEditClick = testing.fn();
+    const onTlsCertificateDownloadClick = testing.fn();
 
     const sorting = {
       apps: {sortField: 'severity', sortReverse: true},
@@ -152,7 +148,7 @@ describe('Delta Report Details Content tests', () => {
     const selects = getAllByTestId('select-selected-value');
     const bars = getAllByTestId('progressbar-box');
 
-    expect(icons.length).toEqual(15)
+    expect(icons.length).toEqual(15);
 
     // Powerfilter
     expect(inputs[0]).toHaveAttribute('name', 'userFilterString');
@@ -229,27 +225,27 @@ describe('Delta Report Details Content tests', () => {
   });
 
   test('should render results tab', () => {
-    const onActivateTab = vi.fn();
-    const onAddToAssetsClick = vi.fn();
-    const onError = vi.fn();
-    const onFilterAddLogLevelClick = vi.fn();
-    const onFilterDecreaseMinQoDClick = vi.fn();
-    const onFilterChanged = vi.fn();
-    const onFilterCreated = vi.fn();
-    const onFilterEditClick = vi.fn();
-    const onFilterRemoveSeverityClick = vi.fn();
-    const onFilterResetClick = vi.fn();
-    const onFilterRemoveClick = vi.fn();
-    const onInteraction = vi.fn();
-    const onRemoveFromAssetsClick = vi.fn();
-    const onReportDownloadClick = vi.fn();
-    const showError = vi.fn();
-    const showErrorMessage = vi.fn();
-    const showSuccessMessage = vi.fn();
-    const onSortChange = vi.fn();
-    const onTagSuccess = vi.fn();
-    const onTargetEditClick = vi.fn();
-    const onTlsCertificateDownloadClick = vi.fn();
+    const onActivateTab = testing.fn();
+    const onAddToAssetsClick = testing.fn();
+    const onError = testing.fn();
+    const onFilterAddLogLevelClick = testing.fn();
+    const onFilterDecreaseMinQoDClick = testing.fn();
+    const onFilterChanged = testing.fn();
+    const onFilterCreated = testing.fn();
+    const onFilterEditClick = testing.fn();
+    const onFilterRemoveSeverityClick = testing.fn();
+    const onFilterResetClick = testing.fn();
+    const onFilterRemoveClick = testing.fn();
+    const onInteraction = testing.fn();
+    const onRemoveFromAssetsClick = testing.fn();
+    const onReportDownloadClick = testing.fn();
+    const showError = testing.fn();
+    const showErrorMessage = testing.fn();
+    const showSuccessMessage = testing.fn();
+    const onSortChange = testing.fn();
+    const onTagSuccess = testing.fn();
+    const onTargetEditClick = testing.fn();
+    const onTlsCertificateDownloadClick = testing.fn();
 
     const sorting = {
       apps: {sortField: 'severity', sortReverse: true},
@@ -325,7 +321,7 @@ describe('Delta Report Details Content tests', () => {
     const bars = getAllByTestId('progressbar-box');
 
     // Toolbar Icons
-    expect(icons.length).toEqual(26)
+    expect(icons.length).toEqual(26);
 
     // Powerfilter
     expect(inputs[0]).toHaveAttribute('name', 'userFilterString');

--- a/src/web/pages/reports/__tests__/detailscontent.jsx
+++ b/src/web/pages/reports/__tests__/detailscontent.jsx
@@ -15,10 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 
@@ -30,15 +29,12 @@ import {getMockReport} from 'web/pages/reports/__mocks__/mockreport';
 
 import DetailsContent from '../detailscontent';
 
-setLocale('en');
-
 const filter = Filter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 
 const filterWithName = Filter.fromElement({
-  term:
-    'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
+  term: 'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
   name: 'foo',
   id: '123',
 });
@@ -49,37 +45,37 @@ const caps = new Capabilities(['everything']);
 
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getReportComposerDefaults = vi.fn().mockResolvedValue({
+const getReportComposerDefaults = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
 describe('Report Details Content tests', () => {
   test('should render Report Details Content', () => {
-    const onActivateTab = vi.fn();
-    const onAddToAssetsClick = vi.fn();
-    const onError = vi.fn();
-    const onFilterAddLogLevelClick = vi.fn();
-    const onFilterDecreaseMinQoDClick = vi.fn();
-    const onFilterChanged = vi.fn();
-    const onFilterCreated = vi.fn();
-    const onFilterEditClick = vi.fn();
-    const onFilterRemoveSeverityClick = vi.fn();
-    const onFilterResetClick = vi.fn();
-    const onFilterRemoveClick = vi.fn();
-    const onInteraction = vi.fn();
-    const onRemoveFromAssetsClick = vi.fn();
-    const onReportDownloadClick = vi.fn();
-    const showError = vi.fn();
-    const showErrorMessage = vi.fn();
-    const showSuccessMessage = vi.fn();
-    const onSortChange = vi.fn();
-    const onTagSuccess = vi.fn();
-    const onTargetEditClick = vi.fn();
-    const onTlsCertificateDownloadClick = vi.fn();
+    const onActivateTab = testing.fn();
+    const onAddToAssetsClick = testing.fn();
+    const onError = testing.fn();
+    const onFilterAddLogLevelClick = testing.fn();
+    const onFilterDecreaseMinQoDClick = testing.fn();
+    const onFilterChanged = testing.fn();
+    const onFilterCreated = testing.fn();
+    const onFilterEditClick = testing.fn();
+    const onFilterRemoveSeverityClick = testing.fn();
+    const onFilterResetClick = testing.fn();
+    const onFilterRemoveClick = testing.fn();
+    const onInteraction = testing.fn();
+    const onRemoveFromAssetsClick = testing.fn();
+    const onReportDownloadClick = testing.fn();
+    const showError = testing.fn();
+    const showErrorMessage = testing.fn();
+    const showSuccessMessage = testing.fn();
+    const onSortChange = testing.fn();
+    const onTagSuccess = testing.fn();
+    const onTargetEditClick = testing.fn();
+    const onTlsCertificateDownloadClick = testing.fn();
 
     const sorting = {
       apps: {sortField: 'severity', sortReverse: true},
@@ -233,27 +229,27 @@ describe('Report Details Content tests', () => {
   });
 
   test('should render threshold panel', () => {
-    const onActivateTab = vi.fn();
-    const onAddToAssetsClick = vi.fn();
-    const onError = vi.fn();
-    const onFilterAddLogLevelClick = vi.fn();
-    const onFilterDecreaseMinQoDClick = vi.fn();
-    const onFilterChanged = vi.fn();
-    const onFilterCreated = vi.fn();
-    const onFilterEditClick = vi.fn();
-    const onFilterRemoveSeverityClick = vi.fn();
-    const onFilterResetClick = vi.fn();
-    const onFilterRemoveClick = vi.fn();
-    const onInteraction = vi.fn();
-    const onRemoveFromAssetsClick = vi.fn();
-    const onReportDownloadClick = vi.fn();
-    const showError = vi.fn();
-    const showErrorMessage = vi.fn();
-    const showSuccessMessage = vi.fn();
-    const onSortChange = vi.fn();
-    const onTagSuccess = vi.fn();
-    const onTargetEditClick = vi.fn();
-    const onTlsCertificateDownloadClick = vi.fn();
+    const onActivateTab = testing.fn();
+    const onAddToAssetsClick = testing.fn();
+    const onError = testing.fn();
+    const onFilterAddLogLevelClick = testing.fn();
+    const onFilterDecreaseMinQoDClick = testing.fn();
+    const onFilterChanged = testing.fn();
+    const onFilterCreated = testing.fn();
+    const onFilterEditClick = testing.fn();
+    const onFilterRemoveSeverityClick = testing.fn();
+    const onFilterResetClick = testing.fn();
+    const onFilterRemoveClick = testing.fn();
+    const onInteraction = testing.fn();
+    const onRemoveFromAssetsClick = testing.fn();
+    const onReportDownloadClick = testing.fn();
+    const showError = testing.fn();
+    const showErrorMessage = testing.fn();
+    const showSuccessMessage = testing.fn();
+    const onSortChange = testing.fn();
+    const onTagSuccess = testing.fn();
+    const onTargetEditClick = testing.fn();
+    const onTlsCertificateDownloadClick = testing.fn();
 
     const sorting = {
       apps: {sortField: 'severity', sortReverse: true},
@@ -338,7 +334,7 @@ describe('Report Details Content tests', () => {
     const bars = getAllByTestId('progressbar-box');
 
     // Toolbar Icons
-    expect(icons.length).toEqual(20)
+    expect(icons.length).toEqual(20);
     // Powerfilter
     expect(inputs[0]).toHaveAttribute('name', 'userFilterString');
     expect(selects[0]).toHaveAttribute('title', 'Loaded filter');

--- a/src/web/pages/reports/details/__tests__/applicationstab.jsx
+++ b/src/web/pages/reports/details/__tests__/applicationstab.jsx
@@ -15,10 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 
@@ -30,8 +29,6 @@ import {getMockReport} from 'web/pages/reports/__mocks__/mockreport';
 
 import ApplicationsTab from '../applicationstab';
 
-setLocale('en');
-
 const filter = Filter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
@@ -42,8 +39,8 @@ describe('Report Applications Tab tests', () => {
   test('should render Report Applications Tab', () => {
     const {applications} = getMockReport();
 
-    const onSortChange = vi.fn();
-    const onInteraction = vi.fn();
+    const onSortChange = testing.fn();
+    const onInteraction = testing.fn();
 
     const {render, store} = rendererWith({
       capabilities: caps,

--- a/src/web/pages/reports/details/__tests__/closedcvestab.jsx
+++ b/src/web/pages/reports/details/__tests__/closedcvestab.jsx
@@ -15,10 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 
@@ -30,8 +29,6 @@ import {getMockReport} from 'web/pages/reports/__mocks__/mockreport';
 
 import ClosedCvesTab from '../closedcvestab';
 
-setLocale('en');
-
 const caps = new Capabilities(['everything']);
 
 const filter = Filter.fromString(
@@ -41,8 +38,8 @@ const filter = Filter.fromString(
 describe('Report Closed CVEs Tab tests', () => {
   test('should render Report Closed CVEs Tab', () => {
     const {closedCves} = getMockReport();
-    const onSortChange = vi.fn();
-    const onInteraction = vi.fn();
+    const onSortChange = testing.fn();
+    const onInteraction = testing.fn();
 
     const {render, store} = rendererWith({
       capabilities: caps,

--- a/src/web/pages/reports/details/__tests__/cvestab.jsx
+++ b/src/web/pages/reports/details/__tests__/cvestab.jsx
@@ -16,10 +16,9 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 
@@ -31,8 +30,6 @@ import {getMockReport} from 'web/pages/reports/__mocks__/mockreport';
 
 import CvesTab from '../cvestab';
 
-setLocale('en');
-
 const caps = new Capabilities(['everything']);
 
 const filter = Filter.fromString(
@@ -42,8 +39,8 @@ const filter = Filter.fromString(
 describe('Report CVEs Tab tests', () => {
   test('should render Report CVEs Tab', () => {
     const {cves} = getMockReport();
-    const onSortChange = vi.fn();
-    const onInteraction = vi.fn();
+    const onSortChange = testing.fn();
+    const onInteraction = testing.fn();
 
     const {render, store} = rendererWith({
       capabilities: caps,

--- a/src/web/pages/reports/details/__tests__/deltaresultstab.jsx
+++ b/src/web/pages/reports/details/__tests__/deltaresultstab.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -31,8 +29,6 @@ import {getMockDeltaReport} from 'web/pages/reports/__mocks__/mockdeltareport';
 
 import DeltaResultsTab from '../deltaresultstab';
 
-setLocale('en');
-
 const filter = Filter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
@@ -45,14 +41,14 @@ const gmp = {
 
 describe('Delta Results Tab tests', () => {
   test('should render Delta Results Tab', () => {
-    const onFilterAddLogLevelClick = vi.fn();
-    const onFilterDecreaseMinQoDClick = vi.fn();
-    const onFilterEditClick = vi.fn();
-    const onFilterRemoveClick = vi.fn();
-    const onFilterRemoveSeverityClick = vi.fn();
-    const onInteraction = vi.fn();
-    const onSortChange = vi.fn();
-    const onTargetEditClick = vi.fn();
+    const onFilterAddLogLevelClick = testing.fn();
+    const onFilterDecreaseMinQoDClick = testing.fn();
+    const onFilterEditClick = testing.fn();
+    const onFilterRemoveClick = testing.fn();
+    const onFilterRemoveSeverityClick = testing.fn();
+    const onInteraction = testing.fn();
+    const onSortChange = testing.fn();
+    const onTargetEditClick = testing.fn();
 
     const {report, results, task} = getMockDeltaReport();
 

--- a/src/web/pages/reports/details/__tests__/emptyreport.jsx
+++ b/src/web/pages/reports/details/__tests__/emptyreport.jsx
@@ -15,23 +15,20 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 
 import {rendererWith, fireEvent} from 'web/utils/testing';
 
 import EmptyReport from '../emptyreport';
-
-setLocale('en');
 
 const caps = new Capabilities(['everything']);
 const wrongCaps = new Capabilities(['get_reports']);
 
 describe('Empty Report tests', () => {
   test('should render empty report', () => {
-    const onTargetEditClick = vi.fn();
+    const onTargetEditClick = testing.fn();
 
     const {render} = rendererWith({
       capabilities: caps,
@@ -78,7 +75,7 @@ describe('Empty Report tests', () => {
   });
 
   test('should render report for newly started task', () => {
-    const onTargetEditClick = vi.fn();
+    const onTargetEditClick = testing.fn();
 
     const {render} = rendererWith({
       capabilities: caps,
@@ -103,7 +100,7 @@ describe('Empty Report tests', () => {
   });
 
   test('should render report for running task', () => {
-    const onTargetEditClick = vi.fn();
+    const onTargetEditClick = testing.fn();
 
     const {render} = rendererWith({
       capabilities: caps,
@@ -125,7 +122,7 @@ describe('Empty Report tests', () => {
   });
 
   test('should call click handler', () => {
-    const onTargetEditClick = vi.fn();
+    const onTargetEditClick = testing.fn();
 
     const {render} = rendererWith({
       capabilities: caps,
@@ -147,7 +144,7 @@ describe('Empty Report tests', () => {
   });
 
   test('should not call click handler with wrong capabilities', () => {
-    const onTargetEditClick = vi.fn();
+    const onTargetEditClick = testing.fn();
 
     const {render} = rendererWith({
       capabilities: wrongCaps,

--- a/src/web/pages/reports/details/__tests__/emptyresultsreport.jsx
+++ b/src/web/pages/reports/details/__tests__/emptyresultsreport.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Filter from 'gmp/models/filter';
 
@@ -25,15 +23,13 @@ import {render, fireEvent} from 'web/utils/testing';
 
 import EmptyResultsReport from '../emptyresultsreport';
 
-setLocale('en');
-
 describe('Empty Results Report tests', () => {
   test('should render empty results report', () => {
-    const onFilterAddLogLevelClick = vi.fn();
-    const onFilterDecreaseMinQoDClick = vi.fn();
-    const onFilterEditClick = vi.fn();
-    const onFilterRemoveClick = vi.fn();
-    const onFilterRemoveSeverityClick = vi.fn();
+    const onFilterAddLogLevelClick = testing.fn();
+    const onFilterDecreaseMinQoDClick = testing.fn();
+    const onFilterEditClick = testing.fn();
+    const onFilterRemoveClick = testing.fn();
+    const onFilterRemoveSeverityClick = testing.fn();
 
     const filter = Filter.fromString(
       'apply_overrides=0 levels=hmlg rows=2 first=1 sort-reverse=severity',
@@ -84,11 +80,11 @@ describe('Empty Results Report tests', () => {
   });
 
   test('should render empty results report with log messages filter', () => {
-    const onFilterAddLogLevelClick = vi.fn();
-    const onFilterDecreaseMinQoDClick = vi.fn();
-    const onFilterEditClick = vi.fn();
-    const onFilterRemoveClick = vi.fn();
-    const onFilterRemoveSeverityClick = vi.fn();
+    const onFilterAddLogLevelClick = testing.fn();
+    const onFilterDecreaseMinQoDClick = testing.fn();
+    const onFilterEditClick = testing.fn();
+    const onFilterRemoveClick = testing.fn();
+    const onFilterRemoveSeverityClick = testing.fn();
 
     const filter = Filter.fromString(
       'apply_overrides=0 levels=hml rows=2 first=1 sort-reverse=severity',
@@ -143,11 +139,11 @@ describe('Empty Results Report tests', () => {
   });
 
   test('should render empty results report with severity filter', () => {
-    const onFilterAddLogLevelClick = vi.fn();
-    const onFilterDecreaseMinQoDClick = vi.fn();
-    const onFilterEditClick = vi.fn();
-    const onFilterRemoveClick = vi.fn();
-    const onFilterRemoveSeverityClick = vi.fn();
+    const onFilterAddLogLevelClick = testing.fn();
+    const onFilterDecreaseMinQoDClick = testing.fn();
+    const onFilterEditClick = testing.fn();
+    const onFilterRemoveClick = testing.fn();
+    const onFilterRemoveSeverityClick = testing.fn();
 
     const filter = Filter.fromString(
       'apply_overrides=0 levels=hmlg severity>50 rows=2 first=1 sort-reverse=severity',
@@ -202,11 +198,11 @@ describe('Empty Results Report tests', () => {
   });
 
   test('should render empty results report with min qod filter', () => {
-    const onFilterAddLogLevelClick = vi.fn();
-    const onFilterDecreaseMinQoDClick = vi.fn();
-    const onFilterEditClick = vi.fn();
-    const onFilterRemoveClick = vi.fn();
-    const onFilterRemoveSeverityClick = vi.fn();
+    const onFilterAddLogLevelClick = testing.fn();
+    const onFilterDecreaseMinQoDClick = testing.fn();
+    const onFilterEditClick = testing.fn();
+    const onFilterRemoveClick = testing.fn();
+    const onFilterRemoveSeverityClick = testing.fn();
 
     const filter = Filter.fromString(
       'apply_overrides=0 levels=hmlg min_qod>70 rows=2 first=1 sort-reverse=severity',
@@ -260,11 +256,11 @@ describe('Empty Results Report tests', () => {
     );
   });
   test('should call click handlers', () => {
-    const onFilterAddLogLevelClick = vi.fn();
-    const onFilterDecreaseMinQoDClick = vi.fn();
-    const onFilterEditClick = vi.fn();
-    const onFilterRemoveClick = vi.fn();
-    const onFilterRemoveSeverityClick = vi.fn();
+    const onFilterAddLogLevelClick = testing.fn();
+    const onFilterDecreaseMinQoDClick = testing.fn();
+    const onFilterEditClick = testing.fn();
+    const onFilterRemoveClick = testing.fn();
+    const onFilterRemoveSeverityClick = testing.fn();
 
     const filter = Filter.fromString(
       'apply_overrides=0 levels=hml rows=2 severity>50 min_qod=70 first=1 sort-reverse=severity',

--- a/src/web/pages/reports/details/__tests__/errorstab.jsx
+++ b/src/web/pages/reports/details/__tests__/errorstab.jsx
@@ -15,10 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 
@@ -30,8 +29,6 @@ import {getMockReport} from 'web/pages/reports/__mocks__/mockreport';
 
 import ErrorsTab from '../errorstab';
 
-setLocale('en');
-
 const caps = new Capabilities(['everything']);
 
 const filter = Filter.fromString(
@@ -42,8 +39,8 @@ describe('Report Errors Tab tests', () => {
   test('should render Report Errors Tab', () => {
     const {errors} = getMockReport();
 
-    const onSortChange = vi.fn();
-    const onInteraction = vi.fn();
+    const onSortChange = testing.fn();
+    const onInteraction = testing.fn();
 
     const {render, store} = rendererWith({
       capabilities: caps,

--- a/src/web/pages/reports/details/__tests__/hoststab.jsx
+++ b/src/web/pages/reports/details/__tests__/hoststab.jsx
@@ -15,10 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 
@@ -29,8 +28,6 @@ import {rendererWith} from 'web/utils/testing';
 import {getMockReport} from 'web/pages/reports/__mocks__/mockreport';
 
 import HostsTab from '../hoststab';
-
-setLocale('en');
 
 const filter = Filter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
@@ -46,8 +43,8 @@ describe('Report Hosts Tab tests', () => {
   test('should render Report Hosts Tab', () => {
     const {hosts} = getMockReport();
 
-    const onSortChange = vi.fn();
-    const onInteraction = vi.fn();
+    const onSortChange = testing.fn();
+    const onInteraction = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,

--- a/src/web/pages/reports/details/__tests__/operatingsystemstab.jsx
+++ b/src/web/pages/reports/details/__tests__/operatingsystemstab.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Filter from 'gmp/models/filter';
 
@@ -29,8 +27,6 @@ import {getMockReport} from 'web/pages/reports/__mocks__/mockreport';
 
 import OperatingSystemsTab from '../operatingsystemstab';
 
-setLocale('en');
-
 const filter = Filter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
@@ -39,8 +35,8 @@ describe('Report Operating Systems Tab tests', () => {
   test('should render Report Operating Systems Tab', () => {
     const {operatingsystems} = getMockReport();
 
-    const onSortChange = vi.fn();
-    const onInteraction = vi.fn();
+    const onSortChange = testing.fn();
+    const onInteraction = testing.fn();
 
     const {render, store} = rendererWith({
       router: true,

--- a/src/web/pages/reports/details/__tests__/portstab.jsx
+++ b/src/web/pages/reports/details/__tests__/portstab.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Filter from 'gmp/models/filter';
 
@@ -29,8 +27,6 @@ import {getMockReport} from 'web/pages/reports/__mocks__/mockreport';
 
 import PortsTab from '../portstab';
 
-setLocale('en');
-
 const filter = Filter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
@@ -39,8 +35,8 @@ describe('Report Ports Tab tests', () => {
   test('should render Report Ports Tab', () => {
     const {ports} = getMockReport();
 
-    const onSortChange = vi.fn();
-    const onInteraction = vi.fn();
+    const onSortChange = testing.fn();
+    const onInteraction = testing.fn();
 
     const {render, store} = rendererWith({
       router: true,

--- a/src/web/pages/reports/details/__tests__/summary.jsx
+++ b/src/web/pages/reports/details/__tests__/summary.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -31,8 +29,6 @@ import {getMockReport} from 'web/pages/reports/__mocks__/mockreport';
 import {getMockDeltaReport} from 'web/pages/reports/__mocks__/mockdeltareport';
 
 import Summary from '../summary';
-
-setLocale('en');
 
 const filter = Filter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',

--- a/src/web/pages/reports/details/__tests__/thresholdpanel.jsx
+++ b/src/web/pages/reports/details/__tests__/thresholdpanel.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Filter from 'gmp/models/filter';
 
@@ -25,12 +23,10 @@ import {render, fireEvent} from 'web/utils/testing';
 
 import Thresholdpanel from '../thresholdpanel';
 
-setLocale('en');
-
 describe('Report Threshold Panel tests', () => {
   test('should render threshold panel', () => {
-    const onFilterEditClick = vi.fn();
-    const onFilterChanged = vi.fn();
+    const onFilterEditClick = testing.fn();
+    const onFilterChanged = testing.fn();
 
     const filter = Filter.fromString(
       'apply_overrides=0 rows=2 first=1 sort-reverse=severity',
@@ -84,8 +80,8 @@ describe('Report Threshold Panel tests', () => {
   });
 
   test('should render threshold panel with different severities included', () => {
-    const onFilterEditClick = vi.fn();
-    const onFilterChanged = vi.fn();
+    const onFilterEditClick = testing.fn();
+    const onFilterChanged = testing.fn();
 
     const filter = Filter.fromString(
       'apply_overrides=0 levels=hmlg rows=2 first=1 sort-reverse=severity',
@@ -141,8 +137,8 @@ describe('Report Threshold Panel tests', () => {
   });
 
   test('should call click handler', () => {
-    const onFilterEditClick = vi.fn();
-    const onFilterChanged = vi.fn();
+    const onFilterEditClick = testing.fn();
+    const onFilterChanged = testing.fn();
 
     const filter = Filter.fromString(
       'apply_overrides=0 rows=2 first=1 sort-reverse=severity',
@@ -175,8 +171,8 @@ describe('Report Threshold Panel tests', () => {
   });
 
   test('should call click handler for different severity levels', () => {
-    const onFilterEditClick = vi.fn();
-    const onFilterChanged = vi.fn();
+    const onFilterEditClick = testing.fn();
+    const onFilterChanged = testing.fn();
 
     const filter = Filter.fromString(
       'apply_overrides=0 levels=hmlg rows=2 first=1 sort-reverse=severity',

--- a/src/web/pages/reports/details/__tests__/tlscertificatestab.jsx
+++ b/src/web/pages/reports/details/__tests__/tlscertificatestab.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Filter from 'gmp/models/filter';
 
@@ -29,8 +27,6 @@ import {getMockReport} from 'web/pages/reports/__mocks__/mockreport';
 
 import TLSCertificatesTab from '../tlscertificatestab';
 
-setLocale('en');
-
 const filter = Filter.fromString(
   'apply_overrides=0 levels=hml rows=3 min_qod=70 first=1 sort-reverse=severity',
 );
@@ -39,9 +35,9 @@ describe('Report TLS Certificates Tab tests', () => {
   test('should render Report TLS Certificates Tab', () => {
     const {tlsCertificates} = getMockReport();
 
-    const onSortChange = vi.fn();
-    const onInteraction = vi.fn();
-    const onTlsCertificateDownloadClick = vi.fn();
+    const onSortChange = testing.fn();
+    const onInteraction = testing.fn();
+    const onTlsCertificateDownloadClick = testing.fn();
 
     const {render, store} = rendererWith({
       router: true,
@@ -136,9 +132,9 @@ describe('Report TLS Certificates Tab tests', () => {
   test('should call click handler', () => {
     const {tlsCertificates} = getMockReport();
 
-    const onSortChange = vi.fn();
-    const onInteraction = vi.fn();
-    const onTlsCertificateDownloadClick = vi.fn();
+    const onSortChange = testing.fn();
+    const onInteraction = testing.fn();
+    const onTlsCertificateDownloadClick = testing.fn();
 
     const {render, store} = rendererWith({
       router: true,

--- a/src/web/pages/reports/details/__tests__/toolbaricons.jsx
+++ b/src/web/pages/reports/details/__tests__/toolbaricons.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -29,8 +27,6 @@ import {getMockReport} from 'web/pages/reports/__mocks__/mockreport';
 
 import ToolBarIcons from '../toolbaricons';
 
-setLocale('en');
-
 const filter = Filter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
@@ -39,11 +35,11 @@ const caps = new Capabilities(['everything']);
 
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getReportComposerDefaults = vi.fn().mockResolvedValue({
+const getReportComposerDefaults = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
@@ -54,13 +50,13 @@ const gmp = {
 
 describe('Report Details ToolBarIcons tests', () => {
   test('should render ToolBarIcons', () => {
-    const showError = vi.fn();
-    const showSuccessMessage = vi.fn();
-    const showErrorMessage = vi.fn();
-    const onAddToAssetsClick = vi.fn();
-    const onInteraction = vi.fn();
-    const onRemoveFromAssetsClick = vi.fn();
-    const onReportDownloadClick = vi.fn();
+    const showError = testing.fn();
+    const showSuccessMessage = testing.fn();
+    const showErrorMessage = testing.fn();
+    const onAddToAssetsClick = testing.fn();
+    const onInteraction = testing.fn();
+    const onRemoveFromAssetsClick = testing.fn();
+    const onReportDownloadClick = testing.fn();
 
     const {report} = getMockReport();
 
@@ -153,13 +149,13 @@ describe('Report Details ToolBarIcons tests', () => {
   });
 
   test('should call click handler', () => {
-    const showError = vi.fn();
-    const showSuccessMessage = vi.fn();
-    const showErrorMessage = vi.fn();
-    const onAddToAssetsClick = vi.fn();
-    const onInteraction = vi.fn();
-    const onRemoveFromAssetsClick = vi.fn();
-    const onReportDownloadClick = vi.fn();
+    const showError = testing.fn();
+    const showSuccessMessage = testing.fn();
+    const showErrorMessage = testing.fn();
+    const onAddToAssetsClick = testing.fn();
+    const onInteraction = testing.fn();
+    const onRemoveFromAssetsClick = testing.fn();
+    const onReportDownloadClick = testing.fn();
 
     const {report} = getMockReport();
 

--- a/src/web/pages/results/__tests__/detailspage.jsx
+++ b/src/web/pages/results/__tests__/detailspage.jsx
@@ -15,18 +15,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
-import {setLocale} from 'gmp/locale/lang';
-
 import Filter from 'gmp/models/filter';
 import Result from 'gmp/models/result';
-
-import {isDefined} from 'gmp/utils/identity';
 
 import {entityLoadingActions} from 'web/store/entities/results';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
@@ -36,13 +32,6 @@ import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 import Detailspage, {ToolBarIcons} from '../detailspage';
 
 // setup
-
-setLocale('en');
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
 
 const reloadInterval = -1;
 const manualUrl = 'test/';
@@ -117,11 +106,11 @@ let currentSettings;
 let renewSession;
 
 beforeEach(() => {
-  getResult = vi.fn().mockResolvedValue({
+  getResult = testing.fn().mockResolvedValue({
     data: result,
   });
 
-  getPermissions = vi.fn().mockResolvedValue({
+  getPermissions = testing.fn().mockResolvedValue({
     data: [],
     meta: {
       filter: Filter.fromString(),
@@ -129,11 +118,11 @@ beforeEach(() => {
     },
   });
 
-  currentSettings = vi.fn().mockResolvedValue({
+  currentSettings = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 
-  renewSession = vi.fn().mockResolvedValue({
+  renewSession = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 });
@@ -294,11 +283,11 @@ describe('Result Detailspage tests', () => {
   });
 
   test('should call commands', async () => {
-    const exportFunc = vi.fn().mockResolvedValue({
+    const exportFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const getUsers = vi.fn().mockResolvedValue({
+    const getUsers = testing.fn().mockResolvedValue({
       data: [],
       meta: {
         filter: Filter.fromString(),
@@ -357,10 +346,10 @@ describe('Result Detailspage tests', () => {
 
 describe('Result ToolBarIcons tests', () => {
   test('should render', () => {
-    const handleNoteCreateClick = vi.fn();
-    const handleOverrideCreateClick = vi.fn();
-    const handleResultDownloadClick = vi.fn();
-    const handleTicketCreateClick = vi.fn();
+    const handleNoteCreateClick = testing.fn();
+    const handleOverrideCreateClick = testing.fn();
+    const handleResultDownloadClick = testing.fn();
+    const handleTicketCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -408,10 +397,10 @@ describe('Result ToolBarIcons tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleNoteCreateClick = vi.fn();
-    const handleOverrideCreateClick = vi.fn();
-    const handleResultDownloadClick = vi.fn();
-    const handleTicketCreateClick = vi.fn();
+    const handleNoteCreateClick = testing.fn();
+    const handleOverrideCreateClick = testing.fn();
+    const handleResultDownloadClick = testing.fn();
+    const handleTicketCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -447,10 +436,10 @@ describe('Result ToolBarIcons tests', () => {
   test('should not show icons without permission', () => {
     const wrongCapabilities = new Capabilities(['get_results']);
 
-    const handleNoteCreateClick = vi.fn();
-    const handleOverrideCreateClick = vi.fn();
-    const handleResultDownloadClick = vi.fn();
-    const handleTicketCreateClick = vi.fn();
+    const handleNoteCreateClick = testing.fn();
+    const handleOverrideCreateClick = testing.fn();
+    const handleResultDownloadClick = testing.fn();
+    const handleTicketCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 

--- a/src/web/pages/results/__tests__/diff.jsx
+++ b/src/web/pages/results/__tests__/diff.jsx
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 

--- a/src/web/pages/results/__tests__/listpage.jsx
+++ b/src/web/pages/results/__tests__/listpage.jsx
@@ -15,11 +15,9 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import CollectionCounts from 'gmp/collection/collectioncounts';
-
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 import Result from 'gmp/models/result';
@@ -35,10 +33,6 @@ import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 import ResultsPage from '../listpage';
 
 // setup
-
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
 
 const reloadInterval = -1;
 const manualUrl = 'test/';
@@ -123,7 +117,7 @@ let renewSession;
 beforeEach(() => {
   // mock gmp commands
 
-  getResults = vi.fn().mockResolvedValue({
+  getResults = testing.fn().mockResolvedValue({
     data: results,
     meta: {
       filter: Filter.fromString(),
@@ -131,7 +125,7 @@ beforeEach(() => {
     },
   });
 
-  getFilters = vi.fn().mockReturnValue(
+  getFilters = testing.fn().mockReturnValue(
     Promise.resolve({
       data: [],
       meta: {
@@ -141,7 +135,7 @@ beforeEach(() => {
     }),
   );
 
-  getDashboardSetting = vi.fn().mockResolvedValue({
+  getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
       filter: Filter.fromString(),
@@ -149,7 +143,7 @@ beforeEach(() => {
     },
   });
 
-  getAggregates = vi.fn().mockResolvedValue({
+  getAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
       filter: Filter.fromString(),
@@ -157,15 +151,15 @@ beforeEach(() => {
     },
   });
 
-  currentSettings = vi.fn().mockResolvedValue({
+  currentSettings = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 
-  getSetting = vi.fn().mockResolvedValue({
+  getSetting = testing.fn().mockResolvedValue({
     filter: null,
   });
 
-  renewSession = vi.fn().mockResolvedValue({
+  renewSession = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 });
@@ -299,7 +293,7 @@ describe('Results listpage tests', () => {
   });
 
   test('should allow to bulk action on page contents', async () => {
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -361,7 +355,7 @@ describe('Results listpage tests', () => {
   });
 
   test('should allow to bulk action on selected results', async () => {
-    const exportByIds = vi.fn().mockResolvedValue({
+    const exportByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -441,7 +435,7 @@ describe('Results listpage tests', () => {
   });
 
   test('should allow to bulk action on filtered results', async () => {
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 

--- a/src/web/pages/results/__tests__/row.jsx
+++ b/src/web/pages/results/__tests__/row.jsx
@@ -15,11 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
-import React from 'react';
-import {rendererWith} from 'web/utils/testing';
-import Row from '../row';
 import Result from 'gmp/models/result';
+
+import {rendererWith} from 'web/utils/testing';
+
+import Row from '../row';
 
 describe('Delta reports V2 with changed severity, qod and hostname', () => {
   const {render} = rendererWith();

--- a/src/web/pages/scanconfigs/__tests__/details.jsx
+++ b/src/web/pages/scanconfigs/__tests__/details.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 

--- a/src/web/pages/scanconfigs/__tests__/detailspage.jsx
+++ b/src/web/pages/scanconfigs/__tests__/detailspage.jsx
@@ -15,12 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-import {act} from 'react-dom/test-utils';
-
-import {setLocale} from 'gmp/locale/lang';
-
-import {isDefined} from 'gmp/utils/identity';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
@@ -31,16 +26,9 @@ import ScanConfig from 'gmp/models/scanconfig';
 import {entityLoadingActions} from 'web/store/entities/scanconfigs';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 
-import {rendererWith, fireEvent} from 'web/utils/testing';
+import {rendererWith, fireEvent, act} from 'web/utils/testing';
 
 import Detailspage, {ToolBarIcons} from '../detailspage';
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
-
-setLocale('en');
 
 const families = [
   {
@@ -217,15 +205,15 @@ const entityType = 'scanconfig';
 const reloadInterval = 1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getPermissions = vi.fn().mockResolvedValue({
+const getPermissions = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -235,7 +223,7 @@ const getPermissions = vi.fn().mockResolvedValue({
 
 describe('Scan Config Detailspage tests', () => {
   test('should render full Detailspage', () => {
-    const getConfig = vi.fn().mockResolvedValue({
+    const getConfig = testing.fn().mockResolvedValue({
       data: config,
     });
 
@@ -302,7 +290,7 @@ describe('Scan Config Detailspage tests', () => {
   });
 
   test('should render nvt families tab', () => {
-    const getConfig = vi.fn().mockResolvedValue({
+    const getConfig = testing.fn().mockResolvedValue({
       data: config,
     });
 
@@ -386,7 +374,7 @@ describe('Scan Config Detailspage tests', () => {
   });
 
   test('should render nvt preferences tab', () => {
-    const getConfig = vi.fn().mockResolvedValue({
+    const getConfig = testing.fn().mockResolvedValue({
       data: config,
     });
 
@@ -443,11 +431,11 @@ describe('Scan Config Detailspage tests', () => {
   });
 
   test('should render user tags tab', () => {
-    const getConfig = vi.fn().mockResolvedValue({
+    const getConfig = testing.fn().mockResolvedValue({
       data: config,
     });
 
-    const getTags = vi.fn().mockResolvedValue({
+    const getTags = testing.fn().mockResolvedValue({
       data: [],
       meta: {
         filter: Filter.fromString(),
@@ -494,7 +482,7 @@ describe('Scan Config Detailspage tests', () => {
   });
 
   test('should render permissions tab', () => {
-    const getConfig = vi.fn().mockResolvedValue({
+    const getConfig = testing.fn().mockResolvedValue({
       data: config,
     });
 
@@ -534,32 +522,32 @@ describe('Scan Config Detailspage tests', () => {
   });
 
   test('should call commands', async () => {
-    const getConfig = vi.fn().mockReturnValue(
+    const getConfig = testing.fn().mockReturnValue(
       Promise.resolve({
         data: config,
       }),
     );
-    const clone = vi.fn().mockReturnValue(
+    const clone = testing.fn().mockReturnValue(
       Promise.resolve({
         data: {id: 'foo'},
       }),
     );
-    const getNvtFamilies = vi.fn().mockReturnValue(
+    const getNvtFamilies = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const getAllScanners = vi.fn().mockReturnValue(
+    const getAllScanners = testing.fn().mockReturnValue(
       Promise.resolve({
         data: scanners,
       }),
     );
-    const deleteFunc = vi.fn().mockReturnValue(
+    const deleteFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const exportFunc = vi.fn().mockReturnValue(
+    const exportFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
@@ -631,33 +619,33 @@ describe('Scan Config Detailspage tests', () => {
   });
 
   test('should not call commands without permission', async () => {
-    const getConfig = vi.fn().mockReturnValue(
+    const getConfig = testing.fn().mockReturnValue(
       Promise.resolve({
         data: config2,
       }),
     );
 
-    const clone = vi.fn().mockReturnValue(
+    const clone = testing.fn().mockReturnValue(
       Promise.resolve({
         data: {id: 'foo'},
       }),
     );
-    const getNvtFamilies = vi.fn().mockReturnValue(
+    const getNvtFamilies = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const getAllScanners = vi.fn().mockReturnValue(
+    const getAllScanners = testing.fn().mockReturnValue(
       Promise.resolve({
         data: scanners,
       }),
     );
-    const deleteFunc = vi.fn().mockReturnValue(
+    const deleteFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const exportFunc = vi.fn().mockReturnValue(
+    const exportFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
@@ -739,33 +727,33 @@ describe('Scan Config Detailspage tests', () => {
   });
 
   test('should (not) call commands if config is in use', async () => {
-    const getConfig = vi.fn().mockReturnValue(
+    const getConfig = testing.fn().mockReturnValue(
       Promise.resolve({
         data: config3,
       }),
     );
 
-    const clone = vi.fn().mockReturnValue(
+    const clone = testing.fn().mockReturnValue(
       Promise.resolve({
         data: {id: 'foo'},
       }),
     );
-    const getNvtFamilies = vi.fn().mockReturnValue(
+    const getNvtFamilies = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const getAllScanners = vi.fn().mockReturnValue(
+    const getAllScanners = testing.fn().mockReturnValue(
       Promise.resolve({
         data: scanners,
       }),
     );
-    const deleteFunc = vi.fn().mockReturnValue(
+    const deleteFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const exportFunc = vi.fn().mockReturnValue(
+    const exportFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
@@ -838,33 +826,33 @@ describe('Scan Config Detailspage tests', () => {
   });
 
   test('should (not) call commands if config is not writable', async () => {
-    const getConfig = vi.fn().mockReturnValue(
+    const getConfig = testing.fn().mockReturnValue(
       Promise.resolve({
         data: config4,
       }),
     );
 
-    const clone = vi.fn().mockReturnValue(
+    const clone = testing.fn().mockReturnValue(
       Promise.resolve({
         data: {id: 'foo'},
       }),
     );
-    const getNvtFamilies = vi.fn().mockReturnValue(
+    const getNvtFamilies = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const getAllScanners = vi.fn().mockReturnValue(
+    const getAllScanners = testing.fn().mockReturnValue(
       Promise.resolve({
         data: scanners,
       }),
     );
-    const deleteFunc = vi.fn().mockReturnValue(
+    const deleteFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
     );
-    const exportFunc = vi.fn().mockReturnValue(
+    const exportFunc = testing.fn().mockReturnValue(
       Promise.resolve({
         foo: 'bar',
       }),
@@ -941,12 +929,12 @@ describe('Scan Config Detailspage tests', () => {
 
 describe('Scan Config ToolBarIcons tests', () => {
   test('should render', () => {
-    const handleScanConfigCreate = vi.fn();
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
-    const handleScanConfigImport = vi.fn();
+    const handleScanConfigCreate = testing.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
+    const handleScanConfigImport = testing.fn();
 
     const {render} = rendererWith({
       gmp: {settings: {manualUrl}},
@@ -982,12 +970,12 @@ describe('Scan Config ToolBarIcons tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleScanConfigCreate = vi.fn();
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
-    const handleScanConfigImport = vi.fn();
+    const handleScanConfigCreate = testing.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
+    const handleScanConfigImport = testing.fn();
 
     const {render} = rendererWith({
       gmp: {settings: {manualUrl}},
@@ -1038,12 +1026,12 @@ describe('Scan Config ToolBarIcons tests', () => {
   });
 
   test('should not call click handlers without permission', () => {
-    const handleScanConfigCreate = vi.fn();
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
-    const handleScanConfigImport = vi.fn();
+    const handleScanConfigCreate = testing.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
+    const handleScanConfigImport = testing.fn();
 
     const {render} = rendererWith({
       gmp: {settings: {manualUrl}},
@@ -1098,12 +1086,12 @@ describe('Scan Config ToolBarIcons tests', () => {
   });
 
   test('should (not) call click handlers if config is in use', () => {
-    const handleScanConfigCreate = vi.fn();
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
-    const handleScanConfigImport = vi.fn();
+    const handleScanConfigCreate = testing.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
+    const handleScanConfigImport = testing.fn();
 
     const {render} = rendererWith({
       gmp: {settings: {manualUrl}},
@@ -1154,12 +1142,12 @@ describe('Scan Config ToolBarIcons tests', () => {
   });
 
   test('should (not) call click handlers if config is not writable', () => {
-    const handleScanConfigCreate = vi.fn();
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
-    const handleScanConfigImport = vi.fn();
+    const handleScanConfigCreate = testing.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
+    const handleScanConfigImport = testing.fn();
 
     const {render} = rendererWith({
       gmp: {settings: {manualUrl}},

--- a/src/web/pages/scanconfigs/__tests__/dialog.jsx
+++ b/src/web/pages/scanconfigs/__tests__/dialog.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -23,8 +23,8 @@ import CreateScanConfigDialog from '../dialog';
 
 describe('CreateScanConfigDialog component tests', () => {
   test('should render dialog with base config as default', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getAllByTestId} = render(
       <CreateScanConfigDialog
@@ -67,8 +67,8 @@ describe('CreateScanConfigDialog component tests', () => {
   });
 
   test('should allow to close the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByTestId} = render(
       <CreateScanConfigDialog
@@ -86,8 +86,8 @@ describe('CreateScanConfigDialog component tests', () => {
   });
 
   test('should allow to cancel the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByTestId} = render(
       <CreateScanConfigDialog
@@ -105,8 +105,8 @@ describe('CreateScanConfigDialog component tests', () => {
   });
 
   test('should allow to save the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByName, getByTestId} = render(
       <CreateScanConfigDialog
@@ -134,8 +134,8 @@ describe('CreateScanConfigDialog component tests', () => {
   });
 
   test('should allow to change the base', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByName, getByTestId, getAllByTestId} = render(
       <CreateScanConfigDialog

--- a/src/web/pages/scanconfigs/__tests__/editconfigfamilydialog.jsx
+++ b/src/web/pages/scanconfigs/__tests__/editconfigfamilydialog.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Nvt from 'gmp/models/nvt';
 
@@ -55,9 +55,9 @@ const selected = {
 
 describe('EditConfigFamilyDialog component tests', () => {
   test('should render dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
     const {baseElement} = render(
@@ -83,9 +83,9 @@ describe('EditConfigFamilyDialog component tests', () => {
   });
 
   test('should render loading indicator', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
     const {baseElement, getByTestId} = render(
@@ -113,9 +113,9 @@ describe('EditConfigFamilyDialog component tests', () => {
   });
 
   test('should save data', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
     const {getByTestId} = render(
@@ -145,9 +145,9 @@ describe('EditConfigFamilyDialog component tests', () => {
   });
 
   test('should allow to close the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
     const {getByTestId} = render(
@@ -175,9 +175,9 @@ describe('EditConfigFamilyDialog component tests', () => {
   });
 
   test('should allow to change data', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
     const {baseElement, getByTestId} = render(
@@ -215,9 +215,9 @@ describe('EditConfigFamilyDialog component tests', () => {
   });
 
   test('should call click handler', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
     const {getAllByTestId} = render(
@@ -243,9 +243,9 @@ describe('EditConfigFamilyDialog component tests', () => {
   });
 
   test('should sort table', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const newSelected = {
       1234: 0,

--- a/src/web/pages/scanconfigs/__tests__/editdialog.jsx
+++ b/src/web/pages/scanconfigs/__tests__/editdialog.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {
   SCANCONFIG_TREND_STATIC,
@@ -27,8 +25,6 @@ import {
 import {rendererWith, fireEvent, getAllByTestId} from 'web/utils/testing';
 
 import EditScanConfigDialog from '../editdialog';
-
-setLocale('en');
 
 const families = [
   {
@@ -134,10 +130,10 @@ const scannerPreferences = [
 
 describe('EditScanConfigDialog component tests', () => {
   test('should render dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditConfigFamilyDialog = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditConfigFamilyDialog = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
 
@@ -182,10 +178,10 @@ describe('EditScanConfigDialog component tests', () => {
   });
 
   test('should render dialog for config in use', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditConfigFamilyDialog = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditConfigFamilyDialog = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
     const {baseElement, getByTestId} = render(
@@ -236,10 +232,10 @@ describe('EditScanConfigDialog component tests', () => {
   });
 
   test('should render dialog inline notification for policy in use', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditConfigFamilyDialog = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditConfigFamilyDialog = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
     const {baseElement, getByTestId} = render(
@@ -288,10 +284,10 @@ describe('EditScanConfigDialog component tests', () => {
   });
 
   test('should save data', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditConfigFamilyDialog = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditConfigFamilyDialog = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true, router: true});
     const {getByTestId} = render(
@@ -335,10 +331,10 @@ describe('EditScanConfigDialog component tests', () => {
   });
 
   test('should allow to close the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditConfigFamilyDialog = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditConfigFamilyDialog = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true, router: true});
     const {getByTestId} = render(
@@ -374,10 +370,10 @@ describe('EditScanConfigDialog component tests', () => {
   });
 
   test('should allow to change name and comment', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditConfigFamilyDialog = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditConfigFamilyDialog = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true, router: true});
     const {getByTestId} = render(
@@ -427,10 +423,10 @@ describe('EditScanConfigDialog component tests', () => {
   });
 
   test('should allow to edit nvt families for openvas configs', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditConfigFamilyDialog = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditConfigFamilyDialog = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true, router: true});
     const {getByTestId, queryAllByName} = render(
@@ -496,10 +492,10 @@ describe('EditScanConfigDialog component tests', () => {
   });
 
   test('should call click handlers for edit families and edit nvt details', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleOpenEditConfigFamilyDialog = vi.fn();
-    const handleOpenEditNvtDetailsDialog = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditConfigFamilyDialog = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true, router: true});
     const {getByTestId} = render(

--- a/src/web/pages/scanconfigs/__tests__/editnvtdetailsdialog.jsx
+++ b/src/web/pages/scanconfigs/__tests__/editnvtdetailsdialog.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import date from 'gmp/models/date';
 
@@ -26,8 +24,6 @@ import {setTimezone} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent} from 'web/utils/testing';
 
 import EditNvtDetailsDialog from '../editnvtdetailsdialog';
-
-setLocale('en');
 
 const preferences = [
   {name: 'pref 1', value: 'no', id: '1', type: 'checkbox'},
@@ -39,8 +35,8 @@ const modified = date('2019-09-09T12:00:00Z');
 
 describe('EditNvtDetailsDialog component tests', () => {
   test('should render dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render, store} = rendererWith({
       capabilities: true,
@@ -81,8 +77,8 @@ describe('EditNvtDetailsDialog component tests', () => {
   });
 
   test('should render loading indicator', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render, store} = rendererWith({
       capabilities: true,
@@ -123,8 +119,8 @@ describe('EditNvtDetailsDialog component tests', () => {
   });
 
   test('should save data', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: true,
@@ -182,8 +178,8 @@ describe('EditNvtDetailsDialog component tests', () => {
   });
 
   test('should allow to close the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: true,
@@ -220,8 +216,8 @@ describe('EditNvtDetailsDialog component tests', () => {
   });
 
   test('should allow to change data', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: true,
@@ -276,8 +272,8 @@ describe('EditNvtDetailsDialog component tests', () => {
   });
 
   test('should handle changing timeout', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: true,

--- a/src/web/pages/scanconfigs/__tests__/listpage.jsx
+++ b/src/web/pages/scanconfigs/__tests__/listpage.jsx
@@ -15,8 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-import {act} from 'react-dom/test-utils';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
@@ -33,11 +32,9 @@ import {entitiesLoadingActions} from 'web/store/entities/scanconfigs';
 import {loadingActions} from 'web/store/usersettings/defaults/actions';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
 
-import {rendererWith, waitFor, fireEvent} from 'web/utils/testing';
+import {rendererWith, waitFor, fireEvent, act} from 'web/utils/testing';
 
 import ScanConfigsPage, {ToolBarIcons} from '../listpage';
-
-window.URL.createObjectURL = vi.fn();
 
 const config = ScanConfig.fromElement({
   _id: '12345',
@@ -73,9 +70,9 @@ const wrongCaps = new Capabilities(['get_config']);
 const reloadInterval = 1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({foo: 'bar'});
+const currentSettings = testing.fn().mockResolvedValue({foo: 'bar'});
 
-const getFilters = vi.fn().mockReturnValue(
+const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
     meta: {
@@ -85,7 +82,7 @@ const getFilters = vi.fn().mockReturnValue(
   }),
 );
 
-const getConfigs = vi.fn().mockResolvedValue({
+const getConfigs = testing.fn().mockResolvedValue({
   data: [config],
   meta: {
     filter: Filter.fromString(),
@@ -93,7 +90,7 @@ const getConfigs = vi.fn().mockResolvedValue({
   },
 });
 
-const getSetting = vi.fn().mockResolvedValue({filter: null});
+const getSetting = testing.fn().mockResolvedValue({filter: null});
 
 describe('ScanConfigsPage tests', () => {
   test('should render full ScanConfigsPage', async () => {
@@ -145,15 +142,15 @@ describe('ScanConfigsPage tests', () => {
   });
 
   test('should call commands for bulk actions', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const renewSession = vi.fn().mockResolvedValue({data: {}});
+    const renewSession = testing.fn().mockResolvedValue({data: {}});
 
     const gmp = {
       scanconfigs: {
@@ -220,8 +217,8 @@ describe('ScanConfigsPage tests', () => {
 
 describe('ScanConfigsPage ToolBarIcons test', () => {
   test('should render', () => {
-    const handleScanConfigCreateClick = vi.fn();
-    const handleScanConfigImportClick = vi.fn();
+    const handleScanConfigCreateClick = testing.fn();
+    const handleScanConfigImportClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -252,8 +249,8 @@ describe('ScanConfigsPage ToolBarIcons test', () => {
   });
 
   test('should call click handlers', () => {
-    const handleScanConfigCreateClick = vi.fn();
-    const handleScanConfigImportClick = vi.fn();
+    const handleScanConfigCreateClick = testing.fn();
+    const handleScanConfigImportClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -284,8 +281,8 @@ describe('ScanConfigsPage ToolBarIcons test', () => {
   });
 
   test('should not show icons if user does not have the right permissions', () => {
-    const handleScanConfigCreateClick = vi.fn();
-    const handleScanConfigImportClick = vi.fn();
+    const handleScanConfigCreateClick = testing.fn();
+    const handleScanConfigImportClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 

--- a/src/web/pages/scanconfigs/__tests__/row.jsx
+++ b/src/web/pages/scanconfigs/__tests__/row.jsx
@@ -17,7 +17,7 @@
  */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-console */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -59,11 +59,11 @@ describe('Scan Config row tests', () => {
   console.error = () => {};
 
   test('should render', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
 
     const {render} = rendererWith({
       gmp,
@@ -119,11 +119,11 @@ describe('Scan Config row tests', () => {
       },
     });
 
-    const handleToggleDetailsClick = vi.fn();
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
 
     const {render} = rendererWith({
       gmp,
@@ -166,11 +166,11 @@ describe('Scan Config row tests', () => {
       },
     });
 
-    const handleToggleDetailsClick = vi.fn();
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -196,11 +196,11 @@ describe('Scan Config row tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
 
     const {render} = rendererWith({
       gmp,
@@ -243,11 +243,11 @@ describe('Scan Config row tests', () => {
   });
 
   test('should not call click handlers without permissions', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
 
     const config = ScanConfig.fromElement({
       _id: '1234',
@@ -315,11 +315,11 @@ describe('Scan Config row tests', () => {
   });
 
   test('should (not) call click handlers if scan config is in use', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
 
     const config = ScanConfig.fromElement({
       _id: '1234',
@@ -379,11 +379,11 @@ describe('Scan Config row tests', () => {
   });
 
   test('should (not) call click handlers if scan config is not writable', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
 
     const config = ScanConfig.fromElement({
       _id: '1234',

--- a/src/web/pages/scanconfigs/__tests__/table.jsx
+++ b/src/web/pages/scanconfigs/__tests__/table.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
@@ -91,10 +91,10 @@ const filter = Filter.fromString('rows=2');
 
 describe('Scan Config table tests', () => {
   test('should render', () => {
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
 
     const gmp = {
       settings: {},
@@ -133,10 +133,10 @@ describe('Scan Config table tests', () => {
   });
 
   test('should unfold all details', () => {
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
 
     const gmp = {
       settings: {},
@@ -172,10 +172,10 @@ describe('Scan Config table tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleScanConfigClone = vi.fn();
-    const handleScanConfigDelete = vi.fn();
-    const handleScanConfigDownload = vi.fn();
-    const handleScanConfigEdit = vi.fn();
+    const handleScanConfigClone = testing.fn();
+    const handleScanConfigDelete = testing.fn();
+    const handleScanConfigDownload = testing.fn();
+    const handleScanConfigEdit = testing.fn();
 
     const gmp = {
       settings: {},

--- a/src/web/pages/scanconfigs/__tests__/trend.jsx
+++ b/src/web/pages/scanconfigs/__tests__/trend.jsx
@@ -16,7 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 /* eslint-disable no-console */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {
   SCANCONFIG_TREND_DYNAMIC,
@@ -26,10 +26,6 @@ import {
 import {render} from 'web/utils/testing';
 
 import Trend from '../trend';
-
-import {setLocale} from 'gmp/locale/lang';
-
-setLocale('en');
 
 describe('Scan Config Trend tests', () => {
   test('should render', () => {

--- a/src/web/pages/scanners/__tests__/dialog.jsx
+++ b/src/web/pages/scanners/__tests__/dialog.jsx
@@ -16,10 +16,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
 
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
 import Credential, {
   USERNAME_PASSWORD_CREDENTIAL_TYPE,
   CLIENT_CERTIFICATE_CREDENTIAL_TYPE,
@@ -29,8 +27,6 @@ import Scanner, {GREENBONE_SENSOR_SCANNER_TYPE} from 'gmp/models/scanner';
 import {rendererWith, fireEvent} from 'web/utils/testing';
 
 import ScannerDialog from 'web/pages/scanners/dialog';
-
-setLocale('en');
 
 const sensorScanner = {
   _id: '1234',
@@ -68,10 +64,10 @@ describe('ScannerDialog component tests', () => {
   test('should render', () => {
     const elem = {_id: 'foo', type: GREENBONE_SENSOR_SCANNER_TYPE};
     const scanner = Scanner.fromElement(elem);
-    const handleClose = vi.fn();
-    const handleCredentialChange = vi.fn();
-    const handleSave = vi.fn();
-    const handleScannerTypeChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleCredentialChange = testing.fn();
+    const handleSave = testing.fn();
+    const handleScannerTypeChange = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -94,10 +90,10 @@ describe('ScannerDialog component tests', () => {
   test('should display default info', () => {
     const scanner = Scanner.fromElement(sensorScanner);
 
-    const handleClose = vi.fn();
-    const handleCredentialChange = vi.fn();
-    const handleSave = vi.fn();
-    const handleScannerTypeChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleCredentialChange = testing.fn();
+    const handleSave = testing.fn();
+    const handleScannerTypeChange = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -133,10 +129,10 @@ describe('ScannerDialog component tests', () => {
   test('should display value from props', () => {
     const scanner = Scanner.fromElement(sensorScanner);
 
-    const handleClose = vi.fn();
-    const handleCredentialChange = vi.fn();
-    const handleSave = vi.fn();
-    const handleScannerTypeChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleCredentialChange = testing.fn();
+    const handleSave = testing.fn();
+    const handleScannerTypeChange = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -174,10 +170,10 @@ describe('ScannerDialog component tests', () => {
 
   test('should save valid form state', () => {
     const scanner = Scanner.fromElement(sensorScanner);
-    const handleClose = vi.fn();
-    const handleCredentialChange = vi.fn();
-    const handleSave = vi.fn();
-    const handleScannerTypeChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleCredentialChange = testing.fn();
+    const handleSave = testing.fn();
+    const handleScannerTypeChange = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -218,10 +214,10 @@ describe('ScannerDialog component tests', () => {
   test('should change fields in create dialog', () => {
     const scanner = Scanner.fromElement(sensorScanner);
 
-    const handleClose = vi.fn();
-    const handleCredentialChange = vi.fn();
-    const handleSave = vi.fn();
-    const handleScannerTypeChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleCredentialChange = testing.fn();
+    const handleSave = testing.fn();
+    const handleScannerTypeChange = testing.fn();
 
     const {render} = rendererWith({gmp});
 
@@ -272,10 +268,10 @@ describe('ScannerDialog component tests', () => {
   test('should allow to close the dialog', () => {
     const elem = {_id: 'foo', type: GREENBONE_SENSOR_SCANNER_TYPE};
     const scanner = Scanner.fromElement(elem);
-    const handleClose = vi.fn();
-    const handleCredentialChange = vi.fn();
-    const handleSave = vi.fn();
-    const handleScannerTypeChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleCredentialChange = testing.fn();
+    const handleSave = testing.fn();
+    const handleScannerTypeChange = testing.fn();
 
     const {render} = rendererWith({gmp});
 

--- a/src/web/pages/schedules/__tests__/detailspage.jsx
+++ b/src/web/pages/schedules/__tests__/detailspage.jsx
@@ -15,17 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
-import {setLocale} from 'gmp/locale/lang';
-
 import Filter from 'gmp/models/filter';
 import Schedule from 'gmp/models/schedule';
-
-import {isDefined} from 'gmp/utils/identity';
 
 import {entityLoadingActions} from 'web/store/entities/schedules';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
@@ -33,13 +29,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import Detailspage, {ToolBarIcons} from '../detailspage';
-
-setLocale('en');
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
 
 const caps = new Capabilities(['everything']);
 
@@ -91,11 +80,11 @@ const noPermSchedule = Schedule.fromElement({
   _id: '23456',
 });
 
-const getSchedule = vi.fn().mockResolvedValue({
+const getSchedule = testing.fn().mockResolvedValue({
   data: schedule,
 });
 
-const getEntities = vi.fn().mockResolvedValue({
+const getEntities = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -103,11 +92,11 @@ const getEntities = vi.fn().mockResolvedValue({
   },
 });
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
@@ -254,15 +243,15 @@ describe('Schedule Detailspage tests', () => {
   });
 
   test('should call commands', async () => {
-    const clone = vi.fn().mockResolvedValue({
+    const clone = testing.fn().mockResolvedValue({
       data: {id: 'foo'},
     });
 
-    const deleteFunc = vi.fn().mockResolvedValue({
+    const deleteFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportFunc = vi.fn().mockResolvedValue({
+    const exportFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -327,11 +316,11 @@ describe('Schedule Detailspage tests', () => {
 
 describe('Schedule ToolBarIcons tests', () => {
   test('should render', () => {
-    const handleScheduleCloneClick = vi.fn();
-    const handleScheduleDeleteClick = vi.fn();
-    const handleScheduleDownloadClick = vi.fn();
-    const handleScheduleEditClick = vi.fn();
-    const handleScheduleCreateClick = vi.fn();
+    const handleScheduleCloneClick = testing.fn();
+    const handleScheduleDeleteClick = testing.fn();
+    const handleScheduleDownloadClick = testing.fn();
+    const handleScheduleEditClick = testing.fn();
+    const handleScheduleCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -365,11 +354,11 @@ describe('Schedule ToolBarIcons tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleScheduleCloneClick = vi.fn();
-    const handleScheduleDeleteClick = vi.fn();
-    const handleScheduleDownloadClick = vi.fn();
-    const handleScheduleEditClick = vi.fn();
-    const handleScheduleCreateClick = vi.fn();
+    const handleScheduleCloneClick = testing.fn();
+    const handleScheduleDeleteClick = testing.fn();
+    const handleScheduleDownloadClick = testing.fn();
+    const handleScheduleEditClick = testing.fn();
+    const handleScheduleCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -413,11 +402,11 @@ describe('Schedule ToolBarIcons tests', () => {
   });
 
   test('should not call click handlers without permission', () => {
-    const handleScheduleCloneClick = vi.fn();
-    const handleScheduleDeleteClick = vi.fn();
-    const handleScheduleDownloadClick = vi.fn();
-    const handleScheduleEditClick = vi.fn();
-    const handleScheduleCreateClick = vi.fn();
+    const handleScheduleCloneClick = testing.fn();
+    const handleScheduleDeleteClick = testing.fn();
+    const handleScheduleDownloadClick = testing.fn();
+    const handleScheduleEditClick = testing.fn();
+    const handleScheduleCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -467,11 +456,11 @@ describe('Schedule ToolBarIcons tests', () => {
   });
 
   test('should (not) call click handlers for schedule in use', () => {
-    const handleScheduleCloneClick = vi.fn();
-    const handleScheduleDeleteClick = vi.fn();
-    const handleScheduleDownloadClick = vi.fn();
-    const handleScheduleEditClick = vi.fn();
-    const handleScheduleCreateClick = vi.fn();
+    const handleScheduleCloneClick = testing.fn();
+    const handleScheduleDeleteClick = testing.fn();
+    const handleScheduleDownloadClick = testing.fn();
+    const handleScheduleEditClick = testing.fn();
+    const handleScheduleCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 

--- a/src/web/pages/schedules/__tests__/dialog.jsx
+++ b/src/web/pages/schedules/__tests__/dialog.jsx
@@ -15,23 +15,20 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
-import {setLocale} from 'gmp/locale/lang';
 import Schedule from 'gmp/models/schedule';
 
 import {render, fireEvent, screen} from 'web/utils/testing';
 
 import ScheduleDialog from '../dialog';
 
-setLocale('en');
-
 let handleSave;
 let handleClose;
 
 beforeEach(() => {
-  handleSave = vi.fn();
-  handleClose = vi.fn();
+  handleSave = testing.fn();
+  handleClose = testing.fn();
 });
 
 const schedule = Schedule.fromElement({

--- a/src/web/pages/schedules/__tests__/listpage.jsx
+++ b/src/web/pages/schedules/__tests__/listpage.jsx
@@ -15,12 +15,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
-
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 import Schedule from 'gmp/models/schedule';
@@ -34,10 +32,6 @@ import {loadingActions} from 'web/store/usersettings/defaults/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import SchedulePage, {ToolBarIcons} from '../listpage';
-
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
 
 const schedule = Schedule.fromElement({
   comment: 'hello world',
@@ -60,15 +54,15 @@ const wrongCaps = new Capabilities(['get_config']);
 const reloadInterval = -1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getSetting = vi.fn().mockResolvedValue({
+const getSetting = testing.fn().mockResolvedValue({
   filter: null,
 });
 
-const getFilters = vi.fn().mockReturnValue(
+const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
     meta: {
@@ -78,7 +72,7 @@ const getFilters = vi.fn().mockReturnValue(
   }),
 );
 
-const getSchedules = vi.fn().mockResolvedValue({
+const getSchedules = testing.fn().mockResolvedValue({
   data: [schedule],
   meta: {
     filter: Filter.fromString(),
@@ -86,7 +80,7 @@ const getSchedules = vi.fn().mockResolvedValue({
   },
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
@@ -181,11 +175,11 @@ describe('SchedulePage tests', () => {
     expect(screen.getAllByTitle('Export Schedule')[0]).toBeInTheDocument();
   });
   test('should allow to bulk action on page contents', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -257,11 +251,11 @@ describe('SchedulePage tests', () => {
   });
 
   test('should allow to bulk action on selected schedules', async () => {
-    const deleteByIds = vi.fn().mockResolvedValue({
+    const deleteByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByIds = vi.fn().mockResolvedValue({
+    const exportByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -348,11 +342,11 @@ describe('SchedulePage tests', () => {
   });
 
   test('should allow to bulk action on filtered schedules', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -437,7 +431,7 @@ describe('SchedulePage tests', () => {
 
 describe('SchedulePage ToolBarIcons test', () => {
   test('should render', () => {
-    const handleScheduleCreateClick = vi.fn();
+    const handleScheduleCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -463,7 +457,7 @@ describe('SchedulePage ToolBarIcons test', () => {
   });
 
   test('should call click handlers', () => {
-    const handleScheduleCreateClick = vi.fn();
+    const handleScheduleCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -486,7 +480,7 @@ describe('SchedulePage ToolBarIcons test', () => {
   });
 
   test('should not show icons if user does not have the right permissions', () => {
-    const handleScheduleCreateClick = vi.fn();
+    const handleScheduleCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},

--- a/src/web/pages/start/__tests__/page.jsx
+++ b/src/web/pages/start/__tests__/page.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
@@ -29,13 +27,9 @@ import {rendererWith, screen} from 'web/utils/testing';
 
 import StartPage from '../page';
 
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
-
 const manualUrl = 'test/';
 
-const getFilters = vi.fn().mockReturnValue(
+const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
     meta: {
@@ -45,7 +39,7 @@ const getFilters = vi.fn().mockReturnValue(
   }),
 );
 
-const getDashboardSetting = vi.fn().mockResolvedValue({
+const getDashboardSetting = testing.fn().mockResolvedValue({
   data: {defaults: {foo: 'bar'}},
   meta: {
     filter: Filter.fromString(),
@@ -53,9 +47,9 @@ const getDashboardSetting = vi.fn().mockResolvedValue({
   },
 });
 
-const saveDashboardSetting = vi.fn().mockResolvedValue({foo: 'bar'});
+const saveDashboardSetting = testing.fn().mockResolvedValue({foo: 'bar'});
 
-const getAggregates = vi.fn().mockResolvedValue({
+const getAggregates = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),

--- a/src/web/pages/targets/__tests__/details.jsx
+++ b/src/web/pages/targets/__tests__/details.jsx
@@ -15,17 +15,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 import Target from 'gmp/models/target';
 
 import {rendererWith} from 'web/utils/testing';
 
 import Details from '../details';
-
-setLocale('en');
 
 const target_elevate = Target.fromElement({
   _id: 'foo',

--- a/src/web/pages/targets/__tests__/detailspage.jsx
+++ b/src/web/pages/targets/__tests__/detailspage.jsx
@@ -15,17 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
-import {setLocale} from 'gmp/locale/lang';
-
 import Filter from 'gmp/models/filter';
 import Target from 'gmp/models/target';
-
-import {isDefined} from 'gmp/utils/identity';
 
 import {entityLoadingActions} from 'web/store/entities/targets';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
@@ -33,13 +29,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import Detailspage, {ToolBarIcons} from '../detailspage';
-
-setLocale('en');
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
 
 const caps = new Capabilities(['everything']);
 
@@ -52,11 +41,11 @@ let currentSettings;
 let renewSession;
 
 beforeEach(() => {
-  getTarget = vi.fn().mockResolvedValue({
+  getTarget = testing.fn().mockResolvedValue({
     data: target,
   });
 
-  getEntities = vi.fn().mockResolvedValue({
+  getEntities = testing.fn().mockResolvedValue({
     data: [],
     meta: {
       filter: Filter.fromString(),
@@ -64,11 +53,11 @@ beforeEach(() => {
     },
   });
 
-  currentSettings = vi.fn().mockResolvedValue({
+  currentSettings = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 
-  renewSession = vi.fn().mockResolvedValue({
+  renewSession = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 });
@@ -342,15 +331,15 @@ describe('Target Detailspage tests', () => {
   });
 
   test('should call commands', async () => {
-    const clone = vi.fn().mockResolvedValue({
+    const clone = testing.fn().mockResolvedValue({
       data: {id: 'foo'},
     });
 
-    const deleteFunc = vi.fn().mockResolvedValue({
+    const deleteFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportFunc = vi.fn().mockResolvedValue({
+    const exportFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -415,11 +404,11 @@ describe('Target Detailspage tests', () => {
 
 describe('Target ToolBarIcons tests', () => {
   test('should render', () => {
-    const handleTargetCloneClick = vi.fn();
-    const handleTargetDeleteClick = vi.fn();
-    const handleTargetDownloadClick = vi.fn();
-    const handleTargetEditClick = vi.fn();
-    const handleTargetCreateClick = vi.fn();
+    const handleTargetCloneClick = testing.fn();
+    const handleTargetDeleteClick = testing.fn();
+    const handleTargetDownloadClick = testing.fn();
+    const handleTargetEditClick = testing.fn();
+    const handleTargetCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -453,11 +442,11 @@ describe('Target ToolBarIcons tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleTargetCloneClick = vi.fn();
-    const handleTargetDeleteClick = vi.fn();
-    const handleTargetDownloadClick = vi.fn();
-    const handleTargetEditClick = vi.fn();
-    const handleTargetCreateClick = vi.fn();
+    const handleTargetCloneClick = testing.fn();
+    const handleTargetDeleteClick = testing.fn();
+    const handleTargetDownloadClick = testing.fn();
+    const handleTargetEditClick = testing.fn();
+    const handleTargetCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -501,11 +490,11 @@ describe('Target ToolBarIcons tests', () => {
   });
 
   test('should not call click handlers without permission', () => {
-    const handleTargetCloneClick = vi.fn();
-    const handleTargetDeleteClick = vi.fn();
-    const handleTargetDownloadClick = vi.fn();
-    const handleTargetEditClick = vi.fn();
-    const handleTargetCreateClick = vi.fn();
+    const handleTargetCloneClick = testing.fn();
+    const handleTargetDeleteClick = testing.fn();
+    const handleTargetDownloadClick = testing.fn();
+    const handleTargetEditClick = testing.fn();
+    const handleTargetCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 
@@ -555,11 +544,11 @@ describe('Target ToolBarIcons tests', () => {
   });
 
   test('should (not) call click handlers for target in use', () => {
-    const handleTargetCloneClick = vi.fn();
-    const handleTargetDeleteClick = vi.fn();
-    const handleTargetDownloadClick = vi.fn();
-    const handleTargetEditClick = vi.fn();
-    const handleTargetCreateClick = vi.fn();
+    const handleTargetCloneClick = testing.fn();
+    const handleTargetDeleteClick = testing.fn();
+    const handleTargetDownloadClick = testing.fn();
+    const handleTargetEditClick = testing.fn();
+    const handleTargetCreateClick = testing.fn();
 
     const gmp = {settings: {manualUrl}};
 

--- a/src/web/pages/targets/__tests__/dialog.jsx
+++ b/src/web/pages/targets/__tests__/dialog.jsx
@@ -15,10 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
 
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
 import Credential, {
   USERNAME_PASSWORD_CREDENTIAL_TYPE,
   CLIENT_CERTIFICATE_CREDENTIAL_TYPE,
@@ -28,8 +26,6 @@ import Credential, {
 import {rendererWith, fireEvent, screen} from 'web/utils/testing';
 
 import TargetDialog from 'web/pages/targets/dialog';
-
-setLocale('en');
 
 const cred1 = Credential.fromElement({
   _id: '5678',
@@ -61,10 +57,10 @@ const gmp = {settings: {enableGreenboneSensor: true}};
 
 describe('TargetDialog component tests', () => {
   test('should render with default values', () => {
-    const handleClose = vi.fn();
-    const handleChange = vi.fn();
-    const handleSave = vi.fn();
-    const handleCreate = vi.fn();
+    const handleClose = testing.fn();
+    const handleChange = testing.fn();
+    const handleSave = testing.fn();
+    const handleCreate = testing.fn();
 
     const {render} = rendererWith({gmp, capabilities: true});
 
@@ -199,10 +195,10 @@ describe('TargetDialog component tests', () => {
   });
 
   test('should display value from props', () => {
-    const handleClose = vi.fn();
-    const handleChange = vi.fn();
-    const handleSave = vi.fn();
-    const handleCreate = vi.fn();
+    const handleClose = testing.fn();
+    const handleChange = testing.fn();
+    const handleSave = testing.fn();
+    const handleCreate = testing.fn();
 
     const {render} = rendererWith({gmp, capabilities: true});
 
@@ -347,10 +343,10 @@ describe('TargetDialog component tests', () => {
   });
 
   test('should allow to change values and save the dialog', () => {
-    const handleClose = vi.fn();
-    const handleChange = vi.fn();
-    const handleSave = vi.fn();
-    const handleCreate = vi.fn();
+    const handleClose = testing.fn();
+    const handleChange = testing.fn();
+    const handleSave = testing.fn();
+    const handleCreate = testing.fn();
 
     const {render} = rendererWith({gmp, capabilities: true});
 
@@ -428,10 +424,10 @@ describe('TargetDialog component tests', () => {
   });
 
   test('should render elevate privilege option if ssh credential is defined', () => {
-    const handleClose = vi.fn();
-    const handleChange = vi.fn();
-    const handleSave = vi.fn();
-    const handleCreate = vi.fn();
+    const handleClose = testing.fn();
+    const handleChange = testing.fn();
+    const handleSave = testing.fn();
+    const handleCreate = testing.fn();
 
     const {render} = rendererWith({gmp, capabilities: true});
 
@@ -476,10 +472,10 @@ describe('TargetDialog component tests', () => {
   });
 
   test('ssh elevate credential dropdown should only allow username + password options and remove ssh credential from list', () => {
-    const handleClose = vi.fn();
-    const handleChange = vi.fn();
-    const handleSave = vi.fn();
-    const handleCreate = vi.fn();
+    const handleClose = testing.fn();
+    const handleChange = testing.fn();
+    const handleSave = testing.fn();
+    const handleCreate = testing.fn();
 
     const {render} = rendererWith({gmp, capabilities: true});
 
@@ -532,10 +528,10 @@ describe('TargetDialog component tests', () => {
   });
 
   test('ssh credential dropdown should remove ssh elevate credential from list', () => {
-    const handleClose = vi.fn();
-    const handleChange = vi.fn();
-    const handleSave = vi.fn();
-    const handleCreate = vi.fn();
+    const handleClose = testing.fn();
+    const handleChange = testing.fn();
+    const handleSave = testing.fn();
+    const handleCreate = testing.fn();
 
     const {render} = rendererWith({gmp, capabilities: true});
 
@@ -589,10 +585,10 @@ describe('TargetDialog component tests', () => {
   });
 
   test('should disable editing certain fields if target is in use', () => {
-    const handleClose = vi.fn();
-    const handleChange = vi.fn();
-    const handleSave = vi.fn();
-    const handleCreate = vi.fn();
+    const handleClose = testing.fn();
+    const handleChange = testing.fn();
+    const handleSave = testing.fn();
+    const handleCreate = testing.fn();
 
     const {render} = rendererWith({gmp, capabilities: true});
 
@@ -653,10 +649,10 @@ describe('TargetDialog component tests', () => {
   });
 
   test('should allow to close the dialog', () => {
-    const handleClose = vi.fn();
-    const handleChange = vi.fn();
-    const handleSave = vi.fn();
-    const handleCreate = vi.fn();
+    const handleClose = testing.fn();
+    const handleChange = testing.fn();
+    const handleSave = testing.fn();
+    const handleCreate = testing.fn();
 
     const {render} = rendererWith({gmp, capabilities: true});
 

--- a/src/web/pages/targets/__tests__/listpage.jsx
+++ b/src/web/pages/targets/__tests__/listpage.jsx
@@ -15,12 +15,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
-
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 import Target from 'gmp/models/target';
@@ -35,10 +33,6 @@ import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import TargetPage, {ToolBarIcons} from '../listpage';
 
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
-
 let currentSettings;
 let getSetting;
 let getFilters;
@@ -46,15 +40,15 @@ let getTargets;
 let renewSession;
 
 beforeEach(() => {
-  currentSettings = vi.fn().mockResolvedValue({
+  currentSettings = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 
-  getSetting = vi.fn().mockResolvedValue({
+  getSetting = testing.fn().mockResolvedValue({
     filter: null,
   });
 
-  getFilters = vi.fn().mockReturnValue(
+  getFilters = testing.fn().mockReturnValue(
     Promise.resolve({
       data: [],
       meta: {
@@ -64,7 +58,7 @@ beforeEach(() => {
     }),
   );
 
-  getTargets = vi.fn().mockResolvedValue({
+  getTargets = testing.fn().mockResolvedValue({
     data: [target],
     meta: {
       filter: Filter.fromString(),
@@ -72,7 +66,7 @@ beforeEach(() => {
     },
   });
 
-  renewSession = vi.fn().mockResolvedValue({
+  renewSession = testing.fn().mockResolvedValue({
     foo: 'bar',
   });
 });
@@ -212,11 +206,11 @@ describe('TargetPage tests', () => {
     expect(screen.getAllByTitle('Export Target')[0]).toBeInTheDocument();
   });
   test('should allow to bulk action on page contents', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -289,11 +283,11 @@ describe('TargetPage tests', () => {
 
   test('should allow to bulk action on selected targets', async () => {
     // mock cache issues will cause these tests to randomly fail. Will fix later.
-    const deleteByIds = vi.fn().mockResolvedValue({
+    const deleteByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByIds = vi.fn().mockResolvedValue({
+    const exportByIds = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -381,11 +375,11 @@ describe('TargetPage tests', () => {
 
   test('should allow to bulk action on filtered targets', async () => {
     // mock cache issues will cause these tests to randomly fail. Will fix later.
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -470,7 +464,7 @@ describe('TargetPage tests', () => {
 
 describe('TargetPage ToolBarIcons test', () => {
   test('should render', () => {
-    const handleTargetCreateClick = vi.fn();
+    const handleTargetCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -496,7 +490,7 @@ describe('TargetPage ToolBarIcons test', () => {
   });
 
   test('should call click handlers', () => {
-    const handleTargetCreateClick = vi.fn();
+    const handleTargetCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -519,7 +513,7 @@ describe('TargetPage ToolBarIcons test', () => {
   });
 
   test('should not show icons if user does not have the right permissions', () => {
-    const handleTargetCreateClick = vi.fn();
+    const handleTargetCreateClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},

--- a/src/web/pages/targets/__tests__/row.jsx
+++ b/src/web/pages/targets/__tests__/row.jsx
@@ -17,10 +17,9 @@
  */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-console */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 
 import Target from 'gmp/models/target';
 
@@ -29,8 +28,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent, screen} from 'web/utils/testing';
 
 import Row from '../row';
-
-setLocale('en');
 
 const gmp = {settings: {}};
 const caps = new Capabilities(['everything']);
@@ -189,11 +186,11 @@ describe('Target row tests', () => {
   console.error = () => {};
 
   test('should render', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleTargetCloneClick = vi.fn();
-    const handleTargetDeleteClick = vi.fn();
-    const handleTargetDownloadClick = vi.fn();
-    const handleTargetEditClick = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleTargetCloneClick = testing.fn();
+    const handleTargetDeleteClick = testing.fn();
+    const handleTargetDownloadClick = testing.fn();
+    const handleTargetEditClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -242,11 +239,11 @@ describe('Target row tests', () => {
   });
 
   test('should render ssh elevate credential', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleTargetCloneClick = vi.fn();
-    const handleTargetDeleteClick = vi.fn();
-    const handleTargetDownloadClick = vi.fn();
-    const handleTargetEditClick = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleTargetCloneClick = testing.fn();
+    const handleTargetDeleteClick = testing.fn();
+    const handleTargetDownloadClick = testing.fn();
+    const handleTargetEditClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -292,11 +289,11 @@ describe('Target row tests', () => {
   });
 
   test('should render with undefined portlist', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleTargetCloneClick = vi.fn();
-    const handleTargetDeleteClick = vi.fn();
-    const handleTargetDownloadClick = vi.fn();
-    const handleTargetEditClick = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleTargetCloneClick = testing.fn();
+    const handleTargetDeleteClick = testing.fn();
+    const handleTargetDownloadClick = testing.fn();
+    const handleTargetEditClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -330,11 +327,11 @@ describe('Target row tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleToggleDetailsClick = vi.fn();
-    const handleTargetCloneClick = vi.fn();
-    const handleTargetDeleteClick = vi.fn();
-    const handleTargetDownloadClick = vi.fn();
-    const handleTargetEditClick = vi.fn();
+    const handleToggleDetailsClick = testing.fn();
+    const handleTargetCloneClick = testing.fn();
+    const handleTargetDeleteClick = testing.fn();
+    const handleTargetDownloadClick = testing.fn();
+    const handleTargetEditClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,

--- a/src/web/pages/tasks/__tests__/actions.jsx
+++ b/src/web/pages/tasks/__tests__/actions.jsx
@@ -16,17 +16,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 /* eslint-disable no-console */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
+import Task, {TASK_STATUS} from 'gmp/models/task';
 
 import {rendererWith, fireEvent} from 'web/utils/testing';
 
 import Actions from '../actions';
-import Task, {TASK_STATUS} from 'gmp/models/task';
-
-setLocale('en');
 
 const caps = new Capabilities(['everything']);
 const wrongCaps = new Capabilities(['get_task']);
@@ -45,14 +42,14 @@ describe('Task Actions tests', () => {
       target: {_id: 'id', name: 'target'},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
     const {baseElement} = render(
@@ -82,14 +79,14 @@ describe('Task Actions tests', () => {
       target: {_id: 'id', name: 'target'},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
     const {getAllByTestId} = render(
@@ -143,14 +140,14 @@ describe('Task Actions tests', () => {
       target: {_id: 'id', name: 'target'},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const {render} = rendererWith({capabilities: wrongCaps});
     const {getAllByTestId} = render(
@@ -213,14 +210,14 @@ describe('Task Actions tests', () => {
       target: {_id: 'id', name: 'target'},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const {render} = rendererWith({capabilities: wrongCaps});
     const {getAllByTestId} = render(
@@ -286,14 +283,14 @@ describe('Task Actions tests', () => {
       target: {_id: 'id', name: 'target'},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const {render} = rendererWith({capabilities: wrongCaps});
     const {getAllByTestId} = render(
@@ -353,14 +350,14 @@ describe('Task Actions tests', () => {
       target: {_id: 'id', name: 'target'},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
     const {getAllByTestId} = render(
@@ -414,14 +411,14 @@ describe('Task Actions tests', () => {
       target: {_id: 'id', name: 'target'},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
     const {getAllByTestId} = render(
@@ -480,14 +477,14 @@ describe('Task Actions tests', () => {
       },
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const {render} = rendererWith({
       capabilities: caps,
@@ -529,14 +526,14 @@ describe('Task Actions tests', () => {
       permissions: {permission: [{name: 'everything'}]},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
     const {getAllByTestId} = render(

--- a/src/web/pages/tasks/__tests__/autodeletereportsgroup.jsx
+++ b/src/web/pages/tasks/__tests__/autodeletereportsgroup.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -28,7 +28,7 @@ import {
 
 describe('AutoDeleteReportsGroup tests', () => {
   test('should render dialog group', () => {
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
 
     const {element} = render(
       <AutoDeleteReportsGroup
@@ -42,7 +42,7 @@ describe('AutoDeleteReportsGroup tests', () => {
   });
 
   test('should allow to change auto delete no', () => {
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
 
     const {queryAllByTestId} = render(
       <AutoDeleteReportsGroup
@@ -60,7 +60,7 @@ describe('AutoDeleteReportsGroup tests', () => {
   });
 
   test('should allow to change auto delete keep', () => {
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
 
     const {queryAllByTestId} = render(
       <AutoDeleteReportsGroup
@@ -78,7 +78,7 @@ describe('AutoDeleteReportsGroup tests', () => {
   });
 
   test('should allow to change auto delete keep value', () => {
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
 
     const {getByTestId} = render(
       <AutoDeleteReportsGroup
@@ -96,7 +96,7 @@ describe('AutoDeleteReportsGroup tests', () => {
   });
 
   test('should keep auto delete keep value in range 2-1200', () => {
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
 
     const {getByTestId} = render(
       <AutoDeleteReportsGroup
@@ -122,7 +122,7 @@ describe('AutoDeleteReportsGroup tests', () => {
   });
 
   test('should not allow to change auto delete keep value', () => {
-    const handleChange = vi.fn();
+    const handleChange = testing.fn();
 
     const {getByTestId} = render(
       <AutoDeleteReportsGroup

--- a/src/web/pages/tasks/__tests__/containerdialog.jsx
+++ b/src/web/pages/tasks/__tests__/containerdialog.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent} from 'web/utils/testing';
 
@@ -24,8 +24,8 @@ import Task from 'gmp/models/task';
 
 describe('ContainerDialog tests', () => {
   test('should render create dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {baseElement} = render(
       <ContainerDialog onClose={handleClose} onSave={handleSave} />,
@@ -36,8 +36,8 @@ describe('ContainerDialog tests', () => {
 
   test('should render edit dialog', () => {
     const task = Task.fromElement({name: 'foo', _id: 't1'});
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {baseElement} = render(
       <ContainerDialog task={task} onClose={handleClose} onSave={handleSave} />,
@@ -47,8 +47,8 @@ describe('ContainerDialog tests', () => {
   });
 
   test('should change fields in create dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByName, getByTestId} = render(
       <ContainerDialog
@@ -78,8 +78,8 @@ describe('ContainerDialog tests', () => {
 
   test('should change fields in edit dialog', () => {
     const task = Task.fromElement({name: 'foo', _id: 't1'});
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByName, queryAllByName, getByTestId} = render(
       <ContainerDialog
@@ -112,8 +112,8 @@ describe('ContainerDialog tests', () => {
   });
 
   test('should allow to close the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByTestId} = render(
       <ContainerDialog

--- a/src/web/pages/tasks/__tests__/details.jsx
+++ b/src/web/pages/tasks/__tests__/details.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -31,8 +29,6 @@ import {entityLoadingActions as scheduleActions} from 'web/store/entities/schedu
 import {rendererWith} from 'web/utils/testing';
 
 import Details from '../details';
-
-setLocale('en');
 
 const config = ScanConfig.fromElement({
   _id: '314',
@@ -88,13 +84,13 @@ const preferences = {
 
 const schedule = Schedule.fromElement({_id: '121314', name: 'schedule1'});
 
-const getConfig = vi.fn().mockReturnValue(
+const getConfig = testing.fn().mockReturnValue(
   Promise.resolve({
     data: config,
   }),
 );
 
-const getSchedule = vi.fn().mockReturnValue(
+const getSchedule = testing.fn().mockReturnValue(
   Promise.resolve({
     data: schedule,
   }),

--- a/src/web/pages/tasks/__tests__/detailspage.jsx
+++ b/src/web/pages/tasks/__tests__/detailspage.jsx
@@ -15,12 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-import {act} from 'react-dom/test-utils';
-
-import {setLocale} from 'gmp/locale/lang';
-
-import {isDefined} from 'gmp/utils/identity';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
@@ -33,16 +28,9 @@ import ScanConfig from 'gmp/models/scanconfig';
 import {entityLoadingActions} from 'web/store/entities/tasks';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 
-import {rendererWith, fireEvent} from 'web/utils/testing';
+import {rendererWith, fireEvent, act} from 'web/utils/testing';
 
 import Detailspage, {ToolBarIcons} from '../detailspage';
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
-
-setLocale('en');
 
 const config = ScanConfig.fromElement({
   _id: '314',
@@ -279,23 +267,23 @@ const caps = new Capabilities(['everything']);
 const reloadInterval = 1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getConfig = vi.fn().mockResolvedValue({
+const getConfig = testing.fn().mockResolvedValue({
   data: config,
 });
 
-const getSchedule = vi.fn().mockResolvedValue({
+const getSchedule = testing.fn().mockResolvedValue({
   data: schedule,
 });
 
-const getEntities = vi.fn().mockResolvedValue({
+const getEntities = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -305,7 +293,7 @@ const getEntities = vi.fn().mockResolvedValue({
 
 describe('Task Detailspage tests', () => {
   test('should render full Detailspage', () => {
-    const getTask = vi.fn().mockResolvedValue({
+    const getTask = testing.fn().mockResolvedValue({
       data: task,
     });
 
@@ -406,11 +394,11 @@ describe('Task Detailspage tests', () => {
   });
 
   test('should render user tags tab', () => {
-    const getTask = vi.fn().mockResolvedValue({
+    const getTask = testing.fn().mockResolvedValue({
       data: task2,
     });
 
-    const getTags = vi.fn().mockResolvedValue({
+    const getTags = testing.fn().mockResolvedValue({
       data: [],
       meta: {
         filter: Filter.fromString(),
@@ -471,7 +459,7 @@ describe('Task Detailspage tests', () => {
   });
 
   test('should render permissions tab', () => {
-    const getTask = vi.fn().mockResolvedValue({
+    const getTask = testing.fn().mockResolvedValue({
       data: task2,
     });
 
@@ -525,27 +513,27 @@ describe('Task Detailspage tests', () => {
   });
 
   test('should call commands', async () => {
-    const getTask = vi.fn().mockResolvedValue({
+    const getTask = testing.fn().mockResolvedValue({
       data: task5,
     });
 
-    const clone = vi.fn().mockResolvedValue({
+    const clone = testing.fn().mockResolvedValue({
       data: {id: 'foo'},
     });
 
-    const deleteFunc = vi.fn().mockResolvedValue({
+    const deleteFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportFunc = vi.fn().mockResolvedValue({
+    const exportFunc = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const start = vi.fn().mockResolvedValue({
+    const start = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const resume = vi.fn().mockResolvedValue({
+    const resume = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -626,16 +614,16 @@ describe('Task Detailspage tests', () => {
 
 describe('Task ToolBarIcons tests', () => {
   test('should render', () => {
-    const handleReportImport = vi.fn();
-    const handleTaskCreate = vi.fn();
-    const handleContainerTaskCreate = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskCreate = testing.fn();
+    const handleContainerTaskCreate = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -681,16 +669,16 @@ describe('Task ToolBarIcons tests', () => {
   });
 
   test('should call click handlers for new task', () => {
-    const handleReportImport = vi.fn();
-    const handleTaskCreate = vi.fn();
-    const handleContainerTaskCreate = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskCreate = testing.fn();
+    const handleContainerTaskCreate = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -776,16 +764,16 @@ describe('Task ToolBarIcons tests', () => {
   });
 
   test('should call click handlers for running task', () => {
-    const handleReportImport = vi.fn();
-    const handleTaskCreate = vi.fn();
-    const handleContainerTaskCreate = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskCreate = testing.fn();
+    const handleContainerTaskCreate = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -878,16 +866,16 @@ describe('Task ToolBarIcons tests', () => {
   });
 
   test('should call click handlers for stopped task', () => {
-    const handleReportImport = vi.fn();
-    const handleTaskCreate = vi.fn();
-    const handleContainerTaskCreate = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskCreate = testing.fn();
+    const handleContainerTaskCreate = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -979,16 +967,16 @@ describe('Task ToolBarIcons tests', () => {
   });
 
   test('should call click handlers for finished task', () => {
-    const handleReportImport = vi.fn();
-    const handleTaskCreate = vi.fn();
-    const handleContainerTaskCreate = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskCreate = testing.fn();
+    const handleContainerTaskCreate = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -1082,16 +1070,16 @@ describe('Task ToolBarIcons tests', () => {
   });
 
   test('should not call click handlers without permission', () => {
-    const handleReportImport = vi.fn();
-    const handleTaskCreate = vi.fn();
-    const handleContainerTaskCreate = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskCreate = testing.fn();
+    const handleContainerTaskCreate = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -1189,16 +1177,16 @@ describe('Task ToolBarIcons tests', () => {
   });
 
   test('should render schedule icon if task is scheduled', () => {
-    const handleReportImport = vi.fn();
-    const handleTaskCreate = vi.fn();
-    const handleContainerTaskCreate = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskCreate = testing.fn();
+    const handleContainerTaskCreate = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -1246,16 +1234,16 @@ describe('Task ToolBarIcons tests', () => {
   });
 
   test('should call click handlers for container task', () => {
-    const handleReportImport = vi.fn();
-    const handleTaskCreate = vi.fn();
-    const handleContainerTaskCreate = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskCreate = testing.fn();
+    const handleContainerTaskCreate = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
 
     const gmp = {
       settings: {manualUrl},

--- a/src/web/pages/tasks/__tests__/listpage.jsx
+++ b/src/web/pages/tasks/__tests__/listpage.jsx
@@ -15,10 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-import {act} from 'react-dom/test-utils';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
@@ -31,13 +28,9 @@ import {entitiesLoadingActions} from 'web/store/entities/tasks';
 import {loadingActions} from 'web/store/usersettings/defaults/actions';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
 
-import {rendererWith, waitFor, fireEvent} from 'web/utils/testing';
+import {rendererWith, waitFor, fireEvent, act} from 'web/utils/testing';
 
 import TaskPage, {ToolBarIcons} from '../listpage';
-
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
 
 const lastReport = {
   report: {
@@ -66,11 +59,11 @@ const wrongCaps = new Capabilities(['get_config']);
 const reloadInterval = 1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getFilters = vi.fn().mockReturnValue(
+const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
     meta: {
@@ -80,7 +73,7 @@ const getFilters = vi.fn().mockReturnValue(
   }),
 );
 
-const getDashboardSetting = vi.fn().mockResolvedValue({
+const getDashboardSetting = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -88,11 +81,11 @@ const getDashboardSetting = vi.fn().mockResolvedValue({
   },
 });
 
-const getUserSetting = vi.fn().mockResolvedValue({
+const getUserSetting = testing.fn().mockResolvedValue({
   filter: null,
 });
 
-const getAggregates = vi.fn().mockResolvedValue({
+const getAggregates = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -100,7 +93,7 @@ const getAggregates = vi.fn().mockResolvedValue({
   },
 });
 
-const getTasks = vi.fn().mockResolvedValue({
+const getTasks = testing.fn().mockResolvedValue({
   data: [task],
   meta: {
     filter: Filter.fromString(),
@@ -108,7 +101,7 @@ const getTasks = vi.fn().mockResolvedValue({
   },
 });
 
-const getReportFormats = vi.fn().mockResolvedValue({
+const getReportFormats = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -116,7 +109,7 @@ const getReportFormats = vi.fn().mockResolvedValue({
   },
 });
 
-const renewSession = vi.fn().mockResolvedValue({
+const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
@@ -229,11 +222,11 @@ describe('TaskPage tests', () => {
   });
 
   test('should call commands for bulk actions', async () => {
-    const deleteByFilter = vi.fn().mockResolvedValue({
+    const deleteByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
-    const exportByFilter = vi.fn().mockResolvedValue({
+    const exportByFilter = testing.fn().mockResolvedValue({
       foo: 'bar',
     });
 
@@ -312,11 +305,11 @@ describe('TaskPage tests', () => {
 
 describe('TaskPage ToolBarIcons test', () => {
   test('should render', () => {
-    const handleAdvancedTaskWizardClick = vi.fn();
-    const handleModifyTaskWizardClick = vi.fn();
-    const handleContainerTaskCreateClick = vi.fn();
-    const handleTaskCreateClick = vi.fn();
-    const handleTaskWizardClick = vi.fn();
+    const handleAdvancedTaskWizardClick = testing.fn();
+    const handleModifyTaskWizardClick = testing.fn();
+    const handleContainerTaskCreateClick = testing.fn();
+    const handleTaskCreateClick = testing.fn();
+    const handleTaskWizardClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -350,11 +343,11 @@ describe('TaskPage ToolBarIcons test', () => {
   });
 
   test('should call click handlers', () => {
-    const handleAdvancedTaskWizardClick = vi.fn();
-    const handleModifyTaskWizardClick = vi.fn();
-    const handleContainerTaskCreateClick = vi.fn();
-    const handleTaskCreateClick = vi.fn();
-    const handleTaskWizardClick = vi.fn();
+    const handleAdvancedTaskWizardClick = testing.fn();
+    const handleModifyTaskWizardClick = testing.fn();
+    const handleContainerTaskCreateClick = testing.fn();
+    const handleTaskCreateClick = testing.fn();
+    const handleTaskWizardClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},
@@ -400,11 +393,11 @@ describe('TaskPage ToolBarIcons test', () => {
   });
 
   test('should not show icons if user does not have the right permissions', () => {
-    const handleAdvancedTaskWizardClick = vi.fn();
-    const handleModifyTaskWizardClick = vi.fn();
-    const handleContainerTaskCreateClick = vi.fn();
-    const handleTaskCreateClick = vi.fn();
-    const handleTaskWizardClick = vi.fn();
+    const handleAdvancedTaskWizardClick = testing.fn();
+    const handleModifyTaskWizardClick = testing.fn();
+    const handleContainerTaskCreateClick = testing.fn();
+    const handleTaskCreateClick = testing.fn();
+    const handleTaskWizardClick = testing.fn();
 
     const gmp = {
       settings: {manualUrl},

--- a/src/web/pages/tasks/__tests__/row.jsx
+++ b/src/web/pages/tasks/__tests__/row.jsx
@@ -16,10 +16,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 /* eslint-disable no-console */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 
 import Task, {TASK_STATUS} from 'gmp/models/task';
 import {GREENBONE_SENSOR_SCANNER_TYPE} from 'gmp/models/scanner';
@@ -29,8 +28,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent} from 'web/utils/testing';
 
 import Row from '../row';
-
-setLocale('en');
 
 const gmp = {settings: {}};
 const caps = new Capabilities(['everything']);
@@ -71,15 +68,15 @@ describe('Task Row tests', () => {
       target: {_id: '5678', name: 'target'},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -183,15 +180,15 @@ describe('Task Row tests', () => {
       },
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -245,15 +242,15 @@ describe('Task Row tests', () => {
       target: {_id: 'id', name: 'target'},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -339,15 +336,15 @@ describe('Task Row tests', () => {
       target: {_id: 'id', name: 'target'},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -454,15 +451,15 @@ describe('Task Row tests', () => {
       target: {_id: 'id', name: 'target'},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -568,15 +565,15 @@ describe('Task Row tests', () => {
       target: {_id: 'id', name: 'target'},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -682,15 +679,15 @@ describe('Task Row tests', () => {
       target: {_id: 'id', name: 'target'},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -800,15 +797,15 @@ describe('Task Row tests', () => {
       permissions: {permission: [{name: 'everything'}]},
     });
 
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,

--- a/src/web/pages/tasks/__tests__/status.jsx
+++ b/src/web/pages/tasks/__tests__/status.jsx
@@ -15,18 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 
 import {rendererWith} from 'web/utils/testing';
 
 import Task, {TASK_STATUS} from 'gmp/models/task';
 
 import Status from '../status';
-
-setLocale('en');
 
 const caps = new Capabilities(['everything']);
 

--- a/src/web/pages/tasks/__tests__/table.jsx
+++ b/src/web/pages/tasks/__tests__/table.jsx
@@ -15,11 +15,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 import Task, {TASK_STATUS} from 'gmp/models/task';
@@ -29,8 +28,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent} from 'web/utils/testing';
 
 import Table from '../table';
-
-setLocale('en');
 
 const caps = new Capabilities(['everything']);
 
@@ -108,15 +105,15 @@ const filter = Filter.fromString('rows=2');
 
 describe('Tasks table tests', () => {
   test('should render', () => {
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const gmp = {
       settings: {},
@@ -161,15 +158,15 @@ describe('Tasks table tests', () => {
   });
 
   test('should unfold all details', () => {
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const gmp = {
       settings: {},
@@ -212,15 +209,15 @@ describe('Tasks table tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleReportImport = vi.fn();
-    const handleTaskClone = vi.fn();
-    const handleTaskDelete = vi.fn();
-    const handleTaskDownload = vi.fn();
-    const handleTaskEdit = vi.fn();
-    const handleTaskResume = vi.fn();
-    const handleTaskStart = vi.fn();
-    const handleTaskStop = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTaskClone = testing.fn();
+    const handleTaskDelete = testing.fn();
+    const handleTaskDownload = testing.fn();
+    const handleTaskEdit = testing.fn();
+    const handleTaskResume = testing.fn();
+    const handleTaskStart = testing.fn();
+    const handleTaskStop = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const gmp = {
       settings: {},

--- a/src/web/pages/tasks/__tests__/trend.jsx
+++ b/src/web/pages/tasks/__tests__/trend.jsx
@@ -15,16 +15,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {render} from 'web/utils/testing';
 
 import Trend from '../trend';
-
-import {setLocale} from 'gmp/locale/lang';
-
-setLocale('en');
 
 describe('Task Trend tests', () => {
   test('should render', () => {

--- a/src/web/pages/tasks/icons/__tests__/resumeicon.jsx
+++ b/src/web/pages/tasks/icons/__tests__/resumeicon.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -36,7 +36,7 @@ describe('Task ResumeIcon component tests', () => {
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -61,7 +61,7 @@ describe('Task ResumeIcon component tests', () => {
       target: {_id: '123'},
       permissions: {permission: [{name: 'get_task'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -89,7 +89,7 @@ describe('Task ResumeIcon component tests', () => {
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -115,7 +115,7 @@ describe('Task ResumeIcon component tests', () => {
       permissions: {permission: [{name: 'get_task'}]},
       usage_type: 'audit',
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -147,7 +147,7 @@ describe('Task ResumeIcon component tests', () => {
       permissions: {permission: [{name: 'everything'}]},
     };
     const task = Task.fromElement(elem);
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -172,7 +172,7 @@ describe('Task ResumeIcon component tests', () => {
       permissions: {permission: [{name: 'everything'}]},
     };
     const task = Task.fromElement(elem);
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 

--- a/src/web/pages/tasks/icons/__tests__/starticon.jsx
+++ b/src/web/pages/tasks/icons/__tests__/starticon.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -37,7 +37,7 @@ describe('Task StartIcon component tests', () => {
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -62,7 +62,7 @@ describe('Task StartIcon component tests', () => {
       target: {_id: '123'},
       permissions: {permission: [{name: 'get_task'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -88,7 +88,7 @@ describe('Task StartIcon component tests', () => {
       permissions: {permission: [{name: 'get_task'}]},
       usage_type: 'audit',
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -132,7 +132,7 @@ END:VCALENDAR
         event: Event.fromIcal(icalendar, 'UTC'),
       },
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -160,7 +160,7 @@ END:VCALENDAR
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -185,7 +185,7 @@ END:VCALENDAR
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 

--- a/src/web/pages/tasks/icons/__tests__/stopicon.jsx
+++ b/src/web/pages/tasks/icons/__tests__/stopicon.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
@@ -36,7 +36,7 @@ describe('Task StopIcon component tests', () => {
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -61,7 +61,7 @@ describe('Task StopIcon component tests', () => {
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -86,7 +86,7 @@ describe('Task StopIcon component tests', () => {
       target: {_id: '123'},
       permissions: {permission: [{name: 'get_task'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -110,7 +110,7 @@ describe('Task StopIcon component tests', () => {
       target: {_id: '123'},
       permissions: {permission: [{name: 'get_task'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -136,7 +136,7 @@ describe('Task StopIcon component tests', () => {
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
@@ -154,7 +154,7 @@ describe('Task StopIcon component tests', () => {
       status: TASK_STATUS.running,
       permissions: {permission: [{name: 'everything'}]},
     });
-    const clickHandler = vi.fn();
+    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 

--- a/src/web/pages/tickets/__tests__/createdialog.jsx
+++ b/src/web/pages/tickets/__tests__/createdialog.jsx
@@ -15,12 +15,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
+
+import User from 'gmp/models/user';
 
 import {render, fireEvent, queryAllByTestId} from 'web/utils/testing';
 
 import CreateTicketDialog from '../createdialog';
-import User from 'gmp/models/user';
 
 const u1 = User.fromElement({
   _id: 'u1',
@@ -35,9 +36,9 @@ const users = [u1, u2];
 
 describe('CreateTicketDialog component tests', () => {
   test('should render dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleUserIdChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleUserIdChange = testing.fn();
 
     const {baseElement} = render(
       <CreateTicketDialog
@@ -54,9 +55,9 @@ describe('CreateTicketDialog component tests', () => {
   });
 
   test('should allow to select user', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleUserIdChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleUserIdChange = testing.fn();
 
     const {getByTestId, baseElement} = render(
       <CreateTicketDialog
@@ -81,9 +82,9 @@ describe('CreateTicketDialog component tests', () => {
   });
 
   test('should allow to close the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleUserIdChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleUserIdChange = testing.fn();
 
     const {getByTestId} = render(
       <CreateTicketDialog
@@ -104,9 +105,9 @@ describe('CreateTicketDialog component tests', () => {
   });
 
   test('should allow to save the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleUserIdChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleUserIdChange = testing.fn();
 
     const {getByTestId, baseElement} = render(
       <CreateTicketDialog
@@ -134,9 +135,9 @@ describe('CreateTicketDialog component tests', () => {
   });
 
   test('should not save invalid form states', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
-    const handleUserIdChange = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleUserIdChange = testing.fn();
 
     const {getByTestId, baseElement} = render(
       <CreateTicketDialog

--- a/src/web/pages/tickets/__tests__/editdialog.jsx
+++ b/src/web/pages/tickets/__tests__/editdialog.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {render, fireEvent, queryAllByTestId} from 'web/utils/testing';
 
@@ -37,8 +37,8 @@ const users = [u1, u2];
 
 describe('EditTicketDialog component tests', () => {
   test('should render dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {baseElement} = render(
       <EditTicketDialog
@@ -55,8 +55,8 @@ describe('EditTicketDialog component tests', () => {
   });
 
   test('should display notes', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {baseElement} = render(
       <EditTicketDialog
@@ -84,8 +84,8 @@ describe('EditTicketDialog component tests', () => {
   });
 
   test('should save data', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByTestId} = render(
       <EditTicketDialog
@@ -116,8 +116,8 @@ describe('EditTicketDialog component tests', () => {
   });
 
   test('should allow to change status', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {baseElement, getByTestId} = render(
       <EditTicketDialog
@@ -154,8 +154,8 @@ describe('EditTicketDialog component tests', () => {
   });
 
   test('should allow to change user', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {baseElement, getByTestId} = render(
       <EditTicketDialog
@@ -192,8 +192,8 @@ describe('EditTicketDialog component tests', () => {
   });
 
   test('should not save invalid form states and render error bubble', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {getByTestId} = render(
       <EditTicketDialog
@@ -214,8 +214,8 @@ describe('EditTicketDialog component tests', () => {
   });
 
   test('should allow to close the dialog', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     // eslint-disable-next-line no-shadow
     const {getByTestId} = render(

--- a/src/web/pages/tlscertificates/__tests__/detailspage.jsx
+++ b/src/web/pages/tlscertificates/__tests__/detailspage.jsx
@@ -15,11 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
-
-import {isDefined} from 'gmp/utils/identity';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
@@ -33,13 +29,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith} from 'web/utils/testing';
 
 import Detailspage from '../detailspage';
-
-if (!isDefined(window.URL)) {
-  window.URL = {};
-}
-window.URL.createObjectURL = vi.fn();
-
-setLocale('en');
 
 const tlsCertificate = TlsCertificate.fromElement({
   _id: '1234',
@@ -67,11 +56,11 @@ const caps = new Capabilities(['everything']);
 const reloadInterval = 1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getEntities = vi.fn().mockResolvedValue({
+const getEntities = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -81,7 +70,7 @@ const getEntities = vi.fn().mockResolvedValue({
 
 describe('TLS Certificate Detailspage tests', () => {
   test('should render full Detailspage', () => {
-    const getTlsCertificate = vi.fn().mockResolvedValue({
+    const getTlsCertificate = testing.fn().mockResolvedValue({
       data: tlsCertificate,
     });
 

--- a/src/web/pages/tlscertificates/__tests__/listpage.jsx
+++ b/src/web/pages/tlscertificates/__tests__/listpage.jsx
@@ -15,9 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import CollectionCounts from 'gmp/collection/collectioncounts';
 
@@ -32,10 +30,6 @@ import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters
 import {rendererWith, waitFor} from 'web/utils/testing';
 
 import TlsCertificatePage from '../listpage';
-
-setLocale('en');
-
-window.URL.createObjectURL = vi.fn();
 
 const tlsCertificate = TlsCertificate.fromElement({
   _id: '1234',
@@ -59,11 +53,11 @@ const tlsCertificate = TlsCertificate.fromElement({
 const reloadInterval = 1;
 const manualUrl = 'test/';
 
-const currentSettings = vi.fn().mockResolvedValue({
+const currentSettings = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-const getFilters = vi.fn().mockReturnValue(
+const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
     meta: {
@@ -73,7 +67,7 @@ const getFilters = vi.fn().mockReturnValue(
   }),
 );
 
-const getDashboardSetting = vi.fn().mockResolvedValue({
+const getDashboardSetting = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -81,11 +75,11 @@ const getDashboardSetting = vi.fn().mockResolvedValue({
   },
 });
 
-const getUserSetting = vi.fn().mockResolvedValue({
+const getUserSetting = testing.fn().mockResolvedValue({
   filter: null,
 });
 
-const getAggregates = vi.fn().mockResolvedValue({
+const getAggregates = testing.fn().mockResolvedValue({
   data: [],
   meta: {
     filter: Filter.fromString(),
@@ -93,7 +87,7 @@ const getAggregates = vi.fn().mockResolvedValue({
   },
 });
 
-const getTlsCertificates = vi.fn().mockResolvedValue({
+const getTlsCertificates = testing.fn().mockResolvedValue({
   data: [tlsCertificate],
   meta: {
     filter: Filter.fromString(),

--- a/src/web/pages/tlscertificates/__tests__/row.jsx
+++ b/src/web/pages/tlscertificates/__tests__/row.jsx
@@ -16,9 +16,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 /* eslint-disable no-console */
-import React from 'react';
-
-import {setLocale} from 'gmp/locale/lang';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import TlsCertificate from 'gmp/models/tlscertificate';
 
@@ -27,8 +25,6 @@ import {setTimezone} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent} from 'web/utils/testing';
 
 import Row from '../row';
-
-setLocale('en');
 
 const gmp = {settings: {}};
 
@@ -58,10 +54,10 @@ describe('Tls Certificate Row tests', () => {
   console.error = () => {};
 
   test('should render', () => {
-    const handleTlsCertificateDelete = vi.fn();
-    const handleTlsCertificateDownload = vi.fn();
-    const handleTlsCertificateExport = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleTlsCertificateDelete = testing.fn();
+    const handleTlsCertificateDownload = testing.fn();
+    const handleTlsCertificateExport = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,
@@ -94,11 +90,11 @@ describe('Tls Certificate Row tests', () => {
   });
 
   test('should render icons', () => {
-    const handleReportImport = vi.fn();
-    const handleTlsCertificateDelete = vi.fn();
-    const handleTlsCertificateDownload = vi.fn();
-    const handleTlsCertificateExport = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleReportImport = testing.fn();
+    const handleTlsCertificateDelete = testing.fn();
+    const handleTlsCertificateDownload = testing.fn();
+    const handleTlsCertificateExport = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({gmp, store: true});
 
@@ -123,10 +119,10 @@ describe('Tls Certificate Row tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleTlsCertificateDelete = vi.fn();
-    const handleTlsCertificateDownload = vi.fn();
-    const handleTlsCertificateExport = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleTlsCertificateDelete = testing.fn();
+    const handleTlsCertificateDownload = testing.fn();
+    const handleTlsCertificateExport = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const {render, store} = rendererWith({
       gmp,

--- a/src/web/pages/tlscertificates/__tests__/table.jsx
+++ b/src/web/pages/tlscertificates/__tests__/table.jsx
@@ -15,11 +15,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collectioncounts';
-import {setLocale} from 'gmp/locale/lang';
 
 import Filter from 'gmp/models/filter';
 import TlsCertificate from 'gmp/models/tlscertificate';
@@ -29,8 +28,6 @@ import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent} from 'web/utils/testing';
 
 import Table from '../table';
-
-setLocale('en');
 
 const caps = new Capabilities(['everything']);
 
@@ -65,9 +62,9 @@ const filter = Filter.fromString('rows=2');
 
 describe('TlsCertificates table tests', () => {
   test('should render', () => {
-    const handleTlsCertificateDelete = vi.fn();
-    const handleTlsCertificateDownload = vi.fn();
-    const handleTlsCertificateExport = vi.fn();
+    const handleTlsCertificateDelete = testing.fn();
+    const handleTlsCertificateDownload = testing.fn();
+    const handleTlsCertificateExport = testing.fn();
 
     const gmp = {
       settings: {},
@@ -103,10 +100,10 @@ describe('TlsCertificates table tests', () => {
   });
 
   test('should unfold all details', () => {
-    const handleTlsCertificateDelete = vi.fn();
-    const handleTlsCertificateDownload = vi.fn();
-    const handleTlsCertificateExport = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleTlsCertificateDelete = testing.fn();
+    const handleTlsCertificateDownload = testing.fn();
+    const handleTlsCertificateExport = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const gmp = {
       settings: {},
@@ -146,10 +143,10 @@ describe('TlsCertificates table tests', () => {
   });
 
   test('should call click handlers', () => {
-    const handleTlsCertificateDelete = vi.fn();
-    const handleTlsCertificateDownload = vi.fn();
-    const handleTlsCertificateExport = vi.fn();
-    const handleToggleDetailsClick = vi.fn();
+    const handleTlsCertificateDelete = testing.fn();
+    const handleTlsCertificateDownload = testing.fn();
+    const handleTlsCertificateExport = testing.fn();
+    const handleToggleDetailsClick = testing.fn();
 
     const gmp = {
       settings: {},

--- a/src/web/setupTests.js
+++ b/src/web/setupTests.js
@@ -30,3 +30,6 @@ global.expect = expect;
 // It is caused by clicking on <a> elements in tests
 // https://stackoverflow.com/a/68038982/11044073
 HTMLAnchorElement.prototype.click = testing.fn();
+
+// createObjectURL is not implemented in JSDOM and required for the Download component
+window.URL.createObjectURL = testing.fn();

--- a/src/web/setupTests.js
+++ b/src/web/setupTests.js
@@ -16,14 +16,17 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {testing, beforeEach, expect} from '@gsa/testing';
+
 import '../setupTests';
 
-// register cleanup handlers. requires globals to be set in vitest config
-import '@testing-library/react';
 // setup additional matchers for vitest
 import '@testing-library/jest-dom/vitest';
+
+global.beforeEach = beforeEach;
+global.expect = expect;
 
 // Avoid "Error: Not implemented: navigation (except hash changes)"
 // It is caused by clicking on <a> elements in tests
 // https://stackoverflow.com/a/68038982/11044073
-HTMLAnchorElement.prototype.click = vi.fn();
+HTMLAnchorElement.prototype.click = testing.fn();

--- a/src/web/store/__tests__/utils.js
+++ b/src/web/store/__tests__/utils.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import Filter from 'gmp/models/filter';
 
 import {combineReducers, filterIdentifier} from 'web/store/utils';
@@ -22,8 +24,8 @@ import {combineReducers, filterIdentifier} from 'web/store/utils';
 describe('store utils module tests', () => {
   describe('combineReducer tests', () => {
     test('should create a combined reducer', () => {
-      const foo = vi.fn();
-      const bar = vi.fn();
+      const foo = testing.fn();
+      const bar = testing.fn();
       const action = {type: 'ipsum'};
 
       const reducer = combineReducers({
@@ -37,8 +39,8 @@ describe('store utils module tests', () => {
     });
 
     test('should pass state[reducerName] to reducers', () => {
-      const foo = vi.fn();
-      const bar = vi.fn();
+      const foo = testing.fn();
+      const bar = testing.fn();
       const action = {type: 'ipsum'};
       const state = {
         foo: 1,
@@ -56,8 +58,8 @@ describe('store utils module tests', () => {
     });
 
     test('should combine state from reducers', () => {
-      const foo = vi.fn().mockReturnValue(99);
-      const bar = vi.fn().mockReturnValue(100);
+      const foo = testing.fn().mockReturnValue(99);
+      const bar = testing.fn().mockReturnValue(100);
       const action = {type: 'ipsum'};
       const state = {
         foo: 1,
@@ -78,8 +80,8 @@ describe('store utils module tests', () => {
     });
 
     test('should drop unknown props from state', () => {
-      const foo = vi.fn().mockReturnValue(99);
-      const bar = vi.fn().mockReturnValue(100);
+      const foo = testing.fn().mockReturnValue(99);
+      const bar = testing.fn().mockReturnValue(100);
       const action = {type: 'ipsum'};
       const state = {
         foo: 1,
@@ -101,8 +103,8 @@ describe('store utils module tests', () => {
     });
 
     test('should allow to return undefined from reducers', () => {
-      const foo = vi.fn().mockReturnValue(undefined);
-      const bar = vi.fn().mockReturnValue(undefined);
+      const foo = testing.fn().mockReturnValue(undefined);
+      const bar = testing.fn().mockReturnValue(undefined);
       const action = {type: 'ipsum'};
       const state = {
         foo: 1,
@@ -135,5 +137,3 @@ describe('store utils module tests', () => {
     });
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/store/dashboard/data/__tests__/actions.js
+++ b/src/web/store/dashboard/data/__tests__/actions.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import Filter from 'gmp/models/filter';
 
 import {

--- a/src/web/store/dashboard/data/__tests__/loader.js
+++ b/src/web/store/dashboard/data/__tests__/loader.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import Filter from 'gmp/models/filter';
 
 import {loadFunc} from '../loader';
@@ -33,12 +35,12 @@ const createState = state => ({
 
 describe('loadFunc tests', () => {
   test('should request dashboard data successfully', () => {
-    const dispatch = vi.fn();
-    const getState = vi.fn();
+    const dispatch = testing.fn();
+    const getState = testing.fn();
     const data = {
       foo: 'bar',
     };
-    const func = vi.fn().mockResolvedValue(data);
+    const func = testing.fn().mockResolvedValue(data);
 
     const id = 'a1';
     const filter = Filter.fromString('foo=bar');
@@ -77,12 +79,12 @@ describe('loadFunc tests', () => {
         },
       },
     });
-    const dispatch = vi.fn();
-    const getState = vi.fn().mockReturnValue(state);
+    const dispatch = testing.fn();
+    const getState = testing.fn().mockReturnValue(state);
     const data = {
       foo: 'bar',
     };
-    const func = vi.fn().mockResolvedValue(data);
+    const func = testing.fn().mockResolvedValue(data);
 
     const props = {
       filter,
@@ -101,9 +103,9 @@ describe('loadFunc tests', () => {
   test('should fail loading dashboard data', () => {
     const id = 'a1';
     const filter = Filter.fromString('foo=bar');
-    const dispatch = vi.fn();
-    const getState = vi.fn();
-    const func = vi.fn().mockRejectedValue('An error');
+    const dispatch = testing.fn();
+    const getState = testing.fn();
+    const func = testing.fn().mockRejectedValue('An error');
 
     const props = {
       filter,

--- a/src/web/store/dashboard/data/__tests__/reducers.js
+++ b/src/web/store/dashboard/data/__tests__/reducers.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import Filter from 'gmp/models/filter';
 
 import {filterIdentifier} from 'web/store/utils';

--- a/src/web/store/dashboard/data/__tests__/selectors.js
+++ b/src/web/store/dashboard/data/__tests__/selectors.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import Filter from 'gmp/models/filter';
 
 import {filterIdentifier} from 'web/store/utils';

--- a/src/web/store/dashboard/settings/__tests__/actions.js
+++ b/src/web/store/dashboard/settings/__tests__/actions.js
@@ -15,8 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-/* eslint-disable max-len */
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {isFunction} from 'gmp/utils/identity';
 
@@ -189,15 +188,15 @@ describe('resetDashboardSettingsError tests', () => {
 describe('loadSettings tests', () => {
   test('should load settings successfully', () => {
     const id = 'a1';
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
     const rootState = createRootState();
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
     const data = {
       foo: 'bar',
     };
 
-    const getSetting = vi.fn().mockReturnValue(Promise.resolve({data}));
+    const getSetting = testing.fn().mockReturnValue(Promise.resolve({data}));
 
     const gmp = {
       dashboard: {
@@ -234,19 +233,19 @@ describe('loadSettings tests', () => {
 
   test('should not load settings if isLoading is true', () => {
     const id = 'a1';
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
     const rootState = createRootState({
       isLoading: {
         [id]: true,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
     const data = {
       foo: 'bar',
     };
 
-    const getSetting = vi.fn().mockReturnValue(Promise.resolve({data}));
+    const getSetting = testing.fn().mockReturnValue(Promise.resolve({data}));
 
     const gmp = {
       dashboard: {
@@ -267,13 +266,13 @@ describe('loadSettings tests', () => {
 
   test('should fail loading settings with an error', () => {
     const id = 'a1';
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
     const rootState = createRootState();
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
     const error = 'An error';
 
-    const getSetting = vi.fn().mockReturnValue(Promise.reject(error));
+    const getSetting = testing.fn().mockReturnValue(Promise.reject(error));
 
     const gmp = {
       dashboard: {
@@ -309,15 +308,15 @@ describe('loadSettings tests', () => {
 describe('saveSettings tests', () => {
   test('should save settings successfully', () => {
     const id = 'a1';
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
     const rootState = createRootState();
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
     const settings = {
       foo: 'bar',
     };
 
-    const saveSettingsPromise = vi.fn().mockReturnValue(Promise.resolve());
+    const saveSettingsPromise = testing.fn().mockReturnValue(Promise.resolve());
 
     const gmp = {
       dashboard: {
@@ -344,16 +343,18 @@ describe('saveSettings tests', () => {
 
   test('should fail saving settings', () => {
     const id = 'a1';
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
     const rootState = createRootState();
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
     const settings = {
       foo: 'bar',
     };
 
     const error = 'An error';
-    const saveSettingsPromise = vi.fn().mockReturnValue(Promise.reject(error));
+    const saveSettingsPromise = testing
+      .fn()
+      .mockReturnValue(Promise.reject(error));
 
     const gmp = {
       dashboard: {
@@ -387,15 +388,15 @@ describe('resetSettings tests', () => {
       foo: 'bar',
     };
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
     const rootState = createRootState({
       defaults: {
         [id]: settings,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const saveSettingsPromise = vi.fn().mockReturnValue(Promise.resolve());
+    const saveSettingsPromise = testing.fn().mockReturnValue(Promise.resolve());
 
     const gmp = {
       dashboard: {
@@ -426,16 +427,18 @@ describe('resetSettings tests', () => {
       foo: 'bar',
     };
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
     const rootState = createRootState({
       defaults: {
         [id]: settings,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
     const error = 'An error';
-    const saveSettingsPromise = vi.fn().mockReturnValue(Promise.reject(error));
+    const saveSettingsPromise = testing
+      .fn()
+      .mockReturnValue(Promise.reject(error));
 
     const gmp = {
       dashboard: {

--- a/src/web/store/dashboard/settings/__tests__/reducers.js
+++ b/src/web/store/dashboard/settings/__tests__/reducers.js
@@ -15,8 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-/* eslint-disable max-len */
+import {describe, test, expect} from '@gsa/testing';
 
 import dashboardSettings from '../reducers';
 

--- a/src/web/store/dashboard/settings/__tests__/selectors.js
+++ b/src/web/store/dashboard/settings/__tests__/selectors.js
@@ -15,8 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-/* eslint-disable max-len */
+import {describe, test, expect} from '@gsa/testing';
 
 import getDashboardSettings from '../selectors';
 

--- a/src/web/store/entities/__tests__/reducers.js
+++ b/src/web/store/entities/__tests__/reducers.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {isFunction} from 'gmp/utils/identity';
 
 import entitiesReducer from '../reducers';

--- a/src/web/store/entities/report/__tests__/actions.js
+++ b/src/web/store/entities/report/__tests__/actions.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Filter from 'gmp/models/filter';
 
@@ -46,11 +47,11 @@ describe('loadReport function tests', () => {
         [id]: false,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
-    const get = vi.fn().mockResolvedValue({
+    const get = testing.fn().mockResolvedValue({
       data: {foo: 'bar'},
     });
 
@@ -90,11 +91,11 @@ describe('loadReport function tests', () => {
         [id]: false,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
-    const get = vi.fn().mockResolvedValue({
+    const get = testing.fn().mockResolvedValue({
       data: {foo: 'bar'},
     });
 
@@ -139,11 +140,11 @@ describe('loadReport function tests', () => {
       },
     });
 
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
-    const get = vi.fn().mockResolvedValue([{id: 'foo'}]);
+    const get = testing.fn().mockResolvedValue([{id: 'foo'}]);
 
     const gmp = {
       report: {
@@ -168,11 +169,11 @@ describe('loadReport function tests', () => {
       },
     });
 
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
-    const get = vi.fn().mockRejectedValue('An Error');
+    const get = testing.fn().mockRejectedValue('An Error');
 
     const gmp = {
       report: {
@@ -209,11 +210,11 @@ describe('report loadReportIfNeeded function tests', () => {
         [id]: false,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
-    const get = vi.fn().mockResolvedValue({data: {foo: 'bar'}});
+    const get = testing.fn().mockResolvedValue({data: {foo: 'bar'}});
 
     const gmp = {
       report: {
@@ -255,11 +256,11 @@ describe('report loadReportIfNeeded function tests', () => {
       },
     });
 
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
-    const get = vi.fn().mockResolvedValue([{id: 'foo'}]);
+    const get = testing.fn().mockResolvedValue([{id: 'foo'}]);
 
     const gmp = {
       report: {
@@ -283,11 +284,11 @@ describe('report loadReportIfNeeded function tests', () => {
         [id]: false,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
-    const get = vi.fn().mockResolvedValue({data: {foo: 'bar'}});
+    const get = testing.fn().mockResolvedValue({data: {foo: 'bar'}});
 
     const gmp = {
       report: {
@@ -332,11 +333,11 @@ describe('report loadReportIfNeeded function tests', () => {
       },
     });
 
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
-    const get = vi.fn().mockResolvedValue([{id: 'foo'}]);
+    const get = testing.fn().mockResolvedValue([{id: 'foo'}]);
 
     const gmp = {
       report: {
@@ -361,11 +362,11 @@ describe('report loadReportIfNeeded function tests', () => {
       },
     });
 
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
-    const get = vi.fn().mockRejectedValue('An Error');
+    const get = testing.fn().mockRejectedValue('An Error');
 
     const gmp = {
       report: {
@@ -406,9 +407,9 @@ describe('loadReportWithThreshold tests', () => {
         [id]: false,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
     const report = {
       report: {
@@ -420,7 +421,7 @@ describe('loadReportWithThreshold tests', () => {
       },
     };
 
-    const get = vi.fn().mockResolvedValue({
+    const get = testing.fn().mockResolvedValue({
       data: report,
     });
 
@@ -463,9 +464,9 @@ describe('loadReportWithThreshold tests', () => {
         [id]: false,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
     const report = {
       report: {
@@ -477,7 +478,7 @@ describe('loadReportWithThreshold tests', () => {
       },
     };
 
-    const get = vi.fn().mockResolvedValue({
+    const get = testing.fn().mockResolvedValue({
       data: report,
     });
 
@@ -542,9 +543,9 @@ describe('loadReportWithThreshold tests', () => {
         [reportIdentifier(id, filter)]: false,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
     const report = {
       report: {
@@ -556,7 +557,7 @@ describe('loadReportWithThreshold tests', () => {
       },
     };
 
-    const get = vi.fn().mockResolvedValue({
+    const get = testing.fn().mockResolvedValue({
       data: report,
     });
 
@@ -604,9 +605,9 @@ describe('loadReportWithThreshold tests', () => {
         [reportIdentifier(id, filter)]: false,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
     const report = {
       report: {
@@ -618,7 +619,7 @@ describe('loadReportWithThreshold tests', () => {
       },
     };
 
-    const get = vi.fn().mockResolvedValue({
+    const get = testing.fn().mockResolvedValue({
       data: report,
     });
 
@@ -680,9 +681,9 @@ describe('loadReportWithThreshold tests', () => {
         [id]: true,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
     const report = {
       report: {
@@ -694,7 +695,7 @@ describe('loadReportWithThreshold tests', () => {
       },
     };
 
-    const get = vi.fn().mockResolvedValue({
+    const get = testing.fn().mockResolvedValue({
       data: report,
     });
 
@@ -727,9 +728,9 @@ describe('loadReportWithThreshold tests', () => {
         [reportIdentifier(id, filter)]: true,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
     const report = {
       report: {
@@ -741,7 +742,7 @@ describe('loadReportWithThreshold tests', () => {
       },
     };
 
-    const get = vi.fn().mockResolvedValue({
+    const get = testing.fn().mockResolvedValue({
       data: report,
     });
 
@@ -780,11 +781,11 @@ describe('loadDeltaReport function tests', () => {
         [identifier]: false,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
-    const getDelta = vi.fn().mockResolvedValue({
+    const getDelta = testing.fn().mockResolvedValue({
       data: {foo: 'bar'},
     });
 
@@ -829,11 +830,11 @@ describe('loadDeltaReport function tests', () => {
         [identifier]: false,
       },
     });
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
-    const getDelta = vi.fn().mockResolvedValue({
+    const getDelta = testing.fn().mockResolvedValue({
       data: {foo: 'bar'},
     });
 
@@ -884,11 +885,11 @@ describe('loadDeltaReport function tests', () => {
       },
     });
 
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
-    const getDelta = vi.fn().mockResolvedValue([{id: 'foo'}]);
+    const getDelta = testing.fn().mockResolvedValue([{id: 'foo'}]);
 
     const gmp = {
       report: {
@@ -913,11 +914,11 @@ describe('loadDeltaReport function tests', () => {
       },
     });
 
-    const getState = vi.fn().mockReturnValue(rootState);
+    const getState = testing.fn().mockReturnValue(rootState);
 
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
 
-    const getDelta = vi.fn().mockRejectedValue('An Error');
+    const getDelta = testing.fn().mockRejectedValue('An Error');
 
     const gmp = {
       report: {

--- a/src/web/store/entities/report/__tests__/reducers.js
+++ b/src/web/store/entities/report/__tests__/reducers.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Filter from 'gmp/models/filter';
 

--- a/src/web/store/entities/report/__tests__/selectors.js
+++ b/src/web/store/entities/report/__tests__/selectors.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Filter from 'gmp/models/filter';
 

--- a/src/web/store/entities/reports/__tests__/reducers.js
+++ b/src/web/store/entities/reports/__tests__/reducers.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import Filter from 'gmp/models/filter';
 

--- a/src/web/store/entities/utils/__tests__/actions.js
+++ b/src/web/store/entities/utils/__tests__/actions.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import {isFunction} from 'gmp/utils/identity';
 
 import Filter from 'gmp/models/filter';
@@ -187,18 +189,18 @@ describe('entities loading actions tests', () => {
     test('test isLoading true', () => {
       const actions = createEntitiesLoadingActions('foo');
 
-      const getState = vi.fn().mockReturnValue({foo: 'bar'});
+      const getState = testing.fn().mockReturnValue({foo: 'bar'});
 
-      const dispatch = vi.fn();
-      const isLoadingEntities = vi.fn().mockReturnValue(true);
-      const get = vi.fn();
+      const dispatch = testing.fn();
+      const isLoadingEntities = testing.fn().mockReturnValue(true);
+      const get = testing.fn();
       const gmp = {
         foos: {
           get,
         },
       };
 
-      const selector = vi.fn(() => ({
+      const selector = testing.fn(() => ({
         isLoadingEntities,
       }));
 
@@ -222,17 +224,17 @@ describe('entities loading actions tests', () => {
 
     test('test loading success', () => {
       const actions = {
-        request: vi.fn().mockReturnValue({type: 'MY_REQUEST_ACTION'}),
-        success: vi.fn().mockReturnValue({type: 'MY_SUCCESS_ACTION'}),
-        error: vi.fn(),
+        request: testing.fn().mockReturnValue({type: 'MY_REQUEST_ACTION'}),
+        success: testing.fn().mockReturnValue({type: 'MY_SUCCESS_ACTION'}),
+        error: testing.fn(),
       };
 
-      const getState = vi.fn().mockReturnValue({foo: 'bar'});
+      const getState = testing.fn().mockReturnValue({foo: 'bar'});
 
       const loadedFilter = Filter.fromString('name=abc');
       const counts = {first: 1};
-      const dispatch = vi.fn();
-      const get = vi.fn().mockReturnValue(
+      const dispatch = testing.fn();
+      const get = testing.fn().mockReturnValue(
         Promise.resolve({
           data: 'foo',
           meta: {
@@ -246,9 +248,9 @@ describe('entities loading actions tests', () => {
           get,
         },
       };
-      const isLoadingEntities = vi.fn().mockReturnValue(false);
+      const isLoadingEntities = testing.fn().mockReturnValue(false);
 
-      const selector = vi.fn(() => ({
+      const selector = testing.fn(() => ({
         isLoadingEntities,
       }));
 
@@ -306,23 +308,23 @@ describe('entities loading actions tests', () => {
 
     test('test loading error', () => {
       const actions = {
-        request: vi.fn().mockReturnValue({type: 'MY_REQUEST_ACTION'}),
-        success: vi.fn().mockReturnValue({type: 'MY_SUCCESS_ACTION'}),
-        error: vi.fn().mockReturnValue({type: 'MY_ERROR_ACTION'}),
+        request: testing.fn().mockReturnValue({type: 'MY_REQUEST_ACTION'}),
+        success: testing.fn().mockReturnValue({type: 'MY_SUCCESS_ACTION'}),
+        error: testing.fn().mockReturnValue({type: 'MY_ERROR_ACTION'}),
       };
 
-      const getState = vi.fn().mockReturnValue({foo: 'bar'});
+      const getState = testing.fn().mockReturnValue({foo: 'bar'});
 
-      const dispatch = vi.fn();
-      const get = vi.fn().mockReturnValue(Promise.reject('AnError'));
+      const dispatch = testing.fn();
+      const get = testing.fn().mockReturnValue(Promise.reject('AnError'));
       const gmp = {
         foos: {
           get,
         },
       };
-      const isLoadingEntities = vi.fn().mockReturnValue(false);
+      const isLoadingEntities = testing.fn().mockReturnValue(false);
 
-      const selector = vi.fn(() => ({
+      const selector = testing.fn(() => ({
         isLoadingEntities,
       }));
 
@@ -379,18 +381,18 @@ describe('entities loading actions tests', () => {
     test('test isLoading true', () => {
       const actions = createEntitiesLoadingActions('foo');
 
-      const getState = vi.fn().mockReturnValue({foo: 'bar'});
+      const getState = testing.fn().mockReturnValue({foo: 'bar'});
 
-      const dispatch = vi.fn();
-      const isLoadingEntities = vi.fn().mockReturnValue(true);
-      const get = vi.fn();
+      const dispatch = testing.fn();
+      const isLoadingEntities = testing.fn().mockReturnValue(true);
+      const get = testing.fn();
       const gmp = {
         foos: {
           get,
         },
       };
 
-      const selector = vi.fn(() => ({
+      const selector = testing.fn(() => ({
         isLoadingEntities,
       }));
 
@@ -414,17 +416,17 @@ describe('entities loading actions tests', () => {
 
     test('test loading success', () => {
       const actions = {
-        request: vi.fn().mockReturnValue({type: 'MY_REQUEST_ACTION'}),
-        success: vi.fn().mockReturnValue({type: 'MY_SUCCESS_ACTION'}),
-        error: vi.fn(),
+        request: testing.fn().mockReturnValue({type: 'MY_REQUEST_ACTION'}),
+        success: testing.fn().mockReturnValue({type: 'MY_SUCCESS_ACTION'}),
+        error: testing.fn(),
       };
 
-      const getState = vi.fn().mockReturnValue({foo: 'bar'});
+      const getState = testing.fn().mockReturnValue({foo: 'bar'});
 
       const loadedFilter = Filter.fromString('name=abc');
       const counts = {first: 1};
-      const dispatch = vi.fn();
-      const get = vi.fn().mockReturnValue(
+      const dispatch = testing.fn();
+      const get = testing.fn().mockReturnValue(
         Promise.resolve({
           data: 'foo',
           meta: {
@@ -438,9 +440,9 @@ describe('entities loading actions tests', () => {
           get,
         },
       };
-      const isLoadingEntities = vi.fn().mockReturnValue(false);
+      const isLoadingEntities = testing.fn().mockReturnValue(false);
 
-      const selector = vi.fn(() => ({
+      const selector = testing.fn(() => ({
         isLoadingEntities,
       }));
 
@@ -476,23 +478,23 @@ describe('entities loading actions tests', () => {
 
     test('test loading error', () => {
       const actions = {
-        request: vi.fn().mockReturnValue({type: 'MY_REQUEST_ACTION'}),
-        success: vi.fn().mockReturnValue({type: 'MY_SUCCESS_ACTION'}),
-        error: vi.fn().mockReturnValue({type: 'MY_ERROR_ACTION'}),
+        request: testing.fn().mockReturnValue({type: 'MY_REQUEST_ACTION'}),
+        success: testing.fn().mockReturnValue({type: 'MY_SUCCESS_ACTION'}),
+        error: testing.fn().mockReturnValue({type: 'MY_ERROR_ACTION'}),
       };
 
-      const getState = vi.fn().mockReturnValue({foo: 'bar'});
+      const getState = testing.fn().mockReturnValue({foo: 'bar'});
 
-      const dispatch = vi.fn();
-      const get = vi.fn().mockReturnValue(Promise.reject('AnError'));
+      const dispatch = testing.fn();
+      const get = testing.fn().mockReturnValue(Promise.reject('AnError'));
       const gmp = {
         foos: {
           get,
         },
       };
-      const isLoadingEntities = vi.fn().mockReturnValue(false);
+      const isLoadingEntities = testing.fn().mockReturnValue(false);
 
-      const selector = vi.fn(() => ({
+      const selector = testing.fn(() => ({
         isLoadingEntities,
       }));
 
@@ -526,23 +528,23 @@ describe('entities loading actions tests', () => {
     test('test isLoading true', () => {
       const id = 'a1';
       const actions = {
-        request: vi.fn().mockReturnValue({type: 'MY_REQUEST_ACTION'}),
-        success: vi.fn().mockReturnValue({type: 'MY_SUCCESS_ACTION'}),
-        error: vi.fn().mockReturnValue({type: 'MY_ERROR_ACTION'}),
+        request: testing.fn().mockReturnValue({type: 'MY_REQUEST_ACTION'}),
+        success: testing.fn().mockReturnValue({type: 'MY_SUCCESS_ACTION'}),
+        error: testing.fn().mockReturnValue({type: 'MY_ERROR_ACTION'}),
       };
 
-      const getState = vi.fn().mockReturnValue({foo: 'bar'});
+      const getState = testing.fn().mockReturnValue({foo: 'bar'});
 
-      const dispatch = vi.fn();
-      const isLoadingEntity = vi.fn().mockReturnValue(true);
-      const get = vi.fn().mockReturnValue(Promise.resolve({id: 'foo'}));
+      const dispatch = testing.fn();
+      const isLoadingEntity = testing.fn().mockReturnValue(true);
+      const get = testing.fn().mockReturnValue(Promise.resolve({id: 'foo'}));
       const gmp = {
         foo: {
           get,
         },
       };
 
-      const selector = vi.fn(() => ({
+      const selector = testing.fn(() => ({
         isLoadingEntity,
       }));
 
@@ -570,16 +572,16 @@ describe('entities loading actions tests', () => {
     test('test loading success', () => {
       const id = 'a1';
       const actions = {
-        request: vi.fn().mockReturnValue({type: 'MY_REQUEST_ACTION'}),
-        success: vi.fn().mockReturnValue({type: 'MY_SUCCESS_ACTION'}),
-        error: vi.fn().mockReturnValue({type: 'MY_ERROR_ACTION'}),
+        request: testing.fn().mockReturnValue({type: 'MY_REQUEST_ACTION'}),
+        success: testing.fn().mockReturnValue({type: 'MY_SUCCESS_ACTION'}),
+        error: testing.fn().mockReturnValue({type: 'MY_ERROR_ACTION'}),
       };
 
-      const getState = vi.fn().mockReturnValue({foo: 'bar'});
+      const getState = testing.fn().mockReturnValue({foo: 'bar'});
 
-      const dispatch = vi.fn();
-      const isLoadingEntity = vi.fn().mockReturnValue(false);
-      const get = vi
+      const dispatch = testing.fn();
+      const isLoadingEntity = testing.fn().mockReturnValue(false);
+      const get = testing
         .fn()
         .mockReturnValue(Promise.resolve({data: {id, name: 'foo'}}));
       const gmp = {
@@ -588,7 +590,7 @@ describe('entities loading actions tests', () => {
         },
       };
 
-      const selector = vi.fn(() => ({
+      const selector = testing.fn(() => ({
         isLoadingEntity,
       }));
 
@@ -618,23 +620,23 @@ describe('entities loading actions tests', () => {
     test('test loading error', () => {
       const id = 'a1';
       const actions = {
-        request: vi.fn().mockReturnValue({type: 'MY_REQUEST_ACTION'}),
-        success: vi.fn().mockReturnValue({type: 'MY_SUCCESS_ACTION'}),
-        error: vi.fn().mockReturnValue({type: 'MY_ERROR_ACTION'}),
+        request: testing.fn().mockReturnValue({type: 'MY_REQUEST_ACTION'}),
+        success: testing.fn().mockReturnValue({type: 'MY_SUCCESS_ACTION'}),
+        error: testing.fn().mockReturnValue({type: 'MY_ERROR_ACTION'}),
       };
 
-      const getState = vi.fn().mockReturnValue({foo: 'bar'});
+      const getState = testing.fn().mockReturnValue({foo: 'bar'});
 
-      const dispatch = vi.fn();
-      const isLoadingEntity = vi.fn().mockReturnValue(false);
-      const get = vi.fn().mockReturnValue(Promise.reject('An error'));
+      const dispatch = testing.fn();
+      const isLoadingEntity = testing.fn().mockReturnValue(false);
+      const get = testing.fn().mockReturnValue(Promise.reject('An error'));
       const gmp = {
         foo: {
           get,
         },
       };
 
-      const selector = vi.fn(() => ({
+      const selector = testing.fn(() => ({
         isLoadingEntity,
       }));
 
@@ -668,10 +670,10 @@ describe('createDeleteEntity tests', () => {
     const id = 'id1';
     const gmp = {
       foo: {
-        delete: vi.fn().mockResolvedValue({data: 'bar'}),
+        delete: testing.fn().mockResolvedValue({data: 'bar'}),
       },
     };
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
     const deleteFunc = createDeleteEntity({entityType: 'foo'});
 
     expect(deleteFunc).toBeDefined();
@@ -687,4 +689,3 @@ describe('createDeleteEntity tests', () => {
     });
   });
 });
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/store/entities/utils/__tests__/main.js
+++ b/src/web/store/entities/utils/__tests__/main.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {isFunction} from 'gmp/utils/identity';
 
 import {createAll} from '../main';

--- a/src/web/store/entities/utils/__tests__/reducers.js
+++ b/src/web/store/entities/utils/__tests__/reducers.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {isFunction} from 'gmp/utils/identity';
 
 import Filter from 'gmp/models/filter';

--- a/src/web/store/entities/utils/__tests__/selectors.js
+++ b/src/web/store/entities/utils/__tests__/selectors.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import Filter from 'gmp/models/filter';
 
 import {filterIdentifier} from 'web/store/utils';

--- a/src/web/store/entities/utils/testing.js
+++ b/src/web/store/entities/utils/testing.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import {isFunction} from 'gmp/utils/identity';
 import {pluralizeType} from 'gmp/utils/entitytype';
 
@@ -226,11 +228,11 @@ export const testLoadEntities = (entityType, loadEntities) => {
           [filterIdentifier(filter)]: false,
         },
       });
-      const getState = vi.fn().mockReturnValue(rootState);
+      const getState = testing.fn().mockReturnValue(rootState);
 
-      const dispatch = vi.fn();
+      const dispatch = testing.fn();
 
-      const get = vi.fn().mockReturnValue(
+      const get = testing.fn().mockReturnValue(
         Promise.resolve({
           data: 'foo',
           meta: {
@@ -281,11 +283,11 @@ export const testLoadEntities = (entityType, loadEntities) => {
         },
       });
 
-      const getState = vi.fn().mockReturnValue(rootState);
+      const getState = testing.fn().mockReturnValue(rootState);
 
-      const dispatch = vi.fn();
+      const dispatch = testing.fn();
 
-      const get = vi.fn().mockReturnValue(Promise.resolve([{id: 'foo'}]));
+      const get = testing.fn().mockReturnValue(Promise.resolve([{id: 'foo'}]));
 
       const gmp = {
         [pluralizeType(entityType)]: {
@@ -308,11 +310,11 @@ export const testLoadEntities = (entityType, loadEntities) => {
         },
       });
 
-      const getState = vi.fn().mockReturnValue(rootState);
+      const getState = testing.fn().mockReturnValue(rootState);
 
-      const dispatch = vi.fn();
+      const dispatch = testing.fn();
 
-      const get = vi.fn().mockReturnValue(Promise.reject('AnError'));
+      const get = testing.fn().mockReturnValue(Promise.reject('AnError'));
 
       const gmp = {
         [pluralizeType(entityType)]: {
@@ -456,11 +458,11 @@ export const testLoadEntity = (entityType, loadEntity) => {
           [id]: false,
         },
       });
-      const getState = vi.fn().mockReturnValue(rootState);
+      const getState = testing.fn().mockReturnValue(rootState);
 
-      const dispatch = vi.fn();
+      const dispatch = testing.fn();
 
-      const get = vi.fn().mockReturnValue(
+      const get = testing.fn().mockReturnValue(
         Promise.resolve({
           data: {foo: 'bar'},
         }),
@@ -505,11 +507,11 @@ export const testLoadEntity = (entityType, loadEntity) => {
         },
       });
 
-      const getState = vi.fn().mockReturnValue(rootState);
+      const getState = testing.fn().mockReturnValue(rootState);
 
-      const dispatch = vi.fn();
+      const dispatch = testing.fn();
 
-      const get = vi.fn().mockReturnValue(Promise.resolve([{id: 'foo'}]));
+      const get = testing.fn().mockReturnValue(Promise.resolve([{id: 'foo'}]));
 
       const gmp = {
         [entityType]: {
@@ -532,11 +534,11 @@ export const testLoadEntity = (entityType, loadEntity) => {
         },
       });
 
-      const getState = vi.fn().mockReturnValue(rootState);
+      const getState = testing.fn().mockReturnValue(rootState);
 
-      const dispatch = vi.fn();
+      const dispatch = testing.fn();
 
-      const get = vi.fn().mockReturnValue(Promise.reject('An Error'));
+      const get = testing.fn().mockReturnValue(Promise.reject('An Error'));
 
       const gmp = {
         [entityType]: {

--- a/src/web/store/pages/__tests__/actions.js
+++ b/src/web/store/pages/__tests__/actions.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {pageFilter, CHANGE_PAGE_FILTER} from '../actions';
 
 describe('page actions tests', () => {

--- a/src/web/store/pages/__tests__/reducers.js
+++ b/src/web/store/pages/__tests__/reducers.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import reducer from '../reducers';
 import {pageFilter} from 'web/store/pages/actions';
 

--- a/src/web/store/pages/__tests__/selectors.js
+++ b/src/web/store/pages/__tests__/selectors.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import getPage from 'web/store/pages/selectors';
 
 describe('pages selectors tests', () => {

--- a/src/web/store/usersettings/__tests__/actions.js
+++ b/src/web/store/usersettings/__tests__/actions.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import moment from 'gmp/models/date';
 
@@ -92,9 +93,9 @@ describe('settings actions tests', () => {
   });
 
   test('should update timezone', () => {
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
     const gmp = {
-      setTimezone: vi.fn(),
+      setTimezone: testing.fn(),
     };
     return updateTimezone(gmp)('cet')(dispatch).then(() => {
       expect(dispatch).toBeCalledWith({
@@ -106,10 +107,10 @@ describe('settings actions tests', () => {
   });
 
   test('should renew the session timeout', () => {
-    const dispatch = vi.fn();
+    const dispatch = testing.fn();
     const sessionTimeout = moment().add(1, 'day');
 
-    const renewSession = vi.fn().mockReturnValue(
+    const renewSession = testing.fn().mockReturnValue(
       Promise.resolve({
         data: sessionTimeout,
       }),
@@ -131,10 +132,10 @@ describe('settings actions tests', () => {
 
   describe('loadReportComposerDefaults tests', () => {
     test('should dispatch success actions', () => {
-      const dispatch = vi.fn();
+      const dispatch = testing.fn();
 
       const data = {foo: 'bar'};
-      const getReportComposerDefaults = vi
+      const getReportComposerDefaults = testing
         .fn()
         .mockReturnValue(Promise.resolve({data}));
 
@@ -158,10 +159,10 @@ describe('settings actions tests', () => {
 
   describe('saveReportComposerDefaults tests', () => {
     test('should dispatch success actions', () => {
-      const dispatch = vi.fn();
+      const dispatch = testing.fn();
 
       const data = {foo: 'bar'};
-      const saveReportComposerDefaultsMock = vi
+      const saveReportComposerDefaultsMock = testing
         .fn()
         .mockReturnValue(Promise.resolve({data}));
 
@@ -185,5 +186,3 @@ describe('settings actions tests', () => {
     });
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/store/usersettings/__tests__/reducers.js
+++ b/src/web/store/usersettings/__tests__/reducers.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {CLEAR_STORE} from 'web/store/actions';
 
 import {

--- a/src/web/store/usersettings/__tests__/selectors.js
+++ b/src/web/store/usersettings/__tests__/selectors.js
@@ -15,6 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
 
 import {
   getLocale,

--- a/src/web/store/usersettings/defaultfilters/__tests__/actions.js
+++ b/src/web/store/usersettings/defaultfilters/__tests__/actions.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import {DEFAULT_FILTER_SETTINGS} from 'gmp/commands/users';
 
 import Filter from 'gmp/models/filter';
@@ -72,8 +74,8 @@ const createState = (type, state) => ({
 
 describe('loadUserSettingsDefaultFilter tests', () => {
   test('should resolve if default is loaded already', () => {
-    const getSetting = vi.fn();
-    const getFilter = vi.fn();
+    const getSetting = testing.fn();
+    const getFilter = testing.fn();
     const gmp = {
       user: {
         getSetting,
@@ -86,8 +88,8 @@ describe('loadUserSettingsDefaultFilter tests', () => {
       isLoading: true,
     });
 
-    const dispatch = vi.fn();
-    const getState = vi.fn().mockReturnValue(state);
+    const dispatch = testing.fn();
+    const getState = testing.fn().mockReturnValue(state);
 
     return loadUserSettingsDefaultFilter(gmp)('foo')(dispatch, getState).then(
       () => {
@@ -101,10 +103,10 @@ describe('loadUserSettingsDefaultFilter tests', () => {
 
   test('should dispatch success if setting is not available', () => {
     const entityType = 'task';
-    const getSetting = vi.fn().mockResolvedValue({
+    const getSetting = testing.fn().mockResolvedValue({
       data: {},
     });
-    const getFilter = vi.fn();
+    const getFilter = testing.fn();
     const gmp = {
       user: {
         getSetting,
@@ -117,8 +119,8 @@ describe('loadUserSettingsDefaultFilter tests', () => {
       isLoading: false,
     });
 
-    const dispatch = vi.fn();
-    const getState = vi.fn().mockReturnValue(state);
+    const dispatch = testing.fn();
+    const getState = testing.fn().mockReturnValue(state);
 
     return loadUserSettingsDefaultFilter(gmp)(entityType)(
       dispatch,
@@ -143,8 +145,8 @@ describe('loadUserSettingsDefaultFilter tests', () => {
 
   test('should dispatch error if loading the setting errors', () => {
     const entityType = 'task';
-    const getSetting = vi.fn().mockRejectedValue('An error');
-    const getFilter = vi.fn();
+    const getSetting = testing.fn().mockRejectedValue('An error');
+    const getFilter = testing.fn();
     const gmp = {
       user: {
         getSetting,
@@ -157,8 +159,8 @@ describe('loadUserSettingsDefaultFilter tests', () => {
       isLoading: false,
     });
 
-    const dispatch = vi.fn();
-    const getState = vi.fn().mockReturnValue(state);
+    const dispatch = testing.fn();
+    const getState = testing.fn().mockReturnValue(state);
 
     return loadUserSettingsDefaultFilter(gmp)(entityType)(
       dispatch,
@@ -184,12 +186,12 @@ describe('loadUserSettingsDefaultFilter tests', () => {
   test('should dispatch success', () => {
     const filter = Filter.fromString('foo=bar');
     const entityType = 'task';
-    const getSetting = vi.fn().mockResolvedValue({
+    const getSetting = testing.fn().mockResolvedValue({
       data: {
         value: 'foo',
       },
     });
-    const getFilter = vi.fn().mockResolvedValue({data: filter});
+    const getFilter = testing.fn().mockResolvedValue({data: filter});
     const gmp = {
       user: {
         getSetting,
@@ -202,8 +204,8 @@ describe('loadUserSettingsDefaultFilter tests', () => {
       isLoading: false,
     });
 
-    const dispatch = vi.fn();
-    const getState = vi.fn().mockReturnValue(state);
+    const dispatch = testing.fn();
+    const getState = testing.fn().mockReturnValue(state);
 
     return loadUserSettingsDefaultFilter(gmp)(entityType)(
       dispatch,
@@ -228,12 +230,12 @@ describe('loadUserSettingsDefaultFilter tests', () => {
 
   test('should dispatch error if getFilter fails', () => {
     const entityType = 'task';
-    const getSetting = vi.fn().mockResolvedValue({
+    const getSetting = testing.fn().mockResolvedValue({
       data: {
         value: 'foo',
       },
     });
-    const getFilter = vi.fn().mockRejectedValue('An error');
+    const getFilter = testing.fn().mockRejectedValue('An error');
     const gmp = {
       user: {
         getSetting,
@@ -246,8 +248,8 @@ describe('loadUserSettingsDefaultFilter tests', () => {
       isLoading: false,
     });
 
-    const dispatch = vi.fn();
-    const getState = vi.fn().mockReturnValue(state);
+    const dispatch = testing.fn();
+    const getState = testing.fn().mockReturnValue(state);
 
     return loadUserSettingsDefaultFilter(gmp)(entityType)(
       dispatch,

--- a/src/web/store/usersettings/defaultfilters/__tests__/reducers.js
+++ b/src/web/store/usersettings/defaultfilters/__tests__/reducers.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {defaultFilterLoadingActions} from '../actions';
 import reducer from '../reducers';
 import Filter from 'gmp/models/filter';

--- a/src/web/store/usersettings/defaultfilters/__tests__/selectors.js
+++ b/src/web/store/usersettings/defaultfilters/__tests__/selectors.js
@@ -1,6 +1,3 @@
-import {getUserSettingsDefaultFilter} from '../selectors';
-import Filter from 'gmp/models/filter';
-
 /* Copyright (C) 2019-2022 Greenbone AG
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -18,6 +15,11 @@ import Filter from 'gmp/models/filter';
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
+import Filter from 'gmp/models/filter';
+
+import {getUserSettingsDefaultFilter} from '../selectors';
 
 describe('getUserSettingsDefaultFilter selector tests', () => {
   test('should return defaults', () => {

--- a/src/web/store/usersettings/defaults/__tests__/actions.js
+++ b/src/web/store/usersettings/defaults/__tests__/actions.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect, testing} from '@gsa/testing';
+
 import {
   loadingActions,
   USER_SETTINGS_DEFAULTS_LOADING_REQUEST,
@@ -53,8 +55,8 @@ describe('UserSettings Defaults action tests', () => {
 
   describe('loadUserSettingDefaults tests', () => {
     test('should not dispatch an action if isLoading is true', () => {
-      const dispatch = vi.fn();
-      const getState = vi.fn().mockReturnValue({
+      const dispatch = testing.fn();
+      const getState = testing.fn().mockReturnValue({
         userSettings: {
           defaults: {
             isLoading: true,
@@ -62,7 +64,7 @@ describe('UserSettings Defaults action tests', () => {
         },
       });
 
-      const currentSettings = vi.fn().mockReturnValue(
+      const currentSettings = testing.fn().mockReturnValue(
         Promise.resolve({
           foo: 'bar',
         }),
@@ -83,8 +85,8 @@ describe('UserSettings Defaults action tests', () => {
     });
 
     test('should dispatch request and success actions', () => {
-      const dispatch = vi.fn();
-      const getState = vi.fn().mockReturnValue({
+      const dispatch = testing.fn();
+      const getState = testing.fn().mockReturnValue({
         userSettings: {
           defaults: {
             isLoading: false,
@@ -93,7 +95,9 @@ describe('UserSettings Defaults action tests', () => {
       });
 
       const data = {foo: 'bar'};
-      const currentSettings = vi.fn().mockReturnValue(Promise.resolve({data}));
+      const currentSettings = testing
+        .fn()
+        .mockReturnValue(Promise.resolve({data}));
 
       const gmp = {
         user: {
@@ -122,8 +126,8 @@ describe('UserSettings Defaults action tests', () => {
     });
 
     test('should dispatch request and error actions', () => {
-      const dispatch = vi.fn();
-      const getState = vi.fn().mockReturnValue({
+      const dispatch = testing.fn();
+      const getState = testing.fn().mockReturnValue({
         userSettings: {
           defaults: {
             isLoading: false,
@@ -131,7 +135,7 @@ describe('UserSettings Defaults action tests', () => {
         },
       });
 
-      const currentSettings = vi
+      const currentSettings = testing
         .fn()
         .mockReturnValue(Promise.reject('An Error'));
 
@@ -164,8 +168,8 @@ describe('UserSettings Defaults action tests', () => {
 
   describe('loadUserSettingDefault tests', () => {
     test('should not dispatch an action if isLoading is true', () => {
-      const dispatch = vi.fn();
-      const getState = vi.fn().mockReturnValue({
+      const dispatch = testing.fn();
+      const getState = testing.fn().mockReturnValue({
         userSettings: {
           defaults: {
             isLoading: true,
@@ -173,7 +177,7 @@ describe('UserSettings Defaults action tests', () => {
         },
       });
 
-      const getSetting = vi.fn().mockReturnValue(
+      const getSetting = testing.fn().mockReturnValue(
         Promise.resolve({
           id: '42',
           name: 'Rows Per Page',
@@ -195,8 +199,8 @@ describe('UserSettings Defaults action tests', () => {
     });
 
     test('should dispatch request and success actions', () => {
-      const dispatch = vi.fn();
-      const getState = vi.fn().mockReturnValue({
+      const dispatch = testing.fn();
+      const getState = testing.fn().mockReturnValue({
         userSettings: {
           defaults: {
             isLoading: false,
@@ -205,7 +209,7 @@ describe('UserSettings Defaults action tests', () => {
       });
 
       const data = {_id: '123', name: 'Rows Per Page', value: 42};
-      const getSetting = vi.fn().mockReturnValue(Promise.resolve({data}));
+      const getSetting = testing.fn().mockReturnValue(Promise.resolve({data}));
 
       const gmp = {
         user: {
@@ -233,8 +237,8 @@ describe('UserSettings Defaults action tests', () => {
     });
 
     test('should dispatch request and error actions', () => {
-      const dispatch = vi.fn();
-      const getState = vi.fn().mockReturnValue({
+      const dispatch = testing.fn();
+      const getState = testing.fn().mockReturnValue({
         userSettings: {
           defaults: {
             isLoading: false,
@@ -242,7 +246,9 @@ describe('UserSettings Defaults action tests', () => {
         },
       });
 
-      const getSetting = vi.fn().mockReturnValue(Promise.reject('An Error'));
+      const getSetting = testing
+        .fn()
+        .mockReturnValue(Promise.reject('An Error'));
 
       const gmp = {
         user: {
@@ -271,5 +277,3 @@ describe('UserSettings Defaults action tests', () => {
     });
   });
 });
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/store/usersettings/defaults/__tests__/reducers.js
+++ b/src/web/store/usersettings/defaults/__tests__/reducers.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {loadingActions} from '../actions';
 import reducer from '../reducers';
 

--- a/src/web/store/usersettings/defaults/__tests__/selectors.js
+++ b/src/web/store/usersettings/defaults/__tests__/selectors.js
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {getUserSettingsDefaults} from '../selectors';
 
 const createRootState = state => ({

--- a/src/web/utils/__tests__/render.jsx
+++ b/src/web/utils/__tests__/render.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import {generateFilename, renderSelectItems} from '../render';
 
 describe('render_select_items test', () => {

--- a/src/web/utils/__tests__/sort.jsx
+++ b/src/web/utils/__tests__/sort.jsx
@@ -15,6 +15,8 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import {describe, test, expect} from '@gsa/testing';
+
 import moment from 'gmp/models/date';
 
 import {
@@ -76,24 +78,47 @@ describe('getProperty tests', () => {
 describe('getValue tests', () => {
   test('should return value for property', () => {
     expect(getValue(v => v, {foo: 'bar'}, 'foo')).toEqual('bar');
-    expect(getValue(v => v, {foo: 'bar'}, obj => obj.foo)).toEqual('bar');
+    expect(
+      getValue(
+        v => v,
+        {foo: 'bar'},
+        obj => obj.foo,
+      ),
+    ).toEqual('bar');
   });
 
   test('should return string for property', () => {
     expect(getValue(v => '' + v, {a: 1}, 'a')).toEqual('1');
-    expect(getValue(v => '' + v, {a: 1}, obj => obj.a)).toEqual('1');
+    expect(
+      getValue(
+        v => '' + v,
+        {a: 1},
+        obj => obj.a,
+      ),
+    ).toEqual('1');
   });
 
   test('should return undefined for unknown property', () => {
     expect(getValue(v => v, {foo: 'bar'}, 'bar')).toBeUndefined();
-    expect(getValue(v => v, {foo: 'bar'}, obj => obj.bar)).toBeUndefined();
+    expect(
+      getValue(
+        v => v,
+        {foo: 'bar'},
+        obj => obj.bar,
+      ),
+    ).toBeUndefined();
   });
 
   test('should return default for unknown property', () => {
     expect(getValue(v => v, {foo: 'bar'}, 'bar', 'ipsum')).toEqual('ipsum');
-    expect(getValue(v => v, {foo: 'bar'}, obj => obj.bar, 'ipsum')).toEqual(
-      'ipsum',
-    );
+    expect(
+      getValue(
+        v => v,
+        {foo: 'bar'},
+        obj => obj.bar,
+        'ipsum',
+      ),
+    ).toEqual('ipsum');
   });
 });
 

--- a/src/web/utils/__tests__/useCapabilities.jsx
+++ b/src/web/utils/__tests__/useCapabilities.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 

--- a/src/web/utils/__tests__/useGmp.jsx
+++ b/src/web/utils/__tests__/useGmp.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import {rendererWith} from '../testing';
 
@@ -28,7 +28,7 @@ const TestUseGmp = () => {
 
 describe('useGmp tests', () => {
   test('should return the current gmp object', () => {
-    const foo = vi.fn().mockReturnValue('foo');
+    const foo = testing.fn().mockReturnValue('foo');
     const gmp = {foo};
 
     const {render} = rendererWith({gmp});

--- a/src/web/utils/__tests__/useUserIsLoggedIn.jsx
+++ b/src/web/utils/__tests__/useUserIsLoggedIn.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {setIsLoggedIn as setIsLoggedInAction} from 'web/store/usersettings/actions';
 

--- a/src/web/utils/__tests__/useUserName.jsx
+++ b/src/web/utils/__tests__/useUserName.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {setUsername} from 'web/store/usersettings/actions';
 

--- a/src/web/utils/__tests__/useUserSessionTimeout.jsx
+++ b/src/web/utils/__tests__/useUserSessionTimeout.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {dateFormat} from 'gmp/locale/date';
 import date from 'gmp/models/date';

--- a/src/web/utils/__tests__/useUserTimezone.jsx
+++ b/src/web/utils/__tests__/useUserTimezone.jsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect} from '@gsa/testing';
 
 import {setTimezone as setTimezoneAction} from 'web/store/usersettings/actions';
 

--- a/src/web/utils/testing.jsx
+++ b/src/web/utils/testing.jsx
@@ -17,8 +17,11 @@
  */
 /* eslint-disable react/prop-types */
 
+import {afterEach} from '@gsa/testing';
+
+// jest-styled-components provides expect.toHaveStyleRule and snapshots for styled-components
+// it requires global.beforeEach and expect
 import 'jest-styled-components';
-import '@testing-library/jest-dom';
 
 import React from 'react';
 
@@ -28,7 +31,7 @@ import {
   cleanup,
   queryAllByAttribute,
   getElementError,
-} from '@testing-library/react';
+} from '@testing-library/react/pure';
 import userEvent from '@testing-library/user-event';
 
 import {Router} from 'react-router-dom';
@@ -49,7 +52,7 @@ import {createQueryHistory} from 'web/routes';
 import configureStore from 'web/store';
 import {StyleSheetManager} from 'styled-components';
 
-export * from '@testing-library/react';
+export * from '@testing-library/react/pure';
 export {userEvent};
 
 afterEach(cleanup);

--- a/src/web/wizard/__tests__/advancedtaskwizard.jsx
+++ b/src/web/wizard/__tests__/advancedtaskwizard.jsx
@@ -15,11 +15,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
-import Date, {setLocale} from 'gmp/models/date';
+import Date from 'gmp/models/date';
 
 import Credential, {
   USERNAME_PASSWORD_CREDENTIAL_TYPE,
@@ -30,8 +30,6 @@ import ScanConfig from 'gmp/models/scanconfig';
 import {rendererWith, fireEvent, screen} from 'web/utils/testing';
 
 import AdvancedTaskWizard from '../advancedtaskwizard';
-
-setLocale('en');
 
 const alertCapabilities = new Capabilities(['create_alert', 'get_alerts']);
 const scheduleCapabilities = new Capabilities([
@@ -72,8 +70,8 @@ const startTimezone = 'UTC';
 
 describe('AdvancedTaskWizard component tests', () => {
   test('should render full advanced wizard', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: true,
@@ -131,8 +129,8 @@ describe('AdvancedTaskWizard component tests', () => {
   });
 
   test('should not render schedule without permission', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: alertCapabilities,
@@ -188,8 +186,8 @@ describe('AdvancedTaskWizard component tests', () => {
   });
 
   test('should not render alert without permission', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: scheduleCapabilities,
@@ -248,8 +246,8 @@ describe('AdvancedTaskWizard component tests', () => {
   });
 
   test('should allow to close the advanced wizard', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: true,
@@ -282,8 +280,8 @@ describe('AdvancedTaskWizard component tests', () => {
   });
 
   test('should allow to cancel the advanced wizard', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: true,
@@ -316,8 +314,8 @@ describe('AdvancedTaskWizard component tests', () => {
   });
 
   test('should allow to save the advanced wizard', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: true,

--- a/src/web/wizard/__tests__/modifytaskwizard.jsx
+++ b/src/web/wizard/__tests__/modifytaskwizard.jsx
@@ -15,19 +15,17 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react';
+import {describe, test, expect, testing} from '@gsa/testing';
 
 import Capabilities from 'gmp/capabilities/capabilities';
 
-import Date, {setLocale} from 'gmp/models/date';
+import Date from 'gmp/models/date';
 
 import Task from 'gmp/models/task';
 
 import {rendererWith, fireEvent, screen} from 'web/utils/testing';
 
 import ModifyTaskWizard from '../modifytaskwizard';
-
-setLocale('en');
 
 const alertCapabilities = new Capabilities(['create_alert', 'get_alerts']);
 const scheduleCapabilities = new Capabilities([
@@ -48,8 +46,8 @@ const startTimezone = 'UTC';
 
 describe('ModifyTaskWizard component tests', () => {
   test('should render full modify wizard', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: true,
@@ -91,8 +89,8 @@ describe('ModifyTaskWizard component tests', () => {
   });
 
   test('should not render schedule without permission', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: alertCapabilities,
@@ -128,8 +126,8 @@ describe('ModifyTaskWizard component tests', () => {
   });
 
   test('should not render alert without permission', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: scheduleCapabilities,
@@ -172,8 +170,8 @@ describe('ModifyTaskWizard component tests', () => {
   });
 
   test('should allow to close the modify wizard', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: true,
@@ -201,8 +199,8 @@ describe('ModifyTaskWizard component tests', () => {
   });
 
   test('should allow to cancel the modify wizard', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: true,
@@ -230,8 +228,8 @@ describe('ModifyTaskWizard component tests', () => {
   });
 
   test('should allow to save the modify wizard', () => {
-    const handleClose = vi.fn();
-    const handleSave = vi.fn();
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
 
     const {render} = rendererWith({
       capabilities: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,10 @@ export default defineConfig({
         find: 'version',
         replacement: path.resolve(projectRootDir, 'src', 'version.js'),
       },
+      {
+        find: '@gsa/testing',
+        replacement: path.resolve(projectRootDir, 'src', 'testing.js'),
+      },
     ],
   },
   server: {

--- a/vitest.projects.ts
+++ b/vitest.projects.ts
@@ -19,11 +19,11 @@ export default defineWorkspace([
     test: {
       name: 'node',
       environment: 'node',
-      globals: true,
       setupFiles: './src/gmp/setupTests.js',
       include: [
         'src/gmp/**/*.{test,spec}.?(c|m)[jt]s?(x)',
         'src/gmp/**/__tests__/*.?(c|m)[jt]s?(x)',
+        'src/__tests__/*.?(c|m)[jt]s?(x)',
       ],
     },
   },

--- a/vitest.projects.ts
+++ b/vitest.projects.ts
@@ -4,7 +4,7 @@ export default defineWorkspace([
   {
     extends: './vite.config.ts',
     test: {
-      name: 'jsdom',
+      name: 'web',
       environment: 'jsdom',
       globals: true,
       setupFiles: './src/web/setupTests.js',
@@ -17,7 +17,7 @@ export default defineWorkspace([
   {
     extends: './vite.config.ts',
     test: {
-      name: 'node',
+      name: 'gmp',
       environment: 'node',
       setupFiles: './src/gmp/setupTests.js',
       include: [

--- a/vitest.projects.ts
+++ b/vitest.projects.ts
@@ -6,7 +6,6 @@ export default defineWorkspace([
     test: {
       name: 'web',
       environment: 'jsdom',
-      globals: true,
       setupFiles: './src/web/setupTests.js',
       include: [
         'src/web/**/*.{test,spec}.?(c|m)[jt]s?(x)',

--- a/vitest.projects.ts
+++ b/vitest.projects.ts
@@ -12,6 +12,7 @@ export default defineWorkspace([
         'src/web/**/*.{test,spec}.?(c|m)[jt]s?(x)',
         'src/web/**/__tests__/*.?(c|m)[jt]s?(x)',
       ],
+      exclude: ['src/web/store/**'],
     },
   },
   {
@@ -24,6 +25,17 @@ export default defineWorkspace([
         'src/gmp/**/*.{test,spec}.?(c|m)[jt]s?(x)',
         'src/gmp/**/__tests__/*.?(c|m)[jt]s?(x)',
         'src/__tests__/*.?(c|m)[jt]s?(x)',
+      ],
+    },
+  },
+  {
+    extends: './vite.config.ts',
+    test: {
+      name: 'store',
+      environment: 'node',
+      include: [
+        'src/web/store/**/*.{test,spec}.?(c|m)[jt]s?(x)',
+        'src/web/store/**/__tests__/*.?(c|m)[jt]s?(x)',
       ],
     },
   },


### PR DESCRIPTION


## What

Abstract differences of testing framework in a testing module.

`describe`, `expect`, `test` (or `it`), `afterEach`, `beforeEach`, ... should be imported from `@gsa/testing` now. `@gsa/testing` also provided a testing object with the mocking and timeout functions (`testing.fn`, `testing.useFakeTimers`, ...) which is actually the vi object when using vitest. By changing the single `@gsa/testing` module it is possible to switch to another testing framework easily.

## Why

Use a central testing module to allow switching easily between different testing frameworks. In our case jest and vitest. Using an own testing module (`@gsa/testing`) allows for providing the necessary testing functions as imports.

## References

GEA-540

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


