### PR TITLE
Change: Differentiate scan and audit report formats

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -1415,6 +1415,7 @@
   "Report Formats List": "Berichtformatliste",
   "Report is selected for delta comparison": "Bericht ist für Delta-Vergleich ausgewählt",
   "Report Result Filter": "Ergebnisfilter für Bericht",
+  "Report Type": "Berichtstyp",
   "Report with ID": "Bericht mit ID",
   "Report:": "Bericht:",
   "Reported Vulnerabilities": "Gemeldete Schwachstellen",

--- a/public/locales/gsa-en.json
+++ b/public/locales/gsa-en.json
@@ -1415,6 +1415,7 @@
   "Report Formats List": "Report Formats List",
   "Report is selected for delta comparison": "Report is selected for delta comparison",
   "Report Result Filter": "Report Result Filter",
+  "Report Type": "Report Type",
   "Report with ID": "Report with ID",
   "Report:": "Report:",
   "Reported Vulnerabilities": "Reported Vulnerabilities",

--- a/public/locales/gsa-zh_CN.json
+++ b/public/locales/gsa-zh_CN.json
@@ -1415,6 +1415,7 @@
   "Report Formats List": "报告格式列表",
   "Report is selected for delta comparison": "已添加对比",
   "Report Result Filter": "报告扫描结果筛选",
+  "Report Type": "",
   "Report with ID": "报告ID",
   "Report:": "报告:",
   "Reported Vulnerabilities": "已报告的漏洞",

--- a/public/locales/gsa-zh_TW.json
+++ b/public/locales/gsa-zh_TW.json
@@ -1415,6 +1415,7 @@
   "Report Formats List": "",
   "Report is selected for delta comparison": "",
   "Report Result Filter": "",
+  "Report Type": "",
   "Report with ID": "報表與 ID",
   "Report:": "報告:",
   "Reported Vulnerabilities": "",

--- a/src/web/pages/reportformats/details.jsx
+++ b/src/web/pages/reportformats/details.jsx
@@ -24,6 +24,7 @@ const ReportFormatDetails = ({entity, links = true}) => {
     deprecated,
     extension,
     content_type,
+    report_type,
     trust = {},
     summary,
     description,
@@ -57,6 +58,13 @@ const ReportFormatDetails = ({entity, links = true}) => {
             <TableData>{_('Content Type')}</TableData>
             <TableData>{content_type}</TableData>
           </TableRow>
+
+          {report_type && (
+            <TableRow>
+              <TableData>{_('Report Type')}</TableData>
+              <TableData>{report_type}</TableData>
+            </TableRow>
+          )}
 
           <TableRow>
             <TableData>{_('Trust')}</TableData>

--- a/src/web/pages/reports/downloadreportdialog.jsx
+++ b/src/web/pages/reports/downloadreportdialog.jsx
@@ -92,6 +92,15 @@ const DownloadReportDialog = ({
             )
           : [];
 
+        const filteredReportFormats = isDefined(reportFormats)
+          ? (reportFormats.filter(
+               format => !isDefined(format.report_type)
+                 ? true
+                 : audit
+                     ? ['audit', 'all'].includes(format.report_type)
+                     : ['scan', 'all'].includes(format.report_type)))
+          : [];
+
         return (
           <>
             <ComposerContent
@@ -105,7 +114,7 @@ const DownloadReportDialog = ({
             <FormGroup title={_('Report Format')}>
               <Select
                 grow="1"
-                items={renderSelectItems(reportFormats)}
+                items={renderSelectItems(filteredReportFormats)}
                 name="reportFormatId"
                 value={reportFormatIdInState}
                 width="auto"


### PR DESCRIPTION
## What
Restrict available report formats when downloading a report according to the supported report type.

requires [#2370](https://github.com/greenbone/gvmd/pull/2370)

## Why
Avoid inconsistencies between reports and report formats.

## References
GEA-873