### PR TITLE
Optional onError and onSuccess in handleNotificationForAction

### DIFF
--- a/src/web/components/notification/__tests__/handleNotificationForAction.test.js
+++ b/src/web/components/notification/__tests__/handleNotificationForAction.test.js
@@ -22,7 +22,7 @@ describe('handleNotificationForAction', () => {
     const onError = testing.fn();
     const successMessage = 'Action was successful';
 
-    await handleNotificationForAction(
+    const result = await handleNotificationForAction(
       promise,
       onSuccess,
       onError,
@@ -32,6 +32,7 @@ describe('handleNotificationForAction', () => {
     expect(onSuccess).toHaveBeenCalledWith('success');
     expect(showSuccessNotification).toHaveBeenCalledWith('', successMessage);
     expect(onError).not.toHaveBeenCalled();
+    expect(result).toEqual('success');
   });
 
   test('should not require onSuccess to be provided if promise resolves successfully', async () => {
@@ -39,7 +40,7 @@ describe('handleNotificationForAction', () => {
     const successMessage = 'Action was successful';
     const onError = testing.fn();
 
-    await handleNotificationForAction(
+    const result = await handleNotificationForAction(
       promise,
       undefined,
       onError,
@@ -47,6 +48,7 @@ describe('handleNotificationForAction', () => {
     );
 
     expect(showSuccessNotification).toHaveBeenCalledWith('', successMessage);
+    expect(result).toEqual('success');
     expect(onError).not.toHaveBeenCalled();
   });
 
@@ -68,6 +70,23 @@ describe('handleNotificationForAction', () => {
     expect(onError).toHaveBeenCalledWith(error);
     expect(showSuccessNotification).not.toHaveBeenCalled();
     expect(result).toBeUndefined();
+  });
+
+  test("should reject if onError isn't provided and action promise rejects", async () => {
+    const error = new Error('Action failed');
+    const promise = Promise.reject(error);
+    const successMessage = 'Action was successful';
+
+    await expect(
+      handleNotificationForAction(
+        promise,
+        undefined,
+        undefined,
+        successMessage,
+      ),
+    ).rejects.toEqual(error);
+
+    expect(showSuccessNotification).not.toHaveBeenCalled();
   });
 
   test("should resolve with onError's return value if onError is provided and action promise rejects", async () => {

--- a/src/web/components/notification/__tests__/handleNotificationForAction.test.js
+++ b/src/web/components/notification/__tests__/handleNotificationForAction.test.js
@@ -18,8 +18,8 @@ describe('handleNotificationForAction', () => {
 
   test('should call onSuccess and showSuccessNotification when promise resolves', async () => {
     const promise = Promise.resolve('success');
-    const onSuccess = vi.fn();
-    const onError = vi.fn();
+    const onSuccess = testing.fn();
+    const onError = testing.fn();
     const successMessage = 'Action was successful';
 
     await handleNotificationForAction(
@@ -34,14 +34,30 @@ describe('handleNotificationForAction', () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  test('should not require onSuccess to be provided if promise resolves successfully', async () => {
+    const promise = Promise.resolve('success');
+    const successMessage = 'Action was successful';
+    const onError = testing.fn();
+
+    await handleNotificationForAction(
+      promise,
+      undefined,
+      onError,
+      successMessage,
+    );
+
+    expect(showSuccessNotification).toHaveBeenCalledWith('', successMessage);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   test('should call onError when promise rejects', async () => {
     const error = new Error('Action failed');
     const promise = Promise.reject(error);
-    const onSuccess = vi.fn();
-    const onError = vi.fn();
+    const onSuccess = testing.fn();
+    const onError = testing.fn();
     const successMessage = 'Action was successful';
 
-    await handleNotificationForAction(
+    const result = await handleNotificationForAction(
       promise,
       onSuccess,
       onError,
@@ -50,6 +66,24 @@ describe('handleNotificationForAction', () => {
 
     expect(onSuccess).not.toHaveBeenCalled();
     expect(onError).toHaveBeenCalledWith(error);
+    expect(showSuccessNotification).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+
+  test("should resolve with onError's return value if onError is provided and action promise rejects", async () => {
+    const error = new Error('Action failed');
+    const promise = Promise.reject(error);
+    const onError = testing.fn(() => 'error handled');
+    const successMessage = 'Action was successful';
+
+    const result = await handleNotificationForAction(
+      promise,
+      undefined,
+      onError,
+      successMessage,
+    );
+
+    expect(result).toEqual('error handled');
     expect(showSuccessNotification).not.toHaveBeenCalled();
   });
 });

--- a/src/web/components/notification/handleNotificationForAction.js
+++ b/src/web/components/notification/handleNotificationForAction.js
@@ -28,9 +28,11 @@ export const handleNotificationForAction = async (
       onSuccess(result);
     }
     showSuccessNotification('', successMessage);
+    return result;
   } catch (error) {
     if (isDefined(onError)) {
-      onError(error);
+      return onError(error);
     }
+    throw error;
   }
 };

--- a/src/web/components/notification/handleNotificationForAction.js
+++ b/src/web/components/notification/handleNotificationForAction.js
@@ -4,13 +4,14 @@
  */
 
 import {showSuccessNotification} from '@greenbone/opensight-ui-components-mantinev7';
+import {isDefined} from 'gmp/utils/identity';
 
 /**
  * Handles notifications by displaying success messages based on the result of a promise.
  *
  * @param {Promise} action - The action representing the action to be performed.
- * @param {Function} onSuccess - The callback function to be called if the promise resolves successfully.
- * @param {Function} onError - The callback function to be called if the promise is rejected.
+ * @param {Function} [onSuccess] - The callback function to be called if the promise resolves successfully.
+ * @param {Function} [onError] - The callback function to be called if the promise is rejected.
  * @param {string} successMessage - The message to display if the action is successful.
  * @returns {Promise} The original promise with success and error handlers attached.
  */
@@ -23,9 +24,13 @@ export const handleNotificationForAction = async (
 ) => {
   try {
     const result = await action;
-    onSuccess(result);
+    if (isDefined(onSuccess)) {
+      onSuccess(result);
+    }
     showSuccessNotification('', successMessage);
   } catch (error) {
-    onError(error);
+    if (isDefined(onError)) {
+      onError(error);
+    }
   }
 };


### PR DESCRIPTION


## What

Optional onError and onSuccess in handleNotificationForAction



## Why

Update handleNotificationForAction to make onSuccess and onError handlers optional. Sometimes these handler wont be provided. Especially in tests.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


