### PR TITLE
Simplify parse properties

### DIFF
--- a/src/gmp/__tests__/parser.test.js
+++ b/src/gmp/__tests__/parser.test.js
@@ -424,31 +424,6 @@ describe('parseProperties tests', () => {
     expect(parsed.lorem).toEqual('ipsum');
   });
 
-  test('should copy additional properties', () => {
-    const obj = {
-      foo: 'bar',
-      lorem: 'ipsum',
-    };
-
-    const parsed = parseProperties(obj, {bar: 'foo'});
-
-    expect(parsed.bar).toEqual('foo');
-    expect(parsed.foo).toEqual('bar');
-    expect(parsed.lorem).toEqual('ipsum');
-  });
-
-  test('should not override properties with additional properties', () => {
-    const obj = {
-      foo: 'bar',
-      lorem: 'ipsum',
-    };
-
-    const parsed = parseProperties(obj, {foo: 'foo'});
-
-    expect(parsed.foo).toEqual('bar');
-    expect(parsed.lorem).toEqual('ipsum');
-  });
-
   test('should parse id', () => {
     const parsed = parseProperties({_id: 'a1'});
     expect(parsed.id).toEqual('a1');

--- a/src/gmp/models/host.js
+++ b/src/gmp/models/host.js
@@ -16,12 +16,10 @@ import {forEach, map} from 'gmp/utils/array';
 import {isDefined} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
 
-
 const get_identifier = (identifiers, name) =>
   identifiers.filter(identifier => identifier.name === name)[0];
 
-const newProperties = (properties, object = {}) =>
-  setProperties(parseProperties(properties, object));
+const newProperties = properties => setProperties(parseProperties(properties));
 
 class Identifier {
   constructor(element) {

--- a/src/gmp/parser.ts
+++ b/src/gmp/parser.ts
@@ -196,13 +196,12 @@ export interface ElementProperties {
 
 export const parseProperties = (
   element: ElementProperties = {},
-  object: Properties = {},
 ): ParsedProperties => {
   // in future the function should only return known properties
   // and not the whole object
   // for now we need to return the whole object
   // to not break existing code
-  const copy: ParsedProperties = {...object, ...element}; // create shallow copy
+  const copy: ParsedProperties = {...element}; // create shallow copy
 
   if ('_id' in element && isString(element._id) && element._id.length > 0) {
     // only set id if it id defined


### PR DESCRIPTION
## What

Remove unused object argument from parseProperties function

## Why

The second argument (object) of the parseProperties function in the
parser module is actually not used anywhere.

## References

Requires https://github.com/greenbone/gsa/pull/4439

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


