### PR TITLE
Improve getting the rendered element and the container

### DIFF
--- a/src/web/testing/Components.tsx
+++ b/src/web/testing/Components.tsx
@@ -17,7 +17,9 @@ import LicenseProvider from 'web/components/provider/LicenseProvider';
 export const Main = ({children}: {children: React.ReactNode}) => {
   return (
     <ThemeProvider defaultColorScheme="light">
-      <StyleSheetManager enableVendorPrefixes>{children}</StyleSheetManager>
+      <StyleSheetManager enableVendorPrefixes>
+        <div data-testid="main-container">{children}</div>
+      </StyleSheetManager>
     </ThemeProvider>
   );
 };

--- a/src/web/testing/Render.tsx
+++ b/src/web/testing/Render.tsx
@@ -41,17 +41,23 @@ export {renderHook} from '@testing-library/react/pure';
 afterEach(cleanup);
 
 export const render = (ui: React.ReactNode) => {
-  const {container, baseElement, rerender} = reactTestingRender(
-    <Main>{ui}</Main>,
-  );
+  const {
+    container: rtlContainer,
+    baseElement,
+    rerender,
+  } = reactTestingRender(<Main>{ui}</Main>);
 
+  const container = rtlContainer.querySelector<HTMLElement>(
+    '[data-testid="main-container"]',
+  ) as HTMLElement;
   return {
     userEvent: userEvent.setup({
       pointerEventsCheck: PointerEventsCheckLevel.Never,
     }),
     baseElement,
+    baseContainer: rtlContainer,
     container,
-    element: container.lastChild as HTMLElement,
+    element: container?.firstChild as HTMLElement,
     rerender: (component: React.ReactNode) =>
       rerender(<Main>{component}</Main>),
   };


### PR DESCRIPTION


## What

Improve getting the rendered element and the container

## Why

We render the style sheets in the react testing container and that results in a not expected container and element. Introduce a div element as parent of all rendered components which will be returned as the container. The original container is returned as baseContainer now.
