### PR TITLE
Change: Replace i18next-xhr-backend with i18next-http-backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "history": "^4.10.1",
         "hoist-non-react-statics": "^3.3.2",
         "i18next": "^23.11.3",
-        "i18next-xhr-backend": "3.2.2",
+        "i18next-http-backend": "^2.5.1",
         "ical.js": "^2.0.0",
         "memoize-one": "^6.0.0",
         "moment": "^2.30.1",
@@ -6281,6 +6281,14 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -8381,13 +8389,12 @@
         "@babel/runtime": "^7.23.2"
       }
     },
-    "node_modules/i18next-xhr-backend": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/i18next-xhr-backend/-/i18next-xhr-backend-3.2.2.tgz",
-      "integrity": "sha512-OtRf2Vo3IqAxsttQbpjYnmMML12IMB5e0fc5B7qKJFLScitYaXa1OhMX0n0X/3vrfFlpHL9Ro/H+ps4Ej2j7QQ==",
-      "deprecated": "replaced by i18next-http-backend",
+    "node_modules/i18next-http-backend": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-2.5.1.tgz",
+      "integrity": "sha512-+rNX1tghdVxdfjfPt0bI1sNg5ahGW9kA7OboG7b4t03Fp69NdDlRIze6yXhIbN8rbHxJ8IP4dzRm/okZ15lkQg==",
       "dependencies": {
-        "@babel/runtime": "^7.5.5"
+        "cross-fetch": "4.0.0"
       }
     },
     "node_modules/ical.js": {
@@ -10914,6 +10921,44 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "history": "^4.10.1",
     "hoist-non-react-statics": "^3.3.2",
     "i18next": "^23.11.3",
-    "i18next-xhr-backend": "3.2.2",
+    "i18next-http-backend": "^2.5.1",
     "ical.js": "^2.0.0",
     "memoize-one": "^6.0.0",
     "moment": "^2.30.1",

--- a/src/gmp/locale/lang.js
+++ b/src/gmp/locale/lang.js
@@ -17,7 +17,7 @@
  */
 
 import i18next from 'i18next';
-import XHRBackend from 'i18next-xhr-backend';
+import HttpBackend from 'i18next-http-backend';
 
 import logger from 'gmp/log';
 
@@ -73,7 +73,7 @@ i18next.on('languageChanged', lang => {
 });
 
 export const initLocale = ({
-  backend = XHRBackend,
+  backend = HttpBackend,
   detector = Detector,
   options = I18N_OPTIONS,
 } = {}) => i18next.use(backend).use(detector).init(options);


### PR DESCRIPTION

## What

 Replace i18next-xhr-backend with i18next-http-backend

## Why

i18next-xhr-backend is deprecated and the i18next-http-backend is a drop in replacement.