### PR TITLE
Update type for first forEach function argument

### DIFF
--- a/src/gmp/utils/array.ts
+++ b/src/gmp/utils/array.ts
@@ -6,7 +6,7 @@
 import {hasValue, isDefined, isArray} from 'gmp/utils/identity';
 
 export const forEach = <T>(
-  array?: T[],
+  array?: T | T[],
   func?: (value: T, index: number, array: T[]) => void,
 ) => {
   if (!hasValue(array) || !isDefined(func)) {


### PR DESCRIPTION


## What

Update type for first forEach function argument

## Why

The forEach function explicitly allows for non arrays as first argument because our responses may return a single object instead of an array with a single object if only one response object is available.
