### PR TITLE
Fix: Added a fallback value to avoid problems with the MultiSelect.

### DIFF
--- a/src/web/pages/audits/Dialog.jsx
+++ b/src/web/pages/audits/Dialog.jsx
@@ -134,7 +134,8 @@ const AuditDialog = ({
 
   policyId = selectSaveId(policies, policyId, undefined);
 
-  const adjustedAlertsIds = alertIds.length === 1 && alertIds[0] === 0 ? [] : alertIds;
+  const adjustedAlertsIds =
+    alertIds.length === 1 && alertIds[0] === 0 ? [] : alertIds;
 
   const alertItems = renderSelectItems(alerts);
 

--- a/src/web/pages/audits/Dialog.jsx
+++ b/src/web/pages/audits/Dialog.jsx
@@ -134,7 +134,7 @@ const AuditDialog = ({
 
   policyId = selectSaveId(policies, policyId, undefined);
 
-  const alertIDS = alertIds.length === 1 && alertIds[0] === 0 ? [] : alertIds;
+  const adjustedAlertsIds = alertIds.length === 1 && alertIds[0] === 0 ? [] : alertIds;
 
   const alertItems = renderSelectItems(alerts);
 
@@ -164,7 +164,7 @@ const AuditDialog = ({
   };
 
   const controlledData = {
-    alertIds: alertIDS,
+    alertIds: adjustedAlertsIds,
     policyId,
     scannerId,
     scannerType,

--- a/src/web/pages/audits/Dialog.jsx
+++ b/src/web/pages/audits/Dialog.jsx
@@ -134,6 +134,8 @@ const AuditDialog = ({
 
   policyId = selectSaveId(policies, policyId, undefined);
 
+  const alertIDS = alertIds.length === 1 && alertIds[0] === 0 ? [] : alertIds;
+
   const alertItems = renderSelectItems(alerts);
 
   // having an audit means we are editing an audit
@@ -162,7 +164,7 @@ const AuditDialog = ({
   };
 
   const controlledData = {
-    alertIds,
+    alertIds: alertIDS,
     policyId,
     scannerId,
     scannerType,

--- a/src/web/pages/tasks/Dialog.jsx
+++ b/src/web/pages/tasks/Dialog.jsx
@@ -153,6 +153,9 @@ const TaskDialog = ({
 
   const openvasScanConfigItems = renderSelectItems(scan_configs);
 
+  const alertIds =
+    alert_ids.length === 1 && alert_ids[0] === 0 ? [] : alert_ids;
+
   const alertItems = renderSelectItems(alerts);
 
   // having a task means we are editing a task
@@ -188,7 +191,7 @@ const TaskDialog = ({
   };
 
   const controlledData = {
-    alert_ids,
+    alert_ids: alertIds,
     config_id,
     schedule_id,
     scanner_id,


### PR DESCRIPTION
## What
A fallback value was added for the alert ids in the audits and the tasks dialog to avoid problems with the MultiSelect.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This fixes a bug.
<!-- Describe why are these changes necessary? -->

## References
GEA-1063
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->


