### PR TITLE
change: Update 'New Task' to button in task view

### DIFF
--- a/src/web/components/menu/IconMenu.tsx
+++ b/src/web/components/menu/IconMenu.tsx
@@ -4,83 +4,28 @@
  */
 
 import React from 'react';
-import styled from 'styled-components';
+import {Menu, Button} from '@mantine/core';
 import {isDefined} from 'gmp/utils/identity';
-import Theme from 'web/utils/Theme';
 
 interface IconMenuProps {
   children: React.ReactNode | React.ReactNode[];
   icon?: React.ReactNode;
 }
 
-const Span = styled.span`
-  display: inline-flex;
-  flex-direction: column;
-`;
-
-const Div = styled.div`
-  position: relative;
-  display: none;
-
-  ${Span}:hover & {
-    display: block;
-  }
-`;
-
-const List = styled.ul`
-  position: absolute;
-  margin: 0;
-  padding: 0;
-  left: 0;
-  top: 0;
-  z-index: ${Theme.Layers.onTop};
-  list-style: none;
-  font-size: 10px;
-  width: 255px;
-`;
-
-const Entry = styled.li`
-  height: 22px;
-  width: 255px;
-  border-left: 1px solid ${Theme.mediumGray};
-  border-right: 1px solid ${Theme.mediumGray};
-  display: flex;
-  align-items: stretch;
-  background-color: ${Theme.white};
-  font-weight: bold;
-  text-indent: 12px;
-  text-align: left;
-
-  &:first-child {
-    border-top: 1px solid ${Theme.mediumGray};
-  }
-  &:last-child {
-    border-bottom: 1px solid ${Theme.mediumGray};
-  }
-  &:hover {
-    background: ${Theme.green};
-    color: ${Theme.white};
-  }
-
-  & div {
-    display: flex;
-    align-items: center;
-    flex-grow: 1;
-    cursor: pointer;
-  }
-`;
-
 const IconMenu = ({children, icon}: IconMenuProps) => {
   const menuEntries = React.Children.map(children, child => (
-    <Entry>{child}</Entry>
+    <Menu.Item>{child}</Menu.Item>
   ));
+
   return (
-    <Span>
-      {isDefined(icon) ? icon : null}
-      <Div>
-        <List>{menuEntries}</List>
-      </Div>
-    </Span>
+    <Menu>
+      <Menu.Target>
+        <Button style={{padding: 0, minWidth: 'auto'}} variant="transparent">
+          {isDefined(icon) ? icon : 'Menu'}
+        </Button>
+      </Menu.Target>
+      <Menu.Dropdown>{menuEntries}</Menu.Dropdown>
+    </Menu>
   );
 };
 

--- a/src/web/components/menu/__tests__/IconMenu.test.tsx
+++ b/src/web/components/menu/__tests__/IconMenu.test.tsx
@@ -1,0 +1,44 @@
+/* SPDX-FileCopyrightText: 2025 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, expect, test} from '@gsa/testing';
+import {fireEvent, render, screen, waitFor} from 'web/testing';
+import IconMenu from 'web/components/menu/IconMenu';
+
+describe('IconMenu', () => {
+  test('renders with children and default icon', async () => {
+    render(
+      <IconMenu>
+        <div>Child 1</div>
+        <div>Child 2</div>
+      </IconMenu>,
+    );
+
+    const button = screen.getByRole('button', {name: /menu/i});
+    fireEvent.click(button);
+
+    expect(screen.getByText('Menu')).toBeVisible();
+    await waitFor(() => {
+      expect(screen.getByText('Child 1')).toBeVisible();
+      expect(screen.getByText('Child 2')).toBeVisible();
+    });
+  });
+
+  test('renders with custom icon', async () => {
+    render(
+      <IconMenu icon={<span>Custom Icon</span>}>
+        <div>Child</div>
+      </IconMenu>,
+    );
+
+    const button = screen.getByRole('button', {name: /custom icon/i});
+    fireEvent.click(button);
+
+    expect(screen.getByText('Custom Icon')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Child')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/web/pages/tasks/__tests__/TaskDetailsPage.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskDetailsPage.test.tsx
@@ -652,7 +652,7 @@ describe('Task ToolBarIcons tests', () => {
     expect(links[1]).toHaveAttribute('href', '/tasks');
   });
 
-  test('should call click handlers for new task', () => {
+  test('should call click handlers for new task', async () => {
     const handleReportImport = testing.fn();
     const handleTaskCreate = testing.fn();
     const handleContainerTaskCreate = testing.fn();
@@ -694,12 +694,23 @@ describe('Task ToolBarIcons tests', () => {
     const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
 
-    const newTaskMenu = screen.getByTestId('new-task-menu');
+    const newButton = screen.getByTestId('new-icon').closest('button');
+    expect(newButton).not.toBeNull();
+    if (newButton) {
+      fireEvent.click(newButton);
+    }
+
+    const newTaskMenu = await screen.findByTestId('new-task-menu');
     expect(newTaskMenu).toHaveTextContent('New Task');
     fireEvent.click(newTaskMenu);
     expect(handleTaskCreate).toHaveBeenCalled();
 
-    const newContainerTaskMenu = screen.getByTestId('new-container-task-menu');
+    if (newButton) {
+      fireEvent.click(newButton);
+    }
+    const newContainerTaskMenu = await screen.findByTestId(
+      'new-container-task-menu',
+    );
     expect(newContainerTaskMenu).toHaveTextContent('New Container Task');
     fireEvent.click(newContainerTaskMenu);
     expect(handleContainerTaskCreate).toHaveBeenCalled();
@@ -754,7 +765,7 @@ describe('Task ToolBarIcons tests', () => {
     expect(badgeIcons[3]).toHaveTextContent('0');
   });
 
-  test('should call click handlers for running task', () => {
+  test('should call click handlers for running task', async () => {
     const handleReportImport = testing.fn();
     const handleTaskCreate = testing.fn();
     const handleContainerTaskCreate = testing.fn();
@@ -796,12 +807,22 @@ describe('Task ToolBarIcons tests', () => {
     const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
 
-    const newTaskMenu = screen.getByTestId('new-task-menu');
+    const newButton = screen.getByTestId('new-icon').closest('button');
+    expect(newButton).not.toBeNull();
+    if (newButton) {
+      fireEvent.click(newButton);
+    }
+    const newTaskMenu = await screen.findByTestId('new-task-menu');
     expect(newTaskMenu).toHaveTextContent('New Task');
     fireEvent.click(newTaskMenu);
     expect(handleTaskCreate).toHaveBeenCalled();
 
-    const newContainerTaskMenu = screen.getByTestId('new-container-task-menu');
+    if (newButton) {
+      fireEvent.click(newButton);
+    }
+    const newContainerTaskMenu = await screen.findByTestId(
+      'new-container-task-menu',
+    );
     expect(newContainerTaskMenu).toHaveTextContent('New Container Task');
     fireEvent.click(newContainerTaskMenu);
     expect(handleContainerTaskCreate).toHaveBeenCalled();
@@ -862,7 +883,7 @@ describe('Task ToolBarIcons tests', () => {
     expect(badgeIcons[3]).toHaveTextContent('0');
   });
 
-  test('should call click handlers for stopped task', () => {
+  test('should call click handlers for stopped task', async () => {
     const handleReportImport = testing.fn();
     const handleTaskCreate = testing.fn();
     const handleContainerTaskCreate = testing.fn();
@@ -904,12 +925,23 @@ describe('Task ToolBarIcons tests', () => {
     const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
 
-    const newTaskMenu = screen.getByTestId('new-task-menu');
+    const newButton = screen.getByTestId('new-icon').closest('button');
+    expect(newButton).not.toBeNull();
+    if (newButton) {
+      fireEvent.click(newButton);
+    }
+
+    const newTaskMenu = await screen.findByTestId('new-task-menu');
     expect(newTaskMenu).toHaveTextContent('New Task');
     fireEvent.click(newTaskMenu);
     expect(handleTaskCreate).toHaveBeenCalled();
 
-    const newContainerTaskMenu = screen.getByTestId('new-container-task-menu');
+    if (newButton) {
+      fireEvent.click(newButton);
+    }
+    const newContainerTaskMenu = await screen.findByTestId(
+      'new-container-task-menu',
+    );
     expect(newContainerTaskMenu).toHaveTextContent('New Container Task');
     fireEvent.click(newContainerTaskMenu);
     expect(handleContainerTaskCreate).toHaveBeenCalled();
@@ -970,7 +1002,7 @@ describe('Task ToolBarIcons tests', () => {
     expect(badgeIcons[3]).toHaveTextContent('0');
   });
 
-  test('should call click handlers for finished task', () => {
+  test('should call click handlers for finished task', async () => {
     const handleReportImport = testing.fn();
     const handleTaskCreate = testing.fn();
     const handleContainerTaskCreate = testing.fn();
@@ -1014,12 +1046,23 @@ describe('Task ToolBarIcons tests', () => {
     const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
 
-    const newTaskMenu = screen.getByTestId('new-task-menu');
+    const newButton = screen.getByTestId('new-icon').closest('button');
+    expect(newButton).not.toBeNull();
+    if (newButton) {
+      fireEvent.click(newButton);
+    }
+
+    const newTaskMenu = await screen.findByTestId('new-task-menu');
     expect(newTaskMenu).toHaveTextContent('New Task');
     fireEvent.click(newTaskMenu);
     expect(handleTaskCreate).toHaveBeenCalled();
 
-    const newContainerTaskMenu = screen.getByTestId('new-container-task-menu');
+    if (newButton) {
+      fireEvent.click(newButton);
+    }
+    const newContainerTaskMenu = await screen.findByTestId(
+      'new-container-task-menu',
+    );
     expect(newContainerTaskMenu).toHaveTextContent('New Container Task');
     fireEvent.click(newContainerTaskMenu);
     expect(handleContainerTaskCreate).toHaveBeenCalled();
@@ -1080,7 +1123,7 @@ describe('Task ToolBarIcons tests', () => {
     expect(badgeIcons[3]).toHaveTextContent('3');
   });
 
-  test('should not call click handlers without permission', () => {
+  test('should not call click handlers without permission', async () => {
     const handleReportImport = testing.fn();
     const handleTaskCreate = testing.fn();
     const handleContainerTaskCreate = testing.fn();
@@ -1122,12 +1165,23 @@ describe('Task ToolBarIcons tests', () => {
     const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
 
-    const newTaskMenu = screen.getByTestId('new-task-menu');
+    const newButton = screen.getByTestId('new-icon').closest('button');
+    expect(newButton).not.toBeNull();
+    if (newButton) {
+      fireEvent.click(newButton);
+    }
+
+    const newTaskMenu = await screen.findByTestId('new-task-menu');
     expect(newTaskMenu).toHaveTextContent('New Task');
     fireEvent.click(newTaskMenu);
     expect(handleTaskCreate).toHaveBeenCalled();
 
-    const newContainerTaskMenu = screen.getByTestId('new-container-task-menu');
+    if (newButton) {
+      fireEvent.click(newButton);
+    }
+    const newContainerTaskMenu = await screen.findByTestId(
+      'new-container-task-menu',
+    );
     expect(newContainerTaskMenu).toHaveTextContent('New Container Task');
     fireEvent.click(newContainerTaskMenu);
     expect(handleContainerTaskCreate).toHaveBeenCalled();
@@ -1252,7 +1306,7 @@ describe('Task ToolBarIcons tests', () => {
     expect(handleTaskResume).not.toHaveBeenCalled();
   });
 
-  test('should call click handlers for container task', () => {
+  test('should call click handlers for container task', async () => {
     const handleReportImport = testing.fn();
     const handleTaskCreate = testing.fn();
     const handleContainerTaskCreate = testing.fn();
@@ -1294,12 +1348,23 @@ describe('Task ToolBarIcons tests', () => {
     const badgeIcons = screen.getAllByTestId('badge-icon');
     const links = baseElement.querySelectorAll('a');
 
-    const newTaskMenu = screen.getByTestId('new-task-menu');
+    const newButton = screen.getByTestId('new-icon').closest('button');
+    expect(newButton).not.toBeNull();
+    if (newButton) {
+      fireEvent.click(newButton);
+    }
+
+    const newTaskMenu = await screen.findByTestId('new-task-menu');
     expect(newTaskMenu).toHaveTextContent('New Task');
     fireEvent.click(newTaskMenu);
     expect(handleTaskCreate).toHaveBeenCalled();
 
-    const newContainerTaskMenu = screen.getByTestId('new-container-task-menu');
+    if (newButton) {
+      fireEvent.click(newButton);
+    }
+    const newContainerTaskMenu = await screen.findByTestId(
+      'new-container-task-menu',
+    );
     expect(newContainerTaskMenu).toHaveTextContent('New Container Task');
     fireEvent.click(newContainerTaskMenu);
     expect(handleContainerTaskCreate).toHaveBeenCalled();

--- a/src/web/pages/tasks/icons/__tests__/NewIconMenu.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/NewIconMenu.test.tsx
@@ -4,16 +4,25 @@
  */
 
 import {describe, test, expect, testing} from '@gsa/testing';
-import {screen, rendererWith, fireEvent} from 'web/testing';
+import {screen, rendererWith, fireEvent, waitFor} from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import NewIconMenu from 'web/pages/tasks/icons/NewIconMenu';
 
 describe('NewIconMenu tests', () => {
-  test('should render', () => {
+  test('should render', async () => {
     const {render} = rendererWith({capabilities: true});
     render(<NewIconMenu />);
-    expect(screen.getByTestId('new-task-menu')).toBeInTheDocument();
-    expect(screen.getByTestId('new-container-task-menu')).toBeInTheDocument();
+
+    const button = screen.getByTestId('new-icon').closest('button');
+    expect(button).not.toBeNull();
+    if (button) {
+      fireEvent.click(button);
+    }
+
+    await waitFor(() => {
+      expect(screen.getByTestId('new-task-menu')).toBeInTheDocument();
+      expect(screen.getByTestId('new-container-task-menu')).toBeInTheDocument();
+    });
   });
 
   test('should not render when capabilities do not allow creating tasks', () => {
@@ -25,19 +34,35 @@ describe('NewIconMenu tests', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('should call onNewClick when New Task is clicked', () => {
+  test('should call onNewClick when New Task is clicked', async () => {
     const onNewClick = testing.fn();
     const {render} = rendererWith({capabilities: true});
     render(<NewIconMenu onNewClick={onNewClick} />);
-    fireEvent.click(screen.getByTestId('new-task-menu'));
+
+    const button = screen.getByTestId('new-icon').closest('button');
+    expect(button).not.toBeNull();
+    if (button) {
+      fireEvent.click(button);
+    }
+
+    const menuItem = await screen.findByTestId('new-task-menu');
+    fireEvent.click(menuItem);
     expect(onNewClick).toHaveBeenCalled();
   });
 
-  test('calls onNewContainerClick when New Container Task is clicked', () => {
+  test('calls onNewContainerClick when New Container Task is clicked', async () => {
     const onNewContainerClick = testing.fn();
     const {render} = rendererWith({capabilities: true});
     render(<NewIconMenu onNewContainerClick={onNewContainerClick} />);
-    fireEvent.click(screen.getByTestId('new-container-task-menu'));
+
+    const button = screen.getByTestId('new-icon').closest('button');
+    expect(button).not.toBeNull();
+    if (button) {
+      fireEvent.click(button);
+    }
+
+    const menuItem = await screen.findByTestId('new-container-task-menu');
+    fireEvent.click(menuItem);
     expect(onNewContainerClick).toHaveBeenCalled();
   });
 });

--- a/src/web/pages/tasks/icons/__tests__/TaskToolBarIcons.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskToolBarIcons.test.tsx
@@ -47,7 +47,7 @@ describe('TaskPage ToolBarIcons test', () => {
     );
   });
 
-  test('should call click handlers', () => {
+  test('should call click handlers', async () => {
     const handleAdvancedTaskWizardClick = testing.fn();
     const handleModifyTaskWizardClick = testing.fn();
     const handleContainerTaskCreateClick = testing.fn();
@@ -74,29 +74,54 @@ describe('TaskPage ToolBarIcons test', () => {
       />,
     );
 
-    const taskWizardMenu = screen.getByTestId('task-wizard-menu');
+    const wizardButton = screen.getByTestId('wizard-icon').closest('button');
+    expect(wizardButton).not.toBeNull();
+    if (wizardButton) {
+      fireEvent.click(wizardButton);
+    }
+
+    const taskWizardMenu = await screen.findByTestId('task-wizard-menu');
     expect(taskWizardMenu).toHaveTextContent('Task Wizard');
     fireEvent.click(taskWizardMenu);
     expect(handleTaskWizardClick).toHaveBeenCalled();
 
-    const advancedTaskWizardMenu = screen.getByTestId(
+    if (wizardButton) {
+      fireEvent.click(wizardButton);
+    }
+    const advancedTaskWizardMenu = await screen.findByTestId(
       'advanced-task-wizard-menu',
     );
     expect(advancedTaskWizardMenu).toHaveTextContent('Advanced Task Wizard');
     fireEvent.click(advancedTaskWizardMenu);
     expect(handleAdvancedTaskWizardClick).toHaveBeenCalled();
 
-    const modifyTaskWizardMenu = screen.getByTestId('modify-task-wizard-menu');
+    if (wizardButton) {
+      fireEvent.click(wizardButton);
+    }
+    const modifyTaskWizardMenu = await screen.findByTestId(
+      'modify-task-wizard-menu',
+    );
     expect(modifyTaskWizardMenu).toHaveTextContent('Modify Task Wizard');
     fireEvent.click(modifyTaskWizardMenu);
     expect(handleModifyTaskWizardClick).toHaveBeenCalled();
 
-    const newTaskMenu = screen.getByTestId('new-task-menu');
+    const newButton = screen.getByTestId('new-icon').closest('button');
+    expect(newButton).not.toBeNull();
+    if (newButton) {
+      fireEvent.click(newButton);
+    }
+
+    const newTaskMenu = await screen.findByTestId('new-task-menu');
     expect(newTaskMenu).toHaveTextContent('New Task');
     fireEvent.click(newTaskMenu);
     expect(handleTaskCreateClick).toHaveBeenCalled();
 
-    const newContainerTaskMenu = screen.getByTestId('new-container-task-menu');
+    if (newButton) {
+      fireEvent.click(newButton);
+    }
+    const newContainerTaskMenu = await screen.findByTestId(
+      'new-container-task-menu',
+    );
     expect(newContainerTaskMenu).toHaveTextContent('New Container Task');
     fireEvent.click(newContainerTaskMenu);
     expect(handleContainerTaskCreateClick).toHaveBeenCalled();


### PR DESCRIPTION
## What

- Change the new task to button, opened by clicking and not hovering.

## Why

- To be more consistent and for accesibility.

## References

GEA-1269

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


