### PR TITLE
Rename chunk for the ui-lib

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,7 +60,7 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: {
-          'opensight-ui': ['@greenbone/ui-lib'],
+          'greenbone-ui-lib': ['@greenbone/ui-lib'],
         },
       },
     },


### PR DESCRIPTION


## What
Rename chunk for the ui-lib

## Why

The name opensight got dropped. Therefore it should not be used in our chunks too.