### PR TITLE
fix: update optimistic update action to use filter object instead of filderId

### DIFF
--- a/src/web/pages/user-settings/FilterSettings.tsx
+++ b/src/web/pages/user-settings/FilterSettings.tsx
@@ -7,7 +7,7 @@ import {useEffect, useMemo, useState} from 'react';
 import {useDispatch} from 'react-redux';
 
 import {DEFAULT_FILTER_SETTINGS} from 'gmp/commands/users';
-import {ALL_FILTER} from 'gmp/models/filter';
+import Filter, {ALL_FILTER} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import Select from 'web/components/form/Select';
 import Layout from 'web/components/layout/Layout';
@@ -254,9 +254,29 @@ export const FilterSettings = ({
       }
 
       if (entityType) {
-        dispatch(
-          defaultFilterLoadingActions.optimisticUpdate(entityType, values[key]),
-        );
+        const filterId = values[key];
+
+        const selectedFilter = filters.find(filter => filter.id === filterId);
+
+        if (selectedFilter) {
+          dispatch(
+            defaultFilterLoadingActions.optimisticUpdate(
+              entityType,
+              selectedFilter,
+            ),
+          );
+        } else if (filterId) {
+          const filter = new Filter();
+          // @ts-expect-error
+          filter.id = filterId;
+          dispatch(
+            defaultFilterLoadingActions.optimisticUpdate(entityType, filter),
+          );
+        } else {
+          dispatch(
+            defaultFilterLoadingActions.optimisticUpdate(entityType, null),
+          );
+        }
       }
 
       await saveSetting(settingId, key, values[key], value =>

--- a/src/web/store/usersettings/defaultfilters/__tests__/actions.test.js
+++ b/src/web/store/usersettings/defaultfilters/__tests__/actions.test.js
@@ -49,14 +49,13 @@ describe('defaultFilterLoadingActions tests', () => {
   });
 
   test('should create an optimistic update action', () => {
-    const action = defaultFilterLoadingActions.optimisticUpdate(
-      'foo',
-      'filterId123',
-    );
+    const filter = {id: 'filterId123'};
+    const action = defaultFilterLoadingActions.optimisticUpdate('foo', filter);
+
     expect(action).toEqual({
       type: 'USER_SETTINGS_DEFAULT_FILTER_OPTIMISTIC_UPDATE',
       entityType: 'foo',
-      filterId: 'filterId123',
+      filter,
     });
   });
 });

--- a/src/web/store/usersettings/defaultfilters/__tests__/reducers.test.js
+++ b/src/web/store/usersettings/defaultfilters/__tests__/reducers.test.js
@@ -118,12 +118,18 @@ describe('default filters reducers tests', () => {
         error: 'old error',
       },
     };
-    const action = defaultFilterLoadingActions.optimisticUpdate('foo', 'newId');
+
+    const newFilter = {id: 'newId', name: 'newFilter'};
+    const action = defaultFilterLoadingActions.optimisticUpdate(
+      'foo',
+      newFilter,
+    );
+
     const state = reducer(prevState, action);
     expect(state).toEqual({
       foo: {
         isLoading: false,
-        filter: {id: 'newId', name: 'oldFilter'},
+        filter: newFilter,
         error: undefined,
       },
     });
@@ -136,12 +142,18 @@ describe('default filters reducers tests', () => {
         error: 'old error',
       },
     };
-    const action = defaultFilterLoadingActions.optimisticUpdate('foo', 'newId');
+
+    const newFilter = {id: 'newId', name: 'newFilter'};
+    const action = defaultFilterLoadingActions.optimisticUpdate(
+      'foo',
+      newFilter,
+    );
+
     const state = reducer(prevState, action);
     expect(state).toEqual({
       foo: {
         isLoading: false,
-        filter: {id: 'newId'},
+        filter: newFilter,
         error: undefined,
       },
     });

--- a/src/web/store/usersettings/defaultfilters/actions.js
+++ b/src/web/store/usersettings/defaultfilters/actions.js
@@ -31,10 +31,10 @@ export const defaultFilterLoadingActions = {
     entityType,
     error,
   }),
-  optimisticUpdate: (entityType, filterId) => ({
+  optimisticUpdate: (entityType, filter) => ({
     type: USER_SETTINGS_DEFAULT_FILTER_OPTIMISTIC_UPDATE,
     entityType,
-    filterId,
+    filter,
   }),
 };
 

--- a/src/web/store/usersettings/defaultfilters/reducers.js
+++ b/src/web/store/usersettings/defaultfilters/reducers.js
@@ -41,13 +41,7 @@ const filter = (state, action) => {
     case USER_SETTINGS_DEFAULT_FILTER_LOADING_SUCCESS:
       return action.filter;
     case USER_SETTINGS_DEFAULT_FILTER_OPTIMISTIC_UPDATE: {
-      if (state && typeof state === 'object') {
-        return {
-          ...state,
-          id: action.filterId,
-        };
-      }
-      return action.filterId ? {id: action.filterId} : null;
+      return action.filter;
     }
     default:
       return state;


### PR DESCRIPTION
## What

fix: update optimistic update action to use filter object instead of filderId

## Why

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


