### PR TITLE
Eslint rule for strict equality and react router unused flags

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -78,6 +78,7 @@ export default [
           properties: 'always',
         },
       ],
+      eqeqeq: ['warn', 'always'],
       'react/display-name': 'off',
       'no-class-assign': 'off',
       'no-prototype-builtins': 'off',

--- a/src/gmp/capabilities/capabilities.js
+++ b/src/gmp/capabilities/capabilities.js
@@ -122,7 +122,7 @@ class Capabilities {
   }
 
   featureEnabled(feature) {
-    return this._featuresEnabled[feature.toUpperCase()] == true;
+    return this._featuresEnabled[feature.toUpperCase()] === true;
   }
 }
 

--- a/src/gmp/models/event.js
+++ b/src/gmp/models/event.js
@@ -10,7 +10,6 @@ import {isEmpty} from 'gmp/utils/string';
 import ical from 'ical.js';
 import {v4 as uuid} from 'uuid';
 
-
 const log = Logger.getLogger('gmp.models.event');
 
 const convertIcalDate = (idate, timezone) => {
@@ -420,8 +419,10 @@ class Event {
 export const isEvent = obj => {
   return (
     obj instanceof Event ||
-    (obj != null && obj.event != null && obj.timezone != null)
+    (obj !== null &&
+      isDefined(obj) &&
+      isDefined(obj.event) &&
+      isDefined(obj.timezone))
   );
 };
-
 export default Event;

--- a/src/web/Routes.jsx
+++ b/src/web/Routes.jsx
@@ -240,16 +240,7 @@ const AppRoutes = () => {
   }
 
   return (
-    <Router
-      future={{
-        // eslint-disable-next-line camelcase
-        v7_startTransition: true,
-        // eslint-disable-next-line camelcase
-        v7_relativeSplatPath: false,
-      }}
-    >
-      {isLoggedIn ? <LoggedInRoutes /> : <LoggedOutRoutes />}
-    </Router>
+    <Router>{isLoggedIn ? <LoggedInRoutes /> : <LoggedOutRoutes />}</Router>
   );
 };
 

--- a/src/web/entities/Header.jsx
+++ b/src/web/entities/Header.jsx
@@ -40,7 +40,7 @@ const defaultactions = (
 export const withEntitiesHeader =
   (actions_column = defaultactions, options = {}) =>
   Component => {
-    if (actions_column === false) {
+    if (!actions_column) {
       actions_column = null;
     }
 
@@ -48,12 +48,8 @@ export const withEntitiesHeader =
       const {selectionType} = props;
       let column = actions_column;
 
-      if (actions_column == true) {
-        if (selectionType === SelectionType.SELECTION_USER) {
-          column = <TableHead width="6em">{_('Actions')}</TableHead>;
-        } else {
-          column = null;
-        }
+      if (actions_column && selectionType === SelectionType.SELECTION_USER) {
+        column = <TableHead width="6em">{_('Actions')}</TableHead>;
       }
       return <Component {...options} actionsColumn={column} {...props} />;
     };


### PR DESCRIPTION
## What

- Remove v6 react router flags
- Add `eslint` strict equality rule and adjust lint files

## Why

- Best practice to have strict equality and avoid falsy, truthy coercion.

## References

GEA-933

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


