### PR TITLE
Remove: Params from report formats dialog

### DIFF
--- a/src/gmp/commands/reportformats.js
+++ b/src/gmp/commands/reportformats.js
@@ -41,7 +41,7 @@ class ReportFormatCommand extends EntityCommand {
   }
 
   save(args) {
-    const {active, id, id_lists = {}, name, preferences = {}, summary} = args;
+    const {active, id, name, summary} = args;
 
     const data = {
       cmd: 'save_report_format',
@@ -50,19 +50,6 @@ class ReportFormatCommand extends EntityCommand {
       name,
       summary,
     };
-    for (const prefname in preferences) {
-      const prefix = 'preference:nvt[string]:'; // only the format of the prefix is important
-      data[prefix + prefname] = preferences[prefname];
-    }
-
-    const id_list = [];
-    for (const lname in id_lists) {
-      data['include_id_list:' + lname] = 1;
-      for (const val of id_lists[lname]) {
-        id_list.push(lname + ':' + val);
-      }
-    }
-    data['id_list:'] = id_list;
 
     log.debug('Saving report format', args, data);
     return this.action(data);

--- a/src/web/pages/reportformats/dialog.jsx
+++ b/src/web/pages/reportformats/dialog.jsx
@@ -20,8 +20,7 @@ import React from 'react';
 
 import _ from 'gmp/locale';
 
-import {isDefined, isArray, hasValue} from 'gmp/utils/identity';
-import {map} from 'gmp/utils/array';
+import {isDefined} from 'gmp/utils/identity';
 
 import PropTypes from 'web/utils/proptypes';
 
@@ -29,155 +28,17 @@ import SaveDialog from 'web/components/dialog/savedialog';
 
 import FileField from 'web/components/form/filefield';
 import FormGroup from 'web/components/form/formgroup';
-import Spinner from 'web/components/form/spinner';
-import TextArea from 'web/components/form/textarea';
 import TextField from 'web/components/form/textfield';
-import MultiSelect from 'web/components/form/multiselect';
-import Select from 'web/components/form/select';
 import YesNoRadio from 'web/components/form/yesnoradio';
 
 import Layout from 'web/components/layout/layout';
 
-import Table from 'web/components/table/table';
-import TableBody from 'web/components/table/body';
-import TableData from 'web/components/table/data';
-import TableHeader from 'web/components/table/header';
-import TableHead from 'web/components/table/head';
-import TableRow from 'web/components/table/row';
-
-const ReportFormatListParam = ({formats, idList, name, onValueChange}) => {
-  const formatOptions = map(formats, format => ({
-    label: format.name,
-    value: format.id,
-  }));
-
-  return (
-    <TableRow>
-      <TableData>{name}</TableData>
-      <TableData>
-        <MultiSelect
-          name={name}
-          items={formatOptions}
-          value={idList}
-          onChange={onValueChange}
-        />
-      </TableData>
-    </TableRow>
-  );
-};
-
-ReportFormatListParam.propTypes = {
-  formats: PropTypes.array.isRequired,
-  idList: PropTypes.array.isRequired,
-  name: PropTypes.string.isRequired,
-  onValueChange: PropTypes.func.isRequired,
-};
-
-const Param = ({data, value, onPrefChange}) => {
-  const {name, type, min, max} = value;
-  const field_value = data[name];
-
-  let field;
-  if (type === 'boolean') {
-    field = (
-      <YesNoRadio name={name} value={field_value} onChange={onPrefChange} />
-    );
-  } else if (type === 'integer') {
-    field = (
-      <Spinner
-        type="int"
-        name={name}
-        min={min}
-        max={max}
-        value={field_value}
-        onChange={onPrefChange}
-      />
-    );
-  } else if (type === 'string') {
-    field = (
-      <TextField
-        name={name}
-        maxLength={max}
-        value={field_value}
-        onChange={onPrefChange}
-      />
-    );
-  } else if (type === 'selection') {
-    const typeOptions = map(value.options, opt => ({
-      label: opt.name,
-      value: opt.value,
-    }));
-
-    field = (
-      <Select
-        name={name}
-        items={typeOptions}
-        value={isArray(field_value) ? field_value : [field_value]}
-        onChange={onPrefChange}
-      />
-    );
-  } else {
-    field = (
-      <TextArea
-        cols="80"
-        rows="5"
-        name={name}
-        value={field_value}
-        onChange={onPrefChange}
-      />
-    );
-  }
-  return (
-    <TableRow>
-      <TableData>{name}</TableData>
-      <TableData>{field}</TableData>
-    </TableRow>
-  );
-};
-
-Param.propTypes = {
-  data: PropTypes.object.isRequired,
-  value: PropTypes.object.isRequired,
-  onPrefChange: PropTypes.func.isRequired,
-};
-
 class Dialog extends React.Component {
   constructor(...args) {
     super(...args);
-
-    this.handlePrefChange = this.handlePrefChange.bind(this);
-    this.handleIdListChange = this.handleIdListsChange.bind(this);
   }
-
-  handlePrefChange(value, name) {
-    const {preferences, onValueChange} = this.props;
-
-    preferences[name] = value;
-
-    if (onValueChange) {
-      onValueChange(preferences, 'preferences');
-    }
-  }
-
-  handleIdListsChange(value, name) {
-    const {id_lists, onValueChange} = this.props;
-
-    if (!hasValue(value)) {
-      value = [];
-    }
-
-    id_lists[name] = value;
-
-    if (onValueChange) {
-      onValueChange(id_lists, 'id_lists');
-    }
-  }
-
   render() {
     const {
-      formats,
-      id_lists,
-      preferences,
       reportformat,
       title = _('Import Report Format'),
       onClose,
@@ -220,41 +81,6 @@ class Dialog extends React.Component {
                     onChange={onValueChange}
                   />
                 </FormGroup>
-
-                {reportformat.params.length > 0 && <h2>Parameters</h2>}
-                {reportformat.params.length > 0 && (
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead width="25%">{_('Name')}</TableHead>
-                        <TableHead width="75%">{_('Value')}</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {reportformat.params.map(param => {
-                        if (param.type === 'report_format_list') {
-                          return (
-                            <ReportFormatListParam
-                              key={param.name}
-                              formats={formats}
-                              idList={id_lists[param.name]}
-                              name={param.name}
-                              onValueChange={this.handleIdListChange}
-                            />
-                          );
-                        }
-                        return (
-                          <Param
-                            key={param.name}
-                            value={param}
-                            data={preferences}
-                            onPrefChange={this.handlePrefChange}
-                          />
-                        );
-                      })}
-                    </TableBody>
-                  </Table>
-                )}
               </Layout>
             );
           }}


### PR DESCRIPTION
## What
The section for editing params has been removed from the report formats dialog.

## Why
Parameters should now only be passed to report formats using report configs.
Additionally, the officially supported report formats that use params are all part of the feed and thus not editable anyway.

## References
GEA-403

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

