### PR TITLE
Fix dockerfile linting issue with using different casing

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -1,7 +1,7 @@
 ARG VERSION=stable
 ARG DEBIAN_FRONTEND=noninteractive
 
-FROM debian:stable-slim as builder
+FROM debian:stable-slim AS builder
 
 ENV NODE_VERSION=node_18.x
 ENV NODE_KEYRING=/usr/share/keyrings/nodesource.gpg


### PR DESCRIPTION
## What

Fix dockerfile linting issue with using different casing.

## Why

See https://docs.docker.com/reference/build-checks/from-as-casing/ for details. This change fixes an warning wich is shown in every PR.


## References

https://github.com/greenbone/gsa/pull/4266/files

![grafik](https://github.com/user-attachments/assets/8bb7c75f-b075-4ed9-86a4-95f171e30949)
