### PR TITLE
Allow to pass an action function to useInstanceVariable hook 

### DIFF
--- a/src/web/hooks/__tests__/useInstanceVariable.test.tsx
+++ b/src/web/hooks/__tests__/useInstanceVariable.test.tsx
@@ -4,8 +4,8 @@
  */
 
 import {useState} from 'react';
-import {describe, test, expect} from '@gsa/testing';
-import {fireEvent, rendererWith, screen} from 'web/testing';
+import {describe, test, expect, testing} from '@gsa/testing';
+import {fireEvent, rendererWith, renderHook, screen} from 'web/testing';
 import useInstanceVariable from 'web/hooks/useInstanceVariable';
 
 const TestComponent = () => {
@@ -25,7 +25,7 @@ const TestComponent = () => {
 };
 
 describe('useInstanceVariable tests', () => {
-  test('should render the value', () => {
+  test('should render example component', () => {
     const {render} = rendererWith();
 
     render(<TestComponent />);
@@ -35,5 +35,48 @@ describe('useInstanceVariable tests', () => {
     const b1 = screen.getByTestId('changeValue');
     fireEvent.click(b1);
     expect(t1).toHaveTextContent('2');
+  });
+
+  test('should initialize with the given initial value', () => {
+    const {result} = renderHook(() => useInstanceVariable(42));
+    const [value] = result.current;
+
+    expect(value).toBe(42);
+  });
+
+  test('should update the value when setInstanceVariable is called with a new value', async () => {
+    const {result, rerender} = renderHook(() => useInstanceVariable(42));
+    const [, setInstanceVariable] = result.current;
+
+    setInstanceVariable(100);
+    rerender();
+
+    const [value] = result.current;
+    expect(value).toBe(100);
+  });
+
+  test('should update the value when setInstanceVariable is called with a function', () => {
+    const {result, rerender} = renderHook(() => useInstanceVariable(42));
+    const [, setInstanceVariable] = result.current;
+
+    setInstanceVariable(prev => prev + 8);
+    rerender();
+
+    const [value] = result.current;
+    expect(value).toBe(50);
+  });
+
+  test('should not cause re-renders when the value is updated', () => {
+    const renderSpy = testing.fn();
+    const {result} = renderHook(() => {
+      renderSpy();
+      return useInstanceVariable(42);
+    });
+
+    const [, setInstanceVariable] = result.current;
+
+    setInstanceVariable(100);
+
+    expect(renderSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION

## What

Allow to derive the next value from the current value via passing an action function.

## Why

Allow to pass an action function to useInstanceVariable hook to implement same behavior as the useState hook.


## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


