### PR TITLE
fix: creating list of different entity

### DIFF
--- a/src/web/pages/alerts/AlertComponent.jsx
+++ b/src/web/pages/alerts/AlertComponent.jsx
@@ -1022,7 +1022,7 @@ const AlertComponent = ({
       onSaveError={onSaveError}
       onSaved={onSaved}
     >
-      {({save, ...other}) => (
+      {({save, create, ...other}) => (
         <Layout>
           {children({
             ...other,
@@ -1161,7 +1161,8 @@ const AlertComponent = ({
               onReportConfigsChange={handleReportConfigsChange}
               onReportFormatsChange={handleReportFormatsChange}
               onSave={d => {
-                return save(d).then(() => closeAlertDialog());
+                const promise = isDefined(d.id) ? save(d) : create(d);
+                return promise.then(() => closeAlertDialog());
               }}
               onScpCredentialChange={handleScpCredentialChange}
               onSmbCredentialChange={handleSmbCredentialChange}

--- a/src/web/pages/credentials/CredentialsComponent.jsx
+++ b/src/web/pages/credentials/CredentialsComponent.jsx
@@ -148,7 +148,7 @@ const CredentialsComponent = ({
       onSaveError={onSaveError}
       onSaved={onSaved}
     >
-      {({save, ...other}) => (
+      {({save, create, ...other}) => (
         <>
           {children({
             ...other,
@@ -162,7 +162,8 @@ const CredentialsComponent = ({
               {...dialogProps}
               onClose={handleCloseCredentialDialog}
               onSave={d => {
-                return save(d).then(() => closeCredentialDialog());
+                const promise = isDefined(d.id) ? save(d) : create(d);
+                return promise.then(() => closeCredentialDialog());
               }}
             />
           )}

--- a/src/web/pages/filters/FilterComponent.jsx
+++ b/src/web/pages/filters/FilterComponent.jsx
@@ -142,7 +142,7 @@ const FilterComponent = ({
       onSaveError={onSaveError}
       onSaved={onSaved}
     >
-      {({save, ...other}) => (
+      {({save, create, ...other}) => (
         <>
           {children({
             ...other,
@@ -160,7 +160,8 @@ const FilterComponent = ({
               types={types}
               onClose={handleCloseFilterDialog}
               onSave={d => {
-                return save(d).then(() => closeFilterDialog());
+                const promise = isDefined(d.id) ? save(d) : create(d);
+                return promise.then(() => closeFilterDialog());
               }}
             />
           )}

--- a/src/web/pages/groups/GroupComponent.jsx
+++ b/src/web/pages/groups/GroupComponent.jsx
@@ -77,7 +77,7 @@ const GroupComponent = ({
       onSaveError={onSaveError}
       onSaved={onSaved}
     >
-      {({save, ...other}) => (
+      {({save, create, ...other}) => (
         <>
           {children({
             ...other,
@@ -91,7 +91,8 @@ const GroupComponent = ({
               title={title}
               onClose={handleCloseGroupDialog}
               onSave={d => {
-                return save(d).then(() => closeGroupDialog());
+                const promise = isDefined(d.id) ? save(d) : create(d);
+                return promise.then(() => closeGroupDialog());
               }}
             />
           )}

--- a/src/web/pages/hosts/HostComponent.jsx
+++ b/src/web/pages/hosts/HostComponent.jsx
@@ -109,7 +109,7 @@ const HostComponent = ({
       onSaveError={onSaveError}
       onSaved={onSaved}
     >
-      {({save, ...other}) => (
+      {({save, create, ...other}) => (
         <>
           {children({
             ...other,
@@ -125,7 +125,8 @@ const HostComponent = ({
               title={title}
               onClose={handleCloseHostDialog}
               onSave={d => {
-                return save(d).then(() => closeHostDialog());
+                const promise = isDefined(d.id) ? save(d) : create(d);
+                return promise.then(() => closeHostDialog());
               }}
             />
           )}

--- a/src/web/pages/overrides/OverrideComponent.jsx
+++ b/src/web/pages/overrides/OverrideComponent.jsx
@@ -197,7 +197,7 @@ const OverrideComponent = ({
       onSaveError={onSaveError}
       onSaved={onSaved}
     >
-      {({save, ...other}) => (
+      {({save, create, ...other}) => (
         <>
           {children({
             ...other,
@@ -229,7 +229,8 @@ const OverrideComponent = ({
               title={title}
               onClose={handleCloseOverrideDialog}
               onSave={d => {
-                return save(d).then(() => closeOverrideDialog());
+                const promise = isDefined(d.id) ? save(d) : create(d);
+                return promise.then(() => closeOverrideDialog());
               }}
               {...initialProps}
             />

--- a/src/web/pages/permissions/PermissionsComponent.jsx
+++ b/src/web/pages/permissions/PermissionsComponent.jsx
@@ -200,7 +200,7 @@ const PermissionsComponent = ({
       onSaveError={onSaveError}
       onSaved={onSaved}
     >
-      {({save, ...other}) => (
+      {({save, create, ...other}) => (
         <>
           {children({
             ...other,
@@ -227,7 +227,8 @@ const PermissionsComponent = ({
               users={users}
               onClose={handleClosePermissionDialog}
               onSave={d => {
-                return save(d).then(() => closePermissionDialog());
+                const promise = isDefined(d.id) ? save(d) : create(d);
+                return promise.then(() => closePermissionDialog());
               }}
             />
           )}

--- a/src/web/pages/policies/PoliciesComponent.jsx
+++ b/src/web/pages/policies/PoliciesComponent.jsx
@@ -570,7 +570,7 @@ const PolicyComponent = ({
         onSaveError={onSaveError}
         onSaved={onSaved}
       >
-        {({save, ...other}) => (
+        {({save, create, ...other}) => (
           <>
             {children({
               ...other,
@@ -630,7 +630,8 @@ const PolicyComponent = ({
               <PolicyDialog
                 onClose={handleCloseCreatePolicyDialog}
                 onSave={d => {
-                  return save(d).then(() => closeCreatePolicyDialog());
+                  const promise = isDefined(d.id) ? save(d) : create(d);
+                  return promise.then(() => closeCreatePolicyDialog());
                 }}
               />
             )}

--- a/src/web/pages/roles/RoleComponent.jsx
+++ b/src/web/pages/roles/RoleComponent.jsx
@@ -186,7 +186,7 @@ const RoleComponent = ({
       onSaveError={onSaveError}
       onSaved={onSaved}
     >
-      {({save, ...other}) => (
+      {({save, create, ...other}) => (
         <>
           {children({
             ...other,
@@ -212,9 +212,8 @@ const RoleComponent = ({
               onDeletePermission={handleDeletePermission}
               onErrorClose={handleErrorClose}
               onSave={d => {
-                return save(d)
-                  .then(() => closeRoleDialog())
-                  .catch(e => setError(e.message));
+                const promise = isDefined(d.id) ? save(d) : create(d);
+                return promise.then(() => closeRoleDialog());
               }}
             />
           )}

--- a/src/web/pages/scanners/ScannerComponent.jsx
+++ b/src/web/pages/scanners/ScannerComponent.jsx
@@ -243,7 +243,7 @@ const ScannerComponent = ({
       onSaveError={onSaveError}
       onSaved={onSaved}
     >
-      {({save, ...other}) => (
+      {({save, create, ...other}) => (
         <>
           {children({
             ...other,
@@ -271,7 +271,8 @@ const ScannerComponent = ({
               onCredentialChange={handleCredentialChange}
               onNewCredentialClick={openCredentialsDialog}
               onSave={d => {
-                return save(d).then(() => closeScannerDialog());
+                const promise = isDefined(d.id) ? save(d) : create(d);
+                return promise.then(() => closeScannerDialog());
               }}
               onScannerCaPubChange={handleScannerCaPubChange}
               onScannerPortChange={handleScannerPortChange}

--- a/src/web/pages/schedules/ScheduleComponent.jsx
+++ b/src/web/pages/schedules/ScheduleComponent.jsx
@@ -109,7 +109,7 @@ const ScheduleComponent = ({
       onSaveError={onSaveError}
       onSaved={onSaved}
     >
-      {({save, ...other}) => (
+      {({save, create, ...other}) => (
         <>
           {children({
             ...other,
@@ -131,7 +131,8 @@ const ScheduleComponent = ({
               weekdays={weekdays}
               onClose={handleCloseScheduleDialog}
               onSave={d => {
-                return save(d).then(() => closeScheduleDialog());
+                const promise = isDefined(d.id) ? save(d) : create(d);
+                return promise.then(() => closeScheduleDialog());
               }}
             />
           )}

--- a/src/web/pages/tags/TagsComponent.jsx
+++ b/src/web/pages/tags/TagsComponent.jsx
@@ -207,7 +207,7 @@ const TagComponent = ({
       onSaveError={onSaveError}
       onSaved={onSaved}
     >
-      {({save, ...other}) => (
+      {({save, create, ...other}) => (
         <>
           {children({
             ...other,
@@ -232,7 +232,8 @@ const TagComponent = ({
               value={value}
               onClose={handleCloseTagDialog}
               onSave={d => {
-                return save(d).then(() => closeTagDialog());
+                const promise = isDefined(d.id) ? save(d) : create(d);
+                return promise.then(() => closeTagDialog());
               }}
               {...initialOptions}
             />

--- a/src/web/pages/targets/Component.jsx
+++ b/src/web/pages/targets/Component.jsx
@@ -228,7 +228,7 @@ function TargetComponent(props) {
       onSaveError={onSaveError}
       onSaved={onSaved}
     >
-      {({save, ...other}) => (
+      {({save, create, ...other}) => (
         <>
           {children({
             ...other,
@@ -269,9 +269,9 @@ function TargetComponent(props) {
               onNewCredentialsClick={openCredentialsDialog}
               onNewPortListClick={openPortListDialog}
               onPortListChange={handlePortListChange}
-              onSave={async d => {
-                await save(d);
-                closeTargetDialog();
+              onSave={d => {
+                const promise = isDefined(d.id) ? save(d) : create(d);
+                return promise.then(() => closeTargetDialog());
               }}
               onSmbCredentialChange={handleSmbCredentialChange}
               onSnmpCredentialChange={handleSnmpCredentialChange}

--- a/src/web/pages/users/UserComponent.jsx
+++ b/src/web/pages/users/UserComponent.jsx
@@ -111,7 +111,7 @@ const UserComponent = props => {
       onSaveError={onSaveError}
       onSaved={onSaved}
     >
-      {({save, ...other}) => (
+      {({save, create, ...other}) => (
         <>
           {children({
             ...other,
@@ -134,7 +134,8 @@ const UserComponent = props => {
               user={user}
               onClose={handleCloseUserDialog}
               onSave={d => {
-                return save(d).then(() => closeUserDialog());
+                const promise = isDefined(d.id) ? save(d) : create(d);
+                return promise.then(() => closeUserDialog());
               }}
             />
           )}


### PR DESCRIPTION
## What

fix creating new elements for the following:

- alerts
- credentials
- filters
- groups
- hosts
- overrides
- permissions
- policies
- roles
- scanners
- schedules
- tags
- targets
- users
- scanconfigs

## Why

With the change of differentiating between save and create in the dialog was not able to create new element any more.

## References

GEA-1189

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


