### PR TITLE
Use page filter hook

### DIFF
--- a/src/web/entities/filterprovider.jsx
+++ b/src/web/entities/filterprovider.jsx
@@ -16,30 +16,12 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, {useEffect, useState} from 'react';
-
-import {useSelector, useDispatch, shallowEqual} from 'react-redux';
-
-import {ROWS_PER_PAGE_SETTING_ID} from 'gmp/commands/users';
-
-import Filter, {
-  DEFAULT_FALLBACK_FILTER,
-  DEFAULT_ROWS_PER_PAGE,
-} from 'gmp/models/filter';
-
-import {isDefined} from 'gmp/utils/identity';
+import React from 'react';
 
 import Loading from 'web/components/loading/loading';
 
-import getPage from 'web/store/pages/selectors';
-import {pageFilter as setPageFilter} from 'web/store/pages/actions';
-import {loadUserSettingDefault} from 'web/store/usersettings/defaults/actions';
-import {getUserSettingsDefaults} from 'web/store/usersettings/defaults/selectors';
-import {loadUserSettingsDefaultFilter} from 'web/store/usersettings/defaultfilters/actions';
-import {getUserSettingsDefaultFilter} from 'web/store/usersettings/defaultfilters/selectors';
-
 import PropTypes from 'web/utils/proptypes';
-import useGmp from 'web/utils/useGmp';
+import usePageFilter from 'web/hooks/usePageFilter';
 
 const FilterProvider = ({
   children,
@@ -48,100 +30,13 @@ const FilterProvider = ({
   pageName = gmpname,
   locationQuery = {},
 }) => {
-  const gmp = useGmp();
-  const dispatch = useDispatch();
-
-  let returnedFilter;
-
-  const defaultSettingFilter = useSelector(state => {
-    const defaultFilterSel = getUserSettingsDefaultFilter(state, gmpname);
-    return defaultFilterSel.getFilter();
+  const [returnedFilter, isLoadingFilter] = usePageFilter(pageName, {
+    fallbackFilter,
+    locationQueryFilterString: locationQuery?.filter,
   });
-
-  const defaultSettingsFilterError = useSelector(state => {
-    const defaultFilterSel = getUserSettingsDefaultFilter(state, gmpname);
-    return defaultFilterSel.getError();
-  });
-
-  useEffect(() => {
-    if (
-      !isDefined(defaultSettingFilter) &&
-      !isDefined(defaultSettingsFilterError)
-    ) {
-      dispatch(loadUserSettingsDefaultFilter(gmp)(gmpname));
-    }
-  }, [
-    defaultSettingFilter,
-    defaultSettingsFilterError,
-    dispatch,
-    gmp,
-    gmpname,
-  ]);
-
-  let [rowsPerPage, rowsPerPageError] = useSelector(state => {
-    const userSettingDefaultSel = getUserSettingsDefaults(state);
-    return [
-      userSettingDefaultSel.getValueByName('rowsperpage'),
-      userSettingDefaultSel.getError(),
-    ];
-  }, shallowEqual);
-
-  useEffect(() => {
-    if (!isDefined(rowsPerPage)) {
-      dispatch(loadUserSettingDefault(gmp)(ROWS_PER_PAGE_SETTING_ID));
-    }
-  }, [returnedFilter, rowsPerPage, gmp, dispatch]);
-
-  const [locationQueryFilter, setLocationQueryFilter] = useState(
-    isDefined(locationQuery.filter)
-      ? Filter.fromString(locationQuery.filter)
-      : undefined,
-  );
-
-  useEffect(() => {
-    if (isDefined(locationQuery.filter)) {
-      dispatch(
-        setPageFilter(pageName, Filter.fromString(locationQuery.filter)),
-      );
-    }
-    setLocationQueryFilter(undefined);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const pageFilter = useSelector(state => getPage(state).getFilter(pageName));
-
-  if (isDefined(locationQueryFilter)) {
-    returnedFilter = locationQueryFilter;
-  } else if (isDefined(pageFilter)) {
-    returnedFilter = pageFilter;
-  } else if (
-    isDefined(defaultSettingFilter) &&
-    !isDefined(defaultSettingsFilterError) &&
-    defaultSettingFilter !== null
-  ) {
-    returnedFilter = defaultSettingFilter;
-  } else if (isDefined(fallbackFilter)) {
-    returnedFilter = fallbackFilter;
-  } else {
-    returnedFilter = DEFAULT_FALLBACK_FILTER;
-  }
-
-  if (!isDefined(rowsPerPage) && isDefined(rowsPerPageError)) {
-    rowsPerPage = DEFAULT_ROWS_PER_PAGE;
-  }
-
-  if (!returnedFilter.has('rows') && isDefined(rowsPerPage)) {
-    returnedFilter = returnedFilter.copy().set('rows', rowsPerPage);
-  }
-
-  const showChildren =
-    isDefined(returnedFilter) &&
-    (isDefined(defaultSettingFilter) ||
-      isDefined(defaultSettingsFilterError)) &&
-    isDefined(rowsPerPage);
-
   return (
     <React.Fragment>
-      {showChildren ? children({filter: returnedFilter}) : <Loading />}
+      {isLoadingFilter ? <Loading /> : children({filter: returnedFilter})}
     </React.Fragment>
   );
 };
@@ -156,5 +51,3 @@ FilterProvider.propTypes = {
 };
 
 export default FilterProvider;
-
-// vim: set ts=2 sw=2 tw=80:

--- a/src/web/hooks/__tests__/usePageFilter.jsx
+++ b/src/web/hooks/__tests__/usePageFilter.jsx
@@ -1,0 +1,378 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/* eslint-disable react/prop-types */
+
+import {describe, test, expect, testing} from '@gsa/testing';
+
+import Filter, {DEFAULT_FALLBACK_FILTER} from 'gmp/models/filter';
+
+import {fireEvent, rendererWith, screen} from 'web/utils/testing';
+
+import {loadingActions} from 'web/store/usersettings/defaults/actions';
+import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
+
+import usePageFilter from '../usePageFilter';
+import {pageFilter} from 'web/store/pages/actions';
+
+const TestComponent = ({fallbackFilter}) => {
+  const [filter, isLoadingFilter, changeFilter, removeFilter, resetFilter] =
+    usePageFilter('somePage', {fallbackFilter});
+  return (
+    <>
+      {isLoadingFilter ? (
+        <div data-testid="loading">Loading...</div>
+      ) : (
+        <>
+          <div data-testid="filter">{filter.toFilterString()}</div>
+          <button data-testid="reset" onClick={resetFilter} />
+          <button data-testid="remove" onClick={removeFilter} />
+          <button
+            data-testid="change"
+            onClick={() => {
+              changeFilter(Filter.fromString('changed=1 rows=123'));
+            }}
+          />
+        </>
+      )}
+    </>
+  );
+};
+
+describe('usePageFilter tests', () => {
+  test('should prefer locationQuery filter over defaultSettingFilter', async () => {
+    const locationQuery = {filter: 'location=query'};
+
+    const defaultSettingFilter = Filter.fromString('foo=bar');
+
+    const getSetting = testing.fn().mockResolvedValue({});
+    const gmp = {
+      user: {
+        getSetting,
+      },
+    };
+
+    const {render, store, history} = rendererWith({
+      gmp,
+      store: true,
+      router: true,
+    });
+
+    history.push({query: locationQuery});
+
+    store.dispatch(loadingActions.success({rowsperpage: {value: '42'}}));
+    store.dispatch(
+      defaultFilterLoadingActions.success('somePage', defaultSettingFilter),
+    );
+
+    render(<TestComponent />);
+
+    const renderedFilter = await screen.findByTestId('filter');
+
+    expect(renderedFilter).toHaveTextContent('location=query rows=42');
+  });
+
+  test('should prefer pageFilter over defaultSettingFilter', async () => {
+    const pFilter = Filter.fromString('page=filter');
+    const defaultSettingFilter = Filter.fromString('foo=bar');
+
+    const getSetting = testing.fn().mockResolvedValue({});
+    const gmp = {
+      user: {
+        getSetting,
+      },
+    };
+
+    const {render, store} = rendererWith({
+      gmp,
+      store: true,
+      router: true,
+    });
+
+    store.dispatch(loadingActions.success({rowsperpage: {value: '42'}}));
+    store.dispatch(
+      defaultFilterLoadingActions.success('somePage', defaultSettingFilter),
+    );
+    store.dispatch(pageFilter('somePage', pFilter));
+
+    render(<TestComponent />);
+
+    const renderedFilter = await screen.findByTestId('filter');
+
+    expect(renderedFilter).toHaveTextContent('page=filter rows=42');
+  });
+
+  test('should use defaultSettingFilter', async () => {
+    const defaultSettingFilter = Filter.fromString('foo=bar');
+
+    const getSetting = testing.fn().mockResolvedValue({});
+    const gmp = {
+      user: {
+        getSetting,
+      },
+    };
+
+    const {render, store} = rendererWith({
+      gmp,
+      store: true,
+      router: true,
+    });
+
+    store.dispatch(loadingActions.success({rowsperpage: {value: '42'}}));
+    store.dispatch(
+      defaultFilterLoadingActions.success('somePage', defaultSettingFilter),
+    );
+
+    render(<TestComponent />);
+
+    const renderedFilter = await screen.findByTestId('filter');
+
+    expect(renderedFilter).toHaveTextContent('foo=bar rows=42');
+  });
+
+  test('should use fallbackFilter if no defaultSettingsFilter is available', async () => {
+    const fallbackFilter = Filter.fromString('fall=back');
+
+    const getSetting = testing.fn().mockResolvedValue({});
+    const subscribe = testing.fn();
+    const gmp = {
+      user: {
+        getSetting,
+      },
+    };
+
+    const {render, store} = rendererWith({
+      gmp,
+      store: true,
+      router: true,
+    });
+
+    store.subscribe(subscribe);
+
+    store.dispatch(loadingActions.success({rowsperpage: {value: '42'}}));
+
+    render(<TestComponent fallbackFilter={fallbackFilter} />);
+
+    const renderedFilter = await screen.findByTestId('filter');
+
+    expect(renderedFilter).toHaveTextContent('fall=back rows=42');
+  });
+
+  test('should use fallbackFilter if defaultSettingFilter could not be loaded', async () => {
+    const fallbackFilter = Filter.fromString('fall=back');
+
+    const getSetting = testing.fn().mockResolvedValue({});
+    const gmp = {
+      user: {
+        getSetting,
+      },
+    };
+
+    const {render, store} = rendererWith({
+      gmp,
+      store: true,
+      router: true,
+    });
+
+    store.dispatch(loadingActions.success({rowsperpage: {value: '42'}}));
+    store.dispatch(
+      defaultFilterLoadingActions.error('task', new Error('an error')),
+    );
+
+    render(<TestComponent fallbackFilter={fallbackFilter} />);
+
+    const renderedFilter = await screen.findByTestId('filter');
+
+    expect(renderedFilter).toHaveTextContent('fall=back rows=42');
+  });
+
+  test('should use default fallback filter as last resort', async () => {
+    const resultingFilter = DEFAULT_FALLBACK_FILTER.copy().set('rows', 42);
+
+    const getSetting = testing.fn().mockResolvedValue({});
+    const subscribe = testing.fn();
+    const gmp = {
+      user: {
+        getSetting,
+      },
+    };
+
+    const {render, store} = rendererWith({
+      gmp,
+      store: true,
+      router: true,
+    });
+
+    store.subscribe(subscribe);
+
+    store.dispatch(loadingActions.success({rowsperpage: {value: '42'}}));
+
+    render(<TestComponent />);
+
+    const renderedFilter = await screen.findByTestId('filter');
+
+    expect(renderedFilter).toHaveTextContent(resultingFilter.toFilterString());
+  });
+
+  test('should use default rows per page if rows per page setting could not be loaded', async () => {
+    const fallbackFilter = Filter.fromString('fall=back');
+
+    const getSetting = testing.fn().mockRejectedValue(new Error('an error'));
+    const gmp = {
+      user: {
+        getSetting,
+      },
+    };
+
+    const {render, store} = rendererWith({
+      gmp,
+      store: true,
+      router: true,
+    });
+
+    store.dispatch(loadingActions.error(new Error('an error')));
+
+    render(<TestComponent fallbackFilter={fallbackFilter} />);
+
+    const renderedFilter = await screen.findByTestId('filter');
+
+    expect(renderedFilter).toHaveTextContent('fall=back rows=50');
+  });
+
+  test('should prefer pageFilter rows over defaultSettingFilter and default rows', async () => {
+    const pFilter = Filter.fromString('page=filter rows=42');
+    const defaultSettingFilter = Filter.fromString('foo=bar');
+
+    const getSetting = testing.fn().mockResolvedValue({});
+    const gmp = {
+      user: {
+        getSetting,
+      },
+    };
+
+    const {render, store} = rendererWith({
+      gmp,
+      store: true,
+      router: true,
+    });
+
+    store.dispatch(loadingActions.success({rowsperpage: {value: '666'}}));
+    store.dispatch(
+      defaultFilterLoadingActions.success('somePage', defaultSettingFilter),
+    );
+    store.dispatch(pageFilter('somePage', pFilter));
+
+    render(<TestComponent />);
+
+    const renderedFilter = await screen.findByTestId('filter');
+
+    expect(renderedFilter).toHaveTextContent('page=filter rows=42');
+  });
+
+  test('should allow to reset the filter to the defaultSettingsFilter', async () => {
+    const pFilter = Filter.fromString('page=filter rows=42');
+    const defaultSettingFilter = Filter.fromString('foo=bar');
+
+    const getSetting = testing.fn().mockResolvedValue({});
+    const gmp = {
+      user: {
+        getSetting,
+      },
+    };
+
+    const {render, store} = rendererWith({
+      gmp,
+      store: true,
+      router: true,
+    });
+
+    store.dispatch(loadingActions.success({rowsperpage: {value: '666'}}));
+    store.dispatch(
+      defaultFilterLoadingActions.success('somePage', defaultSettingFilter),
+    );
+    store.dispatch(pageFilter('somePage', pFilter));
+
+    render(<TestComponent />);
+
+    const renderedFilter = await screen.findByTestId('filter');
+    const resetButton = screen.getByTestId('reset');
+
+    expect(renderedFilter).toHaveTextContent('page=filter rows=42');
+
+    fireEvent.click(resetButton);
+
+    expect(renderedFilter).toHaveTextContent('foo=bar rows=666');
+  });
+
+  test('should allow to remove the filter', async () => {
+    const pFilter = Filter.fromString('page=filter rows=42');
+    const defaultSettingFilter = Filter.fromString('foo=bar');
+
+    const getSetting = testing.fn().mockResolvedValue({});
+    const gmp = {
+      user: {
+        getSetting,
+      },
+    };
+
+    const {render, store} = rendererWith({
+      gmp,
+      store: true,
+      router: true,
+    });
+
+    store.dispatch(loadingActions.success({rowsperpage: {value: '666'}}));
+    store.dispatch(
+      defaultFilterLoadingActions.success('somePage', defaultSettingFilter),
+    );
+    store.dispatch(pageFilter('somePage', pFilter));
+
+    render(<TestComponent />);
+
+    const renderedFilter = await screen.findByTestId('filter');
+    const removeButton = screen.getByTestId('remove');
+
+    expect(renderedFilter).toHaveTextContent('page=filter rows=42');
+
+    fireEvent.click(removeButton);
+
+    expect(renderedFilter).toHaveTextContent('first=1');
+  });
+
+  test('should allow to change the filter', async () => {
+    const pFilter = Filter.fromString('page=filter rows=42');
+    const defaultSettingFilter = Filter.fromString('foo=bar');
+
+    const getSetting = testing.fn().mockResolvedValue({});
+    const gmp = {
+      user: {
+        getSetting,
+      },
+    };
+
+    const {render, store} = rendererWith({
+      gmp,
+      store: true,
+      router: true,
+    });
+
+    store.dispatch(loadingActions.success({rowsperpage: {value: '666'}}));
+    store.dispatch(
+      defaultFilterLoadingActions.success('somePage', defaultSettingFilter),
+    );
+    store.dispatch(pageFilter('somePage', pFilter));
+
+    render(<TestComponent />);
+
+    const renderedFilter = await screen.findByTestId('filter');
+    const changeButton = screen.getByTestId('change');
+
+    expect(renderedFilter).toHaveTextContent('page=filter rows=42');
+
+    fireEvent.click(changeButton);
+
+    expect(renderedFilter).toHaveTextContent('changed=1 rows=123');
+  });
+});

--- a/src/web/hooks/usePageFilter.js
+++ b/src/web/hooks/usePageFilter.js
@@ -7,7 +7,7 @@ import {useCallback, useEffect, useState} from 'react';
 
 import {useLocation, useHistory} from 'react-router-dom';
 
-import {useSelector, useDispatch} from 'react-redux';
+import {useDispatch} from 'react-redux';
 
 import {ROWS_PER_PAGE_SETTING_ID} from 'gmp/commands/users';
 
@@ -28,6 +28,8 @@ import {getUserSettingsDefaultFilter} from 'web/store/usersettings/defaultfilter
 
 import useGmp from 'web/utils/useGmp';
 
+import useShallowEqualSelector from './useShallowEqualSelector';
+
 /**
  * Hook to get the default filter of a page from the store
  *
@@ -35,7 +37,7 @@ import useGmp from 'web/utils/useGmp';
  * @returns Array of the default filter and and error if the filter could not be loaded
  */
 const useDefaultFilter = pageName =>
-  useSelector(state => {
+  useShallowEqualSelector(state => {
     const defaultFilterSel = getUserSettingsDefaultFilter(state, pageName);
     return [defaultFilterSel.getFilter(), defaultFilterSel.getError()];
   });
@@ -84,7 +86,7 @@ const usePageFilter = (
     pageName,
   ]);
 
-  let [rowsPerPage, rowsPerPageError] = useSelector(state => {
+  let [rowsPerPage, rowsPerPageError] = useShallowEqualSelector(state => {
     const userSettingDefaultSel = getUserSettingsDefaults(state);
     return [
       userSettingDefaultSel.getValueByName('rowsperpage'),
@@ -113,7 +115,9 @@ const usePageFilter = (
     setLocationQueryFilter(undefined);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const pageFilter = useSelector(state => getPage(state).getFilter(pageName));
+  const pageFilter = useShallowEqualSelector(state =>
+    getPage(state).getFilter(pageName),
+  );
 
   if (hasValue(locationQueryFilter)) {
     returnedFilter = locationQueryFilter;

--- a/src/web/hooks/usePageFilter.js
+++ b/src/web/hooks/usePageFilter.js
@@ -1,0 +1,147 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {useEffect, useState} from 'react';
+
+import {useLocation} from 'react-router-dom';
+
+import {useSelector, useDispatch} from 'react-redux';
+
+import {ROWS_PER_PAGE_SETTING_ID} from 'gmp/commands/users';
+
+import Filter, {
+  DEFAULT_FALLBACK_FILTER,
+  DEFAULT_ROWS_PER_PAGE,
+} from 'gmp/models/filter';
+
+import {isDefined, hasValue} from 'gmp/utils/identity';
+
+import getPage from 'web/store/pages/selectors';
+import {pageFilter as setPageFilter} from 'web/store/pages/actions';
+import {loadUserSettingDefault} from 'web/store/usersettings/defaults/actions';
+import {getUserSettingsDefaults} from 'web/store/usersettings/defaults/selectors';
+import {loadUserSettingsDefaultFilter} from 'web/store/usersettings/defaultfilters/actions';
+import {getUserSettingsDefaultFilter} from 'web/store/usersettings/defaultfilters/selectors';
+
+import useGmp from 'web/utils/useGmp';
+
+/**
+ * Hook to get the default filter of a page from the store
+ *
+ * @param {String} pageName
+ * @returns Array of the default filter and and error if the filter could not be loaded
+ */
+const useDefaultFilter = pageName =>
+  useSelector(state => {
+    const defaultFilterSel = getUserSettingsDefaultFilter(state, pageName);
+    return [defaultFilterSel.getFilter(), defaultFilterSel.getError()];
+  });
+
+/**
+ * Hook to get the filter of a page
+ *
+ * @param {String} pageName Name of the page
+ * @param {Object} options Options object
+ * @returns Array of the applied filter and boolean indicating if the filter is still loading
+ */
+const usePageFilter = (
+  pageName,
+  {fallbackFilter, locationQueryFilterString} = {},
+) => {
+  const gmp = useGmp();
+  const dispatch = useDispatch();
+  const location = useLocation();
+
+  // only use location directly if locationQueryFilterString is undefined
+  // use null as value for not set at all
+  if (!isDefined(locationQueryFilterString)) {
+    locationQueryFilterString = location?.query?.filter;
+  }
+
+  let returnedFilter;
+
+  const [defaultSettingFilter, defaultSettingsFilterError] =
+    useDefaultFilter(pageName);
+
+  useEffect(() => {
+    if (
+      !isDefined(defaultSettingFilter) &&
+      !isDefined(defaultSettingsFilterError)
+    ) {
+      dispatch(loadUserSettingsDefaultFilter(gmp)(pageName));
+    }
+  }, [
+    defaultSettingFilter,
+    defaultSettingsFilterError,
+    dispatch,
+    gmp,
+    pageName,
+  ]);
+
+  let [rowsPerPage, rowsPerPageError] = useSelector(state => {
+    const userSettingDefaultSel = getUserSettingsDefaults(state);
+    return [
+      userSettingDefaultSel.getValueByName('rowsperpage'),
+      userSettingDefaultSel.getError(),
+    ];
+  });
+
+  useEffect(() => {
+    if (!isDefined(rowsPerPage)) {
+      dispatch(loadUserSettingDefault(gmp)(ROWS_PER_PAGE_SETTING_ID));
+    }
+  }, [returnedFilter, rowsPerPage, gmp, dispatch]);
+
+  const [locationQueryFilter, setLocationQueryFilter] = useState(
+    hasValue(locationQueryFilterString)
+      ? Filter.fromString(locationQueryFilterString)
+      : undefined,
+  );
+
+  useEffect(() => {
+    if (hasValue(locationQueryFilterString)) {
+      dispatch(
+        setPageFilter(pageName, Filter.fromString(locationQueryFilterString)),
+      );
+    }
+    setLocationQueryFilter(undefined);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const pageFilter = useSelector(state => getPage(state).getFilter(pageName));
+
+  if (hasValue(locationQueryFilter)) {
+    returnedFilter = locationQueryFilter;
+  } else if (isDefined(pageFilter)) {
+    returnedFilter = pageFilter;
+  } else if (
+    isDefined(defaultSettingFilter) &&
+    !isDefined(defaultSettingsFilterError) &&
+    defaultSettingFilter !== null
+  ) {
+    returnedFilter = defaultSettingFilter;
+  } else if (isDefined(fallbackFilter)) {
+    returnedFilter = fallbackFilter;
+  } else {
+    returnedFilter = DEFAULT_FALLBACK_FILTER;
+  }
+
+  if (!isDefined(rowsPerPage) && isDefined(rowsPerPageError)) {
+    rowsPerPage = DEFAULT_ROWS_PER_PAGE;
+  }
+
+  if (!returnedFilter.has('rows') && isDefined(rowsPerPage)) {
+    returnedFilter = returnedFilter.set('rows', rowsPerPage);
+  }
+
+  const finishedLoading =
+    isDefined(returnedFilter) &&
+    (isDefined(defaultSettingFilter) ||
+      isDefined(defaultSettingsFilterError)) &&
+    isDefined(rowsPerPage);
+
+  return [returnedFilter, !finishedLoading];
+};
+
+export default usePageFilter;


### PR DESCRIPTION
## What

Implement a usePageFilter hook for getting the current applied filter of a page and also to change, reset and remove this filter.

Some background:

Every (entities) page can have a filter for querying the data. The filter can be specified by
1. the user via the powerfilter or some button that modifies the current filter
1. the filter query argument of the current page via the browser URL (`http://...?filter=...`)
1. the last used filter when returning to the page which is stored in the redux store (aka. page filter)
1. the default filter of the entity (which is stored in the database at the user settings and can be received via a specific UUID)
1. the default filter settings for all pages (for example the rows per page setting)

The precedence of the applied filter is specified in the listed order

The new usePageFilter hook implements this behavior as a hook. It can now replace the `FilterProvider` component that implements a similar behavior but via render props. Internally `FilterProvider` is refactored to use `usePageFilter` now.

## Why

The usePageFilter hook is a necessary step for a possible implementation of an entities pages as a function component with hooks.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


