### PR TITLE
Remove a warning using deprecated isFunction from nodejs utils

### DIFF
--- a/src/gmp/__tests__/log.test.js
+++ b/src/gmp/__tests__/log.test.js
@@ -12,8 +12,7 @@ import {
   testing,
 } from '@gsa/testing';
 import {RootLogger, DEFAULT_LOG_LEVEL, LogLevels} from 'gmp/log.js';
-import {isFunction} from 'util';
-
+import {isFunction} from 'gmp/utils/identity';
 
 let origConsole;
 let testConsole;


### PR DESCRIPTION
Use our own version of that function instead.

## What

Remove a warning using deprecated isFunction from nodejs utils

## Why

Less noise when running the tests.