### PR TITLE
 Allow to change the initial filter string in useFilterDialog hook

### DIFF
--- a/src/web/components/powerfilter/__tests__/useFilterDialog.test.tsx
+++ b/src/web/components/powerfilter/__tests__/useFilterDialog.test.tsx
@@ -1,0 +1,131 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect} from '@gsa/testing';
+import {act, renderHook} from 'web/testing';
+import Filter from 'gmp/models/filter';
+import useFilterDialog, {
+  FilterDialogState,
+} from 'web/components/powerfilter/useFilterDialog';
+
+describe('useFilterDialog', () => {
+  test('should initialize with default values', () => {
+    const {result} = renderHook(() => useFilterDialog());
+
+    expect(result.current.filter).toBeDefined();
+    expect(result.current.filterString).toEqual('');
+    expect(result.current.originalFilter).toBeUndefined();
+  });
+
+  test('should initialize with provided filter and filter string', () => {
+    const initialFilter = new Filter().set('name', 'test');
+    const {result} = renderHook(() =>
+      useFilterDialog(initialFilter, 'foo=bar'),
+    );
+
+    expect(result.current.filter.toFilterString()).toEqual('name=test');
+    expect(result.current.filterString).toEqual('foo=bar');
+    expect(result.current.originalFilter).toBe(initialFilter);
+  });
+
+  test("should use criteria string from filter if initial filter string isn't provided", () => {
+    const initialFilter = new Filter().set('name', 'test');
+    const {result} = renderHook(() => useFilterDialog(initialFilter));
+
+    expect(result.current.filterString).toEqual('name=test');
+  });
+
+  test('should handle filter changes', () => {
+    const initialFilter = new Filter().set('name', 'test');
+    const {result} = renderHook(() => useFilterDialog(initialFilter));
+
+    act(() => {
+      result.current.handleFilterChange(
+        initialFilter.copy().set('status', 'active'),
+      );
+    });
+
+    expect(result.current.filter.toFilterString()).toEqual(
+      'name=test status=active',
+    );
+  });
+
+  test('should handle filter value changes', () => {
+    const initialFilter = new Filter().set('name', 'test');
+    const {result} = renderHook(() => useFilterDialog(initialFilter));
+
+    act(() => {
+      result.current.handleFilterValueChange('active', 'status');
+    });
+
+    expect(result.current.filter.toFilterString()).toEqual(
+      'name=test status=active',
+    );
+  });
+
+  test('should handle search term changes', () => {
+    const initialFilter = new Filter().set('name', 'test');
+    const {result} = renderHook(() => useFilterDialog(initialFilter));
+
+    act(() => {
+      result.current.handleSearchTermChange('keyword', 'description');
+    });
+
+    expect(result.current.filter.toFilterString()).toEqual(
+      'name=test description~"keyword"',
+    );
+  });
+
+  test('should handle filter string changes', () => {
+    const initialFilter = new Filter().set('name', 'test');
+    const {result} = renderHook(() => useFilterDialog(initialFilter));
+
+    act(() => {
+      result.current.handleFilterStringChange('status=active');
+    });
+
+    expect(result.current.filterString).toBe('status=active');
+    expect(result.current.filter.toFilterString()).toEqual('name=test');
+  });
+
+  test('should handle sort by changes', () => {
+    const initialFilter = new Filter().set('name', 'test');
+    const {result} = renderHook(() => useFilterDialog(initialFilter));
+
+    act(() => {
+      result.current.handleSortByChange('name');
+    });
+
+    expect(result.current.filter.toFilterString()).toEqual(
+      'name=test sort=name',
+    );
+  });
+
+  test('should handle sort order changes', () => {
+    const initialFilter = new Filter().set('name', 'test').setSortBy('name');
+    const {result} = renderHook(() => useFilterDialog(initialFilter));
+
+    act(() => {
+      result.current.handleSortOrderChange('sort-reverse');
+    });
+
+    expect(result.current.filter.toFilterString()).toEqual(
+      'name=test sort-reverse=name',
+    );
+  });
+
+  test('should handle dialog state changes', () => {
+    const initialFilter = new Filter().set('name', 'test');
+    const {result} = renderHook(() =>
+      useFilterDialog<FilterDialogState>(initialFilter),
+    );
+
+    act(() => {
+      result.current.handleChange(true, 'saveNamedFilter');
+    });
+
+    expect(result.current.saveNamedFilter).toBe(true);
+  });
+});

--- a/src/web/components/powerfilter/useFilterDialog.tsx
+++ b/src/web/components/powerfilter/useFilterDialog.tsx
@@ -20,6 +20,7 @@ export interface FilterDialogState {
  */
 const useFilterDialog = <TFilterDialogState extends FilterDialogState>(
   initialFilter?: Filter,
+  initialFilterString?: string,
 ) => {
   const [originalFilter] = useState(initialFilter);
   const [filter, setFilter] = useState<Filter>(() =>
@@ -28,9 +29,14 @@ const useFilterDialog = <TFilterDialogState extends FilterDialogState>(
   const [filterDialogState, setFilterDialogState] =
     useState<TFilterDialogState>({} as TFilterDialogState);
 
-  const [filterString, setFilterString] = useState(() =>
-    isDefined(initialFilter) ? initialFilter.toFilterCriteriaString() : '',
-  );
+  const [filterString, setFilterString] = useState(() => {
+    if (isDefined(initialFilterString)) {
+      return initialFilterString;
+    }
+    return isDefined(initialFilter)
+      ? initialFilter.toFilterCriteriaString()
+      : '';
+  });
 
   const handleFilterChange = useCallback((filter: Filter) => {
     setFilter(filter);


### PR DESCRIPTION


## What

 Allow to change the initial filter string in useFilterDialog hook

## Why

When using the useFilterDialog hook for handling the state of a powerfilter dialog, allow to adjust the initial filter string. This allows for not displaying parts of the filter string that are handled via an form input. Ensure this behavior by adding tests for the hook too.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


