### PR TITLE
Fix opening task dialog for alert selection

### DIFF
--- a/src/web/pages/tasks/TaskDialog.tsx
+++ b/src/web/pages/tasks/TaskDialog.tsx
@@ -249,7 +249,7 @@ const TaskDialog = ({
   );
 
   const alertIds =
-    alert_ids.length === 1 && alert_ids[0] === '0' ? [] : alert_ids;
+    alert_ids.length === 1 && String(alert_ids[0]) === '0' ? [] : alert_ids;
 
   const alertItems = renderSelectItems(alerts);
 


### PR DESCRIPTION


## What

Fix opening task dialog for alert selection

## Why

It seems that task.alerts may contain alerts with ID 0. ID 0 is an invalid aka. empty ID. With the XML transformation XML strings with numbers are converted to numbers in JS/TS. Therefore the existing safety check in the TaskDialog failed and the MultiSelect element crashed. The filtering of the 0 alert ID should be moved to the Task parsing code in future too.


