### PR TITLE
Improve excludeObjectProps function to be useable with as const arrays ## Why

### DIFF
--- a/src/gmp/utils/object.ts
+++ b/src/gmp/utils/object.ts
@@ -13,5 +13,7 @@ export const exclude = (object: {}, func: ExcludeFunc) =>
       return obj;
     }, {});
 
-export const excludeObjectProps = (object: {}, excludeArray: string[]) =>
-  exclude(object, key => excludeArray.includes(key));
+export const excludeObjectProps = (
+  object: {},
+  excludeArray: readonly string[],
+) => exclude(object, key => excludeArray.includes(key));


### PR DESCRIPTION


## What

Improve excludeObjectProps function to be useable with as const arrays
## Why

The list of to be excluded props is read only. This allows passing arrays marked with `as const`.

