### PR TITLE
Use TypeScript for App component and fix setting the Theme

### DIFF
--- a/src/web/App.tsx
+++ b/src/web/App.tsx
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {
-  ThemeProvider,
-  theme,
-} from '@greenbone/opensight-ui-components-mantinev7';
-import Gmp from 'gmp';
+import {ThemeProvider} from '@greenbone/opensight-ui-components-mantinev7';
+import Gmp from 'gmp/gmp';
 import GmpSettings from 'gmp/gmpsettings';
 import {_, initLocale} from 'gmp/locale/lang';
 import {LOG_LEVEL_DEBUG} from 'gmp/log';
@@ -27,7 +24,7 @@ import {
   setIsLoggedIn,
 } from 'web/store/usersettings/actions';
 
-initLocale();
+void initLocale();
 
 const settings = new GmpSettings(global.localStorage, global.config);
 const gmp = new Gmp(settings);
@@ -38,6 +35,7 @@ const store = configureStore({
     : settings.logLevel === LOG_LEVEL_DEBUG,
 });
 
+// @ts-expect-error
 window.gmp = gmp;
 
 const initStore = () => {
@@ -52,8 +50,10 @@ const initStore = () => {
   store.dispatch(setIsLoggedIn(gmp.isLoggedIn()));
 };
 
-class App extends React.Component {
-  constructor(props) {
+class App extends React.Component<{}> {
+  private unsubscribeFromLogout!: () => void;
+
+  constructor(props: {}) {
     super(props);
 
     this.handleLogout = this.handleLogout.bind(this);
@@ -78,7 +78,7 @@ class App extends React.Component {
 
   render() {
     return (
-      <ThemeProvider theme={{...theme, colorScheme: 'light'}}>
+      <ThemeProvider defaultColorScheme="light">
         <GlobalStyles />
         <ErrorBoundary message={_('An error occurred on this page')}>
           <GmpContext.Provider value={gmp}>

--- a/src/web/utils/Testing.tsx
+++ b/src/web/utils/Testing.tsx
@@ -7,10 +7,7 @@
 // it requires global.beforeEach and expect
 import 'jest-styled-components';
 
-import {
-  ThemeProvider,
-  theme,
-} from '@greenbone/opensight-ui-components-mantinev7';
+import {ThemeProvider} from '@greenbone/opensight-ui-components-mantinev7';
 import {afterEach} from '@gsa/testing';
 import {
   act,
@@ -91,8 +88,7 @@ export const getByName = (container: HTMLElement, name: string) => {
 
 const Main = ({children}: {children: React.ReactNode}) => {
   return (
-    // @ts-expect-error
-    <ThemeProvider theme={{...theme, colorScheme: 'light'}}>
+    <ThemeProvider defaultColorScheme="light">
       <StyleSheetManager enableVendorPrefixes>{children}</StyleSheetManager>
     </ThemeProvider>
   );


### PR DESCRIPTION


## What

Use TypeScript for App component and fix setting the Theme

## Why

The API of the ThemeProvider did change a while ago and it isn't possible to override the theme anymore. With using TypeScript now this issue became visible.