### PR TITLE
Fix rendering CVE details

### DIFF
--- a/src/web/pages/cves/DetailsPage.jsx
+++ b/src/web/pages/cves/DetailsPage.jsx
@@ -39,6 +39,7 @@ import useTranslation from 'web/hooks/useTranslation';
 import CveDetails from 'web/pages/cves/Details';
 import {selector, loadEntity} from 'web/store/entities/cves';
 import PropTypes from 'web/utils/PropTypes';
+
 const ToolBarIcons = ({entity, onCveDownloadClick}) => {
   const [_] = useTranslation();
 
@@ -70,7 +71,7 @@ const Details = ({entity, links = true}) => {
   const [_] = useTranslation();
   const {certs = [], nvts = []} = entity;
   let {products} = entity;
-  products = products.sort();
+  products = products.toSorted();
   return (
     <Layout flex="column">
       <CveDetails entity={entity} />


### PR DESCRIPTION
## What

Fix rendering CVE details

## Why

When clicking opening the CVE details page via clicking on an entry in the CVE list page an error was raised (at least in the development mode). This was caused by a redux check for a mutated state. With redux the state must not be mutated at all. Therefore Array sort can't be used to sort the CVE products because it sorts in-place which mutates the state of the CVE model. As a solution the sort method got exchanged with the newer toSorted method which returns a sorted array but doesn't change the original array.


## References

https://jira.greenbone.net/browse/GEA-910
https://jira.greenbone.net/browse/GEA-1062


