### PR TITLE
Fix align items is not dom property and test warning

### DIFF
--- a/src/web/components/testing.js
+++ b/src/web/components/testing.js
@@ -81,10 +81,8 @@ export const openSelectElement = async select => {
  * Click on an element/item/node
  */
 export const clickElement = async element => {
-  await act(async () => {
-    await userEvent.click(element, {
-      pointerEventsCheck: PointerEventsCheckLevel.Never,
-    });
+  await userEvent.click(element, {
+    pointerEventsCheck: PointerEventsCheckLevel.Never,
   });
 };
 

--- a/src/web/entities/entitynametabledata.jsx
+++ b/src/web/entities/entitynametabledata.jsx
@@ -48,7 +48,7 @@ const EntityNameTableData = ({
         {isDefined(entity.comment) && <Comment>({entity.comment})</Comment>}
         {children}
       </div>
-      <Layout alignItems="center">
+      <Layout>
         <ObserverIcon
           displayName={displayName}
           entity={entity}


### PR DESCRIPTION
## What

- Remove prop `align-items` has no effect and creates log issues
- Remove `act` from `clickElement`  has no effect and creates log issues

## Why

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


