### PR TITLE
Fix: remove Radio component title string conversions

### DIFF
--- a/src/web/components/form/radio.jsx
+++ b/src/web/components/form/radio.jsx
@@ -30,7 +30,7 @@ const Radio = ({
       {...props}
       checked={checked}
       disabled={disabled}
-      label={String(title)}
+      label={title}
       name={name}
       value={value}
       onChange={handleChange}


### PR DESCRIPTION
## What

- Ensure that label is a string

## Why

- Radio component doesn't always have the prop `title`, ex. if `title` is missing, it would display `undefined`.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


