### PR TITLE
Add a changePassword method to UserCommand

### DIFF
--- a/src/gmp/commands/__tests__/user.test.ts
+++ b/src/gmp/commands/__tests__/user.test.ts
@@ -4,7 +4,11 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import {createResponse, createHttp} from 'gmp/commands/testing';
+import {
+  createResponse,
+  createHttp,
+  createActionResultResponse,
+} from 'gmp/commands/testing';
 import {
   CertificateInfo,
   UserCommand,
@@ -105,6 +109,24 @@ describe('UserCommand tests', () => {
     expect(data?.id).toEqual('123');
     expect(data?.name).toEqual('Rows Per Page');
     expect(data?.value).toEqual('42');
+  });
+
+  test('should allow to change password', async () => {
+    const response = createActionResultResponse({
+      action: 'Change Password',
+    });
+    const fakeHttp = createHttp(response);
+    const cmd = new UserCommand(fakeHttp);
+
+    expect.hasAssertions();
+    await cmd.changePassword('oldPassword', 'newPassword');
+    expect(fakeHttp.request).toHaveBeenCalledWith('post', {
+      data: {
+        cmd: 'change_password',
+        old_password: 'oldPassword',
+        password: 'newPassword',
+      },
+    });
   });
 });
 

--- a/src/gmp/commands/users.ts
+++ b/src/gmp/commands/users.ts
@@ -538,6 +538,14 @@ export class UserCommand extends EntityCommand<User, PortListElement> {
     );
   }
 
+  changePassword(oldPassword: string, newPassword: string) {
+    return this.action({
+      cmd: 'change_password',
+      old_password: oldPassword,
+      password: newPassword,
+    });
+  }
+
   ping() {
     return this.httpGet({
       cmd: 'ping',


### PR DESCRIPTION


## What

Add a changePassword method to UserCommand

## Why

Allow to change only the password via `gmp.user.changePassword`.

## References

https://jira.greenbone.net/browse/GEA-1144

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


