### PR TITLE
Fix: Fix the link to user manual in audit reports list page

### DIFF
--- a/src/web/pages/reports/auditreportslistpage.jsx
+++ b/src/web/pages/reports/auditreportslistpage.jsx
@@ -3,9 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
-
-
 import Filter, {AUDIT_REPORTS_FILTER_FILTER} from 'gmp/models/filter';
 import {isActive} from 'gmp/models/task';
 import {isDefined} from 'gmp/utils/identity';
@@ -41,8 +38,7 @@ const ToolBarIcons = () => {
   return (
     <IconDivider>
       <ManualIcon
-        anchor="using-and-managing-audit-reports"
-        page="reports"
+        page="compliance-and-special-scans"
         title={_('Help: Audit Reports')}
       />
     </IconDivider>


### PR DESCRIPTION
## What
Fix the user manual link in audit reports list page to point to the current compliance/audits chapter until the manual is updated with a new chapter for audit reports.

## Why

Link is currently pointing to a non-existing section

## References
GEA-852


