### PR TITLE
fix:  TargetDetails to conditionally render Kerberos credentials

### DIFF
--- a/src/web/pages/targets/Details.jsx
+++ b/src/web/pages/targets/Details.jsx
@@ -127,7 +127,8 @@ const TargetDetails = ({capabilities, entity}) => {
         (isDefined(ssh_credential) ||
           isDefined(snmp_credential) ||
           isDefined(smb_credential) ||
-          isDefined(esxi_credential)) && (
+          isDefined(esxi_credential) ||
+          (gmp.settings.enableKrb5 && isDefined(krb5Credential))) && (
           <DetailsBlock title={_('Credentials')}>
             <InfoTable>
               <TableBody>

--- a/src/web/pages/targets/__tests__/Details.test.jsx
+++ b/src/web/pages/targets/__tests__/Details.test.jsx
@@ -7,7 +7,7 @@ import {describe, test, expect} from '@gsa/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import Target from 'gmp/models/target';
 import Details from 'web/pages/targets/Details';
-import {rendererWith} from 'web/utils/Testing';
+import {rendererWith, screen} from 'web/utils/Testing';
 
 const gmp = {
   settings: {
@@ -15,7 +15,7 @@ const gmp = {
   },
 };
 
-const target_elevate = Target.fromElement({
+const targetElevate = Target.fromElement({
   _id: 'foo',
   name: 'target',
   owner: {name: 'admin'},
@@ -69,7 +69,7 @@ const target_elevate = Target.fromElement({
   },
 });
 
-const target_no_elevate = Target.fromElement({
+const targetNoElevate = Target.fromElement({
   _id: 'foo',
   name: 'target',
   owner: {name: 'admin'},
@@ -128,59 +128,47 @@ describe('Target Details tests', () => {
       router: true,
     });
 
-    const {element, getAllByTestId} = render(
-      <Details entity={target_no_elevate} />,
-    );
+    render(<Details entity={targetNoElevate} />);
 
-    const headings = element.querySelectorAll('h2');
-    const detailsLinks = getAllByTestId('details-link');
+    const headings = screen.getAllByRole('heading', {level: 2});
+    const detailsLinks = screen.getAllByTestId('details-link');
 
     expect(headings[0]).toHaveTextContent('Hosts');
 
-    expect(element).toHaveTextContent('Included');
-    expect(element).toHaveTextContent('127.0.0.1192.168.0.1');
+    const includedLabel = screen.getByText('Included');
+    const includedRow = includedLabel.closest('tr');
+    expect(includedRow).toHaveTextContent('127.0.0.1');
+    expect(includedRow).toHaveTextContent('192.168.0.1');
 
-    expect(element).toHaveTextContent('Maximum Number of Hosts2');
+    const maxHostsLabel = screen.getByText('Maximum Number of Hosts');
+    const maxHostsRow = maxHostsLabel.closest('tr');
+    expect(maxHostsRow).toHaveTextContent('2');
 
-    expect(element).toHaveTextContent(
-      'Allow simultaneous scanning via multiple IPsNo',
+    const labelElement = screen.getByText(
+      'Allow simultaneous scanning via multiple IPs',
     );
+    const row = labelElement.closest('tr');
+    expect(row).toHaveTextContent('No');
+    const reverseLookupsLabel = screen.getByText('Reverse Lookup Only');
+    const reverseLookupsRow = reverseLookupsLabel.closest('tr');
+    expect(reverseLookupsRow).toHaveTextContent('No');
 
-    expect(element).toHaveTextContent('Reverse Lookup OnlyNo');
-    expect(element).toHaveTextContent('Reverse Lookup UnifyNo');
-    expect(element).toHaveTextContent('Alive TestScan Config Default');
+    const reverseLookupUnifyLabel = screen.getByText('Reverse Lookup Unify');
+    const reverseLookupUnifyRow = reverseLookupUnifyLabel.closest('tr');
+    expect(reverseLookupUnifyRow).toHaveTextContent('No');
 
-    expect(element).toHaveTextContent('Port List');
+    const aliveTestLabel = screen.getByText('Alive Test');
+    const aliveTestRow = aliveTestLabel.closest('tr');
+    expect(aliveTestRow).toHaveTextContent('Scan Config Default');
+
+    expect(screen.getByText('Port List')).toBeInTheDocument();
     expect(detailsLinks[0]).toHaveAttribute('href', '/portlist/pl_id1');
 
     expect(headings[1]).toHaveTextContent('Credentials');
 
-    expect(element).toHaveTextContent('SMB (NTLM)');
+    expect(screen.getByText('SMB (NTLM)')).toBeInTheDocument();
 
     expect(detailsLinks[1]).toHaveAttribute('href', '/credential/4784');
-  });
-
-  test('should render Kerberos in target details, when KRB5 is enabled', () => {
-    const caps = new Capabilities(['everything']);
-
-    const {render} = rendererWith({
-      gmp: {
-        settings: {
-          enableKrb5: true,
-        },
-      },
-      capabilities: caps,
-      router: true,
-    });
-
-    const {element, getAllByTestId} = render(
-      <Details entity={target_no_elevate} />,
-    );
-    const kerberosLink = getAllByTestId('details-link')[1];
-
-    expect(element).toHaveTextContent('SMB (Kerberos)');
-    expect(kerberosLink).toHaveAttribute('href', '/credential/krb5_id');
-    expect(kerberosLink).toHaveTextContent('krb5');
   });
 
   test('should render full target details with elevate credentials and tasks', () => {
@@ -192,44 +180,56 @@ describe('Target Details tests', () => {
       router: true,
     });
 
-    const {element, getAllByTestId} = render(
-      <Details entity={target_elevate} />,
-    );
+    render(<Details entity={targetElevate} />);
 
-    const headings = element.querySelectorAll('h2');
-    const detailsLinks = getAllByTestId('details-link');
+    const headings = screen.getAllByRole('heading', {level: 2});
+    const detailsLinks = screen.getAllByTestId('details-link');
 
     expect(headings[0]).toHaveTextContent('Hosts');
 
-    expect(element).toHaveTextContent('Included');
-    expect(element).toHaveTextContent('127.0.0.1192.168.0.1');
+    const includedLabel = screen.getByText('Included');
+    const includedRow = includedLabel.closest('tr');
+    expect(includedRow).toHaveTextContent('127.0.0.1');
+    expect(includedRow).toHaveTextContent('192.168.0.1');
 
-    expect(element).toHaveTextContent('Maximum Number of Hosts2');
+    const maxHostsLabel = screen.getByText('Maximum Number of Hosts');
+    const maxHostsRow = maxHostsLabel.closest('tr');
+    expect(maxHostsRow).toHaveTextContent('2');
 
-    expect(element).toHaveTextContent(
-      'Allow simultaneous scanning via multiple IPsNo',
+    const allowSimultaneousLabel = screen.getByText(
+      'Allow simultaneous scanning via multiple IPs',
     );
+    const allowSimultaneousRow = allowSimultaneousLabel.closest('tr');
+    expect(allowSimultaneousRow).toHaveTextContent('No');
 
-    expect(element).toHaveTextContent('Reverse Lookup OnlyYes');
-    expect(element).toHaveTextContent('Reverse Lookup UnifyNo');
-    expect(element).toHaveTextContent('Alive TestScan Config Default');
+    const reverseLookupOnlyLabel = screen.getByText('Reverse Lookup Only');
+    const reverseLookupOnlyRow = reverseLookupOnlyLabel.closest('tr');
+    expect(reverseLookupOnlyRow).toHaveTextContent('Yes');
 
-    expect(element).toHaveTextContent('Port List');
+    const reverseLookupUnifyLabel = screen.getByText('Reverse Lookup Unify');
+    const reverseLookupUnifyRow = reverseLookupUnifyLabel.closest('tr');
+    expect(reverseLookupUnifyRow).toHaveTextContent('No');
+
+    const aliveTestLabel = screen.getByText('Alive Test');
+    const aliveTestRow = aliveTestLabel.closest('tr');
+    expect(aliveTestRow).toHaveTextContent('Scan Config Default');
+
+    expect(screen.getByText('Port List')).toBeInTheDocument();
     expect(detailsLinks[0]).toHaveAttribute('href', '/portlist/pl_id1');
     expect(detailsLinks[0]).toHaveTextContent('pl1');
 
     expect(headings[1]).toHaveTextContent('Credentials');
 
-    expect(element).toHaveTextContent('SSH');
+    expect(screen.getByText('SSH')).toBeInTheDocument();
     expect(detailsLinks[1]).toHaveAttribute('href', '/credential/1235');
     expect(detailsLinks[1]).toHaveTextContent('ssh');
 
-    expect(element).toHaveTextContent('on Port 22');
-    expect(element).toHaveTextContent('SSH elevate credential ');
+    expect(screen.getByText(/on Port 22/)).toBeInTheDocument();
+    expect(screen.getByText(/SSH elevate credential/)).toBeInTheDocument();
     expect(detailsLinks[2]).toHaveAttribute('href', '/credential/3456');
     expect(detailsLinks[2]).toHaveTextContent('ssh_elevate');
 
-    expect(element).toHaveTextContent('SMB');
+    expect(screen.getByText('SMB (NTLM)')).toBeInTheDocument();
     expect(detailsLinks[3]).toHaveAttribute('href', '/credential/4784');
     expect(detailsLinks[3]).toHaveTextContent('smb_credential');
 
@@ -237,4 +237,254 @@ describe('Target Details tests', () => {
     expect(detailsLinks[4]).toHaveAttribute('href', '/task/task_id');
     expect(detailsLinks[4]).toHaveTextContent('task1');
   });
+
+  test.each([
+    {
+      name: 'ESXi only',
+      target: {
+        _id: 'esxi_target',
+        name: 'target_with_only_esxi',
+        esxi_credential: {
+          _id: 'esxi_id',
+          name: 'esxi_cred',
+          trash: '0',
+        },
+      },
+      enableKrb5: false,
+      expectedHeadings: 2,
+      expectedLabel: 'ESXi',
+      expectedCredId: 'esxi_id',
+      expectedCredName: 'esxi_cred',
+      notExpectedLabels: [
+        'SSH',
+        'SSH elevate credential',
+        'SMB (NTLM)',
+        'SNMP',
+        'SMB (Kerberos)',
+      ],
+    },
+    {
+      name: 'Kerberos only (enabled)',
+      target: {
+        _id: 'krb5_target',
+        name: 'target_with_only_krb5',
+        krb5_credential: {
+          _id: 'krb5_id',
+          name: 'krb5_cred',
+          trash: '0',
+        },
+      },
+      enableKrb5: true,
+      expectedHeadings: 2,
+      expectedLabel: 'SMB (Kerberos)',
+      expectedCredId: 'krb5_id',
+      expectedCredName: 'krb5_cred',
+      notExpectedLabels: [
+        'SSH',
+        'SSH elevate credential',
+        'SMB (NTLM)',
+        'SNMP',
+        'ESXi',
+      ],
+    },
+    {
+      name: 'Kerberos only (disabled)',
+      target: {
+        _id: 'krb5_target',
+        name: 'target_with_only_krb5',
+        krb5_credential: {
+          _id: 'krb5_id',
+          name: 'krb5_cred',
+          trash: '0',
+        },
+      },
+      enableKrb5: false,
+      expectedHeadings: 1,
+      notExpectedLabels: [
+        'SMB (Kerberos)',
+        'SSH',
+        'SSH elevate credential',
+        'SMB (NTLM)',
+        'SNMP',
+        'ESXi',
+      ],
+    },
+    {
+      name: 'SSH and elevate only',
+      target: {
+        _id: 'ssh_target',
+        name: 'target_with_only_ssh',
+        ssh_credential: {
+          _id: 'ssh_id',
+          name: 'ssh_cred',
+          port: '22',
+          trash: '0',
+        },
+        ssh_elevate_credential: {
+          _id: 'ssh_elevate_id',
+          name: 'ssh_elevate_cred',
+          trash: '0',
+        },
+      },
+      enableKrb5: false,
+      expectedHeadings: 2,
+      expectedLabel: 'SSH',
+      expectedCredId: 'ssh_id',
+      expectedCredName: 'ssh_cred',
+      expectedText: [
+        'on Port 22',
+        'SSH elevate credential',
+        'ssh_elevate_cred',
+      ],
+      notExpectedLabels: ['SMB (NTLM)', 'SNMP', 'ESXi', 'SMB (Kerberos)'],
+    },
+    {
+      name: 'SMB (NTLM) only',
+      target: {
+        _id: 'smb_target',
+        name: 'target_with_only_smb',
+        smb_credential: {
+          _id: 'smb_id',
+          name: 'smb_cred',
+        },
+      },
+      enableKrb5: false,
+      expectedHeadings: 2,
+      expectedLabel: 'SMB (NTLM)',
+      expectedCredId: 'smb_id',
+      expectedCredName: 'smb_cred',
+      notExpectedLabels: [
+        'SSH',
+        'SSH elevate credential',
+        'SNMP',
+        'ESXi',
+        'SMB (Kerberos)',
+      ],
+    },
+    {
+      name: 'SNMP only',
+      target: {
+        _id: 'snmp_target',
+        name: 'target_with_only_snmp',
+        snmp_credential: {
+          _id: 'snmp_id',
+          name: 'snmp_cred',
+          trash: '0',
+        },
+      },
+      enableKrb5: false,
+      expectedHeadings: 2,
+      expectedLabel: 'SNMP',
+      expectedCredId: 'snmp_id',
+      expectedCredName: 'snmp_cred',
+      notExpectedLabels: [
+        'SSH',
+        'SSH elevate credential',
+        'SMB (NTLM)',
+        'ESXi',
+        'SMB (Kerberos)',
+      ],
+    },
+  ])(
+    'should render credentials correctly - $name',
+    ({
+      target,
+      enableKrb5,
+      expectedHeadings,
+      expectedLabel,
+      expectedCredId,
+      expectedCredName,
+      expectedText = [],
+      notExpectedLabels = [],
+    }) => {
+      const caps = new Capabilities(['everything']);
+
+      const baseTarget = {
+        owner: {name: 'admin'},
+        alive_tests: 'Scan Config Default',
+        writable: '1',
+        in_use: '0',
+        permissions: {permission: [{name: 'Everything'}]},
+        hosts: '127.0.0.1',
+        port_list: {
+          _id: 'pl_id1',
+          name: 'pl1',
+          trash: '0',
+        },
+        ssh_credential: {
+          _id: '',
+          name: '',
+          port: '',
+          trash: '0',
+        },
+        ssh_elevate_credential: {
+          _id: '',
+          name: '',
+          trash: '0',
+        },
+        smb_credential: {
+          _id: '',
+          name: '',
+        },
+        esxi_credential: {
+          _id: '',
+          name: '',
+          trash: '0',
+        },
+        snmp_credential: {
+          _id: '',
+          name: '',
+          trash: '0',
+        },
+        krb5_credential: {
+          _id: '',
+          name: '',
+          trash: '0',
+        },
+      };
+
+      const completeTarget = Target.fromElement({
+        ...baseTarget,
+        ...target,
+      });
+
+      const {render} = rendererWith({
+        gmp: {
+          settings: {
+            enableKrb5,
+          },
+        },
+        capabilities: caps,
+        router: true,
+      });
+
+      render(<Details entity={completeTarget} />);
+
+      const headings = screen.getAllByRole('heading', {level: 2});
+      expect(headings.length).toBe(expectedHeadings);
+
+      if (expectedHeadings > 1) {
+        expect(headings[1]).toHaveTextContent('Credentials');
+
+        if (expectedLabel) {
+          expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+          const detailsLinks = screen.getAllByTestId('details-link');
+          const credentialLink = detailsLinks[1];
+          expect(credentialLink).toHaveAttribute(
+            'href',
+            `/credential/${expectedCredId}`,
+          );
+          expect(credentialLink).toHaveTextContent(expectedCredName);
+        }
+
+        expectedText.forEach(text => {
+          expect(screen.getByText(new RegExp(text))).toBeInTheDocument();
+        });
+      }
+
+      notExpectedLabels.forEach(label => {
+        expect(screen.queryByText(label)).toBeNull();
+      });
+    },
+  );
 });


### PR DESCRIPTION
## What

Ensure Kerberos credentials are displayed in target details, even when they are the only credential type defined.

## Why

Currently, Kerberos credentials aren't displayed when they're the only credential available. This change ensures they're consistently shown in the target details regardless of other credential types.

## References

GEA-1066

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


