### PR TITLE
Sorting indicators and align UI with OpenSight

### DIFF
--- a/src/web/components/icon/ArrowDown.jsx
+++ b/src/web/components/icon/ArrowDown.jsx
@@ -1,0 +1,19 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {ArrowDown as Icon} from 'lucide-react';
+import IconWithStrokeWidth from 'web/components/icon/IconWithStrokeWidth';
+
+import withSvgIcon from './withSvgIcon';
+
+const ArrowDown = withSvgIcon()(props => (
+  <IconWithStrokeWidth
+    IconComponent={Icon}
+    {...props}
+    data-testid="arrowDown-icon"
+  />
+));
+
+export default ArrowDown;

--- a/src/web/components/icon/ArrowUp.jsx
+++ b/src/web/components/icon/ArrowUp.jsx
@@ -1,0 +1,19 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {ArrowUp as Icon} from 'lucide-react';
+import IconWithStrokeWidth from 'web/components/icon/IconWithStrokeWidth';
+
+import withSvgIcon from './withSvgIcon';
+
+const ArrowUp = withSvgIcon()(props => (
+  <IconWithStrokeWidth
+    IconComponent={Icon}
+    {...props}
+    data-testid="arrowUp-icon"
+  />
+));
+
+export default ArrowUp;

--- a/src/web/components/icon/ArrowUpDown.jsx
+++ b/src/web/components/icon/ArrowUpDown.jsx
@@ -1,0 +1,19 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {ArrowUpDown as Icon} from 'lucide-react';
+import IconWithStrokeWidth from 'web/components/icon/IconWithStrokeWidth';
+
+import withSvgIcon from './withSvgIcon';
+
+const ArrowUpDown = withSvgIcon()(props => (
+  <IconWithStrokeWidth
+    IconComponent={Icon}
+    {...props}
+    data-testid="arrowUpDown-icon"
+  />
+));
+
+export default ArrowUpDown;

--- a/src/web/components/label/__tests__/severityclass.jsx
+++ b/src/web/components/label/__tests__/severityclass.jsx
@@ -5,6 +5,7 @@
 
 import {describe, test, expect} from '@gsa/testing';
 import {render} from 'web/utils/testing';
+import Theme from 'web/utils/theme';
 
 import SeverityClassLabel from '../severityclass';
 
@@ -18,40 +19,48 @@ describe('SeverityClassLabel tests', () => {
   test('should render HighLabel', () => {
     const {element} = render(<SeverityClassLabel.High />);
 
-    expect(element).toHaveStyleRule('background-color', '#C83814');
-    expect(element).toHaveStyleRule('border-color', '#C83814');
+    expect(element).toHaveStyleRule('background-color', Theme.errorRed);
+    expect(element).toHaveStyleRule('border-color', Theme.errorRed);
+    expect(element).toHaveStyleRule('color', Theme.white);
     expect(element).toHaveTextContent('High');
   });
 
   test('should render MediumLabel', () => {
     const {element} = render(<SeverityClassLabel.Medium />);
 
-    expect(element).toHaveStyleRule('background-color', '#F0A519');
-    expect(element).toHaveStyleRule('border-color', '#F0A519');
+    expect(element).toHaveStyleRule(
+      'background-color',
+      Theme.severityWarnYellow,
+    );
+    expect(element).toHaveStyleRule('border-color', Theme.severityWarnYellow);
+    expect(element).toHaveStyleRule('color', Theme.black);
     expect(element).toHaveTextContent('Medium');
   });
 
   test('should render LowLabel', () => {
     const {element} = render(<SeverityClassLabel.Low />);
 
-    expect(element).toHaveStyleRule('background-color', '#4F91C7');
-    expect(element).toHaveStyleRule('border-color', '#4F91C7');
+    expect(element).toHaveStyleRule('background-color', Theme.severityLowBlue);
+    expect(element).toHaveStyleRule('border-color', Theme.severityLowBlue);
+    expect(element).toHaveStyleRule('color', Theme.white);
     expect(element).toHaveTextContent('Low');
   });
 
   test('should render LogLabel', () => {
     const {element} = render(<SeverityClassLabel.Log />);
 
-    expect(element).toHaveStyleRule('background-color', '#191919');
-    expect(element).toHaveStyleRule('border-color', '#191919');
+    expect(element).toHaveStyleRule('background-color', Theme.mediumGray);
+    expect(element).toHaveStyleRule('border-color', Theme.mediumGray);
+    expect(element).toHaveStyleRule('color', Theme.white);
     expect(element).toHaveTextContent('Log');
   });
 
   test('should render FalsePositiveLabel', () => {
     const {element} = render(<SeverityClassLabel.FalsePositive />);
 
-    expect(element).toHaveStyleRule('background-color', '#191919');
-    expect(element).toHaveStyleRule('border-color', '#191919');
+    expect(element).toHaveStyleRule('background-color', Theme.mediumGray);
+    expect(element).toHaveStyleRule('border-color', Theme.mediumGray);
+    expect(element).toHaveStyleRule('color', Theme.white);
     expect(element).toHaveTextContent('False Pos.');
   });
 });

--- a/src/web/components/label/severityclass.jsx
+++ b/src/web/components/label/severityclass.jsx
@@ -3,89 +3,82 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import _ from 'gmp/locale';
-import React from 'react';
+import {useTranslation} from 'react-i18next';
 import styled from 'styled-components';
-
+import Theme from 'web/utils/theme';
 
 const Label = styled.div`
-  text-align: center;
+  box-sizing: border-box;
+  position: relative;
   font-weight: normal;
   font-style: normal;
   color: white;
   padding: 1px;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   width: 70px;
   height: 1.5em;
   font-size: 0.8em;
+  text-align: center;
+  color: ${props => props.$textColor};
   background-color: ${props => props.$backgroundColor};
+  border-radius: 5px;
+  overflow: hidden;
   border-color: ${props => props.$borderColor};
 `;
 
-const HighLabel = props => {
-  return (
-    <Label
-      {...props}
-      $backgroundColor="#C83814"
-      $borderColor="#C83814"
-      data-testid="severity-class-High"
-    >
-      {_('High')}
-    </Label>
-  );
-};
+const createLabel =
+  (backgroundColor, borderColor, textColor, testId, text) => props => {
+    const [_] = useTranslation();
+    return (
+      <Label
+        {...props}
+        $backgroundColor={backgroundColor}
+        $borderColor={borderColor}
+        $textColor={textColor}
+        data-testid={testId}
+      >
+        {_(text)}
+      </Label>
+    );
+  };
 
-const MediumLabel = props => {
-  return (
-    <Label
-      {...props}
-      $backgroundColor="#F0A519"
-      $borderColor="#F0A519"
-      data-testid="severity-class-Medium"
-    >
-      {_('Medium')}
-    </Label>
-  );
-};
-
-const LowLabel = props => {
-  return (
-    <Label
-      {...props}
-      $backgroundColor="#4F91C7"
-      $borderColor="#4F91C7"
-      data-testid="severity-class-Low"
-    >
-      {_('Low')}
-    </Label>
-  );
-};
-
-const LogLabel = props => {
-  return (
-    <Label
-      {...props}
-      $backgroundColor="#191919"
-      $borderColor="#191919"
-      data-testid="severity-class-Log"
-    >
-      {_('Log')}
-    </Label>
-  );
-};
-
-const FalsePositiveLabel = props => {
-  return (
-    <Label
-      {...props}
-      $backgroundColor="#191919"
-      $borderColor="#191919"
-      data-testid="severity-class-False-Positive"
-    >
-      {_('False Pos.')}
-    </Label>
-  );
-};
+const HighLabel = createLabel(
+  Theme.errorRed,
+  Theme.errorRed,
+  Theme.white,
+  'severity-class-High',
+  'High',
+);
+const MediumLabel = createLabel(
+  Theme.severityWarnYellow,
+  Theme.severityWarnYellow,
+  Theme.black,
+  'severity-class-Medium',
+  'Medium',
+);
+const LowLabel = createLabel(
+  Theme.severityLowBlue,
+  Theme.severityLowBlue,
+  Theme.white,
+  'severity-class-Low',
+  'Low',
+);
+const LogLabel = createLabel(
+  Theme.mediumGray,
+  Theme.mediumGray,
+  Theme.white,
+  'severity-class-Log',
+  'Log',
+);
+const FalsePositiveLabel = createLabel(
+  Theme.mediumGray,
+  Theme.mediumGray,
+  Theme.white,
+  'severity-class-False-Positive',
+  'False Pos.',
+);
 
 export const SeverityClassLabels = {
   High: HighLabel,

--- a/src/web/components/sortby/sortby.jsx
+++ b/src/web/components/sortby/sortby.jsx
@@ -7,39 +7,33 @@ import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'web/utils/proptypes';
 
-const Anchor = styled.a`
+const SortButton = styled.button`
   cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
 `;
 
-class SortBy extends React.Component {
-  static ASC = 'asc';
-  static DESC = 'desc';
-
-  constructor(...args) {
-    super(...args);
-
-    this.handleClick = this.handleClick.bind(this);
-  }
-
-  handleClick() {
-    const {by, onClick} = this.props;
-
+const SortBy = ({by, children, className, onClick}) => {
+  const handleClick = () => {
     if (onClick) {
       onClick(by);
     }
-  }
+  };
 
-  render() {
-    const {children, className} = this.props;
-    return (
-      <Anchor className={className} onClick={this.handleClick}>
-        {children}
-      </Anchor>
-    );
-  }
-}
+  return (
+    <SortButton className={className} onClick={handleClick}>
+      {children}
+    </SortButton>
+  );
+};
+
+SortBy.ASC = 'asc';
+SortBy.DESC = 'desc';
 
 SortBy.propTypes = {
+  children: PropTypes.node,
   by: PropTypes.string,
   className: PropTypes.string,
   onClick: PropTypes.func,

--- a/src/web/components/table/head.jsx
+++ b/src/web/components/table/head.jsx
@@ -7,10 +7,18 @@ import _ from 'gmp/locale';
 import {isDefined} from 'gmp/utils/identity';
 import React from 'react';
 import styled from 'styled-components';
+import ArrowDown from 'web/components/icon/ArrowDown';
+import ArrowUp from 'web/components/icon/ArrowUp';
+import ArrowUpDown from 'web/components/icon/ArrowUpDown';
 import Layout from 'web/components/layout/layout';
 import Sort from 'web/components/sortby/sortby';
 import PropTypes from 'web/utils/proptypes';
 import Theme from 'web/utils/theme';
+
+const SortSymbol = styled.span`
+  display: inline-flex;
+  align-items: center;
+`;
 
 const TableHead = ({
   children,
@@ -26,42 +34,39 @@ const TableHead = ({
   onSortChange,
   ...other
 }) => {
-  let sortSymbol;
-  if (isDefined(sortBy) && currentSortBy === sortBy) {
-    if (currentSortDir === Sort.DESC) {
-      sortSymbol = // triangle pointing down
-        (
-          <span
-            title={_('Sorted In Descending Order By {{sortBy}}', {
-              sortBy: `${title}`,
-            })}
-          >
-            &nbsp;&#9660;
-          </span>
-        );
-    } else if (currentSortDir === Sort.ASC) {
-      sortSymbol = // triangle pointing up
-        (
-          <span
-            title={_('Sorted In Ascending Order By {{sortBy}}', {
-              sortBy: `${title}`,
-            })}
-          >
-            &nbsp;&#9650;
-          </span>
-        );
+  const getSortSymbol = () => {
+    if (!isDefined(sortBy) || currentSortBy !== sortBy) {
+      return (
+        <SortSymbol title={_('Not Sorted')}>
+          &nbsp;
+          <ArrowUpDown />
+        </SortSymbol>
+      );
     }
-  }
+    const titleText =
+      currentSortDir === Sort.DESC
+        ? _('Sorted In Descending Order By {{sortBy}}', {sortBy: `${title}`})
+        : _('Sorted In Ascending Order By {{sortBy}}', {sortBy: `${title}`});
+    const Icon = currentSortDir === Sort.DESC ? ArrowDown : ArrowUp;
+    return (
+      <SortSymbol title={titleText}>
+        &nbsp;
+        <Icon />
+      </SortSymbol>
+    );
+  };
+
   if (isDefined(title) && !isDefined(children)) {
     children = `${title}`;
   }
+
   return (
     <th className={className} colSpan={colSpan} rowSpan={rowSpan}>
       {sort && sortBy && isDefined(onSortChange) ? (
         <Sort by={sortBy} onClick={onSortChange}>
           <Layout {...other}>
             {children}
-            {sortSymbol}
+            {getSortSymbol()}
           </Layout>
         </Sort>
       ) : (
@@ -72,6 +77,7 @@ const TableHead = ({
 };
 
 TableHead.propTypes = {
+  children: PropTypes.node,
   className: PropTypes.string,
   colSpan: PropTypes.numberString,
   currentSortBy: PropTypes.string,

--- a/src/web/pages/alerts/__tests__/listpage.jsx
+++ b/src/web/pages/alerts/__tests__/listpage.jsx
@@ -29,7 +29,6 @@ import {rendererWith, fireEvent, screen, wait} from 'web/utils/testing';
 
 import AlertPage, {ToolBarIcons} from '../listpage';
 
-
 const caps = new Capabilities(['everything']);
 const wrongCaps = new Capabilities(['get_config']);
 
@@ -184,11 +183,11 @@ describe('Alert listpage tests', () => {
     expect(row[1]).toHaveTextContent('report results filter');
     expect(row[1]).toHaveTextContent('Yes');
 
-    expect(icons[13]).toHaveAttribute('title', 'Move Alert to trashcan');
-    expect(icons[14]).toHaveAttribute('title', 'Edit Alert');
-    expect(icons[15]).toHaveAttribute('title', 'Clone Alert');
-    expect(icons[16]).toHaveAttribute('title', 'Export Alert');
-    expect(icons[17]).toHaveAttribute('title', 'Test Alert');
+    expect(icons[19]).toHaveAttribute('title', 'Move Alert to trashcan');
+    expect(icons[20]).toHaveAttribute('title', 'Edit Alert');
+    expect(icons[21]).toHaveAttribute('title', 'Clone Alert');
+    expect(icons[22]).toHaveAttribute('title', 'Export Alert');
+    expect(icons[23]).toHaveAttribute('title', 'Test Alert');
   });
 
   test('should allow to bulk action on page contents', async () => {

--- a/src/web/pages/reports/__tests__/auditdeltadetailspage.jsx
+++ b/src/web/pages/reports/__tests__/auditdeltadetailspage.jsx
@@ -319,7 +319,7 @@ describe('Audit Detla Report Details Content tests', () => {
     const bars = getAllByTestId('progressbar-box');
 
     // Toolbar Icons
-    expect(icons.length).toEqual(25);
+    expect(icons.length).toEqual(33);
 
     // Powerfilter
     expect(inputs[0]).toHaveAttribute('name', 'userFilterString');

--- a/src/web/pages/reports/__tests__/auditreportslistpage.jsx
+++ b/src/web/pages/reports/__tests__/auditreportslistpage.jsx
@@ -256,14 +256,13 @@ describe('AuditReportsPage tests', () => {
       entitiesActions.success([entity], filter, loadedFilter, counts),
     );
 
-    const {baseElement, getAllByTestId} = render(<AuditReportsPage />);
+    const {baseElement, getByTestId} = render(<AuditReportsPage />);
 
     await waitFor(() => baseElement.querySelectorAll('table'));
 
-    const icons = getAllByTestId('svg-icon');
-
-    expect(icons[19]).toHaveAttribute('title', 'Add tag to page contents');
-    fireEvent.click(icons[19]);
+    const icon = getByTestId('tags-icon');
+    expect(icon).toHaveAttribute('title', 'Add tag to page contents');
+    fireEvent.click(icon);
     expect(getAll).toHaveBeenCalled();
 
     fireEvent.click(screen.getAllByTitle('Delete page contents')[0]);

--- a/src/web/pages/reports/details/__tests__/applicationstab.jsx
+++ b/src/web/pages/reports/details/__tests__/applicationstab.jsx
@@ -60,16 +60,16 @@ describe('Report Applications Tab tests', () => {
     expect(header[3]).toHaveTextContent('Severity');
 
     // Row 1
-    expect(links[4]).toHaveAttribute('href', '/cpe/cpe%3A%2Fa%3A%20123');
-    expect(links[4]).toHaveTextContent('123');
+    expect(links[0]).toHaveAttribute('href', '/cpe/cpe%3A%2Fa%3A%20123');
+    expect(links[0]).toHaveTextContent('123');
     expect(images[0]).toHaveAttribute('src', '/img/cpe/other.svg');
     expect(rows[1]).toHaveTextContent('22'); // 2 Hosts, 2 Occurrences
     expect(bars[0]).toHaveAttribute('title', 'High');
     expect(bars[0]).toHaveTextContent('10.0 (High)');
 
     // Row 2
-    expect(links[5]).toHaveAttribute('href', '/cpe/cpe%3A%2Fa%3A%20456');
-    expect(links[5]).toHaveTextContent('456');
+    expect(links[1]).toHaveAttribute('href', '/cpe/cpe%3A%2Fa%3A%20456');
+    expect(links[1]).toHaveTextContent('456');
     expect(images[1]).toHaveAttribute('src', '/img/cpe/other.svg');
     expect(rows[2]).toHaveTextContent('11'); // 1 Hosts, 1 Occurrences
     expect(bars[1]).toHaveAttribute('title', 'Medium');

--- a/src/web/pages/reports/details/__tests__/closedcvestab.jsx
+++ b/src/web/pages/reports/details/__tests__/closedcvestab.jsx
@@ -57,25 +57,25 @@ describe('Report Closed CVEs Tab tests', () => {
     expect(header[3]).toHaveTextContent('Severity');
 
     // Row 1
-    expect(links[4]).toHaveAttribute('href', '/cve/CVE-2000-1234');
-    expect(links[4]).toHaveTextContent('CVE-2000-1234');
-    expect(links[5]).toHaveAttribute('href', '/host/123');
-    expect(links[5]).toHaveTextContent('123.456.78.910');
-    expect(links[6]).toHaveAttribute('href', '/nvt/201');
-    expect(links[6]).toHaveTextContent('This is a description');
+    expect(links[0]).toHaveAttribute('href', '/cve/CVE-2000-1234');
+    expect(links[0]).toHaveTextContent('CVE-2000-1234');
+    expect(links[1]).toHaveAttribute('href', '/host/123');
+    expect(links[1]).toHaveTextContent('123.456.78.910');
+    expect(links[2]).toHaveAttribute('href', '/nvt/201');
+    expect(links[2]).toHaveTextContent('This is a description');
     expect(bars[0]).toHaveAttribute('title', 'High');
     expect(bars[0]).toHaveTextContent('10.0 (High)');
 
     // Row 2
-    expect(links[7]).toHaveAttribute('href', '/cve/CVE-2000-5678');
-    expect(links[7]).toHaveTextContent('CVE-2000-5678');
-    expect(links[8]).toHaveAttribute(
+    expect(links[3]).toHaveAttribute('href', '/cve/CVE-2000-5678');
+    expect(links[3]).toHaveTextContent('CVE-2000-5678');
+    expect(links[4]).toHaveAttribute(
       'href',
       '/hosts?filter=name%3D109.876.54.321',
     ); // because the host has no asset id
-    expect(links[8]).toHaveTextContent('109.876.54.321');
-    expect(links[9]).toHaveAttribute('href', '/nvt/202');
-    expect(links[9]).toHaveTextContent('This is another description');
+    expect(links[4]).toHaveTextContent('109.876.54.321');
+    expect(links[5]).toHaveAttribute('href', '/nvt/202');
+    expect(links[5]).toHaveTextContent('This is another description');
     expect(bars[1]).toHaveAttribute('title', 'Medium');
     expect(bars[1]).toHaveTextContent('5.0 (Medium)');
 

--- a/src/web/pages/reports/details/__tests__/cvestab.jsx
+++ b/src/web/pages/reports/details/__tests__/cvestab.jsx
@@ -59,19 +59,19 @@ describe('Report CVEs Tab tests', () => {
     expect(header[4]).toHaveTextContent('Severity');
 
     // Row 1
-    expect(links[5]).toHaveAttribute('href', '/cve/CVE-2019-1234');
-    expect(links[5]).toHaveTextContent('CVE-2019-1234');
-    expect(links[6]).toHaveAttribute('href', '/nvt/201');
-    expect(links[6]).toHaveTextContent('nvt1');
+    expect(links[0]).toHaveAttribute('href', '/cve/CVE-2019-1234');
+    expect(links[0]).toHaveTextContent('CVE-2019-1234');
+    expect(links[1]).toHaveAttribute('href', '/nvt/201');
+    expect(links[1]).toHaveTextContent('nvt1');
     expect(rows[1]).toHaveTextContent('22'); // 2 Hosts, 2 Occurrences
     expect(bars[0]).toHaveAttribute('title', 'High');
     expect(bars[0]).toHaveTextContent('10.0 (High)');
 
     // Row 2
-    expect(links[7]).toHaveAttribute('href', '/cve/CVE-2019-5678');
-    expect(links[7]).toHaveTextContent('CVE-2019-5678');
-    expect(links[8]).toHaveAttribute('href', '/nvt/202');
-    expect(links[8]).toHaveTextContent('nvt2');
+    expect(links[2]).toHaveAttribute('href', '/cve/CVE-2019-5678');
+    expect(links[2]).toHaveTextContent('CVE-2019-5678');
+    expect(links[3]).toHaveAttribute('href', '/nvt/202');
+    expect(links[3]).toHaveTextContent('nvt2');
     expect(rows[2]).toHaveTextContent('11'); // 1 Hosts, 1 Occurrences
     expect(bars[1]).toHaveAttribute('title', 'Medium');
     expect(bars[1]).toHaveTextContent('5.0 (Medium)');

--- a/src/web/pages/reports/details/__tests__/errorstab.jsx
+++ b/src/web/pages/reports/details/__tests__/errorstab.jsx
@@ -60,20 +60,20 @@ describe('Report Errors Tab tests', () => {
 
     // Row 1
     expect(rows[1]).toHaveTextContent('This is an error.');
-    expect(links[5]).toHaveAttribute('href', '/host/123');
-    expect(links[5]).toHaveTextContent('123.456.78.910');
+    expect(links[0]).toHaveAttribute('href', '/host/123');
+    expect(links[0]).toHaveTextContent('123.456.78.910');
     expect(rows[1]).toHaveTextContent('foo.bar');
-    expect(links[6]).toHaveAttribute('href', '/nvt/314');
-    expect(links[6]).toHaveTextContent('NVT1');
+    expect(links[1]).toHaveAttribute('href', '/nvt/314');
+    expect(links[1]).toHaveTextContent('NVT1');
     expect(rows[1]).toHaveTextContent('123/tcp');
 
     // Row 2
     expect(rows[2]).toHaveTextContent('This is another error');
-    expect(links[7]).toHaveAttribute('href', '/host/109');
-    expect(links[7]).toHaveTextContent('109.876.54.321');
+    expect(links[2]).toHaveAttribute('href', '/host/109');
+    expect(links[2]).toHaveTextContent('109.876.54.321');
     expect(rows[2]).toHaveTextContent('lorem.ipsum');
-    expect(links[8]).toHaveAttribute('href', '/nvt/159');
-    expect(links[8]).toHaveTextContent('NVT2');
+    expect(links[3]).toHaveAttribute('href', '/nvt/159');
+    expect(links[3]).toHaveTextContent('NVT2');
     expect(rows[2]).toHaveTextContent('456/tcp');
 
     // Filter

--- a/src/web/pages/reports/details/__tests__/hoststab.jsx
+++ b/src/web/pages/reports/details/__tests__/hoststab.jsx
@@ -78,8 +78,9 @@ describe('Report Hosts Tab tests', () => {
     expect(header[15]).toHaveTextContent('Severity');
 
     // Row 1
-    expect(links[15]).toHaveAttribute('href', '/host/123');
-    expect(links[15]).toHaveTextContent('123.456.78.910');
+    expect(links[0]).toHaveAttribute('href', '/host/123');
+
+    expect(links[0]).toHaveTextContent('123.456.78.910');
     expect(rows[1]).toHaveTextContent('foo.bar');
     expect(images[0]).toHaveAttribute('src', '/img/os_unknown.svg');
     expect(rows[1]).toHaveTextContent('1032'); // 10 Ports, 3 Apps, 2 Distance
@@ -90,11 +91,11 @@ describe('Report Hosts Tab tests', () => {
     expect(bars[0]).toHaveTextContent('10.0 (High)');
 
     // Row 2
-    expect(links[16]).toHaveAttribute(
+    expect(links[1]).toHaveAttribute(
       'href',
       '/hosts?filter=name%3D109.876.54.321',
     ); // filter by name because host has no asset id
-    expect(links[16]).toHaveTextContent('109.876.54.321');
+    expect(links[1]).toHaveTextContent('109.876.54.321');
     expect(rows[2]).toHaveTextContent('lorem.ipsum');
     expect(images[0]).toHaveAttribute('src', '/img/os_unknown.svg');
     expect(rows[2]).toHaveTextContent('1521'); // 15 Ports, 2 Apps, 1 Distance
@@ -170,11 +171,11 @@ describe('Audit Report Hosts Tab tests', () => {
     expect(header[13]).toHaveTextContent('Compliant');
 
     // Row 1
-    expect(links[13]).toHaveAttribute(
+    expect(links[0]).toHaveAttribute(
       'href',
       '/hosts?filter=name%3D109.876.54.321',
     ); // filter by name because host has no asset id
-    expect(links[13]).toHaveTextContent('109.876.54.321');
+    expect(links[0]).toHaveTextContent('109.876.54.321');
     expect(rows[1]).toHaveTextContent('lorem.ipsum');
     expect(images[0]).toHaveAttribute('src', '/img/os_unknown.svg');
     expect(rows[1]).toHaveTextContent('1521'); // 15 Ports, 2 Apps, 1 Distance
@@ -185,8 +186,8 @@ describe('Audit Report Hosts Tab tests', () => {
     expect(bars[0]).toHaveTextContent('Incomplete');
 
     // Row 2
-    expect(links[14]).toHaveAttribute('href', '/host/123');
-    expect(links[14]).toHaveTextContent('123.456.78.910');
+    expect(links[1]).toHaveAttribute('href', '/host/123');
+    expect(links[1]).toHaveTextContent('123.456.78.910');
     expect(rows[2]).toHaveTextContent('foo.bar');
     expect(images[0]).toHaveAttribute('src', '/img/os_unknown.svg');
     expect(rows[2]).toHaveTextContent('1032'); // 10 Ports, 3 Apps, 2 Distance
@@ -197,8 +198,8 @@ describe('Audit Report Hosts Tab tests', () => {
     expect(bars[1]).toHaveTextContent('No');
 
     // Row 3
-    expect(links[15]).toHaveAttribute('href', '/host/123');
-    expect(links[15]).toHaveTextContent('123.456.78.810');
+    expect(links[2]).toHaveAttribute('href', '/host/123');
+    expect(links[2]).toHaveTextContent('123.456.78.810');
     expect(rows[3]).toHaveTextContent('foo.bar');
     expect(images[0]).toHaveAttribute('src', '/img/os_unknown.svg');
     expect(rows[3]).toHaveTextContent('1032'); // 10 Ports, 3 Apps, 2 Distance

--- a/src/web/pages/reports/details/__tests__/operatingsystemstab.jsx
+++ b/src/web/pages/reports/details/__tests__/operatingsystemstab.jsx
@@ -57,31 +57,31 @@ describe('Report Operating Systems Tab tests', () => {
 
     // Row 1
     expect(images[0]).toHaveAttribute('src', '/img/os_unknown.svg');
-    expect(links[4]).toHaveAttribute(
+    expect(links[1]).toHaveAttribute(
       'href',
       '/operatingsystems?filter=name%3Dcpe%3A%2Ffoo%2Fbar',
     );
-    expect(links[4]).toHaveTextContent('Foo OS');
-    expect(links[5]).toHaveAttribute(
+    expect(links[0]).toHaveTextContent('Foo OS');
+    expect(links[0]).toHaveAttribute(
       'href',
       '/operatingsystems?filter=name%3Dcpe%3A%2Ffoo%2Fbar',
     );
-    expect(links[5]).toHaveTextContent('cpe:/foo/bar');
+    expect(links[1]).toHaveTextContent('cpe:/foo/bar');
     expect(bars[0]).toHaveAttribute('title', 'High');
     expect(bars[0]).toHaveTextContent('10.0 (High)');
 
     // Row 2
     expect(images[1]).toHaveAttribute('src', '/img/os_unknown.svg');
-    expect(links[6]).toHaveAttribute(
+    expect(links[2]).toHaveAttribute(
       'href',
       '/operatingsystems?filter=name%3Dcpe%3A%2Florem%2Fipsum',
     );
-    expect(links[6]).toHaveTextContent('Lorem OS');
-    expect(links[7]).toHaveAttribute(
+    expect(links[2]).toHaveTextContent('Lorem OS');
+    expect(links[2]).toHaveAttribute(
       'href',
       '/operatingsystems?filter=name%3Dcpe%3A%2Florem%2Fipsum',
     );
-    expect(links[7]).toHaveTextContent('cpe:/lorem/ipsum');
+    expect(links[3]).toHaveTextContent('cpe:/lorem/ipsum');
     expect(bars[1]).toHaveAttribute('title', 'Medium');
     expect(bars[1]).toHaveTextContent('5.0 (Medium)');
 
@@ -138,31 +138,31 @@ describe('Audit Report Operating Systems Tab tests', () => {
 
     // Row 1
     expect(images[0]).toHaveAttribute('src', '/img/os_unknown.svg');
-    expect(links[4]).toHaveAttribute(
+    expect(links[0]).toHaveAttribute(
       'href',
       '/operatingsystems?filter=name%3Dcpe%3A%2Ffoo%2Fbar',
     );
-    expect(links[4]).toHaveTextContent('Foo OS');
-    expect(links[5]).toHaveAttribute(
+    expect(links[0]).toHaveTextContent('Foo OS');
+    expect(links[1]).toHaveAttribute(
       'href',
       '/operatingsystems?filter=name%3Dcpe%3A%2Ffoo%2Fbar',
     );
-    expect(links[5]).toHaveTextContent('cpe:/foo/bar');
+    expect(links[1]).toHaveTextContent('cpe:/foo/bar');
     expect(bars[0]).toHaveAttribute('title', 'No');
     expect(bars[0]).toHaveTextContent('No');
 
     // Row 2
     expect(images[1]).toHaveAttribute('src', '/img/os_unknown.svg');
-    expect(links[6]).toHaveAttribute(
+    expect(links[2]).toHaveAttribute(
       'href',
       '/operatingsystems?filter=name%3Dcpe%3A%2Florem%2Fipsum',
     );
-    expect(links[6]).toHaveTextContent('Lorem OS');
-    expect(links[7]).toHaveAttribute(
+    expect(links[2]).toHaveTextContent('Lorem OS');
+    expect(links[2]).toHaveAttribute(
       'href',
       '/operatingsystems?filter=name%3Dcpe%3A%2Florem%2Fipsum',
     );
-    expect(links[7]).toHaveTextContent('cpe:/lorem/ipsum');
+    expect(links[3]).toHaveTextContent('cpe:/lorem/ipsum');
     expect(bars[1]).toHaveAttribute('title', 'Incomplete');
     expect(bars[1]).toHaveTextContent('Incomplete');
 

--- a/src/web/pages/reports/details/__tests__/tlscertificatestab.jsx
+++ b/src/web/pages/reports/details/__tests__/tlscertificatestab.jsx
@@ -64,15 +64,16 @@ describe('Report TLS Certificates Tab tests', () => {
     expect(rows[1]).toHaveTextContent('00B49C541FF5A8E1D9');
     expect(rows[1]).toHaveTextContent('Sat, Aug 10, 2019');
     expect(rows[1]).toHaveTextContent('Tue, Sep 10, 2019');
-    expect(links[7]).toHaveAttribute(
+
+    expect(links[1]).toHaveAttribute(
       'href',
       '/hosts?filter=name%3D192.168.9.90',
     );
-    expect(links[7]).toHaveAttribute(
+    expect(links[1]).toHaveAttribute(
       'title',
       'Show all Hosts with IP 192.168.9.90',
     );
-    expect(links[7]).toHaveTextContent('192.168.9.90');
+    expect(links[1]).toHaveTextContent('192.168.9.90');
     expect(rows[1]).toHaveTextContent('foo.bar');
     expect(rows[1]).toHaveTextContent('4021');
 
@@ -81,30 +82,30 @@ describe('Report TLS Certificates Tab tests', () => {
     expect(rows[2]).toHaveTextContent('00B49C541FF5A8E1D9');
     expect(rows[2]).toHaveTextContent('Sat, Aug 10, 2019');
     expect(rows[2]).toHaveTextContent('Tue, Sep 10, 2019');
-    expect(links[8]).toHaveAttribute(
+    expect(links[1]).toHaveAttribute(
       'href',
       '/hosts?filter=name%3D192.168.9.90',
     );
-    expect(links[8]).toHaveAttribute(
+    expect(links[1]).toHaveAttribute(
       'title',
       'Show all Hosts with IP 192.168.9.90',
     );
-    expect(links[8]).toHaveTextContent('192.168.9.90');
+    expect(links[1]).toHaveTextContent('192.168.9.90');
     expect(rows[2]).toHaveTextContent('foo.bar');
     expect(rows[2]).toHaveTextContent('4023');
 
     // Row 3
     expect(rows[3]).toHaveTextContent('CN=LoremIpsumSubject2 C=Dolor');
     expect(rows[3]).toHaveTextContent('00C387C32CBB861F5C');
-    expect(links[9]).toHaveAttribute(
+    expect(links[2]).toHaveAttribute(
       'href',
       '/hosts?filter=name%3D191.164.9.93',
     );
-    expect(links[9]).toHaveAttribute(
+    expect(links[2]).toHaveAttribute(
       'title',
       'Show all Hosts with IP 191.164.9.93',
     );
-    expect(links[9]).toHaveTextContent('191.164.9.93');
+    expect(links[2]).toHaveTextContent('191.164.9.93');
     expect(rows[3]).toHaveTextContent('8445');
 
     // Filter
@@ -144,12 +145,12 @@ describe('Report TLS Certificates Tab tests', () => {
 
     const icons = baseElement.querySelectorAll('svg');
 
-    fireEvent.click(icons[4]);
+    fireEvent.click(icons[11]);
     expect(onTlsCertificateDownloadClick).toHaveBeenCalledWith(
       tlsCertificates.entities[0],
     );
 
-    fireEvent.click(icons[5]);
+    fireEvent.click(icons[12]);
     expect(onTlsCertificateDownloadClick).toHaveBeenCalledWith(
       tlsCertificates.entities[1],
     );

--- a/src/web/pages/scanconfigs/__tests__/editconfigfamilydialog.jsx
+++ b/src/web/pages/scanconfigs/__tests__/editconfigfamilydialog.jsx
@@ -12,7 +12,15 @@ import {
   getTableBody,
   getTableHeader,
 } from 'web/components/testing';
-import {rendererWith, fireEvent} from 'web/utils/testing';
+import {
+  rendererWith,
+  fireEvent,
+  prettyDOM,
+  within,
+  wait,
+  userEvent,
+  screen,
+} from 'web/utils/testing';
 
 import EditConfigFamilyDialog from '../editconfigfamilydialog';
 
@@ -229,102 +237,72 @@ describe('EditConfigFamilyDialog component tests', () => {
       />,
     );
 
-    const editButtons = getAllByTestId('svg-icon');
+    const editButtons = getAllByTestId('edit-icon');
     fireEvent.click(editButtons[0]);
 
     expect(handleOpenEditNvtDetailsDialog).toHaveBeenCalledWith(nvt.id);
   });
 
-  test('should sort table', async () => {
-    const handleClose = testing.fn();
-    const handleSave = testing.fn();
-    const handleOpenEditNvtDetailsDialog = testing.fn();
+  test.each`
+    columnIndex | columnName    | initialOrder                | sortedOrder
+    ${0}        | ${'Name'}     | ${['1234', '5678', '2345']} | ${['2345', '5678', '1234']}
+    ${1}        | ${'OID'}      | ${['1234', '5678', '2345']} | ${['1234', '2345', '5678']}
+    ${2}        | ${'Severity'} | ${['1234', '5678', '2345']} | ${['2345', '1234', '5678']}
+    ${3}        | ${'Timeout'}  | ${['1234', '5678', '2345']} | ${['1234', '5678', '2345']}
+    ${5}        | ${'Selected'} | ${['1234', '5678', '2345']} | ${['5678', '1234', '2345']}
+  `(
+    'should sort table by $columnName column',
+    async ({columnName, initialOrder, sortedOrder}) => {
+      const handleClose = testing.fn();
+      const handleSave = testing.fn();
+      const handleOpenEditNvtDetailsDialog = testing.fn();
 
-    const newSelected = {
-      1234: 0,
-      5678: 1,
-      2345: 0,
-    };
+      const newSelected = {
+        1234: 0,
+        5678: 1,
+        2345: 0,
+      };
 
-    const {render} = rendererWith({capabilities: true});
-    render(
-      <EditConfigFamilyDialog
-        configId="c1"
-        configName="foo"
-        configNameLabel="Config"
-        familyName="family"
-        isLoadingFamily={false}
-        nvts={[nvt, nvt2, nvt3]}
-        selected={newSelected}
-        title="Foo title"
-        onClose={handleClose}
-        onEditNvtDetailsClick={handleOpenEditNvtDetailsDialog}
-        onSave={handleSave}
-      />,
-    );
-    const getOidColumn = row => row.querySelectorAll('td')[1];
+      const {render} = rendererWith({capabilities: true});
+      render(
+        <EditConfigFamilyDialog
+          configId="c1"
+          configName="foo"
+          configNameLabel="Config"
+          familyName="family"
+          isLoadingFamily={false}
+          nvts={[nvt, nvt2, nvt3]}
+          selected={newSelected}
+          title="Foo title"
+          onClose={handleClose}
+          onEditNvtDetailsClick={handleOpenEditNvtDetailsDialog}
+          onSave={handleSave}
+        />,
+      );
 
-    const dialog = getDialog();
-    const tableHeader = getTableHeader(dialog);
-    const tableBody = getTableBody(dialog);
-    let rows = tableBody.querySelectorAll('tr');
-    const columns = tableHeader.querySelectorAll('a');
+      const getOidColumn = row => row.querySelectorAll('td')[1];
 
-    expect(getOidColumn(rows[0])).toHaveTextContent('1234');
-    expect(getOidColumn(rows[1])).toHaveTextContent('5678');
-    expect(getOidColumn(rows[2])).toHaveTextContent('2345');
+      const dialog = getDialog();
+      const tableHeader = getTableHeader(dialog);
+      const tableBody = getTableBody(dialog);
+      let rows = tableBody.querySelectorAll('tr');
+      const columns = within(tableHeader).getAllByRole('columnheader');
+      expect(columns).toHaveLength(7);
 
-    // sort by name column desc
-    expect(columns[0]).toHaveTextContent('Name');
-    await clickElement(columns[0]);
+      initialOrder.forEach((oid, index) => {
+        expect(getOidColumn(rows[index])).toHaveTextContent(oid);
+      });
 
-    rows = tableBody.querySelectorAll('tr');
+      const columnHeader = screen.getByText(columnName);
+      fireEvent.click(columnHeader);
 
-    expect(getOidColumn(rows[0])).toHaveTextContent('2345');
-    expect(getOidColumn(rows[1])).toHaveTextContent('5678');
-    expect(getOidColumn(rows[2])).toHaveTextContent('1234');
+      rows = tableBody.querySelectorAll('tr');
 
-    // sort by oid column
-    expect(columns[1]).toHaveTextContent('OID');
-    await clickElement(columns[1]);
-
-    rows = tableBody.querySelectorAll('tr');
-
-    expect(getOidColumn(rows[0])).toHaveTextContent('1234');
-    expect(getOidColumn(rows[1])).toHaveTextContent('2345');
-    expect(getOidColumn(rows[2])).toHaveTextContent('5678');
-
-    // sort by severity column
-    expect(columns[2]).toHaveTextContent('Severity');
-    await clickElement(columns[2]);
-
-    rows = tableBody.querySelectorAll('tr');
-
-    expect(getOidColumn(rows[0])).toHaveTextContent('2345');
-    expect(getOidColumn(rows[1])).toHaveTextContent('1234');
-    expect(getOidColumn(rows[2])).toHaveTextContent('5678');
-
-    // sort by timeout column
-    expect(columns[3]).toHaveTextContent('Timeout');
-    await clickElement(columns[3]);
-
-    rows = tableBody.querySelectorAll('tr');
-
-    expect(getOidColumn(rows[0])).toHaveTextContent('1234');
-    expect(getOidColumn(rows[1])).toHaveTextContent('5678');
-    expect(getOidColumn(rows[2])).toHaveTextContent('2345');
-
-    // sort by selected column
-    expect(columns[4]).toHaveTextContent('Selected');
-    fireEvent.click(columns[4]);
-
-    rows = tableBody.querySelectorAll('tr');
-
-    expect(getOidColumn(rows[0])).toHaveTextContent('5678');
-    expect(getOidColumn(rows[1])).toHaveTextContent('1234');
-    expect(getOidColumn(rows[2])).toHaveTextContent('2345');
-  });
-
+      sortedOrder.forEach((oid, index) => {
+        expect(getOidColumn(rows[index])).toHaveTextContent(oid);
+      });
+    },
+  );
   test('should allow selecting an NVT', () => {
     const handleClose = testing.fn();
     const handleSave = testing.fn();

--- a/src/web/pages/scanconfigs/__tests__/editconfigfamilydialog.jsx
+++ b/src/web/pages/scanconfigs/__tests__/editconfigfamilydialog.jsx
@@ -6,21 +6,12 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import Nvt from 'gmp/models/nvt';
 import {
-  clickElement,
   getDialog,
   getDialogSaveButton,
   getTableBody,
   getTableHeader,
 } from 'web/components/testing';
-import {
-  rendererWith,
-  fireEvent,
-  prettyDOM,
-  within,
-  wait,
-  userEvent,
-  screen,
-} from 'web/utils/testing';
+import {rendererWith, fireEvent, within, screen} from 'web/utils/testing';
 
 import EditConfigFamilyDialog from '../editconfigfamilydialog';
 

--- a/src/web/pages/scanconfigs/editconfigfamilydialog.jsx
+++ b/src/web/pages/scanconfigs/editconfigfamilydialog.jsx
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
-
 import {YES_VALUE, NO_VALUE} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
@@ -127,6 +125,20 @@ const sortNvts = (sortBy, sortReverse, selected = {}, nvts = []) => {
   return [...nvts].sort(compare);
 };
 
+const renderTableHead = (sortBy, sortDir, handleSortChange, columns) => {
+  return columns.map(({sortBy: columnSortBy, title, align}) => (
+    <TableHead
+      key={columnSortBy || title}
+      align={align}
+      currentSortBy={sortBy}
+      currentSortDir={sortDir}
+      sortBy={columnSortBy}
+      title={title}
+      onSortChange={handleSortChange}
+    />
+  ));
+};
+
 const EditScanConfigFamilyDialog = ({
   configId,
   configName,
@@ -181,6 +193,12 @@ const EditScanConfigFamilyDialog = ({
     {sortBy: EDIT_CONFIG_COLUMNS_SORT.severity, title: _('Severity')},
     {sortBy: EDIT_CONFIG_COLUMNS_SORT.timeout, title: _('Timeout')},
     {title: _('Prefs')},
+    {
+      sortBy: EDIT_CONFIG_COLUMNS_SORT.selected,
+      title: _('Selected'),
+      align: 'center',
+    },
+    {title: _('Actions'), align: 'center'},
   ];
 
   return (
@@ -204,25 +222,7 @@ const EditScanConfigFamilyDialog = ({
         <Table>
           <TableHeader>
             <TableRow>
-              {tableHeaders.map(({sortBy, title}) => (
-                <TableHead
-                  key={title}
-                  currentSortBy={sortBy}
-                  currentSortDir={sortDir}
-                  sortBy={sortBy}
-                  title={title}
-                  onSortChange={handleSortChange}
-                />
-              ))}
-              <TableHead
-                align="center"
-                currentSortBy={sortBy}
-                currentSortDir={sortDir}
-                sortBy={EDIT_CONFIG_COLUMNS_SORT.selected}
-                title={_('Selected')}
-                onSortChange={handleSortChange}
-              />
-              <TableHead align="center">{_('Actions')}</TableHead>
+              {renderTableHead(sortBy, sortDir, handleSortChange, tableHeaders)}
             </TableRow>
           </TableHeader>
           <TableBody>

--- a/src/web/pages/tasks/__tests__/listpage.jsx
+++ b/src/web/pages/tasks/__tests__/listpage.jsx
@@ -205,12 +205,12 @@ describe('TaskPage tests', () => {
     expect(row[1]).toHaveTextContent('Sat, Aug 10, 2019 2:51 PM CEST');
     expect(row[1]).toHaveTextContent('5.0 (Medium)');
 
-    expect(icons[24]).toHaveAttribute('title', 'Start');
-    expect(icons[25]).toHaveAttribute('title', 'Task is not stopped');
-    expect(icons[26]).toHaveAttribute('title', 'Move Task to trashcan');
-    expect(icons[27]).toHaveAttribute('title', 'Edit Task');
-    expect(icons[28]).toHaveAttribute('title', 'Clone Task');
-    expect(icons[29]).toHaveAttribute('title', 'Export Task');
+    expect(icons[30]).toHaveAttribute('title', 'Start');
+    expect(icons[31]).toHaveAttribute('title', 'Task is not stopped');
+    expect(icons[32]).toHaveAttribute('title', 'Move Task to trashcan');
+    expect(icons[33]).toHaveAttribute('title', 'Edit Task');
+    expect(icons[34]).toHaveAttribute('title', 'Clone Task');
+    expect(icons[35]).toHaveAttribute('title', 'Export Task');
   });
 
   test('should call commands for bulk actions', async () => {

--- a/src/web/pages/tlscertificates/__tests__/listpage.jsx
+++ b/src/web/pages/tlscertificates/__tests__/listpage.jsx
@@ -193,12 +193,12 @@ describe('TlsCertificatePage tests', () => {
     // expect(row[1]).toHaveTextContent('Tue, Sep 10, 2019 12:51 PM UTC');
     // expect(row[1]).toHaveTextContent('Thu, Oct 10, 2019 12:51 PM UTC');
 
-    expect(icons[19]).toHaveAttribute('title', 'Delete TLS Certificate');
-    expect(icons[20]).toHaveAttribute('title', 'Download TLS Certificate');
-    expect(icons[21]).toHaveAttribute('title', 'Export TLS Certificate as XML');
+    expect(icons[24]).toHaveAttribute('title', 'Delete TLS Certificate');
+    expect(icons[25]).toHaveAttribute('title', 'Download TLS Certificate');
+    expect(icons[26]).toHaveAttribute('title', 'Export TLS Certificate as XML');
 
-    expect(icons[22]).toHaveAttribute('title', 'Add tag to page contents');
-    expect(icons[23]).toHaveAttribute('title', 'Delete page contents');
-    expect(icons[24]).toHaveAttribute('title', 'Export page contents');
+    expect(icons[27]).toHaveAttribute('title', 'Add tag to page contents');
+    expect(icons[28]).toHaveAttribute('title', 'Delete page contents');
+    expect(icons[29]).toHaveAttribute('title', 'Export page contents');
   });
 });


### PR DESCRIPTION
## What

1. fix:  sorting indicators in `editconfigfamilydialog.jsx` header table
2. change: sorting icons to match opensight
3. change: ui for `severityclass.jsx` to align with opensight

## Why

1. Once clicking sort on one column the header icons of all columns would change in the table of `editconfigfamilydialog`

## References

GEA-814

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


