### PR TITLE
Improve types of withTranslation HOC and add a test

### DIFF
--- a/src/web/components/dashboard/display/DataDisplay.tsx
+++ b/src/web/components/dashboard/display/DataDisplay.tsx
@@ -18,7 +18,9 @@ import IconDivider from 'web/components/layout/IconDivider';
 import Layout from 'web/components/layout/Layout';
 import Loading from 'web/components/loading/Loading';
 import Theme from 'web/utils/Theme';
-import withTranslation from 'web/utils/withTranslation';
+import withTranslation, {
+  WithTranslationComponentProps,
+} from 'web/utils/withTranslation';
 
 export interface State {
   showLegend?: boolean;
@@ -69,7 +71,7 @@ export interface DataDisplayProps<
   TState extends State,
   TTransformedData = TData,
   TTransformProps = Record<string, unknown>,
-> {
+> extends WithTranslationComponentProps {
   data: TData;
   dataRow: (data: TTransformedData) => string[];
   dataTitles: string[];
@@ -94,7 +96,6 @@ export interface DataDisplayProps<
   state: TState;
   title: TitleFunc<TTransformedData>;
   width: number;
-  _: (text: string, ...args: string[]) => string;
 }
 
 interface DataDisplayState<TData, TTransformedData> {

--- a/src/web/utils/__tests__/withTranslation.test.tsx
+++ b/src/web/utils/__tests__/withTranslation.test.tsx
@@ -1,0 +1,38 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect, testing} from '@gsa/testing';
+import {render, screen} from 'web/testing';
+import i18n from 'i18next';
+import _ from 'gmp/locale';
+
+import withTranslation, {
+  WithTranslationComponentProps,
+} from 'web/utils/withTranslation';
+
+interface MockComponentProps extends WithTranslationComponentProps {
+  someProp: string;
+}
+
+describe('withTranslation HOC', () => {
+  test('should render the wrapped component with translation props', () => {
+    const MockComponent = testing.fn(({_}: MockComponentProps) => (
+      <div>{_('Tasks')}</div>
+    ));
+    const WrappedComponent = withTranslation<MockComponentProps>(MockComponent);
+
+    render(<WrappedComponent someProp="test" />);
+
+    expect(MockComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _,
+        i18n,
+        someProp: 'test',
+      }),
+      {},
+    );
+    expect(screen.getByText('Tasks')).toBeInTheDocument();
+  });
+});

--- a/src/web/utils/withTranslation.tsx
+++ b/src/web/utils/withTranslation.tsx
@@ -7,40 +7,38 @@ import useLanguage from 'web/hooks/useLanguage';
 import useTranslation, {I18n, TranslateFunc} from 'web/hooks/useTranslation';
 import {updateDisplayName} from 'web/utils/displayName';
 
-interface TranslationProps {
+export interface WithTranslationComponentProps {
   _: TranslateFunc;
   i18n: I18n;
 }
+
+type WithTranslationProps<TProps> = Omit<TProps, '_' | 'i18n'>;
 
 /**
  * Higher-Order Component that provides translation capabilities to class components
  * and ensures reactivity when the language changes
  *
- * @param WrappedComponent - The component to wrap with translation capabilities
+ * @param Component - The component to wrap with translation capabilities
  * @returns A new component with translation props injected
  */
-const withTranslation = <TProps extends {} = {}>(
-  WrappedComponent: React.ComponentType<TProps & TranslationProps>,
+const withTranslation = <TProps extends WithTranslationComponentProps>(
+  Component: React.ComponentType<TProps>,
 ) => {
-  const WithTranslation = (props: TProps) => {
+  const WithTranslation = (props: WithTranslationProps<TProps>) => {
     const [_, i18n] = useTranslation();
     const [language] = useLanguage();
 
     // Using language as a key forces re-render of the component when language changes
     return (
-      <WrappedComponent
-        {...props}
+      <Component
+        {...(props as TProps)}
         key={`translation-wrapper-${language}`}
         _={_}
         i18n={i18n}
       />
     );
   };
-  return updateDisplayName(
-    WithTranslation,
-    WrappedComponent,
-    'withTranslation',
-  );
+  return updateDisplayName(WithTranslation, Component, 'withTranslation');
 };
 
 export default withTranslation;


### PR DESCRIPTION
## What

Improve types of withTranslation HOC and add a test

## Why
A component using the withTranslation should be aware of the props that are provided.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


