### PR TITLE
Response _meta and _data properties are considered private

### DIFF
--- a/src/gmp/http/response.ts
+++ b/src/gmp/http/response.ts
@@ -18,8 +18,8 @@ export type Meta = Record<string, unknown>;
  */
 class Response<TData = unknown, TMeta extends Meta = Meta> {
   _xhr: XMLHttpRequest;
-  _data: TData;
-  _meta: TMeta;
+  private _data: TData;
+  private _meta: TMeta;
 
   constructor(xhr: XMLHttpRequest, data: TData, meta: TMeta = {} as TMeta) {
     this._xhr = xhr;


### PR DESCRIPTION


## What

Response _meta and _data properties are considered private

## Why

They should be accessed only via the data and meta getter methods.