### PR TITLE
Address warnings of React Router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "react-dom": "^18.3.1",
         "react-i18next": "^15.4.0",
         "react-redux": "^9.1.2",
-        "react-router-dom": "^6.28.0",
+        "react-router-dom": "^6.28.1",
         "redux": "^5.0.1",
         "redux-logger": "^3.0.6",
         "resize-observer-polyfill": "^1.5.1",
@@ -3037,6 +3037,7 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
       "integrity": "sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -10976,9 +10977,10 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.0.tgz",
-      "integrity": "sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.1.tgz",
+      "integrity": "sha512-2omQTA3rkMljmrvvo6WtewGdVh45SpL9hGiCI9uUrwGGfNFDIvGK4gYJsKlJoNVi6AQZcopSCballL+QGOm7fA==",
+      "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.21.0"
       },
@@ -10990,12 +10992,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.0.tgz",
-      "integrity": "sha512-kQ7Unsl5YdyOltsPGl31zOjLrDv+m2VcIEcIHqYYD3Lp0UppLjrzcfJqDJwXxFw3TH/yvapbnUvPlAj7Kx5nbg==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.1.tgz",
+      "integrity": "sha512-YraE27C/RdjcZwl5UCqF/ffXnZDxpJdk9Q6jw38SZHjXs7NNdpViq2l2c7fO7+4uWaEfcwfGCv3RSg4e1By/fQ==",
+      "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.21.0",
-        "react-router": "6.28.0"
+        "react-router": "6.28.1"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-dom": "^18.3.1",
     "react-i18next": "^15.4.0",
     "react-redux": "^9.1.2",
-    "react-router-dom": "^6.28.0",
+    "react-router-dom": "^6.28.1",
     "redux": "^5.0.1",
     "redux-logger": "^3.0.6",
     "resize-observer-polyfill": "^1.5.1",

--- a/src/web/routes.jsx
+++ b/src/web/routes.jsx
@@ -213,9 +213,14 @@ const LoggedInRoutes = () => {
 
             <Route element={<PageNotFound />} path="/notfound" />
             <Route element={<AuditReportsPage />} path="/auditreports" />
-            <Route element={<DeltaAuditReportDetailsPage />}
-                        path="/auditreport/delta/:id/:deltaid" />
-            <Route element= {<AuditReportDetailsPage />} path="/auditreport/:id" />
+            <Route
+              element={<DeltaAuditReportDetailsPage />}
+              path="/auditreport/delta/:id/:deltaid"
+            />
+            <Route
+              element={<AuditReportDetailsPage />}
+              path="/auditreport/:id"
+            />
             <Route element={<Navigate to="/dashboards" />} path="/" />
 
             <Route element={<PageNotFound />} path="*" />
@@ -241,7 +246,16 @@ const AppRoutes = () => {
   }
 
   return (
-    <Router>{isLoggedIn ? <LoggedInRoutes /> : <LoggedOutRoutes />}</Router>
+    <Router
+      future={{
+        // eslint-disable-next-line camelcase
+        v7_startTransition: true,
+        // eslint-disable-next-line camelcase
+        v7_relativeSplatPath: false,
+      }}
+    >
+      {isLoggedIn ? <LoggedInRoutes /> : <LoggedOutRoutes />}
+    </Router>
   );
 };
 

--- a/src/web/utils/testing.jsx
+++ b/src/web/utils/testing.jsx
@@ -144,7 +144,17 @@ export const rendererWith = (
         <TestingLicenseProvider license={license}>
           <TestingStoreProvider store={store}>
             {router ? (
-              <BrowserRouter initialEntries={['/']}>{children}</BrowserRouter>
+              <BrowserRouter
+                future={{
+                  // eslint-disable-next-line camelcase
+                  v7_startTransition: true,
+                  // eslint-disable-next-line camelcase
+                  v7_relativeSplatPath: false,
+                }}
+                initialEntries={['/']}
+              >
+                {children}
+              </BrowserRouter>
             ) : (
               children
             )}


### PR DESCRIPTION

## What

Address warnings of React Router

## Why

Update to react-router-dom 6.28.1 which will not raise warnings if the future config setting of a router is set.

Enable the start transition setting for react router which should be fine because we don't user React.lazy (yet).

Disable relative splat path because I am not sure if it will affect GSA.


