### PR TITLE
Fix proptypes for DatePicker component

### DIFF
--- a/src/web/components/form/DatePicker.jsx
+++ b/src/web/components/form/DatePicker.jsx
@@ -42,9 +42,9 @@ const DatePickerComponent = (
 
 DatePickerComponent.propTypes = {
   disabled: PropTypes.bool,
-  minDate: PropTypes.instanceOf(date),
+  minDate: PropTypes.oneOfType([PropTypes.date, PropTypes.oneOf([false])]),
   name: PropTypes.string.isRequired,
-  value: PropTypes.instanceOf(date),
+  value: PropTypes.date,
   onChange: PropTypes.func,
   label: PropTypes.string,
 };


### PR DESCRIPTION


## What

Fix proptypes for DatePicker component

## Why

A value of false is allowed for the minDate to deactivate the minimum date and use date proptype to get better error messages. This fixes some warnings in the tests.


