### PR TITLE
Fix: Disable mangling in production build minify

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,5 +48,9 @@ export default defineConfig({
   },
   build: {
     outDir: 'build',
+    minify: 'terser',
+    terserOptions: {
+      mangle: false,
+    },
   },
 });


### PR DESCRIPTION
## What
The production build now uses terser with the "mangle" option deactivated.

## Why
This addresses a false positive Lintian warning from a mangled variable name.

## References
