### PR TITLE
 Improve types EntitiesFooter and EntitiesHeader HOCs

### DIFF
--- a/src/web/entities/createEntitiesFooter.tsx
+++ b/src/web/entities/createEntitiesFooter.tsx
@@ -6,12 +6,8 @@
 import EntitiesFooter, {EntitiesFooterProps} from 'web/entities/EntitiesFooter';
 import withEntitiesFooter from 'web/entities/withEntitiesFooter';
 
-function createEntitiesFooter<
-  TOptions extends EntitiesFooterProps = EntitiesFooterProps,
->(options: TOptions) {
-  return withEntitiesFooter<EntitiesFooterProps, EntitiesFooterProps>(options)(
-    EntitiesFooter,
-  );
+function createEntitiesFooter(options: Partial<EntitiesFooterProps>) {
+  return withEntitiesFooter<EntitiesFooterProps>(options)(EntitiesFooter);
 }
 
 export default createEntitiesFooter;

--- a/src/web/entities/createEntitiesHeader.tsx
+++ b/src/web/entities/createEntitiesHeader.tsx
@@ -50,10 +50,10 @@ interface CreateEntitiesHeaderColumn {
  *
  * @return A new EntitiesHeader component.
  */
-export function createEntitiesHeader<TOptions = {}>(
+export function createEntitiesHeader(
   columns: CreateEntitiesHeaderColumn[],
-  actionsColumn: ActionsColumn,
-  options: TOptions = {} as TOptions,
+  actionsColumn?: ActionsColumn,
+  options: Partial<CreateEntitiesHeaderProps> = {},
 ) {
   const Header = ({
     actionsColumn,
@@ -85,7 +85,7 @@ export function createEntitiesHeader<TOptions = {}>(
     </TableHeader>
   );
 
-  return withEntitiesHeader<CreateEntitiesHeaderProps, TOptions>(
+  return withEntitiesHeader<CreateEntitiesHeaderProps>(
     actionsColumn,
     options,
   )(Header);

--- a/src/web/entities/withEntitiesFooter.tsx
+++ b/src/web/entities/withEntitiesFooter.tsx
@@ -32,8 +32,7 @@ type WithEntitiesFooterProps<TProps> = EntitiesFooterWrapperProps &
 export function withEntitiesFooter<
   TProps extends
     WithEntitiesFooterComponentProps = WithEntitiesFooterComponentProps,
-  TOptions = {},
->(options: TOptions = {} as TOptions) {
+>(options: Partial<TProps> = {}) {
   return (Component: React.ComponentType<TProps>) => {
     const EntitiesFooterWrapper = ({
       onDownloadBulk,
@@ -43,7 +42,7 @@ export function withEntitiesFooter<
     }: WithEntitiesFooterProps<TProps>) => {
       return (
         <Component
-          {...(options as TOptions)}
+          {...options}
           {...(props as TProps)}
           onDeleteClick={onDeleteBulk}
           onDownloadClick={onDownloadBulk}

--- a/src/web/entities/withEntitiesHeader.tsx
+++ b/src/web/entities/withEntitiesHeader.tsx
@@ -45,12 +45,9 @@ export interface WithEntitiesHeaderComponentProps {
  *
  * @return A new EntitiesHeader component.
  */
-function withEntitiesHeader<
-  TProps extends WithEntitiesHeaderComponentProps,
-  TOptions = {},
->(
+function withEntitiesHeader<TProps extends WithEntitiesHeaderComponentProps>(
   actionsColumn: React.ReactElement | null | true = defaultActions,
-  options: TOptions = {} as TOptions,
+  options: Partial<TProps> = {},
 ) {
   return (Component: React.ComponentType<TProps>) => {
     if (!actionsColumn) {
@@ -68,7 +65,7 @@ function withEntitiesHeader<
       }
       return (
         <Component
-          {...(options as TOptions)}
+          {...options}
           {...(props as TProps)}
           actionsColumn={column}
           selectionType={selectionType}


### PR DESCRIPTION

## What

Improve types EntitiesFooter and EntitiesHeader HOCs

## Why

Use the same patter for the type information at all entities HOCs. A component using these HOCs need to extend from a specific interface if options are available these options need to be of the specific interface with optional properties.
