### PR TITLE
Allow to pass and override the data-testid prop of SvgIcon components

### DIFF
--- a/src/web/components/dashboard/Controls.jsx
+++ b/src/web/components/dashboard/Controls.jsx
@@ -29,7 +29,6 @@ import compose from 'web/utils/Compose';
 import PropTypes from 'web/utils/PropTypes';
 import withGmp from 'web/utils/withGmp';
 
-
 export class DashboardControls extends React.Component {
   constructor(...args) {
     super(...args);
@@ -113,6 +112,7 @@ export class DashboardControls extends React.Component {
             onClick={canAdd ? this.handleNewClick : undefined}
           />
           <ResetIcon
+            data-testid="reset-dashboard"
             title={_('Reset to Defaults')}
             onClick={this.handleResetClick}
           />

--- a/src/web/components/icon/CloneIcon.jsx
+++ b/src/web/components/icon/CloneIcon.jsx
@@ -9,7 +9,7 @@ import withSvgIcon from 'web/components/icon/withSvgIcon';
 const CloneIconComponent = withSvgIcon()(Icon);
 
 const CloneIcon = props => (
-  <CloneIconComponent {...props} data-testid="clone-icon" />
+  <CloneIconComponent data-testid="clone-icon" {...props} />
 );
 
 export default CloneIcon;

--- a/src/web/components/icon/DeleteIcon.jsx
+++ b/src/web/components/icon/DeleteIcon.jsx
@@ -12,7 +12,6 @@ import withSvgIcon from 'web/components/icon/withSvgIcon';
 import PropTypes from 'web/utils/PropTypes';
 import SelectionType from 'web/utils/SelectionType';
 
-
 const DeleteSvgIcon = withSvgIcon()(props => (
   <IconWithStrokeWidth
     IconComponent={Icon}
@@ -31,7 +30,7 @@ const DeleteIcon = ({selectionType, title, ...props}) => {
       title = _('Delete all filtered');
     }
   }
-  return <DeleteSvgIcon {...props} title={title} />;
+  return <DeleteSvgIcon data-testid="delete-icon" {...props} title={title} />;
 };
 
 DeleteIcon.propTypes = {

--- a/src/web/components/icon/EditIcon.jsx
+++ b/src/web/components/icon/EditIcon.jsx
@@ -7,12 +7,12 @@ import {Pencil as Icon} from 'lucide-react';
 import IconWithStrokeWidth from 'web/components/icon/IconWithStrokeWidth';
 import withSvgIcon from 'web/components/icon/withSvgIcon';
 
-const EditIcon = withSvgIcon()(props => (
-  <IconWithStrokeWidth
-    IconComponent={Icon}
-    {...props}
-    data-testid="edit-icon"
-  />
+const EditIconComponent = withSvgIcon()(props => (
+  <IconWithStrokeWidth IconComponent={Icon} {...props} />
 ));
+
+const EditIcon = props => (
+  <EditIconComponent data-testid="edit-icon" {...props} />
+);
 
 export default EditIcon;

--- a/src/web/components/icon/ExportIcon.jsx
+++ b/src/web/components/icon/ExportIcon.jsx
@@ -11,7 +11,6 @@ import withSvgIcon from 'web/components/icon/withSvgIcon';
 import PropTypes from 'web/utils/PropTypes';
 import SelectionType from 'web/utils/SelectionType';
 
-
 const ExportSvgIcon = withSvgIcon()(props => (
   <IconWithStrokeWidth IconComponent={Icon} {...props} />
 ));
@@ -27,8 +26,8 @@ const ExportIcon = ({selectionType, title, ...other}) => {
   }
   return (
     <ExportSvgIcon
-      {...other}
       data-testid="export-icon"
+      {...other}
       title={download_title}
     />
   );

--- a/src/web/components/icon/FilterIcon.jsx
+++ b/src/web/components/icon/FilterIcon.jsx
@@ -7,12 +7,12 @@ import {Filter as Icon} from 'lucide-react';
 import IconWithStrokeWidth from 'web/components/icon/IconWithStrokeWidth';
 import withSvgIcon from 'web/components/icon/withSvgIcon';
 
-const FilterIcon = withSvgIcon()(props => (
-  <IconWithStrokeWidth
-    IconComponent={Icon}
-    {...props}
-    data-testid="filter-icon"
-  />
+const FilterIconComponent = withSvgIcon()(props => (
+  <IconWithStrokeWidth IconComponent={Icon} {...props} />
 ));
+
+const FilterIcon = props => (
+  <FilterIconComponent data-testid="filter-icon" {...props} />
+);
 
 export default FilterIcon;

--- a/src/web/components/icon/HelpIcon.jsx
+++ b/src/web/components/icon/HelpIcon.jsx
@@ -7,12 +7,12 @@ import {HelpCircle as Icon} from 'lucide-react';
 import IconWithStrokeWidth from 'web/components/icon/IconWithStrokeWidth';
 import withSvgIcon from 'web/components/icon/withSvgIcon';
 
-const HelpIcon = withSvgIcon()(props => (
-  <IconWithStrokeWidth
-    IconComponent={Icon}
-    {...props}
-    data-testid="help-icon"
-  />
+const HelpIconComponent = withSvgIcon()(props => (
+  <IconWithStrokeWidth IconComponent={Icon} {...props} />
 ));
+
+const HelpIcon = props => (
+  <HelpIconComponent data-testid="help-icon" {...props} />
+);
 
 export default HelpIcon;

--- a/src/web/components/icon/NewIcon.jsx
+++ b/src/web/components/icon/NewIcon.jsx
@@ -8,6 +8,6 @@ import withSvgIcon from 'web/components/icon/withSvgIcon';
 
 const NewIconComponent = withSvgIcon()(Icon);
 
-const NewIcon = props => <NewIconComponent {...props} data-testid="new-icon" />;
+const NewIcon = props => <NewIconComponent data-testid="new-icon" {...props} />;
 
 export default NewIcon;

--- a/src/web/components/icon/NewTicketIcon.jsx
+++ b/src/web/components/icon/NewTicketIcon.jsx
@@ -3,15 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
 import Icon from 'web/components/icon/svg/new_ticket.svg';
-import SvgIcon from 'web/components/icon/SvgIcon';
+import withSvgIcon from 'web/components/icon/withSvgIcon';
 
+const NewTicketIconComponent = withSvgIcon()(Icon);
 
 const NewTicketIcon = props => (
-  <SvgIcon {...props}>
-    <Icon data-testid="new-ticket-icon"/>
-  </SvgIcon>
+  <NewTicketIconComponent data-testid="new-ticket-icon" {...props} />
 );
 
 export default NewTicketIcon;

--- a/src/web/components/icon/ResetIcon.jsx
+++ b/src/web/components/icon/ResetIcon.jsx
@@ -7,12 +7,12 @@ import {RotateCcw as Icon} from 'lucide-react';
 import IconWithStrokeWidth from 'web/components/icon/IconWithStrokeWidth';
 import withSvgIcon from 'web/components/icon/withSvgIcon';
 
-const ResetIcon = withSvgIcon()(props => (
-  <IconWithStrokeWidth
-    IconComponent={Icon}
-    {...props}
-    data-testid="reset-icon"
-  />
+const ResetIconComponent = withSvgIcon()(props => (
+  <IconWithStrokeWidth IconComponent={Icon} {...props} />
 ));
+
+const ResetIcon = props => (
+  <ResetIconComponent data-testid="reset-icon" {...props} />
+);
 
 export default ResetIcon;

--- a/src/web/components/icon/ResumeIcon.jsx
+++ b/src/web/components/icon/ResumeIcon.jsx
@@ -7,12 +7,12 @@ import {StepForward as Icon} from 'lucide-react';
 import IconWithStrokeWidth from 'web/components/icon/IconWithStrokeWidth';
 import withSvgIcon from 'web/components/icon/withSvgIcon';
 
-const ResumeIcon = withSvgIcon()(props => (
-  <IconWithStrokeWidth
-    IconComponent={Icon}
-    {...props}
-    data-testid="resume-icon"
-  />
+const ResumeIconComponent = withSvgIcon()(props => (
+  <IconWithStrokeWidth IconComponent={Icon} {...props} />
 ));
+
+const ResumeIcon = props => (
+  <ResumeIconComponent data-testid="resume-icon" {...props} />
+);
 
 export default ResumeIcon;

--- a/src/web/components/icon/Settings2.jsx
+++ b/src/web/components/icon/Settings2.jsx
@@ -7,12 +7,12 @@ import {Settings2 as Icon} from 'lucide-react';
 import IconWithStrokeWidth from 'web/components/icon/IconWithStrokeWidth';
 import withSvgIcon from 'web/components/icon/withSvgIcon';
 
-const Settings2 = withSvgIcon()(props => (
-  <IconWithStrokeWidth
-    {...props}
-    IconComponent={Icon}
-    data-testid="settings-2-icon"
-  />
+const Settings2Component = withSvgIcon()(props => (
+  <IconWithStrokeWidth {...props} IconComponent={Icon} />
 ));
+
+const Settings2 = props => (
+  <Settings2Component data-testid="settings-2-icon" {...props} />
+);
 
 export default Settings2;

--- a/src/web/components/icon/StartIcon.jsx
+++ b/src/web/components/icon/StartIcon.jsx
@@ -7,12 +7,12 @@ import {Play as Icon} from 'lucide-react';
 import IconWithStrokeWidth from 'web/components/icon/IconWithStrokeWidth';
 import withSvgIcon from 'web/components/icon/withSvgIcon';
 
-const StartIcon = withSvgIcon()(props => (
-  <IconWithStrokeWidth
-    IconComponent={Icon}
-    {...props}
-    data-testid="start-icon"
-  />
+const StartIconComponent = withSvgIcon()(props => (
+  <IconWithStrokeWidth IconComponent={Icon} {...props} />
 ));
+
+const StartIcon = props => (
+  <StartIconComponent data-testid="start-icon" {...props} />
+);
 
 export default StartIcon;

--- a/src/web/components/icon/StopIcon.jsx
+++ b/src/web/components/icon/StopIcon.jsx
@@ -7,12 +7,12 @@ import {Square as Icon} from 'lucide-react';
 import IconWithStrokeWidth from 'web/components/icon/IconWithStrokeWidth';
 import withSvgIcon from 'web/components/icon/withSvgIcon';
 
-const StopIcon = withSvgIcon()(props => (
-  <IconWithStrokeWidth
-    IconComponent={Icon}
-    {...props}
-    data-testid="stop-icon"
-  />
+const StopIconComponent = withSvgIcon()(props => (
+  <IconWithStrokeWidth IconComponent={Icon} {...props} />
 ));
+
+const StopIcon = props => (
+  <StopIconComponent data-testid="stop-icon" {...props} />
+);
 
 export default StopIcon;

--- a/src/web/components/icon/SvgIcon.jsx
+++ b/src/web/components/icon/SvgIcon.jsx
@@ -87,6 +87,7 @@ const SvgIcon = ({
   onClick,
   size,
   color = Theme.black,
+  ['data-testid']: dataTestId = 'svg-icon',
   ...other
 }) => {
   const [loading, setLoading] = useStateWithMountCheck(false);
@@ -125,7 +126,7 @@ const SvgIcon = ({
       $isLoading={loading}
       $width={width}
       color={color}
-      data-testid="svg-icon"
+      data-testid={dataTestId}
       title={title}
       onClick={
         isDefined(onClick) && !disabled && !loading ? handleClick : undefined

--- a/src/web/components/icon/Testing.jsx
+++ b/src/web/components/icon/Testing.jsx
@@ -4,11 +4,12 @@
  */
 
 import {test, expect, testing} from '@gsa/testing';
+import {isDefined} from 'gmp/utils/identity';
 import {ICON_SIZE_SMALL_PIXELS} from 'web/hooks/useIconSize';
 import {render, fireEvent, act} from 'web/utils/Testing';
 import Theme from 'web/utils/Theme';
 
-export const testIcon = Icon => {
+export const testIcon = (Icon, {dataTestId, customDataTestId} = {}) => {
   test('should render with default width and height', () => {
     const {element} = render(<Icon />);
 
@@ -91,4 +92,20 @@ export const testIcon = Icon => {
     expect(element).toHaveAttribute('title', 'foo');
     expect(svgElement).toHaveAttribute('title', 'foo');
   });
+
+  if (isDefined(dataTestId)) {
+    test('should render with default data-testid', () => {
+      const {element} = render(<Icon />);
+
+      expect(element).toHaveAttribute('data-testid', dataTestId);
+    });
+  }
+
+  if (isDefined(customDataTestId)) {
+    test('should render with custom data-testid', () => {
+      const {element} = render(<Icon data-testid={customDataTestId} />);
+
+      expect(element).toHaveAttribute('data-testid', customDataTestId);
+    });
+  }
 };

--- a/src/web/components/icon/TrashCanIcon.jsx
+++ b/src/web/components/icon/TrashCanIcon.jsx
@@ -7,12 +7,12 @@ import {Trash2 as Icon} from 'lucide-react';
 import IconWithStrokeWidth from 'web/components/icon/IconWithStrokeWidth';
 import withSvgIcon from 'web/components/icon/withSvgIcon';
 
-const TrashcanIcon = withSvgIcon()(props => (
-  <IconWithStrokeWidth
-    IconComponent={Icon}
-    {...props}
-    data-testid="trashcan-icon"
-  />
+const TrashcanIconComponent = withSvgIcon()(props => (
+  <IconWithStrokeWidth IconComponent={Icon} {...props} />
 ));
+
+const TrashcanIcon = props => (
+  <TrashcanIconComponent data-testid="trashcan-icon" {...props} />
+);
 
 export default TrashcanIcon;

--- a/src/web/components/icon/TrashIcon.jsx
+++ b/src/web/components/icon/TrashIcon.jsx
@@ -20,7 +20,7 @@ const TrashIcon = ({selectionType, title, ...other}) => {
       title = _('Move all filtered to trashcan');
     }
   }
-  return <TrashcanIcon {...other} data-testid="tash-icon" title={title} />;
+  return <TrashcanIcon data-testid="trash-icon" {...other} title={title} />;
 };
 
 TrashIcon.propTypes = {

--- a/src/web/components/icon/TrendDownIcon.jsx
+++ b/src/web/components/icon/TrendDownIcon.jsx
@@ -9,7 +9,7 @@ import withSvgIcon from 'web/components/icon/withSvgIcon';
 const TrendDownIconComponent = withSvgIcon()(Icon);
 
 const TrendDownIcon = props => (
-  <TrendDownIconComponent {...props} data-testid="trend-down-icon" />
+  <TrendDownIconComponent data-testid="trend-down-icon" {...props} />
 );
 
 export default TrendDownIcon;

--- a/src/web/components/icon/TrendLessIcon.jsx
+++ b/src/web/components/icon/TrendLessIcon.jsx
@@ -9,7 +9,7 @@ import withSvgIcon from 'web/components/icon/withSvgIcon';
 const TrendLessIconComponent = withSvgIcon()(Icon);
 
 const TrendLessIcon = props => (
-  <TrendLessIconComponent {...props} data-testid="trend-less-icon" />
+  <TrendLessIconComponent data-testid="trend-less-icon" {...props} />
 );
 
 export default TrendLessIcon;

--- a/src/web/components/icon/TrendMoreIcon.jsx
+++ b/src/web/components/icon/TrendMoreIcon.jsx
@@ -9,6 +9,6 @@ import withSvgIcon from 'web/components/icon/withSvgIcon';
 const TrendMoreIconComponent = withSvgIcon()(Icon);
 
 const TrendMoreIcon = props => (
-  <TrendMoreIconComponent {...props} data-testid="trend-more-icon" />
+  <TrendMoreIconComponent data-testid="trend-more-icon" {...props} />
 );
 export default TrendMoreIcon;

--- a/src/web/components/icon/TrendNoChangeIcon.jsx
+++ b/src/web/components/icon/TrendNoChangeIcon.jsx
@@ -9,7 +9,7 @@ import withSvgIcon from 'web/components/icon/withSvgIcon';
 const TrendNoChangeIconComponent = withSvgIcon()(Icon);
 
 const TrendNoChangeIcon = props => (
-  <TrendNoChangeIconComponent {...props} data-testid="trend-nochange-icon" />
+  <TrendNoChangeIconComponent data-testid="trend-nochange-icon" {...props} />
 );
 
 export default TrendNoChangeIcon;

--- a/src/web/components/icon/TrendUpIcon.jsx
+++ b/src/web/components/icon/TrendUpIcon.jsx
@@ -9,7 +9,7 @@ import withSvgIcon from 'web/components/icon/withSvgIcon';
 const TrendUpIconComponent = withSvgIcon()(Icon);
 
 const TrendUpIcon = props => (
-  <TrendUpIconComponent {...props} data-testid="trend-up-icon" />
+  <TrendUpIconComponent data-testid="trend-up-icon" {...props} />
 );
 
 export default TrendUpIcon;

--- a/src/web/components/icon/UploadIcon.jsx
+++ b/src/web/components/icon/UploadIcon.jsx
@@ -7,12 +7,12 @@ import {Upload as Icon} from 'lucide-react';
 import IconWithStrokeWidth from 'web/components/icon/IconWithStrokeWidth';
 import withSvgIcon from 'web/components/icon/withSvgIcon';
 
-const UploadIcon = withSvgIcon()(props => (
-  <IconWithStrokeWidth
-    IconComponent={Icon}
-    {...props}
-    data-testid="upload-icon"
-  />
+const UploadIconComponent = withSvgIcon()(props => (
+  <IconWithStrokeWidth IconComponent={Icon} {...props} />
 ));
+
+const UploadIcon = props => (
+  <UploadIconComponent data-testid="upload-icon" {...props} />
+);
 
 export default UploadIcon;

--- a/src/web/components/icon/__tests__/CloneIcon.test.jsx
+++ b/src/web/components/icon/__tests__/CloneIcon.test.jsx
@@ -7,7 +7,9 @@ import {describe} from '@gsa/testing';
 import CloneIcon from 'web/components/icon/CloneIcon';
 import {testIcon} from 'web/components/icon/Testing';
 
-
 describe('CloneIcon component tests', () => {
-  testIcon(CloneIcon);
+  testIcon(CloneIcon, {
+    dataTestId: 'clone-icon',
+    customDataTestId: 'custom-clone-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/DeleteIcon.test.jsx
+++ b/src/web/components/icon/__tests__/DeleteIcon.test.jsx
@@ -7,7 +7,9 @@ import {describe} from '@gsa/testing';
 import DeleteIcon from 'web/components/icon/DeleteIcon';
 import {testIcon} from 'web/components/icon/Testing';
 
-
 describe('DeleteIcon component tests', () => {
-  testIcon(DeleteIcon);
+  testIcon(DeleteIcon, {
+    dataTestId: 'delete-icon',
+    customDataTestId: 'custom-delete-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/EditIcon.test.jsx
+++ b/src/web/components/icon/__tests__/EditIcon.test.jsx
@@ -7,7 +7,9 @@ import {describe} from '@gsa/testing';
 import EditIcon from 'web/components/icon/EditIcon';
 import {testIcon} from 'web/components/icon/Testing';
 
-
 describe('EditIcon component tests', () => {
-  testIcon(EditIcon);
+  testIcon(EditIcon, {
+    dataTestId: 'edit-icon',
+    customDataTestId: 'custom-edit-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/ExportIcon.test.jsx
+++ b/src/web/components/icon/__tests__/ExportIcon.test.jsx
@@ -7,7 +7,9 @@ import {describe} from '@gsa/testing';
 import ExportIcon from 'web/components/icon/ExportIcon';
 import {testIcon} from 'web/components/icon/Testing';
 
-
 describe('ExportIcon component tests', () => {
-  testIcon(ExportIcon);
+  testIcon(ExportIcon, {
+    dataTestId: 'export-icon',
+    customDataTestId: 'custom-export-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/FilterIcon.test.jsx
+++ b/src/web/components/icon/__tests__/FilterIcon.test.jsx
@@ -7,7 +7,9 @@ import {describe} from '@gsa/testing';
 import FilterIcon from 'web/components/icon/FilterIcon';
 import {testIcon} from 'web/components/icon/Testing';
 
-
 describe('FilterIcon component tests', () => {
-  testIcon(FilterIcon);
+  testIcon(FilterIcon, {
+    dataTestId: 'filter-icon',
+    customDataTestId: 'custom-filter-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/HelpIcon.test.jsx
+++ b/src/web/components/icon/__tests__/HelpIcon.test.jsx
@@ -7,7 +7,9 @@ import {describe} from '@gsa/testing';
 import HelpIcon from 'web/components/icon/HelpIcon';
 import {testIcon} from 'web/components/icon/Testing';
 
-
 describe('HelpIcon component tests', () => {
-  testIcon(HelpIcon);
+  testIcon(HelpIcon, {
+    dataTestId: 'help-icon',
+    customDataTestId: 'custom-help-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/NewIcon.test.jsx
+++ b/src/web/components/icon/__tests__/NewIcon.test.jsx
@@ -7,7 +7,9 @@ import {describe} from '@gsa/testing';
 import NewIcon from 'web/components/icon/NewIcon';
 import {testIcon} from 'web/components/icon/Testing';
 
-
 describe('NewIcon component tests', () => {
-  testIcon(NewIcon);
+  testIcon(NewIcon, {
+    dataTestId: 'new-icon',
+    customDataTestId: 'custom-new-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/NewTicketIcon.test.jsx
+++ b/src/web/components/icon/__tests__/NewTicketIcon.test.jsx
@@ -1,0 +1,15 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe} from '@gsa/testing';
+import NewTicketIcon from 'web/components/icon/NewTicketIcon';
+import {testIcon} from 'web/components/icon/Testing';
+
+describe('NewOverrideIcon component tests', () => {
+  testIcon(NewTicketIcon, {
+    dataTestId: 'new-ticket-icon',
+    customDataTestId: 'custom-new-ticket-icon',
+  });
+});

--- a/src/web/components/icon/__tests__/ResetIcon.test.jsx
+++ b/src/web/components/icon/__tests__/ResetIcon.test.jsx
@@ -7,7 +7,9 @@ import {describe} from '@gsa/testing';
 import ResetIcon from 'web/components/icon/ResetIcon';
 import {testIcon} from 'web/components/icon/Testing';
 
-
 describe('ResetIcon component tests', () => {
-  testIcon(ResetIcon);
+  testIcon(ResetIcon, {
+    dataTestId: 'reset-icon',
+    customDataTestId: 'custom-reset-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/ResumeIcon.test.jsx
+++ b/src/web/components/icon/__tests__/ResumeIcon.test.jsx
@@ -7,7 +7,9 @@ import {describe} from '@gsa/testing';
 import ResumeIcon from 'web/components/icon/ResumeIcon';
 import {testIcon} from 'web/components/icon/Testing';
 
-
 describe('ResumeIcon component tests', () => {
-  testIcon(ResumeIcon);
+  testIcon(ResumeIcon, {
+    dataTestId: 'resume-icon',
+    customDataTestId: 'custom-resume-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/Settings2.test.jsx
+++ b/src/web/components/icon/__tests__/Settings2.test.jsx
@@ -7,7 +7,9 @@ import {describe} from '@gsa/testing';
 import Settings2 from 'web/components/icon/Settings2';
 import {testIcon} from 'web/components/icon/Testing';
 
-
 describe('Settings2 component tests', () => {
-  testIcon(Settings2);
+  testIcon(Settings2, {
+    dataTestId: 'settings-2-icon',
+    customDataTestId: 'custom-settings-2-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/StartIcon.test.jsx
+++ b/src/web/components/icon/__tests__/StartIcon.test.jsx
@@ -7,7 +7,9 @@ import {describe} from '@gsa/testing';
 import StartIcon from 'web/components/icon/StartIcon';
 import {testIcon} from 'web/components/icon/Testing';
 
-
 describe('StartIcon component tests', () => {
-  testIcon(StartIcon);
+  testIcon(StartIcon, {
+    dataTestId: 'start-icon',
+    customDataTestId: 'custom-start-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/StopIcon.test.jsx
+++ b/src/web/components/icon/__tests__/StopIcon.test.jsx
@@ -7,7 +7,9 @@ import {describe} from '@gsa/testing';
 import StopIcon from 'web/components/icon/StopIcon';
 import {testIcon} from 'web/components/icon/Testing';
 
-
 describe('StopIcon component tests', () => {
-  testIcon(StopIcon);
+  testIcon(StopIcon, {
+    dataTestId: 'stop-icon',
+    customDataTestId: 'custom-stop-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/SvgIcon.test.jsx
+++ b/src/web/components/icon/__tests__/SvgIcon.test.jsx
@@ -6,7 +6,10 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import React, {useEffect} from 'react';
 import CloneIcon from 'web/components/icon/CloneIcon';
-import {useStateWithMountCheck, useIsMountedRef} from 'web/components/icon/SvgIcon';
+import SvgIcon, {
+  useStateWithMountCheck,
+  useIsMountedRef,
+} from 'web/components/icon/SvgIcon';
 import {render, fireEvent, act} from 'web/utils/Testing';
 
 const entity = {name: 'entity'};
@@ -54,6 +57,22 @@ describe('SVG icon component tests', () => {
 
     expect(element).toHaveAttribute('title', 'Clone Entity');
   });
+
+  test('should render with default data-testid', () => {
+    const {element} = render(<SvgIcon active={true}>{() => null}</SvgIcon>);
+
+    expect(element).toHaveAttribute('data-testid', 'svg-icon');
+  });
+
+  test('should render with custom data-testid', () => {
+    const {element} = render(
+      <SvgIcon active={true} data-testid="foo">
+        {() => null}
+      </SvgIcon>,
+    );
+
+    expect(element).toHaveAttribute('data-testid', 'foo');
+  });
 });
 
 describe('useStateWithMountCheck() hook tests', () => {
@@ -76,6 +95,7 @@ describe('useStateWithMountCheck() hook tests', () => {
     expect(element).toHaveTextContent('false');
   });
 });
+
 describe('useIsMountedRef() hook tests', () => {
   test('should return false after component is unmounted', () => {
     const callback = testing.fn();

--- a/src/web/components/icon/__tests__/TrashCanIcon.test.jsx
+++ b/src/web/components/icon/__tests__/TrashCanIcon.test.jsx
@@ -8,5 +8,8 @@ import {testIcon} from 'web/components/icon/Testing';
 import TrashcanIcon from 'web/components/icon/TrashCanIcon';
 
 describe('TrashcanIcon component tests', () => {
-  testIcon(TrashcanIcon);
+  testIcon(TrashcanIcon, {
+    dataTestId: 'trashcan-icon',
+    customDataTestId: 'custom-trashcan-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/TrendDownIcon.test.jsx
+++ b/src/web/components/icon/__tests__/TrendDownIcon.test.jsx
@@ -8,5 +8,8 @@ import {testIcon} from 'web/components/icon/Testing';
 import TrendDownIcon from 'web/components/icon/TrendDownIcon';
 
 describe('TrendDownIcon component tests', () => {
-  testIcon(TrendDownIcon);
+  testIcon(TrendDownIcon, {
+    dataTestId: 'trend-down-icon',
+    customDataTestId: 'custom-trend-down-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/TrendLessIcon.test.jsx
+++ b/src/web/components/icon/__tests__/TrendLessIcon.test.jsx
@@ -8,5 +8,8 @@ import {testIcon} from 'web/components/icon/Testing';
 import TrendLessIcon from 'web/components/icon/TrendLessIcon';
 
 describe('TrendLessIcon component tests', () => {
-  testIcon(TrendLessIcon);
+  testIcon(TrendLessIcon, {
+    dataTestId: 'trend-less-icon',
+    customDataTestId: 'custom-trend-less-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/TrendMoreIcon.test.jsx
+++ b/src/web/components/icon/__tests__/TrendMoreIcon.test.jsx
@@ -8,5 +8,8 @@ import {testIcon} from 'web/components/icon/Testing';
 import TrendMoreIcon from 'web/components/icon/TrendMoreIcon';
 
 describe('TrendMoreIcon component tests', () => {
-  testIcon(TrendMoreIcon);
+  testIcon(TrendMoreIcon, {
+    dataTestId: 'trend-more-icon',
+    customDataTestId: 'custom-trend-more-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/TrendNoChangeIcon.test.jsx
+++ b/src/web/components/icon/__tests__/TrendNoChangeIcon.test.jsx
@@ -8,5 +8,8 @@ import {testIcon} from 'web/components/icon/Testing';
 import TrendNoChange from 'web/components/icon/TrendNoChangeIcon';
 
 describe('TrendNoChange component tests', () => {
-  testIcon(TrendNoChange);
+  testIcon(TrendNoChange, {
+    defaultTestId: 'trend-nochange-icon',
+    customDataTestId: 'custom-trend-nochange-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/TrendUpIcon.test.jsx
+++ b/src/web/components/icon/__tests__/TrendUpIcon.test.jsx
@@ -8,5 +8,8 @@ import {testIcon} from 'web/components/icon/Testing';
 import TrendUpIcon from 'web/components/icon/TrendUpIcon';
 
 describe('TrendUpIcon component tests', () => {
-  testIcon(TrendUpIcon);
+  testIcon(TrendUpIcon, {
+    dataTestId: 'trend-up-icon',
+    customDataTestId: 'custom-trend-up-icon',
+  });
 });

--- a/src/web/components/icon/__tests__/UploadIcon.test.jsx
+++ b/src/web/components/icon/__tests__/UploadIcon.test.jsx
@@ -8,5 +8,8 @@ import {testIcon} from 'web/components/icon/Testing';
 import UploadIcon from 'web/components/icon/UploadIcon';
 
 describe('UploadIcon component tests', () => {
-  testIcon(UploadIcon);
+  testIcon(UploadIcon, {
+    dataTestId: 'upload-icon',
+    customDataTestId: 'custom-upload-icon',
+  });
 });

--- a/src/web/components/powerfilter/PowerFilter.jsx
+++ b/src/web/components/powerfilter/PowerFilter.jsx
@@ -189,7 +189,7 @@ class PowerFilter extends React.Component {
             </Layout>
             <IconDivider align={['start', 'center']}>
               <RefreshIcon
-                data-testid="powerfiler-refresh"
+                data-testid="powerfilter-refresh"
                 title={_('Update Filter')}
                 onClick={this.handleUpdateFilter}
               />
@@ -197,7 +197,7 @@ class PowerFilter extends React.Component {
               {onRemoveClick && (
                 <DeleteIcon
                   active={isDefined(filter)}
-                  data-testid="powefilter-delete"
+                  data-testid="powerfilter-delete"
                   title={_('Remove Filter')}
                   onClick={
                     isDefined(filter) ? this.handleRemoveClick : undefined

--- a/src/web/components/section/Section.jsx
+++ b/src/web/components/section/Section.jsx
@@ -12,7 +12,6 @@ import Layout from 'web/components/layout/Layout';
 import SectionHeader from 'web/components/section/Header';
 import PropTypes from 'web/utils/PropTypes';
 
-
 const FoldableLayout = withFolding(Layout);
 
 const FoldLayout = styled(Layout)`
@@ -29,6 +28,7 @@ const Section = ({
   header,
   img,
   title,
+  ['data-testid']: dataTestId,
   onFoldToggle,
   onFoldStepEnd,
 }) => {
@@ -51,7 +51,7 @@ const Section = ({
     );
   }
   return (
-    <section className={className}>
+    <section className={className} data-testid={dataTestId}>
       {header}
       {foldable ? (
         <FoldableLayout
@@ -70,6 +70,7 @@ const Section = ({
 
 Section.propTypes = {
   className: PropTypes.string,
+  'data-testid': PropTypes.string,
   extra: PropTypes.element,
   foldState: PropTypes.string,
   foldable: PropTypes.bool,

--- a/src/web/entity/icon/ObserverIcon.jsx
+++ b/src/web/entity/icon/ObserverIcon.jsx
@@ -9,7 +9,12 @@ import React from 'react';
 import ViewOtherIcon from 'web/components/icon/ViewOtherIcon';
 import PropTypes from 'web/utils/PropTypes';
 
-const ObserverIcon = ({entity, userName, displayName = _('Entity')}) => {
+const ObserverIcon = ({
+  entity,
+  userName,
+  displayName = _('Entity'),
+  ['data-testid']: dataTestId = 'observer-icon',
+}) => {
   const owner = isDefined(entity.owner) ? entity.owner.name : undefined;
 
   if (owner === userName) {
@@ -22,13 +27,14 @@ const ObserverIcon = ({entity, userName, displayName = _('Entity')}) => {
   } else {
     title = _('Global {{type}}', {type: displayName});
   }
-  return <ViewOtherIcon alt={title} title={title} />;
+  return <ViewOtherIcon alt={title} data-testid={dataTestId} title={title} />;
 };
 
 ObserverIcon.propTypes = {
   displayName: PropTypes.string,
   entity: PropTypes.model.isRequired,
   userName: PropTypes.string.isRequired,
+  'data-testid': PropTypes.string,
 };
 
 export default ObserverIcon;

--- a/src/web/entity/icon/__tests__/ObserverIcon.test.jsx
+++ b/src/web/entity/icon/__tests__/ObserverIcon.test.jsx
@@ -8,7 +8,6 @@ import Task from 'gmp/models/task';
 import ObserverIcon from 'web/entity/icon/ObserverIcon';
 import {render} from 'web/utils/Testing';
 
-
 describe('Entity ObserverIcon component tests', () => {
   test('should render if the owner is not the current user', () => {
     const entity = Task.fromElement({owner: {name: 'foo'}});
@@ -26,5 +25,27 @@ describe('Entity ObserverIcon component tests', () => {
     );
 
     expect(queryByTestId('observer-icon')).toEqual(null);
+  });
+
+  test('should render with default data-testid', () => {
+    const entity = Task.fromElement({owner: {name: 'foo'}});
+
+    const {element} = render(<ObserverIcon entity={entity} userName={'bar'} />);
+
+    expect(element).toHaveAttribute('data-testid', 'observer-icon');
+  });
+
+  test('should render with custom data-testid', () => {
+    const entity = Task.fromElement({owner: {name: 'foo'}});
+
+    const {element} = render(
+      <ObserverIcon
+        data-testid="custom-observer-icon"
+        entity={entity}
+        userName={'bar'}
+      />,
+    );
+
+    expect(element).toHaveAttribute('data-testid', 'custom-observer-icon');
   });
 });

--- a/src/web/pages/alerts/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/alerts/__tests__/DetailsPage.test.jsx
@@ -9,7 +9,7 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 import Alert from 'gmp/models/alert';
 import Filter from 'gmp/models/filter';
 import {currentSettingsDefaultResponse} from 'web/pages/__mocks__/CurrentSettings';
-import Detailspage, {ToolBarIcons} from 'web/pages/alerts/DetailsPage';
+import DetailsPage, {ToolBarIcons} from 'web/pages/alerts/DetailsPage';
 import {entityLoadingActions} from 'web/store/entities/alerts';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/Testing';
@@ -89,8 +89,8 @@ beforeEach(() => {
   });
 });
 
-describe('Alert Detailspage tests', () => {
-  test('should render full Detailspage', () => {
+describe('Alert DetailsPage tests', () => {
+  test('should render full DetailsPage', () => {
     const gmp = {
       alert: {
         get: getAlert,
@@ -122,20 +122,24 @@ describe('Alert Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', alert));
 
-    const {baseElement} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     expect(baseElement).toHaveTextContent('Alert: foo');
 
     const links = baseElement.querySelectorAll('a');
-    const icons = screen.getAllByTestId('svg-icon');
-
-    expect(icons[0]).toHaveAttribute('title', 'Help: Alerts');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Alerts',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/scanning.html#managing-alerts',
     );
 
-    expect(icons[1]).toHaveAttribute('title', 'Alerts List');
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'Alerts List',
+    );
     expect(links[1]).toHaveAttribute('href', '/alerts');
 
     expect(baseElement).toHaveTextContent('ID:1234');
@@ -194,7 +198,7 @@ describe('Alert Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', alert));
 
-    const {baseElement} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     const spans = baseElement.querySelectorAll('span');
 
@@ -237,7 +241,7 @@ describe('Alert Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', alert));
 
-    const {baseElement} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     const spans = baseElement.querySelectorAll('span');
 
@@ -295,29 +299,24 @@ describe('Alert Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', alert));
 
-    render(<Detailspage id="12345" />);
+    render(<DetailsPage id="12345" />);
 
-    const icons = screen.getAllByTestId('svg-icon');
-
-    expect(icons[3]).toHaveAttribute('title', 'Clone Alert');
-    fireEvent.click(icons[3]);
-
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Alert');
+    fireEvent.click(cloneIcon);
     await wait();
-
     expect(clone).toHaveBeenCalledWith(alert);
 
-    expect(icons[5]).toHaveAttribute('title', 'Move Alert to trashcan');
-    fireEvent.click(icons[5]);
-
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Alert to trashcan');
+    fireEvent.click(deleteIcon);
     await wait();
-
     expect(deleteFunc).toHaveBeenCalledWith({id: alert.id});
 
-    expect(icons[6]).toHaveAttribute('title', 'Export Alert as XML');
-    fireEvent.click(icons[6]);
-
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Alert as XML');
+    fireEvent.click(exportIcon);
     await wait();
-
     expect(exportFunc).toHaveBeenCalledWith(alert);
   });
 });
@@ -349,17 +348,21 @@ describe('Alert ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = screen.getAllByTestId('svg-icon');
     const links = element.querySelectorAll('a');
 
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/scanning.html#managing-alerts',
     );
-    expect(icons[0]).toHaveAttribute('title', 'Help: Alerts');
-
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Alerts',
+    );
     expect(links[1]).toHaveAttribute('href', '/alerts');
-    expect(icons[1]).toHaveAttribute('title', 'Alerts List');
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'Alerts List',
+    );
   });
 
   test('should call click handlers', () => {
@@ -388,23 +391,25 @@ describe('Alert ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = screen.getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[3]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Alert');
+    fireEvent.click(cloneIcon);
     expect(handleAlertCloneClick).toHaveBeenCalledWith(alert);
-    expect(icons[3]).toHaveAttribute('title', 'Clone Alert');
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Alert');
+    fireEvent.click(editIcon);
     expect(handleAlertEditClick).toHaveBeenCalledWith(alert);
-    expect(icons[4]).toHaveAttribute('title', 'Edit Alert');
 
-    fireEvent.click(icons[5]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Alert to trashcan');
+    fireEvent.click(deleteIcon);
     expect(handleAlertDeleteClick).toHaveBeenCalledWith(alert);
-    expect(icons[5]).toHaveAttribute('title', 'Move Alert to trashcan');
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Alert as XML');
+    fireEvent.click(exportIcon);
     expect(handleAlertDownloadClick).toHaveBeenCalledWith(alert);
-    expect(icons[6]).toHaveAttribute('title', 'Export Alert as XML');
   });
 
   test('should not call click handlers without permission', () => {
@@ -433,30 +438,31 @@ describe('Alert ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = screen.getAllByTestId('svg-icon');
-
-    expect(icons[3]).toHaveAttribute('title', 'Clone Alert');
-    fireEvent.click(icons[3]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Alert');
+    fireEvent.click(cloneIcon);
     expect(handleAlertCloneClick).toHaveBeenCalledWith(observedAlert);
-    expect(icons[3]).toHaveAttribute('title', 'Clone Alert');
 
-    expect(icons[4]).toHaveAttribute(
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute(
       'title',
       'Permission to edit Alert denied',
     );
-    fireEvent.click(icons[4]);
+    fireEvent.click(editIcon);
     expect(handleAlertEditClick).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[5]);
-    expect(handleAlertDeleteClick).not.toHaveBeenCalled();
-    expect(icons[5]).toHaveAttribute(
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute(
       'title',
       'Permission to move Alert to trashcan denied',
     );
+    fireEvent.click(deleteIcon);
+    expect(handleAlertDeleteClick).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Alert as XML');
+    fireEvent.click(exportIcon);
     expect(handleAlertDownloadClick).toHaveBeenCalledWith(observedAlert);
-    expect(icons[6]).toHaveAttribute('title', 'Export Alert as XML');
   });
 
   test('should (not) call click handlers for alert in use', () => {
@@ -485,23 +491,24 @@ describe('Alert ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = screen.getAllByTestId('svg-icon');
-
-    expect(icons[3]).toHaveAttribute('title', 'Clone Alert');
-    fireEvent.click(icons[3]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Alert');
+    fireEvent.click(cloneIcon);
     expect(handleAlertCloneClick).toHaveBeenCalledWith(alertInUse);
-    expect(icons[3]).toHaveAttribute('title', 'Clone Alert');
 
-    expect(icons[4]).toHaveAttribute('title', 'Edit Alert');
-    fireEvent.click(icons[4]);
-    expect(handleAlertEditClick).toHaveBeenCalled();
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Alert');
+    fireEvent.click(editIcon);
+    expect(handleAlertEditClick).toHaveBeenCalledWith(alertInUse);
 
-    fireEvent.click(icons[5]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Alert is still in use');
+    fireEvent.click(deleteIcon);
     expect(handleAlertDeleteClick).not.toHaveBeenCalled();
-    expect(icons[5]).toHaveAttribute('title', 'Alert is still in use');
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Alert as XML');
+    fireEvent.click(exportIcon);
     expect(handleAlertDownloadClick).toHaveBeenCalledWith(alertInUse);
-    expect(icons[6]).toHaveAttribute('title', 'Export Alert as XML');
   });
 });

--- a/src/web/pages/alerts/__tests__/ListPage.test.jsx
+++ b/src/web/pages/alerts/__tests__/ListPage.test.jsx
@@ -10,7 +10,6 @@ import Alert from 'gmp/models/alert';
 import Filter from 'gmp/models/filter';
 import {
   clickElement,
-  getBulkActionItems,
   getCheckBoxes,
   getPowerFilter,
   getSelectElement,
@@ -27,7 +26,13 @@ import {entitiesLoadingActions} from 'web/store/entities/alerts';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
 import {loadingActions} from 'web/store/usersettings/defaults/actions';
-import {rendererWith, fireEvent, screen, wait} from 'web/utils/Testing';
+import {
+  rendererWith,
+  fireEvent,
+  screen,
+  wait,
+  getByTestId,
+} from 'web/utils/Testing';
 
 const caps = new Capabilities(['everything']);
 const wrongCaps = new Capabilities(['get_config']);
@@ -97,8 +102,8 @@ beforeEach(() => {
   });
 });
 
-describe('Alert listpage tests', () => {
-  test('should render full alert listpage', async () => {
+describe('Alert ListPage tests', () => {
+  test('should render full alert ListPage', async () => {
     const gmp = {
       alerts: {
         get: getAlerts,
@@ -143,22 +148,18 @@ describe('Alert listpage tests', () => {
 
     await wait();
 
-    const icons = screen.getAllByTestId('svg-icon');
     const powerFilter = getPowerFilter();
     const selects = queryAllSelectElements(powerFilter);
     const inputs = getTextInputs(powerFilter);
 
     // Toolbar Icons
-    expect(icons[0]).toHaveAttribute('title', 'Help: Alerts');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Alerts',
+    );
 
     // Powerfilter
     expect(inputs[0]).toHaveAttribute('name', 'userFilterString');
-    expect(icons[2]).toHaveAttribute('title', 'Update Filter');
-    expect(icons[3]).toHaveAttribute('title', 'Remove Filter');
-    expect(icons[4]).toHaveAttribute('title', 'Reset to Default Filter');
-    expect(icons[5]).toHaveAttribute('title', 'Help: Powerfilter');
-    expect(icons[6]).toHaveAttribute('title', 'Edit Filter');
-
     expect(selects[0]).toHaveAttribute('title', 'Loaded filter');
     expect(selects[0]).toHaveValue('--');
 
@@ -182,12 +183,6 @@ describe('Alert listpage tests', () => {
     expect(row[1]).toHaveTextContent('SMB');
     expect(row[1]).toHaveTextContent('report results filter');
     expect(row[1]).toHaveTextContent('Yes');
-
-    expect(icons[19]).toHaveAttribute('title', 'Move Alert to trashcan');
-    expect(icons[20]).toHaveAttribute('title', 'Edit Alert');
-    expect(icons[21]).toHaveAttribute('title', 'Clone Alert');
-    expect(icons[22]).toHaveAttribute('title', 'Export Alert');
-    expect(icons[23]).toHaveAttribute('title', 'Test Alert');
   });
 
   test('should allow to bulk action on page contents', async () => {
@@ -245,18 +240,22 @@ describe('Alert listpage tests', () => {
 
     await wait();
 
-    const icons = getBulkActionItems();
-
     // export page contents
+    const tableFooter = getTableFooter();
+    const exportIcon = getByTestId(tableFooter, 'export-icon');
     expect(exportByFilter).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute('title', 'Export page contents');
-    await clickElement(icons[2]);
+    expect(exportIcon).toHaveAttribute('title', 'Export page contents');
+    fireEvent.click(exportIcon);
     expect(exportByFilter).toHaveBeenCalled();
 
     // move page contents to trashcan
+    const deleteIcon = getByTestId(tableFooter, 'trash-icon');
     expect(deleteByFilter).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Move page contents to trashcan');
-    await clickElement(icons[1]);
+    expect(deleteIcon).toHaveAttribute(
+      'title',
+      'Move page contents to trashcan',
+    );
+    fireEvent.click(deleteIcon);
     testBulkTrashcanDialog(screen, deleteByFilter);
   });
 
@@ -329,15 +328,16 @@ describe('Alert listpage tests', () => {
 
     // export selected alert
     expect(exportByIds).not.toHaveBeenCalled();
-    const icons = getBulkActionItems();
-    expect(icons[2]).toHaveAttribute('title', 'Export selection');
-    await clickElement(icons[2]);
+    const exportIcon = getByTestId(tableFooter, 'export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export selection');
+    fireEvent.click(exportIcon);
     expect(exportByIds).toHaveBeenCalled();
 
     // move selected alert to trashcan
     expect(deleteByIds).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Move selection to trashcan');
-    await clickElement(icons[1]);
+    const deleteIcon = getByTestId(tableFooter, 'trash-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move selection to trashcan');
+    fireEvent.click(deleteIcon);
     testBulkTrashcanDialog(screen, deleteByIds);
   });
 
@@ -405,20 +405,24 @@ describe('Alert listpage tests', () => {
 
     // export all filtered alerts
     expect(exportByFilter).not.toHaveBeenCalled();
-    const icons = getBulkActionItems();
-    expect(icons[2]).toHaveAttribute('title', 'Export all filtered');
-    await clickElement(icons[2]);
+    const exportIcon = getByTestId(tableFooter, 'export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export all filtered');
+    fireEvent.click(exportIcon);
     expect(exportByFilter).toHaveBeenCalled();
 
     // move all filtered alerts to trashcan
+    const deleteIcon = getByTestId(tableFooter, 'trash-icon');
     expect(deleteByFilter).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Move all filtered to trashcan');
-    await clickElement(icons[1]);
+    expect(deleteIcon).toHaveAttribute(
+      'title',
+      'Move all filtered to trashcan',
+    );
+    fireEvent.click(deleteIcon);
     testBulkTrashcanDialog(screen, deleteByFilter);
   });
 });
 
-describe('Alert listpage ToolBarIcons test', () => {
+describe('Alert ListPage ToolBarIcons test', () => {
   test('should render', () => {
     const handleAlertCreateClick = testing.fn();
 
@@ -436,18 +440,20 @@ describe('Alert listpage ToolBarIcons test', () => {
       <ToolBarIcons onAlertCreateClick={handleAlertCreateClick} />,
     );
 
-    const icons = screen.getAllByTestId('svg-icon');
     const links = element.querySelectorAll('a');
 
-    expect(icons.length).toBe(2);
-
-    expect(icons[0]).toHaveAttribute('title', 'Help: Alerts');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Alerts',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/scanning.html#managing-alerts',
     );
-
-    expect(icons[1]).toHaveAttribute('title', 'New Alert');
+    expect(screen.getByTestId('new-icon')).toHaveAttribute(
+      'title',
+      'New Alert',
+    );
   });
 
   test('should call click handlers', () => {
@@ -465,11 +471,10 @@ describe('Alert listpage ToolBarIcons test', () => {
 
     render(<ToolBarIcons onAlertCreateClick={handleAlertCreateClick} />);
 
-    const icons = screen.getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[1]);
+    const newIcon = screen.getByTestId('new-icon');
+    fireEvent.click(newIcon);
     expect(handleAlertCreateClick).toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'New Alert');
+    expect(newIcon).toHaveAttribute('title', 'New Alert');
   });
 
   test('should not show icons if user does not have the right permissions', () => {
@@ -487,8 +492,6 @@ describe('Alert listpage ToolBarIcons test', () => {
 
     render(<ToolBarIcons onAlertCreateClick={handleAlertCreateClick} />);
 
-    const icons = screen.getAllByTestId('svg-icon');
-    expect(icons.length).toBe(1);
-    expect(icons[0]).toHaveAttribute('title', 'Help: Alerts');
+    expect(screen.queryByTestId('new-icon')).toBeNull();
   });
 });

--- a/src/web/pages/audits/__tests__/Actions.test.jsx
+++ b/src/web/pages/audits/__tests__/Actions.test.jsx
@@ -7,9 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
 import Actions from 'web/pages/audits/Actions';
-import {rendererWith, fireEvent} from 'web/utils/Testing';
-import Theme from 'web/utils/Theme';
-
+import {rendererWith, fireEvent, screen} from 'web/utils/Testing';
 
 const caps = new Capabilities(['everything']);
 const wrongCaps = new Capabilities(['get_task']);
@@ -79,7 +77,7 @@ describe('Audit Actions tests', () => {
     const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
-    const {getAllByTestId} = render(
+    render(
       <Actions
         entity={audit}
         gcrFormatDefined={true}
@@ -95,35 +93,40 @@ describe('Audit Actions tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
+    const startIcon = screen.getByTestId('start-icon');
+    fireEvent.click(startIcon);
     expect(handleAuditStart).toHaveBeenCalledWith(audit);
-    expect(icons[0]).toHaveAttribute('title', 'Start');
+    expect(startIcon).toHaveAttribute('title', 'Start');
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Audit is not stopped');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is not stopped');
 
-    fireEvent.click(icons[2]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleAuditDelete).toHaveBeenCalledWith(audit);
-    expect(icons[2]).toHaveAttribute('title', 'Move Audit to trashcan');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Audit to trashcan');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleAuditEdit).toHaveBeenCalledWith(audit);
-    expect(icons[3]).toHaveAttribute('title', 'Edit Audit');
+    expect(editIcon).toHaveAttribute('title', 'Edit Audit');
 
-    fireEvent.click(icons[4]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleAuditClone).toHaveBeenCalledWith(audit);
-    expect(icons[4]).toHaveAttribute('title', 'Clone Audit');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleAuditDownload).toHaveBeenCalledWith(audit);
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit');
 
-    fireEvent.click(icons[6]);
+    const downloadIcon = screen.getByTestId('download-icon');
+    fireEvent.click(downloadIcon);
     expect(handleReportDownload).toHaveBeenCalledWith(audit);
-    expect(icons[6]).toHaveAttribute(
+    expect(downloadIcon).toHaveAttribute(
       'title',
       'Download Greenbone Compliance Report',
     );
@@ -149,7 +152,7 @@ describe('Audit Actions tests', () => {
     const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: wrongCaps});
-    const {getAllByTestId} = render(
+    render(
       <Actions
         entity={audit}
         gcrFormatDefined={true}
@@ -165,47 +168,52 @@ describe('Audit Actions tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
+    const startIcon = screen.getByTestId('start-icon');
+    fireEvent.click(startIcon);
     expect(handleAuditStart).not.toHaveBeenCalled();
-    expect(icons[0]).toHaveAttribute(
+    expect(startIcon).toHaveAttribute(
       'title',
       'Permission to start audit denied',
     );
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Audit is not stopped');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is not stopped');
 
-    fireEvent.click(icons[2]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleAuditDelete).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute(
+    expect(deleteIcon).toHaveAttribute(
       'title',
       'Permission to move Audit to trashcan denied',
     );
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleAuditEdit).not.toHaveBeenCalled();
-    expect(icons[3]).toHaveAttribute(
+    expect(editIcon).toHaveAttribute(
       'title',
       'Permission to edit Audit denied',
     );
 
-    fireEvent.click(icons[4]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleAuditClone).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute(
+    expect(cloneIcon).toHaveAttribute(
       'title',
       'Permission to clone Audit denied',
     );
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleAuditDownload).toHaveBeenCalledWith(audit);
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit');
 
-    fireEvent.click(icons[6]);
+    const downloadIcon = screen.getByTestId('download-icon');
+    fireEvent.click(downloadIcon);
     expect(handleReportDownload).toHaveBeenCalledWith(audit);
-    expect(icons[6]).toHaveAttribute(
+    expect(downloadIcon).toHaveAttribute(
       'title',
       'Download Greenbone Compliance Report',
     );
@@ -231,7 +239,7 @@ describe('Audit Actions tests', () => {
     const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: wrongCaps});
-    const {getAllByTestId} = render(
+    render(
       <Actions
         entity={audit}
         gcrFormatDefined={true}
@@ -247,50 +255,55 @@ describe('Audit Actions tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
+    const startIcon = screen.getByTestId('start-icon');
+    fireEvent.click(startIcon);
     expect(handleAuditStart).not.toHaveBeenCalled();
-    expect(icons[0]).toHaveAttribute(
+    expect(startIcon).toHaveAttribute(
       'title',
       'Permission to start audit denied',
     );
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute(
+    expect(resumeIcon).toHaveAttribute(
       'title',
       'Permission to resume audit denied',
     );
 
-    fireEvent.click(icons[2]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleAuditDelete).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute(
+    expect(deleteIcon).toHaveAttribute(
       'title',
       'Permission to move Audit to trashcan denied',
     );
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleAuditEdit).not.toHaveBeenCalled();
-    expect(icons[3]).toHaveAttribute(
+    expect(editIcon).toHaveAttribute(
       'title',
       'Permission to edit Audit denied',
     );
 
-    fireEvent.click(icons[4]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleAuditClone).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute(
+    expect(cloneIcon).toHaveAttribute(
       'title',
       'Permission to clone Audit denied',
     );
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleAuditDownload).toHaveBeenCalledWith(audit);
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit');
 
-    fireEvent.click(icons[6]);
+    const downloadIcon = screen.getByTestId('download-icon');
+    fireEvent.click(downloadIcon);
     expect(handleReportDownload).toHaveBeenCalledWith(audit);
-    expect(icons[6]).toHaveAttribute(
+    expect(downloadIcon).toHaveAttribute(
       'title',
       'Download Greenbone Compliance Report',
     );
@@ -316,7 +329,7 @@ describe('Audit Actions tests', () => {
     const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: wrongCaps});
-    const {getAllByTestId} = render(
+    render(
       <Actions
         entity={audit}
         gcrFormatDefined={true}
@@ -332,47 +345,52 @@ describe('Audit Actions tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
+    const stopIcon = screen.getByTestId('stop-icon');
+    fireEvent.click(stopIcon);
     expect(handleAuditStop).not.toHaveBeenCalled();
-    expect(icons[0]).toHaveAttribute(
+    expect(stopIcon).toHaveAttribute(
       'title',
       'Permission to stop audit denied',
     );
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Audit is not stopped');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is not stopped');
 
-    fireEvent.click(icons[2]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleAuditDelete).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute(
+    expect(deleteIcon).toHaveAttribute(
       'title',
       'Permission to move Audit to trashcan denied',
     );
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleAuditEdit).not.toHaveBeenCalled();
-    expect(icons[3]).toHaveAttribute(
+    expect(editIcon).toHaveAttribute(
       'title',
       'Permission to edit Audit denied',
     );
 
-    fireEvent.click(icons[4]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleAuditClone).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute(
+    expect(cloneIcon).toHaveAttribute(
       'title',
       'Permission to clone Audit denied',
     );
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleAuditDownload).toHaveBeenCalledWith(audit);
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit');
 
-    fireEvent.click(icons[6]);
+    const downloadIcon = screen.getByTestId('download-icon');
+    fireEvent.click(downloadIcon);
     expect(handleReportDownload).toHaveBeenCalledWith(audit);
-    expect(icons[6]).toHaveAttribute(
+    expect(downloadIcon).toHaveAttribute(
       'title',
       'Download Greenbone Compliance Report',
     );
@@ -398,7 +416,7 @@ describe('Audit Actions tests', () => {
     const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
-    const {getAllByTestId} = render(
+    render(
       <Actions
         entity={audit}
         gcrFormatDefined={true}
@@ -414,36 +432,44 @@ describe('Audit Actions tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
+    const stopIcon = screen.getByTestId('stop-icon');
+    fireEvent.click(stopIcon);
     expect(handleAuditStop).toHaveBeenCalledWith(audit);
-    expect(icons[0]).toHaveAttribute('title', 'Stop');
+    expect(stopIcon).toHaveAttribute('title', 'Stop');
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Audit is not stopped');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is not stopped');
 
-    fireEvent.click(icons[2]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleAuditDelete).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute('title', 'Audit is still in use');
+    expect(deleteIcon).toHaveAttribute('title', 'Audit is still in use');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleAuditEdit).toHaveBeenCalledWith(audit);
-    expect(icons[3]).toHaveAttribute('title', 'Edit Audit');
+    expect(editIcon).toHaveAttribute('title', 'Edit Audit');
 
-    fireEvent.click(icons[4]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleAuditClone).toHaveBeenCalledWith(audit);
-    expect(icons[4]).toHaveAttribute('title', 'Clone Audit');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleAuditDownload).toHaveBeenCalledWith(audit);
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit');
 
     // should not be called because the audit does not have a report yet
-    fireEvent.click(icons[6]);
+    const downloadIcon = screen.getByTestId('download-icon');
+    fireEvent.click(downloadIcon);
     expect(handleReportDownload).not.toHaveBeenCalled();
-    expect(icons[6]).toHaveAttribute('title', 'Report download not available');
+    expect(downloadIcon).toHaveAttribute(
+      'title',
+      'Report download not available',
+    );
   });
 
   test('should call click handlers for stopped audit', () => {
@@ -466,7 +492,7 @@ describe('Audit Actions tests', () => {
     const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
-    const {getAllByTestId} = render(
+    render(
       <Actions
         entity={audit}
         gcrFormatDefined={true}
@@ -482,35 +508,40 @@ describe('Audit Actions tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
+    const startIcon = screen.getByTestId('start-icon');
+    fireEvent.click(startIcon);
     expect(handleAuditStart).toHaveBeenCalledWith(audit);
-    expect(icons[0]).toHaveAttribute('title', 'Start');
+    expect(startIcon).toHaveAttribute('title', 'Start');
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResume).toHaveBeenCalledWith(audit);
-    expect(icons[1]).toHaveAttribute('title', 'Resume');
+    expect(resumeIcon).toHaveAttribute('title', 'Resume');
 
-    fireEvent.click(icons[2]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleAuditDelete).toHaveBeenCalledWith(audit);
-    expect(icons[2]).toHaveAttribute('title', 'Move Audit to trashcan');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Audit to trashcan');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleAuditEdit).toHaveBeenCalledWith(audit);
-    expect(icons[3]).toHaveAttribute('title', 'Edit Audit');
+    expect(editIcon).toHaveAttribute('title', 'Edit Audit');
 
-    fireEvent.click(icons[4]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleAuditClone).toHaveBeenCalledWith(audit);
-    expect(icons[4]).toHaveAttribute('title', 'Clone Audit');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleAuditDownload).toHaveBeenCalledWith(audit);
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit');
 
-    fireEvent.click(icons[6]);
+    const downloadIcon = screen.getByTestId('download-icon');
+    fireEvent.click(downloadIcon);
     expect(handleReportDownload).toHaveBeenCalledWith(audit);
-    expect(icons[6]).toHaveAttribute(
+    expect(downloadIcon).toHaveAttribute(
       'title',
       'Download Greenbone Compliance Report',
     );
@@ -536,7 +567,7 @@ describe('Audit Actions tests', () => {
     const handleReportDownload = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
-    const {getAllByTestId} = render(
+    render(
       <Actions
         entity={audit}
         gcrFormatDefined={false}
@@ -552,14 +583,13 @@ describe('Audit Actions tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[6]);
+    const downloadIcon = screen.getByTestId('download-icon');
+    fireEvent.click(downloadIcon);
     expect(handleReportDownload).not.toHaveBeenCalled();
-    expect(icons[6]).toHaveAttribute('title', 'Report download not available');
-    expect(icons[6]).toHaveStyleRule('fill', Theme.inputBorderGray, {
-      modifier: 'svg path.gui_icon_class',
-    });
+    expect(downloadIcon).toHaveAttribute(
+      'title',
+      'Report download not available',
+    );
   });
 
   test('should render schedule icon if task is scheduled', () => {
@@ -591,7 +621,7 @@ describe('Audit Actions tests', () => {
       store: true,
       router: true,
     });
-    const {getAllByTestId} = render(
+    render(
       <Actions
         entity={audit}
         gcrFormatDefined={false}
@@ -607,8 +637,7 @@ describe('Audit Actions tests', () => {
       />,
     );
 
-    const detailsLinks = getAllByTestId('details-link');
-    const icons = getAllByTestId('svg-icon');
+    const detailsLinks = screen.getAllByTestId('details-link');
 
     fireEvent.click(detailsLinks[0]);
     expect(detailsLinks[0]).toHaveAttribute(
@@ -616,9 +645,10 @@ describe('Audit Actions tests', () => {
       'View Details of Schedule schedule1 (Next due: over)',
     );
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Audit is scheduled');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is scheduled');
   });
 
   console.warn = consoleError;

--- a/src/web/pages/audits/__tests__/Details.test.jsx
+++ b/src/web/pages/audits/__tests__/Details.test.jsx
@@ -11,8 +11,7 @@ import Schedule from 'gmp/models/schedule';
 import Details from 'web/pages/audits/Details';
 import {entityLoadingActions as policyActions} from 'web/store/entities/policies';
 import {entityLoadingActions as scheduleActions} from 'web/store/entities/schedules';
-import {rendererWith} from 'web/utils/Testing';
-
+import {rendererWith, screen} from 'web/utils/Testing';
 
 const policy = Policy.fromElement({
   _id: '314',
@@ -105,10 +104,10 @@ describe('Audit Details tests', () => {
     store.dispatch(policyActions.success('314', policy));
     store.dispatch(scheduleActions.success('121314', schedule));
 
-    const {element, getAllByTestId} = render(<Details entity={audit} />);
+    const {element} = render(<Details entity={audit} />);
 
     const headings = element.querySelectorAll('h2');
-    const detailsLinks = getAllByTestId('details-link');
+    const detailsLinks = screen.getAllByTestId('details-link');
 
     expect(headings[0]).toHaveTextContent('Target');
     expect(detailsLinks[0]).toHaveAttribute('href', '/target/5678');

--- a/src/web/pages/audits/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/audits/__tests__/DetailsPage.test.jsx
@@ -10,12 +10,11 @@ import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
 import Filter from 'gmp/models/filter';
 import Policy from 'gmp/models/policy';
 import Schedule from 'gmp/models/schedule';
-import {clickElement, getActionItems} from 'web/components/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__mocks__/CurrentSettings';
-import Detailspage, {ToolBarIcons} from 'web/pages/audits/DetailsPage';
+import DetailsPage, {ToolBarIcons} from 'web/pages/audits/DetailsPage';
 import {entityLoadingActions} from 'web/store/entities/audits';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent} from 'web/utils/Testing';
+import {rendererWith, fireEvent, screen} from 'web/utils/Testing';
 
 const policy = Policy.fromElement({
   _id: '314',
@@ -256,8 +255,8 @@ const getEntities = testing.fn().mockResolvedValue({
   },
 });
 
-describe('Audit Detailspage tests', () => {
-  test('should render full Detailspage', () => {
+describe('Audit DetailsPage tests', () => {
+  test('should render full DetailsPage', () => {
     const getAudit = testing.fn().mockResolvedValue({
       data: audit,
     });
@@ -297,22 +296,26 @@ describe('Audit Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', audit));
 
-    const {baseElement, getAllByTestId} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     expect(baseElement).toBeVisible();
-
     expect(baseElement).toHaveTextContent('Audit: foo');
 
     const links = baseElement.querySelectorAll('a');
-    const icons = getActionItems();
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: Audits');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Audits',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/compliance-and-special-scans.html#configuring-and-managing-audits',
     );
 
-    expect(icons[1]).toHaveAttribute('title', 'Audit List');
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'Audit List',
+    );
     expect(links[1]).toHaveAttribute('href', '/audits');
 
     expect(baseElement).toHaveTextContent('12345');
@@ -323,12 +326,12 @@ describe('Audit Detailspage tests', () => {
     expect(baseElement).toHaveTextContent('foo');
     expect(baseElement).toHaveTextContent('bar');
 
-    const progressBars = getAllByTestId('progressbar-box');
+    const progressBars = screen.getAllByTestId('progressbar-box');
     expect(progressBars[0]).toHaveAttribute('title', 'Done');
     expect(progressBars[0]).toHaveTextContent('Done');
 
     const headings = baseElement.querySelectorAll('h2');
-    const detailsLinks = getAllByTestId('details-link');
+    const detailsLinks = screen.getAllByTestId('details-link');
 
     expect(headings[1]).toHaveTextContent('Target');
     expect(detailsLinks[2]).toHaveAttribute('href', '/target/5678');
@@ -393,7 +396,7 @@ describe('Audit Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', audit2));
 
-    const {baseElement} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
     const spans = baseElement.querySelectorAll('span');
     fireEvent.click(spans[16]);
 
@@ -466,34 +469,37 @@ describe('Audit Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', audit5));
 
-    render(<Detailspage id="12345" />);
+    render(<DetailsPage id="12345" />);
 
-    const icons = getActionItems();
-
+    const cloneIcon = screen.getByTestId('clone-icon');
     expect(clone).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute('title', 'Clone Audit');
-    await clickElement(icons[2]);
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
+    fireEvent.click(cloneIcon);
     expect(clone).toHaveBeenCalledWith(audit5);
 
-    expect(deleteFunc).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute('title', 'Move Audit to trashcan');
-    await clickElement(icons[4]);
-    expect(deleteFunc).toHaveBeenCalledWith(audit5Id);
-
+    const exportIcon = screen.getByTestId('export-icon');
     expect(exportFunc).not.toHaveBeenCalled();
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit as XML');
-    await clickElement(icons[5]);
-    // expect(exportFunc).toHaveBeenCalled(audit5);
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit as XML');
+    fireEvent.click(exportIcon);
+    expect(exportFunc).toHaveBeenCalled(audit5);
 
+    const startIcon = screen.getByTestId('start-icon');
     expect(start).not.toHaveBeenCalled();
-    expect(icons[6]).toHaveAttribute('title', 'Start');
-    await clickElement(icons[6]);
-    // expect(start).toHaveBeenCalledWith(audit5);
+    expect(startIcon).toHaveAttribute('title', 'Start');
+    fireEvent.click(startIcon);
+    expect(start).toHaveBeenCalledWith(audit5);
 
+    const resumeIcon = screen.getByTestId('resume-icon');
     expect(resume).not.toHaveBeenCalledWith(audit5);
-    expect(icons[7]).toHaveAttribute('title', 'Resume');
-    await clickElement(icons[7]);
-    // expect(resume).toHaveBeenCalledWith(audit5);
+    expect(resumeIcon).toHaveAttribute('title', 'Resume');
+    fireEvent.click(resumeIcon);
+    expect(resume).toHaveBeenCalledWith(audit5);
+
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteFunc).not.toHaveBeenCalled();
+    expect(deleteIcon).toHaveAttribute('title', 'Move Audit to trashcan');
+    fireEvent.click(deleteIcon);
+    expect(deleteFunc).toHaveBeenCalledWith(audit5Id);
   });
 });
 
@@ -530,17 +536,21 @@ describe('Audit ToolBarIcons tests', () => {
 
     expect(element).toBeVisible();
 
-    const icons = getActionItems();
     const links = element.querySelectorAll('a');
 
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/compliance-and-special-scans.html#configuring-and-managing-audits',
     );
-    expect(icons[0]).toHaveAttribute('title', 'Help: Audits');
-
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Audits',
+    );
     expect(links[1]).toHaveAttribute('href', '/audits');
-    expect(icons[1]).toHaveAttribute('title', 'Audit List');
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'Audit List',
+    );
   });
 
   test('should call click handlers for new audit', () => {
@@ -560,7 +570,7 @@ describe('Audit ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <ToolBarIcons
         entity={audit3}
         onAuditCloneClick={handleAuditCloneClick}
@@ -573,33 +583,38 @@ describe('Audit ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getActionItems();
-    const badgeIcons = getAllByTestId('badge-icon');
+    const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
 
-    fireEvent.click(icons[2]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleAuditCloneClick).toHaveBeenCalledWith(audit3);
-    expect(icons[2]).toHaveAttribute('title', 'Clone Audit');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleAuditEditClick).toHaveBeenCalledWith(audit3);
-    expect(icons[3]).toHaveAttribute('title', 'Edit Audit');
+    expect(editIcon).toHaveAttribute('title', 'Edit Audit');
 
-    fireEvent.click(icons[4]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleAuditDeleteClick).toHaveBeenCalledWith(audit3);
-    expect(icons[4]).toHaveAttribute('title', 'Move Audit to trashcan');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Audit to trashcan');
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleAuditDownloadClick).toHaveBeenCalledWith(audit3);
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit as XML');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit as XML');
 
-    fireEvent.click(icons[6]);
+    const startIcon = screen.getByTestId('start-icon');
+    fireEvent.click(startIcon);
     expect(handleAuditStartClick).toHaveBeenCalledWith(audit3);
-    expect(icons[6]).toHaveAttribute('title', 'Start');
+    expect(startIcon).toHaveAttribute('title', 'Start');
 
-    fireEvent.click(icons[7]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResumeClick).not.toHaveBeenCalled();
-    expect(icons[7]).toHaveAttribute('title', 'Audit is not stopped');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is not stopped');
 
     expect(links[2]).toHaveAttribute(
       'href',
@@ -630,7 +645,7 @@ describe('Audit ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <ToolBarIcons
         entity={audit4}
         onAuditCloneClick={handleAuditCloneClick}
@@ -643,37 +658,42 @@ describe('Audit ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getActionItems();
-    const badgeIcons = getAllByTestId('badge-icon');
+    const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
 
+    const cloneIcon = screen.getByTestId('clone-icon');
     expect(handleAuditCloneClick).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute('title', 'Clone Audit');
-    fireEvent.click(icons[2]);
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
+    fireEvent.click(cloneIcon);
     expect(handleAuditCloneClick).toHaveBeenCalledWith(audit4);
 
+    const editIcon = screen.getByTestId('edit-icon');
     expect(handleAuditEditClick).not.toHaveBeenCalled();
-    expect(icons[3]).toHaveAttribute('title', 'Edit Audit');
-    fireEvent.click(icons[3]);
+    expect(editIcon).toHaveAttribute('title', 'Edit Audit');
+    fireEvent.click(editIcon);
     expect(handleAuditEditClick).toHaveBeenCalledWith(audit4);
 
-    expect(icons[4]).toHaveAttribute('title', 'Audit is still in use');
-    fireEvent.click(icons[4]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Audit is still in use');
+    fireEvent.click(deleteIcon);
     expect(handleAuditDeleteClick).not.toHaveBeenCalled();
 
+    const exportIcon = screen.getByTestId('export-icon');
     expect(handleAuditDownloadClick).not.toHaveBeenCalled();
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit as XML');
-    fireEvent.click(icons[5]);
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit as XML');
+    fireEvent.click(exportIcon);
     expect(handleAuditDownloadClick).toHaveBeenCalledWith(audit4);
 
-    expect(icons[6]).toHaveAttribute('title', 'Stop');
+    const stopIcon = screen.getByTestId('stop-icon');
+    expect(stopIcon).toHaveAttribute('title', 'Stop');
     expect(handleAuditStopClick).not.toHaveBeenCalled();
-    fireEvent.click(icons[6]);
+    fireEvent.click(stopIcon);
     expect(handleAuditStartClick).not.toHaveBeenCalled();
     expect(handleAuditStopClick).toHaveBeenCalledWith(audit4);
 
-    expect(icons[7]).toHaveAttribute('title', 'Audit is not stopped');
-    fireEvent.click(icons[7]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is not stopped');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResumeClick).not.toHaveBeenCalled();
 
     expect(links[2]).toHaveAttribute('href', '/report/12342');
@@ -711,7 +731,7 @@ describe('Audit ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <ToolBarIcons
         entity={audit5}
         onAuditCloneClick={handleAuditCloneClick}
@@ -724,38 +744,43 @@ describe('Audit ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getActionItems();
-    const badgeIcons = getAllByTestId('badge-icon');
+    const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
 
-    expect(icons[2]).toHaveAttribute('title', 'Clone Audit');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
     expect(handleAuditCloneClick).not.toHaveBeenCalled();
-    fireEvent.click(icons[2]);
+    fireEvent.click(cloneIcon);
     expect(handleAuditCloneClick).toHaveBeenCalledWith(audit5);
 
-    expect(icons[3]).toHaveAttribute('title', 'Edit Audit');
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Audit');
     expect(handleAuditEditClick).not.toHaveBeenCalled();
-    fireEvent.click(icons[3]);
+    fireEvent.click(editIcon);
     expect(handleAuditEditClick).toHaveBeenCalledWith(audit5);
 
-    expect(icons[4]).toHaveAttribute('title', 'Move Audit to trashcan');
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Audit to trashcan');
     expect(handleAuditDeleteClick).not.toHaveBeenCalled();
-    fireEvent.click(icons[4]);
+    fireEvent.click(deleteIcon);
     expect(handleAuditDeleteClick).toHaveBeenCalledWith(audit5);
 
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit as XML');
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit as XML');
     expect(handleAuditDownloadClick).not.toHaveBeenCalled();
-    fireEvent.click(icons[5]);
+    fireEvent.click(exportIcon);
     expect(handleAuditDownloadClick).toHaveBeenCalledWith(audit5);
 
-    expect(icons[6]).toHaveAttribute('title', 'Start');
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute('title', 'Start');
     expect(handleAuditStartClick).not.toHaveBeenCalled();
-    fireEvent.click(icons[6]);
+    fireEvent.click(startIcon);
     expect(handleAuditStartClick).toHaveBeenCalledWith(audit5);
 
-    expect(icons[7]).toHaveAttribute('title', 'Resume');
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Resume');
     expect(handleAuditResumeClick).not.toHaveBeenCalled();
-    fireEvent.click(icons[7]);
+    fireEvent.click(resumeIcon);
     expect(handleAuditResumeClick).toHaveBeenCalledWith(audit5);
 
     expect(links[2]).toHaveAttribute('href', '/report/12342');
@@ -793,7 +818,7 @@ describe('Audit ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <ToolBarIcons
         entity={audit2}
         onAuditCloneClick={handleAuditCloneClick}
@@ -806,36 +831,41 @@ describe('Audit ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getActionItems();
-    const badgeIcons = getAllByTestId('badge-icon');
+    const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
 
-    expect(icons[2]).toHaveAttribute('title', 'Clone Audit');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
     expect(handleAuditCloneClick).not.toHaveBeenCalled();
-    fireEvent.click(icons[2]);
+    fireEvent.click(cloneIcon);
     expect(handleAuditCloneClick).toHaveBeenCalledWith(audit2);
 
-    expect(icons[3]).toHaveAttribute('title', 'Edit Audit');
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Audit');
     expect(handleAuditEditClick).not.toHaveBeenCalled();
-    fireEvent.click(icons[3]);
+    fireEvent.click(editIcon);
     expect(handleAuditEditClick).toHaveBeenCalledWith(audit2);
 
-    expect(icons[4]).toHaveAttribute('title', 'Move Audit to trashcan');
-    fireEvent.click(icons[4]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Audit to trashcan');
+    fireEvent.click(deleteIcon);
     expect(handleAuditDeleteClick).toHaveBeenCalled();
 
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit as XML');
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit as XML');
     expect(handleAuditDownloadClick).not.toHaveBeenCalled();
-    fireEvent.click(icons[5]);
+    fireEvent.click(exportIcon);
     expect(handleAuditDownloadClick).toHaveBeenCalledWith(audit2);
 
-    expect(icons[6]).toHaveAttribute('title', 'Start');
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute('title', 'Start');
     expect(handleAuditStartClick).not.toHaveBeenCalled();
-    fireEvent.click(icons[6]);
+    fireEvent.click(startIcon);
     expect(handleAuditStartClick).toHaveBeenCalledWith(audit2);
 
-    expect(icons[7]).toHaveAttribute('title', 'Audit is not stopped');
-    fireEvent.click(icons[7]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is not stopped');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResumeClick).not.toHaveBeenCalled();
 
     expect(links[2]).toHaveAttribute('href', '/auditreport/1234');
@@ -873,7 +903,7 @@ describe('Audit ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <ToolBarIcons
         entity={audit6}
         onAuditCloneClick={handleAuditCloneClick}
@@ -886,43 +916,48 @@ describe('Audit ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getActionItems();
-    const badgeIcons = getAllByTestId('badge-icon');
+    const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
 
-    expect(icons[2]).toHaveAttribute('title', 'Clone Audit');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
     expect(handleAuditCloneClick).not.toHaveBeenCalled();
-    fireEvent.click(icons[2]);
+    fireEvent.click(cloneIcon);
     expect(handleAuditCloneClick).toHaveBeenCalledWith(audit6);
 
-    expect(icons[3]).toHaveAttribute(
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute(
       'title',
       'Permission to edit Audit denied',
     );
-    fireEvent.click(icons[3]);
+    fireEvent.click(editIcon);
     expect(handleAuditEditClick).not.toHaveBeenCalled();
 
-    expect(icons[4]).toHaveAttribute(
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute(
       'title',
       'Permission to move Audit to trashcan denied',
     );
-    fireEvent.click(icons[4]);
+    fireEvent.click(deleteIcon);
     expect(handleAuditDeleteClick).not.toHaveBeenCalled();
 
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit as XML');
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit as XML');
     expect(handleAuditDownloadClick).not.toHaveBeenCalled();
-    fireEvent.click(icons[5]);
+    fireEvent.click(exportIcon);
     expect(handleAuditDownloadClick).toHaveBeenCalledWith(audit6);
 
-    expect(icons[6]).toHaveAttribute(
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute(
       'title',
       'Permission to start audit denied',
     );
-    fireEvent.click(icons[6]);
+    fireEvent.click(startIcon);
     expect(handleAuditStartClick).not.toHaveBeenCalled();
 
-    expect(icons[7]).toHaveAttribute('title', 'Audit is not stopped');
-    fireEvent.click(icons[7]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is not stopped');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResumeClick).not.toHaveBeenCalled();
 
     expect(links[2]).toHaveAttribute('href', '/auditreport/1234');
@@ -961,7 +996,7 @@ describe('Audit ToolBarIcons tests', () => {
       store: true,
     });
 
-    const {getAllByTestId} = render(
+    render(
       <ToolBarIcons
         entity={audit7}
         onAuditCloneClick={handleAuditCloneClick}
@@ -974,8 +1009,7 @@ describe('Audit ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getActionItems();
-    const detailsLinks = getAllByTestId('details-link');
+    const detailsLinks = screen.getAllByTestId('details-link');
 
     expect(detailsLinks[0]).toHaveAttribute('href', '/schedule/121314');
     expect(detailsLinks[0]).toHaveAttribute(
@@ -983,13 +1017,15 @@ describe('Audit ToolBarIcons tests', () => {
       'View Details of Schedule schedule1 (Next due: over)',
     );
 
-    expect(icons[7]).toHaveAttribute('title', 'Start');
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute('title', 'Start');
     expect(handleAuditStartClick).not.toHaveBeenCalled();
-    fireEvent.click(icons[7]);
+    fireEvent.click(startIcon);
     expect(handleAuditStartClick).toHaveBeenCalledWith(audit7);
 
-    expect(icons[8]).toHaveAttribute('title', 'Audit is scheduled');
-    fireEvent.click(icons[8]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is scheduled');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResumeClick).not.toHaveBeenCalled();
   });
 });

--- a/src/web/pages/audits/__tests__/ListPage.test.jsx
+++ b/src/web/pages/audits/__tests__/ListPage.test.jsx
@@ -9,10 +9,8 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
 import Filter from 'gmp/models/filter';
 import {
-  clickElement,
-  getActionItems,
-  getBulkActionItems,
   getTableBody,
+  getTableFooter,
   testBulkTrashcanDialog,
 } from 'web/components/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__mocks__/CurrentSettings';
@@ -21,7 +19,13 @@ import {entitiesLoadingActions} from 'web/store/entities/audits';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
 import {loadingActions} from 'web/store/usersettings/defaults/actions';
-import {rendererWith, fireEvent, wait, screen} from 'web/utils/Testing';
+import {
+  rendererWith,
+  fireEvent,
+  wait,
+  screen,
+  getByTestId,
+} from 'web/utils/Testing';
 
 const lastReport = {
   report: {
@@ -201,21 +205,21 @@ describe('AuditPage tests', () => {
 
     await wait();
 
-    const icons = getBulkActionItems();
-
+    const tableFooter = getTableFooter();
+    const deleteIcon = getByTestId(tableFooter, 'trash-icon');
     expect(deleteByFilter).not.toHaveBeenCalled();
-    const deleteIcon = icons[1];
     expect(deleteIcon).toHaveAttribute(
       'title',
       'Move page contents to trashcan',
     );
-    await clickElement(deleteIcon);
+    fireEvent.click(deleteIcon);
 
     testBulkTrashcanDialog(screen, deleteByFilter);
 
+    const exportIcon = getByTestId(tableFooter, 'export-icon');
     expect(exportByFilter).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute('title', 'Export page contents');
-    await clickElement(icons[2]);
+    expect(exportIcon).toHaveAttribute('title', 'Export page contents');
+    fireEvent.click(exportIcon);
     expect(exportByFilter).toHaveBeenCalled();
   });
 });
@@ -239,10 +243,12 @@ describe('AuditPage ToolBarIcons test', () => {
     );
     expect(element).toBeVisible();
 
-    const icons = getActionItems();
     const links = element.querySelectorAll('a');
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: Audits');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Audits',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/compliance-and-special-scans.html#configuring-and-managing-audits',
@@ -264,11 +270,10 @@ describe('AuditPage ToolBarIcons test', () => {
 
     render(<ToolBarIcons onAuditCreateClick={handleAuditCreateClick} />);
 
-    const icons = getActionItems();
-
-    fireEvent.click(icons[1]);
+    const newIcon = screen.getByTestId('new-icon');
+    fireEvent.click(newIcon);
     expect(handleAuditCreateClick).toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'New Audit');
+    expect(newIcon).toHaveAttribute('title', 'New Audit');
   });
 
   test('should not show icons if user does not have the right permissions', () => {
@@ -286,8 +291,10 @@ describe('AuditPage ToolBarIcons test', () => {
 
     render(<ToolBarIcons onAuditCreateClick={handleAuditCreateClick} />);
 
-    const icons = getActionItems();
-    expect(icons.length).toBe(1);
-    expect(icons[0]).toHaveAttribute('title', 'Help: Audits');
+    expect(screen.queryByTestId('new-icon')).toBeNull();
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Audits',
+    );
   });
 });

--- a/src/web/pages/audits/__tests__/Row.test.jsx
+++ b/src/web/pages/audits/__tests__/Row.test.jsx
@@ -7,11 +7,9 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
 import {GREENBONE_SENSOR_SCANNER_TYPE} from 'gmp/models/scanner';
-import {getActionItems} from 'web/components/testing';
 import Row from 'web/pages/audits/Row';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {screen, rendererWith, fireEvent} from 'web/utils/Testing';
-
+import {screen, rendererWithTable, fireEvent} from 'web/utils/Testing';
 
 const gmp = {settings: {}};
 const caps = new Capabilities(['everything']);
@@ -32,11 +30,6 @@ const currentReport = {
 };
 
 describe('Audit Row tests', () => {
-  // deactivate console.error for tests
-  // to make it possible to test a row without a table
-  const consoleError = console.error;
-  console.error = () => {};
-
   test('should render', () => {
     const audit = Audit.fromElement({
       _id: '314',
@@ -61,7 +54,7 @@ describe('Audit Row tests', () => {
     const handleReportDownload = testing.fn();
     const handleToggleDetailsClick = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
@@ -114,15 +107,28 @@ describe('Audit Row tests', () => {
     expect(bars[1]).toHaveTextContent('50%');
 
     // Actions
-    const icons = getActionItems();
-
-    expect(icons[0]).toHaveAttribute('title', 'Start');
-    expect(icons[1]).toHaveAttribute('title', 'Audit is not stopped');
-    expect(icons[2]).toHaveAttribute('title', 'Move Audit to trashcan');
-    expect(icons[3]).toHaveAttribute('title', 'Edit Audit');
-    expect(icons[4]).toHaveAttribute('title', 'Clone Audit');
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit');
-    expect(icons[6]).toHaveAttribute(
+    expect(screen.getByTestId('start-icon')).toHaveAttribute('title', 'Start');
+    expect(screen.getByTestId('resume-icon')).toHaveAttribute(
+      'title',
+      'Audit is not stopped',
+    );
+    expect(screen.getByTestId('trashcan-icon')).toHaveAttribute(
+      'title',
+      'Move Audit to trashcan',
+    );
+    expect(screen.getByTestId('edit-icon')).toHaveAttribute(
+      'title',
+      'Edit Audit',
+    );
+    expect(screen.getByTestId('clone-icon')).toHaveAttribute(
+      'title',
+      'Clone Audit',
+    );
+    expect(screen.getByTestId('export-icon')).toHaveAttribute(
+      'title',
+      'Export Audit',
+    );
+    expect(screen.getByTestId('download-icon')).toHaveAttribute(
       'title',
       'Download Greenbone Compliance Report',
     );
@@ -161,7 +167,7 @@ describe('Audit Row tests', () => {
     const handleReportDownload = testing.fn();
     const handleToggleDetailsClick = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
@@ -187,15 +193,15 @@ describe('Audit Row tests', () => {
         onToggleDetailsClick={handleToggleDetailsClick}
       />,
     );
-
-    const icons = getActionItems();
-
-    expect(icons[0]).toHaveAttribute('title', 'Audit is alterable');
-    expect(icons[1]).toHaveAttribute(
+    expect(screen.getByTestId('alterable-icon')).toHaveAttribute(
+      'title',
+      'Audit is alterable',
+    );
+    expect(screen.getByTestId('sensor-icon')).toHaveAttribute(
       'title',
       'Audit is configured to run on sensor scanner',
     );
-    expect(icons[2]).toHaveAttribute(
+    expect(screen.getByTestId('provide-view-icon')).toHaveAttribute(
       'title',
       'Audit made visible for:\nUsers anon, nymous\nRoles lorem\nGroups ipsum, dolor',
     );
@@ -224,7 +230,7 @@ describe('Audit Row tests', () => {
     const handleReportDownload = testing.fn();
     const handleToggleDetailsClick = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
@@ -234,7 +240,7 @@ describe('Audit Row tests', () => {
     store.dispatch(setTimezone('CET'));
     store.dispatch(setUsername('username'));
 
-    const {baseElement, getAllByTestId, queryAllByTestId} = render(
+    render(
       <Row
         entity={audit}
         gcrFormatDefined={true}
@@ -251,18 +257,16 @@ describe('Audit Row tests', () => {
       />,
     );
 
-    // Name
-    const spans = baseElement.querySelectorAll('span');
-    fireEvent.click(spans[0]);
+    fireEvent.click(screen.getByTestId('row-details-toggle'));
     expect(handleToggleDetailsClick).toHaveBeenCalledWith(undefined, '314');
 
     // Status
-    const bars = getAllByTestId('progressbar-box');
+    const bars = screen.getAllByTestId('progressbar-box');
 
     expect(bars[0]).toHaveAttribute('title', AUDIT_STATUS.new);
     expect(bars[0]).toHaveTextContent(AUDIT_STATUS.new);
 
-    const detailsLinks = queryAllByTestId('details-link');
+    const detailsLinks = screen.queryAllByTestId('details-link');
     expect(detailsLinks.length).toBe(0);
     // because there are no reports yet
 
@@ -271,35 +275,43 @@ describe('Audit Row tests', () => {
     // because there is no compliance status bar yet
 
     // Actions
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
+    const startIcon = screen.getByTestId('start-icon');
+    fireEvent.click(startIcon);
     expect(handleAuditStart).toHaveBeenCalledWith(audit);
-    expect(icons[0]).toHaveAttribute('title', 'Start');
+    expect(startIcon).toHaveAttribute('title', 'Start');
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Audit is not stopped');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is not stopped');
 
-    fireEvent.click(icons[2]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleAuditDelete).toHaveBeenCalledWith(audit);
-    expect(icons[2]).toHaveAttribute('title', 'Move Audit to trashcan');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Audit to trashcan');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleAuditEdit).toHaveBeenCalledWith(audit);
-    expect(icons[3]).toHaveAttribute('title', 'Edit Audit');
+    expect(editIcon).toHaveAttribute('title', 'Edit Audit');
 
-    fireEvent.click(icons[4]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleAuditClone).toHaveBeenCalledWith(audit);
-    expect(icons[4]).toHaveAttribute('title', 'Clone Audit');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleAuditDownload).toHaveBeenCalledWith(audit);
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit');
 
-    fireEvent.click(icons[6]);
+    const downloadIcon = screen.getByTestId('download-icon');
+    fireEvent.click(downloadIcon);
     expect(handleReportDownload).not.toHaveBeenCalled();
-    expect(icons[6]).toHaveAttribute('title', 'Report download not available');
+    expect(downloadIcon).toHaveAttribute(
+      'title',
+      'Report download not available',
+    );
   });
 
   test('should call click handlers for running audit', () => {
@@ -327,7 +339,7 @@ describe('Audit Row tests', () => {
     const handleReportDownload = testing.fn();
     const handleToggleDetailsClick = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
@@ -337,7 +349,7 @@ describe('Audit Row tests', () => {
     store.dispatch(setTimezone('CET'));
     store.dispatch(setUsername('username'));
 
-    const {baseElement, getAllByTestId} = render(
+    render(
       <Row
         entity={audit}
         gcrFormatDefined={true}
@@ -354,18 +366,16 @@ describe('Audit Row tests', () => {
       />,
     );
 
-    // Name
-    const spans = baseElement.querySelectorAll('span');
-    fireEvent.click(spans[0]);
+    fireEvent.click(screen.getByTestId('row-details-toggle'));
     expect(handleToggleDetailsClick).toHaveBeenCalledWith(undefined, '314');
 
     // Status
-    const bars = getAllByTestId('progressbar-box');
+    const bars = screen.getAllByTestId('progressbar-box');
 
     expect(bars[0]).toHaveAttribute('title', AUDIT_STATUS.running);
     expect(bars[0]).toHaveTextContent('0 %');
 
-    const detailsLinks = getAllByTestId('details-link');
+    const detailsLinks = screen.getAllByTestId('details-link');
 
     expect(detailsLinks[0]).toHaveTextContent('0 %');
     expect(detailsLinks[0]).toHaveAttribute('href', '/auditreport/5678');
@@ -379,35 +389,43 @@ describe('Audit Row tests', () => {
     // because there is no compliance status bar yet
 
     // Actions
-    const icons = getActionItems();
-
-    fireEvent.click(icons[0]);
+    const stopIcon = screen.getByTestId('stop-icon');
+    fireEvent.click(stopIcon);
     expect(handleAuditStart).not.toHaveBeenCalled();
-    expect(icons[0]).toHaveAttribute('title', 'Stop');
+    expect(stopIcon).toHaveAttribute('title', 'Stop');
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Audit is not stopped');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is not stopped');
 
-    fireEvent.click(icons[2]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleAuditDelete).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute('title', 'Audit is still in use');
+    expect(deleteIcon).toHaveAttribute('title', 'Audit is still in use');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleAuditEdit).toHaveBeenCalledWith(audit);
-    expect(icons[3]).toHaveAttribute('title', 'Edit Audit');
+    expect(editIcon).toHaveAttribute('title', 'Edit Audit');
 
-    fireEvent.click(icons[4]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleAuditClone).toHaveBeenCalledWith(audit);
-    expect(icons[4]).toHaveAttribute('title', 'Clone Audit');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleAuditDownload).toHaveBeenCalledWith(audit);
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit');
 
-    fireEvent.click(icons[6]);
+    const downloadIcon = screen.getByTestId('download-icon');
+    fireEvent.click(downloadIcon);
     expect(handleReportDownload).not.toHaveBeenCalled();
-    expect(icons[6]).toHaveAttribute('title', 'Report download not available');
+    expect(downloadIcon).toHaveAttribute(
+      'title',
+      'Report download not available',
+    );
   });
 
   test('should call click handlers for stopped audit', () => {
@@ -435,7 +453,7 @@ describe('Audit Row tests', () => {
     const handleReportDownload = testing.fn();
     const handleToggleDetailsClick = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
@@ -445,7 +463,7 @@ describe('Audit Row tests', () => {
     store.dispatch(setTimezone('CET'));
     store.dispatch(setUsername('username'));
 
-    const {baseElement, getAllByTestId} = render(
+    render(
       <Row
         entity={audit}
         gcrFormatDefined={true}
@@ -462,18 +480,16 @@ describe('Audit Row tests', () => {
       />,
     );
 
-    // Name
-    const spans = baseElement.querySelectorAll('span');
-    fireEvent.click(spans[0]);
+    fireEvent.click(screen.getByTestId('row-details-toggle'));
     expect(handleToggleDetailsClick).toHaveBeenCalledWith(undefined, '314');
 
     // Status
-    const bars = getAllByTestId('progressbar-box');
+    const bars = screen.getAllByTestId('progressbar-box');
 
     expect(bars[0]).toHaveAttribute('title', AUDIT_STATUS.stopped);
     expect(bars[0]).toHaveTextContent(AUDIT_STATUS.stopped);
 
-    const detailsLinks = getAllByTestId('details-link');
+    const detailsLinks = screen.getAllByTestId('details-link');
 
     expect(detailsLinks[0]).toHaveTextContent('Stopped');
     expect(detailsLinks[0]).toHaveAttribute('href', '/auditreport/5678');
@@ -487,35 +503,40 @@ describe('Audit Row tests', () => {
     expect(bars[1]).toHaveTextContent('50%');
 
     // Actions
-    const icons = getActionItems();
-
-    fireEvent.click(icons[0]);
+    const startIcon = screen.getByTestId('start-icon');
+    fireEvent.click(startIcon);
     expect(handleAuditStart).toHaveBeenCalledWith(audit);
-    expect(icons[0]).toHaveAttribute('title', 'Start');
+    expect(startIcon).toHaveAttribute('title', 'Start');
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResume).toHaveBeenCalledWith(audit);
-    expect(icons[1]).toHaveAttribute('title', 'Resume');
+    expect(resumeIcon).toHaveAttribute('title', 'Resume');
 
-    fireEvent.click(icons[2]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleAuditDelete).toHaveBeenCalledWith(audit);
-    expect(icons[2]).toHaveAttribute('title', 'Move Audit to trashcan');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Audit to trashcan');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleAuditEdit).toHaveBeenCalledWith(audit);
-    expect(icons[3]).toHaveAttribute('title', 'Edit Audit');
+    expect(editIcon).toHaveAttribute('title', 'Edit Audit');
 
-    fireEvent.click(icons[4]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleAuditClone).toHaveBeenCalledWith(audit);
-    expect(icons[4]).toHaveAttribute('title', 'Clone Audit');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleAuditDownload).toHaveBeenCalledWith(audit);
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit');
 
-    fireEvent.click(icons[6]);
+    const downloadIcon = screen.getByTestId('download-icon');
+    fireEvent.click(downloadIcon);
     expect(handleReportDownload).toHaveBeenCalledWith(audit);
-    expect(icons[6]).toHaveAttribute(
+    expect(downloadIcon).toHaveAttribute(
       'title',
       'Download Greenbone Compliance Report',
     );
@@ -545,7 +566,7 @@ describe('Audit Row tests', () => {
     const handleReportDownload = testing.fn();
     const handleToggleDetailsClick = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
@@ -555,7 +576,7 @@ describe('Audit Row tests', () => {
     store.dispatch(setTimezone('CET'));
     store.dispatch(setUsername('username'));
 
-    const {baseElement, getAllByTestId} = render(
+    render(
       <Row
         entity={audit}
         gcrFormatDefined={true}
@@ -572,18 +593,16 @@ describe('Audit Row tests', () => {
       />,
     );
 
-    // Name
-    const spans = baseElement.querySelectorAll('span');
-    fireEvent.click(spans[0]);
+    fireEvent.click(screen.getByTestId('row-details-toggle'));
     expect(handleToggleDetailsClick).toHaveBeenCalledWith(undefined, '314');
 
     // Status
-    const bars = getAllByTestId('progressbar-box');
+    const bars = screen.getAllByTestId('progressbar-box');
 
     expect(bars[0]).toHaveAttribute('title', AUDIT_STATUS.done);
     expect(bars[0]).toHaveTextContent(AUDIT_STATUS.done);
 
-    const detailsLinks = getAllByTestId('details-link');
+    const detailsLinks = screen.getAllByTestId('details-link');
 
     expect(detailsLinks[0]).toHaveTextContent('Done');
     expect(detailsLinks[0]).toHaveAttribute('href', '/auditreport/1234');
@@ -597,35 +616,40 @@ describe('Audit Row tests', () => {
     expect(bars[1]).toHaveTextContent('50%');
 
     // Actions
-    const icons = getActionItems();
-
-    fireEvent.click(icons[0]);
+    const startIcon = screen.getByTestId('start-icon');
+    fireEvent.click(startIcon);
     expect(handleAuditStart).toHaveBeenCalledWith(audit);
-    expect(icons[0]).toHaveAttribute('title', 'Start');
+    expect(startIcon).toHaveAttribute('title', 'Start');
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Audit is not stopped');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is not stopped');
 
-    fireEvent.click(icons[2]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleAuditDelete).toHaveBeenCalledWith(audit);
-    expect(icons[2]).toHaveAttribute('title', 'Move Audit to trashcan');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Audit to trashcan');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleAuditEdit).toHaveBeenCalledWith(audit);
-    expect(icons[3]).toHaveAttribute('title', 'Edit Audit');
+    expect(editIcon).toHaveAttribute('title', 'Edit Audit');
 
-    fireEvent.click(icons[4]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleAuditClone).toHaveBeenCalledWith(audit);
-    expect(icons[4]).toHaveAttribute('title', 'Clone Audit');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleAuditDownload).toHaveBeenCalledWith(audit);
-    expect(icons[5]).toHaveAttribute('title', 'Export Audit');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit');
 
-    fireEvent.click(icons[6]);
+    const downloadIcon = screen.getByTestId('download-icon');
+    fireEvent.click(downloadIcon);
     expect(handleReportDownload).toHaveBeenCalledWith(audit);
-    expect(icons[6]).toHaveAttribute(
+    expect(downloadIcon).toHaveAttribute(
       'title',
       'Download Greenbone Compliance Report',
     );
@@ -655,7 +679,7 @@ describe('Audit Row tests', () => {
     const handleReportDownload = testing.fn();
     const handleToggleDetailsClick = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
@@ -665,7 +689,7 @@ describe('Audit Row tests', () => {
     store.dispatch(setTimezone('CET'));
     store.dispatch(setUsername('username'));
 
-    const {baseElement, getAllByTestId} = render(
+    render(
       <Row
         entity={audit}
         gcrFormatDefined={true}
@@ -683,20 +707,21 @@ describe('Audit Row tests', () => {
     );
 
     // Name
-    const spans = baseElement.querySelectorAll('span');
-    fireEvent.click(spans[0]);
+    fireEvent.click(screen.getByTestId('row-details-toggle'));
     expect(handleToggleDetailsClick).toHaveBeenCalledWith(undefined, '314');
 
-    const icons = getActionItems();
-    expect(icons[0]).toHaveAttribute('title', 'Audit owned by user');
+    expect(screen.getByTestId('observer-icon')).toHaveAttribute(
+      'title',
+      'Audit owned by user',
+    );
 
     // Status
-    const bars = getAllByTestId('progressbar-box');
+    const bars = screen.getAllByTestId('progressbar-box');
 
     expect(bars[0]).toHaveAttribute('title', AUDIT_STATUS.done);
     expect(bars[0]).toHaveTextContent(AUDIT_STATUS.done);
 
-    const detailsLinks = getAllByTestId('details-link');
+    const detailsLinks = screen.getAllByTestId('details-link');
 
     expect(detailsLinks[0]).toHaveTextContent('Done');
     expect(detailsLinks[0]).toHaveAttribute('href', '/auditreport/1234');
@@ -709,47 +734,51 @@ describe('Audit Row tests', () => {
     expect(bars[1]).toHaveAttribute('title', '50%');
     expect(bars[1]).toHaveTextContent('50%');
 
-    // Actions
-    fireEvent.click(icons[1]);
+    const startIcon = screen.getByTestId('start-icon');
+    fireEvent.click(startIcon);
     expect(handleAuditStart).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute(
+    expect(startIcon).toHaveAttribute(
       'title',
       'Permission to start audit denied',
     );
 
-    fireEvent.click(icons[2]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    fireEvent.click(resumeIcon);
     expect(handleAuditResume).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute('title', 'Audit is not stopped');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is not stopped');
 
-    fireEvent.click(icons[3]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleAuditDelete).not.toHaveBeenCalled();
-    expect(icons[3]).toHaveAttribute(
+    expect(deleteIcon).toHaveAttribute(
       'title',
       'Permission to move Audit to trashcan denied',
     );
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleAuditEdit).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute(
+    expect(editIcon).toHaveAttribute(
       'title',
       'Permission to edit Audit denied',
     );
 
-    fireEvent.click(icons[5]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleAuditClone).toHaveBeenCalledWith(audit);
-    expect(icons[5]).toHaveAttribute('title', 'Clone Audit');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleAuditDownload).toHaveBeenCalledWith(audit);
-    expect(icons[6]).toHaveAttribute('title', 'Export Audit');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit');
 
-    fireEvent.click(icons[7]);
+    const downloadIcon = screen.getByTestId('download-icon');
+    fireEvent.click(downloadIcon);
     expect(handleReportDownload).toHaveBeenCalledWith(audit);
-    expect(icons[7]).toHaveAttribute(
+    expect(downloadIcon).toHaveAttribute(
       'title',
       'Download Greenbone Compliance Report',
     );
   });
-
-  console.warn = consoleError;
 });

--- a/src/web/pages/audits/__tests__/Table.test.jsx
+++ b/src/web/pages/audits/__tests__/Table.test.jsx
@@ -10,8 +10,7 @@ import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
 import Filter from 'gmp/models/filter';
 import Table from 'web/pages/audits/Table';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent} from 'web/utils/Testing';
-
+import {rendererWith, fireEvent, screen} from 'web/utils/Testing';
 
 const caps = new Capabilities(['everything']);
 
@@ -157,7 +156,7 @@ describe('Audits table tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {element, getAllByTestId} = render(
+    const {element} = render(
       <Table
         entities={[audit, audit2, audit3]}
         entitiesCounts={counts}
@@ -176,9 +175,9 @@ describe('Audits table tests', () => {
     expect(element).not.toHaveTextContent('target1');
     expect(element).not.toHaveTextContent('target2');
 
-    const icons = getAllByTestId('svg-icon');
-    fireEvent.click(icons[0]);
-    expect(icons[0]).toHaveAttribute('title', 'Unfold all details');
+    const foldIcon = screen.getByTestId('fold-state-icon-unfold');
+    fireEvent.click(foldIcon);
+    expect(foldIcon).toHaveAttribute('title', 'Unfold all details');
     expect(element).toHaveTextContent('target1');
     expect(element).toHaveTextContent('target2');
   });
@@ -206,7 +205,7 @@ describe('Audits table tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {getAllByTestId} = render(
+    render(
       <Table
         entities={[audit, audit2, audit3]}
         entitiesCounts={counts}
@@ -223,35 +222,40 @@ describe('Audits table tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[5]);
+    const startIcon = screen.getAllByTestId('start-icon')[0];
+    fireEvent.click(startIcon);
     expect(handleAuditStartClick).toHaveBeenCalledWith(audit);
-    expect(icons[5]).toHaveAttribute('title', 'Start');
+    expect(startIcon).toHaveAttribute('title', 'Start');
 
-    fireEvent.click(icons[6]);
+    const resumeIcon = screen.getAllByTestId('resume-icon')[0];
+    fireEvent.click(resumeIcon);
     expect(handleAuditResumeClick).not.toHaveBeenCalled();
-    expect(icons[6]).toHaveAttribute('title', 'Audit is not stopped');
+    expect(resumeIcon).toHaveAttribute('title', 'Audit is not stopped');
 
-    fireEvent.click(icons[7]);
+    const deleteIcon = screen.getAllByTestId('trashcan-icon')[0];
+    fireEvent.click(deleteIcon);
     expect(handleAuditDeleteClick).toHaveBeenCalledWith(audit);
-    expect(icons[7]).toHaveAttribute('title', 'Move Audit to trashcan');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Audit to trashcan');
 
-    fireEvent.click(icons[8]);
+    const editIcon = screen.getAllByTestId('edit-icon')[0];
+    fireEvent.click(editIcon);
     expect(handleAuditEditClick).toHaveBeenCalledWith(audit);
-    expect(icons[8]).toHaveAttribute('title', 'Edit Audit');
+    expect(editIcon).toHaveAttribute('title', 'Edit Audit');
 
-    fireEvent.click(icons[9]);
+    const cloneIcon = screen.getAllByTestId('clone-icon')[0];
+    fireEvent.click(cloneIcon);
     expect(handleAuditCloneClick).toHaveBeenCalledWith(audit);
-    expect(icons[9]).toHaveAttribute('title', 'Clone Audit');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Audit');
 
-    fireEvent.click(icons[10]);
+    const exportIcon = screen.getAllByTestId('export-icon')[0];
+    fireEvent.click(exportIcon);
     expect(handleAuditDownloadClick).toHaveBeenCalledWith(audit);
-    expect(icons[10]).toHaveAttribute('title', 'Export Audit');
+    expect(exportIcon).toHaveAttribute('title', 'Export Audit');
 
-    fireEvent.click(icons[11]);
+    const downloadIcon = screen.getAllByTestId('download-icon')[0];
+    fireEvent.click(downloadIcon);
     expect(handleReportDownloadClick).toHaveBeenCalledWith(audit);
-    expect(icons[11]).toHaveAttribute(
+    expect(downloadIcon).toHaveAttribute(
       'title',
       'Download Greenbone Compliance Report',
     );

--- a/src/web/pages/cpes/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/cpes/__tests__/DetailsPage.test.jsx
@@ -12,7 +12,7 @@ import {currentSettingsDefaultResponse} from 'web/pages/__mocks__/CurrentSetting
 import CpePage, {ToolBarIcons} from 'web/pages/cpes/DetailsPage';
 import {entityLoadingActions} from 'web/store/entities/cpes';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, wait, fireEvent} from 'web/utils/Testing';
+import {rendererWith, wait, fireEvent, screen} from 'web/utils/Testing';
 
 const cpe = CPE.fromElement({
   _id: 'cpe:/a:foo',
@@ -52,8 +52,8 @@ beforeEach(() => {
   });
 });
 
-describe('CPE Detailspage tests', () => {
-  test('should render full Detailspage', () => {
+describe('CPE DetailsPage tests', () => {
+  test('should render full DetailsPage', () => {
     const getCpe = testing.fn().mockResolvedValue({
       data: cpe,
     });
@@ -81,23 +81,27 @@ describe('CPE Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('cpe:/a:foo', cpe));
 
-    const {baseElement, getAllByTestId} = render(<CpePage id="cpe:/a:foo" />);
+    const {baseElement} = render(<CpePage id="cpe:/a:foo" />);
 
     const links = baseElement.querySelectorAll('a');
-
-    // test icon bar
-    const icons = getAllByTestId('svg-icon');
-
-    expect(icons[0]).toHaveAttribute('title', 'Help: CPEs');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: CPEs',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/managing-secinfo.html#cpe',
     );
 
-    expect(icons[1]).toHaveAttribute('title', 'CPE List');
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'CPE List',
+    );
     expect(links[1]).toHaveAttribute('href', '/cpes');
-
-    expect(icons[2]).toHaveAttribute('title', 'Export CPE');
+    expect(screen.getByTestId('export-icon')).toHaveAttribute(
+      'title',
+      'Export CPE',
+    );
 
     // test title bar
     expect(baseElement).toHaveTextContent('CPE: foo');
@@ -118,7 +122,7 @@ describe('CPE Detailspage tests', () => {
     expect(baseElement).toHaveTextContent('StatusFINAL');
 
     // severity bar(s)
-    const progressBars = getAllByTestId('progressbar-box');
+    const progressBars = screen.getAllByTestId('progressbar-box');
     expect(progressBars[0]).toHaveAttribute('title', 'Critical');
     expect(progressBars[0]).toHaveTextContent('9.8 (Critical)');
     expect(progressBars[1]).toHaveAttribute('title', 'Critical');
@@ -188,11 +192,9 @@ describe('CPE Detailspage tests', () => {
       foo: 'bar',
     });
 
-    const getCpe = testing.fn().mockReturnValue(
-      Promise.resolve({
-        data: cpe,
-      }),
-    );
+    const getCpe = testing.fn().mockResolvedValue({
+      data: cpe,
+    });
 
     const gmp = {
       cpe: {
@@ -217,17 +219,20 @@ describe('CPE Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('cpe:/a:foo', cpe));
 
-    const {getAllByTestId} = render(<CpePage id="cpe:/a:foo" />);
-    const icons = getAllByTestId('svg-icon');
+    render(<CpePage id="cpe:/a:foo" />);
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: CPEs',
+    );
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'CPE List',
+    );
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: CPEs');
-    expect(icons[1]).toHaveAttribute('title', 'CPE List');
-
-    expect(icons[2]).toHaveAttribute('title', 'Export CPE');
-    fireEvent.click(icons[2]);
-
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export CPE');
+    fireEvent.click(exportIcon);
     await wait();
-
     expect(exportFunc).toHaveBeenCalledWith(cpe);
   });
 });
@@ -242,21 +247,25 @@ describe('CPEs ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {element, getAllByTestId} = render(
+    const {element} = render(
       <ToolBarIcons entity={cpe} onCpeDownloadClick={handleCpeDownload} />,
     );
 
     const links = element.querySelectorAll('a');
-    const icons = getAllByTestId('svg-icon');
-
-    expect(icons[0]).toHaveAttribute('title', 'Help: CPEs');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: CPEs',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/managing-secinfo.html#cpe',
     );
 
     expect(links[1]).toHaveAttribute('href', '/cpes');
-    expect(icons[1]).toHaveAttribute('title', 'CPE List');
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'CPE List',
+    );
   });
 
   test('should call click handlers', () => {
@@ -268,17 +277,22 @@ describe('CPEs ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {getAllByTestId} = render(
+    render(
       <ToolBarIcons entity={cpe} onCpeDownloadClick={handleCpeDownload} />,
     );
 
-    const icons = getAllByTestId('svg-icon');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: CPEs',
+    );
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'CPE List',
+    );
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: CPEs');
-    expect(icons[1]).toHaveAttribute('title', 'CPE List');
-
-    fireEvent.click(icons[2]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleCpeDownload).toHaveBeenCalledWith(cpe);
-    expect(icons[2]).toHaveAttribute('title', 'Export CPE');
+    expect(exportIcon).toHaveAttribute('title', 'Export CPE');
   });
 });

--- a/src/web/pages/cpes/__tests__/ListPage.test.jsx
+++ b/src/web/pages/cpes/__tests__/ListPage.test.jsx
@@ -9,7 +9,6 @@ import CPE from 'gmp/models/cpe';
 import Filter from 'gmp/models/filter';
 import {
   clickElement,
-  getBulkActionItems,
   getCheckBoxes,
   getPowerFilter,
   getSelectElement,
@@ -25,7 +24,7 @@ import {entitiesLoadingActions} from 'web/store/entities/cpes';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
 import {loadingActions} from 'web/store/usersettings/defaults/actions';
-import {rendererWith, screen, wait} from 'web/utils/Testing';
+import {getByTestId, rendererWith, screen, wait} from 'web/utils/Testing';
 
 const cpe = CPE.fromElement({
   _id: 'cpe:/a:foo',
@@ -267,8 +266,8 @@ describe('CpesPage tests', () => {
     await wait();
 
     // export page contents
-    const bulkActions = getBulkActionItems();
-    const exportIcon = bulkActions[1];
+    const tableFooter = getTableFooter();
+    const exportIcon = getByTestId(tableFooter, 'export-icon');
     await clickElement(exportIcon);
     expect(exportByFilter).toHaveBeenCalled();
   });
@@ -347,8 +346,7 @@ describe('CpesPage tests', () => {
     await clickElement(inputs[1]);
 
     // export selected cpe
-    const bulkActions = getBulkActionItems();
-    const exportIcon = bulkActions[1];
+    const exportIcon = getByTestId(tableFooter, 'export-icon');
     await clickElement(exportIcon);
 
     expect(exportByIds).toHaveBeenCalled();
@@ -423,8 +421,7 @@ describe('CpesPage tests', () => {
     expect(selectElement).toHaveValue('Apply to all filtered');
 
     // export all filtered cpes
-    const bulkActions = getBulkActionItems();
-    const exportIcon = bulkActions[1];
+    const exportIcon = getByTestId(tableFooter, 'export-icon');
     await clickElement(exportIcon);
 
     expect(exportByFilter).toHaveBeenCalled();

--- a/src/web/pages/credentials/__tests__/ListPage.test.jsx
+++ b/src/web/pages/credentials/__tests__/ListPage.test.jsx
@@ -371,7 +371,10 @@ describe('CredentialPage ToolBarIcons test', () => {
 
     const links = element.querySelectorAll('a');
 
-    expect(screen.getAllByTitle('Help: Credentials')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Credentials',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/scanning.html#managing-credentials',
@@ -395,11 +398,9 @@ describe('CredentialPage ToolBarIcons test', () => {
       <ToolBarIcons onCredentialCreateClick={handleCredentialCreateClick} />,
     );
 
-    const newIcon = screen.getAllByTitle('New Credential');
-
-    expect(newIcon[0]).toBeInTheDocument();
-
-    fireEvent.click(newIcon[0]);
+    const newIcon = screen.getByTestId('new-icon');
+    expect(newIcon).toHaveAttribute('title', 'New Credential');
+    fireEvent.click(newIcon);
     expect(handleCredentialCreateClick).toHaveBeenCalled();
   });
 
@@ -416,12 +417,13 @@ describe('CredentialPage ToolBarIcons test', () => {
       router: true,
     });
 
-    const {queryAllByTestId} = render(
+    render(
       <ToolBarIcons onCredentialCreateClick={handleCredentialCreateClick} />,
     );
 
-    const icons = queryAllByTestId('svg-icon'); // this test is probably appropriate to keep in the old format
-    expect(icons.length).toBe(1);
-    expect(icons[0]).toHaveAttribute('title', 'Help: Credentials');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Credentials',
+    );
   });
 });

--- a/src/web/pages/cves/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/cves/__tests__/DetailsPage.test.jsx
@@ -10,7 +10,7 @@ import {currentSettingsDefaultResponse} from 'web/pages/__mocks__/CurrentSetting
 import CvePage from 'web/pages/cves/DetailsPage';
 import {entityLoadingActions} from 'web/store/entities/cves';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {rendererWith} from 'web/utils/Testing';
+import {rendererWith, screen} from 'web/utils/Testing';
 
 const entity_v2 = Cve.fromElement({
   _id: 'CVE-2020-9997',
@@ -124,8 +124,8 @@ const renewSession = testing.fn().mockResolvedValue({
 const reloadInterval = 1;
 const manualUrl = 'test/';
 
-describe('CVE Detailspage tests', () => {
-  test('should render full Detailspage', () => {
+describe('CVE DetailsPage tests', () => {
+  test('should render full DetailsPage', () => {
     const getCve = testing.fn().mockResolvedValue({
       data: entity_v2,
     });
@@ -157,26 +157,31 @@ describe('CVE Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('CVE-2020-9997', entity_v2));
 
-    const {baseElement, getAllByTestId} = render(
-      <CvePage id="CVE-2020-9997" />,
-    );
+    const {baseElement} = render(<CvePage id="CVE-2020-9997" />);
 
     expect(baseElement).toHaveTextContent('Score0.50000');
     expect(baseElement).toHaveTextContent('Percentage75.000%');
 
     const links = baseElement.querySelectorAll('a');
-    const icons = getAllByTestId('svg-icon');
-
-    expect(icons[0]).toHaveAttribute('title', 'Help: CVEs');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: CVEs',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/managing-secinfo.html#cve',
     );
 
-    expect(icons[1]).toHaveAttribute('title', 'CVE List');
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'CVE List',
+    );
     expect(links[1]).toHaveAttribute('href', '/cves');
 
-    expect(icons[2]).toHaveAttribute('title', 'Export CVE');
+    expect(screen.getByTestId('export-icon')).toHaveAttribute(
+      'title',
+      'Export CVE',
+    );
 
     expect(baseElement).toHaveTextContent('CVE: CVE-2020-9997');
 
@@ -199,7 +204,7 @@ describe('CVE Detailspage tests', () => {
     expect(baseElement).toHaveTextContent('Confidentiality ImpactHigh');
     expect(baseElement).toHaveTextContent('Integrity ImpactNone');
     expect(baseElement).toHaveTextContent('Availability ImpactNone');
-    const progressBars = getAllByTestId('progressbar-box');
+    const progressBars = screen.getAllByTestId('progressbar-box');
     expect(progressBars[0]).toHaveAttribute('title', 'Medium');
     expect(progressBars[0]).toHaveTextContent('5.5 (Medium)');
     expect(baseElement).toHaveTextContent('References');

--- a/src/web/pages/cves/__tests__/ListPage.test.jsx
+++ b/src/web/pages/cves/__tests__/ListPage.test.jsx
@@ -432,7 +432,10 @@ describe('CvesPage ToolBarIcons test', () => {
     const {baseElement} = render(<ToolBarIcons />);
 
     const links = baseElement.querySelectorAll('a');
-    expect(screen.getAllByTitle('Help: CVEs')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: CVEs',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/managing-secinfo.html#cve',

--- a/src/web/pages/cves/__tests__/Row.test.jsx
+++ b/src/web/pages/cves/__tests__/Row.test.jsx
@@ -9,8 +9,7 @@ import Cve from 'gmp/models/cve';
 import {parseDate} from 'gmp/parser';
 import CveRow from 'web/pages/cves/Row';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent} from 'web/utils/Testing';
-
+import {rendererWithTable, fireEvent, screen} from 'web/utils/Testing';
 
 const gmp = {settings: {}};
 const caps = new Capabilities(['everything']);
@@ -26,15 +25,10 @@ const entity = Cve.fromElement({
 });
 
 describe('CVEv2 Row tests', () => {
-  // deactivate console.error for tests
-  // to make it possible to test a row without a table
-  const consoleError = console.error;
-  console.error = () => {};
-
   test('should render', () => {
     const handleToggleDetailsClick = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
@@ -44,7 +38,7 @@ describe('CVEv2 Row tests', () => {
     store.dispatch(setTimezone('CET'));
     store.dispatch(setUsername('username'));
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <CveRow
         entity={entity}
         onToggleDetailsClick={handleToggleDetailsClick}
@@ -67,7 +61,7 @@ describe('CVEv2 Row tests', () => {
     expect(baseElement).toHaveTextContent('Thu, Oct 22, 2020 9:15 PM CEST');
 
     // Severity
-    const bars = getAllByTestId('progressbar-box');
+    const bars = screen.getAllByTestId('progressbar-box');
     expect(bars[0]).toHaveAttribute('title', 'Critical');
     expect(bars[0]).toHaveTextContent('9.3 (Critical)');
 
@@ -78,7 +72,7 @@ describe('CVEv2 Row tests', () => {
   test('should call click handlers', () => {
     const handleToggleDetailsClick = testing.fn();
 
-    const {render} = rendererWith({
+    const {render} = rendererWithTable({
       gmp,
       capabilities: true,
       router: true,
@@ -99,8 +93,6 @@ describe('CVEv2 Row tests', () => {
       'CVE-2020-9992',
     );
   });
-
-  console.warn = consoleError;
 });
 
 const entity_v3 = Cve.fromElement({
@@ -114,15 +106,10 @@ const entity_v3 = Cve.fromElement({
 });
 
 describe('CVEv3 Row tests', () => {
-  // deactivate console.error for tests
-  // to make it possible to test a row without a table
-  const consoleError = console.error;
-  console.error = () => {};
-
   test('should render', () => {
     const handleToggleDetailsClick = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
@@ -132,7 +119,7 @@ describe('CVEv3 Row tests', () => {
     store.dispatch(setTimezone('CET'));
     store.dispatch(setUsername('username'));
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <CveRow
         entity={entity_v3}
         onToggleDetailsClick={handleToggleDetailsClick}
@@ -157,7 +144,7 @@ describe('CVEv3 Row tests', () => {
     expect(baseElement).toHaveTextContent('Thu, Oct 22, 2020 9:15 PM CEST');
 
     // Severity
-    const bars = getAllByTestId('progressbar-box');
+    const bars = screen.getAllByTestId('progressbar-box');
     expect(bars[0]).toHaveAttribute('title', 'High');
     expect(bars[0]).toHaveTextContent('7.1 (High)');
 
@@ -168,7 +155,7 @@ describe('CVEv3 Row tests', () => {
   test('should call click handlers', () => {
     const handleToggleDetailsClick = testing.fn();
 
-    const {render} = rendererWith({
+    const {render} = rendererWithTable({
       gmp,
       capabilities: true,
       router: true,
@@ -189,6 +176,4 @@ describe('CVEv3 Row tests', () => {
       'CVE-2020-9992',
     );
   });
-
-  console.warn = consoleError;
 });

--- a/src/web/pages/cves/__tests__/Table.test.jsx
+++ b/src/web/pages/cves/__tests__/Table.test.jsx
@@ -13,7 +13,6 @@ import CveTable from 'web/pages/cves/Table';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent} from 'web/utils/Testing';
 
-
 const caps = new Capabilities(['everything']);
 
 const entity = Cve.fromElement({
@@ -112,7 +111,7 @@ describe('Cve table tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {element, getAllByTestId} = render(
+    const {element, getByTestId} = render(
       <CveTable
         entities={[entity, entity2, entity3, entity_v3]}
         entitiesCounts={counts}
@@ -124,9 +123,9 @@ describe('Cve table tests', () => {
     expect(element).not.toHaveTextContent('Confidentiality ImpactPartial');
     expect(element).not.toHaveTextContent('Attack VectorLocal');
 
-    const icons = getAllByTestId('svg-icon');
-    fireEvent.click(icons[0]);
-    expect(icons[0]).toHaveAttribute('title', 'Unfold all details');
+    const unfoldIcon = getByTestId('fold-state-icon-unfold');
+    fireEvent.click(unfoldIcon);
+    expect(unfoldIcon).toHaveAttribute('title', 'Unfold all details');
     expect(element).toHaveTextContent('Availability ImpactComplete');
     expect(element).toHaveTextContent('Confidentiality ImpactPartial');
     expect(element).toHaveTextContent('Attack VectorLocal');

--- a/src/web/pages/extras/__tests__/FeedStatusPage.test.jsx
+++ b/src/web/pages/extras/__tests__/FeedStatusPage.test.jsx
@@ -7,8 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {createFeed} from 'gmp/commands/feedstatus';
 import Response from 'gmp/http/response';
 import FeedStatus from 'web/pages/extras/FeedStatusPage';
-import {rendererWith, waitFor} from 'web/utils/Testing';
-
+import {rendererWith, screen, waitFor} from 'web/utils/Testing';
 
 const mockDate = new Date(1595660400000); // Saturday July 25 090000
 
@@ -65,16 +64,14 @@ const gmp = {
 describe('Feed status page tests', () => {
   test('should render', async () => {
     const {render} = rendererWith({gmp, router: true});
-    const {element, getAllByTestId} = render(<FeedStatus />);
+    const {element} = render(<FeedStatus />);
 
     await waitFor(() => element.querySelectorAll('table'));
 
-    // Should render all icons
-    const icons = getAllByTestId('svg-icon');
-
-    expect(icons.length).toEqual(11);
-
-    expect(icons[0]).toHaveAttribute('title', 'Help: Feed Status');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Feed Status',
+    );
 
     // Should render all links
     const links = element.querySelectorAll('a');
@@ -136,7 +133,7 @@ describe('Feed status page tests', () => {
     // Feed Status
 
     const ageText = element.querySelectorAll('strong');
-    const updateMsgs = getAllByTestId('update-msg');
+    const updateMsgs = screen.getAllByTestId('update-msg');
 
     expect(ageText.length).toEqual(4);
     expect(updateMsgs.length).toEqual(4);

--- a/src/web/pages/hosts/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/hosts/__tests__/DetailsPage.test.jsx
@@ -8,7 +8,7 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 import Filter from 'gmp/models/filter';
 import Host from 'gmp/models/host';
 import {currentSettingsDefaultResponse} from 'web/pages/__mocks__/CurrentSettings';
-import Detailspage, {ToolBarIcons} from 'web/pages/hosts/DetailsPage';
+import DetailsPage, {ToolBarIcons} from 'web/pages/hosts/DetailsPage';
 import {entityLoadingActions} from 'web/store/entities/hosts';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/Testing';
@@ -169,8 +169,8 @@ beforeEach(() => {
   });
 });
 
-describe('Host Detailspage tests', () => {
-  test('should render full Detailspage', () => {
+describe('Host DetailsPage tests', () => {
+  test('should render full DetailsPage', () => {
     const gmp = {
       host: {
         get: getHost,
@@ -194,18 +194,24 @@ describe('Host Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', host));
 
-    const {baseElement} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     // Toolbar Icons
     const links = baseElement.querySelectorAll('a');
 
-    expect(screen.getAllByTitle('Help: Hosts')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Hosts',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/managing-assets.html#managing-hosts',
     );
 
-    expect(screen.getAllByTitle('Host List')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'Host List',
+    );
     expect(links[1]).toHaveAttribute('href', '/hosts');
 
     expect(screen.getAllByTitle('Create new Host')[0]).toBeInTheDocument();
@@ -313,7 +319,7 @@ describe('Host Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', host));
 
-    const {baseElement} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     const spans = baseElement.querySelectorAll('span');
 
@@ -350,7 +356,7 @@ describe('Host Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', host));
 
-    const {baseElement} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     const spans = baseElement.querySelectorAll('span');
 
@@ -400,32 +406,23 @@ describe('Host Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', host));
 
-    render(<Detailspage id="12345" />);
+    render(<DetailsPage id="12345" />);
 
     await wait();
 
     // delete identifier
-
     fireEvent.click(screen.getAllByTitle('Delete Identifier')[0]);
-
     await wait();
-
     expect(deleteIdentifier).toHaveBeenCalledWith(host.identifiers[0]);
 
     // export host
-
     fireEvent.click(screen.getAllByTitle('Export Host as XML')[0]);
-
     await wait();
-
     expect(exportFunc).toHaveBeenCalledWith(host);
 
     // delete host
-
     fireEvent.click(screen.getAllByTitle('Delete Host')[0]);
-
     await wait();
-
     expect(deleteFunc).toHaveBeenCalledWith({id: host.id});
   });
 });
@@ -456,17 +453,19 @@ describe('Host ToolBarIcons tests', () => {
     );
 
     const links = element.querySelectorAll('a');
-    const icons = screen.getAllByTestId('svg-icon');
-
-    expect(icons.length).toBe(8);
-
-    expect(screen.getAllByTitle('Help: Hosts')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Hosts',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/managing-assets.html#managing-hosts',
     );
 
-    expect(screen.getAllByTitle('Host List')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'Host List',
+    );
     expect(links[1]).toHaveAttribute('href', '/hosts');
 
     expect(screen.getAllByTitle('Create new Host')[0]).toBeInTheDocument();
@@ -505,16 +504,23 @@ describe('Host ToolBarIcons tests', () => {
       />,
     );
 
-    fireEvent.click(screen.getAllByTitle('Create new Host')[0]);
+    const newIcon = screen.getByTestId('new-icon');
+    expect(newIcon).toHaveAttribute('title', 'Create new Host');
+    fireEvent.click(newIcon);
     expect(handleHostCreateClick).toHaveBeenCalled();
 
-    fireEvent.click(screen.getAllByTitle('Edit Host')[0]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Host');
+    fireEvent.click(editIcon);
     expect(handleHostEditClick).toHaveBeenCalledWith(host);
 
-    fireEvent.click(screen.getAllByTitle('Delete Host')[0]);
+    const deleteIcon = screen.getAllByTestId('delete-icon')[0];
+    fireEvent.click(deleteIcon);
     expect(handleHostDeleteClick).toHaveBeenCalledWith(host);
 
-    fireEvent.click(screen.getAllByTitle('Export Host as XML')[0]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Host as XML');
+    fireEvent.click(exportIcon);
     expect(handleHostDownloadClick).toHaveBeenCalledWith(host);
   });
 
@@ -542,20 +548,27 @@ describe('Host ToolBarIcons tests', () => {
       />,
     );
 
-    fireEvent.click(screen.getAllByTitle('Create new Host')[0]);
+    const newIcon = screen.getByTestId('new-icon');
+    expect(newIcon).toHaveAttribute('title', 'Create new Host');
+    fireEvent.click(newIcon);
     expect(handleHostCreateClick).toHaveBeenCalled();
 
-    expect(screen.queryByTitle('Edit Host')).not.toBeInTheDocument();
-    fireEvent.click(screen.getAllByTitle('Permission to edit Host denied')[0]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Permission to edit Host denied');
+    fireEvent.click(editIcon);
     expect(handleHostEditClick).not.toHaveBeenCalled();
 
-    expect(screen.queryByTitle('Delete Host')).not.toBeInTheDocument();
-    fireEvent.click(
-      screen.getAllByTitle('Permission to delete Host denied')[0],
+    const deleteIcon = screen.getAllByTestId('delete-icon')[0];
+    expect(deleteIcon).toHaveAttribute(
+      'title',
+      'Permission to delete Host denied',
     );
+    fireEvent.click(deleteIcon);
     expect(handleHostDeleteClick).not.toHaveBeenCalledWith(host);
 
-    fireEvent.click(screen.getAllByTitle('Export Host as XML')[0]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Host as XML');
+    fireEvent.click(exportIcon);
     expect(handleHostDownloadClick).toHaveBeenCalledWith(hostWithoutPermission);
   });
 });

--- a/src/web/pages/hosts/__tests__/ListPage.test.jsx
+++ b/src/web/pages/hosts/__tests__/ListPage.test.jsx
@@ -133,8 +133,8 @@ beforeEach(() => {
   });
 });
 
-describe('Host listpage tests', () => {
-  test('should render full host listpage', async () => {
+describe('Host ListPage tests', () => {
+  test('should render full host ListPage', async () => {
     const gmp = {
       hosts: {
         get: getHosts,
@@ -321,16 +321,12 @@ describe('Host listpage tests', () => {
 
     // export page contents
     fireEvent.click(screen.getAllByTitle('Export page contents')[0]);
-
     await wait();
-
     expect(exportByFilter).toHaveBeenCalled();
 
     // delete page contents
     fireEvent.click(screen.getAllByTitle('Delete page contents')[0]);
-
     await wait();
-
     testBulkDeleteDialog(screen, deleteByFilter);
   });
 
@@ -485,7 +481,7 @@ describe('Host listpage tests', () => {
   });
 });
 
-describe('Host listpage ToolBarIcons test', () => {
+describe('Host ListPage ToolBarIcons test', () => {
   test('should render', () => {
     const handleCreateHostClick = testing.fn();
 
@@ -503,18 +499,18 @@ describe('Host listpage ToolBarIcons test', () => {
       <ToolBarIcons onHostCreateClick={handleCreateHostClick} />,
     );
 
-    const icons = screen.getAllByTestId('svg-icon');
     const links = element.querySelectorAll('a');
 
-    expect(icons.length).toBe(2);
-
-    expect(screen.getAllByTitle('Help: Hosts')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Hosts',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/managing-assets.html#managing-hosts',
     );
 
-    expect(screen.getAllByTitle('New Host')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('new-icon')).toHaveAttribute('title', 'New Host');
   });
 
   test('should call click handlers', () => {
@@ -550,10 +546,6 @@ describe('Host listpage ToolBarIcons test', () => {
     });
 
     render(<ToolBarIcons onHostCreateClick={handleCreateHostClick} />);
-
-    const icons = screen.getAllByTestId('svg-icon');
-
-    expect(icons.length).toBe(1);
 
     expect(screen.getAllByTitle('Help: Hosts')[0]).toBeInTheDocument();
     expect(screen.queryByTitle('New Host')).not.toBeInTheDocument();

--- a/src/web/pages/hosts/dashboard/TopologyDisplay.jsx
+++ b/src/web/pages/hosts/dashboard/TopologyDisplay.jsx
@@ -16,7 +16,6 @@ import compose from 'web/utils/Compose';
 import PropTypes from 'web/utils/PropTypes';
 import {withRouter} from 'web/utils/withRouter';
 
-
 const transformTopologyData = (data = []) => {
   if (!hasValue(data)) {
     return {};
@@ -144,7 +143,7 @@ export class HostsTopologyDisplay extends React.Component {
 
 HostsTopologyDisplay.propTypes = {
   filter: PropTypes.filter,
-  navigate: PropTypes.object.isRequired,
+  navigate: PropTypes.func.isRequired,
 };
 
 const DISPLAY_ID = 'host-by-topology';

--- a/src/web/pages/notes/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/notes/__tests__/DetailsPage.test.jsx
@@ -9,7 +9,7 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 import Filter from 'gmp/models/filter';
 import Note from 'gmp/models/note';
 import {currentSettingsDefaultResponse} from 'web/pages/__mocks__/CurrentSettings';
-import Detailspage, {ToolBarIcons} from 'web/pages/notes/DetailsPage';
+import DetailsPage, {ToolBarIcons} from 'web/pages/notes/DetailsPage';
 import {entityLoadingActions} from 'web/store/entities/notes';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/Testing';
@@ -104,7 +104,7 @@ const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-describe('Note detailspage tests', () => {
+describe('Note DetailsPage tests', () => {
   test('should render full /DetailsPage', () => {
     const gmp = {
       note: {
@@ -137,7 +137,7 @@ describe('Note detailspage tests', () => {
     );
 
     const {baseElement} = render(
-      <Detailspage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />,
+      <DetailsPage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />,
     );
 
     expect(baseElement).toHaveTextContent('note text');
@@ -232,7 +232,7 @@ describe('Note detailspage tests', () => {
     );
 
     const {baseElement} = render(
-      <Detailspage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />,
+      <DetailsPage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />,
     );
 
     const spans = baseElement.querySelectorAll('span');
@@ -275,7 +275,7 @@ describe('Note detailspage tests', () => {
     );
 
     const {baseElement} = render(
-      <Detailspage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />,
+      <DetailsPage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />,
     );
 
     const spans = baseElement.querySelectorAll('span');
@@ -332,35 +332,23 @@ describe('Note detailspage tests', () => {
       ),
     );
 
-    render(<Detailspage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />);
+    render(<DetailsPage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />);
 
     await wait();
 
-    const cloneIcon = screen.getAllByTitle('Clone Note');
-    expect(cloneIcon[0]).toBeInTheDocument();
-
-    fireEvent.click(cloneIcon[0]);
-
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     await wait();
-
     expect(clone).toHaveBeenCalledWith(note);
 
-    const exportIcon = screen.getAllByTitle('Export Note as XML');
-    expect(exportIcon[0]).toBeInTheDocument();
-
-    fireEvent.click(exportIcon[0]);
-
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     await wait();
-
     expect(exportFunc).toHaveBeenCalledWith(note);
 
-    const deleteIcon = screen.getAllByTitle('Move Note to trashcan');
-    expect(deleteIcon[0]).toBeInTheDocument();
-
-    fireEvent.click(deleteIcon[0]);
-
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     await wait();
-
     expect(deleteFunc).toHaveBeenCalledWith({id: note.id});
   });
 });
@@ -398,10 +386,16 @@ describe('Note ToolBarIcons tests', () => {
       'href',
       'test/en/reports.html#managing-notes',
     );
-    expect(screen.getAllByTitle('Help: Notes')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Notes',
+    );
 
     expect(links[1]).toHaveAttribute('href', '/notes');
-    expect(screen.getAllByTitle('Note List')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'Note List',
+    );
   });
 
   test('should call click handlers', () => {
@@ -430,25 +424,21 @@ describe('Note ToolBarIcons tests', () => {
       />,
     );
 
-    const cloneIcon = screen.getAllByTitle('Clone Note');
-    const editIcon = screen.getAllByTitle('Edit Note');
-    const deleteIcon = screen.getAllByTitle('Move Note to trashcan');
-    const exportIcon = screen.getAllByTitle('Export Note as XML');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    const editIcon = screen.getByTestId('edit-icon');
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    const exportIcon = screen.getByTestId('export-icon');
 
-    expect(cloneIcon[0]).toBeInTheDocument();
-    fireEvent.click(cloneIcon[0]);
+    fireEvent.click(cloneIcon);
     expect(handleNoteCloneClick).toHaveBeenCalledWith(note);
 
-    expect(editIcon[0]).toBeInTheDocument();
-    fireEvent.click(editIcon[0]);
+    fireEvent.click(editIcon);
     expect(handleNoteEditClick).toHaveBeenCalledWith(note);
 
-    expect(deleteIcon[0]).toBeInTheDocument();
-    fireEvent.click(deleteIcon[0]);
+    fireEvent.click(deleteIcon);
     expect(handleNoteDeleteClick).toHaveBeenCalledWith(note);
 
-    expect(exportIcon[0]).toBeInTheDocument();
-    fireEvent.click(exportIcon[0]);
+    fireEvent.click(exportIcon);
     expect(handleNoteDownloadClick).toHaveBeenCalledWith(note);
   });
 
@@ -478,31 +468,21 @@ describe('Note ToolBarIcons tests', () => {
       />,
     );
 
-    const cloneIcon = screen.getAllByTitle('Clone Note');
-    const editIcon = screen.getAllByTitle('Permission to edit Note denied');
-    const deleteIcon = screen.getAllByTitle(
-      'Permission to move Note to trashcan denied',
-    );
-    const exportIcon = screen.getAllByTitle('Export Note as XML');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    const editIcon = screen.getByTestId('edit-icon');
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    const exportIcon = screen.getByTestId('export-icon');
 
-    expect(cloneIcon[0]).toBeInTheDocument();
-    fireEvent.click(cloneIcon[0]);
-
+    fireEvent.click(cloneIcon);
     expect(handleNoteCloneClick).toHaveBeenCalledWith(noPermNote);
 
-    expect(editIcon[0]).toBeInTheDocument();
-    fireEvent.click(editIcon[0]);
-
+    fireEvent.click(editIcon);
     expect(handleNoteEditClick).not.toHaveBeenCalled();
 
-    expect(deleteIcon[0]).toBeInTheDocument();
-    fireEvent.click(deleteIcon[0]);
-
+    fireEvent.click(deleteIcon);
     expect(handleNoteDeleteClick).not.toHaveBeenCalled();
 
-    expect(exportIcon[0]).toBeInTheDocument();
-    fireEvent.click(exportIcon[0]);
-
+    fireEvent.click(exportIcon);
     expect(handleNoteDownloadClick).toHaveBeenCalledWith(noPermNote);
   });
 
@@ -531,28 +511,21 @@ describe('Note ToolBarIcons tests', () => {
         onNoteEditClick={handleNoteEditClick}
       />,
     );
-    const cloneIcon = screen.getAllByTitle('Clone Note');
-    const editIcon = screen.getAllByTitle('Edit Note');
-    const deleteIcon = screen.getAllByTitle('Note is still in use');
-    const exportIcon = screen.getAllByTitle('Export Note as XML');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    const editIcon = screen.getByTestId('edit-icon');
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    const exportIcon = screen.getByTestId('export-icon');
 
-    expect(cloneIcon[0]).toBeInTheDocument();
-    fireEvent.click(cloneIcon[0]);
-
+    fireEvent.click(cloneIcon);
     expect(handleNoteCloneClick).toHaveBeenCalledWith(noteInUse);
 
-    expect(editIcon[0]).toBeInTheDocument();
-    fireEvent.click(editIcon[0]);
-
+    fireEvent.click(editIcon);
     expect(handleNoteEditClick).toHaveBeenCalled();
 
-    expect(deleteIcon[0]).toBeInTheDocument();
-    fireEvent.click(deleteIcon[0]);
+    fireEvent.click(deleteIcon);
     expect(handleNoteDeleteClick).not.toHaveBeenCalled();
 
-    expect(exportIcon[0]).toBeInTheDocument();
-    fireEvent.click(exportIcon[0]);
-
+    fireEvent.click(exportIcon);
     expect(handleNoteDownloadClick).toHaveBeenCalledWith(noteInUse);
   });
 });

--- a/src/web/pages/notes/__tests__/ListPage.test.jsx
+++ b/src/web/pages/notes/__tests__/ListPage.test.jsx
@@ -463,7 +463,10 @@ describe('NotesPage ToolBarIcons test', () => {
 
     const links = element.querySelectorAll('a');
 
-    expect(screen.getAllByTitle('Help: Notes')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Notes',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/reports.html#managing-notes',
@@ -485,11 +488,9 @@ describe('NotesPage ToolBarIcons test', () => {
 
     render(<ToolBarIcons onNoteCreateClick={handleNoteCreateClick} />);
 
-    const newIcon = screen.getAllByTitle('New Note');
-
-    expect(newIcon[0]).toBeInTheDocument();
-
-    fireEvent.click(newIcon[0]);
+    const newIcon = screen.getByTestId('new-icon');
+    expect(newIcon).toHaveAttribute('title', 'New Note');
+    fireEvent.click(newIcon);
     expect(handleNoteCreateClick).toHaveBeenCalled();
   });
 
@@ -506,12 +507,12 @@ describe('NotesPage ToolBarIcons test', () => {
       router: true,
     });
 
-    const {queryAllByTestId} = render(
-      <ToolBarIcons onNoteCreateClick={handleNoteCreateClick} />,
-    );
+    render(<ToolBarIcons onNoteCreateClick={handleNoteCreateClick} />);
 
-    const icons = queryAllByTestId('svg-icon'); // this test is probably appropriate to keep in the old format
-    expect(icons.length).toBe(1);
-    expect(icons[0]).toHaveAttribute('title', 'Help: Notes');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Notes',
+    );
+    expect(screen.queryByTestId('new-icon')).toBeNull();
   });
 });

--- a/src/web/pages/nvts/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/nvts/__tests__/DetailsPage.test.jsx
@@ -517,20 +517,17 @@ describe('Nvt ToolBarIcons tests', () => {
       />,
     );
 
-    const exportIcon = screen.getAllByTitle('Export NVT');
-    const addNewNoteIcon = screen.getAllByTitle('Add new Note');
-    const addNewOverrideIcon = screen.getAllByTitle('Add new Override');
+    const exportIcon = screen.getAllByTitle('Export NVT')[0];
+    const addNewNoteIcon = screen.getAllByTitle('Add new Note')[0];
+    const addNewOverrideIcon = screen.getAllByTitle('Add new Override')[0];
 
-    expect(exportIcon[0]).toBeInTheDocument();
-    fireEvent.click(exportIcon[0]);
+    fireEvent.click(exportIcon);
     expect(handleNvtDownloadClick).toHaveBeenCalledWith(nvt);
 
-    expect(addNewNoteIcon[0]).toBeInTheDocument();
-    fireEvent.click(addNewNoteIcon[0]);
+    fireEvent.click(addNewNoteIcon);
     expect(handleOnNoteCreateClick).toHaveBeenCalledWith(nvt);
 
-    expect(addNewOverrideIcon[0]).toBeInTheDocument();
-    fireEvent.click(addNewOverrideIcon[0]);
+    fireEvent.click(addNewOverrideIcon);
     expect(handleOnOverrideCreateClick).toHaveBeenCalledWith(nvt);
   });
 });

--- a/src/web/pages/nvts/__tests__/NvtPreference.test.jsx
+++ b/src/web/pages/nvts/__tests__/NvtPreference.test.jsx
@@ -12,12 +12,16 @@ describe('NvtPreference', () => {
 
   const renderComponent = (preference, value) => {
     render(
-      <NvtPreference
-        preference={preference}
-        title="Edit NVT Details"
-        value={value}
-        onChange={mockOnChange}
-      />,
+      <table>
+        <tbody>
+          <NvtPreference
+            preference={preference}
+            title="Edit NVT Details"
+            value={value}
+            onChange={mockOnChange}
+          />
+        </tbody>
+      </table>,
     );
   };
 

--- a/src/web/pages/nvts/__tests__/Row.test.jsx
+++ b/src/web/pages/nvts/__tests__/Row.test.jsx
@@ -3,17 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-/* eslint-disable no-unused-vars */
-
 import {describe, test, expect, testing} from '@gsa/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
-import {setLocale} from 'gmp/locale/lang';
 import Filter from 'gmp/models/filter.js';
 import NVT from 'gmp/models/nvt';
 import Row from 'web/pages/nvts/Row';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent} from 'web/utils/Testing';
-
+import {rendererWithTable, fireEvent, screen} from 'web/utils/Testing';
 
 const gmp = {settings: {}};
 const caps = new Capabilities(['everything']);
@@ -57,16 +53,11 @@ const entity = NVT.fromElement({
 });
 
 describe('NVT row tests', () => {
-  // deactivate console.error for tests
-  // to make it possible to test a row without a table
-  const consoleError = console.error;
-  console.error = () => {};
-
   test('should render', () => {
     const handleToggleDetailsClick = testing.fn();
     const handleFilterChanged = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       router: true,
@@ -76,7 +67,7 @@ describe('NVT row tests', () => {
     store.dispatch(setTimezone('CET'));
     store.dispatch(setUsername('username'));
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <Row
         entity={entity}
         onFilterChanged={handleFilterChanged}
@@ -84,7 +75,7 @@ describe('NVT row tests', () => {
       />,
     );
 
-    const bars = getAllByTestId('progressbar-box');
+    const bars = screen.getAllByTestId('progressbar-box');
     const links = baseElement.querySelectorAll('a');
 
     expect(baseElement).toHaveTextContent('foo');
@@ -113,7 +104,7 @@ describe('NVT row tests', () => {
 
     const filter = Filter.fromString('family="bar"');
 
-    const {render} = rendererWith({
+    const {render} = rendererWithTable({
       gmp,
       capabilities: true,
       router: true,
@@ -139,6 +130,4 @@ describe('NVT row tests', () => {
     fireEvent.click(links[0]);
     expect(handleFilterChanged).toHaveBeenCalledWith(filter);
   });
-
-  console.warn = consoleError;
 });

--- a/src/web/pages/overrides/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/overrides/__tests__/DetailsPage.test.jsx
@@ -9,7 +9,7 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 import Filter from 'gmp/models/filter';
 import Override from 'gmp/models/override';
 import {currentSettingsDefaultResponse} from 'web/pages/__mocks__/CurrentSettings';
-import Detailspage, {ToolBarIcons} from 'web/pages/overrides/DetailsPage';
+import DetailsPage, {ToolBarIcons} from 'web/pages/overrides/DetailsPage';
 import {entityLoadingActions} from 'web/store/entities/overrides';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/Testing';
@@ -106,7 +106,7 @@ const renewSession = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-describe('Override detailspage tests', () => {
+describe('Override DetailsPage tests', () => {
   test('should render full /DetailsPage', () => {
     const gmp = {
       override: {
@@ -139,7 +139,7 @@ describe('Override detailspage tests', () => {
     );
 
     const {baseElement} = render(
-      <Detailspage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />,
+      <DetailsPage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />,
     );
 
     expect(baseElement).toHaveTextContent('override text');
@@ -238,7 +238,7 @@ describe('Override detailspage tests', () => {
     );
 
     const {baseElement} = render(
-      <Detailspage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />,
+      <DetailsPage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />,
     );
 
     const spans = baseElement.querySelectorAll('span');
@@ -282,7 +282,7 @@ describe('Override detailspage tests', () => {
     );
 
     const {baseElement} = render(
-      <Detailspage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />,
+      <DetailsPage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />,
     );
 
     const spans = baseElement.querySelectorAll('span');
@@ -340,7 +340,7 @@ describe('Override detailspage tests', () => {
       ),
     );
 
-    render(<Detailspage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />);
+    render(<DetailsPage id="6d00d22f-551b-4fbe-8215-d8615eff73ea" />);
 
     await wait();
 

--- a/src/web/pages/overrides/__tests__/ListPage.test.jsx
+++ b/src/web/pages/overrides/__tests__/ListPage.test.jsx
@@ -470,7 +470,10 @@ describe('OverridesPage ToolBarIcons test', () => {
 
     const links = element.querySelectorAll('a');
 
-    expect(screen.getAllByTitle('Help: Overrides')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Overrides',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/reports.html#managing-overrides',
@@ -492,11 +495,9 @@ describe('OverridesPage ToolBarIcons test', () => {
 
     render(<ToolBarIcons onOverrideCreateClick={handleOverrideCreateClick} />);
 
-    const newIcon = screen.getAllByTitle('New Override');
-
-    expect(newIcon[0]).toBeInTheDocument();
-
-    fireEvent.click(newIcon[0]);
+    const newIcon = screen.getByTestId('new-icon');
+    expect(newIcon).toHaveAttribute('title', 'New Override');
+    fireEvent.click(newIcon);
     expect(handleOverrideCreateClick).toHaveBeenCalled();
   });
 
@@ -513,12 +514,9 @@ describe('OverridesPage ToolBarIcons test', () => {
       router: true,
     });
 
-    const {queryAllByTestId} = render(
-      <ToolBarIcons onOverrideCreateClick={handleOverrideCreateClick} />,
-    );
+    render(<ToolBarIcons onOverrideCreateClick={handleOverrideCreateClick} />);
 
-    const icons = queryAllByTestId('svg-icon'); // this test is probably appropriate to keep in the old format
-    expect(icons.length).toBe(1);
-    expect(icons[0]).toHaveAttribute('title', 'Help: Overrides');
+    const newIcon = screen.queryByTestId('new-icon');
+    expect(newIcon).toBeNull();
   });
 });

--- a/src/web/pages/policies/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/policies/__tests__/DetailsPage.test.jsx
@@ -10,10 +10,10 @@ import Filter from 'gmp/models/filter';
 import Policy from 'gmp/models/policy';
 import {vi} from 'vitest';
 import {currentSettingsDefaultResponse} from 'web/pages/__mocks__/CurrentSettings';
-import Detailspage, {ToolBarIcons} from 'web/pages/policies/DetailsPage';
+import DetailsPage, {ToolBarIcons} from 'web/pages/policies/DetailsPage';
 import {entityLoadingActions} from 'web/store/entities/policies';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent, act} from 'web/utils/Testing';
+import {rendererWith, fireEvent, screen} from 'web/utils/Testing';
 
 vi.mock('web/pages/scanconfigs/EditDialog', () => ({
   default: () => null,
@@ -209,8 +209,8 @@ const getPermissions = testing.fn().mockResolvedValue({
   },
 });
 
-describe('Policy Detailspage tests', () => {
-  test('should render full Detailspage', () => {
+describe('Policy DetailsPage tests', () => {
+  test('should render full DetailsPage', () => {
     const getPolicy = testing.fn().mockResolvedValue({
       data: policy,
     });
@@ -241,22 +241,23 @@ describe('Policy Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', policy));
 
-    const {baseElement, getAllByTestId} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     expect(baseElement).toBeVisible();
     expect(baseElement).toHaveTextContent('Policy: foo');
 
     const links = baseElement.querySelectorAll('a');
-    const icons = getAllByTestId('svg-icon');
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: Policies');
+    const helpIcon = screen.getByTestId('help-icon');
+    expect(helpIcon).toHaveAttribute('title', 'Help: Policies');
+    const listIcon = screen.getByTestId('list-icon');
+    expect(listIcon).toHaveAttribute('title', 'Policies List');
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/compliance-and-special-scans.html#configuring-and-managing-policies',
     );
 
     expect(links[1]).toHaveAttribute('href', '/policies');
-    expect(icons[1]).toHaveAttribute('title', 'Policies List');
 
     expect(baseElement).toHaveTextContent('12345');
     expect(baseElement).toHaveTextContent('Tue, Jul 16, 2019 8:31 AM CEST');
@@ -268,8 +269,7 @@ describe('Policy Detailspage tests', () => {
     expect(baseElement).toHaveTextContent('audit2');
     expect(baseElement).not.toHaveTextContent('scanner');
 
-    const detailsLinks = getAllByTestId('details-link');
-
+    const detailsLinks = screen.getAllByTestId('details-link');
     expect(detailsLinks[0]).toHaveAttribute('href', '/audit/1234');
     expect(detailsLinks[1]).toHaveAttribute('href', '/audit/5678');
   });
@@ -306,7 +306,7 @@ describe('Policy Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', policy));
 
-    const {baseElement, getAllByTestId} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     const spans = baseElement.querySelectorAll('span');
     fireEvent.click(spans[10]);
@@ -319,8 +319,6 @@ describe('Policy Detailspage tests', () => {
     expect(baseElement).toHaveTextContent('0 of 2');
 
     const links = baseElement.querySelectorAll('a');
-
-    const icons = getAllByTestId('svg-icon');
 
     expect(links[2]).toHaveAttribute(
       'href',
@@ -340,19 +338,21 @@ describe('Policy Detailspage tests', () => {
     );
     expect(links[4]).toHaveAttribute('title', 'NVTs of family family3');
 
-    expect(icons[7]).toHaveAttribute(
+    const dynamicIcons = screen.getAllByTestId('trend-more-icon');
+    expect(dynamicIcons[0]).toHaveAttribute(
       'title',
       'The families selection is DYNAMIC. New families will automatically be added and considered.',
     );
-    expect(icons[8]).toHaveAttribute(
+    expect(dynamicIcons[1]).toHaveAttribute(
       'title',
       'The NVT selection is DYNAMIC. New NVTs will automatically be added and considered.',
     );
-    expect(icons[9]).toHaveAttribute(
+    const staticIcons = screen.getAllByTestId('trend-nochange-icon');
+    expect(staticIcons[0]).toHaveAttribute(
       'title',
       'The NVT selection is STATIC. New NVTs will NOT automatically be added and considered.',
     );
-    expect(icons[10]).toHaveAttribute(
+    expect(staticIcons[1]).toHaveAttribute(
       'title',
       'The NVT selection is STATIC. New NVTs will NOT automatically be added and considered.',
     );
@@ -390,12 +390,12 @@ describe('Policy Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', policy));
 
-    const {baseElement, getAllByTestId} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     const spans = baseElement.querySelectorAll('span');
     fireEvent.click(spans[12]);
 
-    const detailsLinks = getAllByTestId('details-link');
+    const detailsLinks = screen.getAllByTestId('details-link');
 
     expect(detailsLinks[0]).toHaveAttribute('href', '/nvt/0');
     expect(detailsLinks[0]).toHaveTextContent('nvt0');
@@ -445,7 +445,7 @@ describe('Policy Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', policy));
 
-    const {baseElement} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     const spans = baseElement.querySelectorAll('span');
     fireEvent.click(spans[14]);
@@ -520,30 +520,31 @@ describe('Policy Detailspage tests', () => {
     store.dispatch(setUsername('admin'));
     store.dispatch(entityLoadingActions.success('12345', policy));
 
-    const {getAllByTestId} = render(<Detailspage id="12345" />);
+    render(<DetailsPage id="12345" />);
 
-    const icons = getAllByTestId('svg-icon');
+    const listIcon = screen.getByTestId('list-icon');
+    expect(listIcon).toHaveAttribute('title', 'Policies List');
 
-    expect(icons[1]).toHaveAttribute('title', 'Policies List');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Policy');
+    fireEvent.click(cloneIcon);
+    expect(clone).toHaveBeenCalledWith(policy);
 
-    await act(async () => {
-      fireEvent.click(icons[2]);
-      expect(clone).toHaveBeenCalledWith(policy);
-      expect(icons[2]).toHaveAttribute('title', 'Clone Policy');
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Policy');
+    fireEvent.click(editIcon);
+    expect(getNvtFamilies).toHaveBeenCalled();
+    expect(getAllScanners).toHaveBeenCalled();
 
-      fireEvent.click(icons[3]);
-      expect(getNvtFamilies).toHaveBeenCalled();
-      expect(getAllScanners).toHaveBeenCalled();
-      expect(icons[3]).toHaveAttribute('title', 'Edit Policy');
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Policy to trashcan');
+    fireEvent.click(deleteIcon);
+    expect(deleteFunc).toHaveBeenCalledWith(policyId);
 
-      fireEvent.click(icons[4]);
-      expect(deleteFunc).toHaveBeenCalledWith(policyId);
-      expect(icons[4]).toHaveAttribute('title', 'Move Policy to trashcan');
-
-      fireEvent.click(icons[5]);
-      expect(exportFunc).toHaveBeenCalledWith(policy);
-      expect(icons[5]).toHaveAttribute('title', 'Export Policy as XML');
-    });
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Policy as XML');
+    fireEvent.click(exportIcon);
+    expect(exportFunc).toHaveBeenCalledWith(policy);
   });
 
   test('should not call commands without permission', async () => {
@@ -614,39 +615,40 @@ describe('Policy Detailspage tests', () => {
     store.dispatch(setUsername('admin'));
     store.dispatch(entityLoadingActions.success('12345', policy2));
 
-    const {getAllByTestId} = render(<Detailspage id="12345" />);
+    render(<DetailsPage id="12345" />);
 
-    const icons = getAllByTestId('svg-icon');
+    const listIcon = screen.getByTestId('list-icon');
+    expect(listIcon).toHaveAttribute('title', 'Policies List');
 
-    expect(icons[1]).toHaveAttribute('title', 'Policies List');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute(
+      'title',
+      'Permission to clone Policy denied',
+    );
+    fireEvent.click(cloneIcon);
+    expect(clone).not.toHaveBeenCalled();
 
-    await act(async () => {
-      fireEvent.click(icons[2]);
-      expect(clone).not.toHaveBeenCalled();
-      expect(icons[2]).toHaveAttribute(
-        'title',
-        'Permission to clone Policy denied',
-      );
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute(
+      'title',
+      'Permission to edit Policy denied',
+    );
+    fireEvent.click(editIcon);
+    expect(getNvtFamilies).not.toHaveBeenCalled();
+    expect(getAllScanners).not.toHaveBeenCalled();
 
-      fireEvent.click(icons[3]);
-      expect(getNvtFamilies).not.toHaveBeenCalled();
-      expect(getAllScanners).not.toHaveBeenCalled();
-      expect(icons[3]).toHaveAttribute(
-        'title',
-        'Permission to edit Policy denied',
-      );
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute(
+      'title',
+      'Permission to move Policy to trashcan denied',
+    );
+    fireEvent.click(deleteIcon);
+    expect(deleteFunc).not.toHaveBeenCalled();
 
-      fireEvent.click(icons[4]);
-      expect(deleteFunc).not.toHaveBeenCalled();
-      expect(icons[4]).toHaveAttribute(
-        'title',
-        'Permission to move Policy to trashcan denied',
-      );
-
-      fireEvent.click(icons[5]);
-      expect(exportFunc).toHaveBeenCalledWith(policy2);
-      expect(icons[5]).toHaveAttribute('title', 'Export Policy as XML');
-    });
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Policy as XML');
+    fireEvent.click(exportIcon);
+    expect(exportFunc).toHaveBeenCalledWith(policy2);
   });
 
   test('should (not) call commands if policy is in use', async () => {
@@ -717,30 +719,31 @@ describe('Policy Detailspage tests', () => {
     store.dispatch(setUsername('admin'));
     store.dispatch(entityLoadingActions.success('12345', policy3));
 
-    const {getAllByTestId} = render(<Detailspage id="12345" />);
+    render(<DetailsPage id="12345" />);
 
-    const icons = getAllByTestId('svg-icon');
+    const listIcon = screen.getByTestId('list-icon');
+    expect(listIcon).toHaveAttribute('title', 'Policies List');
 
-    expect(icons[1]).toHaveAttribute('title', 'Policies List');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Policy');
+    fireEvent.click(cloneIcon);
+    expect(clone).toHaveBeenCalledWith(policy3);
 
-    await act(async () => {
-      fireEvent.click(icons[2]);
-      expect(clone).toHaveBeenCalledWith(policy3);
-      expect(icons[2]).toHaveAttribute('title', 'Clone Policy');
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Policy');
+    fireEvent.click(editIcon);
+    expect(getNvtFamilies).toHaveBeenCalled();
+    expect(getAllScanners).toHaveBeenCalled();
 
-      fireEvent.click(icons[3]);
-      expect(getNvtFamilies).toHaveBeenCalled();
-      expect(getAllScanners).toHaveBeenCalled();
-      expect(icons[3]).toHaveAttribute('title', 'Edit Policy');
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Policy is still in use');
+    fireEvent.click(deleteIcon);
+    expect(deleteFunc).not.toHaveBeenCalled();
 
-      fireEvent.click(icons[4]);
-      expect(deleteFunc).not.toHaveBeenCalled();
-      expect(icons[4]).toHaveAttribute('title', 'Policy is still in use');
-
-      fireEvent.click(icons[5]);
-      expect(exportFunc).toHaveBeenCalledWith(policy3);
-      expect(icons[5]).toHaveAttribute('title', 'Export Policy as XML');
-    });
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Policy as XML');
+    fireEvent.click(exportIcon);
+    expect(exportFunc).toHaveBeenCalledWith(policy3);
   });
 
   test('should (not) call commands if policy is not writable', async () => {
@@ -811,30 +814,31 @@ describe('Policy Detailspage tests', () => {
     store.dispatch(setUsername('admin'));
     store.dispatch(entityLoadingActions.success('12345', policy4));
 
-    const {getAllByTestId} = render(<Detailspage id="12345" />);
+    render(<DetailsPage id="12345" />);
 
-    const icons = getAllByTestId('svg-icon');
+    const listIcon = screen.getByTestId('list-icon');
+    expect(listIcon).toHaveAttribute('title', 'Policies List');
 
-    expect(icons[1]).toHaveAttribute('title', 'Policies List');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Policy');
+    fireEvent.click(cloneIcon);
+    expect(clone).toHaveBeenCalledWith(policy4);
 
-    await act(async () => {
-      fireEvent.click(icons[2]);
-      expect(clone).toHaveBeenCalledWith(policy4);
-      expect(icons[2]).toHaveAttribute('title', 'Clone Policy');
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Policy is not writable');
+    fireEvent.click(editIcon);
+    expect(getNvtFamilies).not.toHaveBeenCalled();
+    expect(getAllScanners).not.toHaveBeenCalled();
 
-      fireEvent.click(icons[3]);
-      expect(getNvtFamilies).not.toHaveBeenCalled();
-      expect(getAllScanners).not.toHaveBeenCalled();
-      expect(icons[3]).toHaveAttribute('title', 'Policy is not writable');
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Policy is not writable');
+    fireEvent.click(deleteIcon);
+    expect(deleteFunc).not.toHaveBeenCalled();
 
-      fireEvent.click(icons[4]);
-      expect(deleteFunc).not.toHaveBeenCalled();
-      expect(icons[4]).toHaveAttribute('title', 'Policy is not writable');
-
-      fireEvent.click(icons[5]);
-      expect(exportFunc).toHaveBeenCalledWith(policy4);
-      expect(icons[5]).toHaveAttribute('title', 'Export Policy as XML');
-    });
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Policy as XML');
+    fireEvent.click(exportIcon);
+    expect(exportFunc).toHaveBeenCalledWith(policy4);
   });
 
   // TODO: should render scanner preferences tab
@@ -855,7 +859,7 @@ describe('Policy ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {element, getAllByTestId} = render(
+    const {element} = render(
       <ToolBarIcons
         entity={policy}
         onPolicyCloneClick={handlePolicyCloneClick}
@@ -868,16 +872,16 @@ describe('Policy ToolBarIcons tests', () => {
     expect(element).toBeVisible();
 
     const links = element.querySelectorAll('a');
-    const icons = getAllByTestId('svg-icon');
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: Policies');
+    const helpIcon = screen.getByTestId('help-icon');
+    const listIcon = screen.getByTestId('list-icon');
+    expect(helpIcon).toHaveAttribute('title', 'Help: Policies');
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/compliance-and-special-scans.html#configuring-and-managing-policies',
     );
-
+    expect(listIcon).toHaveAttribute('title', 'Policies List');
     expect(links[1]).toHaveAttribute('href', '/policies');
-    expect(icons[1]).toHaveAttribute('title', 'Policies List');
   });
 
   test('should call click handlers', () => {
@@ -894,7 +898,7 @@ describe('Policy ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {getAllByTestId} = render(
+    render(
       <ToolBarIcons
         entity={policy}
         onPolicyCloneClick={handlePolicyCloneClick}
@@ -904,23 +908,25 @@ describe('Policy ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[2]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Policy');
+    fireEvent.click(cloneIcon);
     expect(handlePolicyCloneClick).toHaveBeenCalledWith(policy);
-    expect(icons[2]).toHaveAttribute('title', 'Clone Policy');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Policy');
+    fireEvent.click(editIcon);
     expect(handlePolicyEditClick).toHaveBeenCalledWith(policy);
-    expect(icons[3]).toHaveAttribute('title', 'Edit Policy');
 
-    fireEvent.click(icons[4]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Policy to trashcan');
+    fireEvent.click(deleteIcon);
     expect(handlePolicyDeleteClick).toHaveBeenCalledWith(policy);
-    expect(icons[4]).toHaveAttribute('title', 'Move Policy to trashcan');
 
-    fireEvent.click(icons[5]);
+    const downloadIcon = screen.getByTestId('export-icon');
+    expect(downloadIcon).toHaveAttribute('title', 'Export Policy as XML');
+    fireEvent.click(downloadIcon);
     expect(handlePolicyDownloadClick).toHaveBeenCalledWith(policy);
-    expect(icons[5]).toHaveAttribute('title', 'Export Policy as XML');
   });
 
   test('should not call click handlers without permission', () => {
@@ -937,7 +943,7 @@ describe('Policy ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {getAllByTestId} = render(
+    render(
       <ToolBarIcons
         entity={policy2}
         onPolicyCloneClick={handlePolicyCloneClick}
@@ -947,32 +953,34 @@ describe('Policy ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[2]);
-    expect(handlePolicyCloneClick).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute(
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute(
       'title',
       'Permission to clone Policy denied',
     );
+    fireEvent.click(cloneIcon);
+    expect(handlePolicyCloneClick).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[3]);
-    expect(handlePolicyEditClick).not.toHaveBeenCalled();
-    expect(icons[3]).toHaveAttribute(
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute(
       'title',
       'Permission to edit Policy denied',
     );
+    fireEvent.click(editIcon);
+    expect(handlePolicyEditClick).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[4]);
-    expect(handlePolicyDeleteClick).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute(
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute(
       'title',
       'Permission to move Policy to trashcan denied',
     );
+    fireEvent.click(deleteIcon);
+    expect(handlePolicyDeleteClick).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[5]);
+    const downloadIcon = screen.getByTestId('export-icon');
+    expect(downloadIcon).toHaveAttribute('title', 'Export Policy as XML');
+    fireEvent.click(downloadIcon);
     expect(handlePolicyDownloadClick).toHaveBeenCalledWith(policy2);
-    expect(icons[5]).toHaveAttribute('title', 'Export Policy as XML');
   });
 
   test('should (not) call click handlers if policy is in use', () => {
@@ -989,7 +997,7 @@ describe('Policy ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {getAllByTestId} = render(
+    render(
       <ToolBarIcons
         entity={policy3}
         onPolicyCloneClick={handlePolicyCloneClick}
@@ -999,23 +1007,25 @@ describe('Policy ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[2]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Policy');
+    fireEvent.click(cloneIcon);
     expect(handlePolicyCloneClick).toHaveBeenCalledWith(policy3);
-    expect(icons[2]).toHaveAttribute('title', 'Clone Policy');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Policy');
+    fireEvent.click(editIcon);
     expect(handlePolicyEditClick).toHaveBeenCalledWith(policy3);
-    expect(icons[3]).toHaveAttribute('title', 'Edit Policy');
 
-    fireEvent.click(icons[4]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Policy is still in use');
+    fireEvent.click(deleteIcon);
     expect(handlePolicyDeleteClick).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute('title', 'Policy is still in use');
 
-    fireEvent.click(icons[5]);
+    const downloadIcon = screen.getByTestId('export-icon');
+    expect(downloadIcon).toHaveAttribute('title', 'Export Policy as XML');
+    fireEvent.click(downloadIcon);
     expect(handlePolicyDownloadClick).toHaveBeenCalledWith(policy3);
-    expect(icons[5]).toHaveAttribute('title', 'Export Policy as XML');
   });
 
   test('should (not) call click handlers if policy is not writable', () => {
@@ -1032,7 +1042,7 @@ describe('Policy ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {getAllByTestId} = render(
+    render(
       <ToolBarIcons
         entity={policy4}
         onPolicyCloneClick={handlePolicyCloneClick}
@@ -1042,22 +1052,24 @@ describe('Policy ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[2]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Policy');
+    fireEvent.click(cloneIcon);
     expect(handlePolicyCloneClick).toHaveBeenCalledWith(policy4);
-    expect(icons[2]).toHaveAttribute('title', 'Clone Policy');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Policy is not writable');
+    fireEvent.click(editIcon);
     expect(handlePolicyEditClick).not.toHaveBeenCalled();
-    expect(icons[3]).toHaveAttribute('title', 'Policy is not writable');
 
-    fireEvent.click(icons[4]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Policy is not writable');
+    fireEvent.click(deleteIcon);
     expect(handlePolicyDeleteClick).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute('title', 'Policy is not writable');
 
-    fireEvent.click(icons[5]);
+    const downloadIcon = screen.getByTestId('export-icon');
+    expect(downloadIcon).toHaveAttribute('title', 'Export Policy as XML');
+    fireEvent.click(downloadIcon);
     expect(handlePolicyDownloadClick).toHaveBeenCalledWith(policy4);
-    expect(icons[5]).toHaveAttribute('title', 'Export Policy as XML');
   });
 });

--- a/src/web/pages/policies/__tests__/ListPage.test.jsx
+++ b/src/web/pages/policies/__tests__/ListPage.test.jsx
@@ -199,7 +199,7 @@ describe('PoliciesPage ToolBarIcons test', () => {
       router: true,
     });
 
-    const {element, getAllByTestId} = render(
+    const {element} = render(
       <ToolBarIcons
         onPolicyCreateClick={handlePolicyCreateClick}
         onPolicyImportClick={handlePolicyImportClick}
@@ -207,10 +207,10 @@ describe('PoliciesPage ToolBarIcons test', () => {
     );
     expect(element).toBeVisible();
 
-    const icons = getAllByTestId('svg-icon');
     const links = element.querySelectorAll('a');
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: Policies');
+    const helpIcon = screen.getByTestId('help-icon');
+    expect(helpIcon).toHaveAttribute('title', 'Help: Policies');
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/compliance-and-special-scans.html#configuring-and-managing-policies',
@@ -231,22 +231,22 @@ describe('PoliciesPage ToolBarIcons test', () => {
       router: true,
     });
 
-    const {getAllByTestId} = render(
+    render(
       <ToolBarIcons
         onPolicyCreateClick={handlePolicyCreateClick}
         onPolicyImportClick={handlePolicyImportClick}
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[1]);
+    const newIcon = screen.getByTestId('new-icon');
+    expect(newIcon).toHaveAttribute('title', 'New Policy');
+    fireEvent.click(newIcon);
     expect(handlePolicyCreateClick).toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'New Policy');
 
-    fireEvent.click(icons[2]);
+    const importIcon = screen.getByTestId('upload-icon');
+    expect(importIcon).toHaveAttribute('title', 'Import Policy');
+    fireEvent.click(importIcon);
     expect(handlePolicyImportClick).toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute('title', 'Import Policy');
   });
 
   test('should not show icons if user does not have the right permissions', () => {
@@ -261,15 +261,16 @@ describe('PoliciesPage ToolBarIcons test', () => {
       router: true,
     });
 
-    const {queryAllByTestId} = render(
+    render(
       <ToolBarIcons
         onPolicyCreateClick={handlePolicyCreateClick}
         onPolicyImportClick={handlePolicyImportClick}
       />,
     );
 
-    const icons = queryAllByTestId('svg-icon');
-    expect(icons.length).toBe(1);
-    expect(icons[0]).toHaveAttribute('title', 'Help: Policies');
+    const newIcon = screen.queryByTestId('new-icon');
+    expect(newIcon).toBeNull();
+    const importIcon = screen.queryByTestId('upload-icon');
+    expect(importIcon).toBeNull();
   });
 });

--- a/src/web/pages/policies/__tests__/Table.test.jsx
+++ b/src/web/pages/policies/__tests__/Table.test.jsx
@@ -9,8 +9,7 @@ import Filter from 'gmp/models/filter';
 import Policy from 'gmp/models/policy';
 import Table from 'web/pages/policies/Table';
 import {setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent} from 'web/utils/Testing';
-
+import {rendererWith, fireEvent, screen} from 'web/utils/Testing';
 
 const policy = Policy.fromElement({
   _id: '12345',
@@ -105,7 +104,7 @@ describe('Policies table tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {element, getAllByTestId} = render(
+    const {element} = render(
       <Table
         entities={[policy, policy2, policy3]}
         entitiesCounts={counts}
@@ -120,9 +119,9 @@ describe('Policies table tests', () => {
 
     expect(element).not.toHaveTextContent('Comment');
 
-    const icons = getAllByTestId('svg-icon');
-    fireEvent.click(icons[0]);
-    expect(icons[0]).toHaveAttribute('title', 'Unfold all details');
+    const unfoldIcon = screen.getByTestId('fold-state-icon-unfold');
+    expect(unfoldIcon).toHaveAttribute('title', 'Unfold all details');
+    fireEvent.click(unfoldIcon);
     expect(element).toHaveTextContent('Comment');
   });
 
@@ -146,7 +145,7 @@ describe('Policies table tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {getAllByTestId} = render(
+    render(
       <Table
         entities={[policy, policy2, policy3]}
         entitiesCounts={counts}
@@ -159,26 +158,29 @@ describe('Policies table tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[5]);
+    const deleteIcon = screen.getAllByTestId('trashcan-icon')[0];
+    expect(deleteIcon).toHaveAttribute('title', 'Move Policy to trashcan');
+    fireEvent.click(deleteIcon);
     expect(handlePolicyDeleteClick).toHaveBeenCalledWith(policy);
-    expect(icons[5]).toHaveAttribute('title', 'Move Policy to trashcan');
 
-    fireEvent.click(icons[6]);
+    const editIcon = screen.getAllByTestId('edit-icon')[0];
+    expect(editIcon).toHaveAttribute('title', 'Edit Policy');
+    fireEvent.click(editIcon);
     expect(handlePolicyEditClick).toHaveBeenCalledWith(policy);
-    expect(icons[6]).toHaveAttribute('title', 'Edit Policy');
 
-    fireEvent.click(icons[7]);
+    const cloneIcon = screen.getAllByTestId('clone-icon')[0];
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Policy');
+    fireEvent.click(cloneIcon);
     expect(handlePolicyCloneClick).toHaveBeenCalledWith(policy);
-    expect(icons[7]).toHaveAttribute('title', 'Clone Policy');
 
-    fireEvent.click(icons[8]);
+    const newIcon = screen.getAllByTestId('new-icon')[0];
+    expect(newIcon).toHaveAttribute('title', 'Create Audit from Policy');
+    fireEvent.click(newIcon);
     expect(handleCreateAuditClick).toHaveBeenCalledWith(policy);
-    expect(icons[8]).toHaveAttribute('title', 'Create Audit from Policy');
 
-    fireEvent.click(icons[9]);
+    const exportIcon = screen.getAllByTestId('export-icon')[0];
+    expect(exportIcon).toHaveAttribute('title', 'Export Policy');
+    fireEvent.click(exportIcon);
     expect(handlePolicyDownloadClick).toHaveBeenCalledWith(policy);
-    expect(icons[9]).toHaveAttribute('title', 'Export Policy');
   });
 });

--- a/src/web/pages/reportconfigs/__tests__/ListPage.test.jsx
+++ b/src/web/pages/reportconfigs/__tests__/ListPage.test.jsx
@@ -191,17 +191,23 @@ describe('ReportConfigsPage tests', () => {
         router: true,
       });
 
-      const {element, getAllByTestId} = render(
+      const {element} = render(
         <ToolBarIcons
           onReportConfigCreateClick={handleReportConfigCreateClick}
         />,
       );
       expect(element).toBeVisible();
 
-      const icons = getAllByTestId('svg-icon');
       const links = element.querySelectorAll('a');
 
-      expect(icons[0]).toHaveAttribute('title', 'Help: Report Configs');
+      expect(screen.getByTestId('help-icon')).toHaveAttribute(
+        'title',
+        'Help: Report Configs',
+      );
+      expect(screen.getByTestId('new-icon')).toHaveAttribute(
+        'title',
+        'New Report Config',
+      );
       expect(links[0]).toHaveAttribute(
         'href',
         'test/en/reports.html#customizing-report-formats-with-report-configurations',
@@ -221,17 +227,16 @@ describe('ReportConfigsPage tests', () => {
         router: true,
       });
 
-      const {getAllByTestId} = render(
+      render(
         <ToolBarIcons
           onReportConfigCreateClick={handleReportConfigCreateClick}
         />,
       );
 
-      const icons = getAllByTestId('svg-icon');
-
-      fireEvent.click(icons[1]);
+      const newIcon = screen.getByTestId('new-icon');
+      expect(newIcon).toHaveAttribute('title', 'New Report Config');
+      fireEvent.click(newIcon);
       expect(handleReportConfigCreateClick).toHaveBeenCalled();
-      expect(icons[1]).toHaveAttribute('title', 'New Report Config');
     });
 
     test('should not show icons if user does not have the right permissions', () => {
@@ -245,15 +250,14 @@ describe('ReportConfigsPage tests', () => {
         router: true,
       });
 
-      const {queryAllByTestId} = render(
+      render(
         <ToolBarIcons
           onReportConfigCreateClick={handleReportConfigCreateClick}
         />,
       );
 
-      const icons = queryAllByTestId('svg-icon');
-      expect(icons.length).toBe(1);
-      expect(icons[0]).toHaveAttribute('title', 'Help: Report Configs');
+      const newIcon = screen.queryByTestId('new-icon');
+      expect(newIcon).toBeNull();
     });
   });
 });

--- a/src/web/pages/reportconfigs/__tests__/Row.test.jsx
+++ b/src/web/pages/reportconfigs/__tests__/Row.test.jsx
@@ -8,8 +8,7 @@ import Capabilities from 'gmp/capabilities/capabilities';
 import ReportConfig from 'gmp/models/reportconfig';
 import Row from 'web/pages/reportconfigs/Row';
 import {setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent} from 'web/utils/Testing';
-
+import {rendererWithTable, fireEvent, screen} from 'web/utils/Testing';
 
 const gmp = {settings: {}};
 const caps = new Capabilities(['everything']);
@@ -39,11 +38,6 @@ const orphanEntity = ReportConfig.fromElement({
 });
 
 describe('Report Config row tests', () => {
-  // deactivate console.error for tests
-  // to make it possible to test a row without a table
-  const consoleError = console.error;
-  console.error = () => {};
-
   test('should render', () => {
     const handleToggleDetailsClick = testing.fn();
     const handleReportConfigClone = testing.fn();
@@ -51,12 +45,13 @@ describe('Report Config row tests', () => {
     const handleReportConfigDownload = testing.fn();
     const handleReportConfigEdit = testing.fn();
 
-    const {render} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
       router: true,
     });
+    store.dispatch(setUsername('admin'));
 
     const {baseElement} = render(
       <Row
@@ -82,12 +77,13 @@ describe('Report Config row tests', () => {
     const handleReportConfigDownload = testing.fn();
     const handleReportConfigEdit = testing.fn();
 
-    const {render} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
       router: true,
     });
+    store.dispatch(setUsername('admin'));
 
     const {baseElement} = render(
       <Row
@@ -130,7 +126,7 @@ describe('Report Config row tests', () => {
     const handleReportConfigDownload = testing.fn();
     const handleReportConfigEdit = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
@@ -139,7 +135,7 @@ describe('Report Config row tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {getAllByTestId} = render(
+    render(
       <Row
         entity={config}
         onReportConfigCloneClick={handleReportConfigClone}
@@ -150,8 +146,11 @@ describe('Report Config row tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-    expect(icons[0]).toHaveAttribute('title', 'Report Config owned by user');
+    const observerIcon = screen.getByTestId('observer-icon');
+    expect(observerIcon).toHaveAttribute(
+      'title',
+      'Report Config owned by user',
+    );
   });
 
   test('should call click handlers', () => {
@@ -161,14 +160,15 @@ describe('Report Config row tests', () => {
     const handleReportConfigDownload = testing.fn();
     const handleReportConfigEdit = testing.fn();
 
-    const {render} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: true,
       store: true,
       router: true,
     });
+    store.dispatch(setUsername('admin'));
 
-    const {baseElement, getAllByTestId} = render(
+    render(
       <Row
         entity={entity}
         onReportConfigCloneClick={handleReportConfigClone}
@@ -179,26 +179,30 @@ describe('Report Config row tests', () => {
       />,
     );
 
-    const spans = baseElement.querySelectorAll('span');
-    fireEvent.click(spans[1]);
+    fireEvent.click(screen.getByTestId('row-details-toggle'));
     expect(handleToggleDetailsClick).toHaveBeenCalledWith(undefined, '1234');
 
-    const icons = getAllByTestId('svg-icon');
-
-    expect(icons[1]).toHaveAttribute('title', 'Move Report Config to trashcan');
-    fireEvent.click(icons[1]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute(
+      'title',
+      'Move Report Config to trashcan',
+    );
+    fireEvent.click(deleteIcon);
     expect(handleReportConfigDelete).toHaveBeenCalledWith(entity);
 
-    expect(icons[2]).toHaveAttribute('title', 'Edit Report Config');
-    fireEvent.click(icons[2]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Report Config');
+    fireEvent.click(editIcon);
     expect(handleReportConfigEdit).toHaveBeenCalledWith(entity);
 
-    expect(icons[3]).toHaveAttribute('title', 'Clone Report Config');
-    fireEvent.click(icons[3]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Report Config');
+    fireEvent.click(cloneIcon);
     expect(handleReportConfigClone).toHaveBeenCalledWith(entity);
 
-    expect(icons[4]).toHaveAttribute('title', 'Export Report Config');
-    fireEvent.click(icons[4]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Report Config');
+    fireEvent.click(exportIcon);
     expect(handleReportConfigDownload).toHaveBeenCalledWith(entity);
   });
 
@@ -221,14 +225,15 @@ describe('Report Config row tests', () => {
       },
     });
 
-    const {render} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
       router: true,
     });
+    store.dispatch(setUsername('admin'));
 
-    const {baseElement, getAllByTestId} = render(
+    render(
       <Row
         entity={config}
         onReportConfigCloneClick={handleReportConfigClone}
@@ -239,36 +244,37 @@ describe('Report Config row tests', () => {
       />,
     );
 
-    const spans = baseElement.querySelectorAll('span');
-    fireEvent.click(spans[1]);
+    fireEvent.click(screen.getByTestId('row-details-toggle'));
     expect(handleToggleDetailsClick).toHaveBeenCalledWith(undefined, '1234');
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
-    expect(handleReportConfigDelete).not.toHaveBeenCalled();
-    expect(icons[0]).toHaveAttribute(
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute(
       'title',
       'Permission to move Report Config to trashcan denied',
     );
+    fireEvent.click(deleteIcon);
+    expect(handleReportConfigDelete).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[1]);
-    expect(handleReportConfigEdit).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute(
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute(
       'title',
       'Permission to edit Report Config denied',
     );
+    fireEvent.click(editIcon);
+    expect(handleReportConfigEdit).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[2]);
-    expect(handleReportConfigClone).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute(
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute(
       'title',
       'Permission to clone Report Config denied',
     );
+    fireEvent.click(cloneIcon);
+    expect(handleReportConfigClone).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[3]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Report Config');
+    fireEvent.click(exportIcon);
     expect(handleReportConfigDownload).toHaveBeenCalledWith(config);
-    expect(icons[3]).toHaveAttribute('title', 'Export Report Config');
   });
 
   test('should (not) call click handlers if scan config is in use', () => {
@@ -291,14 +297,15 @@ describe('Report Config row tests', () => {
       },
     });
 
-    const {render} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: true,
       store: true,
       router: true,
     });
+    store.dispatch(setUsername('admin'));
 
-    const {baseElement, getAllByTestId} = render(
+    render(
       <Row
         entity={config}
         onReportConfigCloneClick={handleReportConfigClone}
@@ -309,27 +316,31 @@ describe('Report Config row tests', () => {
       />,
     );
 
-    const spans = baseElement.querySelectorAll('span');
-    fireEvent.click(spans[1]);
+    fireEvent.click(screen.getByTestId('row-details-toggle'));
     expect(handleToggleDetailsClick).toHaveBeenCalledWith(undefined, '1234');
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute(
+      'title',
+      'Report Config is still in use',
+    );
+    fireEvent.click(deleteIcon);
     expect(handleReportConfigDelete).not.toHaveBeenCalled();
-    expect(icons[0]).toHaveAttribute('title', 'Report Config is still in use');
 
-    fireEvent.click(icons[1]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Report Config');
+    fireEvent.click(editIcon);
     expect(handleReportConfigEdit).toHaveBeenCalledWith(config);
-    expect(icons[1]).toHaveAttribute('title', 'Edit Report Config');
 
-    fireEvent.click(icons[2]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Report Config');
+    fireEvent.click(cloneIcon);
     expect(handleReportConfigClone).toHaveBeenCalledWith(config);
-    expect(icons[2]).toHaveAttribute('title', 'Clone Report Config');
 
-    fireEvent.click(icons[3]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Report Config');
+    fireEvent.click(exportIcon);
     expect(handleReportConfigDownload).toHaveBeenCalledWith(config);
-    expect(icons[3]).toHaveAttribute('title', 'Export Report Config');
   });
 
   test('should (not) call click handlers if scan config is not writable', () => {
@@ -352,14 +363,15 @@ describe('Report Config row tests', () => {
       },
     });
 
-    const {render} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: true,
       store: true,
       router: true,
     });
+    store.dispatch(setUsername('admin'));
 
-    const {baseElement, getAllByTestId} = render(
+    render(
       <Row
         entity={config}
         onReportConfigCloneClick={handleReportConfigClone}
@@ -370,24 +382,30 @@ describe('Report Config row tests', () => {
       />,
     );
 
-    const spans = baseElement.querySelectorAll('span');
-    fireEvent.click(spans[1]);
+    fireEvent.click(screen.getByTestId('row-details-toggle'));
     expect(handleToggleDetailsClick).toHaveBeenCalledWith(undefined, '1234');
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[1]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute(
+      'title',
+      'Report Config is not writable',
+    );
+    fireEvent.click(deleteIcon);
     expect(handleReportConfigDelete).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Report Config is not writable');
 
-    fireEvent.click(icons[2]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Report Config');
+    fireEvent.click(cloneIcon);
     expect(handleReportConfigClone).toHaveBeenCalledWith(config);
-    expect(icons[2]).toHaveAttribute('title', 'Clone Report Config');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Report Config is not writable');
+    fireEvent.click(editIcon);
+    expect(handleReportConfigEdit).not.toHaveBeenCalled();
+
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Report Config');
+    fireEvent.click(exportIcon);
     expect(handleReportConfigDownload).toHaveBeenCalledWith(config);
-    expect(icons[3]).toHaveAttribute('title', 'Export Report Config');
   });
-
-  console.warn = consoleError;
 });

--- a/src/web/pages/reportconfigs/__tests__/Table.test.jsx
+++ b/src/web/pages/reportconfigs/__tests__/Table.test.jsx
@@ -9,8 +9,7 @@ import Filter from 'gmp/models/filter';
 import ReportConfig from 'gmp/models/reportconfig';
 import Table from 'web/pages/reportconfigs/Table';
 import {setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent} from 'web/utils/Testing';
-
+import {rendererWith, fireEvent, screen} from 'web/utils/Testing';
 
 const config = ReportConfig.fromElement({
   _id: '12345',
@@ -115,7 +114,7 @@ describe('Scan Config table tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {element, getAllByTestId} = render(
+    const {element} = render(
       <Table
         entities={[config, config2, config3]}
         entitiesCounts={counts}
@@ -129,9 +128,9 @@ describe('Scan Config table tests', () => {
 
     expect(element).not.toHaveTextContent('Parameters');
 
-    const icons = getAllByTestId('svg-icon');
-    fireEvent.click(icons[0]);
-    expect(icons[0]).toHaveAttribute('title', 'Unfold all details');
+    const unfoldIcon = screen.getByTestId('fold-state-icon-unfold');
+    expect(unfoldIcon).toHaveAttribute('title', 'Unfold all details');
+    fireEvent.click(unfoldIcon);
     expect(element).toHaveTextContent('Parameters');
   });
 
@@ -154,7 +153,7 @@ describe('Scan Config table tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {getAllByTestId} = render(
+    render(
       <Table
         entities={[config, config2, config3]}
         entitiesCounts={counts}
@@ -166,22 +165,27 @@ describe('Scan Config table tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    expect(icons[5]).toHaveAttribute('title', 'Move Report Config to trashcan');
-    fireEvent.click(icons[5]);
+    const deleteIcon = screen.getAllByTestId('trashcan-icon')[0];
+    expect(deleteIcon).toHaveAttribute(
+      'title',
+      'Move Report Config to trashcan',
+    );
+    fireEvent.click(deleteIcon);
     expect(handleReportConfigDelete).toHaveBeenCalledWith(config);
 
-    expect(icons[6]).toHaveAttribute('title', 'Edit Report Config');
-    fireEvent.click(icons[6]);
+    const editIcon = screen.getAllByTestId('edit-icon')[0];
+    expect(editIcon).toHaveAttribute('title', 'Edit Report Config');
+    fireEvent.click(editIcon);
     expect(handleReportConfigEdit).toHaveBeenCalledWith(config);
 
-    expect(icons[7]).toHaveAttribute('title', 'Clone Report Config');
-    fireEvent.click(icons[7]);
+    const cloneIcon = screen.getAllByTestId('clone-icon')[0];
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Report Config');
+    fireEvent.click(cloneIcon);
     expect(handleReportConfigClone).toHaveBeenCalledWith(config);
 
-    expect(icons[8]).toHaveAttribute('title', 'Export Report Config');
-    fireEvent.click(icons[8]);
+    const exportIcon = screen.getAllByTestId('export-icon')[0];
+    expect(exportIcon).toHaveAttribute('title', 'Export Report Config');
+    fireEvent.click(exportIcon);
     expect(handleReportConfigDownload).toHaveBeenCalledWith(config);
   });
 });

--- a/src/web/pages/reports/__tests__/AuditReportRow.test.jsx
+++ b/src/web/pages/reports/__tests__/AuditReportRow.test.jsx
@@ -8,8 +8,7 @@ import React from 'react';
 import {getMockAuditReport} from 'web/pages/reports/__mocks__/MockAuditReport';
 import AuditRow from 'web/pages/reports/AuditReportRow';
 import {setTimezone} from 'web/store/usersettings/actions';
-import {rendererWith} from 'web/utils/Testing';
-
+import {rendererWithTable, screen} from 'web/utils/Testing';
 
 describe('Audit report row', () => {
   test('should render row for Audit report', () => {
@@ -17,7 +16,7 @@ describe('Audit report row', () => {
     const onReportDeleteClick = testing.fn();
     const onReportDeltaSelect = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       capabilities: true,
       store: true,
       router: true,
@@ -25,19 +24,15 @@ describe('Audit report row', () => {
 
     store.dispatch(setTimezone('CET'));
 
-    const {baseElement, getAllByTestId} = render(
-      <table>
-        <tbody>
-          <AuditRow
-            entity={entity}
-            onReportDeleteClick={onReportDeleteClick}
-            onReportDeltaSelect={onReportDeltaSelect}
-          />
-        </tbody>
-      </table>,
+    const {baseElement} = render(
+      <AuditRow
+        entity={entity}
+        onReportDeleteClick={onReportDeleteClick}
+        onReportDeltaSelect={onReportDeltaSelect}
+      />,
     );
 
-    const bars = getAllByTestId('progressbar-box');
+    const bars = screen.getAllByTestId('progressbar-box');
     const links = baseElement.querySelectorAll('a');
     const rows = baseElement.querySelectorAll('tr');
 

--- a/src/web/pages/reports/__tests__/AuditReportsListPage.test.jsx
+++ b/src/web/pages/reports/__tests__/AuditReportsListPage.test.jsx
@@ -27,7 +27,6 @@ import {
   wait,
 } from 'web/utils/Testing';
 
-
 window.URL.createObjectURL = testing.fn();
 
 const {entity} = getMockAuditReport();
@@ -124,10 +123,10 @@ describe('AuditReportsPage tests', () => {
     store.dispatch(setTimezone('CET'));
     store.dispatch(setUsername('admin'));
 
-    const defaultSettingfilter = Filter.fromString('foo=bar');
+    const defaultSettingFilter = Filter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
-      defaultFilterLoadingActions.success('auditreport', defaultSettingfilter),
+      defaultFilterLoadingActions.success('auditreport', defaultSettingFilter),
     );
 
     const counts = new CollectionCounts({
@@ -143,33 +142,42 @@ describe('AuditReportsPage tests', () => {
       entitiesActions.success([entity], filter, loadedFilter, counts),
     );
 
-    const {baseElement, getAllByTestId, within} = render(<AuditReportsPage />);
+    const {baseElement, within} = render(<AuditReportsPage />);
 
     await waitFor(() => baseElement.querySelectorAll('table'));
 
-    const display = getAllByTestId('grid-item');
-    const icons = getAllByTestId('svg-icon');
+    const display = screen.getAllByTestId('grid-item');
     const header = baseElement.querySelectorAll('th');
     const row = baseElement.querySelectorAll('tr');
     const powerFilter = getPowerFilter();
     const select = getSelectElement(powerFilter);
     const inputs = getTextInputs(powerFilter);
+
     // Toolbar Icons
-    expect(icons[0]).toHaveAttribute('title', 'Help: Audit Reports');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Audit Reports',
+    );
 
     // Powerfilter
     expect(inputs[0]).toHaveAttribute('name', 'userFilterString');
-    expect(icons[1]).toHaveAttribute('title', 'Update Filter');
-    expect(icons[2]).toHaveAttribute('title', 'Remove Filter');
-    expect(icons[3]).toHaveAttribute('title', 'Reset to Default Filter');
-    expect(icons[4]).toHaveAttribute('title', 'Help: Powerfilter');
-    expect(icons[5]).toHaveAttribute('title', 'Edit Filter');
+    screen.getAllByTitle('Update Filter');
+    screen.getAllByTitle('Remove Filter');
+    screen.getAllByTitle('Reset to Default Filter');
+    screen.getAllByTitle('Help: Powerfilter');
+    screen.getAllByTitle('Edit Filter');
     const input = within(select).getByTitle('Loaded filter');
     expect(input).toHaveValue('--');
 
-    // // Dashboard
-    expect(icons[7]).toHaveAttribute('title', 'Add new Dashboard Display');
-    expect(icons[8]).toHaveAttribute('title', 'Reset to Defaults');
+    // Dashboard
+    expect(screen.getByTestId('add-dashboard-display')).toHaveAttribute(
+      'title',
+      'Add new Dashboard Display',
+    );
+    expect(screen.getByTestId('reset-dashboard')).toHaveAttribute(
+      'title',
+      'Reset to Defaults',
+    );
     expect(display[0]).toHaveTextContent(
       'Audit Reports by Compliance (Total: 0)',
     );
@@ -256,11 +264,11 @@ describe('AuditReportsPage tests', () => {
       entitiesActions.success([entity], filter, loadedFilter, counts),
     );
 
-    const {baseElement, getByTestId} = render(<AuditReportsPage />);
+    const {baseElement} = render(<AuditReportsPage />);
 
     await waitFor(() => baseElement.querySelectorAll('table'));
 
-    const icon = getByTestId('tags-icon');
+    const icon = screen.getByTestId('tags-icon');
     expect(icon).toHaveAttribute('title', 'Add tag to page contents');
     fireEvent.click(icon);
     expect(getAll).toHaveBeenCalled();

--- a/src/web/pages/results/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/results/__tests__/DetailsPage.test.jsx
@@ -9,7 +9,7 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 import Filter from 'gmp/models/filter';
 import Result from 'gmp/models/result';
 import {currentSettingsDefaultResponse} from 'web/pages/__mocks__/CurrentSettings';
-import Detailspage, {ToolBarIcons} from 'web/pages/results/DetailsPage';
+import DetailsPage, {ToolBarIcons} from 'web/pages/results/DetailsPage';
 import {entityLoadingActions} from 'web/store/entities/results';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {rendererWith, fireEvent, screen, wait} from 'web/utils/Testing';
@@ -154,7 +154,7 @@ describe('Result Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', result));
 
-    const {baseElement} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     // Toolbar Icons
     const links = baseElement.querySelectorAll('a');
@@ -288,7 +288,7 @@ describe('Result Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', result));
 
-    const {baseElement} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     const spans = baseElement.querySelectorAll('span');
     expect(spans[12]).toHaveTextContent('User Tags');
@@ -337,7 +337,7 @@ describe('Result Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', result));
 
-    render(<Detailspage id="12345" />);
+    render(<DetailsPage id="12345" />);
 
     await wait();
 
@@ -385,17 +385,20 @@ describe('Result ToolBarIcons tests', () => {
     );
 
     const links = element.querySelectorAll('a');
-    const icons = screen.getAllByTestId('svg-icon');
 
-    expect(icons.length).toBe(9);
-
-    expect(screen.getAllByTitle('Help: Results')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Results',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/reports.html#displaying-all-existing-results',
     );
 
-    expect(screen.getAllByTitle('Results List')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'Results List',
+    );
     expect(links[1]).toHaveAttribute('href', '/results');
 
     expect(screen.getAllByTitle('Export Result as XML')[0]).toBeInTheDocument();
@@ -435,16 +438,23 @@ describe('Result ToolBarIcons tests', () => {
       />,
     );
 
-    fireEvent.click(screen.getAllByTitle('Export Result as XML')[0]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Result as XML');
+    fireEvent.click(exportIcon);
     expect(handleResultDownloadClick).toHaveBeenCalledWith(result);
 
-    fireEvent.click(screen.getAllByTitle('Add new Note')[0]);
-    expect(handleNoteCreateClick).toHaveBeenCalledWith(result);
+    const newNoteIcon = screen.getByTestId('new-note-icon');
+    expect(newNoteIcon).toHaveAttribute('title', 'Add new Note');
+    fireEvent.click(newNoteIcon);
 
-    fireEvent.click(screen.getAllByTitle('Add new Override')[0]);
+    const newOverrideIcon = screen.getByTestId('new-override-icon');
+    expect(newOverrideIcon).toHaveAttribute('title', 'Add new Override');
+    fireEvent.click(newOverrideIcon);
     expect(handleOverrideCreateClick).toHaveBeenCalledWith(result);
 
-    fireEvent.click(screen.getAllByTitle('Create new Ticket')[0]);
+    const newTicketIcon = screen.getByTestId('new-ticket-icon');
+    expect(newTicketIcon).toHaveAttribute('title', 'Create new Ticket');
+    fireEvent.click(newTicketIcon);
     expect(handleTicketCreateClick).toHaveBeenCalledWith(result);
   });
 
@@ -475,20 +485,23 @@ describe('Result ToolBarIcons tests', () => {
     );
 
     const links = element.querySelectorAll('a');
-    const icons = screen.getAllByTestId('svg-icon');
 
-    expect(icons.length).toBe(3);
-
-    expect(screen.getAllByTitle('Help: Results')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Results',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/reports.html#displaying-all-existing-results',
     );
 
-    expect(screen.getAllByTitle('Results List')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'Results List',
+    );
     expect(links[1]).toHaveAttribute('href', '/results');
 
-    expect(screen.getAllByTitle('Export Result as XML')[0]).toBeInTheDocument();
+    screen.getAllByTitle('Export Result as XML');
     expect(screen.queryByTitle('Add new Note')).not.toBeInTheDocument();
     expect(screen.queryByTitle('Add new Override')).not.toBeInTheDocument();
     expect(screen.queryByTitle('Create new Ticket')).not.toBeInTheDocument();

--- a/src/web/pages/results/__tests__/Row.test.jsx
+++ b/src/web/pages/results/__tests__/Row.test.jsx
@@ -6,13 +6,12 @@
 import {describe, test, expect} from '@gsa/testing';
 import Result from 'gmp/models/result';
 import Row from 'web/pages/results/Row';
-import {rendererWith} from 'web/utils/Testing';
-
+import {rendererWithTable, screen} from 'web/utils/Testing';
 
 const gmp = {settings: {enableEPSS: true}};
 
 describe('Should render EPSS fields', () => {
-  const {render} = rendererWith({gmp, store: true});
+  const {render} = rendererWithTable({gmp, store: true});
 
   test('should render EPSS columns', () => {
     const entity = Result.fromElement({
@@ -47,13 +46,7 @@ describe('Should render EPSS fields', () => {
       },
     });
 
-    const {element} = render(
-      <table>
-        <tbody>
-          <Row entity={entity} />
-        </tbody>
-      </table>,
-    );
+    const {element} = render(<Row entity={entity} />);
 
     expect(element).toHaveTextContent('0.87650');
     expect(element).toHaveTextContent('80.000%');
@@ -61,7 +54,7 @@ describe('Should render EPSS fields', () => {
 });
 
 describe('Delta reports V2 with changed severity, qod and hostname', () => {
-  const {render} = rendererWith({gmp, store: true});
+  const {render} = rendererWithTable({gmp, store: true});
 
   test('should render Delta Difference icon', () => {
     const entity = Result.fromElement({
@@ -86,24 +79,25 @@ describe('Delta reports V2 with changed severity, qod and hostname', () => {
       },
     });
 
-    const {getAllByTestId} = render(
-      <table>
-        <tbody>
-          <Row entity={entity} />
-        </tbody>
-      </table>,
-    );
-    const icons = getAllByTestId('svg-icon');
+    render(<Row entity={entity} />);
 
-    expect(icons.length).toEqual(3);
-    expect(icons[0]).toHaveAttribute('title', 'Severity is changed from 2.6.');
-    expect(icons[1]).toHaveAttribute('title', 'QoD is changed from 70.');
-    expect(icons[2]).toHaveAttribute('title', 'Hostname is changed from bar.');
+    expect(screen.getAllByTestId('delta-difference-icon')[0]).toHaveAttribute(
+      'title',
+      'Severity is changed from 2.6.',
+    );
+    expect(screen.getAllByTestId('delta-difference-icon')[1]).toHaveAttribute(
+      'title',
+      'QoD is changed from 70.',
+    );
+    expect(screen.getAllByTestId('delta-difference-icon')[2]).toHaveAttribute(
+      'title',
+      'Hostname is changed from bar.',
+    );
   });
 });
 
 describe('Delta reports V2 with same severity, qod and hostname', () => {
-  const {render} = rendererWith({gmp, store: true});
+  const {render} = rendererWithTable({gmp, store: true});
 
   test('should not render Delta Difference icon', () => {
     const entity = Result.fromElement({
@@ -128,21 +122,15 @@ describe('Delta reports V2 with same severity, qod and hostname', () => {
       },
     });
 
-    const {queryAllByTestId} = render(
-      <table>
-        <tbody>
-          <Row entity={entity} />
-        </tbody>
-      </table>,
-    );
-    const icons = queryAllByTestId('svg-icon');
+    render(<Row entity={entity} />);
 
+    const icons = screen.queryAllByTestId('svg-icon');
     expect(icons.length).toBe(0);
   });
 });
 
 describe('Audit reports with compliance', () => {
-  const {render} = rendererWith({gmp, store: true});
+  const {render} = rendererWithTable({gmp, store: true});
 
   test('should render Audit report with compliance yes', () => {
     const entity = Result.fromElement({
@@ -158,14 +146,8 @@ describe('Audit reports with compliance', () => {
       compliance: 'yes',
     });
 
-    const {getAllByTestId} = render(
-      <table>
-        <tbody>
-          <Row audit={true} entity={entity} />
-        </tbody>
-      </table>,
-    );
-    const bars = getAllByTestId('progressbar-box');
+    render(<Row audit={true} entity={entity} />);
+    const bars = screen.getAllByTestId('progressbar-box');
 
     expect(bars[0]).toHaveAttribute('title', 'Yes');
     expect(bars[0]).toHaveTextContent('Yes');
@@ -185,14 +167,8 @@ describe('Audit reports with compliance', () => {
       compliance: 'no',
     });
 
-    const {getAllByTestId} = render(
-      <table>
-        <tbody>
-          <Row audit={true} entity={entity} />
-        </tbody>
-      </table>,
-    );
-    const bars = getAllByTestId('progressbar-box');
+    render(<Row audit={true} entity={entity} />);
+    const bars = screen.getAllByTestId('progressbar-box');
     expect(bars[0]).toHaveAttribute('title', 'No');
     expect(bars[0]).toHaveTextContent('No');
   });
@@ -211,14 +187,8 @@ describe('Audit reports with compliance', () => {
       compliance: 'incomplete',
     });
 
-    const {getAllByTestId} = render(
-      <table>
-        <tbody>
-          <Row audit={true} entity={entity} />
-        </tbody>
-      </table>,
-    );
-    const bars = getAllByTestId('progressbar-box');
+    render(<Row audit={true} entity={entity} />);
+    const bars = screen.getAllByTestId('progressbar-box');
     expect(bars[0]).toHaveAttribute('title', 'Incomplete');
     expect(bars[0]).toHaveTextContent('Incomplete');
   });
@@ -237,14 +207,8 @@ describe('Audit reports with compliance', () => {
       compliance: 'undefined',
     });
 
-    const {getAllByTestId} = render(
-      <table>
-        <tbody>
-          <Row audit={true} entity={entity} />
-        </tbody>
-      </table>,
-    );
-    const bars = getAllByTestId('progressbar-box');
+    render(<Row audit={true} entity={entity} />);
+    const bars = screen.getAllByTestId('progressbar-box');
     expect(bars[0]).toHaveAttribute('title', 'Undefined');
     expect(bars[0]).toHaveTextContent('Undefined');
   });
@@ -269,14 +233,8 @@ describe('Audit reports with compliance', () => {
       },
     });
 
-    const {getAllByTestId} = render(
-      <table>
-        <tbody>
-          <Row audit={true} entity={entity} />
-        </tbody>
-      </table>,
-    );
-    const icons = getAllByTestId('svg-icon');
+    render(<Row audit={true} entity={entity} />);
+    const icons = screen.getAllByTestId('delta-difference-icon');
     expect(icons.length).toEqual(1);
     expect(icons[0]).toHaveAttribute(
       'title',

--- a/src/web/pages/scanconfigs/NvtFamilies.jsx
+++ b/src/web/pages/scanconfigs/NvtFamilies.jsx
@@ -26,7 +26,6 @@ import useTranslation from 'web/hooks/useTranslation';
 import Trend from 'web/pages/scanconfigs/Trend';
 import PropTypes from 'web/utils/PropTypes';
 
-
 const WHOLE_SELECTION_FAMILIES = [
   'AIX Local Security Checks',
   'AlmaLinux Local Security Checks',
@@ -161,6 +160,7 @@ const NvtFamilies = ({
   return (
     <Section
       foldable
+      data-testid="nvt-families-section"
       title={_('Edit Network Vulnerability Test Families ({{counts}})', {
         counts: families.length,
       })}

--- a/src/web/pages/scanconfigs/NvtPreferences.jsx
+++ b/src/web/pages/scanconfigs/NvtPreferences.jsx
@@ -70,6 +70,7 @@ const NvtPreferences = ({
   return (
     <Section
       foldable
+      data-testid="nvt-preferences-section"
       initialFoldState={FoldState.FOLDED}
       title={_('Network Vulnerability Test Preferences ({{counts}})', {
         counts: preferences.length,

--- a/src/web/pages/scanconfigs/ScannerPreferences.jsx
+++ b/src/web/pages/scanconfigs/ScannerPreferences.jsx
@@ -92,6 +92,7 @@ const ScannerPreferences = ({
   return (
     <Section
       foldable
+      data-testid="scanner-preferences-section"
       initialFoldState={FoldState.FOLDED}
       title={_('Edit Scanner Preferences ({{counts}})', {
         counts: preferences.length,

--- a/src/web/pages/scanconfigs/__tests__/Details.test.jsx
+++ b/src/web/pages/scanconfigs/__tests__/Details.test.jsx
@@ -8,8 +8,7 @@ import Capabilities from 'gmp/capabilities/capabilities';
 import ScanConfig from 'gmp/models/scanconfig';
 import {OPENVAS_SCANNER_TYPE} from 'gmp/models/scanner';
 import Details from 'web/pages/scanconfigs/Details';
-import {rendererWith} from 'web/utils/Testing';
-
+import {rendererWith, screen} from 'web/utils/Testing';
 
 describe('Scan Config Details tests', () => {
   test('should render full Details', () => {
@@ -28,11 +27,11 @@ describe('Scan Config Details tests', () => {
 
     const {render} = rendererWith({capabilities: caps, router: true});
 
-    const {element, getAllByTestId} = render(<Details entity={config} />);
+    const {element} = render(<Details entity={config} />);
 
     expect(element).toHaveTextContent('bar');
 
-    const detailsLinks = getAllByTestId('details-link');
+    const detailsLinks = screen.getAllByTestId('details-link');
 
     expect(element).toHaveTextContent('task1');
     expect(detailsLinks[0]).toHaveAttribute('href', '/task/1234');

--- a/src/web/pages/scanconfigs/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/scanconfigs/__tests__/DetailsPage.test.jsx
@@ -10,10 +10,10 @@ import Filter from 'gmp/models/filter';
 import ScanConfig from 'gmp/models/scanconfig';
 import {vi} from 'vitest';
 import {currentSettingsDefaultResponse} from 'web/pages/__mocks__/CurrentSettings';
-import Detailspage, {ToolBarIcons} from 'web/pages/scanconfigs/DetailsPage';
+import DetailsPage, {ToolBarIcons} from 'web/pages/scanconfigs/DetailsPage';
 import {entityLoadingActions} from 'web/store/entities/scanconfigs';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent, act} from 'web/utils/Testing';
+import {rendererWith, fireEvent, act, wait, screen} from 'web/utils/Testing';
 
 vi.mock('web/pages/scanconfigs/EditDialog', () => ({
   default: () => null,
@@ -210,8 +210,8 @@ const getPermissions = testing.fn().mockResolvedValue({
   },
 });
 
-describe('Scan Config Detailspage tests', () => {
-  test('should render full Detailspage', () => {
+describe('Scan Config DetailsPage tests', () => {
+  test('should render full DetailsPage', () => {
     const getConfig = testing.fn().mockResolvedValue({
       data: config,
     });
@@ -242,23 +242,28 @@ describe('Scan Config Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', config));
 
-    const {baseElement, getAllByTestId} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     expect(baseElement).toBeVisible();
     expect(baseElement).toHaveTextContent('Scan Config: foo');
 
     const links = baseElement.querySelectorAll('a');
-    const icons = getAllByTestId('svg-icon');
-    const detailsLinks = getAllByTestId('details-link');
+    const detailsLinks = screen.getAllByTestId('details-link');
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: ScanConfigs');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: ScanConfigs',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/scanning.html#managing-scan-configurations',
     );
 
     expect(links[1]).toHaveAttribute('href', '/scanconfigs');
-    expect(icons[1]).toHaveAttribute('title', 'ScanConfig List');
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'ScanConfig List',
+    );
 
     expect(baseElement).toHaveTextContent('12345');
     expect(baseElement).toHaveTextContent('Tue, Jul 16, 2019 8:31 AM CEST');
@@ -308,7 +313,7 @@ describe('Scan Config Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', config));
 
-    const {baseElement, getAllByTestId} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     const spans = baseElement.querySelectorAll('span');
     fireEvent.click(spans[12]);
@@ -321,8 +326,6 @@ describe('Scan Config Detailspage tests', () => {
     expect(baseElement).toHaveTextContent('0 of 2');
 
     const links = baseElement.querySelectorAll('a');
-
-    const icons = getAllByTestId('svg-icon');
 
     expect(links[2]).toHaveAttribute(
       'href',
@@ -340,19 +343,19 @@ describe('Scan Config Detailspage tests', () => {
     );
     expect(links[4]).toHaveAttribute('title', 'NVTs of family family3');
 
-    expect(icons[9]).toHaveAttribute(
+    expect(screen.getAllByTestId('trend-more-icon')[0]).toHaveAttribute(
       'title',
       'The families selection is DYNAMIC. New families will automatically be added and considered.',
     );
-    expect(icons[10]).toHaveAttribute(
+    expect(screen.getAllByTestId('trend-more-icon')[1]).toHaveAttribute(
       'title',
       'The NVT selection is DYNAMIC. New NVTs will automatically be added and considered.',
     );
-    expect(icons[11]).toHaveAttribute(
+    expect(screen.getAllByTestId('trend-nochange-icon')[0]).toHaveAttribute(
       'title',
       'The NVT selection is STATIC. New NVTs will NOT automatically be added and considered.',
     );
-    expect(icons[12]).toHaveAttribute(
+    expect(screen.getAllByTestId('trend-nochange-icon')[1]).toHaveAttribute(
       'title',
       'The NVT selection is STATIC. New NVTs will NOT automatically be added and considered.',
     );
@@ -390,7 +393,7 @@ describe('Scan Config Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', config));
 
-    const {baseElement, getAllByTestId} = render(<Detailspage id="12345" />);
+    const {baseElement, getAllByTestId} = render(<DetailsPage id="12345" />);
 
     const spans = baseElement.querySelectorAll('span');
     fireEvent.click(spans[14]);
@@ -456,7 +459,7 @@ describe('Scan Config Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', config));
 
-    const {baseElement} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     const spans = baseElement.querySelectorAll('span');
     fireEvent.click(spans[16]);
@@ -496,7 +499,7 @@ describe('Scan Config Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', config));
 
-    const {baseElement} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     const spans = baseElement.querySelectorAll('span');
     fireEvent.click(spans[18]);
@@ -505,36 +508,24 @@ describe('Scan Config Detailspage tests', () => {
   });
 
   test('should call commands', async () => {
-    const getConfig = testing.fn().mockReturnValue(
-      Promise.resolve({
-        data: config,
-      }),
-    );
-    const clone = testing.fn().mockReturnValue(
-      Promise.resolve({
-        data: {id: 'foo'},
-      }),
-    );
-    const getNvtFamilies = testing.fn().mockReturnValue(
-      Promise.resolve({
-        foo: 'bar',
-      }),
-    );
-    const getAllScanners = testing.fn().mockReturnValue(
-      Promise.resolve({
-        data: scanners,
-      }),
-    );
-    const deleteFunc = testing.fn().mockReturnValue(
-      Promise.resolve({
-        foo: 'bar',
-      }),
-    );
-    const exportFunc = testing.fn().mockReturnValue(
-      Promise.resolve({
-        foo: 'bar',
-      }),
-    );
+    const getConfig = testing.fn().mockResolvedValue({
+      data: config,
+    });
+    const clone = testing.fn().mockResolvedValue({
+      data: {id: 'foo'},
+    });
+    const getNvtFamilies = testing.fn().mockResolvedValue({
+      foo: 'bar',
+    });
+    const getAllScanners = testing.fn().mockResolvedValue({
+      data: scanners,
+    });
+    const deleteFunc = testing.fn().mockRejectedValue({
+      foo: 'bar',
+    });
+    const exportFunc = testing.fn().mockResolvedValue({
+      foo: 'bar',
+    });
 
     const gmp = {
       [entityType]: {
@@ -571,68 +562,74 @@ describe('Scan Config Detailspage tests', () => {
     store.dispatch(setUsername('admin'));
     store.dispatch(entityLoadingActions.success('12345', config));
 
-    const {getAllByTestId} = render(<Detailspage id="12345" />);
+    render(<DetailsPage id="12345" />);
 
-    const icons = getAllByTestId('svg-icon');
-    expect(icons[0]).toHaveAttribute('title', 'Help: ScanConfigs');
-    expect(icons[1]).toHaveAttribute('title', 'ScanConfig List');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: ScanConfigs',
+    );
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'ScanConfig List',
+    );
+    expect(screen.getByTestId('new-icon')).toHaveAttribute(
+      'title',
+      'Create new Scan Config',
+    );
+    expect(screen.getByTestId('upload-icon')).toHaveAttribute(
+      'title',
+      'Import Scan Config',
+    );
 
-    expect(icons[2]).toHaveAttribute('title', 'Create new Scan Config');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
+    expect(clone).toHaveBeenCalledWith(config);
+    await wait();
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Scan Config');
 
-    await act(async () => {
-      fireEvent.click(icons[3]);
-      expect(clone).toHaveBeenCalledWith(config);
-      expect(icons[3]).toHaveAttribute('title', 'Clone Scan Config');
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
+    expect(getNvtFamilies).toHaveBeenCalled();
+    expect(getAllScanners).toHaveBeenCalled();
+    await wait();
+    expect(editIcon).toHaveAttribute('title', 'Edit Scan Config');
 
-      fireEvent.click(icons[4]);
-      expect(getNvtFamilies).toHaveBeenCalled();
-      expect(getAllScanners).toHaveBeenCalled();
-      expect(icons[4]).toHaveAttribute('title', 'Edit Scan Config');
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
+    await wait();
+    expect(exportFunc).toHaveBeenCalledWith(config);
+    expect(exportIcon).toHaveAttribute('title', 'Export Scan Config as XML');
 
-      fireEvent.click(icons[5]);
+    act(() => {
+      const trashcanIcon = screen.getByTestId('trashcan-icon');
+      fireEvent.click(trashcanIcon);
       expect(deleteFunc).toHaveBeenCalledWith(configId);
-      expect(icons[5]).toHaveAttribute('title', 'Move Scan Config to trashcan');
-
-      fireEvent.click(icons[6]);
-      expect(exportFunc).toHaveBeenCalledWith(config);
-      expect(icons[6]).toHaveAttribute('title', 'Export Scan Config as XML');
+      expect(trashcanIcon).toHaveAttribute(
+        'title',
+        'Move Scan Config to trashcan',
+      );
     });
-
-    expect(icons[7]).toHaveAttribute('title', 'Import Scan Config');
   });
 
   test('should not call commands without permission', async () => {
-    const getConfig = testing.fn().mockReturnValue(
-      Promise.resolve({
-        data: config2,
-      }),
-    );
-
-    const clone = testing.fn().mockReturnValue(
-      Promise.resolve({
-        data: {id: 'foo'},
-      }),
-    );
-    const getNvtFamilies = testing.fn().mockReturnValue(
-      Promise.resolve({
-        foo: 'bar',
-      }),
-    );
-    const getAllScanners = testing.fn().mockReturnValue(
-      Promise.resolve({
-        data: scanners,
-      }),
-    );
-    const deleteFunc = testing.fn().mockReturnValue(
-      Promise.resolve({
-        foo: 'bar',
-      }),
-    );
-    const exportFunc = testing.fn().mockReturnValue(
-      Promise.resolve({
-        foo: 'bar',
-      }),
-    );
+    const getConfig = testing.fn().mockResolvedValue({
+      data: config2,
+    });
+    const clone = testing.fn().mockResolvedValue({
+      data: {id: 'foo'},
+    });
+    const getNvtFamilies = testing.fn().mockResolvedValue({
+      foo: 'bar',
+    });
+    const getAllScanners = testing.fn().mockResolvedValue({
+      data: scanners,
+    });
+    const deleteFunc = testing.fn().mockResolvedValue({
+      foo: 'bar',
+    });
+    const exportFunc = testing.fn().mockResolvedValue({
+      foo: 'bar',
+    });
 
     const gmp = {
       [entityType]: {
@@ -669,78 +666,77 @@ describe('Scan Config Detailspage tests', () => {
     store.dispatch(setUsername('admin'));
     store.dispatch(entityLoadingActions.success('12345', config2));
 
-    const {getAllByTestId} = render(<Detailspage id="12345" />);
+    render(<DetailsPage id="12345" />);
 
-    const icons = getAllByTestId('svg-icon');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: ScanConfigs',
+    );
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'ScanConfig List',
+    );
+    expect(screen.getByTestId('new-icon')).toHaveAttribute(
+      'title',
+      'Create new Scan Config',
+    );
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: ScanConfigs');
-    expect(icons[1]).toHaveAttribute('title', 'ScanConfig List');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
+    expect(clone).not.toHaveBeenCalled();
+    expect(cloneIcon).toHaveAttribute(
+      'title',
+      'Permission to clone Scan Config denied',
+    );
 
-    expect(icons[2]).toHaveAttribute('title', 'Create new Scan Config');
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
+    expect(getNvtFamilies).not.toHaveBeenCalled();
+    expect(getAllScanners).not.toHaveBeenCalled();
+    expect(editIcon).toHaveAttribute(
+      'title',
+      'Permission to edit Scan Config denied',
+    );
 
-    await act(async () => {
-      fireEvent.click(icons[3]);
-      expect(clone).not.toHaveBeenCalled();
-      expect(icons[3]).toHaveAttribute(
-        'title',
-        'Permission to clone Scan Config denied',
-      );
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
+    expect(exportFunc).toHaveBeenCalledWith(config2);
+    await wait();
+    expect(exportIcon).toHaveAttribute('title', 'Export Scan Config as XML');
 
-      fireEvent.click(icons[4]);
-      expect(getNvtFamilies).not.toHaveBeenCalled();
-      expect(getAllScanners).not.toHaveBeenCalled();
-      expect(icons[4]).toHaveAttribute(
-        'title',
-        'Permission to edit Scan Config denied',
-      );
+    expect(screen.getByTestId('upload-icon')).toHaveAttribute(
+      'title',
+      'Import Scan Config',
+    );
 
-      fireEvent.click(icons[5]);
-      expect(deleteFunc).not.toHaveBeenCalled();
-      expect(icons[5]).toHaveAttribute(
-        'title',
-        'Permission to move Scan Config to trashcan denied',
-      );
-
-      fireEvent.click(icons[6]);
-      expect(exportFunc).toHaveBeenCalledWith(config2);
-      expect(icons[6]).toHaveAttribute('title', 'Export Scan Config as XML');
-    });
-
-    expect(icons[7]).toHaveAttribute('title', 'Import Scan Config');
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
+    expect(deleteFunc).not.toHaveBeenCalled();
+    expect(deleteIcon).toHaveAttribute(
+      'title',
+      'Permission to move Scan Config to trashcan denied',
+    );
   });
 
   test('should (not) call commands if config is in use', async () => {
-    const getConfig = testing.fn().mockReturnValue(
-      Promise.resolve({
-        data: config3,
-      }),
-    );
-
-    const clone = testing.fn().mockReturnValue(
-      Promise.resolve({
-        data: {id: 'foo'},
-      }),
-    );
-    const getNvtFamilies = testing.fn().mockReturnValue(
-      Promise.resolve({
-        foo: 'bar',
-      }),
-    );
-    const getAllScanners = testing.fn().mockReturnValue(
-      Promise.resolve({
-        data: scanners,
-      }),
-    );
-    const deleteFunc = testing.fn().mockReturnValue(
-      Promise.resolve({
-        foo: 'bar',
-      }),
-    );
-    const exportFunc = testing.fn().mockReturnValue(
-      Promise.resolve({
-        foo: 'bar',
-      }),
-    );
+    const getConfig = testing.fn().mockResolvedValue({
+      data: config3,
+    });
+    const clone = testing.fn().mockResolvedValue({
+      data: {id: 'foo'},
+    });
+    const getNvtFamilies = testing.fn().mockResolvedValue({
+      foo: 'bar',
+    });
+    const getAllScanners = testing.fn().mockResolvedValue({
+      data: scanners,
+    });
+    const deleteFunc = testing.fn().mockResolvedValue({
+      foo: 'bar',
+    });
+    const exportFunc = testing.fn().mockResolvedValue({
+      foo: 'bar',
+    });
 
     const gmp = {
       [entityType]: {
@@ -777,69 +773,69 @@ describe('Scan Config Detailspage tests', () => {
     store.dispatch(setUsername('admin'));
     store.dispatch(entityLoadingActions.success('12345', config3));
 
-    const {getAllByTestId} = render(<Detailspage id="12345" />);
+    render(<DetailsPage id="12345" />);
 
-    const icons = getAllByTestId('svg-icon');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: ScanConfigs',
+    );
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'ScanConfig List',
+    );
+    expect(screen.getByTestId('new-icon')).toHaveAttribute(
+      'title',
+      'Create new Scan Config',
+    );
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: ScanConfigs');
-    expect(icons[1]).toHaveAttribute('title', 'ScanConfig List');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
+    expect(clone).toHaveBeenCalledWith(config3);
+    await wait();
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Scan Config');
 
-    expect(icons[2]).toHaveAttribute('title', 'Create new Scan Config');
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
+    expect(getNvtFamilies).toHaveBeenCalled();
+    expect(getAllScanners).toHaveBeenCalled();
+    expect(editIcon).toHaveAttribute('title', 'Edit Scan Config');
 
-    await act(async () => {
-      fireEvent.click(icons[3]);
-      expect(clone).toHaveBeenCalledWith(config3);
-      expect(icons[3]).toHaveAttribute('title', 'Clone Scan Config');
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
+    expect(deleteFunc).not.toHaveBeenCalled();
+    expect(deleteIcon).toHaveAttribute('title', 'Scan Config is still in use');
 
-      fireEvent.click(icons[4]);
-      expect(getNvtFamilies).toHaveBeenCalled();
-      expect(getAllScanners).toHaveBeenCalled();
-      expect(icons[4]).toHaveAttribute('title', 'Edit Scan Config');
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
+    expect(exportFunc).toHaveBeenCalledWith(config3);
+    await wait();
+    expect(exportIcon).toHaveAttribute('title', 'Export Scan Config as XML');
 
-      fireEvent.click(icons[5]);
-      expect(deleteFunc).not.toHaveBeenCalled();
-      expect(icons[5]).toHaveAttribute('title', 'Scan Config is still in use');
-
-      fireEvent.click(icons[6]);
-      expect(exportFunc).toHaveBeenCalledWith(config3);
-      expect(icons[6]).toHaveAttribute('title', 'Export Scan Config as XML');
-    });
-
-    expect(icons[7]).toHaveAttribute('title', 'Import Scan Config');
+    expect(screen.getByTestId('upload-icon')).toHaveAttribute(
+      'title',
+      'Import Scan Config',
+    );
   });
 
   test('should (not) call commands if config is not writable', async () => {
-    const getConfig = testing.fn().mockReturnValue(
-      Promise.resolve({
-        data: config4,
-      }),
-    );
-
-    const clone = testing.fn().mockReturnValue(
-      Promise.resolve({
-        data: {id: 'foo'},
-      }),
-    );
-    const getNvtFamilies = testing.fn().mockReturnValue(
-      Promise.resolve({
-        foo: 'bar',
-      }),
-    );
-    const getAllScanners = testing.fn().mockReturnValue(
-      Promise.resolve({
-        data: scanners,
-      }),
-    );
-    const deleteFunc = testing.fn().mockReturnValue(
-      Promise.resolve({
-        foo: 'bar',
-      }),
-    );
-    const exportFunc = testing.fn().mockReturnValue(
-      Promise.resolve({
-        foo: 'bar',
-      }),
-    );
+    const getConfig = testing.fn().mockResolvedValue({
+      data: config4,
+    });
+    const clone = testing.fn().mockResolvedValue({
+      data: {id: 'foo'},
+    });
+    const getNvtFamilies = testing.fn().mockResolvedValue({
+      foo: 'bar',
+    });
+    const getAllScanners = testing.fn().mockResolvedValue({
+      data: scanners,
+    });
+    const deleteFunc = testing.fn().mockResolvedValue({
+      foo: 'bar',
+    });
+    const exportFunc = testing.fn().mockResolvedValue({
+      foo: 'bar',
+    });
 
     const gmp = {
       [entityType]: {
@@ -876,38 +872,49 @@ describe('Scan Config Detailspage tests', () => {
     store.dispatch(setUsername('admin'));
     store.dispatch(entityLoadingActions.success('12345', config4));
 
-    const {getAllByTestId} = render(<Detailspage id="12345" />);
+    render(<DetailsPage id="12345" />);
 
-    const icons = getAllByTestId('svg-icon');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: ScanConfigs',
+    );
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'ScanConfig List',
+    );
+    expect(screen.getByTestId('new-icon')).toHaveAttribute(
+      'title',
+      'Create new Scan Config',
+    );
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: ScanConfigs');
-    expect(icons[1]).toHaveAttribute('title', 'ScanConfig List');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
+    expect(clone).toHaveBeenCalledWith(config4);
+    await wait();
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Scan Config');
 
-    expect(icons[2]).toHaveAttribute('title', 'Create new Scan Config');
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
+    expect(getNvtFamilies).not.toHaveBeenCalled();
+    expect(getAllScanners).not.toHaveBeenCalled();
+    expect(editIcon).toHaveAttribute('title', 'Scan Config is not writable');
 
-    await act(async () => {
-      fireEvent.click(icons[3]);
-      expect(clone).toHaveBeenCalledWith(config4);
-      expect(icons[3]).toHaveAttribute('title', 'Clone Scan Config');
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
+    expect(deleteFunc).not.toHaveBeenCalled();
+    expect(deleteIcon).toHaveAttribute('title', 'Scan Config is not writable');
 
-      fireEvent.click(icons[4]);
-      expect(getNvtFamilies).not.toHaveBeenCalled();
-      expect(getAllScanners).not.toHaveBeenCalled();
-      expect(icons[4]).toHaveAttribute('title', 'Scan Config is not writable');
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
+    expect(exportFunc).toHaveBeenCalledWith(config4);
+    await wait();
+    expect(exportIcon).toHaveAttribute('title', 'Export Scan Config as XML');
 
-      fireEvent.click(icons[5]);
-      expect(deleteFunc).not.toHaveBeenCalled();
-      expect(icons[5]).toHaveAttribute('title', 'Scan Config is not writable');
-
-      fireEvent.click(icons[6]);
-      expect(exportFunc).toHaveBeenCalledWith(config4);
-      expect(icons[6]).toHaveAttribute('title', 'Export Scan Config as XML');
-    });
-
-    expect(icons[7]).toHaveAttribute('title', 'Import Scan Config');
+    expect(screen.getByTestId('upload-icon')).toHaveAttribute(
+      'title',
+      'Import Scan Config',
+    );
   });
-
-  // TODO: should render scanner preferences tab
 });
 
 describe('Scan Config ToolBarIcons tests', () => {
@@ -925,7 +932,7 @@ describe('Scan Config ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {element, getAllByTestId} = render(
+    const {element} = render(
       <ToolBarIcons
         entity={config}
         onScanConfigCloneClick={handleScanConfigClone}
@@ -940,16 +947,20 @@ describe('Scan Config ToolBarIcons tests', () => {
     expect(element).toBeVisible();
 
     const links = element.querySelectorAll('a');
-    const icons = getAllByTestId('svg-icon');
-
-    expect(icons[0]).toHaveAttribute('title', 'Help: ScanConfigs');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: ScanConfigs',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/scanning.html#managing-scan-configurations',
     );
 
     expect(links[1]).toHaveAttribute('href', '/scanconfigs');
-    expect(icons[1]).toHaveAttribute('title', 'ScanConfig List');
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'ScanConfig List',
+    );
   });
 
   test('should call click handlers', () => {
@@ -966,7 +977,7 @@ describe('Scan Config ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {getAllByTestId} = render(
+    render(
       <ToolBarIcons
         entity={config}
         onScanConfigCloneClick={handleScanConfigClone}
@@ -978,34 +989,44 @@ describe('Scan Config ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: ScanConfigs',
+    );
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'ScanConfig List',
+    );
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: ScanConfigs');
-    expect(icons[1]).toHaveAttribute('title', 'ScanConfig List');
-
-    fireEvent.click(icons[2]);
+    const createIcon = screen.getByTestId('new-icon');
+    fireEvent.click(createIcon);
     expect(handleScanConfigCreate).toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute('title', 'Create new Scan Config');
+    expect(createIcon).toHaveAttribute('title', 'Create new Scan Config');
 
-    fireEvent.click(icons[3]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleScanConfigClone).toHaveBeenCalledWith(config);
-    expect(icons[3]).toHaveAttribute('title', 'Clone Scan Config');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Scan Config');
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleScanConfigEdit).toHaveBeenCalledWith(config);
-    expect(icons[4]).toHaveAttribute('title', 'Edit Scan Config');
+    expect(editIcon).toHaveAttribute('title', 'Edit Scan Config');
 
-    fireEvent.click(icons[5]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleScanConfigDelete).toHaveBeenCalledWith(config);
-    expect(icons[5]).toHaveAttribute('title', 'Move Scan Config to trashcan');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Scan Config to trashcan');
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleScanConfigDownload).toHaveBeenCalledWith(config);
-    expect(icons[6]).toHaveAttribute('title', 'Export Scan Config as XML');
+    expect(exportIcon).toHaveAttribute('title', 'Export Scan Config as XML');
 
-    fireEvent.click(icons[7]);
+    const uploadIcon = screen.getByTestId('upload-icon');
+    fireEvent.click(uploadIcon);
     expect(handleScanConfigImport).toHaveBeenCalled();
-    expect(icons[7]).toHaveAttribute('title', 'Import Scan Config');
+    expect(uploadIcon).toHaveAttribute('title', 'Import Scan Config');
   });
 
   test('should not call click handlers without permission', () => {
@@ -1022,7 +1043,7 @@ describe('Scan Config ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {getAllByTestId} = render(
+    render(
       <ToolBarIcons
         entity={config2}
         onScanConfigCloneClick={handleScanConfigClone}
@@ -1034,38 +1055,43 @@ describe('Scan Config ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: ScanConfigs',
+    );
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'ScanConfig List',
+    );
 
-    expect(icons.length).toBe(6);
-    // because create icon and import icon are not rendered
-
-    expect(icons[0]).toHaveAttribute('title', 'Help: ScanConfigs');
-    expect(icons[1]).toHaveAttribute('title', 'ScanConfig List');
-
-    fireEvent.click(icons[2]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleScanConfigClone).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute(
+    expect(cloneIcon).toHaveAttribute(
       'title',
       'Permission to clone Scan Config denied',
     );
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleScanConfigEdit).not.toHaveBeenCalled();
-    expect(icons[3]).toHaveAttribute(
+    expect(editIcon).toHaveAttribute(
       'title',
       'Permission to edit Scan Config denied',
     );
 
-    fireEvent.click(icons[4]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleScanConfigDelete).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute(
+    expect(deleteIcon).toHaveAttribute(
       'title',
       'Permission to move Scan Config to trashcan denied',
     );
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleScanConfigDownload).toHaveBeenCalledWith(config2);
-    expect(icons[5]).toHaveAttribute('title', 'Export Scan Config as XML');
+    expect(exportIcon).toHaveAttribute('title', 'Export Scan Config as XML');
   });
 
   test('should (not) call click handlers if config is in use', () => {
@@ -1082,7 +1108,7 @@ describe('Scan Config ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {getAllByTestId} = render(
+    render(
       <ToolBarIcons
         entity={config3}
         onScanConfigCloneClick={handleScanConfigClone}
@@ -1094,34 +1120,44 @@ describe('Scan Config ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: ScanConfigs',
+    );
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'ScanConfig List',
+    );
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: ScanConfigs');
-    expect(icons[1]).toHaveAttribute('title', 'ScanConfig List');
-
-    fireEvent.click(icons[2]);
+    const newIcon = screen.getByTestId('new-icon');
+    fireEvent.click(newIcon);
     expect(handleScanConfigCreate).toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute('title', 'Create new Scan Config');
+    expect(newIcon).toHaveAttribute('title', 'Create new Scan Config');
 
-    fireEvent.click(icons[3]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleScanConfigClone).toHaveBeenCalledWith(config3);
-    expect(icons[3]).toHaveAttribute('title', 'Clone Scan Config');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Scan Config');
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleScanConfigEdit).toHaveBeenCalledWith(config3);
-    expect(icons[4]).toHaveAttribute('title', 'Edit Scan Config');
+    expect(editIcon).toHaveAttribute('title', 'Edit Scan Config');
 
-    fireEvent.click(icons[5]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleScanConfigDelete).not.toHaveBeenCalled();
-    expect(icons[5]).toHaveAttribute('title', 'Scan Config is still in use');
+    expect(deleteIcon).toHaveAttribute('title', 'Scan Config is still in use');
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleScanConfigDownload).toHaveBeenCalledWith(config3);
-    expect(icons[6]).toHaveAttribute('title', 'Export Scan Config as XML');
+    expect(exportIcon).toHaveAttribute('title', 'Export Scan Config as XML');
 
-    fireEvent.click(icons[7]);
+    const uploadIcon = screen.getByTestId('upload-icon');
+    fireEvent.click(uploadIcon);
     expect(handleScanConfigImport).toHaveBeenCalled();
-    expect(icons[7]).toHaveAttribute('title', 'Import Scan Config');
+    expect(uploadIcon).toHaveAttribute('title', 'Import Scan Config');
   });
 
   test('should (not) call click handlers if config is not writable', () => {
@@ -1138,7 +1174,7 @@ describe('Scan Config ToolBarIcons tests', () => {
       router: true,
     });
 
-    const {getAllByTestId} = render(
+    render(
       <ToolBarIcons
         entity={config4}
         onScanConfigCloneClick={handleScanConfigClone}
@@ -1150,33 +1186,43 @@ describe('Scan Config ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: ScanConfigs',
+    );
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'ScanConfig List',
+    );
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: ScanConfigs');
-    expect(icons[1]).toHaveAttribute('title', 'ScanConfig List');
-
-    fireEvent.click(icons[2]);
+    const newIcon = screen.getByTestId('new-icon');
+    fireEvent.click(newIcon);
     expect(handleScanConfigCreate).toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute('title', 'Create new Scan Config');
+    expect(newIcon).toHaveAttribute('title', 'Create new Scan Config');
 
-    fireEvent.click(icons[3]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleScanConfigClone).toHaveBeenCalledWith(config4);
-    expect(icons[3]).toHaveAttribute('title', 'Clone Scan Config');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Scan Config');
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleScanConfigEdit).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute('title', 'Scan Config is not writable');
+    expect(editIcon).toHaveAttribute('title', 'Scan Config is not writable');
 
-    fireEvent.click(icons[5]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(deleteIcon);
     expect(handleScanConfigDelete).not.toHaveBeenCalled();
-    expect(icons[5]).toHaveAttribute('title', 'Scan Config is not writable');
+    expect(deleteIcon).toHaveAttribute('title', 'Scan Config is not writable');
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleScanConfigDownload).toHaveBeenCalledWith(config4);
-    expect(icons[6]).toHaveAttribute('title', 'Export Scan Config as XML');
+    expect(exportIcon).toHaveAttribute('title', 'Export Scan Config as XML');
 
-    fireEvent.click(icons[7]);
+    const uploadIcon = screen.getByTestId('upload-icon');
+    fireEvent.click(uploadIcon);
     expect(handleScanConfigImport).toHaveBeenCalled();
-    expect(icons[7]).toHaveAttribute('title', 'Import Scan Config');
+    expect(uploadIcon).toHaveAttribute('title', 'Import Scan Config');
   });
 });

--- a/src/web/pages/scanconfigs/__tests__/Dialog.test.jsx
+++ b/src/web/pages/scanconfigs/__tests__/Dialog.test.jsx
@@ -15,7 +15,6 @@ import {
 import CreateScanConfigDialog from 'web/pages/scanconfigs/Dialog';
 import {render, fireEvent} from 'web/utils/Testing';
 
-
 describe('CreateScanConfigDialog component tests', () => {
   test('should render dialog with base config as default', () => {
     const handleClose = testing.fn();

--- a/src/web/pages/scanconfigs/__tests__/EditConfigFamilyDialog.test.jsx
+++ b/src/web/pages/scanconfigs/__tests__/EditConfigFamilyDialog.test.jsx
@@ -14,7 +14,6 @@ import {
 import EditConfigFamilyDialog from 'web/pages/scanconfigs/EditConfigFamilyDialog';
 import {rendererWith, fireEvent, within, screen} from 'web/utils/Testing';
 
-
 const nvt = Nvt.fromElement({
   _oid: '1234',
   name: 'nvt',
@@ -80,7 +79,7 @@ describe('EditConfigFamilyDialog component tests', () => {
     const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
-    const {baseElement, getByTestId} = render(
+    const {baseElement} = render(
       <EditConfigFamilyDialog
         configId="c1"
         configName="foo"
@@ -98,7 +97,7 @@ describe('EditConfigFamilyDialog component tests', () => {
 
     expect(baseElement).toBeVisible();
 
-    expect(getByTestId('loading')).toBeInTheDocument();
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
 
     expect(baseElement).not.toHaveTextContent('Config');
     expect(baseElement).not.toHaveTextContent('foo');
@@ -142,7 +141,7 @@ describe('EditConfigFamilyDialog component tests', () => {
     const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
-    const {getByTestId} = render(
+    render(
       <EditConfigFamilyDialog
         configId="c1"
         configName="foo"
@@ -158,7 +157,7 @@ describe('EditConfigFamilyDialog component tests', () => {
       />,
     );
 
-    const closeButton = getByTestId('dialog-close-button');
+    const closeButton = screen.getByTestId('dialog-close-button');
 
     fireEvent.click(closeButton);
 
@@ -172,7 +171,7 @@ describe('EditConfigFamilyDialog component tests', () => {
     const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
-    const {baseElement, getByTestId} = render(
+    const {baseElement} = render(
       <EditConfigFamilyDialog
         configId="c1"
         configName="foo"
@@ -191,7 +190,7 @@ describe('EditConfigFamilyDialog component tests', () => {
     const inputs = baseElement.querySelectorAll('input');
     fireEvent.click(inputs[0]);
 
-    const saveButton = getByTestId('dialog-save-button');
+    const saveButton = screen.getByTestId('dialog-save-button');
     fireEvent.click(saveButton);
 
     const newSelected = {

--- a/src/web/pages/scanconfigs/__tests__/EditDialog.test.jsx
+++ b/src/web/pages/scanconfigs/__tests__/EditDialog.test.jsx
@@ -495,7 +495,10 @@ describe('EditScanConfigDialog component tests', () => {
     const handleOpenEditConfigFamilyDialog = testing.fn();
     const handleOpenEditNvtDetailsDialog = testing.fn();
 
-    const {render} = rendererWith({capabilities: true, router: true});
+    const {render} = rendererWith({
+      capabilities: true,
+      router: true,
+    });
     render(
       <EditScanConfigDialog
         comment="bar"
@@ -520,27 +523,26 @@ describe('EditScanConfigDialog component tests', () => {
       />,
     );
 
-    const content = getDialogContent();
-    const sections = content.querySelectorAll('section');
+    const editNvtFamiliesSection = screen.getByTestId('nvt-families-section');
+    const editFamilyIcons = getAllByTestId(editNvtFamiliesSection, 'edit-icon');
+    fireEvent.click(editFamilyIcons[0]);
 
-    const editFamilyIcons = getAllByTestId(sections[0], 'svg-icon');
-    fireEvent.click(editFamilyIcons[3]);
-
-    expect(editFamilyIcons[3]).toHaveAttribute(
+    expect(editFamilyIcons[0]).toHaveAttribute(
       'title',
       'Edit Scan Config Family',
     );
+    expect(handleOpenEditConfigFamilyDialog).toHaveBeenCalledWith('family1');
 
-    const editNvtIcons = getAllByTestId(sections[2], 'svg-icon');
-    fireEvent.click(editNvtIcons[1]);
+    const editNvtPreferencesSection = screen.getByTestId(
+      'nvt-preferences-section',
+    );
+    const editNvtIcons = getAllByTestId(editNvtPreferencesSection, 'edit-icon');
+    fireEvent.click(editNvtIcons[0]);
 
     expect(editNvtIcons[1]).toHaveAttribute(
       'title',
       'Edit Scan Config NVT Details',
     );
-
-    expect(handleOpenEditConfigFamilyDialog).toHaveBeenCalledWith('family1');
-
     expect(handleOpenEditNvtDetailsDialog).toHaveBeenCalledWith('1.2.1');
   });
 

--- a/src/web/pages/scanconfigs/__tests__/ListPage.test.jsx
+++ b/src/web/pages/scanconfigs/__tests__/ListPage.test.jsx
@@ -218,7 +218,7 @@ describe('ScanConfigsPage ToolBarIcons test', () => {
       router: true,
     });
 
-    const {element, getAllByTestId} = render(
+    const {element} = render(
       <ToolBarIcons
         onScanConfigCreateClick={handleScanConfigCreateClick}
         onScanConfigImportClick={handleScanConfigImportClick}
@@ -226,10 +226,10 @@ describe('ScanConfigsPage ToolBarIcons test', () => {
     );
     expect(element).toBeVisible();
 
-    const icons = getAllByTestId('svg-icon');
+    const helpIcon = screen.getByTestId('help-icon');
     const links = element.querySelectorAll('a');
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: Scan Configs');
+    expect(helpIcon).toHaveAttribute('title', 'Help: Scan Configs');
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/scanning.html#managing-scan-configurations',
@@ -250,22 +250,22 @@ describe('ScanConfigsPage ToolBarIcons test', () => {
       router: true,
     });
 
-    const {getAllByTestId} = render(
+    render(
       <ToolBarIcons
         onScanConfigCreateClick={handleScanConfigCreateClick}
         onScanConfigImportClick={handleScanConfigImportClick}
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[1]);
+    const newIcon = screen.getByTestId('new-icon');
+    fireEvent.click(newIcon);
     expect(handleScanConfigCreateClick).toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'New Scan Config');
+    expect(newIcon).toHaveAttribute('title', 'New Scan Config');
 
-    fireEvent.click(icons[2]);
+    const uploadIcon = screen.getByTestId('upload-icon');
+    fireEvent.click(uploadIcon);
     expect(handleScanConfigImportClick).toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute('title', 'Import Scan Config');
+    expect(uploadIcon).toHaveAttribute('title', 'Import Scan Config');
   });
 
   test('should not show icons if user does not have the right permissions', () => {
@@ -280,15 +280,21 @@ describe('ScanConfigsPage ToolBarIcons test', () => {
       router: true,
     });
 
-    const {queryAllByTestId} = render(
+    render(
       <ToolBarIcons
         onScanConfigCreateClick={handleScanConfigCreateClick}
         onScanConfigImportClick={handleScanConfigImportClick}
       />,
     );
 
-    const icons = queryAllByTestId('svg-icon');
-    expect(icons.length).toBe(1);
-    expect(icons[0]).toHaveAttribute('title', 'Help: Scan Configs');
+    const newIcon = screen.queryByTestId('new-icon');
+    expect(newIcon).toBeNull();
+    const uploadIcon = screen.queryByTestId('upload-icon');
+    expect(uploadIcon).toBeNull();
+
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Scan Configs',
+    );
   });
 });

--- a/src/web/pages/scanconfigs/__tests__/Row.test.jsx
+++ b/src/web/pages/scanconfigs/__tests__/Row.test.jsx
@@ -11,8 +11,7 @@ import ScanConfig, {
 } from 'gmp/models/scanconfig';
 import Row from 'web/pages/scanconfigs/Row';
 import {setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent} from 'web/utils/Testing';
-
+import {rendererWithTable, fireEvent, screen} from 'web/utils/Testing';
 
 const gmp = {settings: {}};
 const caps = new Capabilities(['everything']);
@@ -35,27 +34,25 @@ const entity = ScanConfig.fromElement({
 });
 
 describe('Scan Config row tests', () => {
-  // deactivate console.error for tests
-  // to make it possible to test a row without a table
-  const consoleError = console.error;
-  console.error = () => {};
-
   test('should render', () => {
     const handleToggleDetailsClick = testing.fn();
     const handleScanConfigClone = testing.fn();
     const handleScanConfigDelete = testing.fn();
     const handleScanConfigDownload = testing.fn();
     const handleScanConfigEdit = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
-    const {render} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
     });
+    store.dispatch(setUsername('admin'));
 
-    const {baseElement, getAllByTestId} = render(
+    const {element} = render(
       <Row
         entity={entity}
+        openEditNvtDetailsDialog={handleOpenEditNvtDetailsDialog}
         onScanConfigCloneClick={handleScanConfigClone}
         onScanConfigDeleteClick={handleScanConfigDelete}
         onScanConfigDownloadClick={handleScanConfigDownload}
@@ -64,16 +61,15 @@ describe('Scan Config row tests', () => {
       />,
     );
 
-    expect(baseElement).toBeVisible();
-    expect(baseElement).toHaveTextContent('foo');
-    expect(baseElement).toHaveTextContent('(bar)');
+    expect(element).toBeVisible();
+    expect(element).toHaveTextContent('foo');
+    expect(screen.getByTestId('comment')).toHaveTextContent('(bar)');
 
-    const icons = getAllByTestId('svg-icon');
-    expect(icons[0]).toHaveAttribute(
+    expect(screen.getByTestId('trend-nochange-icon')).toHaveAttribute(
       'title',
       'The family selection is STATIC. New families will NOT automatically be added and considered.',
     );
-    expect(icons[1]).toHaveAttribute(
+    expect(screen.getByTestId('trend-more-icon')).toHaveAttribute(
       'title',
       'The NVT selection is DYNAMIC. New NVTs of selected families will automatically be added and considered.',
     );
@@ -106,16 +102,19 @@ describe('Scan Config row tests', () => {
     const handleScanConfigDelete = testing.fn();
     const handleScanConfigDownload = testing.fn();
     const handleScanConfigEdit = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
-    const {render} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
     });
+    store.dispatch(setUsername('admin'));
 
-    const {baseElement} = render(
+    const {element} = render(
       <Row
         entity={config}
+        openEditNvtDetailsDialog={handleOpenEditNvtDetailsDialog}
         onScanConfigCloneClick={handleScanConfigClone}
         onScanConfigDeleteClick={handleScanConfigDelete}
         onScanConfigDownloadClick={handleScanConfigDownload}
@@ -124,7 +123,7 @@ describe('Scan Config row tests', () => {
       />,
     );
 
-    expect(baseElement).toHaveTextContent('(Deprecated)');
+    expect(element).toHaveTextContent('(Deprecated)');
   });
 
   test('should render observer icon', () => {
@@ -153,18 +152,19 @@ describe('Scan Config row tests', () => {
     const handleScanConfigDelete = testing.fn();
     const handleScanConfigDownload = testing.fn();
     const handleScanConfigEdit = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
     });
-
     store.dispatch(setUsername('admin'));
 
-    const {getAllByTestId} = render(
+    render(
       <Row
         entity={config}
+        openEditNvtDetailsDialog={handleOpenEditNvtDetailsDialog}
         onScanConfigCloneClick={handleScanConfigClone}
         onScanConfigDeleteClick={handleScanConfigDelete}
         onScanConfigDownloadClick={handleScanConfigDownload}
@@ -173,8 +173,8 @@ describe('Scan Config row tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-    expect(icons[0]).toHaveAttribute('title', 'Scan Config owned by user');
+    const observerIcon = screen.getByTestId('observer-icon');
+    expect(observerIcon).toHaveAttribute('title', 'Scan Config owned by user');
   });
 
   test('should call click handlers', () => {
@@ -184,16 +184,19 @@ describe('Scan Config row tests', () => {
     const handleScanConfigDownload = testing.fn();
     const handleScanConfigEdit = testing.fn();
     const handleScanConfigSettings = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
-    const {render} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: true,
       store: true,
     });
+    store.dispatch(setUsername('admin'));
 
-    const {baseElement, getAllByTestId} = render(
+    render(
       <Row
         entity={entity}
+        openEditNvtDetailsDialog={handleOpenEditNvtDetailsDialog}
         onScanConfigCloneClick={handleScanConfigClone}
         onScanConfigDeleteClick={handleScanConfigDelete}
         onScanConfigDownloadClick={handleScanConfigDownload}
@@ -203,31 +206,36 @@ describe('Scan Config row tests', () => {
       />,
     );
 
-    const spans = baseElement.querySelectorAll('span');
-    fireEvent.click(spans[1]);
+    fireEvent.click(screen.getByTestId('row-details-toggle'));
     expect(handleToggleDetailsClick).toHaveBeenCalledWith(undefined, '1234');
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[2]);
+    const settingsIcon = screen.getByTestId('settings-2-icon');
+    fireEvent.click(settingsIcon);
     expect(handleScanConfigSettings).toHaveBeenCalledWith(entity);
-    expect(icons[2]).toHaveAttribute('title', 'Edit Scan Config settings');
+    expect(settingsIcon).toHaveAttribute('title', 'Edit Scan Config settings');
 
-    fireEvent.click(icons[3]);
+    const trashcanIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(trashcanIcon);
     expect(handleScanConfigDelete).toHaveBeenCalledWith(entity);
-    expect(icons[3]).toHaveAttribute('title', 'Move Scan Config to trashcan');
+    expect(trashcanIcon).toHaveAttribute(
+      'title',
+      'Move Scan Config to trashcan',
+    );
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleScanConfigEdit).toHaveBeenCalledWith(entity);
-    expect(icons[4]).toHaveAttribute('title', 'Edit Scan Config');
+    expect(editIcon).toHaveAttribute('title', 'Edit Scan Config');
 
-    fireEvent.click(icons[5]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleScanConfigClone).toHaveBeenCalledWith(entity);
-    expect(icons[5]).toHaveAttribute('title', 'Clone Scan Config');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Scan Config');
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleScanConfigDownload).toHaveBeenCalledWith(entity);
-    expect(icons[6]).toHaveAttribute('title', 'Export Scan Config');
+    expect(exportIcon).toHaveAttribute('title', 'Export Scan Config');
   });
 
   test('should not call click handlers without permissions', () => {
@@ -237,6 +245,7 @@ describe('Scan Config row tests', () => {
     const handleScanConfigDownload = testing.fn();
     const handleScanConfigEdit = testing.fn();
     const handleScanConfigSettings = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const config = ScanConfig.fromElement({
       _id: '1234',
@@ -254,15 +263,17 @@ describe('Scan Config row tests', () => {
       },
     });
 
-    const {render} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       store: true,
     });
+    store.dispatch(setUsername('admin'));
 
-    const {baseElement, getAllByTestId} = render(
+    render(
       <Row
         entity={config}
+        openEditNvtDetailsDialog={handleOpenEditNvtDetailsDialog}
         onScanConfigCloneClick={handleScanConfigClone}
         onScanConfigDeleteClick={handleScanConfigDelete}
         onScanConfigDownloadClick={handleScanConfigDownload}
@@ -272,43 +283,44 @@ describe('Scan Config row tests', () => {
       />,
     );
 
-    const spans = baseElement.querySelectorAll('span');
-    fireEvent.click(spans[1]);
+    fireEvent.click(screen.getByTestId('row-details-toggle'));
     expect(handleToggleDetailsClick).toHaveBeenCalledWith(undefined, '1234');
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[2]);
+    const settingsIcon = screen.getByTestId('settings-2-icon');
+    fireEvent.click(settingsIcon);
     expect(handleScanConfigSettings).not.toHaveBeenCalledWith(entity);
-    expect(icons[2]).toHaveAttribute(
+    expect(settingsIcon).toHaveAttribute(
       'title',
       'Permission to edit Scan Config settings denied',
     );
 
-    fireEvent.click(icons[3]);
+    const trashcanIcon = screen.getByTestId('trashcan-icon');
     expect(handleScanConfigDelete).not.toHaveBeenCalled();
-    expect(icons[3]).toHaveAttribute(
+    expect(trashcanIcon).toHaveAttribute(
       'title',
       'Permission to move Scan Config to trashcan denied',
     );
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleScanConfigEdit).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute(
+    expect(editIcon).toHaveAttribute(
       'title',
       'Permission to edit Scan Config denied',
     );
 
-    fireEvent.click(icons[5]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleScanConfigClone).not.toHaveBeenCalled();
-    expect(icons[5]).toHaveAttribute(
+    expect(cloneIcon).toHaveAttribute(
       'title',
       'Permission to clone Scan Config denied',
     );
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleScanConfigDownload).toHaveBeenCalledWith(config);
-    expect(icons[6]).toHaveAttribute('title', 'Export Scan Config');
+    expect(exportIcon).toHaveAttribute('title', 'Export Scan Config');
   });
 
   test('should (not) call click handlers if scan config is in use', () => {
@@ -318,6 +330,7 @@ describe('Scan Config row tests', () => {
     const handleScanConfigDownload = testing.fn();
     const handleScanConfigEdit = testing.fn();
     const handleScanConfigSettings = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const config = ScanConfig.fromElement({
       _id: '1234',
@@ -336,15 +349,17 @@ describe('Scan Config row tests', () => {
       },
     });
 
-    const {render} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: true,
       store: true,
     });
+    store.dispatch(setUsername('admin'));
 
-    const {baseElement, getAllByTestId} = render(
+    render(
       <Row
         entity={config}
+        openEditNvtDetailsDialog={handleOpenEditNvtDetailsDialog}
         onScanConfigCloneClick={handleScanConfigClone}
         onScanConfigDeleteClick={handleScanConfigDelete}
         onScanConfigDownloadClick={handleScanConfigDownload}
@@ -354,31 +369,36 @@ describe('Scan Config row tests', () => {
       />,
     );
 
-    const spans = baseElement.querySelectorAll('span');
-    fireEvent.click(spans[1]);
+    fireEvent.click(screen.getByTestId('row-details-toggle'));
     expect(handleToggleDetailsClick).toHaveBeenCalledWith(undefined, '1234');
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[2]);
+    const settingsIcon = screen.getByTestId('settings-2-icon');
+    fireEvent.click(settingsIcon);
     expect(handleScanConfigSettings).not.toHaveBeenCalledWith(entity);
-    expect(icons[2]).toHaveAttribute('title', 'Edit Scan Config settings');
+    expect(settingsIcon).toHaveAttribute('title', 'Edit Scan Config settings');
 
-    fireEvent.click(icons[3]);
+    const trashcanIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(trashcanIcon);
     expect(handleScanConfigDelete).not.toHaveBeenCalled();
-    expect(icons[3]).toHaveAttribute('title', 'Scan Config is still in use');
+    expect(trashcanIcon).toHaveAttribute(
+      'title',
+      'Scan Config is still in use',
+    );
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleScanConfigEdit).toHaveBeenCalledWith(config);
-    expect(icons[4]).toHaveAttribute('title', 'Edit Scan Config');
+    expect(editIcon).toHaveAttribute('title', 'Edit Scan Config');
 
-    fireEvent.click(icons[5]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleScanConfigClone).toHaveBeenCalledWith(config);
-    expect(icons[5]).toHaveAttribute('title', 'Clone Scan Config');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Scan Config');
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleScanConfigDownload).toHaveBeenCalledWith(config);
-    expect(icons[6]).toHaveAttribute('title', 'Export Scan Config');
+    expect(exportIcon).toHaveAttribute('title', 'Export Scan Config');
   });
 
   test('should (not) call click handlers if scan config is not writable', () => {
@@ -388,6 +408,7 @@ describe('Scan Config row tests', () => {
     const handleScanConfigDownload = testing.fn();
     const handleScanConfigEdit = testing.fn();
     const handleScanConfigSettings = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
 
     const config = ScanConfig.fromElement({
       _id: '1234',
@@ -406,15 +427,17 @@ describe('Scan Config row tests', () => {
       },
     });
 
-    const {render} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: true,
       store: true,
     });
+    store.dispatch(setUsername('admin'));
 
-    const {baseElement, getAllByTestId} = render(
+    render(
       <Row
         entity={config}
+        openEditNvtDetailsDialog={handleOpenEditNvtDetailsDialog}
         onScanConfigCloneClick={handleScanConfigClone}
         onScanConfigDeleteClick={handleScanConfigDelete}
         onScanConfigDownloadClick={handleScanConfigDownload}
@@ -423,35 +446,38 @@ describe('Scan Config row tests', () => {
       />,
     );
 
-    const spans = baseElement.querySelectorAll('span');
-    fireEvent.click(spans[1]);
+    fireEvent.click(screen.getByTestId('row-details-toggle'));
     expect(handleToggleDetailsClick).toHaveBeenCalledWith(undefined, '1234');
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[2]);
+    const settingsIcon = screen.getByTestId('settings-2-icon');
+    fireEvent.click(settingsIcon);
     expect(handleScanConfigSettings).not.toHaveBeenCalledWith(entity);
-    expect(icons[2]).toHaveAttribute(
+    expect(settingsIcon).toHaveAttribute(
       'title',
       'Scan Config settings is not writable',
     );
 
-    fireEvent.click(icons[3]);
+    const trashcanIcon = screen.getByTestId('trashcan-icon');
+    fireEvent.click(trashcanIcon);
     expect(handleScanConfigDelete).not.toHaveBeenCalled();
-    expect(icons[3]).toHaveAttribute('title', 'Scan Config is not writable');
+    expect(trashcanIcon).toHaveAttribute(
+      'title',
+      'Scan Config is not writable',
+    );
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    fireEvent.click(editIcon);
     expect(handleScanConfigEdit).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute('title', 'Scan Config is not writable');
+    expect(editIcon).toHaveAttribute('title', 'Scan Config is not writable');
 
-    fireEvent.click(icons[5]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    fireEvent.click(cloneIcon);
     expect(handleScanConfigClone).toHaveBeenCalledWith(config);
-    expect(icons[5]).toHaveAttribute('title', 'Clone Scan Config');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Scan Config');
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleScanConfigDownload).toHaveBeenCalledWith(config);
-    expect(icons[6]).toHaveAttribute('title', 'Export Scan Config');
+    expect(exportIcon).toHaveAttribute('title', 'Export Scan Config');
   });
-
-  console.warn = consoleError;
 });

--- a/src/web/pages/scanconfigs/__tests__/Table.test.jsx
+++ b/src/web/pages/scanconfigs/__tests__/Table.test.jsx
@@ -12,8 +12,7 @@ import ScanConfig, {
 } from 'gmp/models/scanconfig';
 import Table from 'web/pages/scanconfigs/Table';
 import {setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent} from 'web/utils/Testing';
-
+import {rendererWith, fireEvent, screen} from 'web/utils/Testing';
 
 const config = ScanConfig.fromElement({
   _id: '12345',
@@ -79,6 +78,7 @@ describe('Scan Config table tests', () => {
     const handleScanConfigDelete = testing.fn();
     const handleScanConfigDownload = testing.fn();
     const handleScanConfigEdit = testing.fn();
+    const openEditNvtDetailsDialog = testing.fn();
 
     const gmp = {
       settings: {},
@@ -92,12 +92,12 @@ describe('Scan Config table tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {baseElement} = render(
+    const {element} = render(
       <Table
         entities={[config, config2, config3]}
         entitiesCounts={counts}
         filter={filter}
-        openEditNvtDetailsDialog={testing.fn()}
+        openEditNvtDetailsDialog={openEditNvtDetailsDialog}
         onScanConfigCloneClick={handleScanConfigClone}
         onScanConfigDeleteClick={handleScanConfigDelete}
         onScanConfigDownloadClick={handleScanConfigDownload}
@@ -105,8 +105,8 @@ describe('Scan Config table tests', () => {
       />,
     );
 
-    expect(baseElement).toBeVisible();
-    const header = baseElement.querySelectorAll('th');
+    expect(element).toBeVisible();
+    const header = element.querySelectorAll('th');
     expect(header[0]).toHaveTextContent('Name');
     expect(header[1]).toHaveTextContent('Family');
     expect(header[2]).toHaveTextContent('NVTs');
@@ -136,7 +136,7 @@ describe('Scan Config table tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {element, getAllByTestId} = render(
+    const {element} = render(
       <Table
         entities={[config, config2, config3]}
         entitiesCounts={counts}
@@ -151,9 +151,9 @@ describe('Scan Config table tests', () => {
 
     expect(element).not.toHaveTextContent('Comment');
 
-    const icons = getAllByTestId('svg-icon');
-    fireEvent.click(icons[0]);
-    expect(icons[0]).toHaveAttribute('title', 'Unfold all details');
+    const foldIcon = screen.getByTestId('fold-state-icon-unfold');
+    fireEvent.click(foldIcon);
+    expect(foldIcon).toHaveAttribute('title', 'Unfold all details');
     expect(element).toHaveTextContent('Comment');
   });
 
@@ -162,6 +162,7 @@ describe('Scan Config table tests', () => {
     const handleScanConfigDelete = testing.fn();
     const handleScanConfigDownload = testing.fn();
     const handleScanConfigEdit = testing.fn();
+    const openEditNvtDetailsDialog = testing.fn();
 
     const gmp = {
       settings: {},
@@ -176,12 +177,12 @@ describe('Scan Config table tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {getAllByTestId} = render(
+    render(
       <Table
         entities={[config, config2, config3]}
         entitiesCounts={counts}
         filter={filter}
-        openEditNvtDetailsDialog={testing.fn()}
+        openEditNvtDetailsDialog={openEditNvtDetailsDialog}
         onScanConfigCloneClick={handleScanConfigClone}
         onScanConfigDeleteClick={handleScanConfigDelete}
         onScanConfigDownloadClick={handleScanConfigDownload}
@@ -189,22 +190,27 @@ describe('Scan Config table tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[8]);
+    const trashcanIcons = screen.getAllByTestId('trashcan-icon')[0];
+    fireEvent.click(trashcanIcons);
     expect(handleScanConfigDelete).toHaveBeenCalledWith(config);
-    expect(icons[8]).toHaveAttribute('title', 'Move Scan Config to trashcan');
+    expect(trashcanIcons).toHaveAttribute(
+      'title',
+      'Move Scan Config to trashcan',
+    );
 
-    fireEvent.click(icons[9]);
+    const editIcons = screen.getAllByTestId('edit-icon')[0];
+    fireEvent.click(editIcons);
     expect(handleScanConfigEdit).toHaveBeenCalledWith(config);
-    expect(icons[9]).toHaveAttribute('title', 'Edit Scan Config');
+    expect(editIcons).toHaveAttribute('title', 'Edit Scan Config');
 
-    fireEvent.click(icons[10]);
+    const cloneIcons = screen.getAllByTestId('clone-icon')[0];
+    fireEvent.click(cloneIcons);
     expect(handleScanConfigClone).toHaveBeenCalledWith(config);
-    expect(icons[10]).toHaveAttribute('title', 'Clone Scan Config');
+    expect(cloneIcons).toHaveAttribute('title', 'Clone Scan Config');
 
-    fireEvent.click(icons[11]);
+    const exportIcons = screen.getAllByTestId('export-icon')[0];
+    fireEvent.click(exportIcons);
     expect(handleScanConfigDownload).toHaveBeenCalledWith(config);
-    expect(icons[11]).toHaveAttribute('title', 'Export Scan Config');
+    expect(exportIcons).toHaveAttribute('title', 'Export Scan Config');
   });
 });

--- a/src/web/pages/scanconfigs/__tests__/Trend.test.jsx
+++ b/src/web/pages/scanconfigs/__tests__/Trend.test.jsx
@@ -9,8 +9,7 @@ import {
   SCANCONFIG_TREND_STATIC,
 } from 'gmp/models/scanconfig';
 import Trend from 'web/pages/scanconfigs/Trend';
-import {render} from 'web/utils/Testing';
-
+import {render, screen} from 'web/utils/Testing';
 
 describe('Scan Config Trend tests', () => {
   test('should render', () => {
@@ -26,7 +25,7 @@ describe('Scan Config Trend tests', () => {
   });
 
   test('should render static title', () => {
-    const {getByTestId} = render(
+    render(
       <Trend
         titleDynamic="Dynamic"
         titleStatic="Static"
@@ -34,13 +33,12 @@ describe('Scan Config Trend tests', () => {
       />,
     );
 
-    const trendIcon = getByTestId('svg-icon');
-
+    const trendIcon = screen.getByTestId('trend-nochange-icon');
     expect(trendIcon).toHaveAttribute('title', 'Static');
   });
 
   test('should render dynamic title', () => {
-    const {getByTestId} = render(
+    render(
       <Trend
         titleDynamic="Dynamic"
         titleStatic="Static"
@@ -48,8 +46,7 @@ describe('Scan Config Trend tests', () => {
       />,
     );
 
-    const trendIcon = getByTestId('svg-icon');
-
+    const trendIcon = screen.getByTestId('trend-more-icon');
     expect(trendIcon).toHaveAttribute('title', 'Dynamic');
   });
 

--- a/src/web/pages/schedules/__tests__/ListPage.test.jsx
+++ b/src/web/pages/schedules/__tests__/ListPage.test.jsx
@@ -410,7 +410,10 @@ describe('SchedulePage ToolBarIcons test', () => {
 
     const links = element.querySelectorAll('a');
 
-    expect(screen.getAllByTitle('Help: Schedules')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Schedules',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/scanning.html#managing-schedules',
@@ -432,11 +435,9 @@ describe('SchedulePage ToolBarIcons test', () => {
 
     render(<ToolBarIcons onScheduleCreateClick={handleScheduleCreateClick} />);
 
-    const newIcon = screen.getAllByTitle('New Schedule');
-
-    expect(newIcon[0]).toBeInTheDocument();
-
-    fireEvent.click(newIcon[0]);
+    const newIcon = screen.getByTestId('new-icon');
+    expect(newIcon).toHaveAttribute('title', 'New Schedule');
+    fireEvent.click(newIcon);
     expect(handleScheduleCreateClick).toHaveBeenCalled();
   });
 
@@ -453,12 +454,9 @@ describe('SchedulePage ToolBarIcons test', () => {
       router: true,
     });
 
-    const {queryAllByTestId} = render(
-      <ToolBarIcons onScheduleCreateClick={handleScheduleCreateClick} />,
-    );
+    render(<ToolBarIcons onScheduleCreateClick={handleScheduleCreateClick} />);
 
-    const icons = queryAllByTestId('svg-icon'); // this test is probably appropriate to keep in the old format
-    expect(icons.length).toBe(1);
-    expect(icons[0]).toHaveAttribute('title', 'Help: Schedules');
+    const newIcon = screen.queryByTestId('new-icon');
+    expect(newIcon).not.toBeInTheDocument();
   });
 });

--- a/src/web/pages/start/Page.jsx
+++ b/src/web/pages/start/Page.jsx
@@ -36,7 +36,9 @@ import Tabs from 'web/components/tab/Tabs';
 import ConfirmRemoveDialog from 'web/pages/start/ConfirmRemoveDialog';
 import Dashboard from 'web/pages/start/Dashboard';
 import EditDashboardDialog from 'web/pages/start/EditDashboardDialog';
-import NewDashboardDialog, {DEFAULT_DISPLAYS} from 'web/pages/start/NewDashboardDialog';
+import NewDashboardDialog, {
+  DEFAULT_DISPLAYS,
+} from 'web/pages/start/NewDashboardDialog';
 import {
   loadSettings,
   saveSettings,
@@ -49,7 +51,6 @@ import {renewSessionTimeout} from 'web/store/usersettings/actions';
 import compose from 'web/utils/Compose';
 import PropTypes from 'web/utils/PropTypes';
 import withGmp from 'web/utils/withGmp';
-
 
 const DASHBOARD_ID = 'd97eca9f-0386-4e5d-88f2-0ed7f60c0646';
 const OVERVIEW_DASHBOARD_ID = '84fbe9f5-8ad4-43f0-9712-850182abb003';
@@ -417,6 +418,7 @@ class StartPage extends React.Component {
                   <Layout grow align={['center', 'center']}>
                     <StyledNewIcon
                       active={canAdd}
+                      data-testid="add-dashboard"
                       title={
                         canAdd
                           ? _('Add new Dashboard')

--- a/src/web/pages/start/__tests__/Page.test.jsx
+++ b/src/web/pages/start/__tests__/Page.test.jsx
@@ -8,8 +8,12 @@ import CollectionCounts from 'gmp/collection/collectioncounts';
 import Filter from 'gmp/models/filter';
 import StartPage from 'web/pages/start/Page';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, screen} from 'web/utils/Testing';
-
+import {
+  rendererWith,
+  wait,
+  getByTestId as getByTestIdFromElement,
+  screen,
+} from 'web/utils/Testing';
 
 const manualUrl = 'test/';
 
@@ -76,43 +80,94 @@ describe('StartPage tests', () => {
 
     const {baseElement} = render(<StartPage />);
 
-    const displays = await screen.findAllByTestId('grid-item');
-    const icons = screen.getAllByTestId('svg-icon');
+    await wait();
+
+    const displays = screen.getAllByTestId('grid-item');
     const spans = baseElement.querySelectorAll('span');
 
     // Toolbar Icons
-    expect(icons[0]).toHaveAttribute('title', 'Help: Dashboards');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Dashboards',
+    );
 
     // Tabs
     expect(spans[3]).toHaveTextContent('Overview');
-    expect(icons[2]).toHaveAttribute('title', 'Add new Dashboard');
+    expect(screen.getByTestId('add-dashboard')).toHaveAttribute(
+      'title',
+      'Add new Dashboard',
+    );
 
     // Dashboard Controls
-    expect(icons[3]).toHaveAttribute('title', 'Add new Dashboard Display');
-    expect(icons[4]).toHaveAttribute('title', 'Reset to Defaults');
+    expect(screen.getByTestId('add-dashboard-display')).toHaveAttribute(
+      'title',
+      'Add new Dashboard Display',
+    );
+    expect(screen.getByTestId('reset-dashboard')).toHaveAttribute(
+      'title',
+      'Reset to Defaults',
+    );
 
     // Displays
-    expect(displays[0]).toHaveTextContent('Tasks by Severity Class (Total: 0)');
-    expect(icons[5]).toHaveAttribute('title', 'Select Filter');
-    expect(icons[6]).toHaveAttribute('title', 'Download SVG');
-    expect(icons[7]).toHaveAttribute('title', 'Toggle Legend');
-    expect(icons[8]).toHaveAttribute('title', 'Toggle 2D/3D view');
+    const tasksBySeverityClass = displays[0];
+    expect(tasksBySeverityClass).toHaveTextContent(
+      'Tasks by Severity Class (Total: 0)',
+    );
+    expect(
+      getByTestIdFromElement(tasksBySeverityClass, 'filter-icon'),
+    ).toHaveAttribute('title', 'Select Filter');
+    expect(
+      getByTestIdFromElement(tasksBySeverityClass, 'download-svg-icon'),
+    ).toHaveAttribute('title', 'Download SVG');
+    expect(
+      getByTestIdFromElement(tasksBySeverityClass, 'legend-icon'),
+    ).toHaveAttribute('title', 'Toggle Legend');
+    expect(
+      getByTestIdFromElement(tasksBySeverityClass, 'toggle-3d-icon'),
+    ).toHaveAttribute('title', 'Toggle 2D/3D view');
 
-    expect(displays[1]).toHaveTextContent('Tasks by Status (Total: 0)');
-    expect(icons[9]).toHaveAttribute('title', 'Select Filter');
-    expect(icons[10]).toHaveAttribute('title', 'Download SVG');
-    expect(icons[11]).toHaveAttribute('title', 'Toggle Legend');
-    expect(icons[12]).toHaveAttribute('title', 'Toggle 2D/3D view');
+    const tasksByStatus = displays[1];
+    expect(tasksByStatus).toHaveTextContent('Tasks by Status (Total: 0)');
+    expect(
+      getByTestIdFromElement(tasksByStatus, 'filter-icon'),
+    ).toHaveAttribute('title', 'Select Filter');
+    expect(
+      getByTestIdFromElement(tasksByStatus, 'download-svg-icon'),
+    ).toHaveAttribute('title', 'Download SVG');
+    expect(
+      getByTestIdFromElement(tasksByStatus, 'legend-icon'),
+    ).toHaveAttribute('title', 'Toggle Legend');
+    expect(
+      getByTestIdFromElement(tasksByStatus, 'toggle-3d-icon'),
+    ).toHaveAttribute('title', 'Toggle 2D/3D view');
 
-    expect(displays[2]).toHaveTextContent('CVEs by Creation Time');
-    expect(icons[13]).toHaveAttribute('title', 'Select Filter');
-    expect(icons[14]).toHaveAttribute('title', 'Download SVG');
-    expect(icons[15]).toHaveAttribute('title', 'Toggle Legend');
+    const cvesByCreationTime = displays[2];
+    expect(cvesByCreationTime).toHaveTextContent('CVEs by Creation Time');
+    expect(
+      getByTestIdFromElement(cvesByCreationTime, 'filter-icon'),
+    ).toHaveAttribute('title', 'Select Filter');
+    expect(
+      getByTestIdFromElement(cvesByCreationTime, 'download-svg-icon'),
+    ).toHaveAttribute('title', 'Download SVG');
+    expect(
+      getByTestIdFromElement(cvesByCreationTime, 'legend-icon'),
+    ).toHaveAttribute('title', 'Toggle Legend');
 
-    expect(displays[3]).toHaveTextContent('NVTs by Severity Class (Total: 0)');
-    expect(icons[16]).toHaveAttribute('title', 'Select Filter');
-    expect(icons[17]).toHaveAttribute('title', 'Download SVG');
-    expect(icons[18]).toHaveAttribute('title', 'Toggle Legend');
-    expect(icons[19]).toHaveAttribute('title', 'Toggle 2D/3D view');
+    const nvtsBySeverityClass = displays[3];
+    expect(nvtsBySeverityClass).toHaveTextContent(
+      'NVTs by Severity Class (Total: 0)',
+    );
+    expect(
+      getByTestIdFromElement(nvtsBySeverityClass, 'filter-icon'),
+    ).toHaveAttribute('title', 'Select Filter');
+    expect(
+      getByTestIdFromElement(nvtsBySeverityClass, 'download-svg-icon'),
+    ).toHaveAttribute('title', 'Download SVG');
+    expect(
+      getByTestIdFromElement(nvtsBySeverityClass, 'legend-icon'),
+    ).toHaveAttribute('title', 'Toggle Legend');
+    expect(
+      getByTestIdFromElement(nvtsBySeverityClass, 'toggle-3d-icon'),
+    ).toHaveAttribute('title', 'Toggle 2D/3D view');
   });
 });

--- a/src/web/pages/targets/__tests__/ListPage.test.jsx
+++ b/src/web/pages/targets/__tests__/ListPage.test.jsx
@@ -68,7 +68,7 @@ beforeEach(() => {
 const target = Target.fromElement({
   _id: '46264',
   name: 'target 1',
-  commen: 'hello world',
+  comment: 'hello world',
   creation_time: '2020-12-23T14:14:11Z',
   modification_time: '2021-01-04T11:54:12Z',
   in_use: 0,
@@ -381,10 +381,10 @@ describe('TargetPage tests', () => {
     store.dispatch(setTimezone('CET'));
     store.dispatch(setUsername('admin'));
 
-    const defaultSettingfilter = Filter.fromString('foo=bar');
+    const defaultSettingFilter = Filter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
-      defaultFilterLoadingActions.success('target', defaultSettingfilter),
+      defaultFilterLoadingActions.success('target', defaultSettingFilter),
     );
 
     const counts = new CollectionCounts({
@@ -465,11 +465,9 @@ describe('TargetPage ToolBarIcons test', () => {
 
     render(<ToolBarIcons onTargetCreateClick={handleTargetCreateClick} />);
 
-    const newIcon = screen.getAllByTitle('New Target');
-
-    expect(newIcon[0]).toBeInTheDocument();
-
-    fireEvent.click(newIcon[0]);
+    const newIcon = screen.getByTestId('new-icon');
+    expect(newIcon).toHaveAttribute('title', 'New Target');
+    fireEvent.click(newIcon);
     expect(handleTargetCreateClick).toHaveBeenCalled();
   });
 
@@ -486,12 +484,9 @@ describe('TargetPage ToolBarIcons test', () => {
       router: true,
     });
 
-    const {queryAllByTestId} = render(
-      <ToolBarIcons onTargetCreateClick={handleTargetCreateClick} />,
-    );
+    render(<ToolBarIcons onTargetCreateClick={handleTargetCreateClick} />);
 
-    const icons = queryAllByTestId('svg-icon'); // this test is probably approppriate to keep in the old format
-    expect(icons.length).toBe(1);
-    expect(icons[0]).toHaveAttribute('title', 'Help: Targets');
+    const newIcon = screen.queryByTestId('new-icon');
+    expect(newIcon).toBeNull();
   });
 });

--- a/src/web/pages/targets/__tests__/Row.test.jsx
+++ b/src/web/pages/targets/__tests__/Row.test.jsx
@@ -8,8 +8,7 @@ import Capabilities from 'gmp/capabilities/capabilities';
 import Target from 'gmp/models/target';
 import Row from 'web/pages/targets/Row';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent, screen} from 'web/utils/Testing';
-
+import {rendererWithTable, fireEvent, screen} from 'web/utils/Testing';
 
 const gmp = {settings: {}};
 const caps = new Capabilities(['everything']);
@@ -162,11 +161,6 @@ const target_no_elevate = Target.fromElement({
 });
 
 describe('Target row tests', () => {
-  // deactivate console.error for tests
-  // to make it possible to test a row without a table
-  const consoleError = console.error;
-  console.error = () => {};
-
   test('should render', () => {
     const handleToggleDetailsClick = testing.fn();
     const handleTargetCloneClick = testing.fn();
@@ -174,7 +168,7 @@ describe('Target row tests', () => {
     const handleTargetDownloadClick = testing.fn();
     const handleTargetEditClick = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       router: true,
@@ -227,7 +221,7 @@ describe('Target row tests', () => {
     const handleTargetDownloadClick = testing.fn();
     const handleTargetEditClick = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       router: true,
@@ -277,7 +271,7 @@ describe('Target row tests', () => {
     const handleTargetDownloadClick = testing.fn();
     const handleTargetEditClick = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       capabilities: caps,
       router: true,
@@ -315,13 +309,14 @@ describe('Target row tests', () => {
     const handleTargetDownloadClick = testing.fn();
     const handleTargetEditClick = testing.fn();
 
-    const {render, store} = rendererWith({
+    const {render, store} = rendererWithTable({
       gmp,
       store: true,
       capabilities: caps,
       router: true,
     });
 
+    store.dispatch(setUsername('admin'));
     store.dispatch(setTimezone('UTC'));
 
     const {baseElement} = render(
@@ -357,6 +352,4 @@ describe('Target row tests', () => {
     fireEvent.click(exportIcon[0]);
     expect(handleTargetDownloadClick).toHaveBeenCalledWith(target_no_elevate);
   });
-
-  console.warn = consoleError;
 });

--- a/src/web/pages/tasks/ListPage.jsx
+++ b/src/web/pages/tasks/ListPage.jsx
@@ -54,16 +54,22 @@ export const ToolBarIcons = ({
       {capabilities.mayOp('run_wizard') && (
         <IconMenu icon={<WizardIcon />} onClick={onTaskWizardClick}>
           {capabilities.mayCreate('task') && (
-            <MenuEntry title={_('Task Wizard')} onClick={onTaskWizardClick} />
+            <MenuEntry
+              data-testid="task-wizard-menu"
+              title={_('Task Wizard')}
+              onClick={onTaskWizardClick}
+            />
           )}
           {capabilities.mayCreate('task') && (
             <MenuEntry
+              data-testid="advanced-task-wizard-menu"
               title={_('Advanced Task Wizard')}
               onClick={onAdvancedTaskWizardClick}
             />
           )}
           {mayUseModifyTaskWizard && (
             <MenuEntry
+              data-testid="modify-task-wizard-menu"
               title={_('Modify Task Wizard')}
               onClick={onModifyTaskWizardClick}
             />

--- a/src/web/pages/tasks/Trend.jsx
+++ b/src/web/pages/tasks/Trend.jsx
@@ -35,7 +35,14 @@ const Trend = ({name}) => {
     return <span />;
   }
 
-  return <IconComponent alt={title} size="small" title={title} />;
+  return (
+    <IconComponent
+      alt={title}
+      data-testid="trend-icon"
+      size="small"
+      title={title}
+    />
+  );
 };
 
 Trend.propTypes = {

--- a/src/web/pages/tasks/__tests__/Actions.test.jsx
+++ b/src/web/pages/tasks/__tests__/Actions.test.jsx
@@ -7,18 +7,12 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import Task, {TASK_STATUS} from 'gmp/models/task';
 import Actions from 'web/pages/tasks/Actions';
-import {rendererWith, fireEvent} from 'web/utils/Testing';
-
+import {rendererWithTableRow, fireEvent, screen} from 'web/utils/Testing';
 
 const caps = new Capabilities(['everything']);
 const wrongCaps = new Capabilities(['get_task']);
 
 describe('Task Actions tests', () => {
-  // deactivate console.error for tests
-  // to make it possible to test actions without a table
-  const consoleError = console.error;
-  console.error = () => {};
-
   test('should render', () => {
     const task = Task.fromElement({
       status: TASK_STATUS.new,
@@ -36,7 +30,7 @@ describe('Task Actions tests', () => {
     const handleTaskStart = testing.fn();
     const handleTaskStop = testing.fn();
 
-    const {render} = rendererWith({capabilities: caps, store: true});
+    const {render} = rendererWithTableRow({capabilities: caps, store: true});
     const {element} = render(
       <Actions
         entity={task}
@@ -73,8 +67,8 @@ describe('Task Actions tests', () => {
     const handleTaskStart = testing.fn();
     const handleTaskStop = testing.fn();
 
-    const {render} = rendererWith({capabilities: caps, store: true});
-    const {getAllByTestId} = render(
+    const {render} = rendererWithTableRow({capabilities: caps, store: true});
+    render(
       <Actions
         entity={task}
         links={true}
@@ -89,31 +83,35 @@ describe('Task Actions tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute('title', 'Start');
+    fireEvent.click(startIcon);
     expect(handleTaskStart).toHaveBeenCalledWith(task);
-    expect(icons[0]).toHaveAttribute('title', 'Start');
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Task is not stopped');
+    fireEvent.click(resumeIcon);
     expect(handleTaskResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Task is not stopped');
 
-    fireEvent.click(icons[2]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Task to trashcan');
+    fireEvent.click(deleteIcon);
     expect(handleTaskDelete).toHaveBeenCalledWith(task);
-    expect(icons[2]).toHaveAttribute('title', 'Move Task to trashcan');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Task');
+    fireEvent.click(editIcon);
     expect(handleTaskEdit).toHaveBeenCalledWith(task);
-    expect(icons[3]).toHaveAttribute('title', 'Edit Task');
 
-    fireEvent.click(icons[4]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Task');
+    fireEvent.click(cloneIcon);
     expect(handleTaskClone).toHaveBeenCalledWith(task);
-    expect(icons[4]).toHaveAttribute('title', 'Clone Task');
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task');
+    fireEvent.click(exportIcon);
     expect(handleTaskDownload).toHaveBeenCalledWith(task);
-    expect(icons[5]).toHaveAttribute('title', 'Export Task');
   });
 
   test('should not call click handlers without permissions', () => {
@@ -134,8 +132,11 @@ describe('Task Actions tests', () => {
     const handleTaskStart = testing.fn();
     const handleTaskStop = testing.fn();
 
-    const {render} = rendererWith({capabilities: wrongCaps, store: true});
-    const {getAllByTestId} = render(
+    const {render} = rendererWithTableRow({
+      capabilities: wrongCaps,
+      store: true,
+    });
+    render(
       <Actions
         entity={task}
         links={true}
@@ -150,40 +151,44 @@ describe('Task Actions tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
-    expect(handleTaskStart).not.toHaveBeenCalled();
-    expect(icons[0]).toHaveAttribute(
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute(
       'title',
       'Permission to start task denied',
     );
+    fireEvent.click(startIcon);
+    expect(handleTaskStart).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Task is not stopped');
+    fireEvent.click(resumeIcon);
     expect(handleTaskResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Task is not stopped');
 
-    fireEvent.click(icons[2]);
-    expect(handleTaskDelete).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute(
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute(
       'title',
       'Permission to move Task to trashcan denied',
     );
+    fireEvent.click(deleteIcon);
+    expect(handleTaskDelete).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Permission to edit Task denied');
+    fireEvent.click(editIcon);
     expect(handleTaskEdit).not.toHaveBeenCalled();
-    expect(icons[3]).toHaveAttribute('title', 'Permission to edit Task denied');
 
-    fireEvent.click(icons[4]);
-    expect(handleTaskClone).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute(
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute(
       'title',
       'Permission to clone Task denied',
     );
+    fireEvent.click(cloneIcon);
+    expect(handleTaskClone).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task');
+    fireEvent.click(exportIcon);
     expect(handleTaskDownload).toHaveBeenCalledWith(task);
-    expect(icons[5]).toHaveAttribute('title', 'Export Task');
   });
 
   test('should not call click handlers for stopped task without permissions', () => {
@@ -204,8 +209,11 @@ describe('Task Actions tests', () => {
     const handleTaskStart = testing.fn();
     const handleTaskStop = testing.fn();
 
-    const {render} = rendererWith({capabilities: wrongCaps, store: true});
-    const {getAllByTestId} = render(
+    const {render} = rendererWithTableRow({
+      capabilities: wrongCaps,
+      store: true,
+    });
+    render(
       <Actions
         entity={task}
         links={true}
@@ -220,43 +228,47 @@ describe('Task Actions tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
-    expect(handleTaskStart).not.toHaveBeenCalled();
-    expect(icons[0]).toHaveAttribute(
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute(
       'title',
       'Permission to start task denied',
     );
+    fireEvent.click(startIcon);
+    expect(handleTaskStart).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[1]);
-    expect(handleTaskResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute(
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute(
       'title',
       'Permission to resume task denied',
     );
+    fireEvent.click(resumeIcon);
+    expect(handleTaskResume).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[2]);
-    expect(handleTaskDelete).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute(
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute(
       'title',
       'Permission to move Task to trashcan denied',
     );
+    fireEvent.click(deleteIcon);
+    expect(handleTaskDelete).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Permission to edit Task denied');
+    fireEvent.click(editIcon);
     expect(handleTaskEdit).not.toHaveBeenCalled();
-    expect(icons[3]).toHaveAttribute('title', 'Permission to edit Task denied');
 
-    fireEvent.click(icons[4]);
-    expect(handleTaskClone).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute(
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute(
       'title',
       'Permission to clone Task denied',
     );
+    fireEvent.click(cloneIcon);
+    expect(handleTaskClone).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task');
+    fireEvent.click(exportIcon);
     expect(handleTaskDownload).toHaveBeenCalledWith(task);
-    expect(icons[5]).toHaveAttribute('title', 'Export Task');
   });
 
   test('should not call click handlers for running task without permissions', () => {
@@ -277,8 +289,11 @@ describe('Task Actions tests', () => {
     const handleTaskStart = testing.fn();
     const handleTaskStop = testing.fn();
 
-    const {render} = rendererWith({capabilities: wrongCaps, store: true});
-    const {getAllByTestId} = render(
+    const {render} = rendererWithTableRow({
+      capabilities: wrongCaps,
+      store: true,
+    });
+    render(
       <Actions
         entity={task}
         links={true}
@@ -293,37 +308,41 @@ describe('Task Actions tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
+    const stopIcon = screen.getByTestId('stop-icon');
+    expect(stopIcon).toHaveAttribute('title', 'Permission to stop task denied');
+    fireEvent.click(stopIcon);
+    expect(handleTaskStart).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[0]);
-    expect(handleTaskStop).not.toHaveBeenCalled();
-    expect(icons[0]).toHaveAttribute('title', 'Permission to stop task denied');
-
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Task is not stopped');
+    fireEvent.click(resumeIcon);
     expect(handleTaskResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Task is not stopped');
 
-    fireEvent.click(icons[2]);
-    expect(handleTaskDelete).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute(
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute(
       'title',
       'Permission to move Task to trashcan denied',
     );
+    fireEvent.click(deleteIcon);
+    expect(handleTaskDelete).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Permission to edit Task denied');
+    fireEvent.click(editIcon);
     expect(handleTaskEdit).not.toHaveBeenCalled();
-    expect(icons[3]).toHaveAttribute('title', 'Permission to edit Task denied');
 
-    fireEvent.click(icons[4]);
-    expect(handleTaskClone).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute(
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute(
       'title',
       'Permission to clone Task denied',
     );
+    fireEvent.click(cloneIcon);
+    expect(handleTaskClone).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task');
+    fireEvent.click(exportIcon);
     expect(handleTaskDownload).toHaveBeenCalledWith(task);
-    expect(icons[5]).toHaveAttribute('title', 'Export Task');
   });
 
   test('should call click handlers for running task', () => {
@@ -344,8 +363,8 @@ describe('Task Actions tests', () => {
     const handleTaskStart = testing.fn();
     const handleTaskStop = testing.fn();
 
-    const {render} = rendererWith({capabilities: caps, store: true});
-    const {getAllByTestId} = render(
+    const {render} = rendererWithTableRow({capabilities: caps, store: true});
+    render(
       <Actions
         entity={task}
         links={true}
@@ -360,31 +379,35 @@ describe('Task Actions tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
+    const stopIcon = screen.getByTestId('stop-icon');
+    expect(stopIcon).toHaveAttribute('title', 'Stop');
+    fireEvent.click(stopIcon);
     expect(handleTaskStop).toHaveBeenCalledWith(task);
-    expect(icons[0]).toHaveAttribute('title', 'Stop');
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Task is not stopped');
+    fireEvent.click(resumeIcon);
     expect(handleTaskResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Task is not stopped');
 
-    fireEvent.click(icons[2]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Task is still in use');
+    fireEvent.click(deleteIcon);
     expect(handleTaskDelete).not.toHaveBeenCalled();
-    expect(icons[2]).toHaveAttribute('title', 'Task is still in use');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Task');
+    fireEvent.click(editIcon);
     expect(handleTaskEdit).toHaveBeenCalledWith(task);
-    expect(icons[3]).toHaveAttribute('title', 'Edit Task');
 
-    fireEvent.click(icons[4]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Task');
+    fireEvent.click(cloneIcon);
     expect(handleTaskClone).toHaveBeenCalledWith(task);
-    expect(icons[4]).toHaveAttribute('title', 'Clone Task');
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task');
+    fireEvent.click(exportIcon);
     expect(handleTaskDownload).toHaveBeenCalledWith(task);
-    expect(icons[5]).toHaveAttribute('title', 'Export Task');
   });
 
   test('should call click handlers for stopped task', () => {
@@ -405,8 +428,8 @@ describe('Task Actions tests', () => {
     const handleTaskStart = testing.fn();
     const handleTaskStop = testing.fn();
 
-    const {render} = rendererWith({capabilities: caps, store: true});
-    const {getAllByTestId} = render(
+    const {render} = rendererWithTableRow({capabilities: caps, store: true});
+    render(
       <Actions
         entity={task}
         links={true}
@@ -421,31 +444,35 @@ describe('Task Actions tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute('title', 'Start');
+    fireEvent.click(startIcon);
     expect(handleTaskStart).toHaveBeenCalledWith(task);
-    expect(icons[0]).toHaveAttribute('title', 'Start');
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Resume');
+    fireEvent.click(resumeIcon);
     expect(handleTaskResume).toHaveBeenCalledWith(task);
-    expect(icons[1]).toHaveAttribute('title', 'Resume');
 
-    fireEvent.click(icons[2]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Task to trashcan');
+    fireEvent.click(deleteIcon);
     expect(handleTaskDelete).toHaveBeenCalledWith(task);
-    expect(icons[2]).toHaveAttribute('title', 'Move Task to trashcan');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Task');
+    fireEvent.click(editIcon);
     expect(handleTaskEdit).toHaveBeenCalledWith(task);
-    expect(icons[3]).toHaveAttribute('title', 'Edit Task');
 
-    fireEvent.click(icons[4]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Task');
+    fireEvent.click(cloneIcon);
     expect(handleTaskClone).toHaveBeenCalledWith(task);
-    expect(icons[4]).toHaveAttribute('title', 'Clone Task');
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task');
+    fireEvent.click(exportIcon);
     expect(handleTaskDownload).toHaveBeenCalledWith(task);
-    expect(icons[5]).toHaveAttribute('title', 'Export Task');
   });
 
   test('should render schedule icon if task is scheduled', () => {
@@ -471,12 +498,12 @@ describe('Task Actions tests', () => {
     const handleTaskStart = testing.fn();
     const handleTaskStop = testing.fn();
 
-    const {render} = rendererWith({
+    const {render} = rendererWithTableRow({
       capabilities: caps,
       store: true,
       router: true,
     });
-    const {getAllByTestId} = render(
+    render(
       <Actions
         entity={task}
         links={true}
@@ -491,19 +518,42 @@ describe('Task Actions tests', () => {
       />,
     );
 
-    const detailslinks = getAllByTestId('details-link');
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(detailslinks[0]);
-    expect(detailslinks[0]).toHaveAttribute(
+    const detailsLinks = screen.getAllByTestId('details-link');
+    fireEvent.click(detailsLinks[0]);
+    expect(detailsLinks[0]).toHaveAttribute(
       'title',
       'View Details of Schedule schedule1 (Next due: over)',
     );
 
-    fireEvent.click(icons[2]);
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute('title', 'Start');
+    fireEvent.click(startIcon);
+    expect(handleTaskStart).toHaveBeenCalledWith(task);
+
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Task is scheduled');
+    fireEvent.click(resumeIcon);
     expect(handleTaskResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Start');
-    expect(icons[2]).toHaveAttribute('title', 'Task is scheduled');
+
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Task to trashcan');
+    fireEvent.click(deleteIcon);
+    expect(handleTaskDelete).toHaveBeenCalledWith(task);
+
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Task');
+    fireEvent.click(editIcon);
+    expect(handleTaskEdit).toHaveBeenCalledWith(task);
+
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Task');
+    fireEvent.click(cloneIcon);
+    expect(handleTaskClone).toHaveBeenCalledWith(task);
+
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task');
+    fireEvent.click(exportIcon);
+    expect(handleTaskDownload).toHaveBeenCalledWith;
   });
 
   test('should call click handlers for container task', () => {
@@ -520,8 +570,8 @@ describe('Task Actions tests', () => {
     const handleTaskStart = testing.fn();
     const handleTaskStop = testing.fn();
 
-    const {render} = rendererWith({capabilities: caps, store: true});
-    const {getAllByTestId} = render(
+    const {render} = rendererWithTableRow({capabilities: caps, store: true});
+    render(
       <Actions
         entity={task}
         links={true}
@@ -536,33 +586,34 @@ describe('Task Actions tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
+    const importIcon = screen.getByTestId('import-icon');
+    expect(importIcon).toHaveAttribute('title', 'Import Report');
+    fireEvent.click(importIcon);
     expect(handleReportImport).toHaveBeenCalledWith(task);
-    expect(handleTaskStart).not.toHaveBeenCalled();
-    expect(icons[0]).toHaveAttribute('title', 'Import Report');
 
-    fireEvent.click(icons[1]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Task is a container');
+    fireEvent.click(resumeIcon);
     expect(handleTaskResume).not.toHaveBeenCalled();
-    expect(icons[1]).toHaveAttribute('title', 'Task is a container');
 
-    fireEvent.click(icons[2]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Task to trashcan');
+    fireEvent.click(deleteIcon);
     expect(handleTaskDelete).toHaveBeenCalledWith(task);
-    expect(icons[2]).toHaveAttribute('title', 'Move Task to trashcan');
 
-    fireEvent.click(icons[3]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Task');
+    fireEvent.click(editIcon);
     expect(handleTaskEdit).toHaveBeenCalledWith(task);
-    expect(icons[3]).toHaveAttribute('title', 'Edit Task');
 
-    fireEvent.click(icons[4]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Task');
+    fireEvent.click(cloneIcon);
     expect(handleTaskClone).toHaveBeenCalledWith(task);
-    expect(icons[4]).toHaveAttribute('title', 'Clone Task');
 
-    fireEvent.click(icons[5]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task');
+    fireEvent.click(exportIcon);
     expect(handleTaskDownload).toHaveBeenCalledWith(task);
-    expect(icons[5]).toHaveAttribute('title', 'Export Task');
   });
-
-  console.warn = consoleError;
 });

--- a/src/web/pages/tasks/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/tasks/__tests__/DetailsPage.test.jsx
@@ -11,10 +11,10 @@ import ScanConfig from 'gmp/models/scanconfig';
 import Schedule from 'gmp/models/schedule';
 import Task, {TASK_STATUS} from 'gmp/models/task';
 import {currentSettingsDefaultResponse} from 'web/pages/__mocks__/CurrentSettings';
-import Detailspage, {ToolBarIcons} from 'web/pages/tasks/DetailsPage';
+import DetailsPage, {ToolBarIcons} from 'web/pages/tasks/DetailsPage';
 import {entityLoadingActions} from 'web/store/entities/tasks';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent, act} from 'web/utils/Testing';
+import {rendererWith, fireEvent, screen} from 'web/utils/Testing';
 
 const config = ScanConfig.fromElement({
   _id: '314',
@@ -275,8 +275,8 @@ const getEntities = testing.fn().mockResolvedValue({
   },
 });
 
-describe('Task Detailspage tests', () => {
-  test('should render full Detailspage', () => {
+describe('Task DetailsPage tests', () => {
+  test('should render full DetailsPage', () => {
     const getTask = testing.fn().mockResolvedValue({
       data: task,
     });
@@ -322,22 +322,22 @@ describe('Task Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', task));
 
-    const {baseElement, getAllByTestId} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
 
     expect(baseElement).toBeVisible();
 
     expect(baseElement).toHaveTextContent('Task: foo');
 
     const links = baseElement.querySelectorAll('a');
-    const icons = getAllByTestId('svg-icon');
-
-    expect(icons[0]).toHaveAttribute('title', 'Help: Tasks');
+    const helpIcon = screen.getByTestId('help-icon');
+    expect(helpIcon).toHaveAttribute('title', 'Help: Tasks');
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/scanning.html#managing-tasks',
     );
 
-    expect(icons[1]).toHaveAttribute('title', 'Task List');
+    const listIcon = screen.getByTestId('list-icon');
+    expect(listIcon).toHaveAttribute('title', 'Task List');
     expect(links[1]).toHaveAttribute('href', '/tasks');
 
     expect(baseElement).toHaveTextContent('12345');
@@ -348,12 +348,12 @@ describe('Task Detailspage tests', () => {
     expect(baseElement).toHaveTextContent('foo');
     expect(baseElement).toHaveTextContent('bar');
 
-    const progressBars = getAllByTestId('progressbar-box');
+    const progressBars = screen.getAllByTestId('progressbar-box');
     expect(progressBars[0]).toHaveAttribute('title', 'Done');
     expect(progressBars[0]).toHaveTextContent('Done');
 
     const headings = baseElement.querySelectorAll('h2');
-    const detailsLinks = getAllByTestId('details-link');
+    const detailsLinks = screen.getAllByTestId('details-link');
 
     expect(headings[1]).toHaveTextContent('Target');
     expect(detailsLinks[2]).toHaveAttribute('href', '/target/5678');
@@ -435,7 +435,7 @@ describe('Task Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', task2));
 
-    const {baseElement} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
     const spans = baseElement.querySelectorAll('span');
     fireEvent.click(spans[22]);
 
@@ -489,7 +489,7 @@ describe('Task Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', task2));
 
-    const {baseElement} = render(<Detailspage id="12345" />);
+    const {baseElement} = render(<DetailsPage id="12345" />);
     const spans = baseElement.querySelectorAll('span');
     fireEvent.click(spans[24]);
 
@@ -568,31 +568,32 @@ describe('Task Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('12345', task5));
 
-    const {getAllByTestId} = render(<Detailspage id="12345" />);
+    render(<DetailsPage id="12345" />);
 
-    const icons = getAllByTestId('svg-icon');
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Task');
+    fireEvent.click(cloneIcon);
+    expect(clone).toHaveBeenCalledWith(task5);
 
-    await act(async () => {
-      fireEvent.click(icons[3]);
-      expect(clone).toHaveBeenCalledWith(task5);
-      expect(icons[3]).toHaveAttribute('title', 'Clone Task');
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Task to trashcan');
+    fireEvent.click(deleteIcon);
+    expect(deleteFunc).toHaveBeenCalledWith(task5Id);
 
-      fireEvent.click(icons[5]);
-      expect(deleteFunc).toHaveBeenCalledWith(task5Id);
-      expect(icons[5]).toHaveAttribute('title', 'Move Task to trashcan');
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task as XML');
+    fireEvent.click(exportIcon);
+    expect(exportFunc).toHaveBeenCalledWith(task5);
 
-      fireEvent.click(icons[6]);
-      expect(exportFunc).toHaveBeenCalledWith(task5);
-      expect(icons[6]).toHaveAttribute('title', 'Export Task as XML');
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute('title', 'Start');
+    fireEvent.click(startIcon);
+    expect(start).toHaveBeenCalledWith(task5);
 
-      fireEvent.click(icons[7]);
-      expect(start).toHaveBeenCalledWith(task5);
-      expect(icons[7]).toHaveAttribute('title', 'Start');
-
-      fireEvent.click(icons[8]);
-      expect(resume).toHaveBeenCalledWith(task5);
-      expect(icons[8]).toHaveAttribute('title', 'Resume');
-    });
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Resume');
+    fireEvent.click(resumeIcon);
+    expect(resume).toHaveBeenCalledWith(task5);
   });
 });
 
@@ -620,7 +621,7 @@ describe('Task ToolBarIcons tests', () => {
       store: true,
     });
 
-    const {element, getAllByTestId} = render(
+    const {element} = render(
       <ToolBarIcons
         entity={task}
         notes={[{_id: '2021'}, {_id: '2223'}]}
@@ -640,16 +641,17 @@ describe('Task ToolBarIcons tests', () => {
 
     expect(element).toBeVisible();
 
-    const icons = getAllByTestId('svg-icon');
     const links = element.querySelectorAll('a');
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: Tasks');
+    const helpIcon = screen.getByTestId('help-icon');
+    expect(helpIcon).toHaveAttribute('title', 'Help: Tasks');
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/scanning.html#managing-tasks',
     );
 
-    expect(icons[1]).toHaveAttribute('title', 'Task List');
+    const listIcon = screen.getByTestId('list-icon');
+    expect(listIcon).toHaveAttribute('title', 'Task List');
     expect(links[1]).toHaveAttribute('href', '/tasks');
   });
 
@@ -676,7 +678,7 @@ describe('Task ToolBarIcons tests', () => {
       store: true,
     });
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <ToolBarIcons
         entity={task3}
         onContainerTaskCreateClick={handleContainerTaskCreate}
@@ -692,43 +694,48 @@ describe('Task ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    const badgeIcons = getAllByTestId('badge-icon');
+    const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
-    const divs = baseElement.querySelectorAll('div');
 
-    fireEvent.click(divs[8]);
+    const newTaskMenu = screen.getByTestId('new-task-menu');
+    expect(newTaskMenu).toHaveTextContent('New Task');
+    fireEvent.click(newTaskMenu);
     expect(handleTaskCreate).toHaveBeenCalled();
-    expect(divs[8]).toHaveTextContent('New Task');
 
-    fireEvent.click(divs[9]);
+    const newContainerTaskMenu = screen.getByTestId('new-container-task-menu');
+    expect(newContainerTaskMenu).toHaveTextContent('New Container Task');
+    fireEvent.click(newContainerTaskMenu);
     expect(handleContainerTaskCreate).toHaveBeenCalled();
-    expect(divs[9]).toHaveTextContent('New Container Task');
 
-    fireEvent.click(icons[3]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Task');
+    fireEvent.click(cloneIcon);
     expect(handleTaskClone).toHaveBeenCalledWith(task3);
-    expect(icons[3]).toHaveAttribute('title', 'Clone Task');
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Task');
+    fireEvent.click(editIcon);
     expect(handleTaskEdit).toHaveBeenCalledWith(task3);
-    expect(icons[4]).toHaveAttribute('title', 'Edit Task');
 
-    fireEvent.click(icons[5]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Task to trashcan');
+    fireEvent.click(deleteIcon);
     expect(handleTaskDelete).toHaveBeenCalledWith(task3);
-    expect(icons[5]).toHaveAttribute('title', 'Move Task to trashcan');
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task as XML');
+    fireEvent.click(exportIcon);
     expect(handleTaskDownload).toHaveBeenCalledWith(task3);
-    expect(icons[6]).toHaveAttribute('title', 'Export Task as XML');
 
-    fireEvent.click(icons[7]);
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute('title', 'Start');
+    fireEvent.click(startIcon);
     expect(handleTaskStart).toHaveBeenCalledWith(task3);
-    expect(icons[7]).toHaveAttribute('title', 'Start');
 
-    fireEvent.click(icons[8]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Task is not stopped');
+    fireEvent.click(resumeIcon);
     expect(handleTaskResume).not.toHaveBeenCalled();
-    expect(icons[8]).toHaveAttribute('title', 'Task is not stopped');
 
     expect(links[2]).toHaveAttribute('href', '/reports?filter=task_id%3D12345');
     expect(links[2]).toHaveAttribute('title', 'Total Reports for Task foo');
@@ -773,7 +780,7 @@ describe('Task ToolBarIcons tests', () => {
       store: true,
     });
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <ToolBarIcons
         entity={task4}
         onContainerTaskCreateClick={handleContainerTaskCreate}
@@ -789,43 +796,48 @@ describe('Task ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-    const badgeIcons = getAllByTestId('badge-icon');
+    const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
-    const divs = baseElement.querySelectorAll('div');
 
-    fireEvent.click(divs[8]);
+    const newTaskMenu = screen.getByTestId('new-task-menu');
+    expect(newTaskMenu).toHaveTextContent('New Task');
+    fireEvent.click(newTaskMenu);
     expect(handleTaskCreate).toHaveBeenCalled();
-    expect(divs[8]).toHaveTextContent('New Task');
 
-    fireEvent.click(divs[9]);
+    const newContainerTaskMenu = screen.getByTestId('new-container-task-menu');
+    expect(newContainerTaskMenu).toHaveTextContent('New Container Task');
+    fireEvent.click(newContainerTaskMenu);
     expect(handleContainerTaskCreate).toHaveBeenCalled();
-    expect(divs[9]).toHaveTextContent('New Container Task');
 
-    fireEvent.click(icons[3]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Task');
+    fireEvent.click(cloneIcon);
     expect(handleTaskClone).toHaveBeenCalledWith(task4);
-    expect(icons[3]).toHaveAttribute('title', 'Clone Task');
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Task');
+    fireEvent.click(editIcon);
     expect(handleTaskEdit).toHaveBeenCalledWith(task4);
-    expect(icons[4]).toHaveAttribute('title', 'Edit Task');
 
-    fireEvent.click(icons[5]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Task is still in use');
+    fireEvent.click(deleteIcon);
     expect(handleTaskDelete).not.toHaveBeenCalled();
-    expect(icons[5]).toHaveAttribute('title', 'Task is still in use');
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task as XML');
+    fireEvent.click(exportIcon);
     expect(handleTaskDownload).toHaveBeenCalledWith(task4);
-    expect(icons[6]).toHaveAttribute('title', 'Export Task as XML');
 
-    fireEvent.click(icons[7]);
-    expect(handleTaskStart).not.toHaveBeenCalled();
+    const stopIcon = screen.getByTestId('stop-icon');
+    expect(stopIcon).toHaveAttribute('title', 'Stop');
+    fireEvent.click(stopIcon);
     expect(handleTaskStop).toHaveBeenCalledWith(task4);
-    expect(icons[7]).toHaveAttribute('title', 'Stop');
 
-    fireEvent.click(icons[8]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Task is not stopped');
+    fireEvent.click(resumeIcon);
     expect(handleTaskResume).not.toHaveBeenCalled();
-    expect(icons[8]).toHaveAttribute('title', 'Task is not stopped');
 
     expect(links[2]).toHaveAttribute('href', '/report/12342');
     expect(links[2]).toHaveAttribute(
@@ -876,7 +888,7 @@ describe('Task ToolBarIcons tests', () => {
       store: true,
     });
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <ToolBarIcons
         entity={task5}
         onContainerTaskCreateClick={handleContainerTaskCreate}
@@ -892,42 +904,48 @@ describe('Task ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-    const badgeIcons = getAllByTestId('badge-icon');
+    const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
-    const divs = baseElement.querySelectorAll('div');
 
-    fireEvent.click(divs[8]);
+    const newTaskMenu = screen.getByTestId('new-task-menu');
+    expect(newTaskMenu).toHaveTextContent('New Task');
+    fireEvent.click(newTaskMenu);
     expect(handleTaskCreate).toHaveBeenCalled();
-    expect(divs[8]).toHaveTextContent('New Task');
 
-    fireEvent.click(divs[9]);
+    const newContainerTaskMenu = screen.getByTestId('new-container-task-menu');
+    expect(newContainerTaskMenu).toHaveTextContent('New Container Task');
+    fireEvent.click(newContainerTaskMenu);
     expect(handleContainerTaskCreate).toHaveBeenCalled();
-    expect(divs[9]).toHaveTextContent('New Container Task');
 
-    fireEvent.click(icons[3]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Task');
+    fireEvent.click(cloneIcon);
     expect(handleTaskClone).toHaveBeenCalledWith(task5);
-    expect(icons[3]).toHaveAttribute('title', 'Clone Task');
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Task');
+    fireEvent.click(editIcon);
     expect(handleTaskEdit).toHaveBeenCalledWith(task5);
-    expect(icons[4]).toHaveAttribute('title', 'Edit Task');
 
-    fireEvent.click(icons[5]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Task to trashcan');
+    fireEvent.click(deleteIcon);
     expect(handleTaskDelete).toHaveBeenCalledWith(task5);
-    expect(icons[5]).toHaveAttribute('title', 'Move Task to trashcan');
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task as XML');
+    fireEvent.click(exportIcon);
     expect(handleTaskDownload).toHaveBeenCalledWith(task5);
-    expect(icons[6]).toHaveAttribute('title', 'Export Task as XML');
 
-    fireEvent.click(icons[7]);
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute('title', 'Start');
+    fireEvent.click(startIcon);
     expect(handleTaskStart).toHaveBeenCalledWith(task5);
-    expect(icons[7]).toHaveAttribute('title', 'Start');
 
-    fireEvent.click(icons[8]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Resume');
+    fireEvent.click(resumeIcon);
     expect(handleTaskResume).toHaveBeenCalledWith(task5);
-    expect(icons[8]).toHaveAttribute('title', 'Resume');
 
     expect(links[2]).toHaveAttribute('href', '/report/12342');
     expect(links[2]).toHaveAttribute(
@@ -978,7 +996,7 @@ describe('Task ToolBarIcons tests', () => {
       store: true,
     });
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <ToolBarIcons
         entity={task2}
         notes={[{_id: '2021'}, {_id: '2223'}]}
@@ -996,42 +1014,48 @@ describe('Task ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-    const badgeIcons = getAllByTestId('badge-icon');
+    const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
-    const divs = baseElement.querySelectorAll('div');
 
-    fireEvent.click(divs[8]);
+    const newTaskMenu = screen.getByTestId('new-task-menu');
+    expect(newTaskMenu).toHaveTextContent('New Task');
+    fireEvent.click(newTaskMenu);
     expect(handleTaskCreate).toHaveBeenCalled();
-    expect(divs[8]).toHaveTextContent('New Task');
 
-    fireEvent.click(divs[9]);
+    const newContainerTaskMenu = screen.getByTestId('new-container-task-menu');
+    expect(newContainerTaskMenu).toHaveTextContent('New Container Task');
+    fireEvent.click(newContainerTaskMenu);
     expect(handleContainerTaskCreate).toHaveBeenCalled();
-    expect(divs[9]).toHaveTextContent('New Container Task');
 
-    fireEvent.click(icons[3]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Task');
+    fireEvent.click(cloneIcon);
     expect(handleTaskClone).toHaveBeenCalledWith(task2);
-    expect(icons[3]).toHaveAttribute('title', 'Clone Task');
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Task');
+    fireEvent.click(editIcon);
     expect(handleTaskEdit).toHaveBeenCalledWith(task2);
-    expect(icons[4]).toHaveAttribute('title', 'Edit Task');
 
-    fireEvent.click(icons[5]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Task to trashcan');
+    fireEvent.click(deleteIcon);
     expect(handleTaskDelete).toHaveBeenCalledWith(task2);
-    expect(icons[5]).toHaveAttribute('title', 'Move Task to trashcan');
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task as XML');
+    fireEvent.click(exportIcon);
     expect(handleTaskDownload).toHaveBeenCalledWith(task2);
-    expect(icons[6]).toHaveAttribute('title', 'Export Task as XML');
 
-    fireEvent.click(icons[7]);
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute('title', 'Start');
+    fireEvent.click(startIcon);
     expect(handleTaskStart).toHaveBeenCalledWith(task2);
-    expect(icons[7]).toHaveAttribute('title', 'Start');
 
-    fireEvent.click(icons[8]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Task is not stopped');
+    fireEvent.click(resumeIcon);
     expect(handleTaskResume).not.toHaveBeenCalled();
-    expect(icons[8]).toHaveAttribute('title', 'Task is not stopped');
 
     expect(links[2]).toHaveAttribute('href', '/report/1234');
     expect(links[2]).toHaveAttribute(
@@ -1082,7 +1106,7 @@ describe('Task ToolBarIcons tests', () => {
       store: true,
     });
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <ToolBarIcons
         entity={task6}
         onContainerTaskCreateClick={handleContainerTaskCreate}
@@ -1098,48 +1122,54 @@ describe('Task ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-    const badgeIcons = getAllByTestId('badge-icon');
+    const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
-    const divs = baseElement.querySelectorAll('div');
 
-    fireEvent.click(divs[8]);
+    const newTaskMenu = screen.getByTestId('new-task-menu');
+    expect(newTaskMenu).toHaveTextContent('New Task');
+    fireEvent.click(newTaskMenu);
     expect(handleTaskCreate).toHaveBeenCalled();
-    expect(divs[8]).toHaveTextContent('New Task');
 
-    fireEvent.click(divs[9]);
+    const newContainerTaskMenu = screen.getByTestId('new-container-task-menu');
+    expect(newContainerTaskMenu).toHaveTextContent('New Container Task');
+    fireEvent.click(newContainerTaskMenu);
     expect(handleContainerTaskCreate).toHaveBeenCalled();
-    expect(divs[9]).toHaveTextContent('New Container Task');
 
-    fireEvent.click(icons[3]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Task');
+    fireEvent.click(cloneIcon);
     expect(handleTaskClone).toHaveBeenCalledWith(task6);
-    expect(icons[3]).toHaveAttribute('title', 'Clone Task');
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Permission to edit Task denied');
+    fireEvent.click(editIcon);
     expect(handleTaskEdit).not.toHaveBeenCalled();
-    expect(icons[4]).toHaveAttribute('title', 'Permission to edit Task denied');
 
-    fireEvent.click(icons[5]);
-    expect(handleTaskDelete).not.toHaveBeenCalled();
-    expect(icons[5]).toHaveAttribute(
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute(
       'title',
       'Permission to move Task to trashcan denied',
     );
+    fireEvent.click(deleteIcon);
+    expect(handleTaskDelete).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task as XML');
+    fireEvent.click(exportIcon);
     expect(handleTaskDownload).toHaveBeenCalledWith(task6);
-    expect(icons[6]).toHaveAttribute('title', 'Export Task as XML');
 
-    fireEvent.click(icons[7]);
-    expect(handleTaskStart).not.toHaveBeenCalled();
-    expect(icons[7]).toHaveAttribute(
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute(
       'title',
       'Permission to start task denied',
     );
+    fireEvent.click(startIcon);
+    expect(handleTaskStart).not.toHaveBeenCalled();
 
-    fireEvent.click(icons[8]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Task is not stopped');
+    fireEvent.click(resumeIcon);
     expect(handleTaskResume).not.toHaveBeenCalled();
-    expect(icons[8]).toHaveAttribute('title', 'Task is not stopped');
 
     expect(links[2]).toHaveAttribute('href', '/report/1234');
     expect(links[2]).toHaveAttribute(
@@ -1190,7 +1220,7 @@ describe('Task ToolBarIcons tests', () => {
       store: true,
     });
 
-    const {getAllByTestId} = render(
+    render(
       <ToolBarIcons
         entity={task7}
         onContainerTaskCreateClick={handleContainerTaskCreate}
@@ -1206,8 +1236,7 @@ describe('Task ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-    const detailsLinks = getAllByTestId('details-link');
+    const detailsLinks = screen.getAllByTestId('details-link');
 
     expect(detailsLinks[0]).toHaveAttribute('href', '/schedule/121314');
     expect(detailsLinks[0]).toHaveAttribute(
@@ -1215,13 +1244,15 @@ describe('Task ToolBarIcons tests', () => {
       'View Details of Schedule schedule1 (Next due: over)',
     );
 
-    fireEvent.click(icons[8]);
-    expect(handleTaskStart).toHaveBeenCalledWith(task7);
-    expect(icons[8]).toHaveAttribute('title', 'Start');
+    const startIcon = screen.getByTestId('start-icon');
+    expect(startIcon).toHaveAttribute('title', 'Start');
+    fireEvent.click(startIcon);
+    expect(handleTaskStart).toHaveBeenCalled(task7);
 
-    fireEvent.click(icons[9]);
+    const resumeIcon = screen.getByTestId('resume-icon');
+    expect(resumeIcon).toHaveAttribute('title', 'Task is scheduled');
+    fireEvent.click(resumeIcon);
     expect(handleTaskResume).not.toHaveBeenCalled();
-    expect(icons[9]).toHaveAttribute('title', 'Task is scheduled');
   });
 
   test('should call click handlers for container task', () => {
@@ -1247,7 +1278,7 @@ describe('Task ToolBarIcons tests', () => {
       store: true,
     });
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <ToolBarIcons
         entity={task8}
         onContainerTaskCreateClick={handleContainerTaskCreate}
@@ -1263,38 +1294,43 @@ describe('Task ToolBarIcons tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-    const badgeIcons = getAllByTestId('badge-icon');
+    const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
-    const divs = baseElement.querySelectorAll('div');
 
-    fireEvent.click(divs[8]);
+    const newTaskMenu = screen.getByTestId('new-task-menu');
+    expect(newTaskMenu).toHaveTextContent('New Task');
+    fireEvent.click(newTaskMenu);
     expect(handleTaskCreate).toHaveBeenCalled();
-    expect(divs[8]).toHaveTextContent('New Task');
 
-    fireEvent.click(divs[9]);
+    const newContainerTaskMenu = screen.getByTestId('new-container-task-menu');
+    expect(newContainerTaskMenu).toHaveTextContent('New Container Task');
+    fireEvent.click(newContainerTaskMenu);
     expect(handleContainerTaskCreate).toHaveBeenCalled();
-    expect(divs[9]).toHaveTextContent('New Container Task');
 
-    fireEvent.click(icons[3]);
+    const cloneIcon = screen.getByTestId('clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Task');
+    fireEvent.click(cloneIcon);
     expect(handleTaskClone).toHaveBeenCalledWith(task8);
-    expect(icons[3]).toHaveAttribute('title', 'Clone Task');
 
-    fireEvent.click(icons[4]);
+    const editIcon = screen.getByTestId('edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Task');
+    fireEvent.click(editIcon);
     expect(handleTaskEdit).toHaveBeenCalledWith(task8);
-    expect(icons[4]).toHaveAttribute('title', 'Edit Task');
 
-    fireEvent.click(icons[5]);
+    const deleteIcon = screen.getByTestId('trashcan-icon');
+    expect(deleteIcon).toHaveAttribute('title', 'Move Task to trashcan');
+    fireEvent.click(deleteIcon);
     expect(handleTaskDelete).toHaveBeenCalledWith(task8);
-    expect(icons[5]).toHaveAttribute('title', 'Move Task to trashcan');
 
-    fireEvent.click(icons[6]);
+    const exportIcon = screen.getByTestId('export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task as XML');
+    fireEvent.click(exportIcon);
     expect(handleTaskDownload).toHaveBeenCalledWith(task8);
-    expect(icons[6]).toHaveAttribute('title', 'Export Task as XML');
 
-    fireEvent.click(icons[7]);
+    const importIcon = screen.getByTestId('import-icon');
+    expect(importIcon).toHaveAttribute('title', 'Import Report');
+    fireEvent.click(importIcon);
     expect(handleReportImport).toHaveBeenCalledWith(task8);
-    expect(icons[7]).toHaveAttribute('title', 'Import Report');
 
     expect(links[2]).toHaveAttribute('href', '/report/1234');
     expect(links[2]).toHaveAttribute(

--- a/src/web/pages/tasks/__tests__/ListPage.test.jsx
+++ b/src/web/pages/tasks/__tests__/ListPage.test.jsx
@@ -12,7 +12,6 @@ import {
   clickElement,
   getPowerFilter,
   getSelectElement,
-  getTextInputs,
   testBulkTrashcanDialog,
 } from 'web/components/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__mocks__/CurrentSettings';
@@ -21,7 +20,13 @@ import {entitiesLoadingActions} from 'web/store/entities/tasks';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
 import {loadingActions} from 'web/store/usersettings/defaults/actions';
-import {rendererWith, fireEvent, wait, screen} from 'web/utils/Testing';
+import {
+  rendererWith,
+  fireEvent,
+  wait,
+  screen,
+  getByTestId,
+} from 'web/utils/Testing';
 
 const lastReport = {
   report: {
@@ -156,34 +161,57 @@ describe('TaskPage tests', () => {
       entitiesLoadingActions.success([task], filter, loadedFilter, counts),
     );
 
-    const {baseElement, getAllByTestId} = render(<TaskPage />);
+    const {baseElement} = render(<TaskPage />);
 
     await wait();
 
-    const display = getAllByTestId('grid-item');
-    const icons = getAllByTestId('svg-icon');
+    const display = screen.getAllByTestId('grid-item');
     const header = baseElement.querySelectorAll('th');
-    const row = baseElement.querySelectorAll('tr');
+    const row = baseElement.querySelectorAll('tbody tr')[0];
     const powerFilter = getPowerFilter();
     const select = getSelectElement(powerFilter);
-    const inputs = getTextInputs(powerFilter);
 
     // Toolbar Icons
-    expect(icons[0]).toHaveAttribute('title', 'Help: Tasks');
+    const helpIcon = screen.getByTestId('help-icon');
+    expect(helpIcon).toHaveAttribute('title', 'Help: Tasks');
 
     // Powerfilter
-    expect(inputs[0]).toHaveAttribute('name', 'userFilterString');
-    expect(icons[3]).toHaveAttribute('title', 'Update Filter');
-    expect(icons[4]).toHaveAttribute('title', 'Remove Filter');
-    expect(icons[5]).toHaveAttribute('title', 'Reset to Default Filter');
-    expect(icons[6]).toHaveAttribute('title', 'Help: Powerfilter');
-    expect(icons[7]).toHaveAttribute('title', 'Edit Filter');
+    expect(screen.getByTestId('powerfilter-text')).toHaveAttribute(
+      'name',
+      'userFilterString',
+    );
+    expect(screen.getByTestId('powerfilter-refresh')).toHaveAttribute(
+      'title',
+      'Update Filter',
+    );
+    expect(screen.getByTestId('powerfilter-delete')).toHaveAttribute(
+      'title',
+      'Remove Filter',
+    );
+    expect(screen.getByTestId('powerfilter-reset')).toHaveAttribute(
+      'title',
+      'Reset to Default Filter',
+    );
+    expect(screen.getByTestId('powerfilter-help')).toHaveAttribute(
+      'title',
+      'Help: Powerfilter',
+    );
+    expect(screen.getByTestId('powerfilter-edit')).toHaveAttribute(
+      'title',
+      'Edit Filter',
+    );
     expect(select).toHaveAttribute('title', 'Loaded filter');
     expect(select).toHaveValue('--');
 
     // Dashboard
-    expect(icons[9]).toHaveAttribute('title', 'Add new Dashboard Display');
-    expect(icons[10]).toHaveAttribute('title', 'Reset to Defaults');
+    expect(screen.getByTestId('add-dashboard-display')).toHaveAttribute(
+      'title',
+      'Add new Dashboard Display',
+    );
+    expect(screen.getByTestId('reset-dashboard')).toHaveAttribute(
+      'title',
+      'Reset to Defaults',
+    );
     expect(display[0]).toHaveTextContent('Tasks by Severity Class (Total: 0)');
     expect(display[1]).toHaveTextContent(
       'Tasks with most High Results per Host',
@@ -199,18 +227,22 @@ describe('TaskPage tests', () => {
     expect(header[5]).toHaveTextContent('Trend');
     expect(header[6]).toHaveTextContent('Actions');
 
-    expect(row[1]).toHaveTextContent('foo');
-    expect(row[1]).toHaveTextContent('(bar)');
-    expect(row[1]).toHaveTextContent('Done');
-    expect(row[1]).toHaveTextContent('Sat, Aug 10, 2019 2:51 PM CEST');
-    expect(row[1]).toHaveTextContent('5.0 (Medium)');
+    expect(row).toHaveTextContent('foo');
+    expect(row).toHaveTextContent('(bar)');
+    expect(row).toHaveTextContent('Done');
+    expect(row).toHaveTextContent('Sat, Aug 10, 2019 2:51 PM CEST');
+    expect(row).toHaveTextContent('5.0 (Medium)');
 
-    expect(icons[30]).toHaveAttribute('title', 'Start');
-    expect(icons[31]).toHaveAttribute('title', 'Task is not stopped');
-    expect(icons[32]).toHaveAttribute('title', 'Move Task to trashcan');
-    expect(icons[33]).toHaveAttribute('title', 'Edit Task');
-    expect(icons[34]).toHaveAttribute('title', 'Clone Task');
-    expect(icons[35]).toHaveAttribute('title', 'Export Task');
+    const startIcon = getByTestId(row, 'start-icon');
+    expect(startIcon).toHaveAttribute('title', 'Start');
+    const trashcanIcon = getByTestId(row, 'trashcan-icon');
+    expect(trashcanIcon).toHaveAttribute('title', 'Move Task to trashcan');
+    const editIcon = getByTestId(row, 'edit-icon');
+    expect(editIcon).toHaveAttribute('title', 'Edit Task');
+    const cloneIcon = getByTestId(row, 'clone-icon');
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Task');
+    const exportIcon = getByTestId(row, 'export-icon');
+    expect(exportIcon).toHaveAttribute('title', 'Export Task');
   });
 
   test('should call commands for bulk actions', async () => {
@@ -310,7 +342,7 @@ describe('TaskPage ToolBarIcons test', () => {
       router: true,
     });
 
-    const {element, getAllByTestId} = render(
+    const {element} = render(
       <ToolBarIcons
         onAdvancedTaskWizardClick={handleAdvancedTaskWizardClick}
         onContainerTaskCreateClick={handleContainerTaskCreateClick}
@@ -322,9 +354,10 @@ describe('TaskPage ToolBarIcons test', () => {
     expect(element).toBeVisible();
 
     const links = element.querySelectorAll('a');
-    const icons = getAllByTestId('svg-icon');
-
-    expect(icons[0]).toHaveAttribute('title', 'Help: Tasks');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: Tasks',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/scanning.html#managing-tasks',
@@ -348,7 +381,7 @@ describe('TaskPage ToolBarIcons test', () => {
       router: true,
     });
 
-    const {baseElement} = render(
+    render(
       <ToolBarIcons
         onAdvancedTaskWizardClick={handleAdvancedTaskWizardClick}
         onContainerTaskCreateClick={handleContainerTaskCreateClick}
@@ -358,27 +391,32 @@ describe('TaskPage ToolBarIcons test', () => {
       />,
     );
 
-    const divs = baseElement.querySelectorAll('div');
-
-    fireEvent.click(divs[5]);
+    const taskWizardMenu = screen.getByTestId('task-wizard-menu');
+    expect(taskWizardMenu).toHaveTextContent('Task Wizard');
+    fireEvent.click(taskWizardMenu);
     expect(handleTaskWizardClick).toHaveBeenCalled();
-    expect(divs[5]).toHaveTextContent('Task Wizard');
 
-    fireEvent.click(divs[6]);
+    const advancedTaskWizardMenu = screen.getByTestId(
+      'advanced-task-wizard-menu',
+    );
+    expect(advancedTaskWizardMenu).toHaveTextContent('Advanced Task Wizard');
+    fireEvent.click(advancedTaskWizardMenu);
     expect(handleAdvancedTaskWizardClick).toHaveBeenCalled();
-    expect(divs[6]).toHaveTextContent('Advanced Task Wizard');
 
-    fireEvent.click(divs[7]);
+    const modifyTaskWizardMenu = screen.getByTestId('modify-task-wizard-menu');
+    expect(modifyTaskWizardMenu).toHaveTextContent('Modify Task Wizard');
+    fireEvent.click(modifyTaskWizardMenu);
     expect(handleModifyTaskWizardClick).toHaveBeenCalled();
-    expect(divs[7]).toHaveTextContent('Modify Task Wizard');
 
-    fireEvent.click(divs[9]);
+    const newTaskMenu = screen.getByTestId('new-task-menu');
+    expect(newTaskMenu).toHaveTextContent('New Task');
+    fireEvent.click(newTaskMenu);
     expect(handleTaskCreateClick).toHaveBeenCalled();
-    expect(divs[9]).toHaveTextContent('New Task');
 
-    fireEvent.click(divs[10]);
+    const newContainerTaskMenu = screen.getByTestId('new-container-task-menu');
+    expect(newContainerTaskMenu).toHaveTextContent('New Container Task');
+    fireEvent.click(newContainerTaskMenu);
     expect(handleContainerTaskCreateClick).toHaveBeenCalled();
-    expect(divs[10]).toHaveTextContent('New Container Task');
   });
 
   test('should not show icons if user does not have the right permissions', () => {
@@ -397,7 +435,7 @@ describe('TaskPage ToolBarIcons test', () => {
       capabilities: wrongCaps,
       router: true,
     });
-    const {queryAllByTestId} = render(
+    render(
       <ToolBarIcons
         onAdvancedTaskWizardClick={handleAdvancedTaskWizardClick}
         onContainerTaskCreateClick={handleContainerTaskCreateClick}
@@ -407,8 +445,25 @@ describe('TaskPage ToolBarIcons test', () => {
       />,
     );
 
-    const icons = queryAllByTestId('svg-icon');
-    expect(icons.length).toBe(1);
-    expect(icons[0]).toHaveAttribute('title', 'Help: Tasks');
+    const taskWizardMenu = screen.queryByTestId('task-wizard-menu');
+    expect(taskWizardMenu).toBeNull();
+
+    const advancedTaskWizardMenu = screen.queryByTestId(
+      'advanced-task-wizard-menu',
+    );
+    expect(advancedTaskWizardMenu).toBeNull();
+
+    const modifyTaskWizardMenu = screen.queryByTestId(
+      'modify-task-wizard-menu',
+    );
+    expect(modifyTaskWizardMenu).toBeNull();
+
+    const newTaskMenu = screen.queryByTestId('new-task-menu');
+    expect(newTaskMenu).toBeNull();
+
+    const newContainerTaskMenu = screen.queryByTestId(
+      'new-container-task-menu',
+    );
+    expect(newContainerTaskMenu).toBeNull();
   });
 });

--- a/src/web/pages/tasks/__tests__/Table.test.jsx
+++ b/src/web/pages/tasks/__tests__/Table.test.jsx
@@ -10,8 +10,7 @@ import Filter from 'gmp/models/filter';
 import Task, {TASK_STATUS} from 'gmp/models/task';
 import Table from 'web/pages/tasks/Table';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent} from 'web/utils/Testing';
-
+import {rendererWith, fireEvent, screen} from 'web/utils/Testing';
 
 const caps = new Capabilities(['everything']);
 
@@ -164,7 +163,7 @@ describe('Tasks table tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {element, getAllByTestId} = render(
+    const {element} = render(
       <Table
         entities={[task, task2, task3]}
         entitiesCounts={counts}
@@ -184,9 +183,8 @@ describe('Tasks table tests', () => {
     expect(element).not.toHaveTextContent('target1');
     expect(element).not.toHaveTextContent('target2');
 
-    const icons = getAllByTestId('svg-icon');
-    fireEvent.click(icons[0]);
-    expect(icons[0]).toHaveAttribute('title', 'Unfold all details');
+    const unfoldIcon = screen.getByTestId('fold-state-icon-unfold');
+    fireEvent.click(unfoldIcon);
     expect(element).toHaveTextContent('target1');
     expect(element).toHaveTextContent('target2');
   });
@@ -215,7 +213,7 @@ describe('Tasks table tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {getAllByTestId} = render(
+    render(
       <Table
         entities={[task, task2, task3]}
         entitiesCounts={counts}
@@ -232,30 +230,34 @@ describe('Tasks table tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[5]);
+    const startIcon = screen.getAllByTestId('start-icon')[0];
+    expect(startIcon).toHaveAttribute('title', 'Start');
+    fireEvent.click(startIcon);
     expect(handleTaskStart).toHaveBeenCalledWith(task);
-    expect(icons[5]).toHaveAttribute('title', 'Start');
 
-    fireEvent.click(icons[6]);
+    const resumeIcon = screen.getAllByTestId('resume-icon')[0];
+    expect(resumeIcon).toHaveAttribute('title', 'Task is not stopped');
+    fireEvent.click(resumeIcon);
     expect(handleTaskResume).not.toHaveBeenCalled();
-    expect(icons[6]).toHaveAttribute('title', 'Task is not stopped');
 
-    fireEvent.click(icons[7]);
+    const deleteIcon = screen.getAllByTestId('trashcan-icon')[0];
+    expect(deleteIcon).toHaveAttribute('title', 'Move Task to trashcan');
+    fireEvent.click(deleteIcon);
     expect(handleTaskDelete).toHaveBeenCalledWith(task);
-    expect(icons[7]).toHaveAttribute('title', 'Move Task to trashcan');
 
-    fireEvent.click(icons[8]);
+    const editIcon = screen.getAllByTestId('edit-icon')[0];
+    expect(editIcon).toHaveAttribute('title', 'Edit Task');
+    fireEvent.click(editIcon);
     expect(handleTaskEdit).toHaveBeenCalledWith(task);
-    expect(icons[8]).toHaveAttribute('title', 'Edit Task');
 
-    fireEvent.click(icons[9]);
+    const cloneIcon = screen.getAllByTestId('clone-icon')[0];
+    expect(cloneIcon).toHaveAttribute('title', 'Clone Task');
+    fireEvent.click(cloneIcon);
     expect(handleTaskClone).toHaveBeenCalledWith(task);
-    expect(icons[9]).toHaveAttribute('title', 'Clone Task');
 
-    fireEvent.click(icons[10]);
+    const exportIcon = screen.getAllByTestId('export-icon')[0];
+    expect(exportIcon).toHaveAttribute('title', 'Export Task');
+    fireEvent.click(exportIcon);
     expect(handleTaskDownload).toHaveBeenCalledWith(task);
-    expect(icons[10]).toHaveAttribute('title', 'Export Task');
   });
 });

--- a/src/web/pages/tasks/icons/NewIconMenu.jsx
+++ b/src/web/pages/tasks/icons/NewIconMenu.jsx
@@ -10,15 +10,19 @@ import IconMenu from 'web/components/menu/IconMenu';
 import MenuEntry from 'web/components/menu/MenuEntry';
 import useCapabilities from 'web/hooks/useCapabilities';
 import PropTypes from 'web/utils/PropTypes';
-import withCapabilities from 'web/utils/withCapabilities';
 
 const NewIconMenu = ({onNewClick, onNewContainerClick}) => {
   const capabilities = useCapabilities();
   if (capabilities.mayCreate('task')) {
     return (
       <IconMenu icon={<NewIcon />} onClick={onNewClick}>
-        <MenuEntry title={_('New Task')} onClick={onNewClick} />
         <MenuEntry
+          data-testid="new-task-menu"
+          title={_('New Task')}
+          onClick={onNewClick}
+        />
+        <MenuEntry
+          data-testid="new-container-task-menu"
           title={_('New Container Task')}
           onClick={onNewContainerClick}
         />
@@ -33,4 +37,4 @@ NewIconMenu.propTypes = {
   onNewContainerClick: PropTypes.func,
 };
 
-export default withCapabilities(NewIconMenu);
+export default NewIconMenu;

--- a/src/web/pages/tasks/icons/NewIconMenu.jsx
+++ b/src/web/pages/tasks/icons/NewIconMenu.jsx
@@ -15,7 +15,7 @@ const NewIconMenu = ({onNewClick, onNewContainerClick}) => {
   const capabilities = useCapabilities();
   if (capabilities.mayCreate('task')) {
     return (
-      <IconMenu icon={<NewIcon />} onClick={onNewClick}>
+      <IconMenu icon={<NewIcon />}>
         <MenuEntry
           data-testid="new-task-menu"
           title={_('New Task')}

--- a/src/web/pages/tasks/icons/__tests__/NewIconMenu.test.jsx
+++ b/src/web/pages/tasks/icons/__tests__/NewIconMenu.test.jsx
@@ -1,0 +1,54 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, testing} from '@gsa/testing';
+import Capabilities from 'gmp/capabilities/capabilities';
+import NewIconMenu from 'web/pages/tasks/icons/NewIconMenu';
+import {fireEvent, rendererWith, screen} from 'web/utils/Testing';
+
+const capabilities = new Capabilities(['everything']);
+
+describe('NewIconMenu tests', () => {
+  test('renders without crashing', () => {
+    const {render} = rendererWith({capabilities});
+
+    render(<NewIconMenu />);
+
+    expect(screen.getByTestId('new-icon')).toBeInTheDocument();
+  });
+
+  test('calls onClick handler when menu item is clicked', () => {
+    const handleClick = testing.fn();
+    const handleContainerClick = testing.fn();
+    const {render} = rendererWith({capabilities});
+
+    render(
+      <NewIconMenu
+        onNewClick={handleClick}
+        onNewContainerClick={handleContainerClick}
+      />,
+    );
+
+    const taskMenu = screen.getByTestId('new-task-menu');
+    fireEvent.click(taskMenu);
+    expect(handleClick).toHaveBeenCalled();
+
+    const containerTaskMenu = screen.getByTestId('new-container-task-menu');
+    fireEvent.click(containerTaskMenu);
+    expect(handleContainerClick).toHaveBeenCalled();
+  });
+
+  test("should not render if user doesn't have the right capabilities", () => {
+    const {render} = rendererWith({capabilities: new Capabilities([])});
+
+    render(<NewIconMenu />);
+
+    expect(screen.queryByTestId('new-icon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('new-task-menu')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('new-container-task-menu'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/web/pages/tlscertificates/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/tlscertificates/__tests__/DetailsPage.test.jsx
@@ -12,7 +12,7 @@ import {currentSettingsDefaultResponse} from 'web/pages/__mocks__/CurrentSetting
 import DetailsPage from 'web/pages/tlscertificates/DetailsPage';
 import {entityLoadingActions} from 'web/store/entities/tlscertificates';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {rendererWith} from 'web/utils/Testing';
+import {rendererWith, screen} from 'web/utils/Testing';
 
 const tlsCertificate = TlsCertificate.fromElement({
   _id: '1234',
@@ -52,8 +52,8 @@ const getEntities = testing.fn().mockResolvedValue({
   },
 });
 
-describe('TLS Certificate Detailspage tests', () => {
-  test('should render full Detailspage', () => {
+describe('TLS Certificate DetailsPage tests', () => {
+  test('should render full DetailsPage', () => {
     const getTlsCertificate = testing.fn().mockResolvedValue({
       data: tlsCertificate,
     });
@@ -84,24 +84,26 @@ describe('TLS Certificate Detailspage tests', () => {
 
     store.dispatch(entityLoadingActions.success('1234', tlsCertificate));
 
-    const {baseElement, container, getAllByTestId} = render(
-      <DetailsPage id="1234" />,
-    );
+    const {baseElement, container} = render(<DetailsPage id="1234" />);
 
     expect(container).toHaveTextContent(
       'TLS Certificate: CN=LoremIpsumSubject C=Dolor',
     );
 
     const links = baseElement.querySelectorAll('a');
-    const icons = getAllByTestId('svg-icon');
 
-    expect(icons[0]).toHaveAttribute('title', 'Help: TLS Certificate Assets');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: TLS Certificate Assets',
+    );
     expect(links[0]).toHaveAttribute(
       'href',
       'test/en/managing-assets.html#managing-tls-certificates',
     );
-
-    expect(icons[1]).toHaveAttribute('title', 'TLS Certificates List');
+    expect(screen.getByTestId('list-icon')).toHaveAttribute(
+      'title',
+      'TLS Certificates List',
+    );
     expect(links[1]).toHaveAttribute('href', '/tlscertificates');
 
     expect(container).toHaveTextContent('1234');

--- a/src/web/pages/tlscertificates/__tests__/ListPage.test.jsx
+++ b/src/web/pages/tlscertificates/__tests__/ListPage.test.jsx
@@ -18,7 +18,7 @@ import {entitiesLoadingActions} from 'web/store/entities/tasks';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
 import {loadingActions} from 'web/store/usersettings/defaults/actions';
-import {rendererWith, wait} from 'web/utils/Testing';
+import {rendererWith, screen, wait} from 'web/utils/Testing';
 
 const tlsCertificate = TlsCertificate.fromElement({
   _id: '1234',
@@ -141,12 +141,11 @@ describe('TlsCertificatePage tests', () => {
       ),
     );
 
-    const {baseElement, getAllByTestId} = render(<TlsCertificatePage />);
+    const {baseElement} = render(<TlsCertificatePage />);
 
     await wait();
 
-    const display = getAllByTestId('grid-item');
-    const icons = getAllByTestId('svg-icon');
+    const display = screen.getAllByTestId('grid-item');
     const header = baseElement.querySelectorAll('th');
     const row = baseElement.querySelectorAll('tr');
     const powerFilter = getPowerFilter();
@@ -154,21 +153,24 @@ describe('TlsCertificatePage tests', () => {
     const inputs = getTextInputs(powerFilter);
 
     // Toolbar Icon
-    expect(icons[0]).toHaveAttribute('title', 'Help: TLS Certificate Assets');
+    expect(screen.getByTestId('help-icon')).toHaveAttribute(
+      'title',
+      'Help: TLS Certificate Assets',
+    );
 
     // Powerfilter
     expect(inputs[0]).toHaveAttribute('name', 'userFilterString');
-    expect(icons[1]).toHaveAttribute('title', 'Update Filter');
-    expect(icons[2]).toHaveAttribute('title', 'Remove Filter');
-    expect(icons[3]).toHaveAttribute('title', 'Reset to Default Filter');
-    expect(icons[4]).toHaveAttribute('title', 'Help: Powerfilter');
-    expect(icons[5]).toHaveAttribute('title', 'Edit Filter');
+    screen.getAllByTitle('Update Filter');
+    screen.getAllByTitle('Remove Filter');
+    screen.getAllByTitle('Reset to Default Filter');
+    screen.getAllByTitle('Help: Powerfilter');
+    screen.getAllByTitle('Edit Filter');
     expect(select).toHaveAttribute('title', 'Loaded filter');
     expect(select).toHaveValue('--');
 
     // Dashboard
-    expect(icons[7]).toHaveAttribute('title', 'Add new Dashboard Display');
-    expect(icons[8]).toHaveAttribute('title', 'Reset to Defaults');
+    screen.getAllByTitle('Add new Dashboard Display');
+    screen.getAllByTitle('Reset to Defaults');
     expect(display[0]).toHaveTextContent(
       'TLS Certificates by Status (Total: 1)',
     );
@@ -193,12 +195,11 @@ describe('TlsCertificatePage tests', () => {
     // expect(row[1]).toHaveTextContent('Tue, Sep 10, 2019 12:51 PM UTC');
     // expect(row[1]).toHaveTextContent('Thu, Oct 10, 2019 12:51 PM UTC');
 
-    expect(icons[24]).toHaveAttribute('title', 'Delete TLS Certificate');
-    expect(icons[25]).toHaveAttribute('title', 'Download TLS Certificate');
-    expect(icons[26]).toHaveAttribute('title', 'Export TLS Certificate as XML');
-
-    expect(icons[27]).toHaveAttribute('title', 'Add tag to page contents');
-    expect(icons[28]).toHaveAttribute('title', 'Delete page contents');
-    expect(icons[29]).toHaveAttribute('title', 'Export page contents');
+    screen.getAllByTitle('Delete TLS Certificate');
+    screen.getAllByTitle('Download TLS Certificate');
+    screen.getAllByTitle('Export TLS Certificate as XML');
+    screen.getAllByTitle('Add tag to page contents');
+    screen.getAllByTitle('Delete page contents');
+    screen.getAllByTitle('Export page contents');
   });
 });

--- a/src/web/pages/tlscertificates/__tests__/Row.test.jsx
+++ b/src/web/pages/tlscertificates/__tests__/Row.test.jsx
@@ -7,8 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import TlsCertificate from 'gmp/models/tlscertificate';
 import Row from 'web/pages/tlscertificates/Row';
 import {setTimezone} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent} from 'web/utils/Testing';
-
+import {rendererWith, fireEvent, screen} from 'web/utils/Testing';
 
 const gmp = {settings: {}};
 
@@ -50,7 +49,7 @@ describe('Tls Certificate Row tests', () => {
 
     store.dispatch(setTimezone('UTC'));
 
-    const {baseElement, getAllByTestId} = render(
+    const {baseElement} = render(
       <Row
         entity={tlsCertificate}
         links={true}
@@ -69,8 +68,9 @@ describe('Tls Certificate Row tests', () => {
     expect(baseElement).toHaveTextContent('Thu, Oct 10, 2019 12:51 PM UTC');
 
     // Actions
-    const icons = getAllByTestId('svg-icon');
-    expect(icons.length).toEqual(3);
+    screen.getAllByTestId('delete-icon');
+    screen.getByTestId('download-icon');
+    screen.getByTestId('export-icon');
   });
 
   test('should render icons', () => {
@@ -84,7 +84,7 @@ describe('Tls Certificate Row tests', () => {
 
     store.dispatch(setTimezone('UTC'));
 
-    const {getAllByTestId} = render(
+    render(
       <Row
         entity={tlsCertificate}
         links={true}
@@ -96,10 +96,18 @@ describe('Tls Certificate Row tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-    expect(icons[0]).toHaveAttribute('title', 'Delete TLS Certificate');
-    expect(icons[1]).toHaveAttribute('title', 'Download TLS Certificate');
-    expect(icons[2]).toHaveAttribute('title', 'Export TLS Certificate as XML');
+    expect(screen.getAllByTestId('delete-icon')[0]).toHaveAttribute(
+      'title',
+      'Delete TLS Certificate',
+    );
+    expect(screen.getByTestId('download-icon')).toHaveAttribute(
+      'title',
+      'Download TLS Certificate',
+    );
+    expect(screen.getByTestId('export-icon')).toHaveAttribute(
+      'title',
+      'Export TLS Certificate as XML',
+    );
   });
 
   test('should call click handlers', () => {
@@ -115,7 +123,7 @@ describe('Tls Certificate Row tests', () => {
 
     store.dispatch(setTimezone('UTC'));
 
-    const {baseElement, getAllByTestId} = render(
+    render(
       <Row
         entity={tlsCertificate}
         links={true}
@@ -127,20 +135,20 @@ describe('Tls Certificate Row tests', () => {
     );
 
     // Name
-    const spans = baseElement.querySelectorAll('span');
-    fireEvent.click(spans[1]);
+    fireEvent.click(screen.getByTestId('row-details-toggle'));
     expect(handleToggleDetailsClick).toHaveBeenCalledWith(undefined, '1234');
 
     // Actions
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[0]);
+    const deleteIcon = screen.getAllByTestId('delete-icon')[0];
+    fireEvent.click(deleteIcon);
     expect(handleTlsCertificateDelete).toHaveBeenCalledWith(tlsCertificate);
 
-    fireEvent.click(icons[1]);
+    const downloadIcon = screen.getByTestId('download-icon');
+    fireEvent.click(downloadIcon);
     expect(handleTlsCertificateDownload).toHaveBeenCalledWith(tlsCertificate);
 
-    fireEvent.click(icons[2]);
+    const exportIcon = screen.getByTestId('export-icon');
+    fireEvent.click(exportIcon);
     expect(handleTlsCertificateExport).toHaveBeenCalledWith(tlsCertificate);
   });
 

--- a/src/web/pages/tlscertificates/__tests__/Table.test.jsx
+++ b/src/web/pages/tlscertificates/__tests__/Table.test.jsx
@@ -10,8 +10,7 @@ import Filter from 'gmp/models/filter';
 import TlsCertificate from 'gmp/models/tlscertificate';
 import Table from 'web/pages/tlscertificates/Table';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
-import {rendererWith, fireEvent} from 'web/utils/Testing';
-
+import {rendererWith, fireEvent, screen} from 'web/utils/Testing';
 
 const caps = new Capabilities(['everything']);
 
@@ -102,7 +101,7 @@ describe('TlsCertificates table tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {element, getAllByTestId} = render(
+    const {element} = render(
       <Table
         entities={[tlsCertificate]}
         entitiesCounts={counts}
@@ -118,9 +117,10 @@ describe('TlsCertificates table tests', () => {
     expect(element).not.toHaveTextContent('SHA-256 Fingerprint');
     expect(element).not.toHaveTextContent('MD5 Fingerprint');
 
-    const icons = getAllByTestId('svg-icon');
-    fireEvent.click(icons[0]);
-    expect(icons[0]).toHaveAttribute('title', 'Unfold all details');
+    const unfoldIcon = screen.getByTestId('fold-state-icon-unfold');
+    fireEvent.click(unfoldIcon);
+    expect(unfoldIcon).toHaveAttribute('title', 'Unfold all details');
+
     expect(element).toHaveTextContent('Valid');
     expect(element).toHaveTextContent('SHA-256 Fingerprint');
     expect(element).toHaveTextContent('MD5 Fingerprint');
@@ -145,7 +145,7 @@ describe('TlsCertificates table tests', () => {
 
     store.dispatch(setUsername('admin'));
 
-    const {getAllByTestId} = render(
+    render(
       <Table
         entities={[tlsCertificate]}
         entitiesCounts={counts}
@@ -157,18 +157,22 @@ describe('TlsCertificates table tests', () => {
       />,
     );
 
-    const icons = getAllByTestId('svg-icon');
-
-    fireEvent.click(icons[5]);
-    expect(icons[5]).toHaveAttribute('title', 'Delete TLS Certificate');
+    const deleteIcon = screen.getAllByTestId('delete-icon')[0];
+    fireEvent.click(deleteIcon);
+    expect(deleteIcon).toHaveAttribute('title', 'Delete TLS Certificate');
     expect(handleTlsCertificateDelete).toHaveBeenCalledWith(tlsCertificate);
 
-    fireEvent.click(icons[6]);
-    expect(icons[6]).toHaveAttribute('title', 'Download TLS Certificate');
+    const downloadIcon = screen.getByTestId('download-icon');
+    fireEvent.click(downloadIcon);
+    expect(downloadIcon).toHaveAttribute('title', 'Download TLS Certificate');
     expect(handleTlsCertificateDownload).toHaveBeenCalledWith(tlsCertificate);
 
-    fireEvent.click(icons[7]);
-    expect(icons[7]).toHaveAttribute('title', 'Export TLS Certificate as XML');
+    const exportIcon = screen.getAllByTestId('export-icon')[0];
+    fireEvent.click(exportIcon);
+    expect(exportIcon).toHaveAttribute(
+      'title',
+      'Export TLS Certificate as XML',
+    );
     expect(handleTlsCertificateDownload).toHaveBeenCalledWith(tlsCertificate);
   });
 });

--- a/src/web/pages/vulns/Table.jsx
+++ b/src/web/pages/vulns/Table.jsx
@@ -14,7 +14,6 @@ import {createEntitiesTable} from 'web/entities/Table';
 import VulnsRow from 'web/pages/vulns/Row';
 import PropTypes from 'web/utils/PropTypes';
 
-
 const Header = ({
   links = true,
   sort = true,


### PR DESCRIPTION
## What

* Allow to pass and override the data-testid prop of SvgIcon and other components
* Add data-testids to several components
* Use screen for querying the DOM consistently
* Cleanup tests to avoid printing errors during test runs

## Why

* The data-testid was hardcoded to `svg-icon` even it should have been overridden in the NewIcon component.
* Some components missed data-testids for easier testing
* Consistent tests (still not perfect but improved a lot)

## References

Required for testing purposes when several icons are available at the page.

