### PR TITLE
add node cmd for faster testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "type": "module",
   "scripts": {
     "test": "vitest",
+    "test:web-fast": "vitest --pool=vmForks --project web --project store",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
     "dev": "vite",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
       "@gsa/testing": ["src/testing.js"]
     }
   },
-  "include": ["src"],
+  "include": ["src", "vitest.projects.ts"],
   "exclude": ["node_modules", "build", "coverage"]
 }

--- a/vitest.projects.ts
+++ b/vitest.projects.ts
@@ -1,3 +1,8 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 import {defineWorkspace} from 'vitest/config';
 
 export default defineWorkspace([
@@ -12,9 +17,9 @@ export default defineWorkspace([
         'src/web/**/__tests__/*.?(c|m)[jt]s?(x)',
       ],
       exclude: ['src/web/store/**'],
-      server: {
-        deps: {
-          inline: ['@greenbone/opensight-ui-components'],
+      css: {
+        modules: {
+          classNameStrategy: 'non-scoped',
         },
       },
     },


### PR DESCRIPTION
## What

Improve vitest: 
- Remove inline import for opensight UI in vitest config.
- add command to run test in `vm` for faster results.

## Why

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


