### PR TITLE
Fix: Outdated 21.04 link in Feed Sync Notification.

### DIFF
--- a/src/web/components/notification/FeedSyncNotification/FeedSyncNotification.jsx
+++ b/src/web/components/notification/FeedSyncNotification/FeedSyncNotification.jsx
@@ -53,7 +53,7 @@ const FeedSyncNotification = () => {
             )}{' '}
             <BlankLink
               to={
-                'https://docs.greenbone.net/GSM-Manual/gos-21.04/en/scanning.html?highlight=scan'
+                'https://docs.greenbone.net/GSM-Manual/gos-22.04/en/scanning.html?highlight=scan'
               }
             >
               {_('Documentation')}.


### PR DESCRIPTION
## What
Introduced in #4120 and currently pointing at a dead / 404 link as the GOS 21.04 documentation is no longer available.

## Why
Obvious...

## References
None