### PR TITLE
Add: Update footer link to support localization based on user language

### DIFF
--- a/src/web/components/structure/Footer.jsx
+++ b/src/web/components/structure/Footer.jsx
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
 import styled from 'styled-components';
+import useLocale from 'web/hooks/useLocale';
 import Theme from 'web/utils/Theme';
 
 const Link = styled.a`
@@ -24,14 +24,17 @@ const Footer = styled.footer`
 `;
 
 const GreenboneFooter = () => {
+  const [language] = useLocale();
+
+  const linkHref =
+    language === 'de'
+      ? 'https://www.greenbone.net'
+      : 'https://www.greenbone.net/en';
+
   return (
     <Footer>
       Copyright © 2009-2025 by Greenbone AG,&nbsp;
-      <Link
-        href="https://www.greenbone.net"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
+      <Link href={linkHref} rel="noopener noreferrer" target="_blank">
         www.greenbone.net
       </Link>
     </Footer>

--- a/src/web/components/structure/__tests__/Footer.test.jsx
+++ b/src/web/components/structure/__tests__/Footer.test.jsx
@@ -6,11 +6,13 @@
 import {describe, test, expect} from '@gsa/testing';
 import date from 'gmp/models/date';
 import Footer from 'web/components/structure/Footer';
-import {render} from 'web/utils/Testing';
-
+import {setLocale} from 'web/store/usersettings/actions';
+import {rendererWith} from 'web/utils/Testing';
 
 describe('Footer tests', () => {
   test('should render footer with copyright', () => {
+    const {render} = rendererWith({store: true});
+
     const currentYear = date().year();
     const {element} = render(<Footer />);
 
@@ -19,5 +21,18 @@ describe('Footer tests', () => {
         currentYear +
         ' by Greenbone AG, www.greenbone.net',
     );
+  });
+
+  test.each([
+    ['de', 'https://www.greenbone.net'],
+    ['en', 'https://www.greenbone.net/en'],
+  ])('should render footer with %s link', (locale, expectedHref) => {
+    const {store, render} = rendererWith({store: true});
+
+    store.dispatch(setLocale(locale));
+
+    const {element} = render(<Footer />);
+
+    expect(element.querySelector('a')).toHaveAttribute('href', expectedHref);
   });
 });


### PR DESCRIPTION
## What

- The footer link now dynamically opens `greenbone.net` based on the language setting. Currently only German and English.

## Why

- Previously, the link always opened the German version of the site.

## References

GEA-944

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


