### PR TITLE
Fix: show response error on user settings save

### DIFF
--- a/src/web/pages/usersettings/UserSettingsPage.jsx
+++ b/src/web/pages/usersettings/UserSettingsPage.jsx
@@ -248,6 +248,8 @@ class UserSettings extends React.Component {
       });
     } catch (error) {
       console.error(error);
+
+      throw error
     }
   }
 


### PR DESCRIPTION

## What
Re-throw any error received while updating the user settings.

## Why
Before, if there was an error response when saving the users settings, there would be no error
message shown

## References
https://jira.greenbone.net/browse/GEA-782