### PR TITLE
Add: Add openvasd scanner type to scanner select options

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -1232,6 +1232,7 @@
   "Open End": "Offenes Ende",
   "Opened": "Eröffnet",
   "OpenVAS Scanner": "OpenVAS-Scanner",
+  "OpenVASD Scanner": "OpenVASD-Scanner",
   "Operating System": "Betriebssystem",
   "Operating System is in use": "Betriebssysteme in Verwendung",
   "Operating System List": "Betriebssystemliste",

--- a/public/locales/gsa-en.json
+++ b/public/locales/gsa-en.json
@@ -1232,6 +1232,7 @@
   "Open End": "Open End",
   "Opened": "Opened",
   "OpenVAS Scanner": "OpenVAS Scanner",
+  "OpenVASD Scanner": "OpenVASD Scanner",
   "Operating System": "Operating System",
   "Operating System is in use": "Operating System is in use",
   "Operating System List": "Operating System List",

--- a/public/locales/gsa-zh_CN.json
+++ b/public/locales/gsa-zh_CN.json
@@ -1232,6 +1232,7 @@
   "Open End": "开放式",
   "Opened": "已打开",
   "OpenVAS Scanner": "OpenVAS 扫描器",
+  "OpenVASD Scanner": "OpenVASD 扫描器",
   "Operating System": "操作系统",
   "Operating System is in use": "操作系统正在使用中",
   "Operating System List": "操作系统列表",

--- a/public/locales/gsa-zh_TW.json
+++ b/public/locales/gsa-zh_TW.json
@@ -1232,6 +1232,7 @@
   "Open End": "",
   "Opened": "已開啟",
   "OpenVAS Scanner": "OpenVAS 掃描器",
+  "OpenVASD Scanner": "OpenVASD 掃描器",
   "Operating System": "作業系統",
   "Operating System is in use": "",
   "Operating System List": "作業系統清單",

--- a/src/gmp/models/__tests__/scanner.test.js
+++ b/src/gmp/models/__tests__/scanner.test.js
@@ -13,6 +13,7 @@ import Scanner, {
   CVE_SCANNER_TYPE,
   OPENVAS_SCANNER_TYPE,
   GREENBONE_SENSOR_SCANNER_TYPE,
+  OPENVASD_SCANNER_TYPE,
 } from 'gmp/models/scanner';
 import {testModel} from 'gmp/models/testing';
 import {YES_VALUE} from 'gmp/parser';
@@ -213,12 +214,14 @@ describe('Scanner model function tests', () => {
     const type3 = scannerTypeName(4);
     const type4 = scannerTypeName(GREENBONE_SENSOR_SCANNER_TYPE);
     const type5 = scannerTypeName(42);
+    const type6 = scannerTypeName(OPENVASD_SCANNER_TYPE);
 
     expect(type1).toEqual('OpenVAS Scanner');
     expect(type2).toEqual('CVE Scanner');
     expect(type3).toEqual('Unknown type (4)');
     expect(type4).toEqual('Greenbone Sensor');
     expect(type5).toEqual('Unknown type (42)');
+    expect(type6).toEqual('OpenVASD Scanner');
   });
 
   test('openVasScannersFilter should return filter with correct true/false', () => {

--- a/src/gmp/models/scanner.js
+++ b/src/gmp/models/scanner.js
@@ -15,6 +15,7 @@ import {isEmpty} from 'gmp/utils/string';
 export const OPENVAS_SCANNER_TYPE = 2;
 export const CVE_SCANNER_TYPE = 3;
 export const GREENBONE_SENSOR_SCANNER_TYPE = 5;
+export const OPENVASD_SCANNER_TYPE = 6;
 
 export const OPENVAS_DEFAULT_SCANNER_ID =
   '08b69003-5fc2-4037-a479-93b440211c73';
@@ -30,6 +31,8 @@ export function scannerTypeName(scannerType) {
     return _('CVE Scanner');
   } else if (scannerType === GREENBONE_SENSOR_SCANNER_TYPE) {
     return _('Greenbone Sensor');
+  } else if (scannerType === OPENVASD_SCANNER_TYPE) {
+    return _('OpenVASD Scanner');
   }
   return _('Unknown type ({{type}})', {type: scannerType});
 }

--- a/src/web/pages/tasks/Dialog.jsx
+++ b/src/web/pages/tasks/Dialog.jsx
@@ -6,6 +6,7 @@
 import {
   OPENVAS_SCANNER_TYPE,
   OPENVAS_DEFAULT_SCANNER_ID,
+  OPENVASD_SCANNER_TYPE,
   GREENBONE_SENSOR_SCANNER_TYPE,
 } from 'gmp/models/scanner';
 import {
@@ -210,7 +211,8 @@ const TaskDialog = ({
 
         const useOpenvasScanConfig =
           state.scanner_type === OPENVAS_SCANNER_TYPE ||
-          state.scanner_type === GREENBONE_SENSOR_SCANNER_TYPE;
+          state.scanner_type === GREENBONE_SENSOR_SCANNER_TYPE ||
+          state.scanner_type === OPENVASD_SCANNER_TYPE;
 
         return (
           <>

--- a/src/web/pages/tasks/__tests__/Dialog.test.jsx
+++ b/src/web/pages/tasks/__tests__/Dialog.test.jsx
@@ -1,0 +1,153 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, expect, test, testing} from '@gsa/testing';
+import ScanConfig from 'gmp/models/scanconfig';
+import {
+    CVE_SCANNER_TYPE,
+    OPENVAS_DEFAULT_SCANNER_ID,
+    OPENVAS_SCANNER_TYPE,
+    OPENVASD_SCANNER_TYPE,
+} from 'gmp/models/scanner';
+import {
+    getDialogCloseButton,
+    getDialogSaveButton,
+    getSelectItemElementsForSelect,
+    queryAllSelectElements,
+} from 'web/components/testing';
+import TaskDialog from 'web/pages/tasks/Dialog';
+import {fireEvent, rendererWith, wait} from 'web/utils/Testing';
+
+describe('TaskDialog component tests', () => {
+  const gmp = {settings: {}};
+  const scanConfig = ScanConfig.fromElement({
+    id: 'config-1',
+    name: 'Test Config',
+  });
+
+  const commonHandlers = () => ({
+    onClose: testing.fn(),
+    onSave: testing.fn(),
+    onAlertsChange: testing.fn(),
+    onNewAlertClick: testing.fn(),
+    onNewScheduleClick: testing.fn(),
+    onNewTargetClick: testing.fn(),
+    onScanConfigChange: testing.fn(),
+    onScannerChange: testing.fn(),
+    onScheduleChange: testing.fn(),
+    onTargetChange: testing.fn(),
+    onEsxiCredentialChange: testing.fn(),
+    onKrb5CredentialChange: testing.fn(),
+    onNewCredentialsClick: testing.fn(),
+    onNewPortListClick: testing.fn(),
+    onPortListChange: testing.fn(),
+    onSmbCredentialChange: testing.fn(),
+    onSnmpCredentialChange: testing.fn(),
+    onSshCredentialChange: testing.fn(),
+    onSshElevateCredentialChange: testing.fn(),
+  });
+
+  const renderDialog = scannerType =>
+    rendererWith({gmp, capabilities: true}).render(
+      <TaskDialog
+          alerts={[]}
+          comment="hello world"
+          config_id="config-1"
+          name="target"
+          scan_configs={[scanConfig]}
+          scanner_id="scanner-id"
+          scanners={[{id: 'scanner-id', scannerType, name: 'Test Scanner'}]}
+          schedules={[]}
+          tags={[]}
+          targets={[]}
+        {...commonHandlers()}
+      />,
+    );
+
+  test('should render scan config section for OPENVAS_SCANNER_TYPE', async () => {
+    renderDialog(OPENVAS_SCANNER_TYPE);
+    const selects = queryAllSelectElements();
+    expect(selects.length).toEqual(5);
+
+    const scanConfigSelect = selects[3];
+    fireEvent.click(scanConfigSelect);
+
+    const options = await getSelectItemElementsForSelect(scanConfigSelect);
+    expect(options[0]).toHaveTextContent('Test Config');
+  });
+
+  test('should render scan config section for OPENVASD_SCANNER_TYPE', async () => {
+    renderDialog(OPENVASD_SCANNER_TYPE);
+    const selects = queryAllSelectElements();
+    expect(selects.length).toEqual(5);
+
+    const scanConfigSelect = selects[3];
+    fireEvent.click(scanConfigSelect);
+
+    const options = await getSelectItemElementsForSelect(scanConfigSelect);
+    expect(options[0]).toHaveTextContent('Test Config');
+  });
+
+  test('should not render scan config section for CVE_SCANNER_TYPE', () => {
+    renderDialog(CVE_SCANNER_TYPE);
+    const selects = queryAllSelectElements();
+    expect(selects.length).toEqual(3); // config select is hidden
+  });
+
+  test('should save dialog with updated values', async () => {
+    const onSave = testing.fn();
+    const {getByName} = rendererWith({gmp, capabilities: true}).render(
+      <TaskDialog
+        {...commonHandlers()}
+        alerts={[]}
+        comment="initial comment"
+        name="InitialTask"
+        scan_configs={[scanConfig]}
+        scanner_id={OPENVAS_DEFAULT_SCANNER_ID}
+        scanners={[
+          {id: OPENVAS_DEFAULT_SCANNER_ID, scanner_type: OPENVAS_SCANNER_TYPE},
+        ]}
+        schedules={[]}
+        tags={[]}
+        targets={[]}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.change(getByName('name'), {target: {value: 'UpdatedTask'}});
+    fireEvent.change(getByName('comment'), {
+      target: {value: 'Updated comment'},
+    });
+
+    fireEvent.click(getDialogSaveButton());
+
+    await wait(() => {
+      expect(onSave).toHaveBeenCalled();
+    });
+  });
+
+  test('should close dialog on close button click', () => {
+    const onClose = testing.fn();
+    rendererWith({gmp, capabilities: true}).render(
+      <TaskDialog {...defaultProps} onClose={onClose} />,
+    );
+
+    fireEvent.click(getDialogCloseButton());
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  const defaultProps = {
+    scan_configs: [scanConfig],
+    scanners: [
+      {id: OPENVAS_DEFAULT_SCANNER_ID, scanner_type: OPENVAS_SCANNER_TYPE},
+    ],
+    scanner_id: OPENVAS_DEFAULT_SCANNER_ID,
+    targets: [],
+    alerts: [],
+    schedules: [],
+    tags: [],
+    ...commonHandlers(),
+  };
+});


### PR DESCRIPTION
## What

This PR adds support for the `OPENVASD_SCANNER_TYPE` to the scanner selection in the TaskDialog component. When this scanner is selected, the "Scan Config" section is now conditionally rendered. The default scanner remains OPENVAS. These changes ensure that OPENVASD is displayed and supported if it is defined in the GVMD.

## Why

This update ensures that the new `OPENVASD_SCANNER_TYPE` is properly supported, maintaining consistency with other scanner types and enabling configuration when the OPENVASD scanner is selected.

## References

GEA-938

## Checklist


- [ ] Tests


