### PR TITLE
Ignore eslint cache file from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ public/config.js
 .directory
 
 .venv
+.eslintcache


### PR DESCRIPTION
## What

Ignore eslint cache file from git

## Why

The file gets created on every eslint run and should not be added to git