### PR TITLE
 Fix code coverage upload by removing lint report

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -55,11 +55,6 @@ jobs:
         run: npm install
       - name: Run JavaScript tests
         run: npm run test:coverage -- --reporter=default --reporter=junit --outputFile=${{ env.REPORT_DIR }}/test-report.xml
-      - name: Load Lint Results
-        uses: actions/download-artifact@v4
-        with:
-          name: linting-report-${{ matrix.node-version }}
-          path: ${{ env.REPORT_DIR }}
       - name: Submit test coverage to codecov.io
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION


## What

 Fix code coverage upload by removing lint report
## Why

The linting report got removed with #4447. Therefore fix the code coverage upload by not expecting an available linting report.

## References
#4447