### PR TITLE
Update jest-dom dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
       },
       "devDependencies": {
         "@babel/cli": "^7.24.1",
-        "@testing-library/jest-dom": "^6.4.2",
+        "@testing-library/jest-dom": "^6.4.5",
         "@testing-library/react": "^15.0.6",
         "@testing-library/user-event": "^13.5.0",
         "@types/react": "^18.3.1",
@@ -4023,9 +4023,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.2.tgz",
-      "integrity": "sha512-CzqH0AFymEMG48CpzXFriYYkOjk6ZGPCLMhW9e9jg3KMCn5OfJecF8GtGW7yGfR/IgCe3SX8BSwjdzI6BBbZLw==",
+      "version": "6.4.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.4.5.tgz",
+      "integrity": "sha512-AguB9yvTXmCnySBP1lWjfNNUwpbElsaQ567lt2VdGqAdHtpieLgjmcVyv1q7PMIvLbgpDdkWV5Ydv3FEejyp2A==",
       "dev": true,
       "dependencies": {
         "@adobe/css-tools": "^4.3.2",
@@ -4034,7 +4034,7 @@
         "chalk": "^3.0.0",
         "css.escape": "^1.5.1",
         "dom-accessibility-api": "^0.6.3",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "redent": "^3.0.0"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.24.1",
-    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/jest-dom": "^6.4.5",
     "@testing-library/react": "^15.0.6",
     "@testing-library/user-event": "^13.5.0",
     "@types/react": "^18.3.1",


### PR DESCRIPTION
## What
Update jest-dom dependency to 6.4.5.


## Why
Dependabot recommends version 6.4.3 in [#4019](https://github.com/greenbone/gsa/pull/4019) which has an issue with importing 'lodash/isEqualWith' that causes CI tests to fail. See https://github.com/testing-library/jest-dom/issues/598. This issue is now fixed in 6.4.5.

## References
GEA-551


