### PR TITLE
Update Model.fromElement type info to return a Model by default

### DIFF
--- a/src/gmp/model.ts
+++ b/src/gmp/model.ts
@@ -118,7 +118,10 @@ class Model implements ModelProperties {
     }, {});
   }
 
-  static fromElement<TModel>(element: Element = {}, type?: string): TModel {
+  static fromElement<TModel = Model>(
+    element: Element = {},
+    type?: string,
+  ): TModel {
     const f = new this(type);
     f.setProperties(this.parseElement(element));
     return f as TModel;


### PR DESCRIPTION


## What

Update Model.fromElement type info to return a Model by default

## Why

For many use cases (for example testing) it is fine to just return a Model instance.