### PR TITLE
Fix downloading a delta report

### DIFF
--- a/src/gmp/commands/report.ts
+++ b/src/gmp/commands/report.ts
@@ -6,8 +6,9 @@
 import {convertBoolean} from 'gmp/commands/convert';
 import EntityCommand from 'gmp/commands/entity';
 import GmpHttp from 'gmp/http/gmp';
+import Response from 'gmp/http/response';
 import DefaultTransform from 'gmp/http/transform/default';
-import {XmlResponseData} from 'gmp/http/transform/fastxml';
+import {XmlMeta, XmlResponseData} from 'gmp/http/transform/fastxml';
 import logger from 'gmp/log';
 import Filter, {ALL_FILTER} from 'gmp/models/filter';
 import Report, {ReportElement} from 'gmp/models/report';
@@ -82,7 +83,8 @@ class ReportCommand extends EntityCommand<Report, ReportElement> {
       deltaReportId,
       filter,
     }: ReportCommandDownloadOptions,
-  ) {
+  ): Promise<Response<ArrayBuffer, XmlMeta>> {
+    // @ts-expect-error
     return this.httpGet(
       {
         cmd: 'get_report',

--- a/src/web/components/form/Download.tsx
+++ b/src/web/components/form/Download.tsx
@@ -9,6 +9,8 @@ interface DownloadProps {
   filename?: string;
 }
 
+export type DownloadData = string | ArrayBuffer;
+
 class Download extends React.Component<DownloadProps> {
   obj_url: string | undefined;
   anchor: HTMLAnchorElement | null = null;
@@ -31,7 +33,7 @@ class Download extends React.Component<DownloadProps> {
     this.anchor.download = name;
   }
 
-  setData(data: string, mimetype: string = 'application/octet-stream') {
+  setData(data: DownloadData, mimetype: string = 'application/octet-stream') {
     const blob = new Blob([data], {type: mimetype});
 
     this.release();

--- a/src/web/components/form/useDownload.ts
+++ b/src/web/components/form/useDownload.ts
@@ -6,11 +6,11 @@
 import React, {useRef, useCallback} from 'react';
 import logger from 'gmp/log';
 import {hasValue} from 'gmp/utils/identity';
-import Download from 'web/components/form/Download';
+import Download, {DownloadData} from 'web/components/form/Download';
 
 type DownloadParams = {
   filename: string;
-  data: string;
+  data: DownloadData;
   mimetype?: string;
 };
 

--- a/src/web/pages/reports/DeltaDetailsPage.tsx
+++ b/src/web/pages/reports/DeltaDetailsPage.tsx
@@ -450,9 +450,6 @@ const DeltaReportDetails = () => {
 
       const {data} = response;
 
-      const stringifiedData =
-        typeof data === 'string' ? data : JSON.stringify(data);
-
       const filename = generateFilename({
         creationTime: entity.creationTime,
         extension,
@@ -465,13 +462,13 @@ const DeltaReportDetails = () => {
         username,
       });
 
-      onDownload({filename, data: stringifiedData});
+      onDownload({filename, data});
     } catch (error) {
       handleError(error);
     }
   };
 
-  const handleFilterCreated = filter => {
+  const handleFilterCreated = (filter: Filter) => {
     void load(filter);
     loadFilters();
   };


### PR DESCRIPTION


## What

Fix downloading a delta report

## Why

Downloading a report from the backend returns an ArrayBuffer and must not be converted into some json string.
## References

https://jira.greenbone.net/browse/GEA-1287

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


