### PR TITLE
Fix: Return an empty string '' instead of the string '0' for a deleted default alert.

### DIFF
--- a/src/web/pages/usersettings/DefaultsPart.jsx
+++ b/src/web/pages/usersettings/DefaultsPart.jsx
@@ -9,7 +9,7 @@ import Select from 'web/components/form/Select';
 import useCapabilities from 'web/hooks/useCapabilities';
 import useTranslation from 'web/hooks/useTranslation';
 import PropTypes from 'web/utils/PropTypes';
-import {renderSelectItems, UNSET_VALUE} from 'web/utils/Render';
+import {renderSelectItems, UNSET_VALUE, UNSET_VALUE_EMPTY_STRING} from 'web/utils/Render';
 
 const DefaultsPart = ({
   alerts,
@@ -38,7 +38,7 @@ const DefaultsPart = ({
       {capabilities.mayAccess('alert') && (
         <FormGroup title={_('Default Alert')} titleSize="3">
           <Select
-            items={renderSelectItems(alerts, UNSET_VALUE)}
+            items={renderSelectItems(alerts, UNSET_VALUE_EMPTY_STRING)}
             name="defaultAlert"
             value={defaultAlert}
             onChange={onChange}

--- a/src/web/utils/Render.jsx
+++ b/src/web/utils/Render.jsx
@@ -12,6 +12,7 @@ import {isEmpty, shorten, split} from 'gmp/utils/string';
 import React from 'react';
 
 export const UNSET_VALUE = '0';
+export const UNSET_VALUE_EMPTY_STRING = '';
 export const UNSET_LABEL = '--';
 
 /**


### PR DESCRIPTION

## What
Now in the settings dialog an empty string '' is returned if the default value for an alert is deleted because the string '0' caused problems.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This fixes a bug.
<!-- Describe why are these changes necessary? -->

## References
GEA-1063
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->


