### PR TITLE
Changelog categories

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -71,6 +71,7 @@ commit_parsers = [
   { message = "^[c|C]hange", group = "<!-- 2 -->:construction_worker: Changed" },
   { message = "^[f|F]ix", group = "<!-- 3 -->:bug: Bug Fixes" },
   { message = "^[r|R]emove", group = "<!-- 4 -->:fire: Removed" },
+  { message = "^[d|D]rop", group = "<!-- 4 -->:fire: Removed" },
   { message = "^[d|D]oc", group = "<!-- 5 -->:books: Documentation" },
   { message = "^[t|T]est", group = "<!-- 6 -->:white_check_mark: Testing" },
   { message = "^[c|C]hore", group = "<!-- 7 -->:wrench: Miscellaneous" },

--- a/cliff.toml
+++ b/cliff.toml
@@ -77,6 +77,7 @@ commit_parsers = [
   { message = "^[c|C]hore", group = "<!-- 7 -->:wrench: Miscellaneous" },
   { message = "^[c|C]i", group = "<!-- 7 -->️:wrench: Miscellaneous" },
   { message = "^[m|M]isc", group = "<!-- 7 -->:wrench: Miscellaneous" },
+  { message = "^[d|D]eps", group = "<!-- 8 -->:ship: Dependencies" },
 ]
 # filter out the commits that are not matched by commit parsers
 filter_commits = true


### PR DESCRIPTION
## What

Allow use `drop` and `Drop` for commits that should go into the `Removed` category in the release changelog and re-introduce the `Dependencies` category which was missing in the new changelog generation process. For the `Dependencies` category, commits starting with `deps` or `Deps` are considered.

Updated list is now


| Group | Commit Message starts with |
|-----------|------------|
|Added | add, Add |
|Changed |change, Change |
|Bug Fixes | fix, Fix |
| Removed | remove, Remove, drop, Drop |
|Documentation | doc, Doc |
| Testing | test, Test |
| Miscellaneous | chore, Chore, ci, Ci misc, Misc |
| Dependencies | deps, Deps |

## Why

Improved changelog generation.

## References

https://jira.greenbone.net/browse/GEA-984


