### PR TITLE
Fix: Allow to set the filter via URL query parameter

### DIFF
--- a/src/web/entities/filterprovider.jsx
+++ b/src/web/entities/filterprovider.jsx
@@ -13,11 +13,9 @@ const FilterProvider = ({
   fallbackFilter,
   gmpname,
   pageName = gmpname,
-  locationQuery = {},
 }) => {
   const [returnedFilter, isLoadingFilter] = usePageFilter(pageName, gmpname, {
     fallbackFilter,
-    locationQueryFilterString: locationQuery?.filter,
   });
   return (
     <React.Fragment>
@@ -29,9 +27,6 @@ const FilterProvider = ({
 FilterProvider.propTypes = {
   fallbackFilter: PropTypes.filter,
   gmpname: PropTypes.string,
-  locationQuery: PropTypes.shape({
-    filter: PropTypes.string,
-  }),
   pageName: PropTypes.string,
 };
 

--- a/src/web/entities/withEntitiesContainer.jsx
+++ b/src/web/entities/withEntitiesContainer.jsx
@@ -5,7 +5,6 @@
 
 import React from 'react';
 import {connect} from 'react-redux';
-import {useSearchParams} from 'react-router-dom';
 import withDownload from 'web/components/form/withDownload';
 import Reload from 'web/components/loading/reload';
 import withDialogNotification from 'web/components/notification/withDialogNotifiaction';
@@ -91,15 +90,10 @@ const withEntitiesContainer =
     )(EntitiesContainerWrapper);
 
     return props => {
-      const [searchParams] = useSearchParams();
       return (
         <SubscriptionProvider>
           {({notify}) => (
-            <FilterProvider
-              fallbackFilter={fallbackFilter}
-              gmpname={gmpname}
-              locationQuery={searchParams.toString()}
-            >
+            <FilterProvider fallbackFilter={fallbackFilter} gmpname={gmpname}>
               {({filter}) => (
                 <EntitiesContainerWrapper
                   {...props}

--- a/src/web/hooks/usePageFilter.js
+++ b/src/web/hooks/usePageFilter.js
@@ -46,14 +46,7 @@ const useDefaultFilter = pageName =>
  *          filter and function to reset the filter
  */
 
-const usePageFilter = (
-  pageName,
-  gmpName,
-  {
-    fallbackFilter,
-    locationQueryFilterString: initialLocationQueryFilterString,
-  } = {},
-) => {
+const usePageFilter = (pageName, gmpName, {fallbackFilter} = {}) => {
   const gmp = useGmp();
   const dispatch = useDispatch();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -73,9 +66,7 @@ const usePageFilter = (
 
   // use null as value for not set at all
   let returnedFilter;
-  // only use searchParams directly if locationQueryFilterString is undefined
-  const locationQueryFilterString =
-    initialLocationQueryFilterString || searchParams.get('filter');
+  const locationQueryFilterString = searchParams.get('filter');
 
   const [locationQueryFilter, setLocationQueryFilter] = useState(
     hasValue(locationQueryFilterString)


### PR DESCRIPTION


## What

Drop `usePageFilter` `locationQueryFilterString` because the query param filter gathered from `useSearchParams` is the only valid value.

Drop `FilterProvider` `locationQuery` prop because a string was passed instead of the expected query object and because usePageFilter already handles its use case internally via `useSearchParams`.

## Why
Allow to pass filters via URL query argument like `/tasks?filter=name=bar`.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


