### PR TITLE
Provide a gmp method to useGetEntities query hook

### DIFF
--- a/src/gmp/commands/entities.ts
+++ b/src/gmp/commands/entities.ts
@@ -100,7 +100,7 @@ interface TransformedAggregatesResponseData {
   groups: Group[];
 }
 
-interface EntitiesMeta extends Meta {
+export interface EntitiesMeta extends Meta {
   filter: Filter;
   counts: CollectionCounts;
 }

--- a/src/web/hooks/useQuery/agentgroups.ts
+++ b/src/web/hooks/useQuery/agentgroups.ts
@@ -4,10 +4,10 @@
  */
 
 import {
-  AgentGroupCreateParams,
-  AgentGroupSaveParams,
+  type AgentGroupCreateParams,
+  type AgentGroupSaveParams,
 } from 'gmp/commands/agentgroup';
-import {EntityActionResponse} from 'gmp/commands/entity';
+import {type EntityActionResponse} from 'gmp/commands/entity';
 import Rejection from 'gmp/http/rejection';
 import AgentGroup from 'gmp/models/agentgroup';
 import Filter from 'gmp/models/filter';
@@ -27,12 +27,14 @@ interface UseModifyAgentGroupParams {
   onError?: (error: Rejection) => void;
 }
 
-export const useGetAgentGroups = ({filter}: {filter?: Filter}) =>
-  useGetEntities<AgentGroup>({
+export const useGetAgentGroups = ({filter}: {filter?: Filter}) => {
+  const gmp = useGmp();
+  return useGetEntities<AgentGroup>({
     queryId: 'get_agent_groups',
     filter,
-    entityType: 'agentgroup',
+    gmpMethod: gmp.agentgroups.get.bind(gmp.agentgroup),
   });
+};
 
 export const useCreateAgentGroup = ({
   onSuccess,

--- a/src/web/hooks/useQuery/agents.ts
+++ b/src/web/hooks/useQuery/agents.ts
@@ -4,10 +4,10 @@
  */
 
 import {useQueryClient} from '@tanstack/react-query';
-import {AgentModifyParams} from 'gmp/commands/agent';
+import {type AgentModifyParams} from 'gmp/commands/agent';
 import Rejection from 'gmp/http/rejection';
 import Response from 'gmp/http/response';
-import {XmlMeta} from 'gmp/http/transform/fastxml';
+import {type XmlMeta} from 'gmp/http/transform/fastxml';
 import Agent from 'gmp/models/agent';
 import Filter from 'gmp/models/filter';
 import {isFilter} from 'gmp/models/filter/utils';
@@ -51,10 +51,11 @@ export const useGetAgents = ({
     finalFilter = finalFilter.set('authorized', parseYesNo(authorized));
   }
 
+  const gmp = useGmp();
   return useGetEntities<Agent>({
+    gmpMethod: gmp.agents.get.bind(gmp.agents),
     queryId: 'get_agents',
     filter: finalFilter,
-    entityType: 'agent',
     enabled,
   });
 };

--- a/src/web/pages/agent-groups/AgentGroupsDialog.tsx
+++ b/src/web/pages/agent-groups/AgentGroupsDialog.tsx
@@ -16,6 +16,7 @@ import SaveDialog from 'web/components/dialog/SaveDialog';
 import MultiSelect from 'web/components/form/MultiSelect';
 import Select from 'web/components/form/Select';
 import TextField from 'web/components/form/TextField';
+import useGmp from 'web/hooks/useGmp';
 import {useGetAgents} from 'web/hooks/useQuery/agents';
 import useTranslation from 'web/hooks/useTranslation';
 import AgentConfigurationSection, {
@@ -63,6 +64,7 @@ const AgentGroupsDialog = ({
   onSave,
 }: AgentGroupsDialogProps) => {
   const [_] = useTranslation();
+  const gmp = useGmp();
 
   title = title ?? _('New Agent Group');
 
@@ -72,8 +74,8 @@ const AgentGroupsDialog = ({
 
   const {data: scannersData} = useGetEntities<Scanner>({
     queryId: 'get_scanners',
-    entityType: 'scanner',
     filter: AGENT_CONTROLLERS_FILTER,
+    gmpMethod: gmp.scanners.get.bind(gmp.scanners),
   });
 
   const agentControllers = renderSelectItems(


### PR DESCRIPTION


## What

Provide a gmp method to useGetEntities query hook

## Why

By providing a gmp method we get full type validation.