### PR TITLE
Use TypeScript for RoleCommand and RolesCommand

### DIFF
--- a/src/gmp/commands/__tests__/role.test.ts
+++ b/src/gmp/commands/__tests__/role.test.ts
@@ -1,0 +1,60 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect} from '@gsa/testing';
+import {RoleCommand} from 'gmp/commands/roles';
+import {createHttp, createActionResultResponse} from 'gmp/commands/testing';
+
+describe('RoleCommand tests', () => {
+  test('should create a new role', async () => {
+    const response = createActionResultResponse({
+      action: 'create_role',
+      id: '123',
+      message: 'Role created successfully',
+    });
+    const fakeHttp = createHttp(response);
+
+    const cmd = new RoleCommand(fakeHttp);
+    const result = await cmd.create({
+      name: 'Test Role',
+      comment: 'A test role',
+    });
+    expect(fakeHttp.request).toHaveBeenCalledWith('post', {
+      data: {
+        cmd: 'create_role',
+        name: 'Test Role',
+        comment: 'A test role',
+        users: '',
+      },
+    });
+    expect(result.data).toEqual({id: '123'});
+  });
+
+  test('should save an existing role', async () => {
+    const response = createActionResultResponse({
+      action: 'save_role',
+      id: '123',
+      message: 'Role saved successfully',
+    });
+    const fakeHttp = createHttp(response);
+
+    const cmd = new RoleCommand(fakeHttp);
+    const result = await cmd.save({
+      id: '123',
+      name: 'Updated Role',
+      comment: 'Updated comment',
+    });
+    expect(fakeHttp.request).toHaveBeenCalledWith('post', {
+      data: {
+        cmd: 'save_role',
+        role_id: '123',
+        name: 'Updated Role',
+        comment: 'Updated comment',
+        users: '',
+      },
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/gmp/commands/__tests__/roles.test.ts
+++ b/src/gmp/commands/__tests__/roles.test.ts
@@ -1,0 +1,61 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect} from '@gsa/testing';
+import {RolesCommand} from 'gmp/commands/roles';
+import {createHttp, createEntitiesResponse} from 'gmp/commands/testing';
+import Role from 'gmp/models/role';
+
+describe('RolesCommand tests', () => {
+  test('should fetch roles with default params', async () => {
+    const response = createEntitiesResponse('role', [
+      {_id: '1', name: 'Admin'},
+      {_id: '2', name: 'User'},
+    ]);
+    const fakeHttp = createHttp(response);
+
+    const cmd = new RolesCommand(fakeHttp);
+    const result = await cmd.get();
+    expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+      args: {cmd: 'get_roles'},
+    });
+    expect(result.data).toEqual([
+      new Role({id: '1', name: 'Admin'}),
+      new Role({id: '2', name: 'User'}),
+    ]);
+  });
+
+  test('should fetch roles with custom params', async () => {
+    const response = createEntitiesResponse('role', [
+      {_id: '3', name: 'Guest'},
+    ]);
+    const fakeHttp = createHttp(response);
+
+    const cmd = new RolesCommand(fakeHttp);
+    const result = await cmd.get({filter: "name='Guest'"});
+    expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+      args: {cmd: 'get_roles', filter: "name='Guest'"},
+    });
+    expect(result.data).toEqual([new Role({id: '3', name: 'Guest'})]);
+  });
+
+  test('should fetch all roles', async () => {
+    const response = createEntitiesResponse('role', [
+      {_id: '4', name: 'Manager'},
+      {_id: '5', name: 'Editor'},
+    ]);
+    const fakeHttp = createHttp(response);
+
+    const cmd = new RolesCommand(fakeHttp);
+    const result = await cmd.getAll();
+    expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+      args: {cmd: 'get_roles', filter: 'first=1 rows=-1'},
+    });
+    expect(result.data).toEqual([
+      new Role({id: '4', name: 'Manager'}),
+      new Role({id: '5', name: 'Editor'}),
+    ]);
+  });
+});

--- a/src/gmp/commands/entities.ts
+++ b/src/gmp/commands/entities.ts
@@ -131,7 +131,7 @@ abstract class EntitiesCommand<
     );
   }
 
-  async get(params: HttpCommandInputParams, options?: HttpCommandOptions) {
+  async get(params: HttpCommandInputParams = {}, options?: HttpCommandOptions) {
     const response = await this.httpGet(params, options);
     const {entities, filter, counts} = this.getCollectionListFromRoot(
       response.data as TRoot,

--- a/src/gmp/gmp.ts
+++ b/src/gmp/gmp.ts
@@ -27,7 +27,6 @@ import 'gmp/commands/policies';
 import 'gmp/commands/reportconfigs';
 import 'gmp/commands/reportformats';
 import 'gmp/commands/results';
-import 'gmp/commands/roles';
 import 'gmp/commands/scanconfigs';
 import 'gmp/commands/scanners';
 import 'gmp/commands/schedules';
@@ -45,6 +44,7 @@ import LoginCommand from 'gmp/commands/login';
 import PerformanceCommand from 'gmp/commands/performance';
 import {PortListCommand, PortListsCommand} from 'gmp/commands/portlists';
 import {ReportCommand, ReportsCommand} from 'gmp/commands/reports';
+import {RoleCommand, RolesCommand} from 'gmp/commands/roles';
 import {TaskCommand, TasksCommand} from 'gmp/commands/tasks';
 import TrashCanCommand from 'gmp/commands/trashcan';
 import {UserCommand, UsersCommand} from 'gmp/commands/users';
@@ -83,6 +83,8 @@ class Gmp {
   readonly wizard: WizardCommand;
   readonly report: ReportCommand;
   readonly reports: ReportsCommand;
+  readonly role: RoleCommand;
+  readonly roles: RolesCommand;
   readonly task: TaskCommand;
   readonly tasks: TasksCommand;
 
@@ -113,6 +115,8 @@ class Gmp {
     this.wizard = new WizardCommand(this.http);
     this.report = new ReportCommand(this.http);
     this.reports = new ReportsCommand(this.http);
+    this.role = new RoleCommand(this.http);
+    this.roles = new RolesCommand(this.http);
     this.task = new TaskCommand(this.http);
     this.tasks = new TasksCommand(this.http);
 

--- a/src/gmp/models/role.ts
+++ b/src/gmp/models/role.ts
@@ -6,7 +6,7 @@
 import Model, {ModelElement, ModelProperties} from 'gmp/models/model';
 import {parseCsv} from 'gmp/parser';
 
-interface RoleElement extends ModelElement {
+export interface RoleElement extends ModelElement {
   users?: string;
 }
 

--- a/src/web/entity/EntityPermissions.tsx
+++ b/src/web/entity/EntityPermissions.tsx
@@ -172,8 +172,7 @@ class PermissionsBase<TEntity extends Model> extends React.Component<
         groupId: selectSaveId(groups),
       });
     });
-    // @ts-expect-error
-    gmp.roles.getAll().then(response => {
+    void gmp.roles.getAll().then(response => {
       const {data: roles} = response;
       this.setState({
         roles,


### PR DESCRIPTION
## What

Use TypeScript for RoleCommand and RolesCommand

Also add tests for both commands.

## Why

Allow to validate all role specific http requests and responses.

## References
https://jira.greenbone.net/browse/GEA-1098

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


