### PR TITLE
Fix: Hide remediation tickets depends on capabilities

### DIFF
--- a/src/gmp/capabilities/__tests__/capabilities.test.js
+++ b/src/gmp/capabilities/__tests__/capabilities.test.js
@@ -227,4 +227,23 @@ describe('Capabilities tests', () => {
     expect(caps.featureEnabled('enabled_feature_2')).toBe(true);
     expect(caps.featureEnabled('UNDEFINED_FEATURE')).toBe(false);
   });
+
+  test('should support ticket capabilities', () => {
+      const caps = new Capabilities([
+          'get_tickets',
+          'create_ticket',
+          'delete_ticket',
+          'modify_ticket',
+      ]);
+
+      expect(caps.mayAccess('ticket')).toEqual(true);
+      expect(caps.mayAccess('tickets')).toEqual(true);
+
+      expect(caps.mayClone('ticket')).toEqual(true);
+      expect(caps.mayCreate('ticket')).toEqual(true);
+      expect(caps.mayDelete('ticket')).toEqual(true);
+      expect(caps.mayEdit('ticket')).toEqual(true);
+
+      expect(caps.mayAccess('other')).toEqual(false);
+  });
 });

--- a/src/gmp/capabilities/capabilities.js
+++ b/src/gmp/capabilities/capabilities.js
@@ -38,6 +38,8 @@ const types = {
   reportformats: 'report_format',
   scanconfig: 'config',
   scanconfigs: 'config',
+  ticket: 'ticket',
+  tickets: 'ticket',
   tlscertificate: 'tls_certificate',
   tlscertificates: 'tls_certificate',
 };

--- a/src/web/components/menu/Menu.jsx
+++ b/src/web/components/menu/Menu.jsx
@@ -63,6 +63,9 @@ const Menu = () => {
 
   const useIsActive = path => Boolean(useMatch(path));
 
+  const conditionalSubNavConfig = (feature, label, to, activeCondition) =>
+        capabilities.mayAccess(feature) && { label, to, activeCondition };
+
   const isUserActive = useIsActive('/users');
   const isGroupsActive = useIsActive('/groups');
   const isRolesActive = useIsActive('/roles');
@@ -127,27 +130,31 @@ const Menu = () => {
       },
     ],
     resilience: [
-      {
-        label: _('Remediation Tickets'),
-        to: '/tickets',
-        activeCondition: useIsActive('/tickets'),
-      },
-      {
-        label: _('Compliance Policies'),
-        to: '/policies',
-        activeCondition: useIsActive('/policies'),
-      },
-      {
-        label: _('Compliance Audits'),
-        to: '/audits',
-        activeCondition: useIsActive('/audits'),
-      },
-      {
-        label: _('Compliance Audit Reports'),
-        to: '/auditreports',
-        activeCondition: useIsActive('/auditreports'),
-      },
-    ],
+      conditionalSubNavConfig(
+        'tickets',
+        _('Remediation Tickets'),
+        '/tickets',
+        useIsActive('/tickets'),
+      ),
+      conditionalSubNavConfig(
+        'policies',
+        _('Compliance Policies'),
+        '/policies',
+        useIsActive('/policies'),
+      ),
+      conditionalSubNavConfig(
+        'audits',
+        _('Compliance Audits'),
+        '/audits',
+        useIsActive('/audits'),
+      ),
+      conditionalSubNavConfig(
+        'auditreports',
+        _('Compliance Audit Reports'),
+        '/auditreports',
+        useIsActive('/auditreports'),
+      ),
+    ].filter(Boolean),
     secInfo: [
       {
         label: _('NVTs'),

--- a/src/web/components/menu/Menu.jsx
+++ b/src/web/components/menu/Menu.jsx
@@ -262,6 +262,7 @@ const Menu = () => {
       {
         label: _('Dashboards'),
         to: '/dashboards',
+        key: 'dashboards',
         icon: BarChart3,
       },
     ],

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -8,10 +8,6 @@ import React from 'react';
 import {rendererWith, screen} from 'web/utils/Testing';
 import Menu from 'web/components/menu/Menu';
 
-testing.mock('web/hooks/useTranslation', () => ({
-  default: () => [key => key],
-}));
-
 afterEach(() => {
   testing.clearAllMocks();
 });
@@ -164,7 +160,7 @@ describe('Menu rendering', () => {
   });
 
   test('should not render Asset menu when enableAssetManagement is false', async () => {
-    const {queryByText} = await renderMenuWith({
+    const {queryByText} = renderMenuWith({
       capabilities: {
         mayAccess: () => false,
         mayOp: () => false,

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -146,7 +146,7 @@ describe('Menu rendering', () => {
       'tags',
     ];
 
-    const {queryByText} = await renderMenuWith({
+    const {queryByText} = renderMenuWith({
       capabilities: {
         mayAccess: feature => !configFeatures.includes(feature),
         mayOp: () => true,

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -156,7 +156,7 @@ describe('Menu rendering', () => {
   });
 
   test('should not render Asset menu when enableAssetManagement is false', async () => {
-    const {queryByText} = renderMenuWith({
+    renderMenuWith({
       capabilities: {
         mayAccess: () => false,
         mayOp: () => false,

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -114,7 +114,7 @@ describe('Menu rendering', () => {
   });
 
   test('should not render Remediation Tickets when mayAccess returns false', async () => {
-    const {queryByText} = await renderMenuWith({
+    const {queryByText} = renderMenuWith({
       capabilities: {
         mayAccess: feature => feature !== 'tickets',
         mayOp: () => true,

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {afterEach, describe, expect, test, testing} from '@gsa/testing';
+import {describe, expect, test} from '@gsa/testing';
 import React from 'react';
 import {rendererWith, screen} from 'web/utils/Testing';
 import Menu from 'web/components/menu/Menu';
@@ -120,7 +120,7 @@ describe('Menu rendering', () => {
       },
     });
 
-    expect(queryByText('Remediation Tickets')).not.toBeInTheDocument();
+    expect(screen.queryByText('Remediation Tickets')).not.toBeInTheDocument();
   });
 
   test('should not render Configuration menu when none of its mayAccess permissions are true', async () => {

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -16,7 +16,7 @@ afterEach(() => {
   testing.clearAllMocks();
 });
 
-const renderMenuWith = async ({capabilities, gmpSettings}) => {
+const renderMenuWith = ({capabilities, gmpSettings}) => {
   const gmp = {
     settings: gmpSettings,
   };

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -96,7 +96,7 @@ describe('Menu rendering', () => {
     'CVSS Calculator',
     'About',
   ])('should render sub-menu: %s', async label => {
-    await renderMenuWith({
+    renderMenuWith({
       capabilities: {
         mayAccess: () => true,
         mayOp: () => true,

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -170,6 +170,6 @@ describe('Menu rendering', () => {
       },
     });
 
-    expect(queryByText('Asset')).not.toBeInTheDocument();
+    expect(screen.queryByText('Asset')).not.toBeInTheDocument();
   });
 });

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -8,10 +8,6 @@ import React from 'react';
 import {rendererWith, screen} from 'web/utils/Testing';
 import Menu from 'web/components/menu/Menu';
 
-afterEach(() => {
-  testing.clearAllMocks();
-});
-
 const renderMenuWith = ({capabilities, gmpSettings}) => {
   const gmp = {
     settings: gmpSettings,

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -106,7 +106,7 @@ describe('Menu rendering', () => {
   });
 
   test('should not render Remediation Tickets when mayAccess returns false', async () => {
-    const {queryByText} = renderMenuWith({
+    renderMenuWith({
       capabilities: {
         mayAccess: feature => feature !== 'tickets',
         mayOp: () => true,

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -152,7 +152,7 @@ describe('Menu rendering', () => {
       },
     });
 
-    expect(queryByText('Configuration')).not.toBeInTheDocument();
+    expect(screen.queryByText('Configuration')).not.toBeInTheDocument();
   });
 
   test('should not render Asset menu when enableAssetManagement is false', async () => {

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -40,7 +40,7 @@ describe('Menu rendering', () => {
     'Administration',
     'Help',
   ])('should render top-level menu: %s', async label => {
-    await renderMenuWith({
+    renderMenuWith({
       capabilities: {
         mayAccess: () => true,
         mayOp: () => true,

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -1,0 +1,216 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {afterEach, describe, expect, test, testing} from '@gsa/testing';
+import React from 'react';
+import {rendererWith} from 'web/utils/Testing';
+
+testing.mock('web/hooks/useTranslation', () => ({
+  default: () => [key => key],
+}));
+
+testing.mock('@greenbone/opensight-ui-components-mantinev7', () => ({
+  AppNavigation: ({menuPoints}) => {
+    return (
+      <ul>
+        {menuPoints?.flat().map((item, index) =>
+          item ? (
+            <li key={index}>
+              {item.label}
+              {item.subNav?.map((subItem, i) => (
+                <ul key={i}>
+                  <li>{subItem.label}</li>
+                </ul>
+              ))}
+            </li>
+          ) : null,
+        )}
+      </ul>
+    );
+  },
+}));
+
+afterEach(() => {
+  testing.clearAllMocks();
+});
+
+/**
+ * Dynamically import the Menu module to bust the cache between tests
+ */
+const importFreshMenu = async () => {
+  const {default: Menu} = await import(
+    /* @vite-ignore */ `web/components/menu/Menu?cacheBust=${Date.now()}`
+  );
+  return Menu;
+};
+
+const renderMenuWith = async ({capabilities, gmpSettings}) => {
+  testing.mock('web/hooks/useCapabilities', () => {
+    return {
+      default: () => {
+        return capabilities;
+      },
+    };
+  });
+
+  testing.mock('web/hooks/useGmp', () => ({
+    default: () => ({
+      settings: gmpSettings,
+    }),
+  }));
+
+  const Menu = await importFreshMenu();
+  const {render} = rendererWith();
+  return render(<Menu />);
+};
+
+describe('Menu rendering', () => {
+  test('should render full menu with mocked capabilities', async () => {
+    const {getByText} = await renderMenuWith({
+      capabilities: {
+        mayAccess: () => true,
+        mayOp: () => true,
+        featureEnabled: () => true,
+      },
+      gmpSettings: {
+        enableAssetManagement: false,
+        reloadInterval: 5000,
+        reloadIntervalActive: 5000,
+        reloadIntervalInactive: 5000,
+      },
+    });
+
+    const topLevelMenus = [
+      'Dashboards',
+      'Scans',
+      'Assets',
+      'Resilience',
+      'Security Information',
+      'Configuration',
+      'Administration',
+      'Help',
+    ];
+
+    const subMenus = [
+      'Tasks',
+      'Reports',
+      'Results',
+      'Vulnerabilities',
+      'Notes',
+      'Overrides',
+      'Remediation Tickets',
+      'Compliance Policies',
+      'Compliance Audits',
+      'Compliance Audit Reports',
+      'NVTs',
+      'CVEs',
+      'CPEs',
+      'CERT-Bund Advisories',
+      'DFN-CERT Advisories',
+      'Targets',
+      'Port Lists',
+      'Credentials',
+      'Scan Configs',
+      'Alerts',
+      'Schedules',
+      'Report Configs',
+      'Report Formats',
+      'Scanners',
+      'Filters',
+      'Tags',
+      'Users',
+      'Groups',
+      'Roles',
+      'Permissions',
+      'Performance',
+      'Trashcan',
+      'Feed Status',
+      'LDAP',
+      'RADIUS',
+      'CVSS Calculator',
+      'About',
+    ];
+
+    topLevelMenus.forEach(label => {
+      expect(getByText(label)).toBeInTheDocument();
+    });
+
+    subMenus.forEach(label => {
+      expect(getByText(label)).toBeInTheDocument();
+    });
+  });
+
+  test('should not render Remediation Tickets when mayAccess returns false', async () => {
+    const {queryByText} = await renderMenuWith({
+      capabilities: {
+        mayAccess: feature => {
+          return feature !== 'tickets';
+        },
+        mayOp: () => true,
+        featureEnabled: () => true,
+      },
+      gmpSettings: {
+        enableAssetManagement: false,
+        reloadInterval: 5000,
+        reloadIntervalActive: 5000,
+        reloadIntervalInactive: 5000,
+      },
+    });
+
+    expect(queryByText('Remediation Tickets')).not.toBeInTheDocument();
+  });
+
+  test('should not render Configuration menu when none of its mayAccess permissions are true', async () => {
+    const configFeatures = [
+      'targets',
+      'port_lists',
+      'credentials',
+      'scan_configs',
+      'alerts',
+      'schedules',
+      'report_configs',
+      'report_formats',
+      'scanners',
+      'filters',
+      'tags',
+    ];
+
+    const {queryByText} = await renderMenuWith({
+      capabilities: {
+        mayAccess: feature => {
+          return !configFeatures.includes(feature);
+        },
+        mayOp: () => true,
+        featureEnabled: () => true,
+      },
+      gmpSettings: {
+        enableAssetManagement: false,
+        reloadInterval: 5000,
+        reloadIntervalActive: 5000,
+        reloadIntervalInactive: 5000,
+      },
+    });
+
+    expect(queryByText('Configuration')).not.toBeInTheDocument();
+  });
+
+  test('should not render Asset menu when enableAssetManagement is false', async () => {
+    const {queryByText} = await renderMenuWith({
+      capabilities: {
+        mayAccess: () => false,
+        mayOp: () => false,
+        featureEnabled: () => false,
+      },
+      gmpSettings: {
+        enableAssetManagement: false,
+        reloadInterval: 5000,
+        reloadIntervalActive: 5000,
+        reloadIntervalInactive: 5000,
+      },
+    });
+
+    expect(queryByText('Asset')).not.toBeInTheDocument();
+  });
+});

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -142,7 +142,7 @@ describe('Menu rendering', () => {
       'tags',
     ];
 
-    const {queryByText} = renderMenuWith({
+    renderMenuWith({
       capabilities: {
         mayAccess: feature => !configFeatures.includes(feature),
         mayOp: () => true,


### PR DESCRIPTION
## What

- Renders "Remediation Tickets" only when `capabilities.mayAccess('tickets') `returns `true`.
- Adds a unit test to verify that "Remediation Tickets" is not rendered when the capability is missing.
- Ensures the frontend respects backend limitations and avoids showing inaccessible links.

## Why

- Previously, the menu was visible on unsupported models, leading to a "Service unavailable: Command disabled" error.
- This change fixes that issue by aligning the frontend visibility with backend permissions.

## References

GEA-1008
## Checklist

- [ ] Tests


