### PR TITLE
Build container images from tags (again)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - 'v24*'
+      - 'v*'
   pull_request:
     branches:
       - main
@@ -18,7 +18,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true 
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION

## What
Build container images from tags (again)

## Why

We released v25 and it didn't get noticed that we don't build new container images from the new GSA tags.