### PR TITLE
add: appliance model to page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/img/favicon.png" type="image/png"/>
+    <link rel="icon" href="/img/favicon.png" type="image/png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Greenbone Security Assistant</title>
     <script type="text/javascript" src="/config.js"></script>
@@ -11,5 +11,24 @@
     <div id="app"></div>
     <div id="portals"></div>
     <script type="module" src="/src/index.jsx"></script>
+    <script>
+      window.addEventListener('DOMContentLoaded', () => {
+        try {
+          const vendorLabel = config.vendorLabel;
+
+          const match = vendorLabel.match(/gsm-(\w+)_label\.svg/);
+          if (match) {
+            let labelPart = match[1];
+            if (isNaN(labelPart)) {
+              labelPart = labelPart.toUpperCase();
+            }
+            const pageTitle = `Greenbone - ${labelPart}`;
+            document.title = pageTitle;
+          } else {
+            document.title = 'Greenbone Security Assistant';
+          }
+        } catch (error) {}
+      });
+    </script>
   </body>
 </html>

--- a/src/web/components/layout/__tests__/__snapshots__/pagetitle.jsx.snap
+++ b/src/web/components/layout/__tests__/__snapshots__/pagetitle.jsx.snap
@@ -1,3 +1,0 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
-
-exports[`PageTitle tests > should render 1`] = `null`;

--- a/src/web/components/layout/__tests__/pagetitle.jsx
+++ b/src/web/components/layout/__tests__/pagetitle.jsx
@@ -3,20 +3,22 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 import {describe, test, expect} from '@gsa/testing';
 
 import PageTitle from 'web/components/layout/pagetitle';
 
-import {render} from 'web/utils/testing';
+import {rendererWith} from 'web/utils/testing';
+
+const gmp = {
+  settings: {
+    vendorLabel: 'someVendorLabel',
+  },
+};
 
 describe('PageTitle tests', () => {
-  test('should render', () => {
-    const {element} = render(<PageTitle />);
-    expect(element).toMatchSnapshot();
-  });
-
   test('Should render default title', () => {
+    const {render} = rendererWith({gmp});
+
     const defaultTitle = 'Greenbone Security Assistant';
     render(<PageTitle />);
 
@@ -24,6 +26,8 @@ describe('PageTitle tests', () => {
   });
 
   test('Should render custom title', () => {
+    const {render} = rendererWith({gmp});
+
     const title = 'foo';
     const defaultTitle = 'Greenbone Security Assistant';
     render(<PageTitle title={title} />);
@@ -32,6 +36,8 @@ describe('PageTitle tests', () => {
   });
 
   test('should update value', () => {
+    const {render} = rendererWith({gmp});
+
     const title1 = 'foo';
     const title2 = 'bar';
     const defaultTitle = 'Greenbone Security Assistant';
@@ -42,5 +48,17 @@ describe('PageTitle tests', () => {
     rerender(<PageTitle title={title2} />);
 
     expect(global.window.document.title).toBe(defaultTitle + ' - ' + title2);
+  });
+  test('should render appliance model title', () => {
+    const {render} = rendererWith({
+      gmp: {
+        settings: {
+          vendorLabel: 'gsm-150_label.svg',
+        },
+      },
+    });
+    render(<PageTitle />);
+
+    expect(global.window.document.title).toBe('Greenbone - 150');
   });
 });

--- a/src/web/components/layout/pagetitle.jsx
+++ b/src/web/components/layout/pagetitle.jsx
@@ -6,10 +6,15 @@
 import {useEffect} from 'react';
 import {isDefined} from 'gmp/utils/identity';
 import PropTypes from 'web/utils/proptypes';
-
-const defaultTitle = 'Greenbone Security Assistant';
+import useGmp from 'web/hooks/useGmp';
+import {applianceTitle} from 'web/utils/applianceData';
 
 const PageTitle = ({title}) => {
+  const gmp = useGmp();
+  const vendorLabel = gmp?.settings?.vendorLabel || 'defaultVendorLabel';
+  const defaultTitle =
+    applianceTitle[vendorLabel] || 'Greenbone Security Assistant';
+
   useEffect(() => {
     if (isDefined(title)) {
       document.title = defaultTitle + ' - ' + title;
@@ -20,7 +25,8 @@ const PageTitle = ({title}) => {
     return () => {
       document.title = defaultTitle;
     };
-  }, [title]);
+  }, [defaultTitle, title]);
+
   return null;
 };
 

--- a/src/web/utils/applianceData.js
+++ b/src/web/utils/applianceData.js
@@ -1,0 +1,62 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+const APPLIANCE_DATA = {
+  'gsm-150_label.svg': {
+    title: 'Greenbone - 150',
+  },
+  'gsm-400_label.svg': {
+    title: 'Greenbone - 400',
+  },
+  'gsm-400r2_label.svg': {
+    title: 'Greenbone - 400',
+  },
+  'gsm-450_label.svg': {
+    title: 'Greenbone - 450',
+  },
+  'gsm-450r2_label.svg': {
+    title: 'Greenbone - 450',
+  },
+  'gsm-600_label.svg': {
+    title: 'Greenbone - 600',
+  },
+  'gsm-600r2_label.svg': {
+    title: 'Greenbone - 600',
+  },
+  'gsm-650_label.svg': {
+    title: 'Greenbone - 650',
+  },
+  'gsm-650r2_label.svg': {
+    title: 'Greenbone - 650',
+  },
+  'gsm-5400_label.svg': {
+    title: 'Greenbone - 5400',
+  },
+  'gsm-6500_label.svg': {
+    title: 'Greenbone - 6500',
+  },
+  'gsm-ceno_label.svg': {
+    title: 'Greenbone - CENO',
+  },
+  'gsm-deca_label.svg': {
+    title: 'Greenbone - DECA',
+  },
+  'gsm-exa_label.svg': {
+    title: 'Greenbone - EXA',
+  },
+  'gsm-peta_label.svg': {
+    title: 'Greenbone - PETA',
+  },
+  'gsm-tera_label.svg': {
+    title: 'Greenbone - TERA',
+  },
+};
+
+export const applianceTitle = Object.fromEntries(
+  Object.entries(APPLIANCE_DATA).map(([vendorLabel, {title}]) => [
+    vendorLabel,
+    title,
+  ]),
+);


### PR DESCRIPTION
## What

- Add appliance model to the page title.

## Why

- To have the page title more specific.

## References

GEA-697

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


