### PR TITLE
Fix select the same VT when editing an override

### DIFF
--- a/src/gmp/models/__tests__/note.test.ts
+++ b/src/gmp/models/__tests__/note.test.ts
@@ -119,12 +119,13 @@ describe('Note model tests', () => {
   test('should parse NVT', () => {
     const note = Note.fromElement({
       nvt: {
-        _id: '123abc',
+        _oid: '1.2.3',
         name: 'foo',
       },
     });
 
     expect(note.nvt).toBeInstanceOf(Nvt);
+    expect(note.nvt?.oid).toEqual('1.2.3');
     expect(note.name).toEqual('foo');
   });
 });

--- a/src/gmp/models/__tests__/override.test.ts
+++ b/src/gmp/models/__tests__/override.test.ts
@@ -118,11 +118,12 @@ describe('Override model tests', () => {
   test('should parse NVT', () => {
     const override = Override.fromElement({
       nvt: {
-        _id: '123abc',
+        _oid: '1.2.3',
         name: 'foo',
       },
     });
     expect(override.nvt).toBeInstanceOf(Nvt);
+    expect(override.nvt?.oid).toEqual('1.2.3');
     expect(override.name).toEqual('foo');
   });
 

--- a/src/gmp/models/note.ts
+++ b/src/gmp/models/note.ts
@@ -4,7 +4,7 @@
  */
 
 import Model, {ModelElement, ModelProperties} from 'gmp/models/model';
-import Nvt from 'gmp/models/nvt';
+import Nvt, {NvtNvtElement} from 'gmp/models/nvt';
 import {
   parseCsv,
   parseSeverity,
@@ -19,7 +19,7 @@ import {isDefined, isModelElement} from 'gmp/utils/identity';
 
 export interface NoteElement extends ModelElement {
   hosts?: string;
-  nvt?: ModelElement;
+  nvt?: NvtNvtElement;
   port?: string;
   result?: ModelElement;
   severity?: number;

--- a/src/gmp/models/nvt.ts
+++ b/src/gmp/models/nvt.ts
@@ -68,37 +68,39 @@ export interface NvtSeveritiesElement {
   severity?: SeverityElement | SeverityElement[];
 }
 
+export interface NvtNvtElement {
+  _oid?: string;
+  category?: number;
+  creation_time?: string;
+  cvss_base?: number;
+  default_timeout?: string | number;
+  epss?: NvtEpssElement;
+  family?: string;
+  modification_time?: string;
+  name?: string;
+  preference_count?: number;
+  preferences?: {
+    default_timeout?: string;
+    timeout?: string;
+    preference?: PreferenceElement | PreferenceElement[];
+  };
+  qod?: QoDParams;
+  refs?: {
+    ref?: NvtRefElement | NvtRefElement[];
+  };
+  severities?: NvtSeveritiesElement;
+  solution?: {
+    __text?: string;
+    _method?: string;
+    _type?: string;
+  };
+  tags?: string;
+  timeout?: string | number;
+}
+
 export interface NvtElement extends ModelElement {
   update_time?: string;
-  nvt?: {
-    _oid?: string;
-    category?: number;
-    creation_time?: string;
-    cvss_base?: number;
-    default_timeout?: string | number;
-    epss?: NvtEpssElement;
-    family?: string;
-    modification_time?: string;
-    name?: string;
-    preference_count?: number;
-    preferences?: {
-      default_timeout?: string;
-      timeout?: string;
-      preference?: PreferenceElement | PreferenceElement[];
-    };
-    qod?: QoDParams;
-    refs?: {
-      ref?: NvtRefElement | NvtRefElement[];
-    };
-    severities?: NvtSeveritiesElement;
-    solution?: {
-      __text?: string;
-      _method?: string;
-      _type?: string;
-    };
-    tags?: string;
-    timeout?: string | number;
-  };
+  nvt?: NvtNvtElement;
 }
 
 interface Preference {

--- a/src/gmp/models/override.ts
+++ b/src/gmp/models/override.ts
@@ -4,7 +4,7 @@
  */
 
 import Model, {ModelElement, ModelProperties} from 'gmp/models/model';
-import Nvt from 'gmp/models/nvt';
+import Nvt, {NvtNvtElement} from 'gmp/models/nvt';
 import {
   parseCsv,
   parseSeverity,
@@ -21,7 +21,7 @@ export interface OverrideElement extends ModelElement {
   hosts?: string;
   new_severity?: number;
   new_thread?: string;
-  nvt?: ModelElement;
+  nvt?: NvtNvtElement;
   port?: string;
   result?: ModelElement;
   severity?: number;
@@ -108,7 +108,7 @@ class Override extends Model {
     const ret = super.parseElement(element) as OverrideProperties;
 
     if (element.nvt) {
-      ret.nvt = Nvt.fromElement(element.nvt);
+      ret.nvt = Nvt.fromElement({nvt: element.nvt});
       ret.name = ret.nvt.name;
     }
 


### PR DESCRIPTION
## What

- Fix select the same VT when editing an override

## Why

- Cannot select the same VT when editing an override, expected different backend response structure.

## References

GEA-1189

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


