### PR TITLE
Use TypeScript for FilterProvider component

### DIFF
--- a/src/web/entities/FilterProvider.tsx
+++ b/src/web/entities/FilterProvider.tsx
@@ -4,30 +4,33 @@
  */
 
 import React from 'react';
+import Filter from 'gmp/models/filter';
 import Loading from 'web/components/loading/Loading';
 import usePageFilter from 'web/hooks/usePageFilter';
-import PropTypes from 'web/utils/PropTypes';
+
+interface FilterProviderRenderProps {
+  filter: Filter;
+}
+
+interface FilterProviderProps {
+  fallbackFilter?: Filter;
+  gmpname: string;
+  pageName?: string;
+  children: (props: FilterProviderRenderProps) => React.ReactNode;
+}
 
 const FilterProvider = ({
   children,
   fallbackFilter,
   gmpname,
   pageName = gmpname,
-}) => {
+}: FilterProviderProps) => {
   const [returnedFilter, isLoadingFilter] = usePageFilter(pageName, gmpname, {
     fallbackFilter,
   });
   return (
-    <React.Fragment>
-      {isLoadingFilter ? <Loading /> : children({filter: returnedFilter})}
-    </React.Fragment>
+    <>{isLoadingFilter ? <Loading /> : children({filter: returnedFilter})}</>
   );
-};
-
-FilterProvider.propTypes = {
-  fallbackFilter: PropTypes.filter,
-  gmpname: PropTypes.string,
-  pageName: PropTypes.string,
 };
 
 export default FilterProvider;

--- a/src/web/entities/__tests__/FilterProvider.test.tsx
+++ b/src/web/entities/__tests__/FilterProvider.test.tsx
@@ -5,42 +5,15 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, screen} from 'web/testing';
-import {beforeEach, vi} from 'vitest';
 import Filter, {DEFAULT_FALLBACK_FILTER} from 'gmp/models/filter';
 import FilterProvider from 'web/entities/FilterProvider';
 import {pageFilter} from 'web/store/pages/actions';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
 import {loadingActions} from 'web/store/usersettings/defaults/actions';
 
-let mockSearchParams = {};
-const mockUseNavigate = vi.fn();
-const mockUseSearchParams = vi
-  .fn()
-  .mockReturnValue([
-    {get: key => mockSearchParams[key]},
-    {set: (key, value) => (mockSearchParams[key] = value)},
-  ]);
-
-vi.mock('react-router', async () => {
-  const actual = await vi.importActual('react-router');
-  return {
-    ...actual,
-    useLocation: () => ({pathname: '/'}),
-    useNavigate: () => mockUseNavigate(),
-    useSearchParams: () => mockUseSearchParams(),
-  };
-});
-
-beforeEach(() => {
-  mockSearchParams = {};
-});
-
 describe('FilterProvider component tests', () => {
   test('should prefer search params filter over defaultSettingFilter', async () => {
     const resultingFilter = Filter.fromString('location=query rows=42');
-
-    mockSearchParams['filter'] = 'location=query';
-
     const defaultSettingFilter = Filter.fromString('foo=bar');
 
     const getSetting = testing.fn().mockResolvedValue({});
@@ -54,6 +27,7 @@ describe('FilterProvider component tests', () => {
       gmp,
       store: true,
       router: true,
+      route: '/task?filter=location=query',
     });
 
     store.dispatch(loadingActions.success({rowsperpage: {value: '42'}}));


### PR DESCRIPTION
## What

Use TypeScript for FilterProvider component

## Why
FilterProvider is used in withEntitiesContainer and therefore in every list page. To convert withEntitiesContainer to TypeScript FilterProvider should to be converted top.

## References

https://jira.greenbone.net/browse/GEA-1153

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


