### PR TITLE
Update Powerfilter component name and onChange handler prop types

### DIFF
--- a/src/web/components/powerfilter/ApplyOverridesGroup.tsx
+++ b/src/web/components/powerfilter/ApplyOverridesGroup.tsx
@@ -14,7 +14,7 @@ interface ApplyOverridesGroupProps {
   filter?: Filter;
   name?: string;
   overrides?: YesNo;
-  onChange: (value: YesNo, name?: string) => void;
+  onChange?: (value: YesNo, name: string) => void;
 }
 
 const ApplyOverridesGroup = ({
@@ -34,7 +34,9 @@ const ApplyOverridesGroup = ({
         data-testid="apply-overrides-yesnoradio"
         name={name}
         value={overrides}
-        onChange={onChange}
+        onChange={
+          onChange as ((value: YesNo, name?: string) => void) | undefined
+        }
       />
     </FormGroup>
   );

--- a/src/web/components/powerfilter/BooleanFilterGroup.tsx
+++ b/src/web/components/powerfilter/BooleanFilterGroup.tsx
@@ -13,7 +13,7 @@ interface BooleanFilterGroupProps {
   filter?: Filter;
   name: string;
   title?: string;
-  onChange?: (value: YesNo, name?: string) => void;
+  onChange?: (value: YesNo, name: string) => void;
 }
 
 const BooleanFilterGroup = ({
@@ -25,7 +25,7 @@ const BooleanFilterGroup = ({
   let filterVal: YesNo | undefined;
 
   if (isDefined(filter)) {
-    filterVal = parseYesNo(filter.get(name) as YesNo | undefined);
+    filterVal = parseYesNo(filter.get(name));
   }
 
   return (
@@ -35,7 +35,9 @@ const BooleanFilterGroup = ({
         data-testid="boolean-filter-yesnoradio"
         name={name}
         value={filterVal}
-        onChange={onChange}
+        onChange={
+          onChange as ((value: YesNo, name?: string) => void) | undefined
+        }
       />
     </FormGroup>
   );

--- a/src/web/components/powerfilter/CreateNamedFilterGroup.tsx
+++ b/src/web/components/powerfilter/CreateNamedFilterGroup.tsx
@@ -11,7 +11,7 @@ import useTranslation from 'web/hooks/useTranslation';
 interface CreateNamedFilterGroupProps {
   filterName?: string;
   saveNamedFilter?: boolean;
-  onValueChange?: (value: string | boolean, name?: string) => void;
+  onValueChange?: (value: string | boolean, name: string) => void;
 }
 
 const CreateNamedFilterGroup = ({
@@ -29,7 +29,7 @@ const CreateNamedFilterGroup = ({
         name="saveNamedFilter"
         title={_('Store filter as: ')}
         unCheckedValue={false}
-        onChange={onValueChange}
+        onChange={onValueChange as (value: boolean, name?: string) => void}
       />
       <TextField
         data-testid="createnamedfiltergroup-textfield"
@@ -38,7 +38,9 @@ const CreateNamedFilterGroup = ({
         name="filterName"
         placeholder={_('Filter Name')}
         value={filterName}
-        onChange={onValueChange}
+        onChange={
+          onValueChange as ((value: string, name?: string) => void) | undefined
+        }
       />
     </Row>
   );

--- a/src/web/components/powerfilter/Dialog.tsx
+++ b/src/web/components/powerfilter/Dialog.tsx
@@ -19,7 +19,7 @@ interface DefaultFilterDialogProps {
   saveNamedFilter?: boolean;
   sortFields?: SortByField[];
   onFilterStringChange?: (value: string) => void;
-  onFilterValueChange?: (value: string | number, name?: string) => void;
+  onFilterValueChange?: (value: string | number, name: string) => void;
   onSortByChange?: (value: string) => void;
   onSortOrderChange?: (value: string) => void;
   onValueChange?: (value: string | boolean, name?: string) => void;
@@ -28,7 +28,7 @@ interface DefaultFilterDialogProps {
 const DefaultFilterDialog = ({
   filter,
   filterName,
-  filterstring,
+  filterstring: filterString,
   saveNamedFilter,
   sortFields,
   onFilterStringChange,
@@ -41,7 +41,7 @@ const DefaultFilterDialog = ({
   return (
     <>
       <FilterStringGroup
-        filter={filterstring}
+        filter={filterString}
         onChange={onFilterStringChange}
       />
       <FirstResultGroup filter={filter} onChange={onFilterValueChange} />

--- a/src/web/components/powerfilter/FilterSearchGroup.tsx
+++ b/src/web/components/powerfilter/FilterSearchGroup.tsx
@@ -15,7 +15,7 @@ interface FilterSearchGroupProps {
   filter?: Filter;
   name: string;
   title?: string;
-  onChange?: (value: string, name?: string) => void;
+  onChange?: (value: string, name: string) => void;
 }
 
 const FilterSearchGroup = ({
@@ -40,7 +40,13 @@ const FilterSearchGroup = ({
 
   return (
     <FormGroup title={title}>
-      <TextField name={name} value={filterVal} onChange={onChange} />
+      <TextField
+        name={name}
+        value={filterVal}
+        onChange={
+          onChange as ((value: string, name?: string) => void) | undefined
+        }
+      />
     </FormGroup>
   );
 };

--- a/src/web/components/powerfilter/FilterStringGroup.tsx
+++ b/src/web/components/powerfilter/FilterStringGroup.tsx
@@ -12,7 +12,7 @@ import useTranslation from 'web/hooks/useTranslation';
 interface FilterStringGroupProps {
   filter: string | Filter;
   name?: string;
-  onChange?: (value: string, name?: string) => void;
+  onChange?: (value: string, name: string) => void;
 }
 
 const FilterStringGroup = ({
@@ -31,7 +31,9 @@ const FilterStringGroup = ({
         name={name}
         size="30"
         value={filterString}
-        onChange={onChange}
+        onChange={
+          onChange as ((value: string, name?: string) => void) | undefined
+        }
       />
     </FormGroup>
   );

--- a/src/web/components/powerfilter/FirstResultGroup.tsx
+++ b/src/web/components/powerfilter/FirstResultGroup.tsx
@@ -13,7 +13,7 @@ interface FirstResultGroupProps {
   first?: number;
   filter?: Filter;
   name?: string;
-  onChange?: (value: number, name?: string) => void;
+  onChange?: (value: number, name: string) => void;
 }
 
 const FirstResultGroup = ({
@@ -34,7 +34,9 @@ const FirstResultGroup = ({
         name={name}
         type="int"
         value={first}
-        onChange={onChange}
+        onChange={
+          onChange as ((value: number, name?: string) => void) | undefined
+        }
       />
     </FormGroup>
   );

--- a/src/web/components/powerfilter/MinQodGroup.tsx
+++ b/src/web/components/powerfilter/MinQodGroup.tsx
@@ -13,7 +13,7 @@ interface MinQodGroupProps {
   qod?: number;
   filter?: Filter;
   name?: string;
-  onChange?: (value: number, name?: string) => void;
+  onChange?: (value: number, name: string) => void;
 }
 
 const MinQodGroup = ({
@@ -38,7 +38,9 @@ const MinQodGroup = ({
         step={1}
         type="int"
         value={qod}
-        onChange={onChange}
+        onChange={
+          onChange as ((value: number, name?: string) => void) | undefined
+        }
       />
       <span>%</span>
     </FormGroup>

--- a/src/web/components/powerfilter/ResultsPerPageGroup.tsx
+++ b/src/web/components/powerfilter/ResultsPerPageGroup.tsx
@@ -13,7 +13,7 @@ interface ResultsPerPageGroupProps {
   rows?: number;
   filter?: Filter;
   name?: string;
-  onChange?: (value: number, name?: string) => void;
+  onChange?: (value: number, name: string) => void;
 }
 
 const ResultsPerPageGroup = ({
@@ -30,7 +30,14 @@ const ResultsPerPageGroup = ({
 
   return (
     <FormGroup data-testid="results-per-page" title={_('Results per page')}>
-      <Spinner name={name} type="int" value={rows} onChange={onChange} />
+      <Spinner
+        name={name}
+        type="int"
+        value={rows}
+        onChange={
+          onChange as ((value: number, name?: string) => void) | undefined
+        }
+      />
     </FormGroup>
   );
 };

--- a/src/web/components/powerfilter/SeverityValuesGroup.tsx
+++ b/src/web/components/powerfilter/SeverityValuesGroup.tsx
@@ -14,9 +14,9 @@ import {UNSET_VALUE} from 'web/utils/Render';
 
 interface SeverityValuesGroupProps {
   filter: Filter;
-  name?: string;
+  name: string;
   title?: string;
-  onChange?: (value: number, name?: string, relation?: string) => void;
+  onChange?: (value: number, name: string, relation?: string) => void;
 }
 
 const SeverityValuesGroup = ({

--- a/src/web/components/powerfilter/TaskTrendGroup.tsx
+++ b/src/web/components/powerfilter/TaskTrendGroup.tsx
@@ -14,7 +14,7 @@ interface TaskTrendGroupProps {
   trend?: TaskTrend;
   name?: string;
   filter?: Filter;
-  onChange?: (value: TaskTrend, name?: string) => void;
+  onChange?: (value: TaskTrend, name: string) => void;
 }
 
 const TaskTrendGroup = ({
@@ -40,7 +40,9 @@ const TaskTrendGroup = ({
         ]}
         name={name}
         value={trend}
-        onChange={onChange as (value: string) => void}
+        onChange={
+          onChange as ((value: string, name?: string) => void) | undefined
+        }
       />
     </FormGroup>
   );

--- a/src/web/components/powerfilter/TicketStatusGroup.tsx
+++ b/src/web/components/powerfilter/TicketStatusGroup.tsx
@@ -14,7 +14,7 @@ interface TicketStatusFilterGroupProps {
   status?: TicketStatus;
   filter?: Filter;
   name?: string;
-  onChange: (value: TicketStatus, name?: string) => void;
+  onChange: (value: TicketStatus, name: string) => void;
 }
 
 const TicketStatusFilterGroup = ({
@@ -41,7 +41,9 @@ const TicketStatusFilterGroup = ({
         ]}
         name={name}
         value={status}
-        onChange={onChange as (value: string) => void}
+        onChange={
+          onChange as ((value: string, name?: string) => void) | undefined
+        }
       />
     </FormGroup>
   );

--- a/src/web/components/powerfilter/useFilterDialog.tsx
+++ b/src/web/components/powerfilter/useFilterDialog.tsx
@@ -37,7 +37,7 @@ const useFilterDialog = <TFilterDialogState extends FilterDialogState>(
   }, []);
 
   const handleFilterValueChange = useCallback(
-    (value: string, name: string, relation: string = '=') => {
+    (value: string | number, name: string, relation: string = '=') => {
       setFilter(filter => filter.copy().set(name, value, relation));
     },
     [],


### PR DESCRIPTION
## What

Update Powerfilter component name and onChange handler prop types


## Why

The name is always provided or needs always to be provided. Therefore it is always available on the onChange handler.

It is always a bit difficult to get this right, but from the usage in the filter dialogs of each list page it is expected that name is defined and provided in the callback handler.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


