### PR TITLE
Fix: Hide EPSS scores columns in compliance view

### DIFF
--- a/src/web/pages/results/row.jsx
+++ b/src/web/pages/results/row.jsx
@@ -162,7 +162,7 @@ const Row = ({
       </TableData>
       <TableData>{entity.port}</TableData>
       {
-        gmp.settings.enableEPSS &&
+        gmp.settings.enableEPSS && !audit &&
         <>
           <TableData>
             {isNumber(epssScore) ? epssScore.toFixed(5) : _("N/A")}

--- a/src/web/pages/results/table.jsx
+++ b/src/web/pages/results/table.jsx
@@ -116,7 +116,7 @@ const Header = ({
           title={_('Location')}
         />
         {
-          gmp.settings.enableEPSS &&
+          gmp.settings.enableEPSS && !audit &&
           <TableHead colSpan="2">
             {_("EPSS")}
           </TableHead>
@@ -148,7 +148,7 @@ const Header = ({
           title={_('Name')}
         />
         {
-          gmp.settings.enableEPSS &&
+          gmp.settings.enableEPSS && !audit &&
           <>
             <TableHead
               width="3%"


### PR DESCRIPTION
## What
Hide EPSS scores columns in compliance view.

## Why
EPSS scores only make sense for vulnerability scans.

## References
GEA-803


