### PR TITLE
Add: ci job to run on opensight-ui branch

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - opensight-ui
   pull_request:
     branches:
       - main
+      - opensight-ui
 
 jobs:
   testing:


### PR DESCRIPTION
## What

- Add `opensight-ui` branch to ci jobs

## Why

- CI jobs aren't running on the branch and respective PR against the branch

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


