### PR TITLE
Use correct container image for building gsad

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -26,6 +26,6 @@ WORKDIR /source
 
 RUN npm install && npm run build
 
-FROM greenbone/gsad:${VERSION}
+FROM registry.community.greenbone.net/community/gsad:${VERSION}
 
 COPY --from=builder /source/build /usr/local/share/gvm/gsad/web/


### PR DESCRIPTION


## What

Use correct container image for building gsad

## Why

We switched to an own registry a while ago and aren't uploading packages to dockerhub anymore.
