### PR TITLE
Allow number for Filter set

### DIFF
--- a/src/gmp/models/__tests__/filter.test.ts
+++ b/src/gmp/models/__tests__/filter.test.ts
@@ -416,7 +416,7 @@ describe('Filter parse from keywords', () => {
 
 describe('Filter set', () => {
   test('should allow to set a filter term', () => {
-    const filter = Filter.fromElement();
+    const filter = new Filter();
     expect(filter.set('abc', '1', '=').toFilterString()).toEqual('abc=1');
   });
 
@@ -426,7 +426,7 @@ describe('Filter set', () => {
   });
 
   test('should remove sort-reverse when adding sort filter term', () => {
-    const filter = Filter.fromElement();
+    const filter = new Filter();
 
     filter.set('sort-reverse', 'foo', '=');
     expect(filter.has('sort-reverse')).toEqual(true);
@@ -438,7 +438,7 @@ describe('Filter set', () => {
   });
 
   test('should remove sort when adding sort-reverse filter term', () => {
-    const filter = Filter.fromElement();
+    const filter = new Filter();
 
     filter.set('sort', 'foo', '=');
     expect(filter.has('sort')).toEqual(true);
@@ -449,8 +449,11 @@ describe('Filter set', () => {
     expect(filter.has('sort-reverse')).toEqual(true);
   });
 
-  test('should convert 0 or negative values for first to 1', () => {
-    const filter = Filter.fromElement();
+  test('should allow to set first keyword', () => {
+    const filter = new Filter();
+    filter.set('first', 123);
+    expect(filter.get('first')).toEqual(123);
+
     filter.set('first', '0');
     expect(filter.get('first')).toEqual(1);
 
@@ -459,7 +462,7 @@ describe('Filter set', () => {
   });
 
   test('should reset filter id', () => {
-    const filter = Filter.fromElement({_id: 'foo'});
+    const filter = new Filter({id: 'foo'});
 
     expect(filter.id).toEqual('foo');
 
@@ -468,7 +471,7 @@ describe('Filter set', () => {
   });
 
   test('should allow to set a filter term with underscore', () => {
-    const filter = Filter.fromElement();
+    const filter = new Filter();
     expect(filter.set('_foo', '1', '=').toFilterString()).toEqual('_foo=1');
   });
 });

--- a/src/gmp/models/__tests__/filter.test.ts
+++ b/src/gmp/models/__tests__/filter.test.ts
@@ -461,6 +461,18 @@ describe('Filter set', () => {
     expect(filter.get('first')).toEqual(1);
   });
 
+  test('should allow to set name keyword', () => {
+    const filter = new Filter();
+    filter.set('name', 'Test Task');
+    expect(filter.get('name')).toEqual('Test Task');
+
+    filter.set('name', '');
+    expect(filter.get('name')).toBeUndefined();
+
+    filter.set('name', 123);
+    expect(filter.get('name')).toEqual('123');
+  });
+
   test('should reset filter id', () => {
     const filter = new Filter({id: 'foo'});
 

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -455,7 +455,7 @@ class Filter extends EntityModel {
    *
    * @return This filter
    */
-  set(keyword: string, value?: string, relation: string = '=') {
+  set(keyword: string, value?: string | number, relation: string = '=') {
     this._resetFilterId(); // reset id because the filter has changed
     const converted = convert(keyword, value, relation);
     this._setTerm(new FilterTerm(converted));

--- a/src/gmp/models/filter/__tests__/convert.test.ts
+++ b/src/gmp/models/filter/__tests__/convert.test.ts
@@ -168,6 +168,24 @@ describe('convert tests', () => {
     });
   });
 
+  test('should convert name keyword', () => {
+    expect(convert('name', 'Test Task', '=')).toEqual({
+      keyword: 'name',
+      relation: '=',
+      value: 'Test Task',
+    });
+    expect(convert('name', '', '=')).toEqual({
+      keyword: 'name',
+      relation: '=',
+      value: undefined,
+    });
+    expect(convert('name', 1, '~')).toEqual({
+      keyword: 'name',
+      relation: '~',
+      value: '1',
+    });
+  });
+
   test('should convert empty keyword', () => {
     expect(convert('', 'foo', '=')).toEqual({
       relation: '=',

--- a/src/gmp/models/filter/convert.ts
+++ b/src/gmp/models/filter/convert.ts
@@ -63,6 +63,16 @@ const convertRows = (
   value: ConvertValue,
 ): FilterTermObject => convertInt(keyword, value, '=');
 
+const convertString = (
+  keyword: ConvertKeyword,
+  value: ConvertValue,
+  relation: ConvertRelation,
+): FilterTermObject => ({
+  keyword,
+  value: !isEmpty(value) ? String(value) : undefined,
+  relation,
+});
+
 const convertNoRelation = (
   keyword: ConvertKeyword,
   value: ConvertValue,
@@ -86,6 +96,7 @@ const KEYWORD_CONVERTERS: Record<string, ConvertFunc> = {
   overrides: convertBooleanInt,
   result_hosts_only: convertBooleanInt,
   rows: convertRows,
+  name: convertString,
 };
 
 const VALUE_CONVERTERS = {

--- a/src/gmp/utils/__tests__/string.test.ts
+++ b/src/gmp/utils/__tests__/string.test.ts
@@ -68,7 +68,7 @@ describe('isEmpty function test', () => {
   });
 
   test('should return false for numbers', () => {
-    // @ts-expect-error
     expect(isEmpty(123)).toBe(false);
+    expect(isEmpty(0)).toBe(false);
   });
 });

--- a/src/gmp/utils/string.ts
+++ b/src/gmp/utils/string.ts
@@ -64,12 +64,13 @@ export const split = (
 };
 
 /**
- * Checks if a given string is empty.
+ * Checks if a given value is empty.
  *
- * A string is considered empty if it is either undefined or has a length of 0.
+ * A value is considered empty if it is either undefined or it is a string and
+ * has a length of 0.
  *
- * @param value - The string to check.
- * @returns - Returns true if the string is empty, otherwise false.
+ * @param value - The value to check.
+ * @returns - Returns true if the value is empty, otherwise false.
  */
-export const isEmpty = (value?: string): boolean =>
-  !isDefined(value) || value.length === 0;
+export const isEmpty = (value?: string | number): boolean =>
+  !isDefined(value) || (isString(value) && value.length === 0);


### PR DESCRIPTION
## What

Allow number to be passed to Filter set and ensure name is always stored as string.

## Why

Internally all filter terms are stored either as number or string. For example `filter.set("severity", "5.5")` is stored as number by using specific conversion functions for defined filter term keywords (here severity). Therefore set should also accept numbers to avoid extra conversions.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


