### PR TITLE
Refactor useInstanceVariable to return a setter function too

### DIFF
--- a/src/web/hooks/__tests__/useInstanceVariable.test.tsx
+++ b/src/web/hooks/__tests__/useInstanceVariable.test.tsx
@@ -3,21 +3,22 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {describe, test, expect, testing} from '@gsa/testing';
-import {useCallback} from 'react';
+import {describe, test, expect} from '@gsa/testing';
+import {useState} from 'react';
 import useInstanceVariable from 'web/hooks/useInstanceVariable';
 import {fireEvent, rendererWith, screen} from 'web/utils/Testing';
 
-
-const TestComponent = ({callback}) => {
-  const someVariable = useInstanceVariable({value: 1});
-  const changeValue = useCallback(() => {
-    someVariable.value = 2;
-    callback(someVariable.value);
-  }, [someVariable, callback]);
+const TestComponent = () => {
+  const [someVariable, setVariable] = useInstanceVariable(1);
+  const [, setToggle] = useState(false);
+  const forceUpdate = () => setToggle(toggle => !toggle);
+  const changeValue = () => {
+    setVariable(2);
+    forceUpdate();
+  };
   return (
     <div>
-      <div data-testid="t1">{someVariable.value}</div>
+      <div data-testid="t1">{someVariable}</div>
       <button data-testid="changeValue" onClick={changeValue} />
     </div>
   );
@@ -25,17 +26,14 @@ const TestComponent = ({callback}) => {
 
 describe('useInstanceVariable tests', () => {
   test('should render the value', () => {
-    const callback = testing.fn();
     const {render} = rendererWith();
 
-    render(<TestComponent callback={callback} />);
+    render(<TestComponent />);
 
     const t1 = screen.getByTestId('t1');
     expect(t1).toHaveTextContent('1');
     const b1 = screen.getByTestId('changeValue');
     fireEvent.click(b1);
-    expect(t1).toHaveTextContent('1');
-
-    expect(callback).toHaveBeenCalledWith(2);
+    expect(t1).toHaveTextContent('2');
   });
 });

--- a/src/web/hooks/useInstanceVariable.ts
+++ b/src/web/hooks/useInstanceVariable.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {useRef} from 'react';
+import {useCallback, useRef} from 'react';
+
+type SetInstanceVariable<T> = (value: T) => void;
 
 /**
  * A hook to store an instance variable for a function component.
@@ -18,9 +20,14 @@ import {useRef} from 'react';
  *                         object. Most of the time it should be initialized
  *                         with an empty object.
  */
-const useInstanceVariable = initialValue => {
-  const ref = useRef(initialValue);
-  return ref.current;
+const useInstanceVariable = <T>(
+  initialValue: T,
+): [T, SetInstanceVariable<T>] => {
+  const ref = useRef<T>(initialValue);
+  const setInstanceVariable = useCallback((value: T) => {
+    ref.current = value;
+  }, []);
+  return [ref.current, setInstanceVariable];
 };
 
 export default useInstanceVariable;

--- a/src/web/hooks/useTiming.js
+++ b/src/web/hooks/useTiming.js
@@ -18,7 +18,7 @@ const log = logger.getLogger('web.hooks.useTiming');
  * @returns Array of startTimer function, clearTimer function and boolean isRunning
  */
 const useTiming = (doFunc, timeout) => {
-  const timer = useInstanceVariable({});
+  const [timer] = useInstanceVariable({});
   const [timerId, setTimerId] = useState(); // store timerId in state too to trigger re-render if it changes
   const isRunning = Boolean(timerId);
   timer.doFunc = doFunc; // always use the latest version of the function


### PR DESCRIPTION

## What

Refactor useInstanceVariable to return a setter function too and convert it module to TypeScript.

## Why

Refactor useInstanceVariable to return the value and a setter function to allow changing the value and not having to use a mutable object.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


