### PR TITLE
Fix: Fixed the revocation of the VT selection.

### DIFF
--- a/src/gmp/commands/__tests__/scanconfig.test.js
+++ b/src/gmp/commands/__tests__/scanconfig.test.js
@@ -263,7 +263,7 @@ describe('ScanConfigCommand tests', () => {
             config_id: 'c1',
             oid: '1.2.3',
             'password:1.2.3:2:password:Bar': 'yes',
-            'preference:scanner:0:scanner:timeout.1.2.3': 123,
+            'preference:1.2.3:0:entry:timeout': 123,
             'preference:1.2.3:1:entry:Foo': 'bar',
             'preference:1.2.3:2:password:Bar': 'foo',
             timeout: 1,

--- a/src/gmp/commands/scanconfigs.js
+++ b/src/gmp/commands/scanconfigs.js
@@ -158,7 +158,7 @@ export class ScanConfigCommand extends EntityCommand {
       timeout: isDefined(timeout) ? 1 : 0,
     };
 
-    data['preference:scanner:0:scanner:timeout.' + oid] = isDefined(timeout)
+    data['preference:' + oid + ':0:entry:timeout'] = isDefined(timeout)
       ? timeout
       : '';
 

--- a/src/web/pages/scanconfigs/Component.jsx
+++ b/src/web/pages/scanconfigs/Component.jsx
@@ -185,7 +185,7 @@ class ScanConfigComponent extends React.Component {
         const configFamily = config.families[familyName];
         const selected = createSelectedNvts(configFamily, nvts);
 
-        this.setState(({prevHasSelection}) => prevHasSelection ? {
+        this.setState(({hasSelection}) => hasSelection ? {
           familyNvts: data.nvts,
           isLoadingFamily: false,
         } : {

--- a/src/web/pages/scanconfigs/Component.jsx
+++ b/src/web/pages/scanconfigs/Component.jsx
@@ -172,9 +172,6 @@ class ScanConfigComponent extends React.Component {
       isLoadingFamily: silent ? isLoadingFamily : true,
     }));
 
-    this.setState(({hasSelection}) => ({
-        hasSelection : hasSelection,
-    }));
 
     return gmp.scanconfig
       .editScanConfigFamilySettings({
@@ -188,19 +185,15 @@ class ScanConfigComponent extends React.Component {
         const configFamily = config.families[familyName];
         const selected = createSelectedNvts(configFamily, nvts);
 
-        if (this.state.hasSelection) {
-          this.setState({
-            familyNvts: data.nvts,
-            isLoadingFamily: false,
-          });
-        } else {
-          this.setState({
-            familyNvts: data.nvts,
-            familySelectedNvts: selected,
-            hasSelection: true,
-            isLoadingFamily: false,
-          });
-        }
+        this.setState(({prevHasSelection}) => prevHasSelection ? {
+          familyNvts: data.nvts,
+          isLoadingFamily: false,
+        } : {
+          familyNvts: data.nvts,
+          familySelectedNvts: selected,
+          hasSelection: true,
+          isLoadingFamily: false,
+       });
       })
       .catch(error => {
         this.setState({

--- a/src/web/pages/scanconfigs/Component.jsx
+++ b/src/web/pages/scanconfigs/Component.jsx
@@ -149,6 +149,10 @@ class ScanConfigComponent extends React.Component {
   openEditConfigFamilyDialog(familyName) {
     this.handleInteraction();
 
+    this.setState(({hasSelection}) => ({
+        hasSelection : false,
+    }));
+
     this.setState({
       editConfigFamilyDialogVisible: true,
       editConfigFamilyDialogTitle: _('Edit Scan Config Family {{name}}', {
@@ -168,6 +172,10 @@ class ScanConfigComponent extends React.Component {
       isLoadingFamily: silent ? isLoadingFamily : true,
     }));
 
+    this.setState(({hasSelection}) => ({
+        hasSelection : hasSelection,
+    }));
+
     return gmp.scanconfig
       .editScanConfigFamilySettings({
         id: config.id,
@@ -180,11 +188,19 @@ class ScanConfigComponent extends React.Component {
         const configFamily = config.families[familyName];
         const selected = createSelectedNvts(configFamily, nvts);
 
-        this.setState({
-          familyNvts: data.nvts,
-          familySelectedNvts: selected,
-          isLoadingFamily: false,
-        });
+        if (this.state.hasSelection) {
+          this.setState({
+            familyNvts: data.nvts,
+            isLoadingFamily: false,
+          });
+        } else {
+          this.setState({
+            familyNvts: data.nvts,
+            familySelectedNvts: selected,
+            hasSelection: true,
+            isLoadingFamily: false,
+          });
+        }
       })
       .catch(error => {
         this.setState({
@@ -443,6 +459,7 @@ class ScanConfigComponent extends React.Component {
       familyName,
       familyNvts,
       familySelectedNvts,
+      hasSelection,
       importDialogVisible,
       isLoadingConfig,
       isLoadingFamilies,
@@ -534,6 +551,7 @@ class ScanConfigComponent extends React.Component {
             configName={config.name}
             configNameLabel={_('Config')}
             familyName={familyName}
+            hasSelection={hasSelection}
             isLoadingFamily={isLoadingFamily}
             nvts={familyNvts}
             selected={familySelectedNvts}

--- a/src/web/pages/scanconfigs/Component.jsx
+++ b/src/web/pages/scanconfigs/Component.jsx
@@ -149,9 +149,9 @@ class ScanConfigComponent extends React.Component {
   openEditConfigFamilyDialog(familyName) {
     this.handleInteraction();
 
-    this.setState(({hasSelection}) => ({
+    this.setState({
         hasSelection : false,
-    }));
+    });
 
     this.setState({
       editConfigFamilyDialogVisible: true,


### PR DESCRIPTION

## What
When selecting VTs in a VT family and in the same step changing some VT settings, the selection of VTs was revoked. This is fixed now. Furthermore the display of the timeout values is fixed.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This is a bug-fix.
<!-- Describe why are these changes necessary? -->

## References
GEA-952
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->



