### PR TITLE
fix:  typo in TagsPage component filter prop not populating filters

### DIFF
--- a/src/web/pages/tags/ListPage.jsx
+++ b/src/web/pages/tags/ListPage.jsx
@@ -76,12 +76,12 @@ const TagsPage = ({
         enable,
         disable,
       }) => (
-        <React.Fragment>
+        <>
           <PageTitle title={_('Tags')} />
           <EntitiesPage
             {...props}
             filterEditDialog={TagsFilterDialog}
-            filterFilter={TAGS_FILTER_FILTER}
+            filtersFilter={TAGS_FILTER_FILTER}
             sectionIcon={<TagIcon size="large" />}
             table={TagsTable}
             tags={false}
@@ -100,7 +100,7 @@ const TagsPage = ({
             onTagEnableClick={enable}
             onTagSaveClick={save}
           />
-        </React.Fragment>
+        </>
       )}
     </TagComponent>
   );
@@ -117,5 +117,3 @@ export default withEntitiesContainer('tag', {
   entitiesSelector,
   loadEntities,
 })(TagsPage);
-
-// vim: set ts=2 sw=2 tw=80:


### PR DESCRIPTION
## What
fix:  typo in TagsPage component filter prop not populating filters

## Why

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


