### PR TITLE
Improve types for Layout component props

### DIFF
--- a/src/web/components/layout/Layout.tsx
+++ b/src/web/components/layout/Layout.tsx
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import withLayout, {LayoutProps} from 'web/components/layout/withLayout';
+import withLayout, {WithLayoutProps} from 'web/components/layout/withLayout';
+
+export type LayoutProps = WithLayoutProps &
+  Omit<React.JSX.IntrinsicElements['div'], 'ref'>;
 
 const Layout: React.FC<LayoutProps> = withLayout()('div');
 
 Layout.displayName = 'Layout';
-
-export type {LayoutProps};
 
 export default Layout;

--- a/src/web/components/layout/withLayout.tsx
+++ b/src/web/components/layout/withLayout.tsx
@@ -18,7 +18,7 @@ const convertAlign = (align: string): string => {
   }
 };
 
-export interface LayoutProps {
+export interface WithLayoutProps {
   align?: string | [string, string];
   children?: React.ReactNode;
   flex?: true | string;
@@ -27,14 +27,13 @@ export interface LayoutProps {
   wrap?: true | string;
   shrink?: true | string;
   'data-testid'?: string;
-  [key: string]: unknown;
 }
 
 const withLayout =
-  (defaults: LayoutProps = {}) =>
+  (defaults: WithLayoutProps = {}) =>
   (Component: React.ComponentType | string) => {
     const LayoutComponent = styled(
-      ({align, basis, flex, grow, shrink, wrap, ...props}: LayoutProps) => (
+      ({align, basis, flex, grow, shrink, wrap, ...props}: WithLayoutProps) => (
         <Component {...props} />
       ),
     )`

--- a/src/web/components/table/Data.tsx
+++ b/src/web/components/table/Data.tsx
@@ -5,17 +5,15 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import Layout from 'web/components/layout/Layout';
-import {LayoutProps} from 'web/components/layout/withLayout';
+import Layout, {LayoutProps} from 'web/components/layout/Layout';
 
 interface TableDataProps extends LayoutProps {
-  children?: React.ReactNode;
   className?: string;
   colSpan?: number;
   rowSpan?: number;
 }
 
-const TableData: React.FC<TableDataProps> = ({
+const TableData = ({
   children,
   className,
   colSpan,


### PR DESCRIPTION


## What

Improve types for Layout component props

## Why

The Layout component may get all props of the div html element. The previous LayoutProps are renamed to WithLayoutProps and contain only specific props that are used within the withLayout HOC.
