### PR TITLE
improve report details name 

### DIFF
--- a/src/web/components/date/DateTime.tsx
+++ b/src/web/components/date/DateTime.tsx
@@ -7,24 +7,48 @@ import {ensureDate} from 'gmp/locale/date';
 import {Date} from 'gmp/models/date';
 import {isDefined, hasValue} from 'gmp/utils/identity';
 import useUserTimezone from 'web/hooks/useUserTimezone';
-import {formattedUserSettingDateTimeWithTimeZone} from 'web/utils/userSettingTimeDateFormatters';
+import {
+  formattedUserSettingDateTimeWithTimeZone,
+  formattedUserSettingDateTimeObject,
+} from 'web/utils/userSettingTimeDateFormatters';
 
 interface DateTimeProps {
   date?: Date | string;
   formatter?: (date: Date, timezone: string) => string | undefined;
   timezone?: string;
+  showTimezoneAsSeparateLine?: boolean;
 }
 
-const DateTime: React.FC<DateTimeProps> = ({
+const DateTime = ({
   formatter = formattedUserSettingDateTimeWithTimeZone,
   timezone,
   date,
+  showTimezoneAsSeparateLine = false,
 }: DateTimeProps) => {
   const [userTimezone] = useUserTimezone();
 
   date = ensureDate(date);
   if (!hasValue(timezone)) {
     timezone = userTimezone;
+  }
+
+  if (!isDefined(date) || !date.isValid()) {
+    return null;
+  }
+
+  if (showTimezoneAsSeparateLine) {
+    const formattedDate = formattedUserSettingDateTimeObject(date, timezone);
+
+    if (!formattedDate) {
+      return null;
+    }
+
+    return (
+      <div>
+        <p>{formattedDate.datetime}</p>
+        <p>{formattedDate.timezone}</p>
+      </div>
+    );
   }
 
   return !isDefined(date) || !date.isValid() ? null : formatter(date, timezone);

--- a/src/web/components/date/__tests__/DateTime.test.jsx
+++ b/src/web/components/date/__tests__/DateTime.test.jsx
@@ -108,6 +108,34 @@ describe('DateTime render tests', () => {
     expect(baseElement).toHaveTextContent('foo');
   });
 
+  test('should render timezone on separate lines when showTimezoneAsSeparateLine is true', () => {
+    const {render, store} = rendererWith({gmp, store: true});
+
+    const date = Date('2019-01-01T12:00:00Z');
+    expect(date.isValid()).toEqual(true);
+
+    store.dispatch(setTimezone('CET'));
+
+    localStorage.setItem('userInterfaceTimeFormat', 12);
+    localStorage.setItem('userInterfaceDateFormat', 'wdmy');
+
+    const {container} = render(
+      <DateTime showTimezoneAsSeparateLine date={date} />,
+    );
+
+    const divElement = container.querySelector('div');
+    expect(divElement).not.toBeNull();
+
+    const paragraphs = container.querySelectorAll('p');
+    expect(paragraphs.length).toBe(2);
+
+    expect(paragraphs[0].textContent).not.toBe('');
+
+    expect(paragraphs[1].textContent).toContain(
+      'Central European Standard Time',
+    );
+  });
+
   test.each([
     [
       'should render with default formatter',

--- a/src/web/components/section/Header.tsx
+++ b/src/web/components/section/Header.tsx
@@ -35,20 +35,22 @@ const WordBreakLayout = styled(Layout)`
 
 interface SectionHeaderProps {
   align?: string | [string, string];
+  alignHeading?: string | [string, string];
   children?: React.ReactNode;
   img?: string | React.ReactNode;
   title?: string | React.ReactNode;
 }
 
-const SectionHeader: React.FC<SectionHeaderProps> = ({
+const SectionHeader = ({
   children,
   align = ['space-between', 'end'],
+  alignHeading = ['start', 'stretch'],
   title,
   img,
 }: SectionHeaderProps) => {
   return (
     <HeaderLayout flex align={align} className="section-header">
-      <HeaderHeading align={['start', 'stretch']}>
+      <HeaderHeading align={alignHeading}>
         {isDefined(img) && (
           <HeaderIconLayout flex align={['start', 'end']}>
             {isString(img) ? <Icon img={img} size="large" /> : img}

--- a/src/web/pages/reports/DetailsContent.jsx
+++ b/src/web/pages/reports/DetailsContent.jsx
@@ -46,6 +46,16 @@ const Span = styled.span`
   margin-top: 2px;
 `;
 
+const HeaderContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  white-space: normal;
+  word-break: normal;
+  word-wrap: break-word;
+`;
+
 const PageContent = ({
   activeTab,
   applicationsCounts,
@@ -140,24 +150,28 @@ const PageContent = ({
     !showThresholdMessage &&
     (!isDefined(results.entities) || results.entities.length === 0);
 
-  const header_title = (
+  const HeaderTitle = (
     <Divider>
-      <span>{_('Report:')}</span>
+      <span style={{whiteSpace: 'nowrap'}}>{_('Report:')}</span>
       {showIsLoading ? (
         <span>{_('Loading')}</span>
       ) : (
-        <Divider>
-          <DateTime date={timestamp} />
+        <HeaderContainer>
+          <DateTime showTimezoneAsSeparateLine date={timestamp} />
           <Span>
             <StatusBar progress={progress} status={status} />
           </Span>
-        </Divider>
+        </HeaderContainer>
       )}
     </Divider>
   );
 
   const header = (
-    <SectionHeader img={<ReportIcon size="large" />} title={header_title}>
+    <SectionHeader
+      alignHeading={['start', 'baseline']}
+      img={<ReportIcon size="large" />}
+      title={HeaderTitle}
+    >
       {hasReport && <EntityInfo entity={entity} />}
     </SectionHeader>
   );

--- a/src/web/pages/reports/__tests__/DetailsContent.test.jsx
+++ b/src/web/pages/reports/__tests__/DetailsContent.test.jsx
@@ -155,8 +155,10 @@ describe('Report Details Content tests', () => {
     expect(input).toHaveAttribute('placeholder', 'Loading...');
 
     // Header
-    expect(baseElement).toHaveTextContent(
-      'Report:Mon, Jun 3, 2019 1:00 PM Central European Summer Time',
+    const headerSection = baseElement.querySelector('.report-header');
+    within(headerSection).getByText('Report:');
+    within(headerSection).getByText(
+      'Mon, Jun 3, 2019 1:00 PM Central European Summer Time',
     );
     expect(bars[0]).toHaveAttribute('title', 'Done');
     expect(bars[0]).toHaveTextContent('Done');
@@ -325,8 +327,10 @@ describe('Report Details Content tests', () => {
     expect(input).toHaveAttribute('placeholder', 'Loading...');
 
     // Header
-    expect(baseElement).toHaveTextContent(
-      'Report:Mon, Jun 3, 2019 1:00 PM Central European Summer Time',
+    const headerSection = baseElement.querySelector('.report-header');
+    within(headerSection).getByText('Report:');
+    within(headerSection).getByText(
+      'Mon, Jun 3, 2019 1:00 PM Central European Summer Time',
     );
     expect(bars[0]).toHaveAttribute('title', 'Done');
     expect(bars[0]).toHaveTextContent('Done');

--- a/src/web/utils/userSettingTimeDateFormatters.js
+++ b/src/web/utils/userSettingTimeDateFormatters.js
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {longDate, shortDate, dateTimeWithTimeZone} from 'gmp/locale/date';
+import {
+  longDate,
+  shortDate,
+  dateTimeWithTimeZone,
+  dateTimeWithTimeZoneObject,
+} from 'gmp/locale/date';
 
 export const formattedUserSettingShortDate = (date, tz) => {
   const userInterfaceDateFormat = localStorage.getItem(
@@ -32,6 +37,31 @@ export const formattedUserSettingDateTimeWithTimeZone = (date, tz) => {
     'userInterfaceTimeFormat',
   );
   return dateTimeWithTimeZone(
+    date,
+    tz,
+    userInterfaceTimeFormat,
+    userInterfaceDateFormat,
+  );
+};
+
+/**
+ * Returns date and timezone as separate object properties
+ * for display on separate lines
+ *
+ * @param {DateInput} date - The date to format
+ * @param {string} tz - The timezone
+ * @returns {Object|undefined} - Object with datetime and timezone properties or undefined
+ */
+
+export const formattedUserSettingDateTimeObject = (date, tz) => {
+  const userInterfaceDateFormat = localStorage.getItem(
+    'userInterfaceDateFormat',
+  );
+  const userInterfaceTimeFormat = localStorage.getItem(
+    'userInterfaceTimeFormat',
+  );
+
+  return dateTimeWithTimeZoneObject(
     date,
     tz,
     userInterfaceTimeFormat,


### PR DESCRIPTION
## What

- Improve `DateTime` to be able to split into lines date-time and timezone.
## Why

- Line breaks were splitting words. 

## References

GEA-1026

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


