### PR TITLE
Adapt colors for medium and low severity

### DIFF
--- a/src/web/utils/Theme.tsx
+++ b/src/web/utils/Theme.tsx
@@ -96,8 +96,8 @@ const Theme: ThemeInterface = {
   severityWarnYellow: '#f0a519', // used by: progressbar
 
   severityClassLog: '#DDDDDD',
-  severityClassLow: 'skyblue',
-  severityClassMedium: '#F0A519',
+  severityClassLow: '#A0C5F9',
+  severityClassMedium: '#F3B865',
   severityClassHigh: '#F0868A',
   severityClassCritical: '#C12C30',
 


### PR DESCRIPTION


## What

Adapt colors for medium and low severity

Use '#A0C5F9' for low and '#F3B865' for medium severity now.

## Why

Use same colors as OPENVAS REPORT

## References

https://jira.greenbone.net/browse/GEA-1111

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


