### PR TITLE
Fix typo in CI step summary for translation command

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -127,4 +127,4 @@ jobs:
       - if: ${{ failure() && steps.check.outcome == 'failure' }}
         run: |
           echo "Translations are not up to date." >> $GITHUB_STEP_SUMMARY
-          echo 'Please run `npm run i18next-extract` and update the translation files.' >> $GITHUB_STEP_SUMMARY
+          echo 'Please run `npm run i18n-extract` and update the translation files.' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION


## What

Fix typo in CI step summary for translation command

## Why

The command is named `i18n-extract` instead of `i18next-extract`.

