### PR TITLE
fix: add loading state to handle authentication status check

### DIFF
--- a/src/web/routes.jsx
+++ b/src/web/routes.jsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
+import {useState, useEffect} from 'react';
 
 import {
   BrowserRouter as Router,
@@ -16,6 +16,7 @@ import LocationObserver from 'web/components/observer/locationobserver';
 import SessionObserver from 'web/components/observer/sessionobserver';
 
 import ConditionalRoute from 'web/components/conditionalRoute/ConditionalRoute';
+import Loading from 'web/components/loading/loading';
 
 import LegacyOmpPage from './pages/omp';
 import Page from './pages/page';
@@ -255,7 +256,18 @@ const LoggedInRoutes = () => {
 };
 
 const AppRoutes = () => {
+  const [isLoading, setIsLoading] = useState(true);
   const isLoggedIn = useSelector(selectIsLoggedIn);
+
+  useEffect(() => {
+    if (isLoggedIn !== undefined) {
+      setIsLoading(false);
+    }
+  }, [isLoggedIn]);
+
+  if (isLoading) {
+    return <Loading />;
+  }
 
   return (
     <Router>{isLoggedIn ? <LoggedInRoutes /> : <LoggedOutRoutes />}</Router>


### PR DESCRIPTION
## What

This PR adds a loading state to the `routes.jsx` component to handle the scenario where the authentication status `isLoggedIn` is not immediately available.

## Why

These changes are necessary to prevent the application from incorrectly redirecting to the logged-out routes when the authentication status is not yet determined. 

## References

GEA-708

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


