### PR TITLE
fix: filtering error on first render for create display

### DIFF
--- a/src/web/hooks/__tests__/usePageFilter.jsx
+++ b/src/web/hooks/__tests__/usePageFilter.jsx
@@ -59,9 +59,11 @@ describe('usePageFilter tests', () => {
       }),
     );
 
-    expect(result.current[0]).toEqual(
-      Filter.fromString('location=query rows=42'),
-    );
+    const expectedFilter = Filter.fromString('location=query rows=42');
+
+    await waitFor(() => {
+      expect(result.current[0].toString()).toEqual(expectedFilter.toString());
+    });
   });
   test('should prefer pageFilter over defaultSettingFilter', async () => {
     const pFilter = Filter.fromString('page=filter');


### PR DESCRIPTION
##What

Updated the `usePageFilter` hook. Introduced `useRef` and `useState` to manage the `returnedFilter` to avoid directly modifying the redux store.


##Why

- Redux error in the charts on first render when resetting the filter to default. 
- Error example
![Screenshot from 2024-11-05 18-02-58](https://github.com/user-attachments/assets/bbdae48a-883f-475d-aeec-5beba487f923)
## References


<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


