### PR TITLE
Refactor RowDetailsToggle

### DIFF
--- a/src/web/entities/Row.jsx
+++ b/src/web/entities/Row.jsx
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import withClickHandler from 'web/components/form/withClickHandler';
+import useClickHandler from 'web/components/form/useClickHandler';
 import Theme from 'web/utils/Theme';
 
-export const RowDetailsToggle = withClickHandler()(styled.span`
+const StyledSpan = styled.span`
   cursor: pointer;
   text-decoration: none;
   color: ${Theme.blue};
@@ -18,4 +19,24 @@ export const RowDetailsToggle = withClickHandler()(styled.span`
   @media print {
     color: ${Theme.black};
   }
-`);
+`;
+
+export const RowDetailsToggle = ({name, onClick, ...props}) => {
+  const handleClick = useClickHandler({
+    onClick,
+    name,
+    nameFunc: (event, props) => props.name,
+  });
+  return (
+    <StyledSpan
+      data-testid="row-details-toggle"
+      {...props}
+      name={name}
+      onClick={handleClick}
+    />
+  );
+};
+
+RowDetailsToggle.propTypes = {name: PropTypes.string, onClick: PropTypes.func};
+
+export default RowDetailsToggle;

--- a/src/web/entities/__tests__/RowDetailsToggle.test.jsx
+++ b/src/web/entities/__tests__/RowDetailsToggle.test.jsx
@@ -1,0 +1,29 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, testing} from '@gsa/testing';
+import RowDetailsToggle from 'web/entities/Row';
+import {fireEvent, rendererWith, screen} from 'web/utils/Testing';
+
+describe('RowDetailsToggle tests', () => {
+  test('renders without crashing', () => {
+    const {render} = rendererWith();
+
+    render(<RowDetailsToggle name="test" />);
+
+    expect(screen.getByTestId('row-details-toggle')).toBeInTheDocument();
+  });
+
+  test('calls onClick handler when row is clicked', async () => {
+    const handleClick = testing.fn();
+    const {render} = rendererWith();
+
+    render(<RowDetailsToggle name="test" onClick={handleClick} />);
+
+    const row = screen.getByTestId('row-details-toggle');
+    fireEvent.click(row);
+    expect(handleClick).toHaveBeenCalledWith(undefined, 'test');
+  });
+});


### PR DESCRIPTION


## What

Refactor RowDetailsToggle

Replace withClickHandler with useClickHandler and add data-testid for easier testing. Export RowDetailsToggle as default export too.

I am going to rename the Row js module to RowDetailsToggle in a future PR too. 

## Why

Easier testing and get rid of HOC.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


