### PR TITLE
fix: bug timezone not set for store in login

### DIFF
--- a/src/web/pages/login/LoginPage.tsx
+++ b/src/web/pages/login/LoginPage.tsx
@@ -28,6 +28,7 @@ import {
   setSessionTimeout,
   setUsername,
   setIsLoggedIn,
+  setTimezone,
 } from 'web/store/usersettings/actions';
 import Theme from 'web/utils/Theme';
 
@@ -103,6 +104,8 @@ const LoginPage: React.FC = () => {
       gmp.setLocale(locale);
       dispatch(setSessionTimeout(sessionTimeout));
       dispatch(setUsername(username));
+      dispatch(setTimezone(timezone));
+
       // must be set before changing the location
 
       dispatch(setIsLoggedIn(true));


### PR DESCRIPTION
## What
     
The timezone was not updated in the redux store on login.

## Why

Currently, after login an incorrect timezone is displayed, the user needs to refresh the page to display the user setting timezone.

## References

GEA-1051

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


