### PR TITLE
Fix default setting for the api server

### DIFF
--- a/src/gmp/__tests__/gmpsettings.js
+++ b/src/gmp/__tests__/gmpsettings.js
@@ -37,7 +37,7 @@ const createStorage = state => {
 
 describe('GmpSettings tests', () => {
   beforeAll(() => {
-    global.location = {protocol: 'http:'};
+    global.location = {protocol: 'http:', host: 'localhost:9392'};
   });
 
   afterAll(() => {

--- a/src/gmp/gmpsettings.js
+++ b/src/gmp/gmpsettings.js
@@ -26,7 +26,6 @@ export const DEFAULT_PROTOCOLDOC_URL = `https://docs.greenbone.net/API/GMP/gmp-2
 export const DEFAULT_REPORT_RESULTS_THRESHOLD = 25000;
 export const DEFAULT_LOG_LEVEL = 'warn';
 export const DEFAULT_TIMEOUT = 300000; // 5 minutes
-export const DEFAULT_API_SERVER = 'localhost:9392';
 
 const set = (storage, name, value) => {
   if (isDefined(value)) {
@@ -109,7 +108,7 @@ class GmpSettings {
       apiProtocol = global.location.protocol;
     }
     if (!isDefined(apiServer)) {
-      apiServer = DEFAULT_API_SERVER;
+      apiServer = global.location.host;
     }
 
     this.logLevel = logLevel;


### PR DESCRIPTION

## What
Fix default setting for the api server

## Why

The api server must be determined from the current host. Otherwise it all ajax requests would go to localhost:9292 by default and it would be required to set the correct host name in the config.js for every installation.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


