### PR TITLE
Add: cancellation of running CI jobs on new commit

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,6 +3,10 @@ name: Show changelog since last release
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true 
+
 jobs:
   changelog:
     name: Show changelog since last release

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,12 +3,6 @@ name: Show changelog since last release
 on:
   workflow_dispatch:
 
-# cancel eventually still running jobs for the same branch and workflow
-# to save resources.
-#
-# NOTE:
-# This *can* lead to the effect that the first job that fails due to an
-# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,6 +3,12 @@ name: Show changelog since last release
 on:
   workflow_dispatch:
 
+# cancel eventually still running jobs for the same branch and workflow
+# to save resources.
+#
+# NOTE:
+# This *can* lead to the effect that the first job that fails due to an
+# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -10,12 +10,6 @@ on:
       - main
       - oldstable
 
-# cancel eventually still running jobs for the same branch and workflow
-# to save resources.
-#
-# NOTE:
-# This *can* lead to the effect that the first job that fails due to an
-# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -10,6 +10,10 @@ on:
       - main
       - oldstable
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true 
+
 jobs:
   testing:
     env:

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -10,6 +10,12 @@ on:
       - main
       - oldstable
 
+# cancel eventually still running jobs for the same branch and workflow
+# to save resources.
+#
+# NOTE:
+# This *can* lead to the effect that the first job that fails due to an
+# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,12 +11,6 @@ on:
   schedule:
     - cron: '30 5 * * 0' # 5:30h on Sundays
 
-# cancel eventually still running jobs for the same branch and workflow
-# to save resources.
-#
-# NOTE:
-# This *can* lead to the effect that the first job that fails due to an
-# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,12 @@ on:
   schedule:
     - cron: '30 5 * * 0' # 5:30h on Sundays
 
+# cancel eventually still running jobs for the same branch and workflow
+# to save resources.
+#
+# NOTE:
+# This *can* lead to the effect that the first job that fails due to an
+# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: '30 5 * * 0' # 5:30h on Sundays
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true 
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -16,6 +16,12 @@ on:
         description: 'The ref to build a container image from. For example a tag v23.0.0.'
         required: true
 
+# cancel eventually still running jobs for the same branch and workflow
+# to save resources.
+#
+# NOTE:
+# This *can* lead to the effect that the first job that fails due to an
+# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -16,6 +16,10 @@ on:
         description: 'The ref to build a container image from. For example a tag v23.0.0.'
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true 
+
 jobs:
   build:
     name: Build and Push to Greenbone Registry

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -16,12 +16,6 @@ on:
         description: 'The ref to build a container image from. For example a tag v23.0.0.'
         required: true
 
-# cancel eventually still running jobs for the same branch and workflow
-# to save resources.
-#
-# NOTE:
-# This *can* lead to the effect that the first job that fails due to an
-# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -7,6 +7,10 @@ permissions:
   pull-requests: write
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true 
+
 jobs:
   conventional-commits:
     name: Conventional Commits

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -7,12 +7,6 @@ permissions:
   pull-requests: write
   contents: read
 
-# cancel eventually still running jobs for the same branch and workflow
-# to save resources.
-#
-# NOTE:
-# This *can* lead to the effect that the first job that fails due to an
-# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -7,6 +7,12 @@ permissions:
   pull-requests: write
   contents: read
 
+# cancel eventually still running jobs for the same branch and workflow
+# to save resources.
+#
+# NOTE:
+# This *can* lead to the effect that the first job that fails due to an
+# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,6 +1,10 @@
 name: 'Dependency Review'
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true 
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,6 +1,12 @@
 name: 'Dependency Review'
 on: [pull_request]
 
+# cancel eventually still running jobs for the same branch and workflow
+# to save resources.
+#
+# NOTE:
+# This *can* lead to the effect that the first job that fails due to an
+# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,12 +1,6 @@
 name: 'Dependency Review'
 on: [pull_request]
 
-# cancel eventually still running jobs for the same branch and workflow
-# to save resources.
-#
-# NOTE:
-# This *can* lead to the effect that the first job that fails due to an
-# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,6 @@ on:
         type: string
         description: Set an explicit version, that will overwrite release-type. Fails if version is not compliant.
 
-# cancel eventually still running jobs for the same branch and workflow
-# to save resources.
-#
-# NOTE:
-# This *can* lead to the effect that the first job that fails due to an
-# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ on:
         type: string
         description: Set an explicit version, that will overwrite release-type. Fails if version is not compliant.
 
+# cancel eventually still running jobs for the same branch and workflow
+# to save resources.
+#
+# NOTE:
+# This *can* lead to the effect that the first job that fails due to an
+# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
         type: string
         description: Set an explicit version, that will overwrite release-type. Fails if version is not compliant.
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true 
+
 jobs:
   release:
     name: Create a new release

--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches: ["main"]
 
-# cancel eventually still running jobs for the same branch and workflow
-# to save resources.
-#
-# NOTE:
-# This *can* lead to the effect that the first job that fails due to an
-# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 

--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -3,6 +3,11 @@ on:
   workflow_dispatch:
   push:
     branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true 
+
 jobs:
   SBOM-upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: ["main"]
 
+# cancel eventually still running jobs for the same branch and workflow
+# to save resources.
+#
+# NOTE:
+# This *can* lead to the effect that the first job that fails due to an
+# error introduced by a commit is *not* the run for the same commit but a later one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true 


### PR DESCRIPTION
## What

When workflows are triggered by a new commit, still running instances of the same workflow on the same git ref / branch will be cancelled to save resources.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

We usually dont need to continue running old jobs when a new commit comes in that starts the same jobs again.

This saves us some running time and ressources.

<!-- Describe why are these changes necessary? -->

## References

See DEVOPS-1538

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ NA] Tests


