### PR TITLE
Ensure that random colors have always six characters

### DIFF
--- a/src/web/components/dashboard/display/utils.js
+++ b/src/web/components/dashboard/display/utils.js
@@ -46,12 +46,13 @@ export const percent = (count, sum) =>
   ((parseInt(count) / sum) * 100).toFixed(1);
 
 /**
- * Generates a random hex color code.
+ * Generates a random RGB color code.
  *
  * @returns {string} A random hex color code in the format '#RRGGBB'.
  */
 export const randomColor = () => {
-  return '#' + Math.floor(Math.random() * 0xffffff).toString(16);
+  const color = Math.floor(Math.random() * 0xffffff).toString(16);
+  return '#' + color.padStart(6, '0');
 };
 
 export const activeDaysColorScale = scaleOrdinal()


### PR DESCRIPTION


## What

Ensure that random colors have always six characters

## Why
Fix a flacky test by ensuring the random color function always returns a RGB color code with six characters.

## References
https://github.com/greenbone/gsa/actions/runs/13515752252/job/37764029875?pr=4348
