### PR TITLE
Fix saving dashboard settings

### DIFF
--- a/src/gmp/commands/dashboards.js
+++ b/src/gmp/commands/dashboards.js
@@ -88,10 +88,10 @@ class DashboardCommand extends HttpCommand {
     });
   }
 
-  saveSetting(id, settings = {}) {
+  async saveSetting(id, settings = {}) {
     log.debug('Saving dashboard settings', id, settings);
 
-    return this.action({
+    await this.httpPost({
       setting_id: id,
       setting_value: JSON.stringify(settings),
       cmd: 'save_setting',


### PR DESCRIPTION
## What

Fix saving dashboard settings

## Why

action method is not available for commands deriving from HttpCommand. As save doesn't need to return anything we can use httpPost directly and return a Promise<void>.

## References
It got broken with https://github.com/greenbone/gsa/pull/4779

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


