### PR TITLE
Raise error if Dialog X Button could not be found 

### DIFF
--- a/src/web/testing/customQueries.ts
+++ b/src/web/testing/customQueries.ts
@@ -241,7 +241,11 @@ export const getDialogCloseButton = (dialog?: HTMLElement) => {
  */
 export const getDialogXButton = (dialog?: HTMLElement) => {
   dialog = isDefined(dialog) ? dialog : getDialog();
-  return dialog.querySelector<HTMLElement>('.mantine-CloseButton-root');
+  const button = dialog.querySelector<HTMLElement>('.mantine-CloseButton-root');
+  if (!button) {
+    throw getElementError('Unable to find dialog X button.', dialog);
+  }
+  return button;
 };
 
 /**


### PR DESCRIPTION

## What

Raise error if Dialog X Button could not be found
## Why

Don't return null from getDialogXButton query function and instead raise an error if the button couldn't be found.


