### PR TITLE
Fix: Fix compliance reports links and tooltips, hide overrides

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -138,7 +138,7 @@
   "Add Tag to Selection": "Tag zu Auswahl hinzufügen",
   "Add to Assets": "Zu Assets hinzufügen",
   "Add to Assets with QoD >= 70% and Overrides enabled": "Zu Assets hinzufügen mit QdE >= 70% und Übersteuerungen aktiviert",
-  "Add to Assets with QoD=>70% and Overrides enabled": "Zu Assets hinzufügen mit QdE =>70% und Übersteuerungen aktiviert",
+  "Add to Assets with QoD >= 70%": "Zu Assets hinzufügen mit QdE >= 70%",
   "Add:": "Hinzufügen:",
   "Adjacent": "Angrenzend",
   "Adjust and update your filter settings.": "Ihre Filtereinstellungen anpassen und aktualisieren.",

--- a/src/web/components/dialog/composercontent.jsx
+++ b/src/web/components/dialog/composercontent.jsx
@@ -30,6 +30,7 @@ const FilterField = styled.div`
 `;
 
 const ComposerContent = ({
+  audit=false,
   filterFieldTitle,
   filterString,
   includeNotes,
@@ -57,15 +58,18 @@ const ComposerContent = ({
           unCheckedValue={NO_VALUE}
           onChange={onValueChange}
         />
-        <CheckBox
-          checked={includeOverrides}
-          checkedValue={YES_VALUE}
-          data-testid="include-overrides"
-          name="includeOverrides"
-          title={_('Overrides')}
-          unCheckedValue={NO_VALUE}
-          onChange={onValueChange}
-        />
+        {!audit && 
+          (
+            <CheckBox
+              checked={includeOverrides}
+              checkedValue={YES_VALUE}
+              data-testid="include-overrides"
+              name="includeOverrides"
+              title={_('Overrides')}
+              unCheckedValue={NO_VALUE}
+              onChange={onValueChange}
+          />
+          )}
         <CheckBox
           checked={true}
           checkedValue={YES_VALUE}
@@ -83,6 +87,7 @@ const ComposerContent = ({
 };
 
 ComposerContent.propTypes = {
+  audit: PropTypes.bool,
   filterFieldTitle: PropTypes.string,
   filterString: PropTypes.string.isRequired,
   includeNotes: PropTypes.number.isRequired,

--- a/src/web/pages/audits/__tests__/detailspage.jsx
+++ b/src/web/pages/audits/__tests__/detailspage.jsx
@@ -601,7 +601,7 @@ describe('Audit ToolBarIcons tests', () => {
     expect(handleAuditResumeClick).not.toHaveBeenCalled();
     expect(icons[7]).toHaveAttribute('title', 'Audit is not stopped');
 
-    expect(links[2]).toHaveAttribute('href', '/reports?filter=task_id%3D12345');
+    expect(links[2]).toHaveAttribute('href', '/auditreports?filter=task_id%3D12345');
     expect(links[2]).toHaveAttribute('title', 'Total Reports for Audit foo');
     expect(badgeIcons[0]).toHaveTextContent('0');
 
@@ -679,7 +679,7 @@ describe('Audit ToolBarIcons tests', () => {
       'Current Report for Audit foo from 07/30/2019',
     );
 
-    expect(links[3]).toHaveAttribute('href', '/reports?filter=task_id%3D12345');
+    expect(links[3]).toHaveAttribute('href', '/auditreports?filter=task_id%3D12345');
     expect(links[3]).toHaveAttribute('title', 'Total Reports for Audit foo');
     expect(badgeIcons[0]).toHaveTextContent('1');
 
@@ -758,7 +758,7 @@ describe('Audit ToolBarIcons tests', () => {
       'Current Report for Audit foo from 07/30/2019',
     );
 
-    expect(links[3]).toHaveAttribute('href', '/reports?filter=task_id%3D12345');
+    expect(links[3]).toHaveAttribute('href', '/auditreports?filter=task_id%3D12345');
     expect(links[3]).toHaveAttribute('title', 'Total Reports for Audit foo');
     expect(badgeIcons[0]).toHaveTextContent('2');
 
@@ -829,13 +829,13 @@ describe('Audit ToolBarIcons tests', () => {
     fireEvent.click(icons[7]);
     expect(handleAuditResumeClick).not.toHaveBeenCalled();
 
-    expect(links[2]).toHaveAttribute('href', '/report/1234');
+    expect(links[2]).toHaveAttribute('href', '/auditreport/1234');
     expect(links[2]).toHaveAttribute(
       'title',
       'Last Report for Audit foo from 07/30/2019',
     );
 
-    expect(links[3]).toHaveAttribute('href', '/reports?filter=task_id%3D12345');
+    expect(links[3]).toHaveAttribute('href', '/auditreports?filter=task_id%3D12345');
     expect(links[3]).toHaveAttribute('title', 'Total Reports for Audit foo');
     expect(badgeIcons[0]).toHaveTextContent('1');
 
@@ -913,13 +913,13 @@ describe('Audit ToolBarIcons tests', () => {
     fireEvent.click(icons[7]);
     expect(handleAuditResumeClick).not.toHaveBeenCalled();
 
-    expect(links[2]).toHaveAttribute('href', '/report/1234');
+    expect(links[2]).toHaveAttribute('href', '/auditreport/1234');
     expect(links[2]).toHaveAttribute(
       'title',
       'Last Report for Audit foo from 07/30/2019',
     );
 
-    expect(links[3]).toHaveAttribute('href', '/reports?filter=task_id%3D12345');
+    expect(links[3]).toHaveAttribute('href', '/auditreports?filter=task_id%3D12345');
     expect(links[3]).toHaveAttribute('title', 'Total Reports for Audit foo');
     expect(badgeIcons[0]).toHaveTextContent('1');
 

--- a/src/web/pages/audits/detailspage.jsx
+++ b/src/web/pages/audits/detailspage.jsx
@@ -175,7 +175,7 @@ export const ToolBarIcons = ({
                     entity.last_report.scan_start,
                   ),
                 })}
-                type="report"
+                type="auditreport"
               >
                 <ReportIcon />
               </DetailsLink>
@@ -184,7 +184,7 @@ export const ToolBarIcons = ({
           <Link
             filter={'task_id=' + entity.id}
             title={_('Total Reports for Audit {{- name}}', entity)}
-            to="reports"
+            to="auditreports"
           >
             <Badge content={entity.report_count.total}>
               <ReportIcon />

--- a/src/web/pages/reports/__tests__/auditdeltadetailspage.jsx
+++ b/src/web/pages/reports/__tests__/auditdeltadetailspage.jsx
@@ -172,7 +172,7 @@ describe('Audit Detla Report Details Content tests', () => {
     expect(tableData[3]).toHaveTextContent('bar');
 
     expect(tableData[4]).toHaveTextContent('Report 1');
-    expect(links[7]).toHaveAttribute('href', '/report/1234');
+    expect(links[7]).toHaveAttribute('href', '/auditreport/1234');
     expect(tableData[5]).toHaveTextContent('1234');
 
     expect(tableData[6]).toHaveTextContent('Scan Time Report 1');
@@ -187,7 +187,7 @@ describe('Audit Detla Report Details Content tests', () => {
     expect(bars[1]).toHaveTextContent('Done');
 
     expect(tableData[12]).toHaveTextContent('Report 2');
-    expect(links[8]).toHaveAttribute('href', '/report/5678');
+    expect(links[8]).toHaveAttribute('href', '/auditreport/5678');
     expect(tableData[13]).toHaveTextContent('5678');
 
     expect(tableData[14]).toHaveTextContent('Scan Time Report 2');

--- a/src/web/pages/reports/auditdeltadetailspage.jsx
+++ b/src/web/pages/reports/auditdeltadetailspage.jsx
@@ -427,6 +427,7 @@ const DeltaAuditReportDetails = props => {
       )}
       {showDownloadReportDialog && (
         <DownloadReportDialog
+          audit={true}
           defaultReportFormatId={reportComposerDefaults.defaultReportFormatId}
           filter={reportFilter}
           includeNotes={reportComposerDefaults.includeNotes}

--- a/src/web/pages/reports/auditdetailspage.jsx
+++ b/src/web/pages/reports/auditdetailspage.jsx
@@ -551,6 +551,7 @@ const ReportDetails = props => {
       )}
       {showDownloadReportDialog && (
         <DownloadReportDialog
+          audit={true}
           defaultReportFormatId={reportComposerDefaults.defaultReportFormatId}
           filter={reportFilter}
           includeNotes={reportComposerDefaults.includeNotes}

--- a/src/web/pages/reports/deltadetailscontent.jsx
+++ b/src/web/pages/reports/deltadetailscontent.jsx
@@ -96,7 +96,9 @@ const PageContent = ({
 
   const header_title = (
     <Divider>
-      <span>{_('Report:')}</span>
+      {audit ? (
+        <span>{_('Audit Report:')}</span>
+      ) : (<span>{_('Report:')}</span>)}
       {isLoading ? (
         <span>{_('Loading')}</span>
       ) : (
@@ -177,6 +179,7 @@ const PageContent = ({
                 <TabPanels>
                   <TabPanel>
                     <Summary
+                      audit={audit}
                       filter={filter}
                       report={report}
                       reportId={reportId}

--- a/src/web/pages/reports/details/__tests__/toolbaricons.jsx
+++ b/src/web/pages/reports/details/__tests__/toolbaricons.jsx
@@ -87,7 +87,7 @@ describe('Report Details ToolBarIcons tests', () => {
     // Add to Assets Icon
     expect(spans[2]).toHaveAttribute(
       'title',
-      'Add to Assets with QoD=>70% and Overrides enabled',
+      'Add to Assets with QoD >= 70% and Overrides enabled',
     );
 
     // Remove from Assets Icon
@@ -173,7 +173,7 @@ describe('Report Details ToolBarIcons tests', () => {
 
     expect(spans[2]).toHaveAttribute(
       'title',
-      'Add to Assets with QoD=>70% and Overrides enabled',
+      'Add to Assets with QoD >= 70% and Overrides enabled',
     );
     fireEvent.click(spans[2]);
     expect(onAddToAssetsClick).toHaveBeenCalled();

--- a/src/web/pages/reports/details/alertactions.jsx
+++ b/src/web/pages/reports/details/alertactions.jsx
@@ -133,6 +133,7 @@ class AlertActions extends React.Component {
   render() {
     const {
       alerts,
+      audit = false,
       capabilities,
       reportComposerDefaults,
       filter,
@@ -163,6 +164,7 @@ class AlertActions extends React.Component {
               <TriggerAlertDialog
                 alertId={alertId}
                 alerts={alerts}
+                audit={audit}
                 defaultAlertId={reportComposerDefaults.defaultAlertId}
                 filter={filter}
                 includeNotes={reportComposerDefaults.includeNotes}
@@ -185,6 +187,7 @@ class AlertActions extends React.Component {
 
 AlertActions.propTypes = {
   alerts: PropTypes.array,
+  audit: PropTypes.bool,
   capabilities: PropTypes.capabilities.isRequired,
   filter: PropTypes.filter,
   gmp: PropTypes.gmp.isRequired,

--- a/src/web/pages/reports/details/summary.jsx
+++ b/src/web/pages/reports/details/summary.jsx
@@ -56,6 +56,7 @@ const scanDuration = (start, end) => {
 };
 
 const Summary = ({
+  audit = false,
   filter,
   isUpdating = false,
   links = true,
@@ -99,6 +100,9 @@ const Summary = ({
     : false;
 
   const is_ended = isDefined(scan_end) && scan_end.isValid();
+
+  const reportType = audit ? 'auditreport' : 'report';
+
   return (
     <Layout flex="column">
       {isDefined(reportError) && (
@@ -134,7 +138,7 @@ const Summary = ({
               <TableData>{_('Report 1')}</TableData>
               <TableData>
                 <span>
-                  <DetailsLink id={report.id} textOnly={!links} type="report">
+                  <DetailsLink id={report.id} textOnly={!links} type={reportType}>
                     {report.id}
                   </DetailsLink>
                 </span>
@@ -181,7 +185,7 @@ const Summary = ({
                   <DetailsLink
                     id={delta_report.id}
                     textOnly={!links}
-                    type="report"
+                    type={reportType}
                   >
                     {delta_report.id}
                   </DetailsLink>
@@ -249,6 +253,7 @@ const Summary = ({
 };
 
 Summary.propTypes = {
+  audit: PropTypes.bool,
   filter: PropTypes.filter.isRequired,
   isUpdating: PropTypes.bool,
   links: PropTypes.bool,

--- a/src/web/pages/reports/details/toolbaricons.jsx
+++ b/src/web/pages/reports/details/toolbaricons.jsx
@@ -60,10 +60,17 @@ const ToolBarIcons = ({
     {!isLoading && (
       <React.Fragment>
         <IconDivider>
-          <AddToAssetsIcon
-            title={_('Add to Assets with QoD=>70% and Overrides enabled')}
-            onClick={onAddToAssetsClick}
-          />
+          {audit ? (
+            <AddToAssetsIcon
+              title= {_('Add to Assets with QoD >= 70%')}
+              onClick={onAddToAssetsClick}
+            />
+          ) : (
+            <AddToAssetsIcon
+              title= {_('Add to Assets with QoD >= 70% and Overrides enabled')}
+              onClick={onAddToAssetsClick}
+            />
+          )}
           <RemoveFromAssetsIcon
             title={_('Remove from Assets')}
             onClick={onRemoveFromAssetsClick}
@@ -128,6 +135,7 @@ const ToolBarIcons = ({
           />
           {!delta && (
             <AlertActions
+              audit={audit}
               filter={filter}
               reportId={reportId}
               showError={showError}

--- a/src/web/pages/reports/downloadreportdialog.jsx
+++ b/src/web/pages/reports/downloadreportdialog.jsx
@@ -21,6 +21,7 @@ import PropTypes from 'web/utils/proptypes';
 import {renderSelectItems} from 'web/utils/render';
 
 const DownloadReportDialog = ({
+  audit = false,
   defaultReportConfigId,
   defaultReportFormatId,
   filter = {},
@@ -77,7 +78,9 @@ const DownloadReportDialog = ({
     <SaveDialog
       buttonTitle={_('OK')}
       defaultValues={unControlledValues}
-      title={_('Compose Content for Scan Report')}
+      title={audit 
+        ? _('Compose Content for Compliance Report')
+        : _('Compose Content for Scan Report')}
       onClose={onClose}
       onSave={handleSave}
     >
@@ -91,6 +94,7 @@ const DownloadReportDialog = ({
         return (
           <>
             <ComposerContent
+              audit={audit}
               filterString={filterString}
               includeNotes={values.includeNotes}
               includeOverrides={values.includeOverrides}
@@ -139,6 +143,7 @@ const DownloadReportDialog = ({
 };
 
 DownloadReportDialog.propTypes = {
+  audit: PropTypes.bool,
   defaultReportConfigId: PropTypes.id,
   defaultReportFormatId: PropTypes.id,
   filter: PropTypes.filter.isRequired,

--- a/src/web/pages/reports/triggeralertdialog.jsx
+++ b/src/web/pages/reports/triggeralertdialog.jsx
@@ -23,6 +23,7 @@ import {renderSelectItems} from 'web/utils/render';
 const TriggerAlertDialog = ({
   alertId,
   alerts = [],
+  audit = false,
   applyOverrides = COMPOSER_CONTENT_DEFAULTS.applyOverrides,
   defaultAlertId,
   filter = {},
@@ -60,7 +61,9 @@ const TriggerAlertDialog = ({
     <SaveDialog
       buttonTitle={_('OK')}
       defaultValues={unControlledValues}
-      title={_('Trigger Alert for Scan Report')}
+      title={audit
+        ? _('Trigger Alert for Compliance Report')
+        : _('Trigger Alert for Scan Report')}
       values={controlledValues}
       onClose={onClose}
       onSave={onSave}
@@ -69,6 +72,7 @@ const TriggerAlertDialog = ({
         <>
           <ComposerContent
             applyOverrides={values.applyOverrides}
+            audit={audit}
             filterString={filterString}
             includeNotes={values.includeNotes}
             includeOverrides={values.includeOverrides}
@@ -105,6 +109,7 @@ const TriggerAlertDialog = ({
 TriggerAlertDialog.propTypes = {
   alertId: PropTypes.id,
   alerts: PropTypes.array,
+  audit: PropTypes.bool,
   applyOverrides: PropTypes.numberOrNumberString,
   defaultAlertId: PropTypes.id,
   filter: PropTypes.filter.isRequired,


### PR DESCRIPTION
## What
Fix compliance reports links redirecting to scan reports, update tooltips to remove override and hide override checkbox in download and alert dialogs

## Why
Links should redirect to compliance reports, overrides are not used for compliance reports.

## References
GEA-844


