### PR TITLE
Port list import xmlFile is a File not a string

### DIFF
--- a/src/gmp/commands/__tests__/portlist.test.ts
+++ b/src/gmp/commands/__tests__/portlist.test.ts
@@ -125,7 +125,7 @@ describe('PortListCommand', () => {
     const http = createHttp(response);
     const command = new PortListCommand(http);
     const result = await command.import({
-      xmlFile: 'some file content',
+      xmlFile: new File(['some file content'], 'portlist.xml'),
     });
     expect(result.data).toEqual({});
   });

--- a/src/gmp/commands/portlists.ts
+++ b/src/gmp/commands/portlists.ts
@@ -45,7 +45,7 @@ interface PortListCommandDeletePortRangeParams {
 }
 
 interface PortListCommandImportParams {
-  xmlFile: string;
+  xmlFile: File;
 }
 
 export class PortListCommand extends EntityCommand<PortList, PortListElement> {

--- a/src/web/pages/portlists/PortListComponent.tsx
+++ b/src/web/pages/portlists/PortListComponent.tsx
@@ -193,7 +193,7 @@ const PortListComponent = ({
     return response.data.id;
   };
 
-  const handleImportPortList = async (data: {xmlFile: string}) => {
+  const handleImportPortList = async (data: {xmlFile: File}) => {
     handleInteraction();
     try {
       const response = await gmp.portlist.import(data);

--- a/src/web/pages/portlists/PortListImportDialog.tsx
+++ b/src/web/pages/portlists/PortListImportDialog.tsx
@@ -10,7 +10,7 @@ import useTranslation from 'web/hooks/useTranslation';
 
 interface PortListImportDialogProps {
   onClose: () => void;
-  onSave: (data: {xmlFile: string}) => void | Promise<void>;
+  onSave: (data: {xmlFile: File}) => void | Promise<void>;
 }
 
 const PortListImportDialog = ({onClose, onSave}: PortListImportDialogProps) => {


### PR DESCRIPTION

## What

Port list import xmlFile is a File not a string
## Why

The xmlFile argument of the port list import is actually a File instance and not a string.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


