### PR TITLE
Update installing nodejs for Debian Trixie

### DIFF
--- a/.docker/prod.Dockerfile
+++ b/.docker/prod.Dockerfile
@@ -5,7 +5,6 @@ FROM debian:stable-slim AS builder
 
 ENV NODE_VERSION=node_20.x
 ENV NODE_KEYRING=/usr/share/keyrings/nodesource.gpg
-ENV DISTRIBUTION=bookworm
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -13,8 +12,8 @@ RUN apt-get update && \
     curl \
     gnupg
 
-RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee "$NODE_KEYRING" >/dev/null && \
-    echo "deb [signed-by=$NODE_KEYRING] https://deb.nodesource.com/$NODE_VERSION $DISTRIBUTION main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o "$NODE_KEYRING" >/dev/null && \
+    echo "deb [signed-by=$NODE_KEYRING] https://deb.nodesource.com/$NODE_VERSION nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## What

Update Dockerfile for installing nodejs for Debian Trixie

## Why

The base image is on Trixie now but the installation routine of nodejs still uses bookworm and therefore fails.

## References

https://github.com/greenbone/gsa/actions/runs/16905653650



