### PR TITLE
 Render name for Checkbox component

### DIFF
--- a/src/web/components/form/Checkbox.tsx
+++ b/src/web/components/form/Checkbox.tsx
@@ -49,6 +49,7 @@ const Checkbox = <TCheck = boolean,>({
       checked={checked}
       disabled={disabled}
       label={title}
+      name={name}
       title={toolTipTitle}
       onChange={handleChange}
     />

--- a/src/web/components/form/__tests__/Checkbox.test.tsx
+++ b/src/web/components/form/__tests__/Checkbox.test.tsx
@@ -103,4 +103,9 @@ describe('CheckBox component tests', () => {
     const checkbox = screen.getByTestId<HTMLInputElement>('checkbox');
     expect(checkbox.checked).toBe(false);
   });
+
+  test('should allow to set custom name', () => {
+    render(<CheckBox checked={true} name="customName" />);
+    expect(screen.getByName('customName')).toBeChecked();
+  });
 });


### PR DESCRIPTION


## What

 Render name for Checkbox component

## Why

Actually pass the name prop to the underlying component so that it shows up in the DOM.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


