### PR TITLE
Add file to PortListDialog save data

### DIFF
--- a/src/web/pages/portlists/PortListDialog.tsx
+++ b/src/web/pages/portlists/PortListDialog.tsx
@@ -21,6 +21,7 @@ import PortRangesTable, {PortRange} from 'web/pages/portlists/PortRangesTable';
 export interface SavePortListData<TPortRange extends PortRange> {
   id?: string;
   comment: string;
+  file?: File;
   fromFile: FromFile;
   name: string;
   portRange: string;


### PR DESCRIPTION


## What

Add file to PortListDialog save data

## Why

The file was missing from the data type description when the PortListDialog gets saved.

