### PR TITLE
Use TypeScript for ReportImportDialog

### DIFF
--- a/src/web/pages/reports/ListPage.jsx
+++ b/src/web/pages/reports/ListPage.jsx
@@ -24,7 +24,7 @@ import ReportsDashboard, {
   REPORTS_DASHBOARD_ID,
 } from 'web/pages/reports/dashboard';
 import ReportFilterDialog from 'web/pages/reports/FilterDialog';
-import ImportReportDialog from 'web/pages/reports/ImportDialog';
+import ReportImportDialog from 'web/pages/reports/ReportImportDialog';
 import ReportsTable from 'web/pages/reports/Table';
 import ContainerTaskDialog from 'web/pages/tasks/ContainerTaskDialog';
 import {
@@ -218,7 +218,7 @@ class Page extends React.Component {
           onUploadReportClick={this.openImportDialog}
         />
         {importDialogVisible && (
-          <ImportReportDialog
+          <ReportImportDialog
             task_id={task_id}
             tasks={tasks}
             onClose={this.handleCloseImportDialog}

--- a/src/web/pages/reports/ReportImportDialog.tsx
+++ b/src/web/pages/reports/ReportImportDialog.tsx
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-import {YES_VALUE} from 'gmp/parser';
+import Task from 'gmp/models/task';
+import {YES_VALUE, YesNo} from 'gmp/parser';
 import SaveDialog from 'web/components/dialog/SaveDialog';
 import FileField from 'web/components/form/FileField';
 import FormGroup from 'web/components/form/FormGroup';
@@ -12,21 +12,46 @@ import Select from 'web/components/form/Select';
 import YesNoRadio from 'web/components/form/YesNoRadio';
 import {NewIcon} from 'web/components/icon';
 import useTranslation from 'web/hooks/useTranslation';
-import PropTypes from 'web/utils/PropTypes';
-import {renderSelectItems} from 'web/utils/Render';
-const ImportDialog = ({
+import {RenderSelectItemProps, renderSelectItems} from 'web/utils/Render';
+
+interface ReportImportDialogState {
+  task_id: string;
+}
+
+interface ReportImportDialogDefaultsState {
+  in_assets: YesNo;
+  xml_file?: File;
+}
+
+export type ReportImportDialogData = ReportImportDialogState &
+  ReportImportDialogDefaultsState;
+
+interface ReportImportDialogProps {
+  in_assets?: YesNo;
+  newContainerTask?: boolean;
+  task_id: string;
+  tasks: Task[];
+  onClose: () => void;
+  onNewContainerTaskClick?: () => void;
+  onSave: (values: ReportImportDialogData) => void;
+  onTaskChange?: (taskId: string) => void;
+}
+
+const ReportImportDialog = ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   in_assets = YES_VALUE,
   newContainerTask = true,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   task_id,
   tasks,
   onClose,
   onNewContainerTaskClick,
   onSave,
   onTaskChange,
-}) => {
+}: ReportImportDialogProps) => {
   const [_] = useTranslation();
   return (
-    <SaveDialog
+    <SaveDialog<ReportImportDialogState, ReportImportDialogDefaultsState>
       buttonTitle={_('Import')}
       defaultValues={{in_assets}}
       title={_('Import Report')}
@@ -42,13 +67,14 @@ const ImportDialog = ({
           <FormGroup direction="row" title={_('Container Task')}>
             <Select
               grow="1"
-              items={renderSelectItems(tasks)}
+              items={renderSelectItems(tasks as RenderSelectItemProps[])}
               name="task_id"
               value={values.task_id}
               onChange={onTaskChange}
             />
             {newContainerTask && (
               <NewIcon
+                data-testid="new-container-task"
                 title={_('Create new Container Task')}
                 onClick={onNewContainerTaskClick}
               />
@@ -70,16 +96,4 @@ const ImportDialog = ({
   );
 };
 
-ImportDialog.propTypes = {
-  in_assets: PropTypes.yesno,
-  newContainerTask: PropTypes.bool,
-  task_id: PropTypes.id,
-  tasks: PropTypes.array,
-  title: PropTypes.string,
-  onClose: PropTypes.func.isRequired,
-  onNewContainerTaskClick: PropTypes.func,
-  onSave: PropTypes.func.isRequired,
-  onTaskChange: PropTypes.func,
-};
-
-export default ImportDialog;
+export default ReportImportDialog;

--- a/src/web/pages/reports/__tests__/ReportImportDialog.test.tsx
+++ b/src/web/pages/reports/__tests__/ReportImportDialog.test.tsx
@@ -1,0 +1,164 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect, testing} from '@gsa/testing';
+import {fireEvent, openSelectElement, render, screen} from 'web/testing';
+import Task from 'gmp/models/task';
+import {YES_VALUE} from 'gmp/parser';
+import ReportImportDialog from 'web/pages/reports/ReportImportDialog';
+
+describe('ReportImportDialog tests', () => {
+  test('renders with default values', async () => {
+    const tasks = [
+      new Task({id: '1', name: 'Task 1'}),
+      new Task({id: '2', name: 'Task 2'}),
+    ];
+    const onSave = testing.fn();
+    const onClose = testing.fn();
+
+    render(
+      <ReportImportDialog
+        task_id="1"
+        tasks={tasks}
+        onClose={onClose}
+        onSave={onSave}
+      />,
+    );
+
+    expect(screen.getByText('Import Report')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Import'})).toBeInTheDocument();
+    expect(screen.getByName('task_id')).toHaveValue('1');
+    expect(screen.getByTestId('new-container-task')).toBeInTheDocument();
+    expect(screen.getByName('in_assets')).toBeChecked();
+  });
+
+  test('should call onSave', async () => {
+    const tasks = [
+      new Task({id: '1', name: 'Task 1'}),
+      new Task({id: '2', name: 'Task 2'}),
+    ];
+    const onSave = testing.fn();
+    const onClose = testing.fn();
+
+    render(
+      <ReportImportDialog
+        task_id="2"
+        tasks={tasks}
+        onClose={onClose}
+        onSave={onSave}
+      />,
+    );
+
+    const importButton = screen.getDialogSaveButton();
+    fireEvent.click(importButton);
+
+    expect(onSave).toHaveBeenCalledWith({
+      task_id: '2',
+      in_assets: YES_VALUE,
+      xml_file: undefined,
+    });
+  });
+
+  test('should call onClose when dialog is closed', async () => {
+    const tasks = [
+      new Task({id: '1', name: 'Task 1'}),
+      new Task({id: '2', name: 'Task 2'}),
+    ];
+    const onSave = testing.fn();
+    const onClose = testing.fn();
+
+    render(
+      <ReportImportDialog
+        task_id="1"
+        tasks={tasks}
+        onClose={onClose}
+        onSave={onSave}
+      />,
+    );
+
+    const closeButton = screen.getDialogCloseButton();
+    fireEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('should allow to change task', async () => {
+    const tasks = [
+      new Task({id: '1', name: 'Task 1'}),
+      new Task({id: '2', name: 'Task 2'}),
+    ];
+    const onSave = testing.fn();
+    const onClose = testing.fn();
+    const onTaskChange = testing.fn();
+
+    render(
+      <ReportImportDialog
+        task_id="1"
+        tasks={tasks}
+        onClose={onClose}
+        onSave={onSave}
+        onTaskChange={onTaskChange}
+      />,
+    );
+
+    const select = screen.getByName('task_id') as HTMLSelectElement;
+    await openSelectElement(select);
+
+    const items = screen.getSelectItemElements();
+    fireEvent.click(items[1]); // Select "Task 2"
+    expect(onTaskChange).toHaveBeenCalledWith('2', 'task_id');
+  });
+
+  test("should allow to change 'in_assets' value", async () => {
+    const tasks = [
+      new Task({id: '1', name: 'Task 1'}),
+      new Task({id: '2', name: 'Task 2'}),
+    ];
+    const onSave = testing.fn();
+    const onClose = testing.fn();
+
+    render(
+      <ReportImportDialog
+        task_id="1"
+        tasks={tasks}
+        onClose={onClose}
+        onSave={onSave}
+      />,
+    );
+
+    const radios = screen.getAllByName('in_assets');
+    expect(radios[0]).toBeChecked(); // Default is YES_VALUE
+    fireEvent.click(radios[1]); // Change to NO_VALUE
+    expect(radios[1]).toBeChecked();
+  });
+
+  test('should allow to add a file', async () => {
+    const tasks = [
+      new Task({id: '1', name: 'Task 1'}),
+      new Task({id: '2', name: 'Task 2'}),
+    ];
+    const onSave = testing.fn();
+    const onClose = testing.fn();
+
+    render(
+      <ReportImportDialog
+        task_id="1"
+        tasks={tasks}
+        onClose={onClose}
+        onSave={onSave}
+      />,
+    );
+
+    const fileInput = screen.getByName('xml_file');
+    fireEvent.change(fileInput, {target: {files: ['bar']}});
+    const importButton = screen.getDialogSaveButton();
+    fireEvent.click(importButton);
+
+    expect(onSave).toHaveBeenCalledWith({
+      task_id: '1',
+      in_assets: YES_VALUE,
+      xml_file: 'bar',
+    });
+  });
+});

--- a/src/web/pages/tasks/TaskComponentComponent.jsx
+++ b/src/web/pages/tasks/TaskComponentComponent.jsx
@@ -19,7 +19,7 @@ import useGmp from 'web/hooks/useGmp';
 import useShallowEqualSelector from 'web/hooks/useShallowEqualSelector';
 import useTranslation from 'web/hooks/useTranslation';
 import AlertComponent from 'web/pages/alerts/AlertComponent';
-import ImportReportDialog from 'web/pages/reports/ImportDialog';
+import ReportImportDialog from 'web/pages/reports/ReportImportDialog';
 import ScheduleComponent from 'web/pages/schedules/ScheduleComponent';
 import TargetComponent from 'web/pages/targets/Component';
 import ContainerTaskDialog from 'web/pages/tasks/ContainerTaskDialog';
@@ -854,7 +854,7 @@ const TaskComponent = ({
       )}
 
       {reportImportDialogVisible && (
-        <ImportReportDialog
+        <ReportImportDialog
           newContainerTask={false}
           task_id={taskId}
           tasks={tasks}


### PR DESCRIPTION


## What

Use TypeScript for ReportImportDialog

## Why

Also add tests and rename module to the components name. The dialog is used in the TaskComponent

## References

https://jira.greenbone.net/browse/GEA-1153

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


