### PR TITLE
Add a useActiveTab react hook

### DIFF
--- a/src/web/entity/hooks/__tests__/useActiveTab.test.ts
+++ b/src/web/entity/hooks/__tests__/useActiveTab.test.ts
@@ -1,0 +1,37 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect, testing} from '@gsa/testing';
+import useActiveTab from 'web/entity/hooks/useActiveTab';
+import {rendererWith, wait} from 'web/utils/Testing';
+
+describe('useActiveTab', () => {
+  test('should set active tab to 0 by default', () => {
+    const {renderHook} = rendererWith();
+    const {result} = renderHook(() => useActiveTab());
+    const [activeTab] = result.current;
+    expect(activeTab).toBe(0);
+  });
+
+  test('should set active tab to 1 when activated', async () => {
+    const {renderHook} = rendererWith();
+    const {result} = renderHook(() => useActiveTab());
+    const [activeTab, setActiveTab] = result.current;
+    expect(activeTab).toBe(0);
+    setActiveTab(1);
+    await wait();
+    expect(result.current[0]).toBe(1);
+  });
+
+  test('should call onInteraction when active tab changes', async () => {
+    const onInteraction = testing.fn();
+    const {renderHook} = rendererWith();
+    const {result} = renderHook(() => useActiveTab({onInteraction}));
+    const [, setActiveTab] = result.current;
+    setActiveTab(1);
+    await wait();
+    expect(onInteraction).toHaveBeenCalled();
+  });
+});

--- a/src/web/entity/hooks/useActiveTab.ts
+++ b/src/web/entity/hooks/useActiveTab.ts
@@ -1,0 +1,26 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {isDefined} from 'gmp/utils/identity';
+import {useState} from 'react';
+
+interface UseActiveTabProps {
+  onInteraction?: () => void;
+}
+
+const useActiveTab = ({onInteraction}: UseActiveTabProps = {}) => {
+  const [activeTab, setActiveTab] = useState(0);
+
+  const handleActivateTab = (index: number) => {
+    setActiveTab(index);
+
+    if (index !== activeTab && isDefined(onInteraction)) {
+      onInteraction();
+    }
+  };
+  return [activeTab, handleActivateTab] as const;
+};
+
+export default useActiveTab;


### PR DESCRIPTION


## What

Add a useActiveTab react hook

## Why

The hook will allow to simplify the rendering of section components of entity detail pages in future. It may replace render props.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


