### PR TITLE
Don't cancel manually run container build from main

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -17,7 +17,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.ref-name || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION


## What

Don't cancel manually run container build from main

## Why

When starting a container image build manually github.ref will be main but we are building a for some different ref most likely for a tag. In this case all pushes to main will cancel the manually run container build despite it's building for a different ref. To fix this behavior use input.ref-name as an identifier for cancelling a workflow run and fallback to github.ref if it is not set.