### PR TITLE
Bind correct object to the gmp method

### DIFF
--- a/src/web/hooks/useQuery/agentgroups.ts
+++ b/src/web/hooks/useQuery/agentgroups.ts
@@ -32,7 +32,7 @@ export const useGetAgentGroups = ({filter}: {filter?: Filter}) => {
   return useGetEntities<AgentGroup>({
     queryId: 'get_agent_groups',
     filter,
-    gmpMethod: gmp.agentgroups.get.bind(gmp.agentgroup),
+    gmpMethod: gmp.agentgroups.get.bind(gmp.agentgroups),
   });
 };
 


### PR DESCRIPTION


## What

Bind correct object to the gmp method

## Why

When a method is used as a function it requires the object to be passed as first argument. For the useGetAgentGroups query hook the wrong object was passed.
