### PR TITLE
Update setting the default page title

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ config = {
 ```
 
 It is evaluated in the `GmpSettings` object implemented in the
-[gmpsettings.js](./src/gmp/gmpsettings.js) file. The `GmpSettings` object is
-instantiated once for the [GSA application](./src/web/app.js#L53)
+[gmpsettings.ts](./src/gmp/gmpsettings.ts) file. The `GmpSettings` object is
+instantiated once for the [GSA application](./src/web/App.tsx#L29)
 
 ### Config Variables
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ instantiated once for the [GSA application](./src/web/app.js#L53)
 | [severityRating](#severityrating)                                   | `'CVSSv2'` or `'CVSSv3'`   | `'CVSSv2'`                                                                       | -                         | x                       |
 | [vendorVersion](#vendorversion)                                     | String                     | undefined                                                                        | -                         | x                       |
 | [vendorLabel](#vendorlabel)                                         | String                     | undefined                                                                        | -                         | x                       |
-| [vendorTitle](#vendortitle)                                         | String                     | Greenbone Security Assistant                                                     | x                         | x                       |
+| [vendorTitle](#vendortitle)                                         | String                     | OPENVAS                                                                          | x                         | x                       |
 
 #### vendorVersion
 

--- a/src/gmp/__tests__/gmpsettings.test.ts
+++ b/src/gmp/__tests__/gmpsettings.test.ts
@@ -20,6 +20,7 @@ import GmpSettings, {
   DEFAULT_RELOAD_INTERVAL_INACTIVE,
   DEFAULT_TIMEOUT,
   DEFAULT_REPORT_RESULTS_THRESHOLD,
+  DEFAULT_TITLE,
 } from 'gmp/gmpsettings';
 import {
   DEFAULT_SEVERITY_RATING,
@@ -83,7 +84,7 @@ describe('GmpSettings tests', () => {
     expect(settings.username).toBeUndefined();
     expect(settings.vendorVersion).toBeUndefined();
     expect(settings.vendorLabel).toBeUndefined();
-    expect(settings.vendorTitle).toBeUndefined();
+    expect(settings.vendorTitle).toEqual(DEFAULT_TITLE);
 
     expect(storage.setItem).toHaveBeenCalledTimes(1);
     expect(storage.setItem).toHaveBeenCalledWith('logLevel', DEFAULT_LOG_LEVEL);

--- a/src/gmp/gmpsettings.ts
+++ b/src/gmp/gmpsettings.ts
@@ -59,6 +59,7 @@ export const DEFAULT_PROTOCOLDOC_URL = `https://docs.greenbone.net/API/GMP/gmp-2
 export const DEFAULT_REPORT_RESULTS_THRESHOLD = 25000;
 export const DEFAULT_LOG_LEVEL = 'warn';
 export const DEFAULT_TIMEOUT = 300000; // 5 minutes
+export const DEFAULT_TITLE = 'OPENVAS';
 
 const set = (
   storage: GmpSettingsStorage,
@@ -115,7 +116,7 @@ class GmpSettings {
   readonly protocolDocUrl!: string;
   readonly severityRating!: SeverityRating;
   readonly vendorLabel?: string;
-  readonly vendorTitle?: string;
+  readonly vendorTitle!: string;
   readonly vendorVersion?: string;
 
   constructor(
@@ -145,7 +146,7 @@ class GmpSettings {
       timeout = DEFAULT_TIMEOUT,
       vendorVersion,
       vendorLabel,
-      vendorTitle,
+      vendorTitle = DEFAULT_TITLE,
     } = options;
     let {
       apiProtocol = protocol,

--- a/src/web/components/layout/PageTitle.tsx
+++ b/src/web/components/layout/PageTitle.tsx
@@ -12,8 +12,6 @@ interface PageTitleProps {
   title?: string;
 }
 
-export const DEFAULT_TITLE = 'Greenbone Security Assistant';
-
 const PageTitle = ({title: pageTitle}: PageTitleProps) => {
   const gmp = useGmp();
   const vendorLabel = gmp?.settings?.vendorLabel ?? 'defaultVendorLabel';


### PR DESCRIPTION


## What

Update setting the default page title

## Why

Move the default title into the gmp settings module to have a central place for defining the page title.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


