### PR TITLE
Change: Update node version for build in release-pontos

### DIFF
--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v4
         with:
-          node-version: "14"
+          node-version: "18"
           cache: "npm"
       - name: Install npm dependencies
         run: npm install


### PR DESCRIPTION
## What

Update node version to 18

## Why

Avoid build errors during release that prevent tarballs creation. See https://github.com/greenbone/gsa/actions/runs/9709185199/job/26797380392

## References
GEA-616


