### PR TITLE
Rename Row module to RowDetailsToggle and remove named export

### DIFF
--- a/src/web/entities/EntityNameTableData.jsx
+++ b/src/web/entities/EntityNameTableData.jsx
@@ -11,7 +11,7 @@ import Comment from 'web/components/comment/Comment';
 import Layout from 'web/components/layout/Layout';
 import DetailsLink from 'web/components/link/DetailsLink';
 import TableData from 'web/components/table/Data';
-import {RowDetailsToggle} from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import ObserverIcon from 'web/entity/icon/ObserverIcon';
 import useUserName from 'web/hooks/useUserName';
 import PropTypes from 'web/utils/PropTypes';

--- a/src/web/entities/RowDetailsToggle.jsx
+++ b/src/web/entities/RowDetailsToggle.jsx
@@ -21,7 +21,7 @@ const StyledSpan = styled.span`
   }
 `;
 
-export const RowDetailsToggle = ({name, onClick, ...props}) => {
+const RowDetailsToggle = ({name, onClick, ...props}) => {
   const handleClick = useClickHandler({
     onClick,
     name,

--- a/src/web/entities/__tests__/RowDetailsToggle.test.jsx
+++ b/src/web/entities/__tests__/RowDetailsToggle.test.jsx
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, testing} from '@gsa/testing';
-import RowDetailsToggle from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import {fireEvent, rendererWith, screen} from 'web/utils/Testing';
 
 describe('RowDetailsToggle tests', () => {

--- a/src/web/pages/audits/Row.jsx
+++ b/src/web/pages/audits/Row.jsx
@@ -18,7 +18,7 @@ import Layout from 'web/components/layout/Layout';
 import DetailsLink from 'web/components/link/DetailsLink';
 import TableData from 'web/components/table/Data';
 import TableRow from 'web/components/table/Row';
-import {RowDetailsToggle} from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import ObserverIcon from 'web/entity/icon/ObserverIcon';
 import useUserName from 'web/hooks/useUserName';
 import Actions from 'web/pages/audits/Actions';

--- a/src/web/pages/certbund/Row.jsx
+++ b/src/web/pages/certbund/Row.jsx
@@ -10,7 +10,7 @@ import DateTime from 'web/components/date/DateTime';
 import TableData from 'web/components/table/Data';
 import TableRow from 'web/components/table/Row';
 import EntitiesActions from 'web/entities/Actions';
-import {RowDetailsToggle} from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import PropTypes from 'web/utils/PropTypes';
 import {na} from 'web/utils/Render';
 

--- a/src/web/pages/cpes/Row.jsx
+++ b/src/web/pages/cpes/Row.jsx
@@ -10,7 +10,7 @@ import DateTime from 'web/components/date/DateTime';
 import TableData from 'web/components/table/Data';
 import TableRow from 'web/components/table/Row';
 import EntitiesActions from 'web/entities/Actions';
-import {RowDetailsToggle} from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import PropTypes from 'web/utils/PropTypes';
 import {na} from 'web/utils/Render';
 

--- a/src/web/pages/cves/Row.jsx
+++ b/src/web/pages/cves/Row.jsx
@@ -14,7 +14,7 @@ import Link from 'web/components/link/Link';
 import TableData from 'web/components/table/Data';
 import TableRow from 'web/components/table/Row';
 import EntitiesActions from 'web/entities/Actions';
-import {RowDetailsToggle} from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import useGmp from 'web/hooks/useGmp';
 import PropTypes from 'web/utils/PropTypes';
 

--- a/src/web/pages/dfncert/Row.jsx
+++ b/src/web/pages/dfncert/Row.jsx
@@ -10,7 +10,7 @@ import DateTime from 'web/components/date/DateTime';
 import TableData from 'web/components/table/Data';
 import TableRow from 'web/components/table/Row';
 import EntitiesActions from 'web/entities/Actions';
-import {RowDetailsToggle} from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import PropTypes from 'web/utils/PropTypes';
 import {na} from 'web/utils/Render';
 

--- a/src/web/pages/hosts/Row.jsx
+++ b/src/web/pages/hosts/Row.jsx
@@ -15,7 +15,7 @@ import OsIcon from 'web/components/icon/OsIcon';
 import IconDivider from 'web/components/layout/IconDivider';
 import TableData from 'web/components/table/Data';
 import TableRow from 'web/components/table/Row';
-import {RowDetailsToggle} from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import withEntitiesActions from 'web/entities/withEntitiesActions';
 import DeleteIcon from 'web/entity/icon/DeleteIcon';
 import EditIcon from 'web/entity/icon/EditIcon';

--- a/src/web/pages/notes/Row.jsx
+++ b/src/web/pages/notes/Row.jsx
@@ -10,7 +10,7 @@ import ExportIcon from 'web/components/icon/ExportIcon';
 import IconDivider from 'web/components/layout/IconDivider';
 import TableData from 'web/components/table/Data';
 import TableRow from 'web/components/table/Row';
-import {RowDetailsToggle} from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import withEntitiesActions from 'web/entities/withEntitiesActions';
 import CloneIcon from 'web/entity/icon/CloneIcon';
 import EditIcon from 'web/entity/icon/EditIcon';

--- a/src/web/pages/nvts/Row.jsx
+++ b/src/web/pages/nvts/Row.jsx
@@ -17,7 +17,7 @@ import Qod from 'web/components/qod/Qod';
 import TableData from 'web/components/table/Data';
 import TableRow from 'web/components/table/Row';
 import EntitiesActions from 'web/entities/Actions';
-import {RowDetailsToggle} from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import useGmp from 'web/hooks/useGmp';
 import PropTypes from 'web/utils/PropTypes';
 

--- a/src/web/pages/overrides/Row.jsx
+++ b/src/web/pages/overrides/Row.jsx
@@ -13,7 +13,7 @@ import ExportIcon from 'web/components/icon/ExportIcon';
 import IconDivider from 'web/components/layout/IconDivider';
 import TableData from 'web/components/table/Data';
 import TableRow from 'web/components/table/Row';
-import {RowDetailsToggle} from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import withEntitiesActions from 'web/entities/withEntitiesActions';
 import CloneIcon from 'web/entity/icon/CloneIcon';
 import EditIcon from 'web/entity/icon/EditIcon';

--- a/src/web/pages/reports/details/TlsCertificatesTable.jsx
+++ b/src/web/pages/reports/details/TlsCertificatesTable.jsx
@@ -13,7 +13,7 @@ import TableData from 'web/components/table/Data';
 import TableHead from 'web/components/table/Head';
 import TableHeader from 'web/components/table/Header';
 import TableRow from 'web/components/table/Row';
-import {RowDetailsToggle} from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import {createEntitiesTable} from 'web/entities/Table';
 import withRowDetails from 'web/entities/withRowDetails';
 import TlsCertificateDetails from 'web/pages/tlscertificates/Details';

--- a/src/web/pages/results/Row.jsx
+++ b/src/web/pages/results/Row.jsx
@@ -22,11 +22,10 @@ import Qod from 'web/components/qod/Qod';
 import TableData from 'web/components/table/Data';
 import TableRow from 'web/components/table/Row';
 import EntitiesActions from 'web/entities/Actions';
-import {RowDetailsToggle} from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import useGmp from 'web/hooks/useGmp';
 import ResultDelta from 'web/pages/results/Delta';
 import PropTypes from 'web/utils/PropTypes';
-
 
 const Row = ({
   actionsComponent: ActionsComponent = EntitiesActions,

--- a/src/web/pages/tasks/Row.jsx
+++ b/src/web/pages/tasks/Row.jsx
@@ -19,7 +19,7 @@ import DetailsLink from 'web/components/link/DetailsLink';
 import Link from 'web/components/link/Link';
 import TableData from 'web/components/table/Data';
 import TableRow from 'web/components/table/Row';
-import {RowDetailsToggle} from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import ObserverIcon from 'web/entity/icon/ObserverIcon';
 import useUserName from 'web/hooks/useUserName';
 import Actions from 'web/pages/tasks/Actions';

--- a/src/web/pages/tlscertificates/Row.jsx
+++ b/src/web/pages/tlscertificates/Row.jsx
@@ -13,7 +13,7 @@ import ExportIcon from 'web/components/icon/ExportIcon';
 import IconDivider from 'web/components/layout/IconDivider';
 import TableData from 'web/components/table/Data';
 import TableRow from 'web/components/table/Row';
-import {RowDetailsToggle} from 'web/entities/Row';
+import RowDetailsToggle from 'web/entities/RowDetailsToggle';
 import withEntitiesActions from 'web/entities/withEntitiesActions';
 import PropTypes from 'web/utils/PropTypes';
 


### PR DESCRIPTION

## What

Rename Row module to RowDetailsToggle and remove named export
## Why

The Row module only contains the RowDetailsToggle component. Therefore the name of the module is adjusted. Because the module only has a single export using the default export only is cleaner.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


