### PR TITLE
Mark type and size props of NumberField optional

### DIFF
--- a/src/web/components/form/NumberField.tsx
+++ b/src/web/components/form/NumberField.tsx
@@ -52,8 +52,8 @@ export interface NumberFieldProps
   errorContent?: string;
   onChange?: (value: number | string, name?: string) => void;
   precision?: number | string;
-  type: 'int' | 'float';
-  size: 'sm' | 'md' | 'lg';
+  type?: 'int' | 'float';
+  size?: 'sm' | 'md' | 'lg';
 }
 
 const NumberField = forwardRef<HTMLInputElement, NumberFieldProps>(


### PR DESCRIPTION


## What

Mark type and size props of NumberField optional

## Why

Both props have a default. Therefore they are actually optional.
