### PR TITLE
Add a useDownload hook

### DIFF
--- a/src/web/components/form/__tests__/useDownload.jsx
+++ b/src/web/components/form/__tests__/useDownload.jsx
@@ -1,0 +1,40 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/* eslint-disable react/prop-types */
+
+import {describe, test, expect, testing} from '@gsa/testing';
+
+import {fireEvent, render, screen} from 'web/utils/testing';
+
+import useDownload from '../useDownload';
+import Download from '../download';
+
+const TestComponent = () => {
+  const [ref, download] = useDownload();
+  return (
+    <>
+      <Download ref={ref} />
+      <button
+        data-testid="download"
+        onClick={() => download({filename: 'foo', data: 'bar'})}
+      />
+    </>
+  );
+};
+
+describe('useDownload', () => {
+  test('should download a file', () => {
+    const createObjectURL = testing.fn().mockReturnValue('foo://bar');
+    window.URL.createObjectURL = createObjectURL;
+    window.URL.revokeObjectURL = testing.fn();
+
+    render(<TestComponent />);
+
+    fireEvent.click(screen.getByTestId('download'));
+
+    expect(createObjectURL).toHaveBeenCalled();
+  });
+});

--- a/src/web/components/form/useDownload.jsx
+++ b/src/web/components/form/useDownload.jsx
@@ -1,0 +1,37 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {useRef, useCallback} from 'react';
+
+import logger from 'gmp/log';
+
+import {hasValue} from 'gmp/utils/identity';
+
+const log = logger.getLogger('web.components.form.useDownload');
+
+/**
+ * Hook to download a file
+ *
+ * Should be used in combination with the Download component
+ *
+ * @returns Array of downloadRef and download function
+ */
+const useDownload = () => {
+  const downloadRef = useRef(null);
+
+  const download = useCallback(({filename, data, mimetype}) => {
+    if (!hasValue(downloadRef.current)) {
+      log.warn('Download ref not set.');
+      return;
+    }
+
+    downloadRef.current.setFilename(filename);
+    downloadRef.current.setData(data, mimetype);
+    downloadRef.current.download();
+  }, []);
+  return [downloadRef, download];
+};
+
+export default useDownload;


### PR DESCRIPTION


## What

Add a useDownload hook

## Why

The useDownload hook in conjunction with the Download component should replace the withDownload HOC in future.

## References

HOCless enities pages

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


