### PR TITLE
Introduce a Filter identifier method

### DIFF
--- a/src/gmp/models/__tests__/filter.test.ts
+++ b/src/gmp/models/__tests__/filter.test.ts
@@ -1464,3 +1464,23 @@ describe('Filter merge', () => {
     expect(filter3.toFilterString()).toEqual('foo=bar rows=10 first=1');
   });
 });
+
+describe('Filter identifier', () => {
+  test('should return identifier', () => {
+    const filter = Filter.fromString('foo=bar');
+    expect(filter.identifier()).toEqual('foo=bar');
+  });
+
+  test('should use filter terms for identifier', () => {
+    const filter = Filter.fromString('foo=bar first=1 rows=10');
+    expect(filter.identifier()).toEqual('foo=bar first=1 rows=10');
+  });
+
+  test('should use different identifiers for different filter term order', () => {
+    const filter1 = Filter.fromString('foo=bar first=1 rows=10');
+    const filter2 = Filter.fromString('rows=10 first=1 foo=bar');
+    expect(filter1.identifier()).toEqual('foo=bar first=1 rows=10');
+    expect(filter2.identifier()).toEqual('rows=10 first=1 foo=bar');
+    expect(filter1.identifier()).not.toEqual(filter2.identifier());
+  });
+});

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -493,6 +493,15 @@ class Filter extends EntityModel {
   }
 
   /**
+   * Provides a unique identifier string for the filter
+   *
+   * @returns A string representation of this filter to be used as an identifier
+   */
+  identifier() {
+    return this.toFilterString();
+  }
+
+  /**
    * Compare this filter with another filter
    *
    * @param {Filter|undefined|null} filter  Other filter to compare to.

--- a/src/web/pages/portlists/ListPage.jsx
+++ b/src/web/pages/portlists/ListPage.jsx
@@ -146,18 +146,17 @@ const PortListsPage = () => {
 
   useEffect(() => {
     /*
-     * Check if the filters are changed in a way that matters for fetching:
+     * Check if the filters are changed in a way that matters for fetching and
+     *  loading data from the store:
      * - Either the the previous filter wasn't defined yet
-     * - or the terms are different
-     * - or the normal equality check fails (for cases where both filters have IDs).
+     * - the filter is defined and loaded
+     * - the filter identifier is different from the previous one
      */
-
     const shouldFetch =
       isDefined(filter) &&
       !isLoadingFilter &&
-      (!isDefined(previousFilter) ||
-        filter.toFilterString() !== previousFilter?.toFilterString() ||
-        !filter.equals(previousFilter));
+      filter.identifier() !== previousFilter?.identifier();
+
     if (shouldFetch) {
       fetch(filter);
     }

--- a/src/web/pages/user-settings/__tests__/FilterSettings.test.tsx
+++ b/src/web/pages/user-settings/__tests__/FilterSettings.test.tsx
@@ -6,6 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, within, wait, rendererWith, fireEvent} from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
+import Filter from 'gmp/models/filter';
 import FilterSettings from 'web/pages/user-settings/FilterSettings';
 
 const USER_SETTINGS_DEFAULT_FILTER_LOADING_SUCCESS =
@@ -20,10 +21,6 @@ function createGmpMock() {
       renewSession: testing.fn().mockResolvedValue({data: 123}),
     },
   };
-}
-
-function createFilterString(id, name) {
-  return `${name} (${id})`;
 }
 
 describe('FilterSettings', () => {
@@ -81,20 +78,11 @@ describe('FilterSettings', () => {
 
     const entityTypes = Object.keys(entityTypeToDisplayName);
 
-    const createMockFilter = (id, name) => ({
-      id,
-      name,
-      toFilterString: testing
-        .fn()
-        .mockReturnValue(createFilterString(id, name)),
-      _id: id,
-    });
-
     entityTypes.forEach(entityType => {
-      const mockFilter = createMockFilter(
-        `${entityType}-filter-uuid`,
-        `${entityType} Filter`,
-      );
+      const mockFilter = new Filter({
+        id: `${entityType}-filter-uuid`,
+        name: `${entityType} Filter`,
+      });
       store.dispatch({
         type: USER_SETTINGS_DEFAULT_FILTER_LOADING_SUCCESS,
         entityType,
@@ -143,6 +131,7 @@ describe('FilterSettings', () => {
       }),
     ).toHaveAttribute('href', '/filter/dfncert-filter-uuid');
   });
+
   test('handles filter selection changes and saves correctly', async () => {
     const gmp = createGmpMock();
     const {render, store} = rendererWith({
@@ -157,25 +146,25 @@ describe('FilterSettings', () => {
         id: 'alert-filter-uuid',
         name: 'Alert Filter',
         filter_type: 'alert',
-        toFilterString: () => 'Alert Filter (alert-filter-uuid)',
+        identifier: () => 'Alert Filter (alert-filter-uuid)',
       },
       {
         id: 'alert-filter-uuid-2',
         name: 'Alert Filter 2',
         filter_type: 'alert',
-        toFilterString: () => 'Alert Filter 2 (alert-filter-uuid-2)',
+        identifier: () => 'Alert Filter 2 (alert-filter-uuid-2)',
       },
       {
         id: 'credential-filter-uuid',
         name: 'Credential Filter',
         filter_type: 'credential',
-        toFilterString: () => 'Credential Filter (credential-filter-uuid)',
+        identifier: () => 'Credential Filter (credential-filter-uuid)',
       },
       {
         id: 'credential-filter-uuid-2',
         name: 'Credential Filter 2',
         filter_type: 'credential',
-        toFilterString: () => 'Credential Filter 2 (credential-filter-uuid-2)',
+        identifier: () => 'Credential Filter 2 (credential-filter-uuid-2)',
       },
     ];
 

--- a/src/web/pages/user-settings/__tests__/UserSettingsPage.test.tsx
+++ b/src/web/pages/user-settings/__tests__/UserSettingsPage.test.tsx
@@ -6,6 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, within, rendererWith, wait} from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
+import Filter from 'gmp/models/filter';
 import Setting from 'gmp/models/setting';
 import UserSettingsPage, {
   ToolBarIcons,
@@ -13,8 +14,6 @@ import UserSettingsPage, {
 import {setTimezone} from 'web/store/usersettings/actions';
 import {USER_SETTINGS_DEFAULT_FILTER_LOADING_SUCCESS} from 'web/store/usersettings/defaultfilters/actions';
 import {USER_SETTINGS_DEFAULTS_LOADING_SUCCESS} from 'web/store/usersettings/defaults/actions';
-
-const createFilterString = (id, name) => `${id}=${name}`;
 
 const manualUrl = 'test/';
 
@@ -675,15 +674,6 @@ describe('UserSettingsPage', () => {
         store: true,
       });
 
-      const createMockFilter = (id, name) => ({
-        id,
-        name,
-        toFilterString: testing
-          .fn()
-          .mockReturnValue(createFilterString(id, name)),
-        _id: id,
-      });
-
       const entityTypeToDisplayName = {
         alert: 'Alerts',
         auditreport: 'Audit Reports',
@@ -720,15 +710,15 @@ describe('UserSettingsPage', () => {
       const entityTypes = Object.keys(entityTypeToDisplayName);
 
       entityTypes.forEach(entityType => {
-        const mockFilter = createMockFilter(
-          `${entityType}-filter-uuid`,
-          `${entityType} Filter`,
-        );
+        const filter = new Filter({
+          id: `${entityType}-filter-uuid`,
+          name: `${entityType} Filter`,
+        });
 
         store.dispatch({
           type: USER_SETTINGS_DEFAULT_FILTER_LOADING_SUCCESS,
           entityType,
-          filter: mockFilter,
+          filter,
         });
       });
 

--- a/src/web/store/utils.js
+++ b/src/web/store/utils.js
@@ -12,9 +12,8 @@ import {hasValue} from 'gmp/utils/identity';
  *
  * @returns {String} A filter identifier to be used in the store
  */
-
 export const filterIdentifier = filter =>
-  hasValue(filter) ? `filter:${filter.toFilterString()}` : 'default';
+  hasValue(filter) ? `filter:${filter.identifier()}` : 'default';
 
 /**
  * A combineReducers version to allow to return undefined for a state.


### PR DESCRIPTION

## What

Introduce a Filter identifier method

## Why

The identifier method returns a unique string for being used in the store. By adding an explicit method for the identifier we can change the implementation details without having to change the toFilterString method which the store relied on before. For example we could consider the id as part of the identifier in future or consider the order of terms irrelevant.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


