### PR TITLE
Use correct format for performance report start and end date

### DIFF
--- a/src/gmp/commands/performance.ts
+++ b/src/gmp/commands/performance.ts
@@ -136,8 +136,8 @@ class PerformanceCommand extends HttpCommand {
     if (isDefined(duration)) {
       params.duration = String(duration);
     } else if (isDefined(startDate) && isDefined(endDate)) {
-      params.start_time = startDate.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]');
-      params.end_time = endDate.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]');
+      params.start_time = startDate.format('YYYY-MM-DDTHH:mm:ssZ');
+      params.end_time = endDate.format('YYYY-MM-DDTHH:mm:ssZ');
     }
     const response = await this.httpGet(params);
     const data = response.data as GetSystemReportResponseData;

--- a/src/web/pages/performance/PerformancePage.tsx
+++ b/src/web/pages/performance/PerformancePage.tsx
@@ -128,7 +128,7 @@ const PerformancePage = () => {
     const scannerEntitiesSelector = scannerSelector(state);
     return scannerEntitiesSelector.getEntities(SENSOR_SCANNER_FILTER);
   });
-  const timezone = useShallowEqualSelector(getTimezone);
+  const timezone = useShallowEqualSelector<unknown, string>(getTimezone);
   const dispatch = useDispatch();
 
   const fetchScanners = useCallback(


### PR DESCRIPTION

## What

Use correct format for performance report start and end date

## Why

Fix the date format to include the timezone offset when requesting a performance report with start and end dates. The format has to include the actual timezone. Z always means UTC. Drop the microseconds from the dates too because they are unnecessary. This change includes also a test for providing both dates.

## References
https://jira.greenbone.net/browse/GEA-1221

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


