### PR TITLE
Fix: Ensure time is valid before settings

### DIFF
--- a/src/web/pages/schedules/Dialog.jsx
+++ b/src/web/pages/schedules/Dialog.jsx
@@ -215,12 +215,16 @@ const ScheduleDialog = ({
 
     if (type === 'startTime') {
       const newStartDate = startDate.clone().hour(hour).minute(minute);
-      setStartDate(newStartDate);
-      setStartTime(selectedTime);
+      if (newStartDate.isValid()) {
+        setStartDate(newStartDate);
+        setStartTime(selectedTime);
+      }
     } else if (type === 'endTime') {
       const newEndDate = endDate.clone().hour(hour).minute(minute);
-      setEndDate(newEndDate);
-      setEndTime(selectedTime);
+      if (newEndDate.isValid()) {
+        setEndDate(newEndDate);
+        setEndTime(selectedTime);
+      }
     }
   };
 

--- a/src/web/pages/schedules/Dialog.jsx
+++ b/src/web/pages/schedules/Dialog.jsx
@@ -215,13 +215,13 @@ const ScheduleDialog = ({
 
     if (type === 'startTime') {
       const newStartDate = date(selectedTime, 'HH:mm');
-      if (newStartDate.isValid && newStartDate.isValid()) {
+      if (newStartDate.isValid()) {
         setStartDate(newStartDate);
         setStartTime(selectedTime);
       }
     } else if (type === 'endTime') {
       const newEndDate = date(selectedTime, 'HH:mm');
-      if (newEndDate.isValid && newEndDate.isValid()) {
+      if (newEndDate.isValid()) {
         setEndDate(newEndDate);
         setEndTime(selectedTime);
       }

--- a/src/web/pages/schedules/Dialog.jsx
+++ b/src/web/pages/schedules/Dialog.jsx
@@ -214,14 +214,14 @@ const ScheduleDialog = ({
     const [hour, minute] = selectedTime.split(':').map(Number);
 
     if (type === 'startTime') {
-      const newStartDate = startDate.clone().hour(hour).minute(minute);
-      if (newStartDate.isValid()) {
+      const newStartDate = date(selectedTime, 'HH:mm');
+      if (newStartDate.isValid && newStartDate.isValid()) {
         setStartDate(newStartDate);
         setStartTime(selectedTime);
       }
     } else if (type === 'endTime') {
-      const newEndDate = endDate.clone().hour(hour).minute(minute);
-      if (newEndDate.isValid()) {
+      const newEndDate = date(selectedTime, 'HH:mm');
+      if (newEndDate.isValid && newEndDate.isValid()) {
         setEndDate(newEndDate);
         setEndTime(selectedTime);
       }

--- a/src/web/pages/schedules/Dialog.jsx
+++ b/src/web/pages/schedules/Dialog.jsx
@@ -211,8 +211,6 @@ const ScheduleDialog = ({
   };
 
   const handleTimeChange = (selectedTime, type) => {
-    const [hour, minute] = selectedTime.split(':').map(Number);
-
     if (type === 'startTime') {
       const newStartDate = date(selectedTime, 'HH:mm');
       if (newStartDate.isValid()) {

--- a/src/web/pages/schedules/__tests__/Dialog.test.jsx
+++ b/src/web/pages/schedules/__tests__/Dialog.test.jsx
@@ -217,4 +217,36 @@ describe('ScheduleDialog component tests', () => {
 
     expect(handleSave).toHaveBeenCalled();
   });
+
+  test('should allow changing start and end times', async () => {
+    handleSave.mockResolvedValue({});
+
+    const {getByName} = render(
+      <ScheduleDialog
+        comment={scheduleComment}
+        duration={scheduleDuration}
+        freq={scheduleFrequency}
+        id={scheduleId}
+        interval={scheduleInterval}
+        monthdays={scheduleMonthDays}
+        name={scheduleName}
+        startDate={scheduleStartDate}
+        timezone={scheduleTimezone}
+        title={`Edit Schedule ${scheduleName}`}
+        weekdays={scheduleWeekDays}
+        onClose={handleClose}
+        onSave={handleSave}
+      />,
+    );
+
+    const startTimeInput = getByName('startDate')
+    expect(startTimeInput).toHaveValue('15:00')
+    changeInputValue(startTimeInput, '12:00')
+    expect(startTimeInput).toHaveValue('12:00')
+
+    const endTimeInput = getByName('endTime')
+    expect(endTimeInput).toHaveValue('19:45')
+    changeInputValue(endTimeInput, '13:00')
+    expect(endTimeInput).toHaveValue('13:00')
+  })
 });

--- a/src/web/pages/schedules/__tests__/Dialog.test.jsx
+++ b/src/web/pages/schedules/__tests__/Dialog.test.jsx
@@ -249,4 +249,68 @@ describe('ScheduleDialog component tests', () => {
     changeInputValue(endTimeInput, '13:00')
     expect(endTimeInput).toHaveValue('13:00')
   })
+
+  test('should prevent changing start and end times when value is invalid', async () => {
+    handleSave.mockResolvedValue({});
+
+    const {getByName} = render(
+      <ScheduleDialog
+        comment={scheduleComment}
+        duration={scheduleDuration}
+        freq={scheduleFrequency}
+        id={scheduleId}
+        interval={scheduleInterval}
+        monthdays={scheduleMonthDays}
+        name={scheduleName}
+        startDate={scheduleStartDate}
+        timezone={scheduleTimezone}
+        title={`Edit Schedule ${scheduleName}`}
+        weekdays={scheduleWeekDays}
+        onClose={handleClose}
+        onSave={handleSave}
+      />,
+    );
+
+    const startTimeInput = getByName('startDate')
+    expect(startTimeInput).toHaveValue('15:00')
+    changeInputValue(startTimeInput, '')
+    expect(startTimeInput).toHaveValue('15:00')
+    changeInputValue(startTimeInput, '13')
+    expect(startTimeInput).toHaveValue('15:00')
+    changeInputValue(startTimeInput, 'a:00')
+    expect(startTimeInput).toHaveValue('15:00')
+    changeInputValue(startTimeInput, ':00')
+    expect(startTimeInput).toHaveValue('15:00')
+    changeInputValue(startTimeInput, '25:00')
+    expect(startTimeInput).toHaveValue('15:00')
+    changeInputValue(startTimeInput, '15:a')
+    expect(startTimeInput).toHaveValue('15:00')
+    changeInputValue(startTimeInput, '15:0')
+    expect(startTimeInput).toHaveValue('15:00')
+    changeInputValue(startTimeInput, '15:')
+    expect(startTimeInput).toHaveValue('15:00')
+    changeInputValue(startTimeInput, '15:62')
+    expect(startTimeInput).toHaveValue('15:00')
+
+    const endTimeInput = getByName('endTime')
+    expect(endTimeInput).toHaveValue('19:45')
+    changeInputValue(endTimeInput, '')
+    expect(endTimeInput).toHaveValue('19:45')
+    changeInputValue(endTimeInput, '15')
+    expect(endTimeInput).toHaveValue('19:45')
+    changeInputValue(endTimeInput, 'a:00')
+    expect(endTimeInput).toHaveValue('19:45')
+    changeInputValue(endTimeInput, ':00')
+    expect(endTimeInput).toHaveValue('19:45')
+    changeInputValue(endTimeInput, '25:00')
+    expect(endTimeInput).toHaveValue('19:45')
+    changeInputValue(endTimeInput, '19:a')
+    expect(endTimeInput).toHaveValue('19:45')
+    changeInputValue(endTimeInput, '19:0')
+    expect(endTimeInput).toHaveValue('19:45')
+    changeInputValue(endTimeInput, '19:')
+    expect(endTimeInput).toHaveValue('19:45')
+    changeInputValue(endTimeInput, '19:62')
+    expect(endTimeInput).toHaveValue('19:45')
+  })
 });


### PR DESCRIPTION
## What
Add check to ensure time is valid before updating state

## Why
A method call on an invalid moment throws an error

## References
https://jira.greenbone.net/browse/GEA-948

