### PR TITLE
Only consider development files for vite dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,6 +50,10 @@ export default defineConfig({
   server: {
     port: 8080,
     host: '127.0.0.1',
+    fs: {
+      strict: true,
+      allow: ['index.html', 'src', 'node_modules'],
+    },
   },
   build: {
     outDir: 'build',


### PR DESCRIPTION


## What

Only consider development files for vite dev server

## Why

Don't serve other files from the root folder then the index.html. The root folder might contain files that are used as a route. For example an `agent-installers.json` in the root would be served instead of displaying the agent-installers list page.