### PR TITLE
fix: improve row key and update nvt preference text wrapping

### DIFF
--- a/src/web/components/table/row.jsx
+++ b/src/web/components/table/row.jsx
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-
 import PropTypes from '../../utils/proptypes';
 
 const TableRow = ({items = [], children, ...other}) => {
   const data = items.map((item, i) => {
-    return <th key={i}>{item}</th>;
+    return (
+      <th key={item.id && item.name ? `${item.id}-${item.name}` : i}>{item}</th>
+    );
   });
   return (
     <tr {...other}>
@@ -20,6 +20,7 @@ const TableRow = ({items = [], children, ...other}) => {
 };
 
 TableRow.propTypes = {
+  children: PropTypes.node,
   items: PropTypes.array,
 };
 

--- a/src/web/pages/scanconfigs/nvtpreferences.jsx
+++ b/src/web/pages/scanconfigs/nvtpreferences.jsx
@@ -19,6 +19,8 @@ import PropTypes from 'web/utils/proptypes';
 
 const StyledTableData = styled(TableData)`
   overflow-wrap: break-word;
+  white-space: normal;
+  word-break: break-word;
 `;
 
 const shouldComponentUpdate = (props, nextProps) =>


### PR DESCRIPTION
## What

- Improved table row key
- Fix `Nvt prferences` text wrapping

## Why

- In rows the index is used as key and should be avoided
- text in cells was not wrapping, causing it to overflow.

## References

GEA-813

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


