### PR TITLE
change: copyright year is set dynamically

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,8 @@ import allowedSnakeCase from './allowedSnakeCase.js';
 
 pluginHeader.rules.header.meta.schema = false; // https://github.com/Stuk/eslint-plugin-header/issues/57
 
+const year = new Date().getFullYear();
+
 export default [
   pluginJs.configs.recommended,
   pluginReact.configs.flat?.recommended,
@@ -88,7 +90,7 @@ export default [
         [
           {
             pattern: ' SPDX-FileCopyrightText: \\d{4} Greenbone AG',
-            template: ' SPDX-FileCopyrightText: 2024 Greenbone AG',
+            template: ` SPDX-FileCopyrightText: ${year} Greenbone AG`,
           },
           ' *',
           ' * SPDX-License-Identifier: AGPL-3.0-or-later',

--- a/src/web/components/structure/footer.jsx
+++ b/src/web/components/structure/footer.jsx
@@ -26,7 +26,7 @@ const Footer = styled.footer`
 const GreenboneFooter = () => {
   return (
     <Footer>
-      Copyright © 2009-2024 by Greenbone AG,&nbsp;
+      Copyright © 2009-2025 by Greenbone AG,&nbsp;
       <Link
         href="http://www.greenbone.net"
         rel="noopener noreferrer"


### PR DESCRIPTION
## What
 
- Update the copyright year in the header and footer to reflect the current year dynamically. 

## Why

- Updates the year automatically without manual intervention.

## References

GEA-819

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests
