### PR TITLE
Bug edit credentials dialog fields not disabled

### DIFF
--- a/src/gmp/models/credential.js
+++ b/src/gmp/models/credential.js
@@ -71,7 +71,7 @@ export const vFire_credential_filter = credential =>
 export const SNMP_AUTH_ALGORITHM_MD5 = 'md5';
 export const SNMP_AUTH_ALGORITHM_SHA1 = 'sha1';
 
-export const SNMP_PRIVACY_ALOGRITHM_NONE = '';
+export const SNMP_PRIVACY_ALGORITHM_NONE = '';
 export const SNMP_PRIVACY_ALGORITHM_AES = 'aes';
 export const SNMP_PRIVACY_ALGORITHM_DES = 'des';
 

--- a/src/web/pages/credentials/__tests__/dialog.jsx
+++ b/src/web/pages/credentials/__tests__/dialog.jsx
@@ -16,7 +16,7 @@ import {
   getSelectElement,
   getSelectItemElementsForSelect,
 } from 'web/components/testing';
-import {rendererWith, fireEvent} from 'web/utils/testing';
+import {rendererWith, fireEvent, screen, render} from 'web/utils/testing';
 
 import CredentialsDialog from '../dialog';
 
@@ -30,7 +30,7 @@ beforeEach(() => {
   handleErrorClose = testing.fn();
 });
 
-const credential = Credential.fromElement({
+const credentialMock = Credential.fromElement({
   _id: 'foo',
   allow_insecure: 1,
   creation_time: '2020-12-16T15:23:59Z',
@@ -49,10 +49,6 @@ const credential = Credential.fromElement({
 
 describe('CredentialsDialog component tests', () => {
   test('should render', () => {
-    const {render} = rendererWith({
-      capabilities: true,
-    });
-
     const {getByName} = render(
       <CredentialsDialog
         types={ALL_CREDENTIAL_TYPES}
@@ -96,11 +92,11 @@ describe('CredentialsDialog component tests', () => {
 
     const {getByName, getAllByName} = render(
       <CredentialsDialog
-        allow_insecure={credential.allow_insecure}
-        comment={credential.comment}
-        credential={credential}
-        credential_type={credential.credential_type}
-        name={credential.name}
+        allow_insecure={credentialMock.allow_insecure}
+        comment={credentialMock.comment}
+        credential={credentialMock}
+        credential_type={credentialMock.credential_type}
+        name={credentialMock.name}
         types={ALL_CREDENTIAL_TYPES}
         onClose={handleClose}
         onErrorClose={handleErrorClose}
@@ -125,10 +121,6 @@ describe('CredentialsDialog component tests', () => {
   });
 
   test('should allow to change text field', () => {
-    const {render} = rendererWith({
-      capabilities: true,
-    });
-
     const {getByName} = render(
       <CredentialsDialog
         types={ALL_CREDENTIAL_TYPES}
@@ -156,8 +148,8 @@ describe('CredentialsDialog component tests', () => {
       auth_algorithm: 'sha1',
       autogenerate: 0,
       change_community: undefined,
-      change_passphrase: undefined,
       change_password: undefined,
+      change_passphrase: undefined,
       change_privacy_password: undefined,
       comment: 'bar',
       community: '',
@@ -174,10 +166,6 @@ describe('CredentialsDialog component tests', () => {
   });
 
   test('should allow changing select values', async () => {
-    const {render} = rendererWith({
-      capabilities: true,
-    });
-
     render(
       <CredentialsDialog
         types={ALL_CREDENTIAL_TYPES}
@@ -223,10 +211,6 @@ describe('CredentialsDialog component tests', () => {
   });
 
   test('should allow to close the dialog', () => {
-    const {render} = rendererWith({
-      capabilities: true,
-    });
-
     render(
       <CredentialsDialog
         types={ALL_CREDENTIAL_TYPES}
@@ -241,10 +225,6 @@ describe('CredentialsDialog component tests', () => {
   });
 
   test('should render form fields for Username + SSH', () => {
-    const {render} = rendererWith({
-      capabilities: true,
-    });
-
     const {getByName} = render(
       <CredentialsDialog
         credential_type={'usk'}
@@ -267,10 +247,6 @@ describe('CredentialsDialog component tests', () => {
   });
 
   test('should render form fields for SNMP', () => {
-    const {render} = rendererWith({
-      capabilities: true,
-    });
-
     const {getByName, getAllByName} = render(
       <CredentialsDialog
         credential_type="snmp"
@@ -311,10 +287,6 @@ describe('CredentialsDialog component tests', () => {
   });
 
   test('should render form fields for S/MIME Certificate', () => {
-    const {render} = rendererWith({
-      capabilities: true,
-    });
-
     const {getByName} = render(
       <CredentialsDialog
         credential_type="smime"
@@ -334,10 +306,6 @@ describe('CredentialsDialog component tests', () => {
   });
 
   test('should render form fields for PGP Encryption Key', () => {
-    const {render} = rendererWith({
-      capabilities: true,
-    });
-
     const {getByName} = render(
       <CredentialsDialog
         credential_type={'pgp'}
@@ -356,11 +324,7 @@ describe('CredentialsDialog component tests', () => {
   });
 
   test('should render form fields for Password Only', () => {
-    const {render} = rendererWith({
-      capabilities: true,
-    });
-
-    const {getByName} = render(
+    render(
       <CredentialsDialog
         credential_type={'pw'}
         types={ALL_CREDENTIAL_TYPES}
@@ -373,8 +337,58 @@ describe('CredentialsDialog component tests', () => {
     const select = getSelectElement();
     expect(select).toHaveValue('Password only');
 
-    const password = getByName('password');
+    const password = screen.getByTestId('password-input');
     expect(password).toHaveValue('');
     expect(password).toHaveAttribute('type', 'password');
+  });
+
+  test('should render CredentialsDialog and handle replace password interactions correctly', () => {
+    const credentialEntryMock = Credential.fromElement({
+      _id: '9b0',
+      allow_insecure: 1,
+      creation_time: '2025-01-08T15:50:23.000Z',
+      comment: 'MockComment',
+      formats: {format: 'exe'},
+      full_type: 'username + password',
+      in_use: 0,
+      login: 'user42',
+      modification_time: '2025-01-09T08:58:33.000Z',
+      name: 'Unnamed',
+      owner: {name: 'admin'},
+      permissions: {permission: {name: 'Everything'}},
+      type: 'up',
+      writable: 1,
+    });
+
+    render(
+      <CredentialsDialog
+        allow_insecure={credentialEntryMock.allow_insecure}
+        comment={credentialEntryMock.comment}
+        credential={credentialEntryMock}
+        credential_type={credentialEntryMock.credential_type}
+        name={credentialEntryMock.name}
+        title={'Edit Credential'}
+        types={ALL_CREDENTIAL_TYPES}
+        onClose={handleClose}
+        onErrorClose={handleErrorClose}
+        onSave={handleSave}
+      />,
+    );
+
+    const title = screen.getByText('Edit Credential');
+    expect(title).toBeVisible();
+
+    const passwordField = screen.getByTestId('password-input');
+    expect(passwordField).toBeDisabled();
+
+    const checkbox = screen.getByLabelText('Replace existing password with');
+
+    expect(checkbox).not.toBeChecked();
+
+    fireEvent.click(checkbox);
+
+    expect(checkbox).toBeChecked();
+
+    expect(passwordField).not.toBeDisabled();
   });
 });

--- a/src/web/pages/credentials/details.jsx
+++ b/src/web/pages/credentials/details.jsx
@@ -6,7 +6,7 @@
 import _ from 'gmp/locale';
 import {
   SNMP_CREDENTIAL_TYPE,
-  SNMP_PRIVACY_ALOGRITHM_NONE,
+  SNMP_PRIVACY_ALGORITHM_NONE,
   getCredentialTypeName,
 } from 'gmp/models/credential';
 import React from 'react';
@@ -29,7 +29,7 @@ const CredentialDetails = ({entity}) => {
     login,
     auth_algorithm,
     privacy = {
-      algorithm: SNMP_PRIVACY_ALOGRITHM_NONE,
+      algorithm: SNMP_PRIVACY_ALGORITHM_NONE,
     },
     targets = [],
     scanners = [],
@@ -78,7 +78,7 @@ const CredentialDetails = ({entity}) => {
             <TableRow>
               <TableData>{_('Privacy Algorithm')}</TableData>
               <TableData>
-                {privacy.algorithm === SNMP_PRIVACY_ALOGRITHM_NONE
+                {privacy.algorithm === SNMP_PRIVACY_ALGORITHM_NONE
                   ? _('None')
                   : privacy.algorithm}
               </TableData>

--- a/src/web/pages/credentials/dialog.jsx
+++ b/src/web/pages/credentials/dialog.jsx
@@ -70,8 +70,8 @@ const CredentialsDialog = props => {
   const isEdit = isDefined(credential);
 
   useEffect(() => {
-    const {autogenerate: pAutogen, credential_type} = props;
-    setCredentialTypeAndAutoGenerate(credential_type, pAutogen);
+    const {autogenerate: pAutogenerate, credential_type} = props;
+    setCredentialTypeAndAutoGenerate(credential_type, pAutogenerate);
   }, [props]);
 
   const setCredentialTypeAndAutoGenerate = (type, autogenerate) => {
@@ -270,7 +270,7 @@ const CredentialsDialog = props => {
                   autoComplete="new-password"
                   disabled={
                     state.autogenerate === YES_VALUE ||
-                    state.change_password === NO_VALUE
+                    (isEdit && state.change_password !== YES_VALUE)
                   }
                   grow="1"
                   name="password"
@@ -296,7 +296,7 @@ const CredentialsDialog = props => {
                   autoComplete="new-password"
                   disabled={
                     state.autogenerate === YES_VALUE ||
-                    state.change_passphrase === NO_VALUE
+                    (isEdit && state.change_passphrase !== YES_VALUE)
                   }
                   grow="1"
                   name="passphrase"
@@ -320,7 +320,10 @@ const CredentialsDialog = props => {
                 )}
                 <PasswordField
                   autoComplete="new-password"
-                  disabled={state.change_privacy_password === NO_VALUE}
+                  disabled={
+                    state.autogenerate === YES_VALUE ||
+                    (isEdit && state.change_privacy_password !== YES_VALUE)
+                  }
                   grow="1"
                   name="privacy_password"
                   value={state.privacy_password}

--- a/src/web/pages/credentials/dialog.jsx
+++ b/src/web/pages/credentials/dialog.jsx
@@ -3,27 +3,26 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {_} from 'gmp/locale/lang';
 import {
-  SNMP_CREDENTIAL_TYPE,
-  USERNAME_PASSWORD_CREDENTIAL_TYPE,
-  USERNAME_SSH_KEY_CREDENTIAL_TYPE,
-  SNMP_AUTH_ALGORITHM_MD5,
-  SNMP_AUTH_ALGORITHM_SHA1,
-  SNMP_PRIVACY_ALOGRITHM_NONE,
-  SNMP_PRIVACY_ALGORITHM_AES,
-  SNMP_PRIVACY_ALGORITHM_DES,
+  ALL_CREDENTIAL_TYPES,
+  getCredentialTypeName,
   PASSWORD_ONLY_CREDENTIAL_TYPE,
   PGP_CREDENTIAL_TYPE,
   SMIME_CREDENTIAL_TYPE,
+  SNMP_AUTH_ALGORITHM_MD5,
+  SNMP_AUTH_ALGORITHM_SHA1,
+  SNMP_CREDENTIAL_TYPE,
+  SNMP_PRIVACY_ALGORITHM_AES,
+  SNMP_PRIVACY_ALGORITHM_DES,
+  SNMP_PRIVACY_ALGORITHM_NONE,
+  USERNAME_PASSWORD_CREDENTIAL_TYPE,
+  USERNAME_SSH_KEY_CREDENTIAL_TYPE,
   VFIRE_CREDENTIAL_TYPES,
-  ALL_CREDENTIAL_TYPES,
-  getCredentialTypeName,
 } from 'gmp/models/credential';
 import {NO_VALUE, YES_VALUE} from 'gmp/parser';
 import {first, map} from 'gmp/utils/array';
 import {isDefined} from 'gmp/utils/identity';
-import React from 'react';
+import {useEffect, useState} from 'react';
 import SaveDialog from 'web/components/dialog/savedialog';
 import Checkbox from 'web/components/form/checkbox';
 import FileField from 'web/components/form/filefield';
@@ -33,410 +32,379 @@ import Radio from 'web/components/form/radio';
 import Select from 'web/components/form/select';
 import TextField from 'web/components/form/textfield';
 import YesNoRadio from 'web/components/form/yesnoradio';
+import useTranslation from 'web/hooks/useTranslation';
 import PropTypes from 'web/utils/proptypes';
-import withCapabilities from 'web/utils/withCapabilities';
 
 const PGP_PUBLIC_KEY_LINE = '-----BEGIN PGP PUBLIC KEY BLOCK-----';
 
-class CredentialsDialog extends React.Component {
-  constructor(...args) {
-    super(...args);
+const CredentialsDialog = props => {
+  const [_] = useTranslation();
 
-    this.state = {};
+  const [credentialType, setCredentialType] = useState();
+  const [autogenerate, setAutogenerate] = useState();
+  const [publicKey, setPublicKey] = useState();
+  const [error, setError] = useState();
 
-    this.handleCredentialTypeChange =
-      this.handleCredentialTypeChange.bind(this);
-    this.handlePublicKeyChange = this.handlePublicKeyChange.bind(this);
-    this.handleErrorClose = this.handleErrorClose.bind(this);
-    this.handleError = this.handleError.bind(this);
-  }
+  const {
+    credential,
+    title = _('New Credential'),
+    types = [],
+    allow_insecure,
+    auth_algorithm = SNMP_AUTH_ALGORITHM_SHA1,
+    change_community,
+    change_passphrase,
+    change_password,
+    change_privacy_password,
+    comment = '',
+    community = '',
+    credential_login = '',
+    name = _('Unnamed'),
+    passphrase = '',
+    password = '',
+    privacy_algorithm = SNMP_PRIVACY_ALGORITHM_AES,
+    privacy_password = '',
+    onClose,
+    onSave,
+  } = props;
 
-  static getDerivedStateFromProps(props, state) {
-    const {error} = props;
-    if (isDefined(error)) {
-      return {
-        error: error,
-      };
-    }
-    return null;
-  }
+  const isEdit = isDefined(credential);
 
-  componentDidMount() {
-    const {autogenerate, credential_type} = this.props;
+  useEffect(() => {
+    const {autogenerate: pAutogen, credential_type} = props;
+    setCredentialTypeAndAutoGenerate(credential_type, pAutogen);
+  }, [props]);
 
-    this.setCredentialTypeAndAutoGenerate(credential_type, autogenerate);
-  }
-
-  setCredentialTypeAndAutoGenerate(credential_type, autogenerate = NO_VALUE) {
+  const setCredentialTypeAndAutoGenerate = (type, autogenerate) => {
     if (
-      credential_type !== USERNAME_PASSWORD_CREDENTIAL_TYPE &&
-      credential_type !== USERNAME_SSH_KEY_CREDENTIAL_TYPE
+      type !== USERNAME_PASSWORD_CREDENTIAL_TYPE &&
+      type !== USERNAME_SSH_KEY_CREDENTIAL_TYPE
     ) {
       // autogenerate is only possible with username+password and username+ssh
       autogenerate = NO_VALUE;
     }
+    setCredentialType(type);
+    setAutogenerate(autogenerate);
+  };
 
-    this.setState({
-      autogenerate,
-      credential_type,
-    });
-  }
+  const handleCredentialTypeChange = (type, autogenerate) => {
+    setCredentialTypeAndAutoGenerate(type, autogenerate);
+  };
 
-  handleCredentialTypeChange(credential_type, autogenerate) {
-    this.setCredentialTypeAndAutoGenerate(credential_type, autogenerate);
-  }
-
-  handlePublicKeyChange(file) {
+  const handlePublicKeyChange = file => {
     const reader = new FileReader();
     reader.onload = e => {
       const {result} = e.target;
       if (result.startsWith(PGP_PUBLIC_KEY_LINE)) {
-        this.setState({public_key: result});
+        setPublicKey(result);
       } else {
-        this.setState({error: _('Not a valid PGP file')});
+        setError(_('Not a valid PGP file'));
       }
     };
     reader.readAsText(file);
-  }
+  };
 
-  handleErrorClose() {
-    const {onErrorClose} = this.props;
-
+  const handleErrorClose = () => {
+    const {onErrorClose} = props;
     if (isDefined(onErrorClose)) {
       onErrorClose();
     }
+    setError(undefined);
+  };
 
-    this.setState({error: undefined});
-  }
+  const handleError = e => {
+    setError(e.message);
+  };
 
-  handleError(error) {
-    this.setState({error: error.message});
-  }
+  let cType = credentialType;
 
-  render() {
-    let {credential_type} = this.state;
+  const typeOptions = map(types, type => ({
+    label: getCredentialTypeName(type),
+    value: type,
+  }));
 
-    const {autogenerate, public_key, error} = this.state;
-
-    const {
-      credential,
-      title = _('New Credential'),
-      types = [],
-      allow_insecure,
-      auth_algorithm = SNMP_AUTH_ALGORITHM_SHA1,
-      change_community,
-      change_passphrase,
-      change_password,
-      change_privacy_password,
-      comment = '',
-      community = '',
-      credential_login = '',
-      name = _('Unnamed'),
-      passphrase = '',
-      password = '',
-      privacy_algorithm = SNMP_PRIVACY_ALGORITHM_AES,
-      privacy_password = '',
-      onClose,
-      onSave,
-    } = this.props;
-
-    const typeOptions = map(types, type => ({
-      label: getCredentialTypeName(type),
-      value: type,
-    }));
-
-    const is_edit = isDefined(credential);
-
-    if (!isDefined(credential_type)) {
-      if (types.includes(USERNAME_PASSWORD_CREDENTIAL_TYPE)) {
-        credential_type = USERNAME_PASSWORD_CREDENTIAL_TYPE;
-      } else {
-        credential_type = first(types);
-      }
+  if (!isDefined(cType)) {
+    if (types.includes(USERNAME_PASSWORD_CREDENTIAL_TYPE)) {
+      cType = USERNAME_PASSWORD_CREDENTIAL_TYPE;
+    } else {
+      cType = first(types);
     }
-
-    const data = {
-      allow_insecure,
-      auth_algorithm,
-      change_community,
-      change_passphrase,
-      change_password,
-      change_privacy_password,
-      comment,
-      community,
-      credential_login,
-      name,
-      passphrase,
-      password,
-      privacy_algorithm,
-      privacy_password,
-      id: isDefined(credential) ? credential.id : undefined,
-    };
-
-    const values = {
-      autogenerate,
-      credential_type,
-      public_key,
-    };
-
-    return (
-      <SaveDialog
-        defaultValues={data}
-        error={error}
-        title={title}
-        values={values}
-        onClose={onClose}
-        onError={this.handleError}
-        onErrorClose={this.handleErrorClose}
-        onSave={onSave}
-      >
-        {({values: state, onValueChange}) => {
-          return (
-            <>
-              <FormGroup title={_('Name')}>
-                <TextField
-                  name="name"
-                  value={state.name}
-                  onChange={onValueChange}
-                />
-              </FormGroup>
-
-              <FormGroup title={_('Comment')}>
-                <TextField
-                  name="comment"
-                  value={state.comment}
-                  onChange={onValueChange}
-                />
-              </FormGroup>
-
-              <FormGroup title={_('Type')}>
-                <Select
-                  disabled={is_edit}
-                  items={typeOptions}
-                  value={state.credential_type}
-                  onChange={value =>
-                    this.handleCredentialTypeChange(value, state.autogenerate)
-                  }
-                />
-              </FormGroup>
-
-              <FormGroup title={_('Allow insecure use')}>
-                <YesNoRadio
-                  name="allow_insecure"
-                  value={state.allow_insecure}
-                  onChange={onValueChange}
-                />
-              </FormGroup>
-
-              {(state.credential_type === USERNAME_PASSWORD_CREDENTIAL_TYPE ||
-                state.credential_type === USERNAME_SSH_KEY_CREDENTIAL_TYPE) &&
-                !is_edit && (
-                  <FormGroup title={_('Auto-generate')}>
-                    <YesNoRadio
-                      name="autogenerate"
-                      value={state.autogenerate}
-                      onChange={value =>
-                        this.handleCredentialTypeChange(
-                          state.credential_type,
-                          value,
-                        )
-                      }
-                    />
-                  </FormGroup>
-                )}
-
-              {state.credential_type === SNMP_CREDENTIAL_TYPE && (
-                <FormGroup direction="row" title={_('SNMP Community')}>
-                  {is_edit && (
-                    <Checkbox
-                      checked={state.change_community === YES_VALUE}
-                      checkedValue={YES_VALUE}
-                      name="change_community"
-                      title={_('Replace existing SNMP community with')}
-                      unCheckedValue={NO_VALUE}
-                      onChange={onValueChange}
-                    />
-                  )}
-                  <PasswordField
-                    disabled={state.change_community === NO_VALUE}
-                    grow="1"
-                    name="community"
-                    value={state.community}
-                    onChange={onValueChange}
-                  />
-                </FormGroup>
-              )}
-
-              {(state.credential_type === USERNAME_PASSWORD_CREDENTIAL_TYPE ||
-                state.credential_type === USERNAME_SSH_KEY_CREDENTIAL_TYPE ||
-                state.credential_type === SNMP_CREDENTIAL_TYPE) && (
-                <FormGroup title={_('Username')}>
-                  <TextField
-                    name="credential_login"
-                    value={state.credential_login}
-                    onChange={onValueChange}
-                  />
-                </FormGroup>
-              )}
-
-              {(state.credential_type === USERNAME_PASSWORD_CREDENTIAL_TYPE ||
-                state.credential_type === SNMP_CREDENTIAL_TYPE ||
-                state.credential_type === VFIRE_CREDENTIAL_TYPES ||
-                state.credential_type === PASSWORD_ONLY_CREDENTIAL_TYPE) && (
-                <FormGroup direction="row" title={_('Password')}>
-                  {is_edit && (
-                    <Checkbox
-                      checked={state.change_password === YES_VALUE}
-                      checkedValue={YES_VALUE}
-                      name="change_password"
-                      title={_('Replace existing password with')}
-                      unCheckedValue={NO_VALUE}
-                      onChange={onValueChange}
-                    />
-                  )}
-                  <PasswordField
-                    autoComplete="new-password"
-                    disabled={
-                      state.autogenerate === YES_VALUE ||
-                      state.change_password === NO_VALUE
-                    }
-                    grow="1"
-                    name="password"
-                    value={state.password}
-                    onChange={onValueChange}
-                  />
-                </FormGroup>
-              )}
-
-              {state.credential_type === USERNAME_SSH_KEY_CREDENTIAL_TYPE && (
-                <FormGroup direction="row" title={_('Passphrase')}>
-                  {is_edit && (
-                    <Checkbox
-                      checked={state.change_passphrase === YES_VALUE}
-                      checkedValue={YES_VALUE}
-                      name="change_passphrase"
-                      title={_('Replace existing passphrase with')}
-                      unCheckedValue={NO_VALUE}
-                      onChange={onValueChange}
-                    />
-                  )}
-                  <PasswordField
-                    autoComplete="new-password"
-                    disabled={
-                      state.autogenerate === YES_VALUE ||
-                      state.change_passphrase === NO_VALUE
-                    }
-                    grow="1"
-                    name="passphrase"
-                    value={state.passphrase}
-                    onChange={onValueChange}
-                  />
-                </FormGroup>
-              )}
-
-              {state.credential_type === SNMP_CREDENTIAL_TYPE && (
-                <FormGroup direction="row" title={_('Privacy Password')}>
-                  {is_edit && (
-                    <Checkbox
-                      checked={state.change_privacy_password === YES_VALUE}
-                      checkedValue={YES_VALUE}
-                      name="change_privacy_password"
-                      title={_('Replace existing privacy password with')}
-                      unCheckedValue={NO_VALUE}
-                      onChange={onValueChange}
-                    />
-                  )}
-                  <PasswordField
-                    autoComplete="new-password"
-                    disabled={state.change_privacy_password === NO_VALUE}
-                    grow="1"
-                    name="privacy_password"
-                    value={state.privacy_password}
-                    onChange={onValueChange}
-                  />
-                </FormGroup>
-              )}
-
-              {state.credential_type === USERNAME_SSH_KEY_CREDENTIAL_TYPE && (
-                <FormGroup title={_('Private Key')}>
-                  <FileField name="private_key" onChange={onValueChange} />
-                </FormGroup>
-              )}
-
-              {state.credential_type === SNMP_CREDENTIAL_TYPE && (
-                <FormGroup direction="row" title={_('Auth Algorithm')}>
-                  <Radio
-                    checked={state.auth_algorithm === SNMP_AUTH_ALGORITHM_MD5}
-                    name="auth_algorithm"
-                    title="MD5"
-                    value={SNMP_AUTH_ALGORITHM_MD5}
-                    onChange={onValueChange}
-                  />
-                  <Radio
-                    checked={state.auth_algorithm === SNMP_AUTH_ALGORITHM_SHA1}
-                    name="auth_algorithm"
-                    title="SHA1"
-                    value={SNMP_AUTH_ALGORITHM_SHA1}
-                    onChange={onValueChange}
-                  />
-                </FormGroup>
-              )}
-
-              {state.credential_type === SNMP_CREDENTIAL_TYPE && (
-                <FormGroup direction="row" title={_('Privacy Algorithm')}>
-                  <Radio
-                    checked={
-                      state.privacy_algorithm === SNMP_PRIVACY_ALGORITHM_AES
-                    }
-                    name="privacy_algorithm"
-                    title="AES"
-                    value={SNMP_PRIVACY_ALGORITHM_AES}
-                    onChange={onValueChange}
-                  />
-                  <Radio
-                    checked={
-                      state.privacy_algorithm === SNMP_PRIVACY_ALGORITHM_DES
-                    }
-                    name="privacy_algorithm"
-                    title="DES"
-                    value={SNMP_PRIVACY_ALGORITHM_DES}
-                    onChange={onValueChange}
-                  />
-                  <Radio
-                    checked={
-                      state.privacy_algorithm === SNMP_PRIVACY_ALOGRITHM_NONE
-                    }
-                    name="privacy_algorithm"
-                    title={_('None')}
-                    value={SNMP_PRIVACY_ALOGRITHM_NONE}
-                    onChange={onValueChange}
-                  />
-                </FormGroup>
-              )}
-
-              {state.credential_type === PGP_CREDENTIAL_TYPE && (
-                <FormGroup title={_('PGP Public Key')}>
-                  <FileField
-                    name="public_key"
-                    onChange={this.handlePublicKeyChange}
-                  />
-                </FormGroup>
-              )}
-
-              {state.credential_type === SMIME_CREDENTIAL_TYPE && (
-                <FormGroup title={_('S/MIME Certificate')}>
-                  <FileField name="certificate" onChange={onValueChange} />
-                </FormGroup>
-              )}
-            </>
-          );
-        }}
-      </SaveDialog>
-    );
   }
-}
 
-const pwtypes = PropTypes.oneOf(ALL_CREDENTIAL_TYPES);
+  const data = {
+    allow_insecure,
+    auth_algorithm,
+    change_community,
+    change_passphrase,
+    change_password,
+    change_privacy_password,
+    comment,
+    community,
+    credential_login,
+    name,
+    passphrase,
+    password,
+    privacy_algorithm,
+    privacy_password,
+    id: isDefined(credential) ? credential.id : undefined,
+  };
+
+  const values = {
+    autogenerate,
+    credential_type: cType,
+    public_key: publicKey,
+  };
+
+  return (
+    <SaveDialog
+      defaultValues={data}
+      error={error}
+      title={title}
+      values={values}
+      onClose={onClose}
+      onError={handleError}
+      onErrorClose={handleErrorClose}
+      onSave={onSave}
+    >
+      {({values: state, onValueChange}) => {
+        return (
+          <>
+            <FormGroup title={_('Name')}>
+              <TextField
+                name="name"
+                value={state.name}
+                onChange={onValueChange}
+              />
+            </FormGroup>
+
+            <FormGroup title={_('Comment')}>
+              <TextField
+                name="comment"
+                value={state.comment}
+                onChange={onValueChange}
+              />
+            </FormGroup>
+
+            <FormGroup title={_('Type')}>
+              <Select
+                disabled={isEdit}
+                items={typeOptions}
+                value={state.credential_type}
+                onChange={value =>
+                  handleCredentialTypeChange(value, state.autogenerate)
+                }
+              />
+            </FormGroup>
+
+            <FormGroup title={_('Allow insecure use')}>
+              <YesNoRadio
+                name="allow_insecure"
+                value={state.allow_insecure}
+                onChange={onValueChange}
+              />
+            </FormGroup>
+
+            {(state.credential_type === USERNAME_PASSWORD_CREDENTIAL_TYPE ||
+              state.credential_type === USERNAME_SSH_KEY_CREDENTIAL_TYPE) &&
+              !isEdit && (
+                <FormGroup title={_('Auto-generate')}>
+                  <YesNoRadio
+                    name="autogenerate"
+                    value={state.autogenerate}
+                    onChange={value =>
+                      handleCredentialTypeChange(state.credential_type, value)
+                    }
+                  />
+                </FormGroup>
+              )}
+
+            {state.credential_type === SNMP_CREDENTIAL_TYPE && (
+              <FormGroup direction="row" title={_('SNMP Community')}>
+                {isEdit && (
+                  <Checkbox
+                    checked={state.change_community === YES_VALUE}
+                    checkedValue={YES_VALUE}
+                    name="change_community"
+                    title={_('Replace existing SNMP community with')}
+                    unCheckedValue={NO_VALUE}
+                    onChange={onValueChange}
+                  />
+                )}
+                <PasswordField
+                  disabled={state.change_community === NO_VALUE}
+                  grow="1"
+                  name="community"
+                  value={state.community}
+                  onChange={onValueChange}
+                />
+              </FormGroup>
+            )}
+
+            {(state.credential_type === USERNAME_PASSWORD_CREDENTIAL_TYPE ||
+              state.credential_type === USERNAME_SSH_KEY_CREDENTIAL_TYPE ||
+              state.credential_type === SNMP_CREDENTIAL_TYPE) && (
+              <FormGroup title={_('Username')}>
+                <TextField
+                  name="credential_login"
+                  value={state.credential_login}
+                  onChange={onValueChange}
+                />
+              </FormGroup>
+            )}
+
+            {(state.credential_type === USERNAME_PASSWORD_CREDENTIAL_TYPE ||
+              state.credential_type === SNMP_CREDENTIAL_TYPE ||
+              state.credential_type === VFIRE_CREDENTIAL_TYPES ||
+              state.credential_type === PASSWORD_ONLY_CREDENTIAL_TYPE) && (
+              <FormGroup direction="row" title={_('Password')}>
+                {isEdit && (
+                  <Checkbox
+                    checked={state.change_password === YES_VALUE}
+                    checkedValue={YES_VALUE}
+                    name="change_password"
+                    title={_('Replace existing password with')}
+                    unCheckedValue={NO_VALUE}
+                    onChange={onValueChange}
+                  />
+                )}
+                <PasswordField
+                  autoComplete="new-password"
+                  disabled={
+                    state.autogenerate === YES_VALUE ||
+                    state.change_password === NO_VALUE
+                  }
+                  grow="1"
+                  name="password"
+                  value={state.password}
+                  onChange={onValueChange}
+                />
+              </FormGroup>
+            )}
+
+            {state.credential_type === USERNAME_SSH_KEY_CREDENTIAL_TYPE && (
+              <FormGroup direction="row" title={_('Passphrase')}>
+                {isEdit && (
+                  <Checkbox
+                    checked={state.change_passphrase === YES_VALUE}
+                    checkedValue={YES_VALUE}
+                    name="change_passphrase"
+                    title={_('Replace existing passphrase with')}
+                    unCheckedValue={NO_VALUE}
+                    onChange={onValueChange}
+                  />
+                )}
+                <PasswordField
+                  autoComplete="new-password"
+                  disabled={
+                    state.autogenerate === YES_VALUE ||
+                    state.change_passphrase === NO_VALUE
+                  }
+                  grow="1"
+                  name="passphrase"
+                  value={state.passphrase}
+                  onChange={onValueChange}
+                />
+              </FormGroup>
+            )}
+
+            {state.credential_type === SNMP_CREDENTIAL_TYPE && (
+              <FormGroup direction="row" title={_('Privacy Password')}>
+                {isEdit && (
+                  <Checkbox
+                    checked={state.change_privacy_password === YES_VALUE}
+                    checkedValue={YES_VALUE}
+                    name="change_privacy_password"
+                    title={_('Replace existing privacy password with')}
+                    unCheckedValue={NO_VALUE}
+                    onChange={onValueChange}
+                  />
+                )}
+                <PasswordField
+                  autoComplete="new-password"
+                  disabled={state.change_privacy_password === NO_VALUE}
+                  grow="1"
+                  name="privacy_password"
+                  value={state.privacy_password}
+                  onChange={onValueChange}
+                />
+              </FormGroup>
+            )}
+
+            {state.credential_type === USERNAME_SSH_KEY_CREDENTIAL_TYPE && (
+              <FormGroup title={_('Private Key')}>
+                <FileField name="private_key" onChange={onValueChange} />
+              </FormGroup>
+            )}
+
+            {state.credential_type === SNMP_CREDENTIAL_TYPE && (
+              <FormGroup direction="row" title={_('Auth Algorithm')}>
+                <Radio
+                  checked={state.auth_algorithm === SNMP_AUTH_ALGORITHM_MD5}
+                  name="auth_algorithm"
+                  title="MD5"
+                  value={SNMP_AUTH_ALGORITHM_MD5}
+                  onChange={onValueChange}
+                />
+                <Radio
+                  checked={state.auth_algorithm === SNMP_AUTH_ALGORITHM_SHA1}
+                  name="auth_algorithm"
+                  title="SHA1"
+                  value={SNMP_AUTH_ALGORITHM_SHA1}
+                  onChange={onValueChange}
+                />
+              </FormGroup>
+            )}
+
+            {state.credential_type === SNMP_CREDENTIAL_TYPE && (
+              <FormGroup direction="row" title={_('Privacy Algorithm')}>
+                <Radio
+                  checked={
+                    state.privacy_algorithm === SNMP_PRIVACY_ALGORITHM_AES
+                  }
+                  name="privacy_algorithm"
+                  title="AES"
+                  value={SNMP_PRIVACY_ALGORITHM_AES}
+                  onChange={onValueChange}
+                />
+                <Radio
+                  checked={
+                    state.privacy_algorithm === SNMP_PRIVACY_ALGORITHM_DES
+                  }
+                  name="privacy_algorithm"
+                  title="DES"
+                  value={SNMP_PRIVACY_ALGORITHM_DES}
+                  onChange={onValueChange}
+                />
+                <Radio
+                  checked={
+                    state.privacy_algorithm === SNMP_PRIVACY_ALGORITHM_NONE
+                  }
+                  name="privacy_algorithm"
+                  title={_('None')}
+                  value={SNMP_PRIVACY_ALGORITHM_NONE}
+                  onChange={onValueChange}
+                />
+              </FormGroup>
+            )}
+
+            {state.credential_type === PGP_CREDENTIAL_TYPE && (
+              <FormGroup title={_('PGP Public Key')}>
+                <FileField name="public_key" onChange={handlePublicKeyChange} />
+              </FormGroup>
+            )}
+
+            {state.credential_type === SMIME_CREDENTIAL_TYPE && (
+              <FormGroup title={_('S/MIME Certificate')}>
+                <FileField name="certificate" onChange={onValueChange} />
+              </FormGroup>
+            )}
+          </>
+        );
+      }}
+    </SaveDialog>
+  );
+};
+
+const pwTypes = PropTypes.oneOf(ALL_CREDENTIAL_TYPES);
 
 CredentialsDialog.propTypes = {
   allow_insecure: PropTypes.yesno,
@@ -445,7 +413,6 @@ CredentialsDialog.propTypes = {
     SNMP_AUTH_ALGORITHM_MD5,
   ]),
   autogenerate: PropTypes.yesno,
-  capabilities: PropTypes.capabilities.isRequired,
   change_community: PropTypes.yesno,
   change_passphrase: PropTypes.yesno,
   change_password: PropTypes.yesno,
@@ -454,22 +421,21 @@ CredentialsDialog.propTypes = {
   community: PropTypes.string,
   credential: PropTypes.model,
   credential_login: PropTypes.string,
-  credential_type: pwtypes,
-  error: PropTypes.string,
+  credential_type: pwTypes,
   name: PropTypes.string,
   passphrase: PropTypes.string,
   password: PropTypes.string,
   privacy_algorithm: PropTypes.oneOf([
     SNMP_PRIVACY_ALGORITHM_AES,
     SNMP_PRIVACY_ALGORITHM_DES,
-    SNMP_PRIVACY_ALOGRITHM_NONE,
+    SNMP_PRIVACY_ALGORITHM_NONE,
   ]),
   privacy_password: PropTypes.string,
   title: PropTypes.string,
-  types: PropTypes.arrayOf(pwtypes),
+  types: PropTypes.arrayOf(pwTypes),
   onClose: PropTypes.func.isRequired,
   onErrorClose: PropTypes.func,
   onSave: PropTypes.func.isRequired,
 };
 
-export default withCapabilities(CredentialsDialog);
+export default CredentialsDialog;


### PR DESCRIPTION
## What

- Migrated the component to RFC
- Fixed the field being disabled on first render if the checkbox is not selected
- Updated test

## Why

- In the credential dialog when in edit mode the fields for replacing `password`, `passphrase`,  `privacy_password`  are not disabled if the checkbox for replacing is not selected on first render.

## References

GEA-834

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests

![Screenshot from 2025-01-09 12-23-03](https://github.com/user-attachments/assets/b53562b5-cd0b-4151-94bc-c71f9eb362d4)

