### PR TITLE
change: Select dropdown scrollbar to show on hover

### DIFF
--- a/src/web/components/form/Select.jsx
+++ b/src/web/components/form/Select.jsx
@@ -77,6 +77,8 @@ const Select = ({
   searchable = true,
   toolTipTitle,
   value,
+  withScrollArea = true,
+  scrollAreaProps = {type: 'hover', scrollbarSize: 12},
   onChange,
   ...props
 }) => {
@@ -118,6 +120,7 @@ const Select = ({
       placeholder={selectPlaceholder}
       renderOption={renderSelectOption}
       rightSection={rightSection}
+      scrollAreaProps={scrollAreaProps}
       searchValue={searchValue}
       searchable={searchable}
       styles={{root: {flexGrow: grow}}}
@@ -149,6 +152,11 @@ Select.propTypes = {
   toolTipTitle: PropTypes.string,
   value: selectValue,
   width: PropTypes.string,
+  withScrollArea: PropTypes.bool,
+  scrollAreaProps: PropTypes.shape({
+    type: PropTypes.oneOf(['auto', 'scroll', 'always', 'hover', 'never']),
+    scrollbarSize: PropTypes.number,
+  }),
   onChange: PropTypes.func,
 };
 


### PR DESCRIPTION
## What

- For select components, enforced by default the `type: hover` and `scrollbarSize` property for the dropdown scrollbar.

## Why

- Previously, scrollbar was visible only if scrolling.

## References

GEA-907

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests

