### PR TITLE
Add: Support OPENVASD_SENSOR_SCANNER_TYPE in GSA

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -1262,6 +1262,7 @@
   "Opened": "Eröffnet",
   "OpenVAS Scanner": "OpenVAS-Scanner",
   "OpenVASD Scanner": "OpenVASD-Scanner",
+  "OpenVASD Sensor": "OpenVASD Sensor",
   "Operating System": "Betriebssystem",
   "Operating System is in use": "Betriebssysteme in Verwendung",
   "Operating System List": "Betriebssystemliste",

--- a/public/locales/gsa-en.json
+++ b/public/locales/gsa-en.json
@@ -1262,6 +1262,7 @@
   "Opened": "Opened",
   "OpenVAS Scanner": "OpenVAS Scanner",
   "OpenVASD Scanner": "OpenVASD Scanner",
+  "OpenVASD Sensor": "OpenVASD Sensor",
   "Operating System": "Operating System",
   "Operating System is in use": "Operating System is in use",
   "Operating System List": "Operating System List",

--- a/public/locales/gsa-zh_CN.json
+++ b/public/locales/gsa-zh_CN.json
@@ -1262,6 +1262,7 @@
   "Opened": "已打开",
   "OpenVAS Scanner": "OpenVAS 扫描器",
   "OpenVASD Scanner": "OpenVASD 扫描器",
+  "OpenVASD Sensor": "OpenVASD Sensor",
   "Operating System": "操作系统",
   "Operating System is in use": "操作系统正在使用中",
   "Operating System List": "操作系统列表",

--- a/public/locales/gsa-zh_TW.json
+++ b/public/locales/gsa-zh_TW.json
@@ -1262,6 +1262,7 @@
   "Opened": "已開啟",
   "OpenVAS Scanner": "OpenVAS 掃描器",
   "OpenVASD Scanner": "OpenVASD 掃描器",
+  "OpenVASD Sensor": "",
   "Operating System": "作業系統",
   "Operating System is in use": "",
   "Operating System List": "作業系統清單",

--- a/src/gmp/models/__tests__/scanner.test.js
+++ b/src/gmp/models/__tests__/scanner.test.js
@@ -14,6 +14,7 @@ import Scanner, {
   OPENVAS_SCANNER_TYPE,
   GREENBONE_SENSOR_SCANNER_TYPE,
   OPENVASD_SCANNER_TYPE,
+  OPENVASD_SENSOR_SCANNER_TYPE,
 } from 'gmp/models/scanner';
 import {testModel} from 'gmp/models/testing';
 import {YES_VALUE} from 'gmp/parser';
@@ -215,6 +216,7 @@ describe('Scanner model function tests', () => {
     const type4 = scannerTypeName(GREENBONE_SENSOR_SCANNER_TYPE);
     const type5 = scannerTypeName(42);
     const type6 = scannerTypeName(OPENVASD_SCANNER_TYPE);
+    const type7 = scannerTypeName(OPENVASD_SENSOR_SCANNER_TYPE);
 
     expect(type1).toEqual('OpenVAS Scanner');
     expect(type2).toEqual('CVE Scanner');
@@ -222,6 +224,7 @@ describe('Scanner model function tests', () => {
     expect(type4).toEqual('Greenbone Sensor');
     expect(type5).toEqual('Unknown type (42)');
     expect(type6).toEqual('OpenVASD Scanner');
+    expect(type7).toEqual('OpenVASD Sensor');
   });
 
   test('openVasScannersFilter should return filter with correct true/false', () => {

--- a/src/gmp/models/scanner.js
+++ b/src/gmp/models/scanner.js
@@ -15,6 +15,7 @@ export const OPENVAS_SCANNER_TYPE = 2;
 export const CVE_SCANNER_TYPE = 3;
 export const GREENBONE_SENSOR_SCANNER_TYPE = 5;
 export const OPENVASD_SCANNER_TYPE = 6;
+export const OPENVASD_SENSOR_SCANNER_TYPE = 8;
 
 export const OPENVAS_DEFAULT_SCANNER_ID =
   '08b69003-5fc2-4037-a479-93b440211c73';
@@ -32,6 +33,8 @@ export function scannerTypeName(scannerType) {
     return _('Greenbone Sensor');
   } else if (scannerType === OPENVASD_SCANNER_TYPE) {
     return _('OpenVASD Scanner');
+  } else if (scannerType === OPENVASD_SENSOR_SCANNER_TYPE) {
+    return _('OpenVASD Sensor');
   }
   return _('Unknown type ({{type}})', {type: scannerType});
 }

--- a/src/web/pages/tasks/Dialog.jsx
+++ b/src/web/pages/tasks/Dialog.jsx
@@ -10,6 +10,7 @@ import {
   OPENVAS_DEFAULT_SCANNER_ID,
   OPENVASD_SCANNER_TYPE,
   GREENBONE_SENSOR_SCANNER_TYPE,
+  OPENVASD_SENSOR_SCANNER_TYPE,
 } from 'gmp/models/scanner';
 import {
   AUTO_DELETE_KEEP_DEFAULT_VALUE,
@@ -213,7 +214,8 @@ const TaskDialog = ({
         const useOpenvasScanConfig =
           state.scanner_type === OPENVAS_SCANNER_TYPE ||
           state.scanner_type === GREENBONE_SENSOR_SCANNER_TYPE ||
-          state.scanner_type === OPENVASD_SCANNER_TYPE;
+          state.scanner_type === OPENVASD_SCANNER_TYPE ||
+          state.scanner_type === OPENVASD_SENSOR_SCANNER_TYPE;
 
         return (
           <>

--- a/src/web/pages/tasks/__tests__/Dialog.test.jsx
+++ b/src/web/pages/tasks/__tests__/Dialog.test.jsx
@@ -18,6 +18,7 @@ import {
   OPENVAS_DEFAULT_SCANNER_ID,
   OPENVAS_SCANNER_TYPE,
   OPENVASD_SCANNER_TYPE,
+  OPENVASD_SENSOR_SCANNER_TYPE,
 } from 'gmp/models/scanner';
 import TaskDialog from 'web/pages/tasks/Dialog';
 
@@ -81,6 +82,18 @@ describe('TaskDialog component tests', () => {
 
   test('should render scan config section for OPENVASD_SCANNER_TYPE', async () => {
     renderDialog(OPENVASD_SCANNER_TYPE);
+    const selects = screen.queryAllSelectElements();
+    expect(selects.length).toEqual(5);
+
+    const scanConfigSelect = selects[3];
+    fireEvent.click(scanConfigSelect);
+
+    const options = await getSelectItemElementsForSelect(scanConfigSelect);
+    expect(options[0]).toHaveTextContent('Test Config');
+  });
+
+  test('should render scan config section for OPENVASD_SENSOR_SCANNER_TYPE', async () => {
+    renderDialog(OPENVASD_SENSOR_SCANNER_TYPE);
     const selects = screen.queryAllSelectElements();
     expect(selects.length).toEqual(5);
 


### PR DESCRIPTION
## What

This PR adds support for the new OPENVASD_SENSOR_SCANNER_TYPE in GSA.


## Why

This change is needed to distinguish OpenVASD sensor scanners from other types in the frontend.
It aligns with GVMD changes introducing `SCANNER_TYPE_OPENVASD_SENSOR`

## References

GEA-940

## Checklist

- [x] Tests


