### PR TITLE
CI: Allow the dependency review workflow to write a message to the PR

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   dependency-review:


### PR DESCRIPTION


## What

Allow the dependency review workflow to write a message to the PR

## Why

The dependency review workflow is able to write a summary message to the PR if it is allowed to write to the workflow.