### PR TITLE
Fix linting job to fail again if a warning or error was found

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -80,10 +80,12 @@ jobs:
         run: npm install
       - name: Lint JavaScript files
         run: |
+          set -o pipefail
           echo "## Linting JavaScript files" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           npm run lint | tee -a $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+        shell: bash
 
   typecheck:
     name: Typecheck


### PR DESCRIPTION


## What
Fix linting job to fail again if a warning or error was found

## Why

Piping the linting output to tee will hide the status code of the npm command if pipefail is not set.
