### PR TITLE
Add codecov token to CI workflow

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -61,6 +61,7 @@ jobs:
       - name: Submit test coverage to codecov.io
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
   linting:


### PR DESCRIPTION
## What
Added the codecov token to the CI workflow

## Why
The codecov action v4 requires a token except for forks of public repositories.
