### PR TITLE
Mark the onSave method of the SaveDialog as optional

### DIFF
--- a/src/web/components/dialog/SaveDialog.tsx
+++ b/src/web/components/dialog/SaveDialog.tsx
@@ -35,7 +35,7 @@ interface SaveDialogProps<TValues, TDefaultValues> {
   onClose: () => void; // function to call when dialog is closed
   onError?: (error: Error) => void; // function to call when an error occurs
   onErrorClose?: () => void; // function to call when error dialog is closed
-  onSave: (state: TValues & TDefaultValues) => Promise<void> | void; // function to call when save button is clicked
+  onSave?: (state: TValues & TDefaultValues) => Promise<void> | void; // function to call when save button is clicked
 }
 
 const SaveDialog = <TValues, TDefaultValues = {}>({


### PR DESCRIPTION

## What

Mark the onSave method of the SaveDialog as optional

## Why

Actually it was optional already before but the type info was incorrect.