### PR TITLE
Add feed version to tests to avoid momentjs warnings

### DIFF
--- a/src/gmp/commands/__tests__/feedstatus.test.js
+++ b/src/gmp/commands/__tests__/feedstatus.test.js
@@ -51,8 +51,18 @@ describe('FeedStatusCommand tests', () => {
       get_feeds: {
         get_feeds_response: {
           feed: [
-            {type: 'NVT', currently_syncing: true, sync_not_available: false},
-            {type: 'SCAP', currently_syncing: false, sync_not_available: false},
+            {
+              type: 'NVT',
+              currently_syncing: true,
+              sync_not_available: false,
+              version: 202502170647,
+            },
+            {
+              type: 'SCAP',
+              currently_syncing: false,
+              sync_not_available: false,
+              version: 202502170647,
+            },
           ],
         },
       },
@@ -74,6 +84,7 @@ describe('FeedStatusCommand tests', () => {
               type: 'OTHER',
               currently_syncing: false,
               sync_not_available: false,
+              version: 202502170647,
             },
           ],
         },
@@ -92,8 +103,18 @@ describe('FeedStatusCommand tests', () => {
       get_feeds: {
         get_feeds_response: {
           feed: [
-            {type: 'NVT', currently_syncing: false, sync_not_available: false},
-            {type: 'SCAP', currently_syncing: false, sync_not_available: false},
+            {
+              type: 'NVT',
+              currently_syncing: false,
+              sync_not_available: false,
+              version: 202502170647,
+            },
+            {
+              type: 'SCAP',
+              currently_syncing: false,
+              sync_not_available: false,
+              version: 202502170647,
+            },
           ],
         },
       },

--- a/src/gmp/commands/__tests__/tasks.test.js
+++ b/src/gmp/commands/__tests__/tasks.test.js
@@ -290,8 +290,18 @@ describe('TaskCommand tests', () => {
       get_feeds: {
         get_feeds_response: {
           feed: [
-            {type: 'NVT', currently_syncing: true, sync_not_available: false},
-            {type: 'SCAP', currently_syncing: false, sync_not_available: false},
+            {
+              type: 'NVT',
+              currently_syncing: true,
+              sync_not_available: false,
+              version: 202502170647,
+            },
+            {
+              type: 'SCAP',
+              currently_syncing: false,
+              sync_not_available: false,
+              version: 202502170647,
+            },
           ],
         },
       },


### PR DESCRIPTION
## What

Add feed version to tests to avoid momentjs warnings
## Why

The feed version is parsed as date and if it is missing momentjs will complain. Therefore add the version to all feed sync tests to avoid warnings when running them.

## References

https://jira.greenbone.net/browse/GEA-923

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


