### PR TITLE
Add a react hook for storing instance variables

### DIFF
--- a/src/web/hooks/__tests__/useInstanceVariable.jsx
+++ b/src/web/hooks/__tests__/useInstanceVariable.jsx
@@ -1,0 +1,45 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/* eslint-disable react/prop-types */
+
+import {describe, test, expect, testing} from '@gsa/testing';
+
+import {useCallback} from 'react';
+
+import {fireEvent, rendererWith, screen} from 'web/utils/testing';
+
+import useInstanceVariable from '../useInstanceVariable';
+
+const TestComponent = ({callback}) => {
+  const someVariable = useInstanceVariable({value: 1});
+  const changeValue = useCallback(() => {
+    someVariable.value = 2;
+    callback(someVariable.value);
+  }, [someVariable, callback]);
+  return (
+    <div>
+      <div data-testid="t1">{someVariable.value}</div>
+      <button data-testid="changeValue" onClick={changeValue} />
+    </div>
+  );
+};
+
+describe('useInstanceVariable tests', () => {
+  test('should render the value', () => {
+    const callback = testing.fn();
+    const {render} = rendererWith();
+
+    render(<TestComponent callback={callback} />);
+
+    const t1 = screen.getByTestId('t1');
+    expect(t1).toHaveTextContent('1');
+    const b1 = screen.getByTestId('changeValue');
+    fireEvent.click(b1);
+    expect(t1).toHaveTextContent('1');
+
+    expect(callback).toHaveBeenCalledWith(2);
+  });
+});

--- a/src/web/hooks/useInstanceVariable.js
+++ b/src/web/hooks/useInstanceVariable.js
@@ -1,0 +1,26 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {useRef} from 'react';
+
+/**
+ * A hook to store an instance variable for a function component.
+ *
+ * This variable is persistent during render phases and changes to the variable
+ * don't cause re-renders like useState does. It is comparable to storing a
+ * variable to this in a class component.
+ *
+ * https://reactjs.org/docs/hooks-faq.html#is-there-something-like-instance-variables
+ *
+ * @param {*} initialValue Initial value of the variable. Can be any kind of
+ *                         object. Most of the time it should be initialized
+ *                         with an empty object.
+ */
+const useInstanceVariable = initialValue => {
+  const ref = useRef(initialValue);
+  return ref.current;
+};
+
+export default useInstanceVariable;


### PR DESCRIPTION


## What

Add a react hooks for storing instance variables

## Why
An instance variable stores the value directly and doesn't cause re-renders if it is changed. Variables returned from this hooks are comparable to instance variables for class components.

Required for HOC less entities pages.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


