### PR TITLE
filter prop of TaskFilterDialog is optional

### DIFF
--- a/src/web/pages/tasks/TaskFilterDialog.tsx
+++ b/src/web/pages/tasks/TaskFilterDialog.tsx
@@ -23,7 +23,7 @@ import useCapabilities from 'web/hooks/useCapabilities';
 import useTranslation from 'web/hooks/useTranslation';
 
 interface TaskFilterDialogProps {
-  filter: Filter;
+  filter?: Filter;
   onClose?: () => void;
   onCloseClick?: () => void; // should be removed in future
   onFilterChanged?: (filter: Filter) => void;


### PR DESCRIPTION


## What

filter prop of TaskFilterDialog is optional

## Why

There might be no filter at all.