### PR TITLE
Refactor Report Config

### DIFF
--- a/src/gmp/commands/__tests__/reportconfig.js
+++ b/src/gmp/commands/__tests__/reportconfig.js
@@ -47,20 +47,20 @@ describe('ReportConfigCommand tests', () => {
       .create({
         name: 'foo',
         comment: 'bar',
-        report_format_id: 'baz',
+        reportFormatId: 'baz',
         params: {
           'param 1': 'value 1',
           'param 2': 'value 2',
           'param 3': ['report-format-1', 'report-format-2'],
           'param 4': ['option-1', 'option-2'],
         },
-        params_using_default: {
+        paramsUsingDefault: {
           'param 1': false,
           'param 2': true,
           'param 3': false,
           'param 4': false,
         },
-        param_types: {
+        paramTypes: {
           'param 1': 'string',
           'param 2': 'text',
           'param 3': 'report_format_list',
@@ -98,20 +98,20 @@ describe('ReportConfigCommand tests', () => {
       .save({
         name: 'foo',
         comment: 'bar',
-        report_format_id: 'should-be-ignored-in-save',
+        reportFormatId: 'should-be-ignored-in-save',
         params: {
           'param 1': 'value A',
           'param 2': 'value B',
           'param 3': ['report-format-A', 'report-format-B'],
           'param 4': ['option-1', 'option-2'],
         },
-        params_using_default: {
+        paramsUsingDefault: {
           'param 1': true,
           'param 2': false,
           'param 3': false,
           'param 4': false,
         },
-        param_types: {
+        paramTypes: {
           'param 1': 'string',
           'param 2': 'text',
           'param 3': 'report_format_list',

--- a/src/gmp/commands/reportconfigs.js
+++ b/src/gmp/commands/reportconfigs.js
@@ -23,35 +23,35 @@ export class ReportConfigCommand extends EntityCommand {
     const {
       comment,
       name,
-      report_format_id,
+      reportFormatId,
       params = {},
-      params_using_default = {},
-      param_types = {},
+      paramsUsingDefault = {},
+      paramTypes = {},
     } = args;
 
     const data = {
       cmd: 'create_report_config',
       name,
       comment,
-      report_format_id,
+      report_format_id: reportFormatId,
     };
 
-    for (const prefname in params) {
-      let value = params[prefname];
+    for (const prefName in params) {
+      let value = params[prefName];
       if (isArray(value)) {
-        if (param_types[prefname] === 'report_format_list') {
-          value = params[prefname].join(',');
+        if (paramTypes[prefName] === 'report_format_list') {
+          value = params[prefName].join(',');
         } else {
-          value = JSON.stringify(params[prefname]);
+          value = JSON.stringify(params[prefName]);
         }
       }
-      data['param:' + prefname] = value;
+      data['param:' + prefName] = value;
     }
 
-    for (const param_name in params_using_default) {
-      if (params_using_default[param_name]) {
+    for (const param_name in paramsUsingDefault) {
+      if (paramsUsingDefault[param_name]) {
         data['param_using_default:' + param_name] = convertBoolean(
-          params_using_default[param_name],
+          paramsUsingDefault[param_name],
         );
       }
     }
@@ -66,8 +66,8 @@ export class ReportConfigCommand extends EntityCommand {
       comment,
       name,
       params = {},
-      params_using_default = {},
-      param_types = {},
+      paramsUsingDefault = {},
+      paramTypes = {},
     } = args;
 
     const data = {
@@ -77,24 +77,24 @@ export class ReportConfigCommand extends EntityCommand {
       comment,
     };
 
-    for (const param_name in params_using_default) {
-      if (params_using_default[param_name]) {
-        data['param_using_default:' + param_name] = convertBoolean(
-          params_using_default[param_name],
+    for (const paramName in paramsUsingDefault) {
+      if (paramsUsingDefault[paramName]) {
+        data['param_using_default:' + paramName] = convertBoolean(
+          paramsUsingDefault[paramName],
         );
       }
     }
 
-    for (const prefname in params) {
-      let value = params[prefname];
-      if (isArray(params[prefname])) {
-        if (param_types[prefname] === 'report_format_list') {
-          value = params[prefname].join(',');
+    for (const prefName in params) {
+      let value = params[prefName];
+      if (isArray(params[prefName])) {
+        if (paramTypes[prefName] === 'report_format_list') {
+          value = params[prefName].join(',');
         } else {
-          value = JSON.stringify(params[prefname]);
+          value = JSON.stringify(params[prefName]);
         }
       }
-      data['param:' + prefname] = value;
+      data['param:' + prefName] = value;
     }
 
     log.debug('Saving report config', args, data);

--- a/src/gmp/models/__tests__/reportconfig.js
+++ b/src/gmp/models/__tests__/reportconfig.js
@@ -164,7 +164,7 @@ describe('Report Config model tests', () => {
       expect(reportConfig.params[0].name).toEqual('foo');
     });
 
-    test('should parse param value_using_default', () => {
+    test('should parse param valueUsingDefault', () => {
       const elem = {
         param: [
           {
@@ -192,9 +192,9 @@ describe('Report Config model tests', () => {
 
       const reportConfig = ReportConfig.fromElement(elem);
       expect(reportConfig.params[0].name).toEqual('foo');
-      expect(reportConfig.params[0].value_using_default).toEqual(true);
+      expect(reportConfig.params[0].valueUsingDefault).toEqual(true);
       expect(reportConfig.params[1].name).toEqual('bar');
-      expect(reportConfig.params[1].value_using_default).toEqual(false);
+      expect(reportConfig.params[1].valueUsingDefault).toEqual(false);
     });
 
     test('should parse value, default and type in string params', () => {
@@ -229,12 +229,12 @@ describe('Report Config model tests', () => {
       expect(reportConfig.params[0].type).toEqual('string');
       expect(reportConfig.params[0].value).toEqual('foo');
       expect(reportConfig.params[0].default).toEqual('bar');
-      expect(reportConfig.params[0].value_using_default).toEqual(false);
+      expect(reportConfig.params[0].valueUsingDefault).toEqual(false);
 
       expect(reportConfig.params[1].type).toEqual('string');
       expect(reportConfig.params[1].value).toEqual('baz');
       expect(reportConfig.params[1].default).toEqual('boo');
-      expect(reportConfig.params[0].value_using_default).toEqual(false);
+      expect(reportConfig.params[0].valueUsingDefault).toEqual(false);
     });
 
     test('should parse value, default and type in text params', () => {
@@ -269,12 +269,12 @@ describe('Report Config model tests', () => {
       expect(reportConfig.params[0].type).toEqual('text');
       expect(reportConfig.params[0].value).toEqual('foo');
       expect(reportConfig.params[0].default).toEqual('bar');
-      expect(reportConfig.params[0].value_using_default).toEqual(false);
+      expect(reportConfig.params[0].valueUsingDefault).toEqual(false);
 
       expect(reportConfig.params[1].type).toEqual('text');
       expect(reportConfig.params[1].value).toEqual('baz');
       expect(reportConfig.params[1].default).toEqual('boo');
-      expect(reportConfig.params[0].value_using_default).toEqual(false);
+      expect(reportConfig.params[0].valueUsingDefault).toEqual(false);
     });
 
     test('should parse value, default and type in integer params', () => {
@@ -309,12 +309,12 @@ describe('Report Config model tests', () => {
       expect(reportConfig.params[0].type).toEqual('integer');
       expect(reportConfig.params[0].value).toEqual(123);
       expect(reportConfig.params[0].default).toEqual(234);
-      expect(reportConfig.params[0].value_using_default).toEqual(false);
+      expect(reportConfig.params[0].valueUsingDefault).toEqual(false);
 
       expect(reportConfig.params[1].type).toEqual('integer');
       expect(reportConfig.params[1].value).toEqual(345);
       expect(reportConfig.params[1].default).toEqual(456);
-      expect(reportConfig.params[0].value_using_default).toEqual(false);
+      expect(reportConfig.params[0].valueUsingDefault).toEqual(false);
     });
 
     test('should parse value, default and type in boolean params', () => {
@@ -349,12 +349,12 @@ describe('Report Config model tests', () => {
       expect(reportConfig.params[0].type).toEqual('boolean');
       expect(reportConfig.params[0].value).toEqual(false);
       expect(reportConfig.params[0].default).toEqual(true);
-      expect(reportConfig.params[0].value_using_default).toEqual(false);
+      expect(reportConfig.params[0].valueUsingDefault).toEqual(false);
 
       expect(reportConfig.params[1].type).toEqual('boolean');
       expect(reportConfig.params[1].value).toEqual(true);
       expect(reportConfig.params[1].default).toEqual(true);
-      expect(reportConfig.params[0].value_using_default).toEqual(false);
+      expect(reportConfig.params[0].valueUsingDefault).toEqual(false);
     });
 
     test('should parse options, value, default and type in selection params', () => {
@@ -475,14 +475,14 @@ describe('Report Config model tests', () => {
         12: 'GHI',
         34: 'JKL',
       });
-      expect(reportConfig.params[0].value_using_default).toEqual(false);
+      expect(reportConfig.params[0].valueUsingDefault).toEqual(false);
 
       expect(reportConfig.params[1].type).toEqual('report_format_list');
       expect(reportConfig.params[1].value).toEqual(['123']);
       expect(reportConfig.params[1].value_labels).toEqual({123: 'XYZ'});
       expect(reportConfig.params[1].default).toEqual(['456']);
       expect(reportConfig.params[1].default_labels).toEqual({456: 'UVW'});
-      expect(reportConfig.params[0].value_using_default).toEqual(false);
+      expect(reportConfig.params[0].valueUsingDefault).toEqual(false);
     });
   });
 });

--- a/src/gmp/models/__tests__/reportconfig.js
+++ b/src/gmp/models/__tests__/reportconfig.js
@@ -466,12 +466,12 @@ describe('Report Config model tests', () => {
 
       expect(reportConfig.params[0].type).toEqual('report_format_list');
       expect(reportConfig.params[0].value).toEqual(['42', '21']);
-      expect(reportConfig.params[0].value_labels).toEqual({
+      expect(reportConfig.params[0].valueLabels).toEqual({
         42: 'ABC',
         21: 'DEF',
       });
       expect(reportConfig.params[0].default).toEqual(['12', '34']);
-      expect(reportConfig.params[0].default_labels).toEqual({
+      expect(reportConfig.params[0].defaultLabels).toEqual({
         12: 'GHI',
         34: 'JKL',
       });
@@ -479,9 +479,9 @@ describe('Report Config model tests', () => {
 
       expect(reportConfig.params[1].type).toEqual('report_format_list');
       expect(reportConfig.params[1].value).toEqual(['123']);
-      expect(reportConfig.params[1].value_labels).toEqual({123: 'XYZ'});
+      expect(reportConfig.params[1].valueLabels).toEqual({123: 'XYZ'});
       expect(reportConfig.params[1].default).toEqual(['456']);
-      expect(reportConfig.params[1].default_labels).toEqual({456: 'UVW'});
+      expect(reportConfig.params[1].defaultLabels).toEqual({456: 'UVW'});
       expect(reportConfig.params[0].valueUsingDefault).toEqual(false);
     });
   });

--- a/src/gmp/models/__tests__/reportconfig.js
+++ b/src/gmp/models/__tests__/reportconfig.js
@@ -19,8 +19,8 @@ describe('Report Config model tests', () => {
     };
     const reportConfig = ReportConfig.fromElement(elem);
 
-    expect(reportConfig.report_format.id).toEqual('foo');
-    expect(reportConfig.report_format.name).toEqual('bar');
+    expect(reportConfig.reportFormat.id).toEqual('foo');
+    expect(reportConfig.reportFormat.name).toEqual('bar');
   });
 
   test('should parse alerts', () => {

--- a/src/gmp/models/reportconfig.js
+++ b/src/gmp/models/reportconfig.js
@@ -34,13 +34,13 @@ class Param {
     if (this.type === 'report_format_list') {
       this.value = map(value.report_format, format => format._id);
       this.default = map(other.default.report_format, format => format._id);
-      this.value_labels = {};
-      this.default_labels = {};
+      this.valueLabels = {};
+      this.defaultLabels = {};
       forEach(value.report_format, format => {
-        this.value_labels[format._id] = format.name;
+        this.valueLabels[format._id] = format.name;
       });
       forEach(other.default.report_format, format => {
-        this.default_labels[format._id] = format.name;
+        this.defaultLabels[format._id] = format.name;
       });
     } else if (this.type === 'multi_selection') {
       this.value = JSON.parse(get_value(value));

--- a/src/gmp/models/reportconfig.js
+++ b/src/gmp/models/reportconfig.js
@@ -18,7 +18,7 @@ class Param {
     this.max = type.max;
     this.min = type.min;
     this.type = get_value(type);
-    this.value_using_default = parseBoolean(value?._using_default);
+    this.valueUsingDefault = parseBoolean(value?._using_default);
 
     if (isObject(options)) {
       this.options = map(options.option, opt => {

--- a/src/gmp/models/reportconfig.js
+++ b/src/gmp/models/reportconfig.js
@@ -65,13 +65,14 @@ class ReportConfig extends Model {
     const ret = super.parseElement(element);
 
     if (isDefined(ret.report_format)) {
-      ret.report_format = {
+      ret.reportFormat = {
         id: ret.report_format._id,
         name: ret.report_format.name,
       };
     } else {
-      ret.report_format = {};
+      ret.reportFormat = {};
     }
+    delete ret.report_format;
 
     ret.params = map(ret.param, param => {
       return new Param(param);

--- a/src/web/pages/reportconfigs/__mocks__/mockreportconfig.jsx
+++ b/src/web/pages/reportconfigs/__mocks__/mockreportconfig.jsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-
 export const mockReportConfig = {
   _id: '12345',
   name: 'foo',

--- a/src/web/pages/reportconfigs/__tests__/component.jsx
+++ b/src/web/pages/reportconfigs/__tests__/component.jsx
@@ -4,7 +4,6 @@
  */
 
 import {describe, test, expect, testing} from '@gsa/testing';
-import Capabilities from 'gmp/capabilities/capabilities';
 import ReportConfig from 'gmp/models/reportconfig';
 import {
   clickElement,

--- a/src/web/pages/reportconfigs/__tests__/component.jsx
+++ b/src/web/pages/reportconfigs/__tests__/component.jsx
@@ -119,24 +119,19 @@ describe('Report Config Component tests', () => {
     fireEvent.click(saveButton);
 
     expect(saveReportConfig).toHaveBeenCalledWith({
-      alerts: [],
       comment: '',
-      entityType: 'reportconfig',
       id: 'rc123',
       name: 'test report config',
-      param_types: {
+      paramTypes: {
         'test param': 'string',
       },
       params: {
         'test param': 'ABC',
       },
-      params_using_default: {
+      paramsUsingDefault: {
         'test param': false,
       },
-      report_format: 'rf456',
-      report_format_id: undefined,
-      userCapabilities: new Capabilities(),
-      userTags: [],
+      reportFormatId: 'rf456',
     });
   });
 
@@ -210,16 +205,16 @@ describe('Report Config Component tests', () => {
     expect(createReportConfig).toHaveBeenCalledWith({
       name: 'Unnamed',
       comment: '',
-      param_types: {
+      paramTypes: {
         'test param': 'string',
       },
       params: {
         'test param': 'ABC',
       },
-      params_using_default: {
+      paramsUsingDefault: {
         'test param': true,
       },
-      report_format_id: 'rf456',
+      reportFormatId: 'rf456',
     });
   });
 

--- a/src/web/pages/reportconfigs/__tests__/dialog.jsx
+++ b/src/web/pages/reportconfigs/__tests__/dialog.jsx
@@ -86,8 +86,10 @@ describe('Edit Report Config Dialog component tests', () => {
     fireEvent.click(saveButton);
 
     expect(handleSave).toHaveBeenCalledWith({
-      ...config,
-      param_types: {
+      id: '12345',
+      name: 'foo',
+      comment: 'bar',
+      paramTypes: {
         BooleanParam: 'boolean',
         IntegerParam: 'integer',
         ReportFormatListParam: 'report_format_list',
@@ -103,7 +105,7 @@ describe('Edit Report Config Dialog component tests', () => {
         StringParam: 'StringValue',
         TextParam: 'TextValue',
       },
-      params_using_default: {
+      paramsUsingDefault: {
         BooleanParam: false,
         IntegerParam: true,
         ReportFormatListParam: false,
@@ -111,8 +113,7 @@ describe('Edit Report Config Dialog component tests', () => {
         StringParam: true,
         TextParam: false,
       },
-      report_format: config.report_format.id,
-      report_format_id: undefined,
+      reportFormatId: '123456',
     });
   });
 
@@ -202,10 +203,10 @@ describe('Edit Report Config Dialog component tests', () => {
     fireEvent.click(saveButton);
 
     expect(handleSave).toHaveBeenCalledWith({
-      ...config,
+      id: '12345',
       name: 'lorem',
       comment: 'ipsum',
-      param_types: {
+      paramTypes: {
         BooleanParam: 'boolean',
         IntegerParam: 'integer',
         ReportFormatListParam: 'report_format_list',
@@ -221,7 +222,7 @@ describe('Edit Report Config Dialog component tests', () => {
         SelectionParam: 'OptionA',
         TextParam: 'NewText',
       },
-      params_using_default: {
+      paramsUsingDefault: {
         BooleanParam: false,
         IntegerParam: false,
         StringParam: false,
@@ -229,8 +230,7 @@ describe('Edit Report Config Dialog component tests', () => {
         SelectionParam: false,
         TextParam: false,
       },
-      report_format: config.report_format.id,
-      report_format_id: undefined,
+      reportFormatId: '123456',
     });
   });
 
@@ -282,8 +282,10 @@ describe('Edit Report Config Dialog component tests', () => {
     fireEvent.click(saveButton);
 
     expect(handleSave).toHaveBeenCalledWith({
-      ...config,
-      param_types: {
+      id: '12345',
+      name: 'foo',
+      comment: 'bar',
+      paramTypes: {
         BooleanParam: 'boolean',
         IntegerParam: 'integer',
         ReportFormatListParam: 'report_format_list',
@@ -300,7 +302,7 @@ describe('Edit Report Config Dialog component tests', () => {
         TextParam: 'TextValue',
       },
       // Should be reverse of "should save data" case
-      params_using_default: {
+      paramsUsingDefault: {
         BooleanParam: true,
         IntegerParam: false,
         ReportFormatListParam: true,
@@ -308,8 +310,7 @@ describe('Edit Report Config Dialog component tests', () => {
         StringParam: false,
         TextParam: true,
       },
-      report_format: config.report_format.id,
-      report_format_id: undefined,
+      reportFormatId: '123456',
     });
   });
 });
@@ -452,8 +453,8 @@ describe('New Report Config Dialog component tests', () => {
     expect(handleSave).toHaveBeenCalledWith({
       name: 'lorem',
       comment: 'ipsum',
-      report_format_id: '1234567',
-      param_types: {
+      reportFormatId: '1234567',
+      paramTypes: {
         Param1: 'string',
         Param2: 'string',
         ReportFormatListParam: 'report_format_list',
@@ -463,7 +464,7 @@ describe('New Report Config Dialog component tests', () => {
         Param2: 'XYZ',
         ReportFormatListParam: ['654321'],
       },
-      params_using_default: {
+      paramsUsingDefault: {
         Param1: true,
         Param2: false,
         ReportFormatListParam: false,

--- a/src/web/pages/reportconfigs/__tests__/dialog.jsx
+++ b/src/web/pages/reportconfigs/__tests__/dialog.jsx
@@ -49,7 +49,7 @@ describe('Edit Report Config Dialog component tests', () => {
     render(
       <ReportConfigDialog
         formats={formats}
-        reportconfig={config}
+        reportConfig={config}
         title="Edit Report Config"
         onClose={handleClose}
         onSave={handleSave}
@@ -75,7 +75,7 @@ describe('Edit Report Config Dialog component tests', () => {
     render(
       <ReportConfigDialog
         formats={formats}
-        reportconfig={config}
+        reportConfig={config}
         title="Edit Report Config"
         onClose={handleClose}
         onSave={handleSave}
@@ -128,7 +128,7 @@ describe('Edit Report Config Dialog component tests', () => {
     render(
       <ReportConfigDialog
         formats={formats}
-        reportconfig={config}
+        reportConfig={config}
         title="Edit Report Config"
         onClose={handleClose}
         onSave={handleSave}
@@ -154,7 +154,7 @@ describe('Edit Report Config Dialog component tests', () => {
     render(
       <ReportConfigDialog
         formats={formats}
-        reportconfig={config}
+        reportConfig={config}
         title="Edit Report Config"
         onClose={handleClose}
         onSave={handleSave}
@@ -246,7 +246,7 @@ describe('Edit Report Config Dialog component tests', () => {
     render(
       <ReportConfigDialog
         formats={formats}
-        reportconfig={config}
+        reportConfig={config}
         title="Edit Report Config"
         onClose={handleClose}
         onSave={handleSave}
@@ -328,7 +328,7 @@ describe('New Report Config Dialog component tests', () => {
     const {baseElement} = render(
       <ReportConfigDialog
         formats={formats}
-        reportconfig={undefined}
+        reportConfig={undefined}
         onClose={handleClose}
         onSave={handleSave}
       />,
@@ -408,7 +408,7 @@ describe('New Report Config Dialog component tests', () => {
     render(
       <ReportConfigDialog
         formats={formats}
-        reportconfig={undefined}
+        reportConfig={undefined}
         onClose={handleClose}
         onSave={handleSave}
         onValueChange={handleValueChange}

--- a/src/web/pages/reportconfigs/component.jsx
+++ b/src/web/pages/reportconfigs/component.jsx
@@ -148,7 +148,7 @@ class ReportConfigComponent extends React.Component {
               <ReportConfigDialog
                 formats={formats}
                 preferences={preferences}
-                reportconfig={reportconfig}
+                reportConfig={reportconfig}
                 title={title}
                 onClose={this.handleCloseReportConfigDialog}
                 onSave={this.handleSave}

--- a/src/web/pages/reportconfigs/component.jsx
+++ b/src/web/pages/reportconfigs/component.jsx
@@ -24,13 +24,13 @@ class ReportConfigComponent extends React.Component {
     this.openReportConfigDialog = this.openReportConfigDialog.bind(this);
   }
 
-  openReportConfigDialog(reportconfig) {
+  openReportConfigDialog(reportConfig) {
     this.handleInteraction();
     const {gmp} = this.props;
 
-    if (isDefined(reportconfig)) {
+    if (isDefined(reportConfig)) {
       // (re-)load report config to get params
-      gmp.reportconfig.get(reportconfig).then(response => {
+      gmp.reportconfig.get(reportConfig).then(response => {
         const config = response.data;
         const preferences = {};
         const id_lists = {};
@@ -50,8 +50,8 @@ class ReportConfigComponent extends React.Component {
             formats,
             id_lists,
             preferences,
-            reportconfig: config,
-            originalParamInfo: reportconfig.params,
+            reportConfig: config,
+            originalParamInfo: reportConfig.params,
             title: _('Edit Report Config {{name}}', {name: config.name}),
           });
         });
@@ -63,7 +63,7 @@ class ReportConfigComponent extends React.Component {
         .then(formats => {
           this.setState({
             dialogVisible: true,
-            reportconfig: undefined,
+            reportConfig: undefined,
             formats,
             title: _('New Report Config'),
           });
@@ -121,7 +121,7 @@ class ReportConfigComponent extends React.Component {
       onInteraction,
     } = this.props;
 
-    const {dialogVisible, formats, reportconfig, title, preferences} =
+    const {dialogVisible, formats, reportConfig, title, preferences} =
       this.state;
 
     return (
@@ -148,7 +148,7 @@ class ReportConfigComponent extends React.Component {
               <ReportConfigDialog
                 formats={formats}
                 preferences={preferences}
-                reportConfig={reportconfig}
+                reportConfig={reportConfig}
                 title={title}
                 onClose={this.handleCloseReportConfigDialog}
                 onSave={this.handleSave}

--- a/src/web/pages/reportconfigs/details.jsx
+++ b/src/web/pages/reportconfigs/details.jsx
@@ -25,14 +25,14 @@ export const ReportConfigParamValue = ({
   links = true,
 }) => {
   if (param.type === 'report_format_list') {
-    return map(value, report_format_id => {
-      const label = isDefined(value_labels[report_format_id])
-        ? value_labels[report_format_id]
-        : report_format_id;
+    return map(value, reportFormatId => {
+      const label = isDefined(value_labels[reportFormatId])
+        ? value_labels[reportFormatId]
+        : reportFormatId;
       return (
         <DetailsLink
-          key={param.name + '_' + report_format_id}
-          id={report_format_id}
+          key={param.name + '_' + reportFormatId}
+          id={reportFormatId}
           textOnly={!links}
           type="reportformat"
         >
@@ -69,13 +69,13 @@ ReportConfigParamValue.propTypes = {
 };
 
 const ReportConfigDetails = ({entity, links = true}) => {
-  const {orphan, report_format, params, alerts = []} = entity;
+  const {orphan, reportFormat, params, alerts = []} = entity;
 
   const reportFormatLink = orphan ? (
-    report_format.id
+    reportFormat.id
   ) : (
-    <DetailsLink id={report_format.id} textOnly={!links} type="reportformat">
-      {report_format.name}
+    <DetailsLink id={reportFormat.id} textOnly={!links} type="reportformat">
+      {reportFormat.name}
     </DetailsLink>
   );
   const paramRows = orphan ? (

--- a/src/web/pages/reportconfigs/details.jsx
+++ b/src/web/pages/reportconfigs/details.jsx
@@ -21,13 +21,13 @@ import {renderYesNo} from 'web/utils/render';
 export const ReportConfigParamValue = ({
   param,
   value = param.value,
-  value_labels = param.value_labels,
+  valueLabels = param.valueLabels,
   links = true,
 }) => {
   if (param.type === 'report_format_list') {
     return map(value, reportFormatId => {
-      const label = isDefined(value_labels[reportFormatId])
-        ? value_labels[reportFormatId]
+      const label = isDefined(valueLabels[reportFormatId])
+        ? valueLabels[reportFormatId]
         : reportFormatId;
       return (
         <DetailsLink
@@ -65,7 +65,7 @@ ReportConfigParamValue.propTypes = {
   links: PropTypes.bool,
   param: PropTypes.any.isRequired,
   value: PropTypes.any,
-  value_labels: PropTypes.object,
+  valueLabels: PropTypes.object,
 };
 
 const ReportConfigDetails = ({entity, links = true}) => {

--- a/src/web/pages/reportconfigs/detailspage.jsx
+++ b/src/web/pages/reportconfigs/detailspage.jsx
@@ -133,7 +133,7 @@ const Parameters = ({entity}) => {
                 <TableData>
                   <ReportConfigParamValue param={param} />
                 </TableData>
-                <TableData>{renderYesNo(param.value_using_default)}</TableData>
+                <TableData>{renderYesNo(param.valueUsingDefault)}</TableData>
                 <TableData>
                   <ReportConfigParamValue
                     param={param}

--- a/src/web/pages/reportconfigs/detailspage.jsx
+++ b/src/web/pages/reportconfigs/detailspage.jsx
@@ -138,7 +138,7 @@ const Parameters = ({entity}) => {
                   <ReportConfigParamValue
                     param={param}
                     value={param.default}
-                    value_labels={param.default_labels}
+                    valueLabels={param.defaultLabels}
                   />
                 </TableData>
                 <TableData>{param.min}</TableData>

--- a/src/web/pages/reportconfigs/dialog.jsx
+++ b/src/web/pages/reportconfigs/dialog.jsx
@@ -133,7 +133,7 @@ const Param = ({
     <TableRow>
       <TableData>{name}</TableData>
       <TableData>{field}</TableData>
-      <TableData>{useDefaultCheck}</TableData>
+      <TableData align={['center', 'center']}>{useDefaultCheck}</TableData>
     </TableRow>
   );
 };

--- a/src/web/pages/reportconfigs/dialog.jsx
+++ b/src/web/pages/reportconfigs/dialog.jsx
@@ -225,9 +225,9 @@ class Dialog extends React.Component {
       onSave({
         ...data,
         params,
-        params_using_default: paramsUsingDefault,
-        param_types: paramTypes,
-        report_format_id: reportFormatId,
+        paramsUsingDefault,
+        paramTypes,
+        reportFormatId,
       });
     }
   }

--- a/src/web/pages/reportconfigs/dialog.jsx
+++ b/src/web/pages/reportconfigs/dialog.jsx
@@ -242,8 +242,8 @@ class Dialog extends React.Component {
       originalParamInfo.forEach(param => {
         params[param.name] = param.value;
         paramsUsingDefault[param.name] = false;
-        if (isDefined(param.value_using_default)) {
-          paramsUsingDefault[param.name] = param.value_using_default;
+        if (isDefined(param.valueUsingDefault)) {
+          paramsUsingDefault[param.name] = param.valueUsingDefault;
         }
       });
 

--- a/src/web/pages/reportconfigs/dialog.jsx
+++ b/src/web/pages/reportconfigs/dialog.jsx
@@ -251,7 +251,7 @@ class Dialog extends React.Component {
         originalParamInfo,
         params,
         paramsUsingDefault,
-        reportFormatId: reportConfig.report_format.id,
+        reportFormatId: reportConfig.reportFormat.id,
       });
     }
   }

--- a/src/web/pages/reportconfigs/dialog.jsx
+++ b/src/web/pages/reportconfigs/dialog.jsx
@@ -236,9 +236,9 @@ class Dialog extends React.Component {
   }
 
   componentDidMount() {
-    const {reportconfig} = this.props;
-    if (isDefined(reportconfig)) {
-      const originalParamInfo = reportconfig.params;
+    const {reportConfig} = this.props;
+    if (isDefined(reportConfig)) {
+      const originalParamInfo = reportConfig.params;
       const params = {};
       const params_using_default = {};
 
@@ -261,12 +261,12 @@ class Dialog extends React.Component {
   render() {
     const {
       formats,
-      reportconfig,
+      reportConfig,
       title = _('New Report Config'),
       onClose,
     } = this.props;
 
-    const is_edit = isDefined(reportconfig);
+    const is_edit = isDefined(reportConfig);
 
     const configurable_formats = isDefined(formats)
       ? formats.filter(format => format.configurable)
@@ -282,11 +282,11 @@ class Dialog extends React.Component {
       comment: '',
     };
 
-    const report_config_values = isDefined(reportconfig)
+    const report_config_values = isDefined(reportConfig)
       ? {
-          ...reportconfig,
-          report_format: reportconfig.report_format.id,
-          comment: isDefined(reportconfig.comment) ? reportconfig.comment : '',
+          ...reportConfig,
+          report_format: reportConfig.report_format.id,
+          comment: isDefined(reportConfig.comment) ? reportConfig.comment : '',
         }
       : undefined;
 
@@ -382,7 +382,7 @@ Dialog.propTypes = {
   gmp: PropTypes.gmp.isRequired,
   name: PropTypes.string,
   params: PropTypes.object,
-  reportconfig: PropTypes.model,
+  reportConfig: PropTypes.model,
   summary: PropTypes.string,
   title: PropTypes.string,
   onClose: PropTypes.func.isRequired,

--- a/src/web/pages/reportconfigs/dialog.jsx
+++ b/src/web/pages/reportconfigs/dialog.jsx
@@ -178,6 +178,7 @@ class Dialog extends React.Component {
         originalParamInfo,
         params,
         paramsUsingDefault,
+        reportFormatId: value,
       });
     });
 
@@ -250,6 +251,7 @@ class Dialog extends React.Component {
         originalParamInfo,
         params,
         paramsUsingDefault,
+        reportFormatId: reportConfig.report_format.id,
       });
     }
   }
@@ -285,7 +287,8 @@ class Dialog extends React.Component {
         }
       : undefined;
 
-    const {originalParamInfo, params, paramsUsingDefault} = this.state;
+    const {reportFormatId, originalParamInfo, params, paramsUsingDefault} =
+      this.state;
 
     return (
       <SaveDialog
@@ -322,7 +325,7 @@ class Dialog extends React.Component {
                     grow="1"
                     items={formatItems}
                     name="reportFormat"
-                    value={state.reportFormat}
+                    value={reportFormatId}
                     onChange={this.handleReportFormatChange}
                   />
                 ) : (

--- a/src/web/pages/reportconfigs/dialog.jsx
+++ b/src/web/pages/reportconfigs/dialog.jsx
@@ -275,26 +275,23 @@ class Dialog extends React.Component {
       value: format.id,
     }));
 
-    const defaultValues = {
-      name: _('Unnamed'),
-      comment: '',
-    };
-
-    const reportConfigValues = isDefined(reportConfig)
+    const defaultValues = isDefined(reportConfig)
       ? {
-          ...reportConfig,
+          id: reportConfig.id,
+          name: reportConfig.name,
           comment: isDefined(reportConfig.comment) ? reportConfig.comment : '',
         }
-      : undefined;
+      : {
+          name: _('Unnamed'),
+          comment: '',
+        };
 
     const {reportFormatId, originalParamInfo, params, paramsUsingDefault} =
       this.state;
 
     return (
       <SaveDialog
-        defaultValues={
-          isDefined(reportConfigValues) ? reportConfigValues : defaultValues
-        }
+        defaultValues={defaultValues}
         title={title}
         onClose={onClose}
         onSave={this.handleSave}

--- a/src/web/pages/reportconfigs/dialog.jsx
+++ b/src/web/pages/reportconfigs/dialog.jsx
@@ -167,18 +167,17 @@ class Dialog extends React.Component {
     gmp.reportformat.get({id: value}).then(response => {
       const originalParamInfo = response.data.params;
       const params = {};
-      const params_using_default = {};
+      const paramsUsingDefault = {};
 
       originalParamInfo.forEach(param => {
         params[param.name] = param.value;
-        params_using_default[param.name] = true;
+        paramsUsingDefault[param.name] = true;
       });
 
       this.setState({
         originalParamInfo,
         params,
-        params_using_default,
-        report_format_id: value,
+        paramsUsingDefault,
       });
     });
 
@@ -189,11 +188,11 @@ class Dialog extends React.Component {
 
   handlePrefChange(value, name) {
     const {onValueChange} = this.props;
-    const {params, params_using_default} = this.state;
+    const {params, paramsUsingDefault} = this.state;
 
     params[name] = value;
-    params_using_default[name] = false;
-    this.setState({params, params_using_default});
+    paramsUsingDefault[name] = false;
+    this.setState({params, paramsUsingDefault});
 
     if (onValueChange) {
       onValueChange(params, 'params');
@@ -202,35 +201,32 @@ class Dialog extends React.Component {
 
   handleParamUsingDefaultChange(value, name) {
     const {onValueChange} = this.props;
-    const {params_using_default} = this.state;
+    const {paramsUsingDefault} = this.state;
 
-    params_using_default[name] = value;
-    this.setState({params_using_default});
+    paramsUsingDefault[name] = value;
+    this.setState({paramsUsingDefault});
 
     if (onValueChange) {
-      onValueChange(params_using_default, 'params_using_default');
+      onValueChange(paramsUsingDefault, 'params_using_default');
     }
   }
 
   handleSave(data) {
     const {onSave} = this.props;
     if (isDefined(onSave)) {
-      const {
-        params,
-        params_using_default,
-        report_format_id,
-        originalParamInfo,
-      } = this.state;
-      const param_types = {};
-      originalParamInfo.forEach(param_item => {
-        param_types[param_item.name] = param_item.type;
+      const {params, paramsUsingDefault, reportFormatId, originalParamInfo} =
+        this.state;
+      const paramTypes = {};
+      originalParamInfo.forEach(paramItem => {
+        paramTypes[paramItem.name] = paramItem.type;
       });
+
       onSave({
         ...data,
         params,
-        params_using_default,
-        param_types,
-        report_format_id,
+        params_using_default: paramsUsingDefault,
+        param_types: paramTypes,
+        report_format_id: reportFormatId,
       });
     }
   }
@@ -240,20 +236,20 @@ class Dialog extends React.Component {
     if (isDefined(reportConfig)) {
       const originalParamInfo = reportConfig.params;
       const params = {};
-      const params_using_default = {};
+      const paramsUsingDefault = {};
 
       originalParamInfo.forEach(param => {
         params[param.name] = param.value;
-        params_using_default[param.name] = false;
+        paramsUsingDefault[param.name] = false;
         if (isDefined(param.value_using_default)) {
-          params_using_default[param.name] = param.value_using_default;
+          paramsUsingDefault[param.name] = param.value_using_default;
         }
       });
 
       this.setState({
         originalParamInfo,
         params,
-        params_using_default,
+        paramsUsingDefault,
       });
     }
   }
@@ -266,38 +262,35 @@ class Dialog extends React.Component {
       onClose,
     } = this.props;
 
-    const is_edit = isDefined(reportConfig);
+    const isEdit = isDefined(reportConfig);
 
-    const configurable_formats = isDefined(formats)
+    const configurableFormats = isDefined(formats)
       ? formats.filter(format => format.configurable)
       : [];
 
-    const format_items = configurable_formats.map(format => ({
+    const formatItems = configurableFormats.map(format => ({
       label: format.name,
       value: format.id,
     }));
 
-    const default_values = {
+    const defaultValues = {
       name: _('Unnamed'),
       comment: '',
     };
 
-    const report_config_values = isDefined(reportConfig)
+    const reportConfigValues = isDefined(reportConfig)
       ? {
           ...reportConfig,
-          report_format: reportConfig.report_format.id,
           comment: isDefined(reportConfig.comment) ? reportConfig.comment : '',
         }
       : undefined;
 
-    const {originalParamInfo, params, params_using_default} = this.state;
+    const {originalParamInfo, params, paramsUsingDefault} = this.state;
 
     return (
       <SaveDialog
         defaultValues={
-          isDefined(report_config_values)
-            ? report_config_values
-            : default_values
+          isDefined(reportConfigValues) ? reportConfigValues : defaultValues
         }
         title={title}
         onClose={onClose}
@@ -323,13 +316,13 @@ class Dialog extends React.Component {
               </FormGroup>
 
               <FormGroup title={_('Report Format')}>
-                {isDefined(format_items) && format_items.length > 0 ? (
+                {isDefined(formatItems) && formatItems.length > 0 ? (
                   <Select
-                    disabled={is_edit}
+                    disabled={isEdit}
                     grow="1"
-                    items={format_items}
-                    name="report_format"
-                    value={state.report_format}
+                    items={formatItems}
+                    name="reportFormat"
+                    value={state.reportFormat}
                     onChange={this.handleReportFormatChange}
                   />
                 ) : (
@@ -354,8 +347,8 @@ class Dialog extends React.Component {
                           key={param.name}
                           data={params}
                           formats={formats}
-                          isEdit={is_edit}
-                          usingDefaultData={params_using_default}
+                          isEdit={isEdit}
+                          usingDefaultData={paramsUsingDefault}
                           value={param}
                           onParamUsingDefaultChange={
                             this.handleParamUsingDefaultChange

--- a/src/web/pages/reportconfigs/row.jsx
+++ b/src/web/pages/reportconfigs/row.jsx
@@ -74,14 +74,14 @@ const Row = ({
   ...props
 }) => {
   const reportFormat = entity.orphan ? (
-    entity.report_format.id
+    entity.reportFormat.id
   ) : (
     <DetailsLink
-      id={entity.report_format.id}
+      id={entity.reportFormat.id}
       textOnly={!links}
       type="reportformat"
     >
-      {entity.report_format.name}
+      {entity.reportFormat.name}
     </DetailsLink>
   );
 


### PR DESCRIPTION
## What

Fix displaying the selected report format in the report config dialog and being at it use camelCase for all report config variables.

## Why
Get a working report config dialog and always use camelCase for variables.

## References

https://jira.greenbone.net/browse/GEA-838

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


