### PR TITLE
Improve queryAllSelectElements by returning a HTMLSelectElement array

### DIFF
--- a/src/web/testing/customQueries.ts
+++ b/src/web/testing/customQueries.ts
@@ -74,7 +74,7 @@ export const getSelectElement = (element?: HTMLElement) => {
  */
 export const queryAllSelectElements = (element?: HTMLElement) => {
   element = getElementOrReturnDocument(element);
-  return queryAllByTestId(element, 'form-select');
+  return queryAllByTestId(element, 'form-select') as HTMLSelectElement[];
 };
 
 /**


### PR DESCRIPTION
## What

Improve queryAllSelectElements by returning a HTMLSelectElement array

## Why

Allow for easier testing. We expect to query select elements here. Thus select elements should be returned.