### PR TITLE
Add: Add new whole only families

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,3 @@ public/config.js
 
 .venv
 .eslintcache
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ public/config.js
 
 .venv
 .eslintcache
+.idea

--- a/src/web/pages/scanconfigs/NvtFamilies.jsx
+++ b/src/web/pages/scanconfigs/NvtFamilies.jsx
@@ -40,6 +40,8 @@ const WHOLE_SELECTION_FAMILIES = [
   'Huawei EulerOS Local Security Checks',
   'Mageia Linux Local Security Checks',
   'Mandrake Local Security Checks',
+  'openSUSE Local Security Checks',
+  'openEuler Local Security Checks',
   'Oracle Linux Local Security Checks',
   'Red Hat Local Security Checks',
   'Rocky Linux Local Security Checks',


### PR DESCRIPTION
## What

Add `openSUSE Local Security Checks` and `openEuler Local Security Checks` into the `LSC_FAMILY_LIST` and `FAMILIES_WHOLE_ONLY`

## Why

These families have been added by VT-Dev Team

## References

GEA-921
GEA-929

## Checklist


- [ ] Tests


