### PR TITLE
Fix initial rendering when a direct page URL is used

### DIFF
--- a/src/web/pages/Page.tsx
+++ b/src/web/pages/Page.tsx
@@ -62,9 +62,9 @@ const Page = ({children}: PageProps) => {
   const gmp = useGmp();
   const [_] = useTranslation();
 
-  if (!isDefined(capabilities)) {
-    // only show content after caps have been loaded
-    // this avoids ugly re-rendering of parts of the ui (e.g. the menu)
+  if (!isDefined(capabilities) || !isDefined(features)) {
+    // only show content after caps and features have been loaded
+    // otherwise missing capabilities or features would throw errors
     return null;
   }
 


### PR DESCRIPTION

## What

Fix initial rendering when a direct page URL is used (for example `https://127.0.0.1:8080/tasks`)

## Why

We need to ensure features and capabilities are both available before rendering anything because without them errors will be raised.

