### PR TITLE
Add renderer functions to render within tables

### DIFF
--- a/src/web/utils/Testing.jsx
+++ b/src/web/utils/Testing.jsx
@@ -186,3 +186,31 @@ export const rendererWith = (
     renderHook: hook => rtlRenderHook(hook, {wrapper}),
   };
 };
+
+export const rendererWithTable = options => {
+  const {render, ...other} = rendererWith(options);
+  return {
+    ...other,
+    render: element =>
+      render(
+        <table>
+          <tbody>{element}</tbody>
+        </table>,
+      ),
+  };
+};
+
+export const rendererWithTableRow = options => {
+  const {render, ...other} = rendererWith(options);
+  return {
+    ...other,
+    render: element =>
+      render(
+        <table>
+          <tbody>
+            <tr>{element}</tr>
+          </tbody>
+        </table>,
+      ),
+  };
+};


### PR DESCRIPTION


## What

Add renderer functions to render within tables

## Why

Introduce new renderer function rendererWithTable and rendererWithTableRow for testing purposes and avoid warnings when rendering table row or table data elements.

