### PR TITLE
fix: Scan Config check box not selectable

### DIFF
--- a/allowedSnakeCase.cjs
+++ b/allowedSnakeCase.cjs
@@ -464,7 +464,6 @@ module.exports = [
   'port_range_start',
   'ports_array',
   'port_type',
-  'pref_count',
   'preference_count',
   'privacy_algorithm',
   'privacy_password',

--- a/src/web/pages/scanconfigs/__tests__/editconfigfamilydialog.jsx
+++ b/src/web/pages/scanconfigs/__tests__/editconfigfamilydialog.jsx
@@ -327,4 +327,35 @@ describe('EditConfigFamilyDialog component tests', () => {
     expect(getOidColumn(rows[1])).toHaveTextContent('1234');
     expect(getOidColumn(rows[2])).toHaveTextContent('2345');
   });
+
+  test('should allow selecting an NVT', () => {
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
+
+    const {render} = rendererWith({capabilities: true});
+    const {getAllByRole} = render(
+      <EditConfigFamilyDialog
+        configId="c1"
+        configName="foo"
+        configNameLabel="Config"
+        familyName="family"
+        isLoadingFamily={false}
+        nvts={[nvt, nvt2]}
+        selected={selected}
+        title="Foo title"
+        onClose={handleClose}
+        onEditNvtDetailsClick={handleOpenEditNvtDetailsDialog}
+        onSave={handleSave}
+      />,
+    );
+
+    const checkboxes = getAllByRole('checkbox');
+
+    expect(checkboxes[0].checked).toBe(false);
+
+    fireEvent.click(checkboxes[0]);
+
+    expect(checkboxes[0].checked).toBe(true);
+  });
 });


### PR DESCRIPTION
## What

- Fixed NVT `React.Memo` comparison for allowing selection
- Improve code readability and standards
## Why

- Select checkboxes in Scan config edit were not selectable

## References

GEA-795

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


