### PR TITLE
fix: Show success notification only if successMessage is defined in actionFunction

### DIFF
--- a/src/web/entity/hooks/__tests__/actionFunction.test.js
+++ b/src/web/entity/hooks/__tests__/actionFunction.test.js
@@ -1,0 +1,60 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {showSuccessNotification} from '@greenbone/opensight-ui-components-mantinev7';
+import {describe, test, expect, testing} from '@gsa/testing';
+import actionFunction from 'web/entity/hooks/actionFunction';
+
+vi.mock('@greenbone/opensight-ui-components-mantinev7', () => ({
+  showSuccessNotification: vi.fn(),
+}));
+
+describe('actionFunction', () => {
+  beforeEach(() => {
+    testing.resetAllMocks();
+  });
+  test('should call onSuccess with response and show success notification if successMessage is defined', async () => {
+    const promise = Promise.resolve('response');
+    const onSuccess = testing.fn();
+    const onError = testing.fn();
+    const successMessage = 'Success!';
+
+    await actionFunction(promise, onSuccess, onError, successMessage);
+
+    expect(onSuccess).toHaveBeenCalledWith('response');
+    expect(showSuccessNotification).toHaveBeenCalledWith(successMessage);
+  });
+
+  test('should call onSuccess with response and not show success notification if successMessage is not defined', async () => {
+    const promise = Promise.resolve('response');
+    const onSuccess = testing.fn();
+    const onError = testing.fn();
+
+    await actionFunction(promise, onSuccess, onError);
+
+    expect(onSuccess).toHaveBeenCalledWith('response');
+    expect(showSuccessNotification).not.toHaveBeenCalled();
+  });
+
+  test('should call onError with error if promise rejects and onError is defined', async () => {
+    const promise = Promise.reject('error');
+    const onSuccess = testing.fn();
+    const onError = testing.fn();
+
+    await actionFunction(promise, onSuccess, onError);
+
+    expect(onError).toHaveBeenCalledWith('error');
+  });
+
+  test('should throw error if promise rejects and onError is not defined', async () => {
+    const promise = Promise.reject('error');
+    const onSuccess = testing.fn();
+    const onError = undefined;
+
+    await expect(actionFunction(promise, onSuccess, onError)).rejects.toEqual(
+      'error',
+    );
+  });
+});

--- a/src/web/entity/hooks/actionFunction.js
+++ b/src/web/entity/hooks/actionFunction.js
@@ -22,7 +22,7 @@ const actionFunction = async (promise, onSuccess, onError, successMessage) => {
   try {
     const response = await promise;
     if (isDefined(onSuccess)) {
-      showSuccessNotification('', successMessage);
+      isDefined(successMessage) && showSuccessNotification(successMessage);
       return onSuccess(response);
     }
   } catch (error) {


### PR DESCRIPTION

## What

-  Show success notification only if `successMessage` is defined in `actionFunction`
- Add test for `actionfunction`
- 
## Why

- Show notification was always triggered show an empty notification

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


