### PR TITLE
Remove: Remove delta reports version from user settings

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -473,7 +473,6 @@
   "Delete {{entity}}": "{{entity}} löschen",
   "Delta": "Delta",
   "Delta Report": "Delta-Bericht",
-  "Delta Reports Version (immutable)": "Delta-Bericht-Version (unveränderlich)",
   "Delta Results": "Delta-Ergebnisse",
   "Deny all": "Alle verweigern",
   "Deny all and allow": "Verweigere alle und erlaube",

--- a/src/web/pages/usersettings/usersettingspage.jsx
+++ b/src/web/pages/usersettings/usersettingspage.jsx
@@ -344,7 +344,6 @@ class UserSettings extends React.Component {
       certBundFilter,
       dfnCertFilter,
       autoCacheRebuild = {},
-      deltaReportsVersion,
     } = this.props;
 
     alertsFilter = hasValue(alertsFilter) ? alertsFilter : {};
@@ -486,12 +485,6 @@ class UserSettings extends React.Component {
                                 : _('No')
                               : ''}
                           </TableData>
-                        </TableRow>
-                        <TableRow>
-                          <TableData>
-                            {_('Delta Reports Version (immutable)')}
-                          </TableData>
-                          <TableData>{deltaReportsVersion}</TableData>
                         </TableRow>
                       </TableBody>
                     </Table>
@@ -859,7 +852,6 @@ UserSettings.propTypes = {
   defaultSnmpCredential: PropTypes.object,
   defaultSshCredential: PropTypes.object,
   defaultTarget: PropTypes.object,
-  deltaReportsVersion: PropTypes.numberOrNumberString,
   detailsExportFileName: PropTypes.object,
   dfnCertFilter: PropTypes.object,
   dynamicSeverity: PropTypes.object,
@@ -1036,9 +1028,6 @@ const mapStateToProps = rootState => {
   const certBundFilter = userDefaultFilterSelector.getFilter('certbund');
   const dfnCertFilter = userDefaultFilterSelector.getFilter('dfncert');
   const nvtFilter = userDefaultFilterSelector.getFilter('nvt');
-  const deltaReportsVersion = userDefaultsSelector.getValueByName(
-    'deltareportsversion',
-  );
 
   let scanconfigs = scanConfigsSel.getEntities(ALL_FILTER);
   if (isDefined(scanconfigs)) {
@@ -1107,7 +1096,6 @@ const mapStateToProps = rootState => {
     dfnCertFilter,
     nvtFilter,
     autoCacheRebuild,
-    deltaReportsVersion,
   };
 };
 


### PR DESCRIPTION
## What
Remove the display of delta reports version in user settings

## Why
Feature toggle has been removed from gvmd as well as the non-default code (v1) in [#2317](https://github.com/greenbone/gvmd/pull/2317). No need to keep showing the setting.

## References
GEA-701

