### PR TITLE
fix: scan config and policy dialog error

### DIFF
--- a/src/gmp/models/__tests__/policy.test.ts
+++ b/src/gmp/models/__tests__/policy.test.ts
@@ -28,7 +28,10 @@ describe('Policy model tests', () => {
     expect(policy.family_list).toEqual([]);
     expect(policy.nvts).toBeUndefined();
     expect(policy.predefined).toBeUndefined();
-    expect(policy.preferences).toBeUndefined();
+    expect(policy.preferences).toEqual({
+      nvt: [],
+      scanner: [],
+    });
     expect(policy.scanner).toBeUndefined();
     expect(policy.audits).toEqual([]);
   });

--- a/src/gmp/models/__tests__/policy.test.ts
+++ b/src/gmp/models/__tests__/policy.test.ts
@@ -17,7 +17,10 @@ describe('Policy model tests', () => {
     expect(policy.family_list).toEqual([]);
     expect(policy.nvts).toBeUndefined();
     expect(policy.predefined).toBeUndefined();
-    expect(policy.preferences).toBeUndefined();
+    expect(policy.preferences).toEqual({
+      nvt: [],
+      scanner: [],
+    });
     expect(policy.scanner).toBeUndefined();
     expect(policy.audits).toEqual([]);
   });

--- a/src/gmp/models/__tests__/scanconfig.test.ts
+++ b/src/gmp/models/__tests__/scanconfig.test.ts
@@ -19,7 +19,10 @@ describe('ScanConfig model tests', () => {
     expect(scanConfig.families).toBeUndefined();
     expect(scanConfig.nvts).toBeUndefined();
     expect(scanConfig.predefined).toBeUndefined();
-    expect(scanConfig.preferences).toBeUndefined();
+    expect(scanConfig.preferences).toEqual({
+      nvt: [],
+      scanner: [],
+    });
     expect(scanConfig.scanner).toBeUndefined();
     expect(scanConfig.tasks).toEqual([]);
   });

--- a/src/gmp/models/__tests__/scanconfig.test.ts
+++ b/src/gmp/models/__tests__/scanconfig.test.ts
@@ -30,7 +30,10 @@ describe('ScanConfig model tests', () => {
     expect(scanConfig.families).toEqual({count: 0});
     expect(scanConfig.nvts).toBeUndefined();
     expect(scanConfig.predefined).toBeUndefined();
-    expect(scanConfig.preferences).toBeUndefined();
+    expect(scanConfig.preferences).toEqual({
+      nvt: [],
+      scanner: [],
+    });
     expect(scanConfig.scanner).toBeUndefined();
     expect(scanConfig.tasks).toEqual([]);
   });

--- a/src/gmp/models/policy.ts
+++ b/src/gmp/models/policy.ts
@@ -73,7 +73,7 @@ class Policy extends Model {
   readonly family_list: PolicyFamily[];
   readonly nvts?: PolicyNvts;
   readonly predefined?: boolean;
-  readonly preferences?: PolicyPreferences;
+  readonly preferences: PolicyPreferences;
   readonly scanner?: Model;
   readonly audits: Model[];
 
@@ -83,7 +83,7 @@ class Policy extends Model {
     family_list = [],
     nvts,
     predefined,
-    preferences,
+    preferences = {nvt: [], scanner: []},
     scanner,
     audits = [],
     ...properties

--- a/src/gmp/models/policy.ts
+++ b/src/gmp/models/policy.ts
@@ -170,11 +170,11 @@ class Policy extends Model {
           nvtPreferences.push(pref);
         }
       });
-      ret.preferences = {
-        scanner: scannerPreferences,
-        nvt: nvtPreferences,
-      };
     }
+    ret.preferences = {
+      scanner: scannerPreferences,
+      nvt: nvtPreferences,
+    };
 
     if (isDefined(element.scanner)) {
       const scanner = {

--- a/src/gmp/models/scanconfig.ts
+++ b/src/gmp/models/scanconfig.ts
@@ -26,7 +26,6 @@ export interface ScanConfigPreferenceElement {
   nvt?: {
     name?: string;
     _oid?: string;
-    oid?: string;
   };
   type?: string;
   value?: ScanConfigPreferenceValue;
@@ -135,7 +134,7 @@ class ScanConfig extends Model {
   readonly families?: ScanConfigFamilies;
   readonly nvts?: ScanConfigNvts;
   readonly predefined?: boolean;
-  readonly preferences?: {
+  readonly preferences: {
     nvt: ScanConfigPreference[];
     scanner: ScanConfigPreference[];
   };
@@ -149,7 +148,7 @@ class ScanConfig extends Model {
     families,
     nvts,
     predefined,
-    preferences,
+    preferences = {nvt: [], scanner: []},
     scanner,
     tasks = [],
     ...properties

--- a/src/gmp/models/scanconfig.ts
+++ b/src/gmp/models/scanconfig.ts
@@ -26,6 +26,7 @@ export interface ScanConfigPreferenceElement {
   nvt?: {
     name?: string;
     _oid?: string;
+    oid?: string;
   };
   type?: string;
   value?: ScanConfigPreferenceValue;
@@ -242,11 +243,12 @@ class ScanConfig extends Model {
           nvtPreferences.push(pref);
         }
       });
-      ret.preferences = {
-        scanner: scannerPreferences,
-        nvt: nvtPreferences,
-      };
     }
+
+    ret.preferences = {
+      scanner: scannerPreferences,
+      nvt: nvtPreferences,
+    };
 
     if (isDefined(element.scanner)) {
       const scanner = {


### PR DESCRIPTION
## What

- On opening of the scancofig and policy edit dialog, it would display error.

## Why

- Object structure was missing key/value

## References

GEA-1195

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


