### PR TITLE
Use the correct epss variable names after refactoring

### DIFF
--- a/src/web/pages/results/Row.jsx
+++ b/src/web/pages/results/Row.jsx
@@ -28,6 +28,7 @@ import useGmp from 'web/hooks/useGmp';
 import useTranslation from 'web/hooks/useTranslation';
 import ResultDelta from 'web/pages/results/Delta';
 import PropTypes from 'web/utils/PropTypes';
+
 const Row = ({
   actionsComponent: ActionsComponent = EntitiesActions,
   audit = false,
@@ -52,8 +53,8 @@ const Row = ({
   const deltaCompliance = entity.delta?.result?.compliance;
   const deltaHostname = entity.delta?.result?.host?.hostname;
   const deltaQoD = entity.delta?.result?.qod?.value;
-  const epssScore = entity?.information?.epss?.max_severity?.score;
-  const epssPercentile = entity?.information?.epss?.max_severity?.percentile;
+  const epssScore = entity?.information?.epss?.maxSeverity?.score;
+  const epssPercentile = entity?.information?.epss?.maxSeverity?.percentile;
   const gmp = useGmp();
   return (
     <TableRow>

--- a/src/web/pages/results/__tests__/Row.test.jsx
+++ b/src/web/pages/results/__tests__/Row.test.jsx
@@ -25,6 +25,7 @@ describe('Should render EPSS fields', () => {
       overrides: [],
       tickets: [],
       nvt: {
+        type: 'nvt',
         epss: {
           max_severity: {
             score: 0.8765,


### PR DESCRIPTION


## What
Use the correct epss variable names after refactoring
## Why

During the refactoring of the NVT model to TypeScript the epss variable names got adjusted to camel case too. The Result model uses it internally too.


