### PR TITLE
TableHead Component Props

### DIFF
--- a/src/web/components/icon/index.tsx
+++ b/src/web/components/icon/index.tsx
@@ -178,14 +178,14 @@ export const icons: IconDefinition[] = [
   {
     name: 'ArrowUpDown',
     component: ArrowUpDown,
-    dataTestId: 'arrowUpDown-icon',
+    dataTestId: 'arrow-up-down-icon',
     ariaLabel: 'Arrow Up Down Icon',
     isLucide: true,
   },
   {
     name: 'ArrowUp',
     component: ArrowUp,
-    dataTestId: 'arrowUp-icon',
+    dataTestId: 'arrow-up-icon',
     ariaLabel: 'Arrow Up Icon',
     isLucide: true,
   },

--- a/src/web/components/sortby/SortBy.tsx
+++ b/src/web/components/sortby/SortBy.tsx
@@ -18,10 +18,17 @@ interface SortByProps {
   by: string;
   children?: React.ReactNode;
   className?: string;
+  'data-testid'?: string;
   onClick?: (by: string) => void;
 }
 
-const SortBy = ({by, children, className, onClick}: SortByProps) => {
+const SortBy = ({
+  by,
+  children,
+  className,
+  'data-testid': dataTestId,
+  onClick,
+}: SortByProps) => {
   const handleClick = () => {
     if (onClick) {
       onClick(by);
@@ -29,7 +36,11 @@ const SortBy = ({by, children, className, onClick}: SortByProps) => {
   };
 
   return (
-    <SortButton className={className} onClick={handleClick}>
+    <SortButton
+      className={className}
+      data-testid={dataTestId}
+      onClick={handleClick}
+    >
       {children}
     </SortButton>
   );

--- a/src/web/components/table/Head.tsx
+++ b/src/web/components/table/Head.tsx
@@ -6,10 +6,10 @@
 import styled from 'styled-components';
 import {isDefined} from 'gmp/utils/identity';
 import {ArrowDownIcon, ArrowUpIcon, ArrowUpDownIcon} from 'web/components/icon';
-import Layout from 'web/components/layout/Layout';
+import Layout, {LayoutProps} from 'web/components/layout/Layout';
 import SortBy from 'web/components/sortby/SortBy';
 import useTranslation from 'web/hooks/useTranslation';
-import SortDirection from 'web/utils/SortDirection';
+import SortDirection, {SortDirectionType} from 'web/utils/SortDirection';
 import Theme from 'web/utils/Theme';
 
 const SortSymbol = styled.span`
@@ -17,16 +17,19 @@ const SortSymbol = styled.span`
   align-items: center;
 `;
 
-interface TableHeadProps {
-  children?: React.ReactNode;
+interface ToString {
+  toString: () => string;
+}
+
+interface TableHeadProps extends Omit<LayoutProps, 'title'> {
   className?: string;
   colSpan?: number;
   currentSortBy?: string;
-  currentSortDir?: string;
+  currentSortDir?: SortDirectionType;
   rowSpan?: number;
   sort?: boolean;
   sortBy?: string;
-  title?: string;
+  title?: ToString;
   width?: string;
   withBorder?: boolean;
   onSortChange?: (sortBy: string) => void;
@@ -48,7 +51,7 @@ const TableHead = ({
 }: TableHeadProps) => {
   const [_] = useTranslation();
   const getSortSymbol = () => {
-    if (!isDefined(sortBy) || currentSortBy !== sortBy) {
+    if (sort && currentSortBy !== sortBy) {
       return (
         <SortSymbol title={_('Not Sorted')}>
           &nbsp;
@@ -71,13 +74,17 @@ const TableHead = ({
   };
 
   if (isDefined(title) && !isDefined(children)) {
-    children = `${title}`;
+    children = String(title);
   }
 
   return (
     <th className={className} colSpan={colSpan} rowSpan={rowSpan}>
-      {sort && sortBy && isDefined(onSortChange) ? (
-        <SortBy by={sortBy} onClick={onSortChange}>
+      {sort && isDefined(sortBy) ? (
+        <SortBy
+          by={sortBy}
+          data-testid={`table-header-sort-by-${sortBy}`}
+          onClick={onSortChange}
+        >
           <Layout {...other}>
             {children}
             {getSortSymbol()}

--- a/src/web/components/table/__tests__/TableHead.test.tsx
+++ b/src/web/components/table/__tests__/TableHead.test.tsx
@@ -1,0 +1,133 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect, testing} from '@gsa/testing';
+import {screen, rendererWith, fireEvent, RendererOptions} from 'web/testing';
+import TableHead from 'web/components/table/Head';
+
+const rendererWithTableHeader = (options: RendererOptions = {}) => {
+  const {render, ...other} = rendererWith(options);
+  return {
+    ...other,
+    render: (element: React.ReactNode) =>
+      render(
+        <table>
+          <thead>
+            <tr>{element}</tr>
+          </thead>
+        </table>,
+      ),
+  };
+};
+
+describe('TableHead tests', () => {
+  test('should render with default props', () => {
+    const {render} = rendererWithTableHeader();
+    render(<TableHead />);
+    expect(screen.getByRole('columnheader')).toBeInTheDocument();
+  });
+
+  test('should render', () => {
+    const {render} = rendererWithTableHeader();
+    render(
+      <TableHead currentSortBy="name" currentSortDir="asc" sortBy="name" />,
+    );
+    expect(screen.getByTestId('table-header-sort-by-name')).toBeVisible();
+  });
+
+  test('should handle sorting', () => {
+    const onSortChange = testing.fn();
+    const {render} = rendererWithTableHeader();
+    render(
+      <TableHead
+        currentSortBy="name"
+        currentSortDir="asc"
+        sortBy="name"
+        onSortChange={onSortChange}
+      />,
+    );
+    const sortButton = screen.getByRole('button');
+    fireEvent.click(sortButton);
+    expect(onSortChange).toHaveBeenCalledWith('name');
+  });
+
+  test('should render title', () => {
+    const {render} = rendererWithTableHeader();
+    const title = 'Test Title';
+    render(<TableHead title={title} />);
+    expect(screen.getByText(title)).toBeInTheDocument();
+
+    const onSortChange = testing.fn();
+    render(
+      <TableHead
+        currentSortBy="name"
+        currentSortDir="asc"
+        sortBy="name"
+        title="Foo Bar"
+        onSortChange={onSortChange}
+      />,
+    );
+    expect(screen.getByText('Foo Bar')).toBeInTheDocument();
+  });
+
+  test('should not render not sorted', () => {
+    const onSortChange = testing.fn();
+    const {render} = rendererWithTableHeader();
+    render(
+      <TableHead
+        currentSortBy="name"
+        sortBy="foo"
+        onSortChange={onSortChange}
+      />,
+    );
+    expect(screen.getByTitle('Not Sorted')).toBeVisible();
+    expect(screen.getByTestId('arrow-up-down-icon')).toBeVisible();
+  });
+
+  test('should not render sort symbol if not sorted', () => {
+    const {render} = rendererWithTableHeader();
+    render(<TableHead sort={false} sortBy="name" />);
+    expect(
+      screen.queryByTestId('table-header-sort-by-name'),
+    ).not.toBeInTheDocument();
+
+    render(<TableHead />);
+    expect(
+      screen.queryByTestId('table-header-sort-by-'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('should render sort with ascending icon', () => {
+    const {render} = rendererWithTableHeader();
+    render(
+      <TableHead
+        currentSortBy="name"
+        currentSortDir="asc"
+        sortBy="name"
+        title="Name"
+      />,
+    );
+    expect(
+      screen.getByTitle('Sorted In Ascending Order By Name'),
+    ).toBeVisible();
+    expect(screen.getByTestId('arrow-up-icon')).toBeVisible();
+  });
+
+  test('should render sort with descending icon', () => {
+    const {render} = rendererWithTableHeader();
+    render(
+      <TableHead
+        currentSortBy="name"
+        currentSortDir="desc"
+        sortBy="name"
+        title="Name"
+      />,
+    );
+    expect(
+      screen.getByTitle('Sorted In Descending Order By Name'),
+    ).toBeVisible();
+    expect(screen.getByTestId('arrow-down-icon')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## What

Extend TableHead component props

## Why

TableHead encapsulates the Layout component and therefore Layout props are allowed too.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


