### PR TITLE
Fix capabilities checks for displaying menu entries

### DIFF
--- a/src/web/components/menu/Menu.jsx
+++ b/src/web/components/menu/Menu.jsx
@@ -79,13 +79,13 @@ const Menu = () => {
   ]);
   const mayOpConfiguration = mayAccessAny([
     'targets',
-    'port_lists',
+    'portlists',
     'credentials',
-    'scan_configs',
+    'scanconfigs',
     'alerts',
     'schedules',
-    'report_configs',
-    'report_formats',
+    'reportconfigs',
+    'reportformats',
     'scanners',
     'filters',
     'tags',
@@ -160,7 +160,7 @@ const Menu = () => {
             to: '/operatingsystems',
             active: isOperatingSystemsActive,
           },
-          capabilities.mayAccess('tls_certificates') && {
+          capabilities.mayAccess('tlscertificates') && {
             label: _('TLS Certificates'),
             to: '/tlscertificates',
             active: isTlsCertificatesActive,
@@ -236,7 +236,7 @@ const Menu = () => {
             to: '/targets',
             active: isTargetsActive,
           },
-          capabilities.mayAccess('port_lists') && {
+          capabilities.mayAccess('portlists') && {
             label: _('Port Lists'),
             to: '/portlists',
             active: isPortlistsActive,
@@ -246,7 +246,7 @@ const Menu = () => {
             to: '/credentials',
             active: isCredentialsActive,
           },
-          capabilities.mayAccess('scan_configs') && {
+          capabilities.mayAccess('scanconfigs') && {
             label: _('Scan Configs'),
             to: '/scanconfigs',
             active: isScanConfigsActive,
@@ -261,12 +261,12 @@ const Menu = () => {
             to: '/schedules',
             active: isSchedulesActive,
           },
-          capabilities.mayAccess('report_configs') && {
+          capabilities.mayAccess('reportconfigs') && {
             label: _('Report Configs'),
             to: '/reportconfigs',
             active: isReportConfigsActive,
           },
-          capabilities.mayAccess('report_formats') && {
+          capabilities.mayAccess('reportformats') && {
             label: _('Report Formats'),
             to: '/reportformats',
             active: isReportFormatsActive,

--- a/src/web/components/menu/__tests__/Menu.test.jsx
+++ b/src/web/components/menu/__tests__/Menu.test.jsx
@@ -6,6 +6,8 @@
 import React from 'react';
 import {describe, expect, test} from '@gsa/testing';
 import {rendererWith, screen} from 'web/testing';
+import Capabilities from 'gmp/capabilities/capabilities';
+import EverythingCapabilities from 'gmp/capabilities/everything';
 import Menu from 'web/components/menu/Menu';
 
 const renderMenuWith = ({capabilities, gmpSettings}) => {
@@ -33,11 +35,7 @@ describe('Menu rendering', () => {
     'Help',
   ])('should render top-level menu: %s', async label => {
     renderMenuWith({
-      capabilities: {
-        mayAccess: () => true,
-        mayOp: () => true,
-        featureEnabled: () => true,
-      },
+      capabilities: new EverythingCapabilities(),
       gmpSettings: {
         enableAssetManagement: false,
         reloadInterval: 5000,
@@ -89,11 +87,7 @@ describe('Menu rendering', () => {
     'About',
   ])('should render sub-menu: %s', async label => {
     renderMenuWith({
-      capabilities: {
-        mayAccess: () => true,
-        mayOp: () => true,
-        featureEnabled: () => true,
-      },
+      capabilities: new EverythingCapabilities(),
       gmpSettings: {
         enableAssetManagement: false,
         reloadInterval: 5000,
@@ -105,63 +99,26 @@ describe('Menu rendering', () => {
     expect(screen.getByText(label)).toBeInTheDocument();
   });
 
-  test('should not render Remediation Tickets when mayAccess returns false', async () => {
-    renderMenuWith({
-      capabilities: {
-        mayAccess: feature => feature !== 'tickets',
-        mayOp: () => true,
-        featureEnabled: () => true,
-      },
-      gmpSettings: {
-        enableAssetManagement: false,
-        reloadInterval: 5000,
-        reloadIntervalActive: 5000,
-        reloadIntervalInactive: 5000,
-      },
-    });
+  test.each(['Remediation Tickets', 'Configuration'])(
+    'should not render %s when mayAccess returns false',
+    async text => {
+      renderMenuWith({
+        capabilities: new Capabilities(),
+        gmpSettings: {
+          enableAssetManagement: false,
+          reloadInterval: 5000,
+          reloadIntervalActive: 5000,
+          reloadIntervalInactive: 5000,
+        },
+      });
 
-    expect(screen.queryByText('Remediation Tickets')).not.toBeInTheDocument();
-  });
-
-  test('should not render Configuration menu when none of its mayAccess permissions are true', async () => {
-    const configFeatures = [
-      'targets',
-      'port_lists',
-      'credentials',
-      'scan_configs',
-      'alerts',
-      'schedules',
-      'report_configs',
-      'report_formats',
-      'scanners',
-      'filters',
-      'tags',
-    ];
-
-    renderMenuWith({
-      capabilities: {
-        mayAccess: feature => !configFeatures.includes(feature),
-        mayOp: () => true,
-        featureEnabled: () => true,
-      },
-      gmpSettings: {
-        enableAssetManagement: false,
-        reloadInterval: 5000,
-        reloadIntervalActive: 5000,
-        reloadIntervalInactive: 5000,
-      },
-    });
-
-    expect(screen.queryByText('Configuration')).not.toBeInTheDocument();
-  });
+      expect(screen.queryByText(text)).not.toBeInTheDocument();
+    },
+  );
 
   test('should not render Asset menu when enableAssetManagement is false', async () => {
     renderMenuWith({
-      capabilities: {
-        mayAccess: () => false,
-        mayOp: () => false,
-        featureEnabled: () => false,
-      },
+      capabilities: new EverythingCapabilities(),
       gmpSettings: {
         enableAssetManagement: false,
         reloadInterval: 5000,


### PR DESCRIPTION
## What

Fix capabilities checks for displaying menu entries

## Why

`scan_config` or `scan_config` is currently not a type that can be passed to the capabilities methods. It must be `config`, `configs`, `scanconfig` or `scanconfigs` at the moment. This is quite confusing and has to be improved in future.

Because I had the stunning idea to use *"better"* names for the entities in the UI then in the backend we introduced a translation mechanism between UI entity types and backend entity types. The backend entity types are used for the capabilities. Sadly we also  removed the underscore word separation for the UI entity names and this made the UI entity names even more confusing. As last resort of confusion, the capabilities methods accept both UI and backend entity types.

