### PR TITLE
Fix: Make report configs optional in alerts and reports

### DIFF
--- a/src/gmp/commands/alerts.js
+++ b/src/gmp/commands/alerts.js
@@ -9,6 +9,7 @@ import {map} from 'gmp/utils/array';
 
 import registerCommand from 'gmp/command';
 import {parseModelFromElement} from 'gmp/model';
+import {isDefined} from 'gmp/utils/identity';
 
 import Alert from 'gmp/models/alert';
 import Credential from 'gmp/models/credential';
@@ -190,10 +191,12 @@ class AlertCommand extends EntityCommand {
         new_alert.get_report_formats_response.report_format,
         format => parseModelFromElement(format, 'reportformat'),
       );
-      new_alert.report_configs = map(
-        new_alert.get_report_configs_response.report_config,
-        config => parseModelFromElement(config, 'reportconfig'),
-      );
+      if (isDefined(new_alert.get_report_configs_response)) {
+        new_alert.report_configs = map(
+          new_alert.get_report_configs_response.report_config,
+          config => parseModelFromElement(config, 'reportconfig'),
+        );
+      }
       new_alert.credentials = map(
         new_alert.get_credentials_response.credential,
         credential => Credential.fromElement(credential),
@@ -226,11 +229,13 @@ class AlertCommand extends EntityCommand {
       );
       delete edit_alert.get_report_formats_response;
 
-      edit_alert.report_configs = map(
-        edit_alert.get_report_configs_response.report_config,
-        config => parseModelFromElement(config, 'reportconfig'),
-      );
-      delete edit_alert.get_report_configs_response;
+      if (isDefined(edit_alert.get_report_configs_response)) {
+        edit_alert.report_configs = map(
+          edit_alert.get_report_configs_response.report_config,
+          config => parseModelFromElement(config, 'reportconfig'),
+        );
+        delete edit_alert.get_report_configs_response;
+      }
 
       edit_alert.credentials = map(
         edit_alert.get_credentials_response.credential,

--- a/src/web/pages/alerts/dialog.jsx
+++ b/src/web/pages/alerts/dialog.jsx
@@ -717,6 +717,7 @@ class AlertDialog extends React.Component {
               {values.method === METHOD_TYPE_SCP && (
                 <ScpMethodPart
                   prefix="method_data"
+                  capabilities={capabilities}
                   credentials={credentials}
                   reportConfigs={report_configs}
                   reportFormats={report_formats}
@@ -736,6 +737,7 @@ class AlertDialog extends React.Component {
               {values.method === METHOD_TYPE_SEND && (
                 <SendMethodPart
                   prefix="method_data"
+                  capabilities={capabilities}
                   sendHost={values.method_data_send_host}
                   sendPort={values.method_data_send_port}
                   sendReportConfig={values.method_data_send_report_config}
@@ -758,6 +760,7 @@ class AlertDialog extends React.Component {
               {values.method === METHOD_TYPE_SMB && (
                 <SmbMethodPart
                   prefix="method_data"
+                  capabilities={capabilities}
                   credentials={credentials}
                   reportConfigs={report_configs}
                   reportFormats={report_formats}
@@ -801,6 +804,7 @@ class AlertDialog extends React.Component {
               {values.method === METHOD_TYPE_VERINICE && (
                 <VeriniceMethodPart
                   prefix="method_data"
+                  capabilities={capabilities}
                   credentials={credentials}
                   reportConfigs={report_configs}
                   reportFormats={report_formats}

--- a/src/web/pages/alerts/dialog.jsx
+++ b/src/web/pages/alerts/dialog.jsx
@@ -717,7 +717,6 @@ class AlertDialog extends React.Component {
               {values.method === METHOD_TYPE_SCP && (
                 <ScpMethodPart
                   prefix="method_data"
-                  capabilities={capabilities}
                   credentials={credentials}
                   reportConfigs={report_configs}
                   reportFormats={report_formats}
@@ -737,7 +736,6 @@ class AlertDialog extends React.Component {
               {values.method === METHOD_TYPE_SEND && (
                 <SendMethodPart
                   prefix="method_data"
-                  capabilities={capabilities}
                   sendHost={values.method_data_send_host}
                   sendPort={values.method_data_send_port}
                   sendReportConfig={values.method_data_send_report_config}
@@ -760,7 +758,6 @@ class AlertDialog extends React.Component {
               {values.method === METHOD_TYPE_SMB && (
                 <SmbMethodPart
                   prefix="method_data"
-                  capabilities={capabilities}
                   credentials={credentials}
                   reportConfigs={report_configs}
                   reportFormats={report_formats}
@@ -804,7 +801,6 @@ class AlertDialog extends React.Component {
               {values.method === METHOD_TYPE_VERINICE && (
                 <VeriniceMethodPart
                   prefix="method_data"
-                  capabilities={capabilities}
                   credentials={credentials}
                   reportConfigs={report_configs}
                   reportFormats={report_formats}

--- a/src/web/pages/alerts/emailmethodpart.jsx
+++ b/src/web/pages/alerts/emailmethodpart.jsx
@@ -34,14 +34,13 @@ import Divider from 'web/components/layout/divider';
 import IconDivider from 'web/components/layout/icondivider';
 import Layout from 'web/components/layout/layout';
 
-import compose from 'web/utils/compose';
+import useCapabilities from "web/hooks/useCapabilities";
+
 import PropTypes from 'web/utils/proptypes';
 import {renderSelectItems, UNSET_VALUE} from 'web/utils/render';
-import withCapabilities from 'web/utils/withCapabilities';
 import withPrefix from 'web/utils/withPrefix';
 
 const EmailMethodPart = ({
-  capabilities,
   credentials = [],
   fromAddress,
   event,
@@ -62,6 +61,7 @@ const EmailMethodPart = ({
   onCredentialChange,
   onNewCredentialClick,
 }) => {
+  const capabilities = useCapabilities();
   const taskEvent = isTaskEvent(event);
   const secinfoEvent = isSecinfoEvent(event);
   const textReportFormatItems = renderSelectItems(
@@ -295,7 +295,6 @@ const EmailMethodPart = ({
 
 EmailMethodPart.propTypes = {
   attachConfigItems: PropTypes.array,
-  capabilities: PropTypes.capabilities.isRequired,
   credentials: PropTypes.array,
   event: PropTypes.string.isRequired,
   fromAddress: PropTypes.string.isRequired,
@@ -318,6 +317,6 @@ EmailMethodPart.propTypes = {
   onNewCredentialClick: PropTypes.func,
 };
 
-export default compose(withCapabilities, withPrefix)(EmailMethodPart);
+export default withPrefix(EmailMethodPart);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/src/web/pages/alerts/emailmethodpart.jsx
+++ b/src/web/pages/alerts/emailmethodpart.jsx
@@ -199,16 +199,20 @@ const EmailMethodPart = ({
                       onChange={handleReportFormatIdChange}
                     />
                   )}
-
-                  <label htmlFor="report-config-select">Report Config</label>
-                  <Select
-                    disabled={notice !== EMAIL_NOTICE_INCLUDE}
-                    name={prefix + 'notice_report_config'}
-                    id="report-config-select"
-                    value={reportConfigIdInState}
-                    items={reportConfigItems}
-                    onChange={handleReportConfigIdChange}
-                  />
+                  {
+                    capabilities.mayOp("get_report_configs") &&
+                    <>
+                      <label htmlFor="report-config-select">Report Config</label>
+                      <Select
+                        disabled={notice !== EMAIL_NOTICE_INCLUDE}
+                        name={prefix + 'notice_report_config'}
+                        id="report-config-select"
+                        value={reportConfigIdInState}
+                        items={reportConfigItems}
+                        onChange={handleReportConfigIdChange}
+                      />
+                    </>
+                  }
                 </Divider>
 
                 <TextArea
@@ -251,15 +255,20 @@ const EmailMethodPart = ({
                         onChange={handleAttachFormatIdChange}
                       />
                     )}
-                    <label htmlFor="attach-config-select">Report Config</label>
-                    <Select
-                      disabled={notice !== EMAIL_NOTICE_ATTACH}
-                      name={prefix + 'notice_attach_config'}
-                      id="attach-config-select"
-                      value={attachConfigIdInState}
-                      items={attachConfigItems}
-                      onChange={handleAttachConfigIdChange}
-                    />
+                    {
+                      capabilities.mayOp('get_report_configs') &&
+                      <>
+                        <label htmlFor="attach-config-select">Report Config</label>
+                        <Select
+                          disabled={notice !== EMAIL_NOTICE_ATTACH}
+                          name={prefix + 'notice_attach_config'}
+                          id="attach-config-select"
+                          value={attachConfigIdInState}
+                          items={attachConfigItems}
+                          onChange={handleAttachConfigIdChange}
+                        />
+                      </>
+                    }
                   </Divider>
                 </Layout>
                 <TextArea

--- a/src/web/pages/alerts/scpmethodpart.jsx
+++ b/src/web/pages/alerts/scpmethodpart.jsx
@@ -31,6 +31,7 @@ import NewIcon from 'web/components/icon/newicon';
 
 const ScpMethodPart = ({
   prefix,
+  capabilities,
   credentials = [],
   reportFormats,
   reportConfigs,
@@ -136,20 +137,26 @@ const ScpMethodPart = ({
           items={renderSelectItems(reportFormats)}
           onChange={handleReportFormatIdChange}
         />
-        <label htmlFor="report-config-select">&nbsp; Report Config &nbsp; </label>
-        <Select
-          name={prefix + 'scp_report_config'}
-          id="report-config-select"
-          value={scpConfigIdInState}
-          items={reportConfigItems}
-          onChange={handleReportConfigIdChange}
-        />
+        {
+          capabilities.mayOp('get_report_configs') &&
+          <>
+            <label htmlFor="report-config-select">&nbsp; Report Config &nbsp; </label>
+            <Select
+              name={prefix + 'scp_report_config'}
+              id="report-config-select"
+              value={scpConfigIdInState}
+              items={reportConfigItems}
+              onChange={handleReportConfigIdChange}
+            />
+          </>
+        }
       </FormGroup>
     </Layout>
   );
 };
 
 ScpMethodPart.propTypes = {
+  capabilities: PropTypes.capabilities.isRequired,
   credentials: PropTypes.array,
   prefix: PropTypes.string,
   reportConfigs: PropTypes.array,

--- a/src/web/pages/alerts/scpmethodpart.jsx
+++ b/src/web/pages/alerts/scpmethodpart.jsx
@@ -18,9 +18,8 @@ import Layout from 'web/components/layout/layout';
 
 import PropTypes from 'web/utils/proptypes';
 
+import useCapabilities from "web/hooks/useCapabilities";
 import {renderSelectItems, UNSET_VALUE} from '../../utils/render';
-import compose from "web/utils/compose";
-import withCapabilities from "web/utils/withCapabilities";
 import withPrefix from 'web/utils/withPrefix';
 
 import Select from 'web/components/form/select';
@@ -33,7 +32,6 @@ import NewIcon from 'web/components/icon/newicon';
 
 const ScpMethodPart = ({
   prefix,
-  capabilities,
   credentials = [],
   reportFormats,
   reportConfigs,
@@ -48,6 +46,7 @@ const ScpMethodPart = ({
   onCredentialChange,
   onNewCredentialClick,
 }) => {
+  const capabilities = useCapabilities();
   const [reportFormatIdInState, setReportFormatId] = useState(
     selectSaveId(reportFormats, scpReportFormat),
   );
@@ -158,7 +157,6 @@ const ScpMethodPart = ({
 };
 
 ScpMethodPart.propTypes = {
-  capabilities: PropTypes.capabilities.isRequired,
   credentials: PropTypes.array,
   prefix: PropTypes.string,
   reportConfigs: PropTypes.array,
@@ -175,6 +173,6 @@ ScpMethodPart.propTypes = {
   onNewCredentialClick: PropTypes.func.isRequired,
 };
 
-export default compose(withCapabilities, withPrefix)(ScpMethodPart);
+export default withPrefix(ScpMethodPart);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/src/web/pages/alerts/scpmethodpart.jsx
+++ b/src/web/pages/alerts/scpmethodpart.jsx
@@ -19,6 +19,8 @@ import Layout from 'web/components/layout/layout';
 import PropTypes from 'web/utils/proptypes';
 
 import {renderSelectItems, UNSET_VALUE} from '../../utils/render';
+import compose from "web/utils/compose";
+import withCapabilities from "web/utils/withCapabilities";
 import withPrefix from 'web/utils/withPrefix';
 
 import Select from 'web/components/form/select';
@@ -173,6 +175,6 @@ ScpMethodPart.propTypes = {
   onNewCredentialClick: PropTypes.func.isRequired,
 };
 
-export default withPrefix(ScpMethodPart);
+export default compose(withCapabilities, withPrefix)(ScpMethodPart);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/src/web/pages/alerts/sendmethodpart.jsx
+++ b/src/web/pages/alerts/sendmethodpart.jsx
@@ -13,6 +13,8 @@ import Divider from 'web/components/layout/divider';
 import Layout from 'web/components/layout/layout';
 
 import PropTypes from 'web/utils/proptypes';
+import compose from "web/utils/compose";
+import withCapabilities from "web/utils/withCapabilities";
 import withPrefix from 'web/utils/withPrefix';
 
 import Select from 'web/components/form/select';
@@ -110,6 +112,6 @@ SendMethodPart.propTypes = {
   onChange: PropTypes.func,
 };
 
-export default withPrefix(SendMethodPart);
+export default compose(withCapabilities, withPrefix)(SendMethodPart);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/src/web/pages/alerts/sendmethodpart.jsx
+++ b/src/web/pages/alerts/sendmethodpart.jsx
@@ -12,9 +12,8 @@ import _ from 'gmp/locale';
 import Divider from 'web/components/layout/divider';
 import Layout from 'web/components/layout/layout';
 
+import useCapabilities from "web/hooks/useCapabilities";
 import PropTypes from 'web/utils/proptypes';
-import compose from "web/utils/compose";
-import withCapabilities from "web/utils/withCapabilities";
 import withPrefix from 'web/utils/withPrefix';
 
 import Select from 'web/components/form/select';
@@ -23,7 +22,6 @@ import TextField from 'web/components/form/textfield';
 
 const SendMethodPart = ({
   prefix,
-  capabilities,
   reportConfigs,
   reportFormats,
   sendHost,
@@ -32,6 +30,7 @@ const SendMethodPart = ({
   sendReportFormat,
   onChange,
 }) => {
+  const capabilities = useCapabilities();
   const [reportFormatIdInState, setReportFormatId] = useState(
     selectSaveId(reportFormats, sendReportFormat),
   );
@@ -101,7 +100,6 @@ const SendMethodPart = ({
 };
 
 SendMethodPart.propTypes = {
-  capabilities: PropTypes.capabilities.isRequired,
   prefix: PropTypes.string,
   reportConfigs: PropTypes.array,
   reportFormats: PropTypes.array,
@@ -112,6 +110,6 @@ SendMethodPart.propTypes = {
   onChange: PropTypes.func,
 };
 
-export default compose(withCapabilities, withPrefix)(SendMethodPart);
+export default withPrefix(SendMethodPart);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/src/web/pages/alerts/sendmethodpart.jsx
+++ b/src/web/pages/alerts/sendmethodpart.jsx
@@ -21,6 +21,7 @@ import TextField from 'web/components/form/textfield';
 
 const SendMethodPart = ({
   prefix,
+  capabilities,
   reportConfigs,
   reportFormats,
   sendHost,
@@ -79,20 +80,26 @@ const SendMethodPart = ({
           items={renderSelectItems(reportFormats)}
           onChange={handleReportFormatIdChange}
         />
-        <label htmlFor="report-config-select">&nbsp; Report Config &nbsp; </label>
-        <Select
-          name={prefix + 'send_report_config'}
-          id="report-config-select"
-          value={sendConfigIdInState}
-          items={reportConfigItems}
-          onChange={handleReportConfigIdChange}
-        />
+        {
+          capabilities.mayOp('get_report_configs') &&
+          <>
+            <label htmlFor="report-config-select">&nbsp; Report Config &nbsp; </label>
+            <Select
+              name={prefix + 'send_report_config'}
+              id="report-config-select"
+              value={sendConfigIdInState}
+              items={reportConfigItems}
+              onChange={handleReportConfigIdChange}
+            />
+          </>
+        }
       </FormGroup>
     </Layout>
   );
 };
 
 SendMethodPart.propTypes = {
+  capabilities: PropTypes.capabilities.isRequired,
   prefix: PropTypes.string,
   reportConfigs: PropTypes.array,
   reportFormats: PropTypes.array,

--- a/src/web/pages/alerts/smbmethodpart.jsx
+++ b/src/web/pages/alerts/smbmethodpart.jsx
@@ -37,6 +37,7 @@ const smbMaxProtocolItems = [
 
 const SmbMethodPart = ({
   prefix,
+  capabilities,
   credentials = [],
   reportConfigs,
   reportFormats,
@@ -129,14 +130,19 @@ const SmbMethodPart = ({
           value={reportFormatIdInState}
           onChange={handleReportFormatIdChange}
         />
-        <label htmlFor="report-config-select">&nbsp; Report Config &nbsp; </label>
-        <Select
-          name={prefix + 'smb_report_config'}
-          id="report-config-select"
-          value={smbConfigIdInState}
-          items={reportConfigItems}
-          onChange={handleReportConfigIdChange}
-        />
+        {
+          capabilities.mayOp('get_report_configs') &&
+          <>
+            <label htmlFor="report-config-select">&nbsp; Report Config &nbsp; </label>
+            <Select
+              name={prefix + 'smb_report_config'}
+              id="report-config-select"
+              value={smbConfigIdInState}
+              items={reportConfigItems}
+              onChange={handleReportConfigIdChange}
+            />
+          </>
+        }
       </FormGroup>
 
       <FormGroup title={_('Max Protocol')}>
@@ -152,6 +158,7 @@ const SmbMethodPart = ({
 };
 
 SmbMethodPart.propTypes = {
+  capabilities: PropTypes.capabilities.isRequired,
   credentials: PropTypes.array,
   prefix: PropTypes.string,
   reportConfigs: PropTypes.array,

--- a/src/web/pages/alerts/smbmethodpart.jsx
+++ b/src/web/pages/alerts/smbmethodpart.jsx
@@ -20,6 +20,8 @@ import Layout from 'web/components/layout/layout';
 import PropTypes from 'web/utils/proptypes';
 
 import {renderSelectItems, UNSET_VALUE} from 'web/utils/render';
+import compose from "web/utils/compose";
+import withCapabilities from "web/utils/withCapabilities";
 import withPrefix from 'web/utils/withPrefix';
 
 import Select from 'web/components/form/select';
@@ -174,6 +176,6 @@ SmbMethodPart.propTypes = {
   onNewCredentialClick: PropTypes.func.isRequired,
 };
 
-export default withPrefix(SmbMethodPart);
+export default compose(withCapabilities, withPrefix)(SmbMethodPart);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/src/web/pages/alerts/smbmethodpart.jsx
+++ b/src/web/pages/alerts/smbmethodpart.jsx
@@ -19,9 +19,8 @@ import Layout from 'web/components/layout/layout';
 
 import PropTypes from 'web/utils/proptypes';
 
+import useCapabilities from "web/hooks/useCapabilities";
 import {renderSelectItems, UNSET_VALUE} from 'web/utils/render';
-import compose from "web/utils/compose";
-import withCapabilities from "web/utils/withCapabilities";
 import withPrefix from 'web/utils/withPrefix';
 
 import Select from 'web/components/form/select';
@@ -39,7 +38,6 @@ const smbMaxProtocolItems = [
 
 const SmbMethodPart = ({
   prefix,
-  capabilities,
   credentials = [],
   reportConfigs,
   reportFormats,
@@ -53,6 +51,7 @@ const SmbMethodPart = ({
   onNewCredentialClick,
   onCredentialChange,
 }) => {
+  const capabilities = useCapabilities();
   const [reportFormatIdInState, setReportFormatId] = useState(
     selectSaveId(reportFormats, smbReportFormat),
   );
@@ -160,7 +159,6 @@ const SmbMethodPart = ({
 };
 
 SmbMethodPart.propTypes = {
-  capabilities: PropTypes.capabilities.isRequired,
   credentials: PropTypes.array,
   prefix: PropTypes.string,
   reportConfigs: PropTypes.array,
@@ -176,6 +174,6 @@ SmbMethodPart.propTypes = {
   onNewCredentialClick: PropTypes.func.isRequired,
 };
 
-export default compose(withCapabilities, withPrefix)(SmbMethodPart);
+export default withPrefix(SmbMethodPart);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/src/web/pages/alerts/verinicemethodpart.jsx
+++ b/src/web/pages/alerts/verinicemethodpart.jsx
@@ -27,6 +27,7 @@ const VERINICE_CREDENTIAL_TYPES = [USERNAME_PASSWORD_CREDENTIAL_TYPE];
 
 const VeriniceMethodPart = ({
   prefix,
+  capabilities,
   veriniceServerUrl,
   veriniceServerCredential,
   veriniceServerReportConfig,
@@ -102,20 +103,26 @@ const VeriniceMethodPart = ({
           value={reportFormatIdInState}
           onChange={handleReportFormatIdChange}
         />
-        <label htmlFor="report-config-select">&nbsp; Report Config &nbsp; </label>
-        <Select
-          name={prefix + 'verinice_server_report_config'}
-          id="report-config-select"
-          value={veriniceServerConfigIdInState}
-          items={reportConfigItems}
-          onChange={handleReportConfigIdChange}
-        />
+        {
+          capabilities.mayOp('get_report_configs') &&
+          <>
+            <label htmlFor="report-config-select">&nbsp; Report Config &nbsp; </label>
+            <Select
+              name={prefix + 'verinice_server_report_config'}
+              id="report-config-select"
+              value={veriniceServerConfigIdInState}
+              items={reportConfigItems}
+              onChange={handleReportConfigIdChange}
+            />
+          </>
+        }
       </FormGroup>
     </Layout>
   );
 };
 
 VeriniceMethodPart.propTypes = {
+  capabilities: PropTypes.capabilities,
   credentials: PropTypes.array,
   prefix: PropTypes.string,
   reportConfigs: PropTypes.array,

--- a/src/web/pages/alerts/verinicemethodpart.jsx
+++ b/src/web/pages/alerts/verinicemethodpart.jsx
@@ -13,10 +13,9 @@ import {USERNAME_PASSWORD_CREDENTIAL_TYPE} from 'gmp/models/credential';
 import Divider from 'web/components/layout/divider';
 import Layout from 'web/components/layout/layout';
 
+import useCapabilities from "web/hooks/useCapabilities";
 import PropTypes from 'web/utils/proptypes';
 import {renderSelectItems, UNSET_VALUE} from '../../utils/render';
-import compose from "web/utils/compose";
-import withCapabilities from "web/utils/withCapabilities";
 import withPrefix from 'web/utils/withPrefix';
 
 import Select from 'web/components/form/select';
@@ -29,7 +28,6 @@ const VERINICE_CREDENTIAL_TYPES = [USERNAME_PASSWORD_CREDENTIAL_TYPE];
 
 const VeriniceMethodPart = ({
   prefix,
-  capabilities,
   veriniceServerUrl,
   veriniceServerCredential,
   veriniceServerReportConfig,
@@ -41,6 +39,7 @@ const VeriniceMethodPart = ({
   onCredentialChange,
   onNewCredentialClick,
 }) => {
+  const capabilities = useCapabilities();
   reportFormats = reportFormats.filter(format => format.extension === 'vna');
   credentials = credentials.filter(
     cred => cred.credential_type === USERNAME_PASSWORD_CREDENTIAL_TYPE,
@@ -124,7 +123,6 @@ const VeriniceMethodPart = ({
 };
 
 VeriniceMethodPart.propTypes = {
-  capabilities: PropTypes.capabilities,
   credentials: PropTypes.array,
   prefix: PropTypes.string,
   reportConfigs: PropTypes.array,
@@ -138,6 +136,6 @@ VeriniceMethodPart.propTypes = {
   onNewCredentialClick: PropTypes.func.isRequired,
 };
 
-export default compose(withCapabilities, withPrefix)(VeriniceMethodPart);
+export default withPrefix(VeriniceMethodPart);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/src/web/pages/alerts/verinicemethodpart.jsx
+++ b/src/web/pages/alerts/verinicemethodpart.jsx
@@ -15,6 +15,8 @@ import Layout from 'web/components/layout/layout';
 
 import PropTypes from 'web/utils/proptypes';
 import {renderSelectItems, UNSET_VALUE} from '../../utils/render';
+import compose from "web/utils/compose";
+import withCapabilities from "web/utils/withCapabilities";
 import withPrefix from 'web/utils/withPrefix';
 
 import Select from 'web/components/form/select';
@@ -136,6 +138,6 @@ VeriniceMethodPart.propTypes = {
   onNewCredentialClick: PropTypes.func.isRequired,
 };
 
-export default withPrefix(VeriniceMethodPart);
+export default compose(withCapabilities, withPrefix)(VeriniceMethodPart);
 
 // vim: set ts=2 sw=2 tw=80:

--- a/src/web/pages/reports/downloadreportdialog.jsx
+++ b/src/web/pages/reports/downloadreportdialog.jsx
@@ -95,9 +95,11 @@ const DownloadReportDialog = ({
       onSave={handleSave}
     >
       {({values, onValueChange}) => {
-        const filteredReportConfigs = reportConfigs.filter(
-          config => config.report_format.id === reportFormatIdInState,
-        );
+        const filteredReportConfigs = isDefined(reportConfigs)
+          ? reportConfigs.filter(
+              config => config.report_format.id === reportFormatIdInState,
+            )
+          : [];
 
         return (
           <Layout flex="column">
@@ -118,17 +120,20 @@ const DownloadReportDialog = ({
                 />
               </Divider>
             </FormGroup>
-            <FormGroup title={_('Report Config')} titleSize="3">
-              <Divider flex="column">
-                <Select
-                  name="reportConfigId"
-                  value={reportConfigIdInState}
-                  items={renderSelectItems(filteredReportConfigs, '')}
-                  width="auto"
-                  onChange={handleReportConfigIdChange}
-                />
-              </Divider>
-            </FormGroup>
+            {
+              isDefined(reportConfigs) &&
+              <FormGroup title={_('Report Config')} titleSize="3">
+                <Divider flex="column">
+                  <Select
+                    name="reportConfigId"
+                    value={reportConfigIdInState}
+                    items={renderSelectItems(filteredReportConfigs, '')}
+                    width="auto"
+                    onChange={handleReportConfigIdChange}
+                  />
+                </Divider>
+              </FormGroup>
+            }
             <StyledDiv>
               <CheckBox
                 name="storeAsDefault"


### PR DESCRIPTION
## What
If the report configs are not available, the report export and alert dialogs will hide the report config fields.

## Why
This will make the dialogs work as expected if the report config commands are disabled.

## References
GEA-647

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


