### PR TITLE
deps: update node version

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -3,7 +3,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 FROM debian:stable-slim AS builder
 
-ENV NODE_VERSION=node_18.x
+ENV NODE_VERSION=node_20.x
 ENV NODE_KEYRING=/usr/share/keyrings/nodesource.gpg
 ENV DISTRIBUTION=bookworm
 

--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -18,7 +18,7 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dear
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    nodejs npm && \
+    nodejs && \
     rm -rf /var/lib/apt/lists/*
 
 COPY . /source

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 18
           - 20
+          - 22
     steps:
       - uses: actions/checkout@v4
       - name: Set up node ${{ matrix.node-version }}
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 18
+          - 22
     steps:
       - uses: actions/checkout@v4
       - name: Set up node ${{ matrix.node-version }}
@@ -74,8 +74,8 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 18
           - 20
+          - 22
     steps:
       - uses: actions/checkout@v4
       - name: Set up node ${{ matrix.node-version }}

--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -52,12 +52,12 @@ jobs:
           release-type: ${{ steps.release-type.outputs.release-type }}
           release-version: ${{ inputs.release-version }}
           ref: ${{ steps.release-type.outputs.release-ref }}
-          versioning-scheme: "semver"
-          sign-release-files: "false"
+          versioning-scheme: 'semver'
+          sign-release-files: 'false'
 
   build-dist:
     name: Build JavaScript files
-    runs-on: "ubuntu-latest"
+    runs-on: 'ubuntu-latest'
     needs: release
     steps:
       - uses: actions/checkout@v4
@@ -66,8 +66,8 @@ jobs:
       - name: Set up node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
-          cache: "npm"
+          node-version: '22'
+          cache: 'npm'
       - name: Install npm dependencies
         run: npm install
       - name: Build dist files
@@ -83,7 +83,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}
 
   sign:
-    runs-on: "ubuntu-latest"
+    runs-on: 'ubuntu-latest'
     needs: [release, build-dist]
     steps:
       - name: Sign release files

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ and the fingerprint is `8AE4 BE42 9B60 A59B 311C  2E73 9823 FAA6 0ED1 E580`.
 
 Prerequisites for GSA:
 
-- node.js >= 18.0
+- node.js >= 20.0
 
 To install nodejs the following commands can be used
 
 ```bash
-export VERSION=18
+export VERSION=20
 export KEYRING=/usr/share/keyrings/nodesource.gpg
 
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee "$KEYRING" >/dev/null

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "vitest": "^3.0.5"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=20.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clean-up-translations": "node scripts/cleanuptranslations"
   },
   "engines": {
-    "node": ">=18.0"
+    "node": ">=20.0"
   },
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop-react-beautiful-dnd-migration": "^1.4.0",

--- a/src/gmp/locale/__tests__/detector.js
+++ b/src/gmp/locale/__tests__/detector.js
@@ -62,15 +62,17 @@ describe('LanguageDetector tests', () => {
 
   test('should return language from navigator', () => {
     const storage = {};
-    global.navigator = {language: 'en-US'};
-
     const languageUtils = {
       formatLanguageCode: testing.fn().mockImplementation(l => l),
       isSupportedCode: testing.fn().mockReturnValue(true),
     };
 
-    const detector = new LanguageDetector();
+    Object.defineProperty(global, 'navigator', {
+      value: {language: 'en-US'},
+      configurable: true,
+    });
 
+    const detector = new LanguageDetector();
     detector.init({languageUtils}, {storage}, {fallbackLng: 'bar'});
 
     expect(detector.detect()).toEqual('en-US');
@@ -78,8 +80,6 @@ describe('LanguageDetector tests', () => {
     expect(languageUtils.formatLanguageCode).toHaveBeenCalledWith('en-US');
     expect(languageUtils.isSupportedCode).toHaveBeenCalledTimes(1);
     expect(languageUtils.isSupportedCode).toHaveBeenCalledWith('en-US');
-
-    global.navigator = undefined;
   });
 
   test('should return languages from fake navigator', () => {


### PR DESCRIPTION
## What

- Update the Node.js version in `package.json` to set the new minimum version to 20.

## Why

- Node.js version 18 will not be maintained beyond April 2025

## References

https://jira.greenbone.net/browse/GEA-850
https://jira.greenbone.net/browse/GEA-891

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


