### PR TITLE
Rename HttpCommand httpGet and httpPost methods

### DIFF
--- a/src/gmp/commands/__tests__/http.test.js
+++ b/src/gmp/commands/__tests__/http.test.js
@@ -38,7 +38,7 @@ describe('HttpCommand tests', () => {
 
     const cmd = new HttpCommand(http);
 
-    expect(cmd.httpGet({foo: 'bar'})).toBe(retval);
+    expect(cmd.httpGetWithTransform({foo: 'bar'})).toBe(retval);
 
     expect(http.request).toHaveBeenCalledWith('get', {args: {foo: 'bar'}});
   });
@@ -53,7 +53,7 @@ describe('HttpCommand tests', () => {
 
     cmd.setDefaultParam('lorem', 'ipsum');
 
-    expect(cmd.httpGet({foo: 'bar'})).toBe(retval);
+    expect(cmd.httpGetWithTransform({foo: 'bar'})).toBe(retval);
 
     expect(http.request).toHaveBeenCalledWith('get', {
       args: {foo: 'bar', bar: 1, lorem: 'ipsum'},
@@ -72,7 +72,9 @@ describe('HttpCommand tests', () => {
 
     expect(cmd.getDefaultParam('foo')).toEqual('foo');
 
-    expect(cmd.httpGet({foo: 'bar', bar: 2, lorem: 'ipsum'})).toBe(retval);
+    expect(cmd.httpGetWithTransform({foo: 'bar', bar: 2, lorem: 'ipsum'})).toBe(
+      retval,
+    );
 
     expect(http.request).toHaveBeenCalledWith('get', {
       args: {foo: 'bar', bar: 2, lorem: 'ipsum'},
@@ -87,9 +89,9 @@ describe('HttpCommand tests', () => {
 
     const cmd = new HttpCommand(http, {bar: 1});
 
-    expect(cmd.httpGet({foo: 'bar'}, {extraParams: {lorem: 'ipsum'}})).toBe(
-      retval,
-    );
+    expect(
+      cmd.httpGetWithTransform({foo: 'bar'}, {extraParams: {lorem: 'ipsum'}}),
+    ).toBe(retval);
 
     expect(http.request).toHaveBeenCalledWith('get', {
       args: {foo: 'bar', bar: 1, lorem: 'ipsum'},
@@ -105,7 +107,7 @@ describe('HttpCommand tests', () => {
     const cmd = new HttpCommand(http, {bar: 1, a: 1});
 
     expect(
-      cmd.httpGet(
+      cmd.httpGetWithTransform(
         {foo: 'bar', b: 2},
         {extraParams: {a: 3, b: 4, lorem: 'ipsum'}},
       ),
@@ -125,7 +127,7 @@ describe('HttpCommand tests', () => {
     const cmd = new HttpCommand(http, {bar: 1});
 
     expect(
-      cmd.httpGet(
+      cmd.httpGetWithTransform(
         {foo: 'bar'},
         {
           extraParams: {
@@ -151,7 +153,7 @@ describe('HttpCommand tests', () => {
 
     cmd.setDefaultParam('lorem', 'ipsum');
 
-    expect(cmd.httpPost({foo: 'bar'})).toBe(retval);
+    expect(cmd.httpPostWithTransform({foo: 'bar'})).toBe(retval);
 
     expect(http.request).toHaveBeenCalledWith('post', {
       data: {foo: 'bar', bar: 1, lorem: 'ipsum'},
@@ -170,7 +172,9 @@ describe('HttpCommand tests', () => {
 
     expect(cmd.getDefaultParam('foo')).toEqual('foo');
 
-    expect(cmd.httpPost({foo: 'bar', bar: 2, lorem: 'ipsum'})).toBe(retval);
+    expect(
+      cmd.httpPostWithTransform({foo: 'bar', bar: 2, lorem: 'ipsum'}),
+    ).toBe(retval);
 
     expect(http.request).toHaveBeenCalledWith('post', {
       data: {foo: 'bar', bar: 2, lorem: 'ipsum'},
@@ -185,9 +189,9 @@ describe('HttpCommand tests', () => {
 
     const cmd = new HttpCommand(http, {bar: 1});
 
-    expect(cmd.httpPost({foo: 'bar'}, {extraParams: {lorem: 'ipsum'}})).toBe(
-      retval,
-    );
+    expect(
+      cmd.httpPostWithTransform({foo: 'bar'}, {extraParams: {lorem: 'ipsum'}}),
+    ).toBe(retval);
 
     expect(http.request).toHaveBeenCalledWith('post', {
       data: {foo: 'bar', bar: 1, lorem: 'ipsum'},
@@ -203,7 +207,7 @@ describe('HttpCommand tests', () => {
     const cmd = new HttpCommand(http, {bar: 1, a: 1});
 
     expect(
-      cmd.httpPost(
+      cmd.httpPostWithTransform(
         {foo: 'bar', b: 2},
         {extraParams: {a: 3, b: 4, lorem: 'ipsum'}},
       ),
@@ -223,7 +227,7 @@ describe('HttpCommand tests', () => {
     const cmd = new HttpCommand(http, {bar: 1});
 
     expect(
-      cmd.httpPost(
+      cmd.httpPostWithTransform(
         {foo: 'bar'},
         {
           extraParams: {

--- a/src/gmp/commands/agent.ts
+++ b/src/gmp/commands/agent.ts
@@ -35,7 +35,7 @@ class AgentCommand extends EntityCommand<Agent, AgentElement> {
 
   async delete({id}: {id: string}) {
     log.debug('Deleting agent', {id});
-    await this.httpPost({
+    await this.httpPostWithTransform({
       cmd: 'delete_agent',
       'agent_ids:': id,
     });

--- a/src/gmp/commands/agentgroups.ts
+++ b/src/gmp/commands/agentgroups.ts
@@ -30,7 +30,7 @@ class AgentGroupsCommand extends EntitiesCommand<AgentGroup> {
         .join(',');
     }
 
-    return this.httpPost(data);
+    return this.httpPostWithTransform(data);
   }
 
   getSeverityAggregates({filter}: {filter?: Filter} = {}) {

--- a/src/gmp/commands/agentinstaller.ts
+++ b/src/gmp/commands/agentinstaller.ts
@@ -20,7 +20,7 @@ class AgentInstallerCommand extends EntityCommand<
   }
 
   async download(id: string) {
-    return await this.httpGet(
+    return await this.httpGetWithTransform(
       {
         cmd: 'get_agent_installer_file',
         agent_installer_id: id,

--- a/src/gmp/commands/agents.ts
+++ b/src/gmp/commands/agents.ts
@@ -39,13 +39,13 @@ class AgentsCommand extends EntitiesCommand<Agent> {
       cmd: 'delete_agent',
       'agent_ids:': ids,
     };
-    const response = await this.httpPost(params);
+    const response = await this.httpPostWithTransform(params);
     return response.setData(ids);
   }
 
   async authorize(agents: Agent[]) {
     log.debug('Authorizing agent', {agents});
-    await this.httpPost({
+    await this.httpPostWithTransform({
       cmd: 'modify_agent',
       authorized: YES_VALUE,
       'agent_ids:': map(agents, agent => agent.id),
@@ -59,7 +59,7 @@ class AgentsCommand extends EntitiesCommand<Agent> {
 
   async revoke(agents: Agent[]) {
     log.debug('Revoking agent', {agents});
-    await this.httpPost({
+    await this.httpPostWithTransform({
       cmd: 'modify_agent',
       authorized: NO_VALUE,
       'agent_ids:': map(agents, agent => agent.id),

--- a/src/gmp/commands/alerts.js
+++ b/src/gmp/commands/alerts.js
@@ -179,7 +179,7 @@ class AlertCommand extends EntityCommand {
 
   newAlertSettings() {
     // should be removed after all corresponding omp commands are implemented
-    return this.httpGet({
+    return this.httpGetWithTransform({
       cmd: 'new_alert',
     }).then(response => {
       const {new_alert} = response.data;
@@ -208,7 +208,7 @@ class AlertCommand extends EntityCommand {
   }
 
   editAlertSettings({id}) {
-    return this.httpGet({
+    return this.httpGetWithTransform({
       cmd: 'edit_alert',
       id,
     }).then(response => {
@@ -256,7 +256,7 @@ class AlertCommand extends EntityCommand {
   }
 
   test({id}) {
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'test_alert',
       id,
     });

--- a/src/gmp/commands/auditreports.js
+++ b/src/gmp/commands/auditreports.js
@@ -48,7 +48,7 @@ export class AuditReportCommand extends EntityCommand {
   }
 
   download({id}, {reportFormatId, deltaReportId, filter}) {
-    return this.httpGet(
+    return this.httpGetWithTransform(
       {
         cmd: 'get_report',
         delta_report_id: deltaReportId,
@@ -62,7 +62,7 @@ export class AuditReportCommand extends EntityCommand {
   }
 
   addAssets({id}, {filter = ''}) {
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'create_asset',
       report_id: id,
       filter,
@@ -70,7 +70,7 @@ export class AuditReportCommand extends EntityCommand {
   }
 
   removeAssets({id}, {filter = ''}) {
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'delete_asset',
       report_id: id,
       filter,
@@ -78,7 +78,7 @@ export class AuditReportCommand extends EntityCommand {
   }
 
   alert({alert_id, report_id, filter}) {
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'report_alert',
       alert_id,
       report_id,
@@ -91,7 +91,7 @@ export class AuditReportCommand extends EntityCommand {
     {id: delta_report_id},
     {filter, details = true, ...options} = {},
   ) {
-    return this.httpGet(
+    return this.httpGetWithTransform(
       {
         id,
         delta_report_id,
@@ -113,7 +113,7 @@ export class AuditReportCommand extends EntityCommand {
       ...options
     } = {},
   ) {
-    return this.httpGet(
+    return this.httpGetWithTransform(
       {
         id,
         filter,

--- a/src/gmp/commands/audits.js
+++ b/src/gmp/commands/audits.js
@@ -20,7 +20,7 @@ export class AuditCommand extends EntityCommand {
   start({id}) {
     log.debug('Starting audit...');
 
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'start_task',
       id,
     })
@@ -37,7 +37,7 @@ export class AuditCommand extends EntityCommand {
   stop({id}) {
     log.debug('Stopping audit');
 
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'stop_task',
       id,
     })
@@ -52,7 +52,7 @@ export class AuditCommand extends EntityCommand {
   }
 
   resume({id}) {
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'resume_task',
       id,
     })
@@ -183,7 +183,7 @@ export class AuditsCommand extends EntitiesCommand {
 
   get(params, options) {
     params = {...params, usage_type: 'audit'};
-    return this.httpGet(params, options).then(response => {
+    return this.httpGetWithTransform(params, options).then(response => {
       const {entities, filter, counts} = this.getCollectionListFromRoot(
         response.data,
       );

--- a/src/gmp/commands/auth.ts
+++ b/src/gmp/commands/auth.ts
@@ -28,7 +28,7 @@ class AuthenticationCommand extends HttpCommand {
     ldapHost,
     ldapsOnly,
   }: SaveLdapArguments) {
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'save_auth',
       group: 'method:ldap_connect',
       authdn,
@@ -40,7 +40,7 @@ class AuthenticationCommand extends HttpCommand {
   }
 
   saveRadius({radiusEnabled, radiusHost, radiusKey}: SaveRadiusArguments) {
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'save_auth',
       group: 'method:radius_connect',
       enable: convertBoolean(radiusEnabled),

--- a/src/gmp/commands/credentials.js
+++ b/src/gmp/commands/credentials.js
@@ -112,7 +112,7 @@ export class CredentialCommand extends EntityCommand {
   }
 
   download({id}, format = 'pem') {
-    return this.httpGet(
+    return this.httpGetWithTransform(
       {
         cmd: 'download_credential',
         package_format: format,

--- a/src/gmp/commands/cvsscalculator.js
+++ b/src/gmp/commands/cvsscalculator.js
@@ -13,7 +13,7 @@ class CvssCalculator extends HttpCommand {
   }
 
   calculateScoreFromVector(cvss_vector) {
-    return this.httpGet({
+    return this.httpGetWithTransform({
       cvss_vector,
     }).then(response => {
       const {data: envelope} = response;

--- a/src/gmp/commands/dashboards.ts
+++ b/src/gmp/commands/dashboards.ts
@@ -87,7 +87,7 @@ const convertLoadedSettings = <
 
 class DashboardCommand extends HttpCommand {
   async getSetting(id: string) {
-    const response = await this.httpGet({
+    const response = await this.httpGetWithTransform({
       cmd: 'get_setting',
       setting_id: id,
     });
@@ -120,7 +120,7 @@ class DashboardCommand extends HttpCommand {
   ) {
     log.debug('Saving dashboard settings', id, settings);
 
-    await this.httpPost({
+    await this.httpPostWithTransform({
       setting_id: id,
       setting_value: JSON.stringify(settings),
       cmd: 'save_setting',

--- a/src/gmp/commands/entities.ts
+++ b/src/gmp/commands/entities.ts
@@ -132,7 +132,7 @@ abstract class EntitiesCommand<
   }
 
   async get(params: HttpCommandInputParams = {}, options?: HttpCommandOptions) {
-    const response = await this.httpGet(params, options);
+    const response = await this.httpGetWithTransform(params, options);
     const {entities, filter, counts} = this.getCollectionListFromRoot(
       response.data as TRoot,
     );
@@ -166,7 +166,7 @@ abstract class EntitiesCommand<
     for (const id of ids) {
       params['bulk_selected:' + id] = 1;
     }
-    return this.httpPost(params, {
+    return this.httpPostWithTransform(params, {
       transform: DefaultTransform,
     } as HttpCommandOptions);
   }
@@ -178,7 +178,7 @@ abstract class EntitiesCommand<
       bulk_select: BULK_SELECT_BY_FILTER,
       filter,
     };
-    return this.httpPost(params, {
+    return this.httpPostWithTransform(params, {
       transform: DefaultTransform,
     } as HttpCommandOptions);
   }
@@ -203,7 +203,7 @@ abstract class EntitiesCommand<
     for (const id of ids) {
       params['bulk_selected:' + id] = 1;
     }
-    const response = await this.httpPost(params);
+    const response = await this.httpPostWithTransform(params);
     return response.setData(ids);
   }
 
@@ -306,7 +306,7 @@ abstract class EntitiesCommand<
       requestParams.subgroup_column = subgroupColumn;
     }
 
-    const response = await this.httpGet({
+    const response = await this.httpGetWithTransform({
       ...requestParams,
       ...params,
       cmd: 'get_aggregate',

--- a/src/gmp/commands/entity.ts
+++ b/src/gmp/commands/entity.ts
@@ -127,7 +127,7 @@ abstract class EntityCommand<
     params: HttpCommandPostParams,
     options?: HttpCommandOptions,
   ) {
-    const response = await this.httpPost(params, options);
+    const response = await this.httpPostWithTransform(params, options);
     return this.transformActionResult(response);
   }
 
@@ -148,7 +148,7 @@ abstract class EntityCommand<
     {id}: EntityCommandParams,
     {filter, ...options}: EntityCommandGetParams = {},
   ) {
-    const response = await this.httpGet({id, filter}, options);
+    const response = await this.httpGetWithTransform({id, filter}, options);
     return this.transformResponse(response as Response<TRoot, XmlMeta>);
   }
 
@@ -177,7 +177,7 @@ abstract class EntityCommand<
   async delete({id}: EntityCommandParams) {
     log.debug('Deleting', this.name, id);
 
-    await this.httpPost({
+    await this.httpPostWithTransform({
       cmd: 'delete_' + this.name,
       id,
     });
@@ -190,7 +190,7 @@ abstract class EntityCommand<
       bulk_select: BULK_SELECT_BY_IDS,
       ['bulk_selected:' + id]: 1,
     };
-    const response = await this.httpPost(params, {
+    const response = await this.httpPostWithTransform(params, {
       transform: DefaultTransform,
     } as HttpCommandOptions);
     return response as unknown as Response<string, Meta>;

--- a/src/gmp/commands/feedstatus.ts
+++ b/src/gmp/commands/feedstatus.ts
@@ -117,7 +117,7 @@ class FeedStatusCommand extends HttpCommand {
   }
 
   async readFeedInformation() {
-    const response = await this.httpGet();
+    const response = await this.httpGetWithTransform();
     const envelope = response.data as FeedStatusElement;
     const {get_feeds_response: feedsResponse} = envelope.get_feeds;
     const feeds = map(feedsResponse.feed, feed => createFeed(feed));
@@ -163,7 +163,7 @@ class FeedStatusCommand extends HttpCommand {
    */
   async checkFeedOwnerAndPermissions() {
     try {
-      const response = await this.httpGet();
+      const response = await this.httpGetWithTransform();
       const data = response.data as FeedStatusElement;
       const isFeedOwnerSet = parseBoolean(
         data.get_feeds.get_feeds_response.feed_owner_set,

--- a/src/gmp/commands/hosts.js
+++ b/src/gmp/commands/hosts.js
@@ -39,7 +39,7 @@ class HostCommand extends EntityCommand {
 
   deleteIdentifier({id}) {
     log.debug('Deleting Host Identifier with id', id);
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'delete_asset',
       asset_id: id,
     });

--- a/src/gmp/commands/http.ts
+++ b/src/gmp/commands/http.ts
@@ -118,7 +118,7 @@ class HttpCommand {
     };
   }
 
-  protected httpGet(
+  protected httpGetWithTransform(
     params: HttpCommandInputParams = {},
     options: HttpCommandOptions = {},
   ) {
@@ -129,7 +129,7 @@ class HttpCommand {
     });
   }
 
-  protected httpPost(
+  protected httpPostWithTransform(
     params: HttpCommandInputParams = {},
     options: HttpCommandOptions = {},
   ) {

--- a/src/gmp/commands/license.js
+++ b/src/gmp/commands/license.js
@@ -13,7 +13,7 @@ export class LicenseCommand extends HttpCommand {
   }
 
   getLicenseInformation() {
-    return this.httpGet().then(response => {
+    return this.httpGetWithTransform().then(response => {
       const {data: envelope} = response;
       const {get_license_response: licenseResponse} = envelope.get_license;
       const license = License.fromElement(licenseResponse.license);

--- a/src/gmp/commands/login.ts
+++ b/src/gmp/commands/login.ts
@@ -18,7 +18,7 @@ class LoginCommand extends HttpCommand {
 
   async login(username: string, password: string) {
     try {
-      const response = await this.httpPost({
+      const response = await this.httpPostWithTransform({
         login: username,
         password,
       });

--- a/src/gmp/commands/nvt.js
+++ b/src/gmp/commands/nvt.js
@@ -17,7 +17,7 @@ export class NvtCommand extends InfoEntityCommand {
   }
 
   getConfigNvt({oid, configId}) {
-    return this.httpGet(
+    return this.httpGetWithTransform(
       {
         cmd: 'get_config_nvt',
         config_id: configId,

--- a/src/gmp/commands/nvtfamilies.js
+++ b/src/gmp/commands/nvtfamilies.js
@@ -14,7 +14,7 @@ export class NvtFamiliesCommand extends HttpCommand {
   }
 
   get(params, options) {
-    return this.httpGet(params, options).then(response => {
+    return this.httpGetWithTransform(params, options).then(response => {
       const {data} = response;
       const {family: families} =
         data.get_nvt_families.get_nvt_families_response.families;

--- a/src/gmp/commands/performance.ts
+++ b/src/gmp/commands/performance.ts
@@ -106,7 +106,7 @@ class PerformanceCommand extends HttpCommand {
   }
 
   async getAll({sensorId = DEFAULT_SENSOR_ID} = {}) {
-    const response = await this.httpGet({
+    const response = await this.httpGetWithTransform({
       slave_id: sensorId,
     });
     const {get_system_reports: sys_reports = {}} =
@@ -139,7 +139,7 @@ class PerformanceCommand extends HttpCommand {
       params.start_time = startDate.format('YYYY-MM-DDTHH:mm:ssZ');
       params.end_time = endDate.format('YYYY-MM-DDTHH:mm:ssZ');
     }
-    const response = await this.httpGet(params);
+    const response = await this.httpGetWithTransform(params);
     const data = response.data as GetSystemReportResponseData;
     const report =
       data?.get_system_report?.get_system_reports_response?.system_report;

--- a/src/gmp/commands/permissions.js
+++ b/src/gmp/commands/permissions.js
@@ -110,7 +110,7 @@ class PermissionsCommand extends EntitiesCommand {
     });
 
     log.debug('Creating new permission', data);
-    return this.httpPost(data);
+    return this.httpPostWithTransform(data);
   }
 
   getEntitiesResponse(root) {

--- a/src/gmp/commands/policies.js
+++ b/src/gmp/commands/policies.js
@@ -31,7 +31,7 @@ export class PolicyCommand extends EntityCommand {
       xml_file,
     };
     log.debug('Importing policy', data);
-    return this.httpPost(data);
+    return this.httpPostWithTransform(data);
   }
 
   create({name, comment}) {
@@ -76,16 +76,16 @@ export class PolicyCommand extends EntityCommand {
       family: familyName,
     };
     log.debug('Saving scanconfigfamily', data);
-    return this.httpPost(data);
+    return this.httpPostWithTransform(data);
   }
 
   editPolicyFamilySettings({id, familyName}) {
-    const get = this.httpGet({
+    const get = this.httpGetWithTransform({
       cmd: 'edit_config_family',
       id,
       family: familyName,
     });
-    const all = this.httpGet({
+    const all = this.httpGetWithTransform({
       cmd: 'edit_config_family_all',
       id,
       family: familyName,
@@ -132,7 +132,7 @@ export class PolicyCommand extends EntityCommand {
       : '';
 
     log.debug('Saving policynvt', data);
-    return this.httpPost(data);
+    return this.httpPostWithTransform(data);
   }
 
   getElementFromRoot(root) {
@@ -151,7 +151,7 @@ export class PoliciesCommand extends EntitiesCommand {
 
   get(params, options) {
     params = {...params, usage_type: 'policy'};
-    return this.httpGet(params, options).then(response => {
+    return this.httpGetWithTransform(params, options).then(response => {
       const {entities, filter, counts} = this.getCollectionListFromRoot(
         response.data,
       );

--- a/src/gmp/commands/portlists.ts
+++ b/src/gmp/commands/portlists.ts
@@ -106,7 +106,7 @@ export class PortListCommand extends EntityCommand<PortList, PortListElement> {
     id,
     portListId,
   }: PortListCommandDeletePortRangeParams) {
-    await this.httpPost({
+    await this.httpPostWithTransform({
       cmd: 'delete_port_range',
       port_range_id: id,
       no_redirect: 1,
@@ -116,7 +116,7 @@ export class PortListCommand extends EntityCommand<PortList, PortListElement> {
 
   import({xmlFile}: PortListCommandImportParams) {
     log.debug('Importing port list', {xml_file: xmlFile});
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'import_port_list',
       xml_file: xmlFile,
     });

--- a/src/gmp/commands/report.ts
+++ b/src/gmp/commands/report.ts
@@ -67,7 +67,7 @@ class ReportCommand extends EntityCommand<Report, ReportElement> {
   import(args: ReportCommandImportParams) {
     const {task_id, in_assets = 1, xml_file} = args;
     log.debug('Creating report', args);
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'create_report',
       task_id,
       in_assets,
@@ -85,7 +85,7 @@ class ReportCommand extends EntityCommand<Report, ReportElement> {
     }: ReportCommandDownloadOptions,
   ): Promise<Response<ArrayBuffer, XmlMeta>> {
     // @ts-expect-error
-    return this.httpGet(
+    return this.httpGetWithTransform(
       {
         cmd: 'get_report',
         delta_report_id: deltaReportId,
@@ -101,7 +101,7 @@ class ReportCommand extends EntityCommand<Report, ReportElement> {
   }
 
   addAssets({id, filter = ''}: ReportCommandAddAssetsParams) {
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'create_asset',
       report_id: id,
       filter,
@@ -109,7 +109,7 @@ class ReportCommand extends EntityCommand<Report, ReportElement> {
   }
 
   removeAssets({id, filter = ''}: ReportCommandARemoveAssetsParams) {
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'delete_asset',
       report_id: id,
       filter,
@@ -118,7 +118,7 @@ class ReportCommand extends EntityCommand<Report, ReportElement> {
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   alert({alert_id, report_id, filter}: ReportCommandAlertParams) {
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'report_alert',
       alert_id,
       report_id,
@@ -136,7 +136,7 @@ class ReportCommand extends EntityCommand<Report, ReportElement> {
       ...options
     }: {filter?: string; details?: boolean; [key: string]: unknown} = {},
   ) {
-    const response = await this.httpGet(
+    const response = await this.httpGetWithTransform(
       {
         id,
         delta_report_id,
@@ -159,7 +159,7 @@ class ReportCommand extends EntityCommand<Report, ReportElement> {
       ...options
     }: ReportCommandGetParams = {},
   ) {
-    const response = await this.httpGet({
+    const response = await this.httpGetWithTransform({
       id,
       filter,
       lean: convertBoolean(lean),

--- a/src/gmp/commands/role.ts
+++ b/src/gmp/commands/role.ts
@@ -50,7 +50,7 @@ class RoleCommand extends EntityCommand<Role, RoleElement> {
       users: isArray(users) ? users.join(',') : '',
     };
     log.debug('Saving role', data);
-    await this.httpPost(data);
+    await this.httpPostWithTransform(data);
   }
 
   getElementFromRoot(root: XmlResponseData): RoleElement {

--- a/src/gmp/commands/scanconfigs.js
+++ b/src/gmp/commands/scanconfigs.js
@@ -61,7 +61,7 @@ export class ScanConfigCommand extends EntityCommand {
       xml_file,
     };
     log.debug('Importing scan config', data);
-    return this.httpPost(data);
+    return this.httpPostWithTransform(data);
   }
 
   create({baseScanConfig, name, comment}) {
@@ -115,16 +115,16 @@ export class ScanConfigCommand extends EntityCommand {
       family: familyName,
     };
     log.debug('Saving scanconfigfamily', data);
-    return this.httpPost(data);
+    return this.httpPostWithTransform(data);
   }
 
   editScanConfigFamilySettings({id, familyName}) {
-    const get = this.httpGet({
+    const get = this.httpGetWithTransform({
       cmd: 'edit_config_family',
       id,
       family: familyName,
     });
-    const all = this.httpGet({
+    const all = this.httpGetWithTransform({
       cmd: 'edit_config_family_all',
       id,
       family: familyName,
@@ -171,11 +171,11 @@ export class ScanConfigCommand extends EntityCommand {
       : '';
 
     log.debug('Saving scanconfignvt', data);
-    return this.httpPost(data);
+    return this.httpPostWithTransform(data);
   }
 
   editScanConfigNvtSettings({id, oid}) {
-    return this.httpGet({
+    return this.httpGetWithTransform({
       cmd: 'get_config_nvt',
       id,
       oid,
@@ -206,7 +206,7 @@ class ScanConfigsCommand extends EntitiesCommand {
 
   get(params, options) {
     params = {...params, usage_type: 'scan'};
-    return this.httpGet(params, options).then(response => {
+    return this.httpGetWithTransform(params, options).then(response => {
       const {entities, filter, counts} = this.getCollectionListFromRoot(
         response.data,
       );

--- a/src/gmp/commands/tags.js
+++ b/src/gmp/commands/tags.js
@@ -80,7 +80,7 @@ export class TagCommand extends EntityCommand {
       id,
     };
     log.debug('Enabling tag', data);
-    return this.httpPost(data);
+    return this.httpPostWithTransform(data);
   }
 
   disable({id}) {
@@ -90,7 +90,7 @@ export class TagCommand extends EntityCommand {
       id,
     };
     log.debug('Disabling tag', data);
-    return this.httpPost(data);
+    return this.httpPostWithTransform(data);
   }
 }
 

--- a/src/gmp/commands/task.ts
+++ b/src/gmp/commands/task.ts
@@ -120,7 +120,7 @@ class TaskCommand extends EntityCommand<Task, TaskElement> {
         throw new Error('Feed is currently syncing. Please try again later.');
       }
 
-      await this.httpPost({
+      await this.httpPostWithTransform({
         cmd: 'start_task',
         id,
       });
@@ -136,7 +136,7 @@ class TaskCommand extends EntityCommand<Task, TaskElement> {
     log.debug('Stopping task');
 
     try {
-      await this.httpPost({
+      await this.httpPostWithTransform({
         cmd: 'stop_task',
         id,
       });
@@ -150,7 +150,7 @@ class TaskCommand extends EntityCommand<Task, TaskElement> {
 
   async resume({id}: EntityCommandParams) {
     try {
-      await this.httpPost({
+      await this.httpPostWithTransform({
         cmd: 'resume_task',
         id,
       });
@@ -321,7 +321,7 @@ class TaskCommand extends EntityCommand<Task, TaskElement> {
     };
     log.debug('Saving task', data);
     try {
-      await this.httpPost(data);
+      await this.httpPostWithTransform(data);
     } catch (rejection) {
       await feedStatusRejection(this.http, rejection as Rejection);
     }
@@ -360,7 +360,7 @@ class TaskCommand extends EntityCommand<Task, TaskElement> {
     };
     log.debug('Saving agent task', data);
     try {
-      await this.httpPost(data);
+      await this.httpPostWithTransform(data);
     } catch (rejection) {
       await feedStatusRejection(this.http, rejection as Rejection);
     }
@@ -373,7 +373,7 @@ class TaskCommand extends EntityCommand<Task, TaskElement> {
     id,
   }: TaskCommandSaveContainerParams) {
     log.debug('Saving container task', {name, comment, in_assets, id});
-    await this.httpPost({
+    await this.httpPostWithTransform({
       cmd: 'save_container_task',
       name,
       comment,

--- a/src/gmp/commands/tasks.ts
+++ b/src/gmp/commands/tasks.ts
@@ -56,7 +56,7 @@ class TasksCommand extends EntitiesCommand<Task, GetTasksResponse> {
     options?: HttpCommandOptions,
   ) {
     const params = {filter, usage_type: 'scan'};
-    const response = await this.httpGet(params, options);
+    const response = await this.httpGetWithTransform(params, options);
     const {
       entities,
       filter: responseFilter,

--- a/src/gmp/commands/trashcan.ts
+++ b/src/gmp/commands/trashcan.ts
@@ -190,14 +190,14 @@ class TrashCanCommand extends HttpCommand {
       cmd: 'restore',
       target_id: id,
     };
-    await this.httpPost(data);
+    await this.httpPostWithTransform(data);
   }
 
   async delete({id, entityType}: {id: string; entityType: EntityType}) {
     const cmdApiType = apiType(entityType);
     const cmd = 'delete_from_trash';
     const typeId = cmdApiType + '_id';
-    await this.httpPost({
+    await this.httpPostWithTransform({
       cmd,
       [typeId]: id,
       resource_type: cmdApiType,
@@ -205,65 +205,65 @@ class TrashCanCommand extends HttpCommand {
   }
 
   async empty() {
-    await this.httpPost({cmd: 'empty_trashcan'});
+    await this.httpPostWithTransform({cmd: 'empty_trashcan'});
   }
 
   async get(): Promise<Response<TrashCanGetData, XmlMeta>> {
-    const alertsRequest = this.httpGet({
+    const alertsRequest = this.httpGetWithTransform({
       cmd: 'get_trash_alerts',
     }) as TrashCanGetPromise<AlertResponseData>;
-    const configsRequest = this.httpGet({
+    const configsRequest = this.httpGetWithTransform({
       cmd: 'get_trash_configs',
     }) as TrashCanGetPromise<ConfigsResponseData>;
-    const credentialsRequest = this.httpGet({
+    const credentialsRequest = this.httpGetWithTransform({
       cmd: 'get_trash_credentials',
     }) as TrashCanGetPromise<CredentialsResponseData>;
-    const filtersRequest = this.httpGet({
+    const filtersRequest = this.httpGetWithTransform({
       cmd: 'get_trash_filters',
     }) as TrashCanGetPromise<FiltersResponseData>;
-    const groupsRequest = this.httpGet({
+    const groupsRequest = this.httpGetWithTransform({
       cmd: 'get_trash_groups',
     }) as TrashCanGetPromise<GroupsResponseData>;
-    const notesRequest = this.httpGet({
+    const notesRequest = this.httpGetWithTransform({
       cmd: 'get_trash_notes',
     }) as TrashCanGetPromise<NotesResponseData>;
-    const overridesRequest = this.httpGet({
+    const overridesRequest = this.httpGetWithTransform({
       cmd: 'get_trash_overrides',
     }) as TrashCanGetPromise<OverridesResponseData>;
-    const permissionsRequest = this.httpGet({
+    const permissionsRequest = this.httpGetWithTransform({
       cmd: 'get_trash_permissions',
     }) as TrashCanGetPromise<PermissionsResponseData>;
-    const portListsRequest = this.httpGet({
+    const portListsRequest = this.httpGetWithTransform({
       cmd: 'get_trash_port_lists',
     }) as TrashCanGetPromise<PortListsResponseData>;
-    const reportConfigsRequest = this.httpGet({
+    const reportConfigsRequest = this.httpGetWithTransform({
       cmd: 'get_trash_report_configs',
     }) as TrashCanGetPromise<ReportConfigsResponseData>;
-    const reportFormatsRequest = this.httpGet({
+    const reportFormatsRequest = this.httpGetWithTransform({
       cmd: 'get_trash_report_formats',
     }) as TrashCanGetPromise<ReportFormatsResponseData>;
-    const rolesRequest = this.httpGet({
+    const rolesRequest = this.httpGetWithTransform({
       cmd: 'get_trash_roles',
     }) as TrashCanGetPromise<RolesResponseData>;
-    const scannersRequest = this.httpGet({
+    const scannersRequest = this.httpGetWithTransform({
       cmd: 'get_trash_scanners',
     }) as TrashCanGetPromise<ScannersResponseData>;
-    const schedulesRequest = this.httpGet({
+    const schedulesRequest = this.httpGetWithTransform({
       cmd: 'get_trash_schedules',
     }) as TrashCanGetPromise<SchedulesResponseData>;
-    const tagsRequest = this.httpGet({
+    const tagsRequest = this.httpGetWithTransform({
       cmd: 'get_trash_tags',
     }) as TrashCanGetPromise<TagsResponseData>;
-    const targetsRequest = this.httpGet({
+    const targetsRequest = this.httpGetWithTransform({
       cmd: 'get_trash_targets',
     }) as TrashCanGetPromise<TargetsResponseData>;
-    const tasksRequest = this.httpGet({
+    const tasksRequest = this.httpGetWithTransform({
       cmd: 'get_trash_tasks',
     }) as TrashCanGetPromise<TasksResponseData>;
-    const ticketsRequest = this.httpGet({
+    const ticketsRequest = this.httpGetWithTransform({
       cmd: 'get_trash_tickets',
     }) as TrashCanGetPromise<TicketsResponseData>;
-    const agentGroupRequest = this.httpGet({
+    const agentGroupRequest = this.httpGetWithTransform({
       cmd: 'get_trash_agent_group',
     }) as TrashCanGetPromise<AgentGroupResponseData>;
     const [

--- a/src/gmp/commands/user.ts
+++ b/src/gmp/commands/user.ts
@@ -259,7 +259,7 @@ class UserCommand extends EntityCommand<User, PortListElement> {
   }
 
   async currentAuthSettings(options: HttpCommandOptions = {}) {
-    const response = await this.httpGet(
+    const response = await this.httpGetWithTransform(
       {
         cmd: 'auth_settings',
         name: '--', // only used in old xslt and can be any string
@@ -301,7 +301,7 @@ class UserCommand extends EntityCommand<User, PortListElement> {
   }
 
   async getSetting(id: string) {
-    const response = await this.httpGet({
+    const response = await this.httpGetWithTransform({
       cmd: 'get_setting',
       setting_id: id,
     });
@@ -316,7 +316,7 @@ class UserCommand extends EntityCommand<User, PortListElement> {
   }
 
   async currentSettings(options: HttpCommandOptions = {}) {
-    const response = await this.httpGet(
+    const response = await this.httpGetWithTransform(
       {
         cmd: 'get_settings',
       },
@@ -333,7 +333,7 @@ class UserCommand extends EntityCommand<User, PortListElement> {
   }
 
   async currentCapabilities(options: HttpCommandOptions = {}) {
-    const response = await this.httpGet(
+    const response = await this.httpGetWithTransform(
       {
         cmd: 'get_capabilities',
       },
@@ -346,7 +346,7 @@ class UserCommand extends EntityCommand<User, PortListElement> {
   }
 
   async currentFeatures(options: HttpCommandOptions = {}) {
-    const response = await this.httpGet(
+    const response = await this.httpGetWithTransform(
       {
         cmd: 'get_capabilities',
       },
@@ -448,7 +448,7 @@ class UserCommand extends EntityCommand<User, PortListElement> {
       inheritor_id: inheritorId,
     };
     log.debug('Deleting user', data);
-    await this.httpPost(data);
+    await this.httpPostWithTransform(data);
   }
 
   /**
@@ -457,7 +457,7 @@ class UserCommand extends EntityCommand<User, PortListElement> {
   saveSettings(data: SaveSettingsArguments) {
     log.debug('Saving settings', data);
 
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'save_my_settings',
       text: data.timezone,
       [PARAM_KEYS.DATE]: data.userInterfaceDateFormat,
@@ -530,7 +530,7 @@ class UserCommand extends EntityCommand<User, PortListElement> {
   }
 
   async saveSetting(settingId: string, settingValue: string | number) {
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'save_setting',
       setting_id: settingId,
       setting_value: settingValue,
@@ -538,7 +538,7 @@ class UserCommand extends EntityCommand<User, PortListElement> {
   }
 
   async saveTimezone(settingValue: string | number) {
-    return this.httpPost({
+    return this.httpPostWithTransform({
       cmd: 'save_setting',
       setting_name: 'Timezone',
       setting_value: settingValue,
@@ -592,7 +592,7 @@ class UserCommand extends EntityCommand<User, PortListElement> {
   }
 
   ping() {
-    return this.httpGet({
+    return this.httpGetWithTransform({
       cmd: 'ping',
     });
   }

--- a/src/gmp/commands/wizard.ts
+++ b/src/gmp/commands/wizard.ts
@@ -99,7 +99,7 @@ class WizardCommand extends HttpCommand {
   }
 
   async task() {
-    const response = await this.httpGet({
+    const response = await this.httpGetWithTransform({
       name: 'quick_first_scan',
     });
     const {data} = response as Response<RunWizardResponseData, XmlMeta>;
@@ -122,7 +122,7 @@ class WizardCommand extends HttpCommand {
   }
 
   async advancedTask() {
-    const response = await this.httpGet({
+    const response = await this.httpGetWithTransform({
       name: 'quick_task',
     });
     const {data} = response as Response<RunWizardResponseData, XmlMeta>;
@@ -151,7 +151,7 @@ class WizardCommand extends HttpCommand {
   }
 
   async modifyTask() {
-    const response = await this.httpGet({
+    const response = await this.httpGetWithTransform({
       name: 'modify_task',
     });
     const {data} = response as Response<RunWizardResponseData, XmlMeta>;
@@ -180,7 +180,7 @@ class WizardCommand extends HttpCommand {
 
   async runQuickFirstScan({hosts}: RunQuickFirstScanArguments) {
     try {
-      return await this.httpPost({
+      return await this.httpPostWithTransform({
         'event_data:hosts': hosts,
         cmd: 'run_wizard',
         name: 'quick_first_scan',
@@ -206,7 +206,7 @@ class WizardCommand extends HttpCommand {
     taskName,
   }: RunQuickTaskArguments) {
     try {
-      return await this.httpPost({
+      return await this.httpPostWithTransform({
         'event_data:alert_email': alertEmail,
         'event_data:auto_start': autoStart,
         'event_data:config_id': scanConfigId,
@@ -241,7 +241,7 @@ class WizardCommand extends HttpCommand {
     startMinute,
     startTimezone,
   }: RunModifyTaskArguments) {
-    return this.httpPost({
+    return this.httpPostWithTransform({
       'event_data:alert_email': alertEmail,
       'event_data:reschedule': reschedule,
       'event_data:start_hour': startHour,


### PR DESCRIPTION


## What

Rename HttpCommand httpGet and httpPost methods

## Why

Use a more descriptive name for what they are supposed to do. They create a request and transform the response to the expected data objects (aka. elements). This will allow to introduce new methods for doing plain http get and post requests in future.