### PR TITLE
Improve EntityCommand properties and methods

### DIFF
--- a/src/gmp/commands/auditreports.js
+++ b/src/gmp/commands/auditreports.js
@@ -86,12 +86,12 @@ export class AuditReportCommand extends EntityCommand {
     });
   }
 
-  getDelta(
+  async getDelta(
     {id},
     {id: delta_report_id},
     {filter, details = true, ...options} = {},
   ) {
-    return this.httpGetWithTransform(
+    const response = await this.httpGetWithTransform(
       {
         id,
         delta_report_id,
@@ -100,10 +100,11 @@ export class AuditReportCommand extends EntityCommand {
         details: convertBoolean(details),
       },
       options,
-    ).then(this.transformResponse);
+    );
+    return this.transformResponseToModel(response);
   }
 
-  get(
+  async get(
     {id},
     {
       filter,
@@ -113,7 +114,7 @@ export class AuditReportCommand extends EntityCommand {
       ...options
     } = {},
   ) {
-    return this.httpGetWithTransform(
+    const response = await this.httpGetWithTransform(
       {
         id,
         filter,
@@ -122,7 +123,8 @@ export class AuditReportCommand extends EntityCommand {
         details: convertBoolean(details),
       },
       options,
-    ).then(this.transformResponse);
+    );
+    return this.transformResponseToModel(response);
   }
 
   getElementFromRoot(root) {

--- a/src/gmp/commands/entities.ts
+++ b/src/gmp/commands/entities.ts
@@ -110,7 +110,7 @@ abstract class EntitiesCommand<
   TEntitiesResponse extends Element = Element,
   TRoot extends Element = Element,
 > extends HttpCommand {
-  readonly clazz: ModelClass<Model>;
+  private readonly clazz: ModelClass<Model>;
   readonly name: string;
 
   constructor(http: Http, name: string, clazz: ModelClass<Model>) {
@@ -120,9 +120,9 @@ abstract class EntitiesCommand<
     this.name = name;
   }
 
-  abstract getEntitiesResponse(root: TRoot): TEntitiesResponse;
+  protected abstract getEntitiesResponse(root: TRoot): TEntitiesResponse;
 
-  getCollectionListFromRoot(root: TRoot): CollectionList<TModel> {
+  protected getCollectionListFromRoot(root: TRoot): CollectionList<TModel> {
     const response = this.getEntitiesResponse(root);
     return parseCollectionList<TModel>(
       response,
@@ -215,7 +215,9 @@ abstract class EntitiesCommand<
     return deleteResponse.setData(deleted);
   }
 
-  transformAggregates(response: Response<GetAggregatesResponseData, XmlMeta>) {
+  protected transformAggregates(
+    response: Response<GetAggregatesResponseData, XmlMeta>,
+  ) {
     const {data} = response;
     if (!data.get_aggregate) {
       throw new Error('Invalid response: get_aggregate not found');

--- a/src/gmp/commands/entity.ts
+++ b/src/gmp/commands/entity.ts
@@ -50,9 +50,9 @@ abstract class EntityCommand<
   TElement = XmlResponseData,
   TRoot extends XmlResponseData = XmlResponseData,
 > extends HttpCommand {
-  readonly clazz: ModelClass<Model>;
+  private readonly clazz: ModelClass<Model>;
+  private readonly id_name: string;
   readonly name: string;
-  readonly id_name: string;
 
   constructor(http: Http, name: string, clazz: ModelClass<Model>) {
     super(http, {cmd: 'get_' + name});
@@ -61,10 +61,10 @@ abstract class EntityCommand<
     this.name = name;
     this.id_name = name + '_id';
 
-    this.transformResponse = this.transformResponse.bind(this);
+    this.transformResponseToModel = this.transformResponseToModel.bind(this);
   }
 
-  abstract getElementFromRoot(root: TRoot): TElement;
+  protected abstract getElementFromRoot(root: TRoot): TElement;
 
   protected postParams(
     params: EntityCommandInputParams = {},
@@ -100,7 +100,7 @@ abstract class EntityCommand<
     ) as TModel;
   }
 
-  protected transformResponse(
+  protected transformResponseToModel(
     response: Response<TRoot, XmlMeta>,
   ): Response<TModel, XmlMeta> {
     let entity = this.getModelFromResponse(response);
@@ -149,7 +149,7 @@ abstract class EntityCommand<
     {filter, ...options}: EntityCommandGetParams = {},
   ) {
     const response = await this.httpGetWithTransform({id, filter}, options);
-    return this.transformResponse(response as Response<TRoot, XmlMeta>);
+    return this.transformResponseToModel(response as Response<TRoot, XmlMeta>);
   }
 
   async clone({id}: EntityCommandParams) {

--- a/src/gmp/commands/report.ts
+++ b/src/gmp/commands/report.ts
@@ -146,7 +146,7 @@ class ReportCommand extends EntityCommand<Report, ReportElement> {
       },
       options,
     );
-    return this.transformResponse(response);
+    return this.transformResponseToModel(response);
   }
 
   async get(
@@ -168,7 +168,7 @@ class ReportCommand extends EntityCommand<Report, ReportElement> {
       ...options,
       ...params,
     });
-    return this.transformResponse(response);
+    return this.transformResponseToModel(response);
   }
 
   getElementFromRoot(root: XmlResponseData): ReportElement {


### PR DESCRIPTION


## What

Improve EntityCommand properties and methods

## Why

Add visibility specifiers to all properties and methods that should not be public. Rename transfromResponse to transformResponseToModel to use a more precise name.

