### PR TITLE
fix: active icons color

### DIFF
--- a/src/web/components/icon/DeleteIcon.tsx
+++ b/src/web/components/icon/DeleteIcon.tsx
@@ -4,8 +4,8 @@
  */
 
 import {isDefined} from 'gmp/utils/identity';
-import {CircleX as Icon} from 'lucide-react';
-import {DynamicIcon, DynamicIconProps} from 'web/components/icon/DynamicIcon';
+import {CircleXIcon} from 'web/components/icon';
+import {DynamicIconProps} from 'web/components/icon/DynamicIcon';
 import useTranslation from 'web/hooks/useTranslation';
 import SelectionType from 'web/utils/SelectionType';
 
@@ -35,9 +35,8 @@ function DeleteIcon<TValue = string>({
     }
   }
   return (
-    <DynamicIcon<TValue>
-      dataTestId="delete-icon"
-      icon={Icon}
+    <CircleXIcon
+      data-testid="delete-icon"
       loading={loading}
       title={title}
       {...props}

--- a/src/web/components/icon/DynamicIcon.tsx
+++ b/src/web/components/icon/DynamicIcon.tsx
@@ -24,11 +24,13 @@ export interface DynamicIconProps<TValue = string>
   title?: string;
   loadingTitle?: string;
   value?: TValue;
-  strokeWidth?: number;
   dataTestId?: string;
   forceStatic?: boolean;
+  isLucide?: boolean;
   onClick?: (value?: TValue) => void | Promise<void>;
 }
+
+const inheritColor = undefined;
 
 export function DynamicIcon<TValue = string>({
   icon: Icon,
@@ -37,12 +39,12 @@ export function DynamicIcon<TValue = string>({
   active = true,
   title,
   loadingTitle,
-  strokeWidth,
   color = 'black',
   value,
   variant = 'transparent',
   dataTestId,
   forceStatic = false,
+  isLucide = false,
   onClick,
   ...restProps
 }: Readonly<DynamicIconProps<TValue>>) {
@@ -75,38 +77,91 @@ export function DynamicIcon<TValue = string>({
     }
   };
 
-  if (forceStatic || (active && !isDefined(onClick))) {
+  const renderActionIcon = (child: React.ReactNode) => {
+    return (
+      <ActionIcon
+        aria-label={ariaLabel}
+        color={color}
+        data-testid={dataTestId}
+        disabled={!active || loading}
+        loaderProps={{
+          type: 'bars',
+          color: Theme.darkGray,
+          size: width,
+        }}
+        loading={loading}
+        size={mantineSize}
+        title={displayedTitle}
+        variant={variant}
+        onClick={handleClick}
+        {...restProps}
+      >
+        {child}
+      </ActionIcon>
+    );
+  };
+
+  const renderSpanIcon = (child: React.ReactNode) => {
     return (
       <span
+        aria-label={ariaLabel}
         data-testid={dataTestId}
-        style={{display: 'inline-flex', color}}
-        title={title}
+        style={{display: 'inline-flex'}}
+        title={displayedTitle}
       >
-        <Icon height={height} strokeWidth={strokeWidth} width={width} />
+        {child}
       </span>
+    );
+  };
+
+  /*
+   * - SVG icons from Lucide package
+   */
+
+  if (isLucide) {
+    const defaultLucideStrokeWidth = 1.5;
+    if (forceStatic || (active && !isDefined(onClick))) {
+      return renderSpanIcon(
+        <Icon
+          color={color}
+          height={height}
+          strokeWidth={defaultLucideStrokeWidth}
+          width={width}
+        />,
+      );
+    }
+
+    return renderActionIcon(
+      <Icon
+        height={height}
+        strokeWidth={defaultLucideStrokeWidth}
+        width={width}
+      />,
     );
   }
 
-  return (
-    <ActionIcon
-      aria-label={ariaLabel}
-      color={color}
-      data-testid={dataTestId}
-      disabled={!active || loading}
-      loaderProps={{
-        type: 'bars',
-        color: Theme.darkGray,
-        size: width,
-      }}
-      loading={loading}
-      size={mantineSize}
-      title={displayedTitle}
-      variant={variant}
-      onClick={handleClick}
-      {...restProps}
-    >
-      <Icon height={height} strokeWidth={strokeWidth} width={width} />
-    </ActionIcon>
+  /*
+   * - SVG icons not from Lucide package
+   */
+
+  const svgIconsStyle = !isLucide
+    ? {fill: !active ? 'var(--mantine-color-gray-5)' : inheritColor}
+    : inheritColor;
+
+  if (forceStatic || (active && !isDefined(onClick))) {
+    return renderSpanIcon(
+      <Icon
+        height={height}
+        style={{
+          fill: color,
+        }}
+        width={width}
+      />,
+    );
+  }
+
+  return renderActionIcon(
+    <Icon height={height} style={svgIconsStyle} width={width} />,
   );
 }
 export default DynamicIcon;

--- a/src/web/components/icon/ExportIcon.tsx
+++ b/src/web/components/icon/ExportIcon.tsx
@@ -4,8 +4,8 @@
  */
 
 import {isDefined} from 'gmp/utils/identity';
-import {FileOutput as Icon} from 'lucide-react';
-import {DynamicIcon, DynamicIconProps} from 'web/components/icon/DynamicIcon';
+import {FileOutputIcon} from 'web/components/icon';
+import {DynamicIconProps} from 'web/components/icon/DynamicIcon';
 import useTranslation from 'web/hooks/useTranslation';
 import SelectionType from 'web/utils/SelectionType';
 
@@ -32,9 +32,8 @@ function ExportIcon<TValue = string>({
     }
   }
   return (
-    <DynamicIcon<TValue>
-      dataTestId="export-icon"
-      icon={Icon}
+    <FileOutputIcon
+      data-testid="export-icon"
       title={downloadTitle}
       {...props}
     />

--- a/src/web/components/icon/createIconComponents.tsx
+++ b/src/web/components/icon/createIconComponents.tsx
@@ -26,22 +26,6 @@ export interface IconDefinition {
   isLucide: boolean;
 }
 
-export const getIconStyling = (
-  isLucide: boolean,
-  color?: string,
-  active?: boolean,
-) => {
-  return {
-    strokeWidth: isLucide ? 1.5 : undefined,
-    style: !isLucide
-      ? {
-          color: color,
-          fill: !active ? 'var(--mantine-color-gray-5)' : undefined,
-        }
-      : undefined,
-  };
-};
-
 const createIconComponents = (icons: IconDefinition[]): IconComponentsType => {
   return icons.reduce(
     (acc, {name, component, dataTestId, ariaLabel, isLucide}) => {
@@ -53,7 +37,6 @@ const createIconComponents = (icons: IconDefinition[]): IconComponentsType => {
           ...otherProps
         } = props;
         const finalDataTestId = dataTestIdFromProps ?? dataTestId;
-        const {strokeWidth, style} = getIconStyling(isLucide, color, active);
 
         return (
           <DynamicIcon
@@ -62,8 +45,7 @@ const createIconComponents = (icons: IconDefinition[]): IconComponentsType => {
             color={color}
             dataTestId={finalDataTestId}
             icon={component}
-            strokeWidth={strokeWidth}
-            style={style}
+            isLucide={isLucide}
             {...otherProps}
           />
         );

--- a/src/web/components/icon/index.tsx
+++ b/src/web/components/icon/index.tsx
@@ -5,6 +5,8 @@
 
 // Import LucideIcon type once
 import {
+  CircleX,
+  FileOutput,
   LucideIcon,
   Megaphone,
   FilePenLine,
@@ -130,6 +132,20 @@ export interface IconDefinition {
 
 export const icons: IconDefinition[] = [
   // Lucide icons
+  {
+    name: 'FileOutput',
+    component: FileOutput,
+    dataTestId: 'export-icon',
+    ariaLabel: 'Export Icon',
+    isLucide: true,
+  },
+  {
+    name: 'CircleX',
+    component: CircleX,
+    dataTestId: 'delete-icon',
+    ariaLabel: 'Delete Icon',
+    isLucide: true,
+  },
   {
     name: 'RefreshCcw',
     component: RefreshCcw,
@@ -917,6 +933,8 @@ export const {
   ArrowUp: ArrowUpIcon,
   Calendar: CalendarIcon,
   CertBundAdv: CertBundAdvIcon,
+  CircleX: CircleXIcon,
+  Config: ConfigIcon,
   Clone: CloneIcon,
   CpeLogo: CpeLogoIcon,
   KeyRound: CredentialIcon,
@@ -925,6 +943,7 @@ export const {
   BarChart3: DashboardIcon,
   Trash2: DeleteIcon,
   DeltaDifference: DeltaDifferenceIcon,
+  FileOutput: FileOutputIcon,
   Delta: DeltaIcon,
   ZoomIn: DetailsIcon,
   DfnCertAdv: DfnCertAdvIcon,

--- a/src/web/components/icon/test/DynamicIcon.test.tsx
+++ b/src/web/components/icon/test/DynamicIcon.test.tsx
@@ -4,14 +4,10 @@
  */
 
 import {describe, test, expect, testing} from '@gsa/testing';
-import {LucideIcon} from 'lucide-react';
-import React from 'react';
 import DynamicIcon from 'web/components/icon/DynamicIcon';
-import {render, screen, fireEvent} from 'web/utils/Testing';
+import {render, screen, fireEvent, within} from 'web/utils/Testing';
 
-const MockIcon: LucideIcon = React.forwardRef((props, ref) => (
-  <svg {...props} ref={ref} data-testid="mock-icon" />
-));
+const MockIcon = props => <svg {...props} data-testid="mock-icon" />;
 
 describe('DynamicIcon', () => {
   test('renders static icon when forceStatic is true', () => {
@@ -23,8 +19,8 @@ describe('DynamicIcon', () => {
       />,
     );
     const staticIcon = screen.getByTestId('static-icon');
-    expect(staticIcon).toBeInTheDocument();
-    expect(staticIcon.querySelector('svg')).toBeInTheDocument();
+    expect(staticIcon).toBeVisible();
+    expect(staticIcon.querySelector('svg')).toBeVisible();
   });
 
   test('renders DynamicIcon when forceStatic is false', () => {
@@ -36,8 +32,8 @@ describe('DynamicIcon', () => {
       />,
     );
     const dynamicIcon = screen.getByTestId('dynamic-icon');
-    expect(dynamicIcon).toBeInTheDocument();
-    expect(dynamicIcon.querySelector('svg')).toBeInTheDocument();
+    expect(dynamicIcon).toBeVisible();
+    expect(dynamicIcon.querySelector('svg')).toBeVisible();
   });
 
   test('displays loading state when onClick returns a promise', async () => {
@@ -75,19 +71,6 @@ describe('DynamicIcon', () => {
     expect(mockOnClick).not.toHaveBeenCalled();
   });
 
-  test('applies correct size and color', () => {
-    render(
-      <DynamicIcon
-        color="red"
-        dataTestId="sized-icon"
-        icon={MockIcon}
-        size="large"
-      />,
-    );
-    const dynamicIcon = screen.getByTestId('sized-icon');
-    expect(dynamicIcon).toHaveStyle({color: 'rgb(255, 0, 0)'});
-  });
-
   test('displays loading title when loading', () => {
     const mockOnClick = testing.fn<() => Promise<void>>(
       () => new Promise<void>(resolve => setTimeout(resolve, 100)),
@@ -116,5 +99,139 @@ describe('DynamicIcon', () => {
     );
     const dynamicIcon = screen.getByTestId('title-icon');
     expect(dynamicIcon).toHaveAttribute('title', 'Test Title');
+  });
+
+  describe('Lucide', () => {
+    test('renders Lucide icon size', () => {
+      render(
+        <DynamicIcon
+          dataTestId="lucide-icon"
+          icon={MockIcon}
+          isLucide={true}
+        />,
+      );
+      const lucideIcon = screen.getByTestId('lucide-icon');
+      const svgElement = within(lucideIcon).getByText('', {
+        selector: 'svg',
+      });
+
+      expect(svgElement).toHaveAttribute('color', 'black');
+    });
+
+    test('renders Lucide icon with custom size and color', () => {
+      render(
+        <DynamicIcon
+          color="red"
+          dataTestId="custom-lucide-icon"
+          icon={MockIcon}
+          isLucide={true}
+          size="large"
+        />,
+      );
+      const customLucideIcon = screen.getByTestId('custom-lucide-icon');
+      const svgElement = within(customLucideIcon).getByText('', {
+        selector: 'svg',
+      });
+
+      expect(svgElement).toHaveAttribute('color', 'red');
+    });
+
+    test('renders disabled icon', () => {
+      render(
+        <DynamicIcon
+          active={false}
+          dataTestId="disabled-icon"
+          icon={MockIcon}
+          isLucide={true}
+          onClick={testing.fn()}
+        />,
+      );
+      const disabledIcon = screen.getByTestId('disabled-icon');
+      expect(disabledIcon.querySelector('svg')).toBeVisible();
+      expect(disabledIcon).toHaveStyle('color: GrayText');
+    });
+
+    test('renders custom action icon', () => {
+      render(
+        <DynamicIcon
+          active={true}
+          color="red"
+          dataTestId="action-icon"
+          icon={MockIcon}
+          isLucide={true}
+          onClick={testing.fn()}
+        />,
+      );
+      const actionIcon = screen.getByTestId('action-icon');
+
+      const svg = actionIcon.querySelector('svg');
+      expect(svg).toBeVisible();
+      expect(actionIcon).toHaveStyle(
+        '--ai-color: var(--mantine-color-red-light-color);',
+      );
+    });
+  });
+  describe('Non-Lucide', () => {
+    test('renders non-Lucide icon', () => {
+      render(
+        <DynamicIcon
+          dataTestId="non-lucide-icon"
+          icon={MockIcon}
+          isLucide={false}
+        />,
+      );
+      const nonLucideIcon = screen.getByTestId('non-lucide-icon');
+      expect(nonLucideIcon).toBeVisible();
+      const svg = nonLucideIcon.querySelector('svg');
+      expect(svg).toHaveStyle('fill: black');
+    });
+
+    test('renders non-Lucide icon with custom size and color', () => {
+      render(
+        <DynamicIcon
+          color="blue"
+          dataTestId="custom-non-lucide-icon"
+          icon={MockIcon}
+          isLucide={false}
+          size="large"
+        />,
+      );
+      const customNonLucideIcon = screen.getByTestId('custom-non-lucide-icon');
+      const svg = customNonLucideIcon.querySelector('svg');
+      expect(svg).toHaveStyle('fill: blue');
+    });
+
+    test('renders disabled non-Lucide icon', () => {
+      render(
+        <DynamicIcon
+          active={false}
+          dataTestId="disabled-non-lucide-icon"
+          icon={MockIcon}
+          isLucide={false}
+          onClick={testing.fn()}
+        />,
+      );
+      const disabledNonLucideIcon = screen.getByTestId(
+        'disabled-non-lucide-icon',
+      );
+      expect(disabledNonLucideIcon.querySelector('svg')).toBeVisible();
+      expect(disabledNonLucideIcon).toHaveStyle('color: GrayText');
+    });
+
+    test('renders custom action icon', () => {
+      render(
+        <DynamicIcon
+          active={true}
+          color="purple"
+          dataTestId="action-icon"
+          icon={MockIcon}
+          isLucide={false}
+          onClick={testing.fn()}
+        />,
+      );
+      const actionIcon = screen.getByTestId('action-icon');
+
+      expect(actionIcon).toHaveStyle('--ai-color: purple;');
+    });
   });
 });

--- a/src/web/components/icon/test/createIconComponent.test.tsx
+++ b/src/web/components/icon/test/createIconComponent.test.tsx
@@ -3,73 +3,123 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {describe, test, expect} from '@gsa/testing';
-import {getIconStyling} from 'web/components/icon/createIconComponents';
+import {describe, test, expect, testing} from '@gsa/testing';
+import {createIconComponents} from 'web/components/icon/createIconComponents';
+import {render, screen, within} from 'web/utils/Testing';
 
-describe('getIconStyling', () => {
-  test('should return correct styling for Lucide icons', () => {
-    const result = getIconStyling(true);
+const MockIcon = props => <svg {...props} data-testid="mock-icon" />;
 
-    expect(result).toEqual({
-      strokeWidth: 1.5,
-      style: undefined,
-    });
-  });
-
-  test('should return correct styling for Lucide icons with color', () => {
-    const result = getIconStyling(true, 'red');
-
-    expect(result).toEqual({
-      strokeWidth: 1.5,
-      style: undefined,
-    });
-  });
-
-  test('should return correct styling for non-Lucide icons', () => {
-    const result = getIconStyling(false);
-
-    expect(result).toEqual({
-      strokeWidth: undefined,
-      style: {
-        color: undefined,
-        fill: 'var(--mantine-color-gray-5)',
+describe('createIconComponents', () => {
+  describe('Lucide icon', () => {
+    const lucideIconSet = [
+      {
+        name: 'DummyLucideIcon',
+        component: MockIcon,
+        dataTestId: 'dummy-lucide-icon',
+        ariaLabel: 'Dummy Lucide Icon',
+        isLucide: true,
       },
+    ];
+
+    test('should create static icon components with correct props', () => {
+      const IconComponents = createIconComponents(lucideIconSet);
+      const DummyLucideIcon = IconComponents.DummyLucideIcon;
+
+      render(<DummyLucideIcon active={true} color="red" />);
+
+      const iconElement = screen.getByTestId('dummy-lucide-icon');
+      expect(iconElement).toHaveAttribute('aria-label', 'Dummy Lucide Icon');
+      expect(iconElement).toHaveAttribute('data-testid', 'dummy-lucide-icon');
+      const svgElement = within(iconElement).getByText('', {selector: 'svg'});
+      expect(svgElement).toBeVisible();
+      expect(iconElement).toHaveStyle('color: red(255, 0, 0)');
+    });
+
+    test('should create action icon components with default props', () => {
+      const IconComponents = createIconComponents(lucideIconSet);
+      const DummyLucideIcon = IconComponents.DummyLucideIcon;
+
+      render(
+        <DummyLucideIcon active={true} color="red" onClick={testing.fn()} />,
+      );
+
+      const iconElement = screen.getByTestId('dummy-lucide-icon');
+      expect(iconElement).toHaveAttribute('aria-label', 'Dummy Lucide Icon');
+      expect(iconElement).toHaveAttribute('data-testid', 'dummy-lucide-icon');
+    });
+
+    test('should create action icon components with custom props and disabled', () => {
+      const IconComponents = createIconComponents(lucideIconSet);
+      const DummyLucideIcon = IconComponents.DummyLucideIcon;
+
+      render(
+        <DummyLucideIcon
+          active={false}
+          color="red"
+          data-testid="custom-icon"
+        />,
+      );
+
+      const iconElement = screen.getByTestId('custom-icon');
+      expect(iconElement).toHaveAttribute('aria-label', 'Dummy Lucide Icon');
+      expect(iconElement).toHaveAttribute('data-testid', 'custom-icon');
+      expect(iconElement).toHaveStyle('color: GrayText');
     });
   });
 
-  test('should return correct styling for non-Lucide icons with color', () => {
-    const result = getIconStyling(false, 'blue');
-
-    expect(result).toEqual({
-      strokeWidth: undefined,
-      style: {
-        color: 'blue',
-        fill: 'var(--mantine-color-gray-5)',
+  describe('Non-Lucide icon', () => {
+    const svgIconDefinitions = [
+      {
+        name: 'DummyLucideIcon',
+        component: MockIcon,
+        dataTestId: 'dummy-lucide-icon',
+        ariaLabel: 'Dummy Lucide Icon',
+        isLucide: false,
       },
+    ];
+    test('should create static icon components with correct props', () => {
+      const IconComponents = createIconComponents(svgIconDefinitions);
+      const DummyLucideIcon = IconComponents.DummyLucideIcon;
+
+      render(<DummyLucideIcon active={true} color="red" />);
+
+      const iconElement = screen.getByTestId('dummy-lucide-icon');
+      expect(iconElement).toHaveAttribute('aria-label', 'Dummy Lucide Icon');
+      expect(iconElement).toHaveAttribute('data-testid', 'dummy-lucide-icon');
+      const svgElement = within(iconElement).getByText('', {selector: 'svg'});
+      expect(svgElement).toHaveStyle('fill:red');
     });
-  });
 
-  test('should return correct styling for active non-Lucide icons', () => {
-    const result = getIconStyling(false, undefined, true);
+    test('should create action icon components with default props', () => {
+      const IconComponents = createIconComponents(svgIconDefinitions);
+      const DummyLucideIcon = IconComponents.DummyLucideIcon;
 
-    expect(result).toEqual({
-      strokeWidth: undefined,
-      style: {
-        color: undefined,
-        fill: undefined,
-      },
+      render(
+        <DummyLucideIcon active={true} color="red" onClick={testing.fn()} />,
+      );
+
+      const iconElement = screen.getByTestId('dummy-lucide-icon');
+      expect(iconElement).toHaveAttribute('aria-label', 'Dummy Lucide Icon');
+      expect(iconElement).toHaveAttribute('data-testid', 'dummy-lucide-icon');
     });
-  });
 
-  test('should return correct styling for active non-Lucide icons with color', () => {
-    const result = getIconStyling(false, 'green', true);
+    test('should create action icon components with custom props and disabled', () => {
+      const IconComponents = createIconComponents(svgIconDefinitions);
+      const DummyLucideIcon = IconComponents.DummyLucideIcon;
 
-    expect(result).toEqual({
-      strokeWidth: undefined,
-      style: {
-        color: 'green',
-        fill: undefined,
-      },
+      render(
+        <DummyLucideIcon
+          active={false}
+          color="red"
+          data-testid="custom-icon"
+          onClick={testing.fn()}
+        />,
+      );
+
+      const iconElement = screen.getByTestId('custom-icon');
+      expect(iconElement).toHaveAttribute('aria-label', 'Dummy Lucide Icon');
+      expect(iconElement).toHaveAttribute('data-testid', 'custom-icon');
+      expect(iconElement).toHaveStyle('color: GrayText');
     });
   });
 });

--- a/src/web/components/structure/__tests__/Header.test.jsx
+++ b/src/web/components/structure/__tests__/Header.test.jsx
@@ -40,7 +40,7 @@ describe('Header', () => {
     expect(langBtn).toBeVisible();
 
     const renewBtn = screen.getByRole('button', {
-      name: 'Renew session timeout',
+      name: 'Refresh Icon',
     });
     expect(renewBtn).toBeVisible();
 


### PR DESCRIPTION
## What

- Refactor how icons are managed, creating a more defined differentiation between SVG and Lucide icons.

## Why

- Some SVGs were not showing the correct colors.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


