### PR TITLE
Fix passing true as actions column to withEntitiesHeader

### DIFF
--- a/src/web/entities/Header.jsx
+++ b/src/web/entities/Header.jsx
@@ -31,9 +31,9 @@ const defaultActions = (
  * If actionsColumn is false, no actions (a null value in React) will be passed to
  * the Component.
  *
- * @param {Element}   actionsColumn   React element, undefined or boolean value.
- * @param {Object}    options         Default properties for Component.
- * @param {Component} Component       React component rendered as header
+ * @param {React.Element|undefined|boolean} actionsColumn - React element, undefined, or boolean value.
+ * @param {Object} options - Default properties for the Component.
+ * @param {React.Component} Component - React component rendered as header.
  *
  * @return {React.Component} A new EntitiesHeader component.
  */
@@ -69,21 +69,21 @@ export const withEntitiesHeader =
 
 /**
  * A higher order component to create table headers from a column description
- * array
+ * array.
  *
- * @param {Array}   columns   An array in the form of
- *                            [{
- *                                name: 'foo',
- *                                displayName: _l('Foo'),
- *                                width: '20%',
- *                                align: ['center', 'center'],
- *                             }, {
- *                               ...
- *                             }, ... ]
- * @param {Element} actionsColumn   React element, undefined or boolean value.
- * @param {Object}  options   Default properties for Component.
+ * @param {Array<Object>} columns - An array of column description objects in the form of:
+ *                                  [{
+ *                                      name: 'foo',
+ *                                      displayName: _l('Foo'),
+ *                                      width: '20%',
+ *                                      align: ['center', 'center'],
+ *                                   }, {
+ *                                     ...
+ *                                   }, ... ]
+ * @param {React.Element|undefined|boolean} actionsColumn - React element, undefined, or boolean value.
+ * @param {Object} options - Default properties for the Component.
  *
- * @return A new EntitiesHeader component
+ * @return {React.Component} A new EntitiesHeader component.
  */
 export const createEntitiesHeader = (columns, actionsColumn, options = {}) => {
   const Header = ({

--- a/src/web/entities/Header.jsx
+++ b/src/web/entities/Header.jsx
@@ -17,25 +17,25 @@ const defaultActions = (
 
 /**
  * A higher order component to create table headers which support entity
- * selection
+ * selection.
  *
- * If a react element instance is passed via actions the element will be
- * forwarded as actions to Component.
+ * If a React element instance is passed via actionsColumn, the element will be
+ * forwarded as actionsColumn to the Component.
  *
- * If actions is undefined a default table head column will be passed as
- * actions to Component.
+ * If actionsColumn is undefined, a default table head column will be passed as
+ * actionsColumn to the Component.
  *
- * If actions is true a default table head column will be passed as actions to
- * Component if the current selectionType (passed via props) is SELECTION_USER.
+ * If actionsColumn is true, a default table head column will be passed as actionsColumn
+ * to the Component if the current selectionType (passed via props) is SELECTION_USER.
  *
- * If actions is false no actions (a null value in react) will be passed to
- * Component.
+ * If actionsColumn is false, no actions (a null value in React) will be passed to
+ * the Component.
  *
  * @param {Element}   actionsColumn   React element, undefined or boolean value.
  * @param {Object}    options         Default properties for Component.
  * @param {Component} Component       React component rendered as header
  *
- * @return A new EntitiesHeader component
+ * @return {React.Component} A new EntitiesHeader component.
  */
 export const withEntitiesHeader =
   (actionsColumn = defaultActions, options = {}) =>

--- a/src/web/entities/Header.jsx
+++ b/src/web/entities/Header.jsx
@@ -11,7 +11,7 @@ import TableRow from 'web/components/table/Row';
 import PropTypes from 'web/utils/PropTypes';
 import SelectionType from 'web/utils/SelectionType';
 
-const defaultactions = (
+const defaultActions = (
   <TableHead align="center" title={_l('Actions')} width="8%" />
 );
 
@@ -31,25 +31,27 @@ const defaultactions = (
  * If actions is false no actions (a null value in react) will be passed to
  * Component.
  *
- * @param {Element}   actions_column  React element, undefined or boolean value.
+ * @param {Element}   actionsColumn   React element, undefined or boolean value.
  * @param {Object}    options         Default properties for Component.
  * @param {Component} Component       React component rendered as header
  *
  * @return A new EntitiesHeader component
  */
 export const withEntitiesHeader =
-  (actions_column = defaultactions, options = {}) =>
+  (actionsColumn = defaultActions, options = {}) =>
   Component => {
-    if (!actions_column) {
-      actions_column = null;
+    if (!actionsColumn) {
+      actionsColumn = null;
     }
 
     const HeaderWrapper = props => {
       const {selectionType} = props;
-      let column = actions_column;
+      let column = actionsColumn;
 
-      if (actions_column && selectionType === SelectionType.SELECTION_USER) {
+      if (actionsColumn && selectionType === SelectionType.SELECTION_USER) {
         column = <TableHead width="6em">{_('Actions')}</TableHead>;
+      } else if (actionsColumn === true) {
+        column = null;
       }
       return <Component {...options} actionsColumn={column} {...props} />;
     };
@@ -78,12 +80,12 @@ export const withEntitiesHeader =
  *                             }, {
  *                               ...
  *                             }, ... ]
- * @param {Element} actions_column   React element, undefined or boolean value.
+ * @param {Element} actionsColumn   React element, undefined or boolean value.
  * @param {Object}  options   Default properties for Component.
  *
  * @return A new EntitiesHeader component
  */
-export const createEntitiesHeader = (columns, actions_column, options = {}) => {
+export const createEntitiesHeader = (columns, actionsColumn, options = {}) => {
   const Header = ({
     actionsColumn,
     links = true,
@@ -122,5 +124,5 @@ export const createEntitiesHeader = (columns, actions_column, options = {}) => {
     sort: PropTypes.bool,
     onSortChange: PropTypes.func,
   };
-  return withEntitiesHeader(actions_column, options)(Header);
+  return withEntitiesHeader(actionsColumn, options)(Header);
 };


### PR DESCRIPTION


## What

Fix passing true as actions column to withEntitiesHeader

## Why

List pages that allow bulk selections but have no dedicated actions column like CVEs pass false for the action column when using withEntitiesHeader. This allows displaying the action column conditionally if the user selection is selected for the list table. Additionally the variables are changed to camelCase naming instead of underscore.

This changes removes proptype warnings in a bunch of tests and during development.

