### PR TITLE
Display CPE Name ID and deprecation status at CPE details

### DIFF
--- a/src/gmp/models/__tests__/cpe.js
+++ b/src/gmp/models/__tests__/cpe.js
@@ -8,6 +8,8 @@ import Cpe from 'gmp/models/cpe';
 import {isDate} from 'gmp/models/date';
 import {testModel} from 'gmp/models/testing';
 
+/* eslint-disable camelcase */
+
 testModel(Cpe, 'cpe');
 
 describe('CPE model tests', () => {
@@ -88,17 +90,72 @@ describe('CPE model tests', () => {
     expect(isDate(cpe.updateTime)).toBe(true);
   });
 
-  test('should parse deprecatedBy', () => {
+  test('should parse deprecatedBy from raw data', () => {
     const cpe = Cpe.fromElement({
       raw_data: {'cpe-item': {_deprecated_by: 'foo:/bar'}},
     });
-
     expect(cpe.deprecatedBy).toEqual('foo:/bar');
+
+    const cpe2 = Cpe.fromElement({
+      deprecated: 0,
+      deprecated_by: {_cpe_id: 'foo:/bar'},
+      raw_data: {'cpe-item': {_deprecated_by: 'foo:/baz'}},
+    });
+    expect(cpe2.deprecatedBy).toEqual('foo:/baz');
+  });
+
+  test('should parse deprecated', () => {
+    const cpe = Cpe.fromElement({
+      deprecated: 1,
+    });
+    expect(cpe.deprecated).toBe(true);
+
+    const cpe2 = Cpe.fromElement({
+      deprecated: 0,
+    });
+    expect(cpe2.deprecated).toBe(false);
+
+    const cpe3 = Cpe.fromElement({});
+    expect(cpe3.deprecated).toBe(false);
+  });
+
+  test('should parse deprecatedBy', () => {
+    const cpe = Cpe.fromElement({
+      deprecated: 1,
+      deprecated_by: {_cpe_id: 'foo:/bar'},
+    });
+    expect(cpe.deprecatedBy).toEqual('foo:/bar');
+
+    const cpe2 = Cpe.fromElement({
+      deprecated: 1,
+      deprecated_by: {_cpe_id: 'foo:/bar'},
+      raw_data: {'cpe-item': {_deprecated_by: 'foo:/baz'}},
+    });
+
+    expect(cpe2.deprecatedBy).toEqual('foo:/bar');
   });
 
   test('should not parse deprecatedBy', () => {
     const cpe = Cpe.fromElement({raw_data: {'cpe-item': {}}});
 
     expect(cpe.deprecatedBy).toBeUndefined();
+  });
+
+  test('should parse old nvd_id', () => {
+    const cpe = Cpe.fromElement({nvd_id: 'ABC'});
+
+    expect(cpe.cpeNameId).toEqual('ABC');
+    expect(cpe.nvd_id).toBeUndefined();
+  });
+
+  test('should parse cpeNameId', () => {
+    const cpe = Cpe.fromElement({cpe_name_id: 'ABC'});
+    const cpe2 = Cpe.fromElement({cpe_name_id: 'ABC', nvd_id: 'DEF'});
+
+    expect(cpe.cpeNameId).toEqual('ABC');
+    expect(cpe.cpe_name_id).toBeUndefined();
+
+    expect(cpe2.cpeNameId).toEqual('ABC');
+    expect(cpe2.cpe_name_id).toBeUndefined();
   });
 });

--- a/src/gmp/models/cpe.js
+++ b/src/gmp/models/cpe.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {parseSeverity, parseDate} from 'gmp/parser';
+import {parseSeverity, parseDate, parseBoolean} from 'gmp/parser';
 import {map} from 'gmp/utils/array';
 import {isDefined} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
@@ -31,7 +31,14 @@ class Cpe extends Info {
     }
 
     if (isDefined(ret.nvd_id)) {
-      ret.nvdId = ret.nvd_id;
+      // old ID from nvd just kept for backwards compatibility and should be removed in future
+      ret.cpeNameId = ret.nvd_id;
+      delete ret.nvd_id;
+    }
+
+    if (isDefined(ret.cpe_name_id)) {
+      ret.cpeNameId = ret.cpe_name_id;
+      delete ret.cpe_name_id;
     }
 
     if (isDefined(ret.update_time)) {
@@ -44,8 +51,15 @@ class Cpe extends Info {
      * Once `raw_data` is removed from the API, this backup check can be removed.
      */
 
-    if (ret.deprecated === 1 && isDefined(ret.deprecated_by)) {
+    if (isDefined(ret.deprecated)) {
+      ret.deprecated = parseBoolean(ret.deprecated);
+    } else {
+      ret.deprecated = false;
+    }
+
+    if (ret.deprecated === true && isDefined(ret.deprecated_by)) {
       ret.deprecatedBy = ret.deprecated_by._cpe_id;
+      delete ret.deprecated_by;
     } else if (isDefined(ret.raw_data?.['cpe-item']?._deprecated_by)) {
       ret.deprecatedBy = ret.raw_data['cpe-item']._deprecated_by;
     }

--- a/src/web/pages/cpes/details.jsx
+++ b/src/web/pages/cpes/details.jsx
@@ -16,9 +16,18 @@ import InfoTable from 'web/components/table/infotable';
 import TableRow from 'web/components/table/row';
 import {Col} from 'web/entity/page';
 import PropTypes from 'web/utils/proptypes';
+import {renderYesNo} from 'web/utils/render';
 
 const CpeDetails = ({entity, links = true}) => {
-  const {title, nvdId, deprecatedBy, updateTime, status, severity} = entity;
+  const {
+    title,
+    cpeNameId,
+    deprecated,
+    deprecatedBy,
+    updateTime,
+    status,
+    severity,
+  } = entity;
   return (
     <Layout flex="column" grow="1">
       {!isDefined(title) && (
@@ -42,12 +51,16 @@ const CpeDetails = ({entity, links = true}) => {
               <TableData>{title}</TableData>
             </TableRow>
           )}
-          {isDefined(nvdId) && (
+          {isDefined(cpeNameId) && (
             <TableRow>
-              <TableData>{_('NVD ID')}</TableData>
-              <TableData>{nvdId}</TableData>
+              <TableData>{_('CPE Name ID')}</TableData>
+              <TableData>{cpeNameId}</TableData>
             </TableRow>
           )}
+          <TableRow>
+            <TableData>{_('Deprecated')}</TableData>
+            <TableData>{renderYesNo(deprecated)}</TableData>
+          </TableRow>
           {isDefined(deprecatedBy) && (
             <TableRow>
               <TableData>{_('Deprecated By')}</TableData>


### PR DESCRIPTION

## What
Display CPE Name ID and deprecation status at CPE details

![image](https://github.com/user-attachments/assets/000f771f-9fa6-4c66-a70b-fd6fed644a3a)


## Why

Ensure the model data is parsed correctly and contains the expected values. Display the CPE Name ID instead of the former NVD ID at the CPE details. Also the CPE status is not available anymore and only the deprecation status is shown.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


