### PR TITLE
Add: Add KDCs and realm display to CredentialDetails component

### DIFF
--- a/src/gmp/models/__tests__/credential.test.ts
+++ b/src/gmp/models/__tests__/credential.test.ts
@@ -55,6 +55,8 @@ describe('Credential Model tests', () => {
     expect(credential.targets).toEqual([]);
     expect(credential.scanners).toEqual([]);
     expect(credential.kdcs).toEqual([]);
+    expect(credential.login).toBeUndefined();
+    expect(credential.realm).toBeUndefined();
   });
 
   test('should parse empty element', () => {
@@ -65,6 +67,8 @@ describe('Credential Model tests', () => {
     expect(credential.targets).toEqual([]);
     expect(credential.scanners).toEqual([]);
     expect(credential.kdcs).toEqual([]);
+    expect(credential.login).toBeUndefined();
+    expect(credential.realm).toBeUndefined();
   });
 
   test('should parse certificate_info', () => {
@@ -214,11 +218,20 @@ describe('Credential model function tests', () => {
       kdcs: {kdc: ['kdc1.example.com', 'kdc2.example.com']},
     });
     expect(credential.kdcs).toEqual(['kdc1.example.com', 'kdc2.example.com']);
+  });
 
-    const credential2 = Credential.fromElement({
-      kdcs: {kdc: 'kdc1.example.com'},
+  test('should parse login', () => {
+    const credential = Credential.fromElement({
+      login: 'test-user',
     });
-    expect(credential2.kdcs).toEqual(['kdc1.example.com']);
+    expect(credential.login).toEqual('test-user');
+  });
+
+  test('should parse realm', () => {
+    const credential = Credential.fromElement({
+      realm: 'test-realm',
+    });
+    expect(credential.realm).toEqual('test-realm');
   });
 });
 

--- a/src/gmp/models/credential.ts
+++ b/src/gmp/models/credential.ts
@@ -121,6 +121,8 @@ interface CredentialElement extends ModelElement {
   kdcs?: {
     kdc: string | string[];
   };
+  login?: string;
+  realm?: string;
   targets?: {
     target?: ModelElement | ModelElement[];
   };
@@ -139,6 +141,8 @@ interface CredentialProperties extends ModelProperties {
   certificate_info?: CertificateInfo;
   credential_type?: CredentialType;
   kdcs?: string[];
+  login?: string;
+  realm?: string;
   targets?: Model[];
   scanners?: Model[];
 }
@@ -150,6 +154,8 @@ class Credential extends Model {
   readonly certificate_info?: CertificateInfo;
   readonly credential_type?: CredentialType;
   readonly kdcs: string[];
+  readonly login: string | undefined;
+  readonly realm: string | undefined;
   readonly targets: Model[];
   readonly scanners: Model[];
 
@@ -161,6 +167,8 @@ class Credential extends Model {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     credential_type,
     kdcs = [],
+    login,
+    realm,
     targets = [],
     scanners = [],
     ...properties
@@ -170,6 +178,8 @@ class Credential extends Model {
     this.certificate_info = certificate_info;
     this.credential_type = credential_type;
     this.kdcs = kdcs;
+    this.login = login;
+    this.realm = realm;
     this.targets = targets;
     this.scanners = scanners;
   }
@@ -196,6 +206,14 @@ class Credential extends Model {
       ret.kdcs = Array.isArray(element.kdcs.kdc)
         ? element.kdcs.kdc
         : [element.kdcs.kdc];
+    }
+
+    if (isDefined(element.login)) {
+      ret.login = element.login;
+    }
+
+    if (isDefined(element.realm)) {
+      ret.realm = element.realm;
     }
 
     ret.targets = map(element.targets?.target, target =>

--- a/src/web/components/form/MultiValueTextField.tsx
+++ b/src/web/components/form/MultiValueTextField.tsx
@@ -4,6 +4,7 @@
  */
 
 import {TagsInput} from '@mantine/core';
+import tagStyles from 'web/components/form/tagStyles';
 import Theme from 'web/utils/Theme';
 
 interface MultiValueTextFieldProps {
@@ -16,25 +17,6 @@ interface MultiValueTextFieldProps {
   onChange?: (value: string[], name?: string) => void;
   validate?: (value: string) => boolean;
 }
-
-const tagStyles: Record<string, {bg: string; color: string}> = {
-  green: {
-    bg: Theme.lightGreen,
-    color: Theme.darkGreen,
-  },
-  red: {
-    bg: Theme.lightRed,
-    color: Theme.darkRed,
-  },
-  blue: {
-    bg: Theme.lightBlue,
-    color: Theme.blue,
-  },
-  gray: {
-    bg: Theme.dialogGray,
-    color: Theme.mediumGray,
-  },
-};
 
 const MultiValueTextField = ({
   color = 'green',

--- a/src/web/components/form/TagListDisplay.tsx
+++ b/src/web/components/form/TagListDisplay.tsx
@@ -1,0 +1,46 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import styled from 'styled-components';
+import tagStyles from 'web/components/form/tagStyles';
+
+interface TagListDisplayProps {
+  values: string[];
+  color?: keyof typeof tagStyles;
+}
+
+const Tag = styled.span<{bg: string; color: string}>`
+  background-color: ${({bg}) => bg};
+  color: ${({color}) => color};
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.85em;
+  font-weight: 500;
+  margin-right: 6px;
+`;
+
+const TagList = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+`;
+
+const TagListDisplay = ({values, color = 'green'}: TagListDisplayProps) => {
+  const resolvedColor = tagStyles[color] ?? tagStyles.green;
+
+  return (
+    <TagList>
+      {values.map((val, idx) => (
+        <span key={idx} style={{display: 'flex', alignItems: 'center'}}>
+          <Tag bg={resolvedColor.bg} color={resolvedColor.color}>
+            {val}
+          </Tag>
+        </span>
+      ))}
+    </TagList>
+  );
+};
+
+export default TagListDisplay;

--- a/src/web/components/form/__tests__/TagListDisplay.test.tsx
+++ b/src/web/components/form/__tests__/TagListDisplay.test.tsx
@@ -1,0 +1,22 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect} from '@gsa/testing';
+import {render, screen} from 'web/testing';
+import TagListDisplay from 'web/components/form/TagListDisplay';
+
+describe('TagListDisplay', () => {
+  test('should render all values as tags', () => {
+    render(<TagListDisplay values={['kdc1.example.com', '192.168.1.1']} />);
+
+    expect(screen.getByText('kdc1.example.com')).toBeVisible();
+    expect(screen.getByText('192.168.1.1')).toBeVisible();
+  });
+
+  test('should render nothing if values array is empty', () => {
+    render(<TagListDisplay values={[]} />);
+    expect(screen.queryByText(/.+/)).not.toBeInTheDocument();
+  });
+});

--- a/src/web/components/form/tagStyles.ts
+++ b/src/web/components/form/tagStyles.ts
@@ -1,0 +1,27 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import Theme from 'web/utils/Theme';
+
+const tagStyles = {
+  green: {
+    bg: Theme.lightGreen,
+    color: Theme.darkGreen,
+  },
+  red: {
+    bg: Theme.lightRed,
+    color: Theme.darkRed,
+  },
+  blue: {
+    bg: Theme.lightBlue,
+    color: Theme.blue,
+  },
+  gray: {
+    bg: Theme.dialogGray,
+    color: Theme.mediumGray,
+  },
+};
+
+export default tagStyles;

--- a/src/web/pages/credentials/Details.jsx
+++ b/src/web/pages/credentials/Details.jsx
@@ -5,11 +5,13 @@
 
 import React from 'react';
 import {
+  getCredentialTypeName,
+  KRB5_CREDENTIAL_TYPE,
   SNMP_CREDENTIAL_TYPE,
   SNMP_PRIVACY_ALGORITHM_NONE,
-  getCredentialTypeName,
 } from 'gmp/models/credential';
 import Footnote from 'web/components/footnote/Footnote';
+import TagListDisplay from 'web/components/form/TagListDisplay.js';
 import Divider from 'web/components/layout/Divider';
 import HorizontalSep from 'web/components/layout/HorizontalSep';
 import Layout from 'web/components/layout/Layout';
@@ -27,6 +29,8 @@ const CredentialDetails = ({entity}) => {
   const {
     comment,
     credential_type,
+    kdcs = [],
+    realm,
     login,
     auth_algorithm,
     privacy = {
@@ -73,6 +77,20 @@ const CredentialDetails = ({entity}) => {
             <TableRow>
               <TableData>{_('Auth Algorithm')}</TableData>
               <TableData>{auth_algorithm}</TableData>
+            </TableRow>
+          )}
+          {credential_type === KRB5_CREDENTIAL_TYPE && (
+            <TableRow>
+              <TableData>{_('Realm')}</TableData>
+              <TableData>{realm}</TableData>
+            </TableRow>
+          )}
+          {credential_type === KRB5_CREDENTIAL_TYPE && (
+            <TableRow>
+              <TableData>{_('Key Distribution Center')}</TableData>
+              <TableData>
+                <TagListDisplay values={kdcs} />
+              </TableData>
             </TableRow>
           )}
           {credential_type === SNMP_CREDENTIAL_TYPE && (

--- a/src/web/pages/credentials/__tests__/Details.test.tsx
+++ b/src/web/pages/credentials/__tests__/Details.test.tsx
@@ -1,0 +1,91 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, expect, test} from '@gsa/testing';
+import {render, screen} from 'web/testing';
+import Credential, {SNMP_CREDENTIAL_TYPE} from 'gmp/models/credential';
+import CredentialDetails from 'web/pages/credentials/Details';
+
+const defaultEntity = Credential.fromElement({
+  _id: 'c1',
+  name: 'test-cred',
+  comment: 'Test credential comment',
+  type: 'krb5',
+  credential_type: 'krb5',
+  allow_insecure: 1,
+  login: 'testuser',
+  realm: 'EXAMPLE.REALM',
+  kdcs: {
+    kdc: ['kdc1.example.com', 'kdc2.example.com'],
+  },
+  targets: {
+    target: [
+      {_id: 't1', name: 'Target One'},
+      {_id: 't2', name: 'Target Two'},
+    ],
+  },
+  scanners: {
+    scanner: [
+      {_id: 's1', name: 'Scanner One'},
+      {_id: 's2', name: 'Scanner Two'},
+    ],
+  },
+});
+
+describe('CredentialDetails', () => {
+  test('should render basic credential details', () => {
+    render(<CredentialDetails entity={defaultEntity} />);
+    expect(screen.getByText('Test credential comment')).toBeVisible();
+    expect(screen.getByText('Yes')).toBeVisible();
+    expect(screen.getByText('testuser')).toBeVisible();
+  });
+
+  test('should render realm and kdcs when credential type is KRB5', () => {
+    render(<CredentialDetails entity={defaultEntity} />);
+    expect(screen.getByText('EXAMPLE.REALM')).toBeVisible();
+    expect(screen.getByText('kdc1.example.com')).toBeVisible();
+    expect(screen.getByText('kdc2.example.com')).toBeVisible();
+  });
+
+  test('should render SNMP fields when credential type is SNMP', () => {
+    const entity = Credential.fromElement({
+      _id: 'cred-snmp',
+      type: SNMP_CREDENTIAL_TYPE,
+      comment: 'SNMP cred',
+      login: 'snmp-user',
+      credential_type: SNMP_CREDENTIAL_TYPE,
+    });
+
+    // @ts-expect-error: test override
+    entity.auth_algorithm = 'sha1';
+    // @ts-expect-error: test override
+    entity.privacy = {algorithm: ''};
+
+    render(<CredentialDetails entity={entity} />);
+    expect(screen.getByText('sha1')).toBeVisible();
+    expect(screen.getByText('None')).toBeVisible();
+  });
+
+  test('should render targets and scanners as links', () => {
+    render(<CredentialDetails entity={defaultEntity} />);
+    expect(screen.getByText('Target One')).toBeVisible();
+    expect(screen.getByText('Target Two')).toBeVisible();
+    expect(screen.getByText('Scanner One')).toBeVisible();
+    expect(screen.getByText('Scanner Two')).toBeVisible();
+  });
+
+  test('should fallback safely when optional fields are missing', () => {
+    const entity = Credential.fromElement({
+      _id: 'c-krb5',
+      type: 'krb5',
+      comment: 'KRB5 cred',
+      login: 'kerbuser',
+      realm: undefined,
+      kdcs: undefined,
+    });
+    render(<CredentialDetails entity={entity} />);
+    expect(screen.queryByText('Key Distribution Center')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Added support to show the realm and KDCs in the CredentialDetails component for Kerberos credentials.


## Why

These fields are important for users to view when working with Kerberos credentials.

## References

GEA-1129

## Checklist

- [ ] Tests


