### PR TITLE
Update the heading level for the severity rating setting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ github](https://github.com/greenbone/gsa/issues) first.
 
 ## License
 
-Copyright (C) 2009-2023 [Greenbone AG](https://www.greenbone.net/)
+Copyright (C) 2009-2025 [Greenbone AG](https://www.greenbone.net/)
 
 Licensed under the AGPL-3.0 [GNU Affero General Public License v3.0 or later](LICENSE).
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ written in [React](https://reactjs.org/).
     - [reloadIntervalActive](#reloadintervalactive)
     - [reloadIntervalInactive](#reloadintervalinactive)
     - [reportResultsThreshold](#reportresultsthreshold)
-- [severityRating](#severityrating)
+    - [severityRating](#severityrating)
 - [Support](#support)
 - [Maintainer](#maintainer)
 - [Contributing](#contributing)
@@ -366,7 +366,7 @@ Certificates tabs to prompt the user for lowering the number of results by
 additional filtering. This setting can be used to improve the responsiveness of
 the report details page.
 
-## severityRating
+#### severityRating
 
 Defines which Severity Rating should be used for the severity classes. Currently
 the values `CVSSv2` and `CVSSv3` are allowed. CVSS version 3 introduces a new


### PR DESCRIPTION

## What

Update the heading level for the severity rating setting in README

## Why
It should be in the Settings chapter.


