### PR TITLE
Fix calling the commands method in useGmpMutation hook

### DIFF
--- a/src/web/queries/useGmpMutation.ts
+++ b/src/web/queries/useGmpMutation.ts
@@ -40,7 +40,7 @@ export function useGmpMutation<
       if (!gmpCommand || !gmpCommand) {
         throw new Error(`GMP command for ${entityType}.${method} not found`);
       }
-      return await gmpMethod.call(gmpMethod, input);
+      return await gmpMethod.call(gmpCommand, input);
     },
     onSuccess: data => {
       if (isDefined(invalidateQueryIds)) {


### PR DESCRIPTION


## What

Fix calling the commands method in useGmpMutation hook

## Why

When having a variable pointing to a method we need to call it with the object instance as first parameter.
