### PR TITLE
Change: file type preference styling

### DIFF
--- a/src/web/pages/nvts/NvtPreference.jsx
+++ b/src/web/pages/nvts/NvtPreference.jsx
@@ -14,7 +14,6 @@ import Radio from 'web/components/form/Radio';
 import TextField from 'web/components/form/TextField';
 import YesNoRadio from 'web/components/form/YesNoRadio';
 import Column from 'web/components/layout/Column';
-import Divider from 'web/components/layout/Divider';
 import TableData from 'web/components/table/Data';
 import TableRow from 'web/components/table/Row';
 import useTranslation from 'web/hooks/useTranslation';

--- a/src/web/pages/nvts/NvtPreference.jsx
+++ b/src/web/pages/nvts/NvtPreference.jsx
@@ -75,7 +75,7 @@ const NvtPreference = ({preference, value = '', onChange}) => {
     );
   } else if (type === 'file') {
     input = (
-      <Divider>
+      <Column>
         <Checkbox
           checked={checked}
           title={
@@ -86,7 +86,7 @@ const NvtPreference = ({preference, value = '', onChange}) => {
           onChange={onCheckedChange}
         />
         <FileField disabled={!checked} onChange={onPreferenceChange} />
-      </Divider>
+      </Column>
     );
   } else if (type === 'radio') {
     input = (


### PR DESCRIPTION
## What
Moved checkbox to enable credentials file upload and file input onto separate files

## Why
Originally the checkbox to enable uploads and the file input where on the same line.
This caused issues with actually being able to upload files due to the file input being too
small to click.
The checkbox to enable and the file input arenow on separate lines.

## References
https://jira.greenbone.net/browse/GEA-1036