### PR TITLE
Set host in vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
   },
   server: {
     port: 8080,
+    host: '127.0.0.1',
   },
   build: {
     outDir: 'build',


### PR DESCRIPTION


## What

Set host in vite config

## Why

Ensure the development server is running on the IPv4 address of the localhost.

