### PR TITLE
Expect EntityType as argument to useEntity hooks

### DIFF
--- a/src/web/entity/hooks/__tests__/useEntityClone.test.ts
+++ b/src/web/entity/hooks/__tests__/useEntityClone.test.ts
@@ -12,7 +12,7 @@ describe('useEntityClone', () => {
     const entity = {id: '123'};
     const cloneEntity = testing.fn().mockResolvedValue(entity);
     const gmp = {
-      foo: {clone: cloneEntity},
+      task: {clone: cloneEntity},
     };
     const onCloned = testing.fn();
     const onCloneError = testing.fn();
@@ -20,7 +20,7 @@ describe('useEntityClone', () => {
     const {renderHook} = rendererWith({gmp, store: true});
 
     const {result} = renderHook(() =>
-      useEntityClone('foo', {
+      useEntityClone('task', {
         onCloned,
         onCloneError,
       }),
@@ -36,7 +36,7 @@ describe('useEntityClone', () => {
     const cloneEntity = testing.fn().mockRejectedValue(new Error('error'));
     const entity = {id: '123'};
     const gmp = {
-      foo: {clone: cloneEntity},
+      task: {clone: cloneEntity},
     };
     const onCloned = testing.fn();
     const onCloneError = testing.fn();
@@ -44,7 +44,7 @@ describe('useEntityClone', () => {
     const {renderHook} = rendererWith({gmp, store: true});
 
     const {result} = renderHook(() =>
-      useEntityClone('foo', {
+      useEntityClone('task', {
         onCloned,
         onCloneError,
       }),

--- a/src/web/entity/hooks/__tests__/useEntityCreate.test.ts
+++ b/src/web/entity/hooks/__tests__/useEntityCreate.test.ts
@@ -12,14 +12,14 @@ describe('useEntityCreate', () => {
     const entity = {name: 'foo'};
     const createEntity = testing.fn().mockResolvedValue(entity);
     const gmp = {
-      foo: {create: createEntity},
+      task: {create: createEntity},
     };
     const onCreated = testing.fn();
     const onCreateError = testing.fn();
     const {renderHook} = rendererWith({gmp, store: true});
 
     const {result} = renderHook(() =>
-      useEntityCreate('foo', {
+      useEntityCreate('task', {
         onCreated,
         onCreateError,
       }),
@@ -35,14 +35,14 @@ describe('useEntityCreate', () => {
     const createEntity = testing.fn().mockRejectedValue(new Error('error'));
     const entity = {name: 'foo'};
     const gmp = {
-      foo: {create: createEntity},
+      task: {create: createEntity},
     };
     const onCreated = testing.fn();
     const onCreateError = testing.fn();
     const {renderHook} = rendererWith({gmp, store: true});
 
     const {result} = renderHook(() =>
-      useEntityCreate('foo', {
+      useEntityCreate('task', {
         onCreated,
         onCreateError,
       }),

--- a/src/web/entity/hooks/__tests__/useEntityDelete.test.ts
+++ b/src/web/entity/hooks/__tests__/useEntityDelete.test.ts
@@ -12,14 +12,14 @@ describe('useEntityDelete', () => {
     const entity = {id: '123'};
     const deleteEntity = testing.fn().mockResolvedValue(entity);
     const gmp = {
-      foo: {delete: deleteEntity},
+      task: {delete: deleteEntity},
     };
     const onDeleted = testing.fn();
     const onDeleteError = testing.fn();
 
     const {renderHook} = rendererWith({gmp, store: true});
     const {result} = renderHook(() =>
-      useEntityDelete('foo', {
+      useEntityDelete('task', {
         onDeleted,
         onDeleteError,
       }),
@@ -35,14 +35,14 @@ describe('useEntityDelete', () => {
     const deleteEntity = testing.fn().mockRejectedValue(new Error('error'));
     const entity = {id: '123'};
     const gmp = {
-      foo: {delete: deleteEntity},
+      task: {delete: deleteEntity},
     };
     const onDeleted = testing.fn();
     const onDeleteError = testing.fn();
 
     const {renderHook} = rendererWith({gmp, store: true});
     const {result} = renderHook(() =>
-      useEntityDelete('foo', {
+      useEntityDelete('task', {
         onDeleted,
         onDeleteError,
       }),

--- a/src/web/entity/hooks/__tests__/useEntityDownload.test.ts
+++ b/src/web/entity/hooks/__tests__/useEntityDownload.test.ts
@@ -26,14 +26,14 @@ describe('useEntityDownload', () => {
     const onDownloadError = testing.fn();
 
     const gmp = {
-      foo: {
+      task: {
         export: testing.fn().mockResolvedValue({data: downloadedData}),
       },
       user: {currentSettings},
     };
     const {renderHook} = rendererWith({gmp, store: true});
     const {result} = renderHook(() =>
-      useEntityDownload('foo', {
+      useEntityDownload('task', {
         onDownloaded,
         onDownloadError,
       }),
@@ -43,7 +43,7 @@ describe('useEntityDownload', () => {
     expect(result.current).toBeDefined();
     await result.current(entity);
     expect(onDownloaded).toHaveBeenCalledWith({
-      filename: 'foo-123.xml',
+      filename: 'task-123.xml',
       data: downloadedData,
     });
     expect(onDownloadError).not.toHaveBeenCalled();
@@ -59,12 +59,12 @@ describe('useEntityDownload', () => {
     const onDownloadError = testing.fn();
 
     const gmp = {
-      foo: {export: testing.fn().mockRejectedValue(error)},
+      task: {export: testing.fn().mockRejectedValue(error)},
       user: {currentSettings},
     };
     const {renderHook} = rendererWith({gmp, store: true});
     const {result} = renderHook(() =>
-      useEntityDownload('foo', {
+      useEntityDownload('task', {
         onDownloaded,
         onDownloadError,
       }),

--- a/src/web/entity/hooks/__tests__/useEntitySave.test.ts
+++ b/src/web/entity/hooks/__tests__/useEntitySave.test.ts
@@ -12,14 +12,14 @@ describe('useEntitySave', () => {
     const entity = {id: '123'};
     const saveEntity = testing.fn().mockResolvedValue(entity);
     const gmp = {
-      foo: {save: saveEntity},
+      task: {save: saveEntity},
     };
     const onSaved = testing.fn();
     const onSaveError = testing.fn();
     const {renderHook} = rendererWith({gmp, store: true});
 
     const {result} = renderHook(() =>
-      useEntitySave('foo', {
+      useEntitySave('task', {
         onSaved,
         onSaveError,
       }),
@@ -35,14 +35,14 @@ describe('useEntitySave', () => {
     const saveEntity = testing.fn().mockRejectedValue(new Error('error'));
     const entity = {id: '123'};
     const gmp = {
-      foo: {save: saveEntity},
+      task: {save: saveEntity},
     };
     const onSaved = testing.fn();
     const onSaveError = testing.fn();
     const {renderHook} = rendererWith({gmp, store: true});
 
     const {result} = renderHook(() =>
-      useEntitySave('foo', {
+      useEntitySave('task', {
         onSaved,
         onSaveError,
       }),

--- a/src/web/entity/hooks/useEntityClone.ts
+++ b/src/web/entity/hooks/useEntityClone.ts
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import {EntityActionData} from 'gmp/commands/entity';
 import Rejection from 'gmp/http/rejection';
+import Response from 'gmp/http/response';
+import {XmlMeta} from 'gmp/http/transform/fastxml';
+import {EntityType} from 'gmp/utils/entitytype';
 import actionFunction from 'web/entity/hooks/actionFunction';
 import useGmp from 'web/hooks/useGmp';
 import useTranslation from 'web/hooks/useTranslation';
@@ -15,8 +19,10 @@ interface EntityClone {
   name?: string;
 }
 
+type EntityCloneResponse = Response<EntityActionData, XmlMeta>;
+
 interface EntityCloneCallbacks<
-  TCloneResponse = unknown,
+  TCloneResponse = EntityCloneResponse,
   TCloneError = Rejection | Error,
 > {
   onCloneError?: (error: TCloneError) => void;
@@ -34,10 +40,10 @@ interface EntityCloneCallbacks<
  */
 const useEntityClone = <
   TEntity extends EntityClone = EntityClone,
-  TCloneResponse = unknown,
+  TCloneResponse = EntityCloneResponse,
   TCloneError = Rejection,
 >(
-  name: string,
+  name: EntityType,
   {
     onCloneError,
     onCloned,
@@ -50,7 +56,7 @@ const useEntityClone = <
   const [_] = useTranslation();
 
   const handleEntityClone = async (entity: TEntity) => {
-    return actionFunction(cmd.clone(entity), {
+    return actionFunction<TCloneResponse, TCloneError>(cmd.clone(entity), {
       onSuccess: onCloned,
       onError: onCloneError,
       successMessage: _('{{name}} cloned successfully.', {

--- a/src/web/entity/hooks/useEntityCreate.ts
+++ b/src/web/entity/hooks/useEntityCreate.ts
@@ -4,6 +4,7 @@
  */
 
 import Rejection from 'gmp/http/rejection';
+import {EntityType} from 'gmp/utils/entitytype';
 import actionFunction from 'web/entity/hooks/actionFunction';
 import useGmp from 'web/hooks/useGmp';
 
@@ -24,7 +25,7 @@ const useEntityCreate = <
   TCreateResponse = unknown,
   TCreateError = Rejection,
 >(
-  name: string,
+  name: EntityType,
   {
     onCreated,
     onCreateError,

--- a/src/web/entity/hooks/useEntityDelete.ts
+++ b/src/web/entity/hooks/useEntityDelete.ts
@@ -5,6 +5,7 @@
 
 import {useDispatch} from 'react-redux';
 import Rejection from 'gmp/http/rejection';
+import {EntityType} from 'gmp/utils/entitytype';
 import actionFunction from 'web/entity/hooks/actionFunction';
 import useGmp from 'web/hooks/useGmp';
 import useTranslation from 'web/hooks/useTranslation';
@@ -33,7 +34,7 @@ const useEntityDelete = <
   TEntity extends EntityDelete = EntityDelete,
   TDeleteError = Rejection,
 >(
-  name: string,
+  name: EntityType,
   {onDeleteError, onDeleted}: EntityDeleteCallbacks<TDeleteError> = {},
 ) => {
   const [_] = useTranslation();
@@ -44,7 +45,7 @@ const useEntityDelete = <
     dispatch(createDeleteEntity({entityType: name})(gmp)(entity.id as string));
 
   const handleEntityDelete = async (entity: TEntity) => {
-    return actionFunction(
+    return actionFunction<void>(
       // @ts-expect-error
       deleteEntity(entity),
       {

--- a/src/web/entity/hooks/useEntityDownload.ts
+++ b/src/web/entity/hooks/useEntityDownload.ts
@@ -8,6 +8,7 @@ import {showSuccessNotification} from '@greenbone/ui-lib';
 import {useDispatch, useSelector} from 'react-redux';
 import Rejection from 'gmp/http/rejection';
 import Model from 'gmp/models/model';
+import {EntityType} from 'gmp/utils/entitytype';
 import {isDefined} from 'gmp/utils/identity';
 import useGmp from 'web/hooks/useGmp';
 import useShallowEqualSelector from 'web/hooks/useShallowEqualSelector';
@@ -37,7 +38,7 @@ interface EntityDownloadCallbacks<TDownloadError = unknown> {
  * @returns Function to handle the entity download.
  */
 const useEntityDownload = <TEntity extends Model, TDownloadError = Rejection>(
-  name: string,
+  name: EntityType,
   {onDownloadError, onDownloaded}: EntityDownloadCallbacks<TDownloadError> = {},
 ) => {
   const [_] = useTranslation();

--- a/src/web/entity/hooks/useEntitySave.ts
+++ b/src/web/entity/hooks/useEntitySave.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import {EntityType} from 'gmp/utils/entitytype';
 import actionFunction from 'web/entity/hooks/actionFunction';
 import useGmp from 'web/hooks/useGmp';
 
@@ -20,7 +21,7 @@ const useEntitySave = <
   TSaveResponse = unknown,
   TSaveError = unknown,
 >(
-  name: string,
+  name: EntityType,
   {onSaveError, onSaved}: EntitySaveCallbacks<TSaveResponse, TSaveError> = {},
 ) => {
   const gmp = useGmp();


### PR DESCRIPTION


## What

Expect EntityType as argument to useEntity hooks
## Why

Also refactor useEntityClone for improved default return type.
## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


