### PR TITLE
Fix displaying the OS by Vulnerability Score chart

### DIFF
--- a/src/web/pages/operatingsystems/dashboard/VulnScoreDisplay.jsx
+++ b/src/web/pages/operatingsystems/dashboard/VulnScoreDisplay.jsx
@@ -132,8 +132,6 @@ OsVulnScoreDisplay.propTypes = {
   navigate: PropTypes.func.isRequired,
 };
 
-OsVulnScoreDisplay.displayId = 'os-by-most-vulnerable';
-
 OsVulnScoreDisplay = compose(
   withGmp,
   withRouter,
@@ -141,6 +139,8 @@ OsVulnScoreDisplay = compose(
     filtersFilter: OS_FILTER_FILTER,
   }),
 )(OsVulnScoreDisplay);
+
+OsVulnScoreDisplay.displayId = 'os-by-most-vulnerable';
 
 export const OsVulnScoreTableDisplay = createDisplay({
   loaderComponent: OsVulnScoreLoader,


### PR DESCRIPTION

## What
Fix displaying the OS by Vulnerability Score chart

## Why

The display ID was not set correctly and therefore the Operating System by Vulnerability Score chart was not available at all. Not having the display ID set raised a warning in the browser console which is fixed now.

## References

https://jira.greenbone.net/browse/GEA-1067

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


