### PR TITLE
fix: correct date handling in ToolbarIcons component in reports details

### DIFF
--- a/src/web/pages/performance/PerformancePage.jsx
+++ b/src/web/pages/performance/PerformancePage.jsx
@@ -40,7 +40,6 @@ import {renderSelectItems} from 'web/utils/Render';
 import withGmp from 'web/utils/withGmp';
 import {withRouter} from 'web/utils/withRouter';
 
-
 const DURATION_HOUR = 60 * 60;
 const DURATION_DAY = DURATION_HOUR * 24;
 const DURATION_WEEK = DURATION_DAY * 7;
@@ -110,8 +109,8 @@ const ReportImage = ({name, duration, scannerId, endDate, startDate}) => {
   if (isDefined(duration)) {
     params.duration = DURATIONS[duration];
   } else {
-    params.start_time = startDate.toISOString();
-    params.end_time = endDate.toISOString();
+    params.start_time = startDate.utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]');
+    params.end_time = endDate.utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]');
   }
   const url = gmp.buildUrl('system_report/' + name + '/report.', params);
   return <img alt="" src={url} />;

--- a/src/web/pages/reports/details/ToolbarIcons.jsx
+++ b/src/web/pages/reports/details/ToolbarIcons.jsx
@@ -23,7 +23,6 @@ import Link from 'web/components/link/Link';
 import AlertActions from 'web/pages/reports/details/AlertActions';
 import PropTypes from 'web/utils/PropTypes';
 
-
 const ToolBarIcons = ({
   audit = false,
   delta = false,
@@ -121,10 +120,10 @@ const ToolBarIcons = ({
             <Link
               query={{
                 start: isDefined(report.scan_start)
-                  ? report.scan_start.toISOString()
+                  ? report.scan_start.utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')
                   : undefined,
                 end: isDefined(report.scan_end)
-                  ? report.scan_end.toISOString()
+                  ? report.scan_end.utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]')
                   : undefined,
                 ...(isDefined(report.slave) && {scanner: report.slave.id}),
               }}


### PR DESCRIPTION
## What

- Fix date handling in `ToolbarIcons` component reports details performance icon

## Why

- Trying to format a not valid date.

## References

https://github.com/greenbone/gsa/issues/4444
https://jira.greenbone.net/browse/GEA-1024

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


