### PR TITLE
Dates inconsistencies in new advance task wizard and schedules

### DIFF
--- a/src/gmp/commands/wizard.js
+++ b/src/gmp/commands/wizard.js
@@ -178,7 +178,7 @@ class WizardCommand extends HttpCommand {
       event_data_quick_task_fields,
     );
 
-    event_data['event_data:start_day'] = start_date.day();
+    event_data['event_data:start_day'] = start_date.date();
     event_data['event_data:start_month'] = start_date.month() + 1;
     event_data['event_data:start_year'] = start_date.year();
 

--- a/src/gmp/models/event.js
+++ b/src/gmp/models/event.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 import ical from 'ical.js';
 
 import {v4 as uuid} from 'uuid';
@@ -305,7 +304,8 @@ class Event {
   }
 
   get duration() {
-    return createDuration({...this.event.duration});
+    const {weeks, ...durationWithoutWeeks} = this.event.duration;
+    return createDuration(durationWithoutWeeks);
   }
 
   get durationInSeconds() {


### PR DESCRIPTION
## What

This PR addresses two bugs:

1. **Incorrect Duration Display in Schedules Table**: The issue was with the `event.duration` getter, which incorrectly included weeks in the duration calculation, leading to inaccurate duration displays in the schedules table.

2. **Start Date Issue in Task Advance Wizard**: The problem is from using `moment.day()` (which returns the day of the week) instead of `moment.date()` (which returns the calendar day) when setting the start date for a new task, resulting in incorrect start dates.

## Why

These fixes ensure the application's scheduling and task management functionalities work as intended, preventing confusion.

## References

GEA-610

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


