### PR TITLE
fix: svg icons color disabled

### DIFF
--- a/src/web/components/icon/createIconComponents.tsx
+++ b/src/web/components/icon/createIconComponents.tsx
@@ -26,19 +26,44 @@ export interface IconDefinition {
   isLucide: boolean;
 }
 
+export const getIconStyling = (
+  isLucide: boolean,
+  color?: string,
+  active?: boolean,
+) => {
+  return {
+    strokeWidth: isLucide ? 1.5 : undefined,
+    style: !isLucide
+      ? {
+          color: color,
+          fill: !active ? 'var(--mantine-color-gray-5)' : undefined,
+        }
+      : undefined,
+  };
+};
+
 const createIconComponents = (icons: IconDefinition[]): IconComponentsType => {
   return icons.reduce(
     (acc, {name, component, dataTestId, ariaLabel, isLucide}) => {
       acc[name] = (props: ExtendedDynamicIconProps) => {
-        const {'data-testid': dataTestIdFromProps, ...otherProps} = props;
+        const {
+          'data-testid': dataTestIdFromProps,
+          color,
+          active,
+          ...otherProps
+        } = props;
         const finalDataTestId = dataTestIdFromProps ?? dataTestId;
+        const {strokeWidth, style} = getIconStyling(isLucide, color, active);
 
         return (
           <DynamicIcon
+            active={active}
             ariaLabel={ariaLabel}
+            color={color}
             dataTestId={finalDataTestId}
             icon={component}
-            strokeWidth={isLucide ? 1.5 : undefined}
+            strokeWidth={strokeWidth}
+            style={style}
             {...otherProps}
           />
         );

--- a/src/web/components/icon/test/createIconComponent.test.tsx
+++ b/src/web/components/icon/test/createIconComponent.test.tsx
@@ -1,0 +1,75 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect} from '@gsa/testing';
+import {getIconStyling} from 'web/components/icon/createIconComponents';
+
+describe('getIconStyling', () => {
+  test('should return correct styling for Lucide icons', () => {
+    const result = getIconStyling(true);
+
+    expect(result).toEqual({
+      strokeWidth: 1.5,
+      style: undefined,
+    });
+  });
+
+  test('should return correct styling for Lucide icons with color', () => {
+    const result = getIconStyling(true, 'red');
+
+    expect(result).toEqual({
+      strokeWidth: 1.5,
+      style: undefined,
+    });
+  });
+
+  test('should return correct styling for non-Lucide icons', () => {
+    const result = getIconStyling(false);
+
+    expect(result).toEqual({
+      strokeWidth: undefined,
+      style: {
+        color: undefined,
+        fill: 'var(--mantine-color-gray-5)',
+      },
+    });
+  });
+
+  test('should return correct styling for non-Lucide icons with color', () => {
+    const result = getIconStyling(false, 'blue');
+
+    expect(result).toEqual({
+      strokeWidth: undefined,
+      style: {
+        color: 'blue',
+        fill: 'var(--mantine-color-gray-5)',
+      },
+    });
+  });
+
+  test('should return correct styling for active non-Lucide icons', () => {
+    const result = getIconStyling(false, undefined, true);
+
+    expect(result).toEqual({
+      strokeWidth: undefined,
+      style: {
+        color: undefined,
+        fill: undefined,
+      },
+    });
+  });
+
+  test('should return correct styling for active non-Lucide icons with color', () => {
+    const result = getIconStyling(false, 'green', true);
+
+    expect(result).toEqual({
+      strokeWidth: undefined,
+      style: {
+        color: 'green',
+        fill: undefined,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## What

Svg icons color should reflect the state, which should be gray if disabled.

## Why

<!-- Describe why are these changes necessary? -->

## References

GEA-1081

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


