### PR TITLE
Show errors if a port range could not be created

### DIFF
--- a/src/web/pages/portlists/PortListComponent.tsx
+++ b/src/web/pages/portlists/PortListComponent.tsx
@@ -256,7 +256,7 @@ const PortListComponent = ({
     closePortListDialog();
   };
 
-  const handleTmpAddPortRange = ({
+  const handleTmpAddPortRange = async ({
     id,
     // eslint-disable-next-line @typescript-eslint/naming-convention
     port_range_end,


### PR DESCRIPTION


## What

Show errors if a port range could not be created

## Why

Return a promise to show errors if a to be created port range has issues with existing port ranges.

