### PR TITLE
Use guest as password and username by default for guest login

### DIFF
--- a/src/web/pages/login/LoginPage.tsx
+++ b/src/web/pages/login/LoginPage.tsx
@@ -149,7 +149,10 @@ const LoginPage: React.FC = () => {
   };
 
   const handleGuestLogin = async () => {
-    await login(gmp.settings.guestUsername, gmp.settings.guestPassword);
+    await login(
+      gmp.settings.guestUsername ?? 'guest',
+      gmp.settings.guestPassword ?? 'guest',
+    );
   };
 
   let message: string | undefined;


### PR DESCRIPTION
## What

Use guest as password and username by default for guest login

## Why

If the guestUsername and guestPassword settings are not set use "guest" as username and password when trying to login. With this change we ensure that we get an error from the backend if the settings are not set.



