### PR TITLE
Fix rendering of ReportListPage after withEntitiesContainer refactoring

### DIFF
--- a/src/web/pages/reports/ListPage.jsx
+++ b/src/web/pages/reports/ListPage.jsx
@@ -37,7 +37,6 @@ import {
 } from 'web/store/entities/tasks';
 import compose from 'web/utils/Compose';
 import PropTypes from 'web/utils/PropTypes';
-import withGmp from 'web/utils/withGmp';
 import withTranslation from 'web/utils/withTranslation';
 
 const CONTAINER_TASK_FILTER = Filter.fromString('target=""');
@@ -273,13 +272,12 @@ const FALLBACK_REPORT_LIST_FILTER = Filter.fromString(
 );
 
 export default compose(
-  withTranslation,
-  withGmp,
-  connect(mapStateToProps, mapDispatchToProps),
   withEntitiesContainer('report', {
     fallbackFilter: FALLBACK_REPORT_LIST_FILTER,
     entitiesSelector,
     loadEntities,
     reloadInterval: reportsReloadInterval,
   }),
+  connect(mapStateToProps, mapDispatchToProps),
+  withTranslation,
 )(Page);


### PR DESCRIPTION


## What

Fix rendering of ReportListPage after withEntitiesContainer refactoring

## Why

Reorder applied HOCs for the ReportListPage to fix its rendering. The withEntitiesContainer HOC has been refactored and doesn't forward all props unsolicitedly anymore. Just forwarding all props has the disadvantage of figuring out where the prop actually comes from. Therefore being explicit about the props is better at the end.