### PR TITLE
Change: rename title to vendorTitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ instantiated once for the [GSA application](./src/web/app.js#L53)
 | [severityRating](#severityrating)                 | `'CVSSv2'` or `'CVSSv3'`   | `'CVSSv2'`                                                                       | -                         | x                       |
 | [vendorVersion](#vendorversion)                   | String                     | undefined                                                                        | -                         | x                       |
 | [vendorLabel](#vendorlabel)                       | String                     | undefined                                                                        | -                         | x                       |
-| [title](#title)                                   | String                     | Greenbone Security Assistant                                                     | x                         | x                       |
+| [vendorTitle](#vendorTitle)                       | String                     | Greenbone Security Assistant                                                     | x                         | x                       |
 #### vendorVersion
 
 Allows to adjust the shown product version string at the Login and About pages.
@@ -263,7 +263,7 @@ Allows to adjust the product info image at the Login page. It must be a relative
 path e.g. `foo.png`. The path will be mapped to `$INSTALL_PREFIX/share/gvm/gsad/web/img/`
 on production (with [gsad]) and `gsa/public/img` for the [development server](#developing).
 
-#### title
+#### vendorTitle
 
 Allows to adjust the HTML title, i.e. the text shown in browser tabs which have GSA open.
 

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       window.addEventListener('DOMContentLoaded', () => {
         try {
           const vendorLabel = config.vendorLabel;
-          const title = config.title
+          const vendorTitle = config.vendorTitle
 
           const match = vendorLabel?.match(/gsm-(\w+)_label\.svg/);
           if (match) {
@@ -23,9 +23,9 @@
             if (isNaN(labelPart)) {
               labelPart = labelPart.toUpperCase();
             }
-            document.title = `${title} - ${labelPart}`;
+            document.title = `${vendorTitle} - ${labelPart}`;
           } else {
-            document.title = title;
+            document.title = vendorTitle;
           }
         } catch (error) {}
       });

--- a/src/gmp/__tests__/gmpsettings.test.ts
+++ b/src/gmp/__tests__/gmpsettings.test.ts
@@ -20,7 +20,7 @@ import GmpSettings, {
   DEFAULT_RELOAD_INTERVAL_INACTIVE,
   DEFAULT_TIMEOUT,
   DEFAULT_REPORT_RESULTS_THRESHOLD,
-  DEFAULT_TITLE
+  DEFAULT_VENDOR_TITLE
 } from 'gmp/gmpsettings';
 import {
   DEFAULT_SEVERITY_RATING,
@@ -85,7 +85,7 @@ describe('GmpSettings tests', () => {
     expect(settings.vendorVersion).toBeUndefined();
     expect(settings.vendorLabel).toBeUndefined();
 
-    expect(settings.title).toEqual(DEFAULT_TITLE);
+    expect(settings.vendorTitle).toEqual(DEFAULT_VENDOR_TITLE);
 
     expect(storage.setItem).toHaveBeenCalledTimes(1);
     expect(storage.setItem).toHaveBeenCalledWith('logLevel', DEFAULT_LOG_LEVEL);
@@ -116,7 +116,7 @@ describe('GmpSettings tests', () => {
       timeout: 30000,
       vendorVersion: 'foo',
       vendorLabel: 'foo.bar',
-      title: 'test title'
+      vendorTitle: 'test title'
     });
 
     expect(settings.apiProtocol).toEqual('http');
@@ -143,7 +143,7 @@ describe('GmpSettings tests', () => {
     expect(settings.username).toBeUndefined();
     expect(settings.vendorVersion).toEqual('foo');
     expect(settings.vendorLabel).toEqual('foo.bar');
-    expect(settings.title).toEqual('test title');
+    expect(settings.vendorTitle).toEqual('test title');
 
     expect(storage.setItem).toHaveBeenCalledTimes(2);
     expect(storage.setItem).toHaveBeenNthCalledWith(
@@ -194,7 +194,7 @@ describe('GmpSettings tests', () => {
     expect(settings.timeout).toEqual(DEFAULT_TIMEOUT);
     expect(settings.timezone).toEqual('cet');
     expect(settings.username).toEqual('foo');
-    expect(settings.title).toEqual(DEFAULT_TITLE);
+    expect(settings.vendorTitle).toEqual(DEFAULT_VENDOR_TITLE);
 
     expect(storage.setItem).toHaveBeenCalledTimes(1);
     expect(storage.setItem).toHaveBeenCalledWith('logLevel', 'error');
@@ -219,7 +219,7 @@ describe('GmpSettings tests', () => {
       username: 'bar',
       vendorVersion: 'foo',
       vendorLabel: 'foo.bar',
-      title: 'test title',
+      vendorTitle: 'test title',
     });
     const settings = new GmpSettings(storage, {
       apiProtocol: 'http',
@@ -236,7 +236,7 @@ describe('GmpSettings tests', () => {
       timeout: 30000,
       vendorVersion: 'bar',
       vendorLabel: 'bar.foo',
-      title: 'title test',
+      vendorTitle: 'title test',
     });
 
     expect(settings.apiProtocol).toEqual('http');
@@ -258,7 +258,7 @@ describe('GmpSettings tests', () => {
     expect(settings.username).toEqual('bar');
     expect(settings.vendorVersion).toEqual('bar');
     expect(settings.vendorLabel).toEqual('bar.foo');
-    expect(settings.title).toEqual('title test');
+    expect(settings.vendorTitle).toEqual('title test');
 
     expect(storage.setItem).toHaveBeenCalledTimes(2);
     expect(storage.setItem).toHaveBeenNthCalledWith(
@@ -286,7 +286,7 @@ describe('GmpSettings tests', () => {
     expect(settings.token).toEqual('atoken');
     expect(settings.timezone).toEqual('cet');
     expect(settings.username).toEqual('foo');
-    expect(settings.title).toEqual(DEFAULT_TITLE);
+    expect(settings.vendorTitle).toEqual(DEFAULT_VENDOR_TITLE);
 
     expect(storage.setItem).toHaveBeenCalledTimes(1);
     expect(storage.setItem).toHaveBeenCalledWith('logLevel', 'error');

--- a/src/gmp/gmpsettings.ts
+++ b/src/gmp/gmpsettings.ts
@@ -19,7 +19,7 @@ export const DEFAULT_PROTOCOLDOC_URL = `https://docs.greenbone.net/API/GMP/gmp-2
 export const DEFAULT_REPORT_RESULTS_THRESHOLD = 25000;
 export const DEFAULT_LOG_LEVEL = 'warn';
 export const DEFAULT_TIMEOUT = 300000; // 5 minutes
-export const DEFAULT_TITLE = 'Greenbone Security Assistant'
+export const DEFAULT_VENDOR_TITLE = 'Greenbone Security Assistant'
 
 interface GmpSettingsOptions {
   apiProtocol?: string;
@@ -47,7 +47,7 @@ interface GmpSettingsOptions {
   timeout?: number;
   vendorVersion?: string;
   vendorLabel?: string;
-  title?: string;
+  vendorTitle?: string;
 }
 
 interface GmpSettingsStorage {
@@ -100,7 +100,7 @@ class GmpSettings {
   reloadIntervalInactive: number;
   reportResultsThreshold: number;
   timeout: number;
-  title!: string;
+  vendorTitle!: string;
   readonly apiProtocol!: string;
   readonly apiServer!: string;
   readonly disableLoginForm!: boolean;
@@ -143,7 +143,7 @@ class GmpSettings {
       timeout = DEFAULT_TIMEOUT,
       vendorVersion,
       vendorLabel,
-      title = DEFAULT_TITLE
+      vendorTitle: vendorTitle = DEFAULT_VENDOR_TITLE
     } = options;
     let {
       apiProtocol = protocol,
@@ -195,7 +195,7 @@ class GmpSettings {
     this.reloadIntervalInactive = reloadIntervalInactive;
     this.reportResultsThreshold = reportResultsThreshold;
     this.timeout = timeout;
-    this.title = title
+    this.vendorTitle = vendorTitle
 
     setAndFreeze(this, 'apiProtocol', apiProtocol);
     setAndFreeze(this, 'apiServer', apiServer);


### PR DESCRIPTION
## What
Rename GMPSettings "title" field to "vendorTitle"

## Why
In order to keep naming consistent

## References
https://jira.greenbone.net/browse/GEA-747
