### PR TITLE
Ensure name is string

### DIFF
--- a/src/gmp/__tests__/parser.test.js
+++ b/src/gmp/__tests__/parser.test.js
@@ -25,6 +25,7 @@ import {
   YES_VALUE,
   NO_VALUE,
   setProperties,
+  parseToString,
 } from '../parser';
 import {
   parseCvssV2BaseVector,
@@ -67,7 +68,7 @@ describe('parseInt tests', () => {
     expect(parseInt('5a')).toBeUndefined();
   });
 
-  test('should parse infintiy as undefined', () => {
+  test('should parse infinity as undefined', () => {
     expect(parseInt(Infinity)).toBeUndefined();
     expect(parseInt('Infinity')).toBeUndefined();
   });
@@ -1351,5 +1352,19 @@ describe('parseBoolean tests', () => {
   test('should parse boolean', () => {
     expect(parseBoolean(false)).toBe(false);
     expect(parseBoolean(true)).toBe(true);
+  });
+});
+
+describe('parseToString tests', () => {
+  test('should return undefined for undefined', () => {
+    expect(parseToString()).toBeUndefined();
+  });
+
+  test('should return string for string', () => {
+    expect(parseToString('foo')).toEqual('foo');
+  });
+
+  test('should return string for numbers', () => {
+    expect(parseToString(1)).toEqual('1');
   });
 });

--- a/src/gmp/model.js
+++ b/src/gmp/model.js
@@ -7,7 +7,7 @@ import {map} from 'gmp/utils/array';
 import {isDefined} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
 
-import Capabilities from './capabilities/capabilities.js';
+import Capabilities from './capabilities/capabilities';
 import {
   parseProperties as parseDefaultProperties,
   parseYesNo,
@@ -17,7 +17,8 @@ import {
   setProperties,
   NO_VALUE,
   YES_VALUE,
-} from './parser.js';
+  parseToString,
+} from './parser';
 
 export const parseModelFromElement = (element, entityType) => {
   const m = new Model(entityType);
@@ -52,6 +53,10 @@ class Model {
 
   static parseElement(element = {}) {
     const copy = parseDefaultProperties(element);
+
+    if (isDefined(element.name)) {
+      copy.name = parseToString(element.name);
+    }
 
     if (isDefined(element.end_time)) {
       if (element.end_time.length > 0) {

--- a/src/gmp/models/__tests__/tlscertificate.test.js
+++ b/src/gmp/models/__tests__/tlscertificate.test.js
@@ -10,7 +10,7 @@ import {parseDate} from 'gmp/parser';
 import TlsCertificate, {TIME_STATUS} from '../tlscertificate';
 
 describe('TlsCertificate Model tests', () => {
-  testModel(TlsCertificate, 'tlscertificate');
+  testModel(TlsCertificate, 'tlscertificate', {testName: false});
 
   test('should parse certificate', () => {
     const element = {

--- a/src/gmp/models/testing.js
+++ b/src/gmp/models/testing.js
@@ -25,7 +25,11 @@ const testId = modelClass => {
   });
 };
 
-export const testModelFromElement = (modelClass, type) => {
+export const testModelFromElement = (
+  modelClass,
+  type,
+  {testName = true} = {},
+) => {
   test('should create instance of modelclass in fromElement', () => {
     const model = modelClass.fromElement();
     expect(model).toBeInstanceOf(modelClass);
@@ -152,6 +156,14 @@ export const testModelFromElement = (modelClass, type) => {
 
     expect(model.type).toBeUndefined();
   });
+
+  if (testName) {
+    test('should ensure name is parsed as string', () => {
+      const model = modelClass.fromElement({name: 1337});
+
+      expect(model.name).toEqual('1337');
+    });
+  }
 };
 
 export const testModelMethods = (modelClass, {testIsActive = true} = {}) => {
@@ -292,7 +304,7 @@ const testModelGetProperties = (modelClass, type) => {
 };
 
 export const testModel = (modelClass, type, options) => {
-  testModelFromElement(modelClass, type);
+  testModelFromElement(modelClass, type, options);
   testModelMethods(modelClass, options);
   testModelSetProperties(modelClass);
   testModelGetProperties(modelClass, type);

--- a/src/gmp/models/tlscertificate.js
+++ b/src/gmp/models/tlscertificate.js
@@ -5,7 +5,7 @@
 
 import {_l} from 'gmp/locale/lang';
 import Model from 'gmp/model';
-import {parseBoolean, parseDate} from 'gmp/parser';
+import {parseBoolean, parseDate, parseToString} from 'gmp/parser';
 import {forEach} from 'gmp/utils/array';
 import {isDefined} from 'gmp/utils/identity';
 
@@ -37,7 +37,7 @@ class TlsCertificate extends Model {
       : undefined;
 
     // Use subject DN as name
-    ret.name = ret.subject_dn;
+    ret.name = parseToString(ret.subject_dn);
 
     ret.subjectDn = element.subject_dn;
     delete ret.subject_dn;

--- a/src/gmp/parser.js
+++ b/src/gmp/parser.js
@@ -224,3 +224,16 @@ export const parseBoolean = value => {
   }
   return value === true;
 };
+
+/**
+ * Parses the given value into a string if it is defined.
+ *
+ * @param {*} value - The value to be parsed into a string.
+ * @returns {string|undefined} The parsed string if the value is defined, otherwise undefined.
+ */
+export const parseToString = value => {
+  if (isDefined(value)) {
+    return String(value);
+  }
+  return undefined;
+};

--- a/src/web/components/form/multiselect.jsx
+++ b/src/web/components/form/multiselect.jsx
@@ -109,8 +109,8 @@ MultiSelect.propTypes = {
   isLoading: PropTypes.bool,
   items: PropTypes.arrayOf(
     PropTypes.shape({
-      label: PropTypes.any.isRequired,
-      value: PropTypes.any.isRequired,
+      label: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
     }),
   ),
   label: PropTypes.string,
@@ -118,7 +118,7 @@ MultiSelect.propTypes = {
   placeholder: PropTypes.string,
   searchable: PropTypes.bool,
   title: PropTypes.string,
-  value: PropTypes.array,
+  value: PropTypes.arrayOf(PropTypes.string),
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
   height: PropTypes.number,
   onChange: PropTypes.func,


### PR DESCRIPTION
## What

Ensure name properties of our models are always of type string.

## Why

Fix a crash of the group dialog when a user name only contains digits. Our XML to JS parsing library converts converts XML content and attributes which only contain digits as numbers. Sadly our MultiSelect component can't handle non-string values and labels anymore.

## References

https://forum.greenbone.net/t/error-in-new-group-dialog-when-there-are-users-with-login-names-formed-by-numbers-only/20465/3
https://jira.greenbone.net/browse/GEA-922

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


