### PR TITLE
Change: Refactor TrashCanCommand to use Promise.allSettled for request handling

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -839,6 +839,7 @@
   "Extension": "Dateiendung",
   "Failed to create a new Target because the default Port List is not available.": "Ein neues Ziel konnte nicht erstellt werden, da die Standard-Portliste nicht verfügbar ist.",
   "Failed to create a new Task because the default Scan Config is not available.": "Ein neue Aufgabe konnte nicht erstellt werden, da die Standard-Scan-Konfiguration nicht verfügbar ist.",
+  "Failed to load {{type}} from trashcan": "{{type}} konnte nicht aus dem Papierkorb geladen werden",
   "Failed to run alert.": "Ausführung der Benachrichtigung ist fehlgeschlagen.",
   "Failed to save filter setting": "Fehler beim Speichern der Filtereinstellung",
   "False Pos.": "Falsch-Positiv",

--- a/public/locales/gsa-en.json
+++ b/public/locales/gsa-en.json
@@ -839,6 +839,7 @@
   "Extension": "Extension",
   "Failed to create a new Target because the default Port List is not available.": "Failed to create a new Target because the default Port List is not available.",
   "Failed to create a new Task because the default Scan Config is not available.": "Failed to create a new Task because the default Scan Config is not available.",
+  "Failed to load {{type}} from trashcan": "Failed to load {{type}} from trashcan",
   "Failed to run alert.": "Failed to run alert.",
   "Failed to save filter setting": "Failed to save filter setting",
   "False Pos.": "False Pos.",

--- a/public/locales/gsa-zh_CN.json
+++ b/public/locales/gsa-zh_CN.json
@@ -839,6 +839,7 @@
   "Extension": "扩展名",
   "Failed to create a new Target because the default Port List is not available.": "",
   "Failed to create a new Task because the default Scan Config is not available.": "",
+  "Failed to load {{type}} from trashcan": "",
   "Failed to run alert.": "运行告警失败.",
   "Failed to save filter setting": "",
   "False Pos.": "误报",

--- a/public/locales/gsa-zh_TW.json
+++ b/public/locales/gsa-zh_TW.json
@@ -839,6 +839,7 @@
   "Extension": "",
   "Failed to create a new Target because the default Port List is not available.": "",
   "Failed to create a new Task because the default Scan Config is not available.": "",
+  "Failed to load {{type}} from trashcan": "",
   "Failed to run alert.": "",
   "Failed to save filter setting": "",
   "False Pos.": "",

--- a/src/gmp/commands/__tests__/trashcan.test.ts
+++ b/src/gmp/commands/__tests__/trashcan.test.ts
@@ -152,5 +152,26 @@ describe('TrashCanCommand tests', () => {
     expect(data.data.targets.length).toBe(2);
     expect(data.data.tasks.length).toBe(1);
     expect(data.data.tickets.length).toBe(2);
+    expect(data.data.agentGroups.length).toBe(0);
+    expect(data.data.failedRequests).toBeUndefined();
+  });
+
+  test('should handle failed requests gracefully', async () => {
+    const response = createResponse({
+      get_trash: {
+        get_alerts_response: {
+          alert: [{_id: 'alert1'}],
+        },
+      },
+    });
+
+    const fakeHttp = createHttp(response);
+    const cmd = new TrashCanCommand(fakeHttp);
+    const data = await cmd.get();
+
+    expect(data.data.alerts.length).toBe(1);
+    expect(data.data.scanConfigs.length).toBe(0);
+
+    expect(data.data).toHaveProperty('failedRequests');
   });
 });

--- a/src/gmp/commands/trashcan.ts
+++ b/src/gmp/commands/trashcan.ts
@@ -53,6 +53,7 @@ export interface TrashCanGetData {
   tasks: Task[];
   tickets: Ticket[];
   agentGroups: AgentGroup[];
+  failedRequests?: string[];
 }
 
 interface UsageTypeElement extends ModelElement {
@@ -296,6 +297,35 @@ class TrashCanCommand extends HttpCommand {
         ? (results[index].value as T)
         : null;
 
+    const failedRequests: string[] = [];
+    const requestNames = [
+      'alerts',
+      'configs',
+      'credentials',
+      'filters',
+      'groups',
+      'notes',
+      'overrides',
+      'permissions',
+      'portLists',
+      'reportConfigs',
+      'reportFormats',
+      'roles',
+      'scanners',
+      'schedules',
+      'tags',
+      'targets',
+      'tasks',
+      'tickets',
+      'agentGroups',
+    ];
+
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        failedRequests.push(requestNames[index]);
+      }
+    });
+
     const [
       alertsResponse,
       configsResponse,
@@ -486,6 +516,7 @@ class TrashCanCommand extends HttpCommand {
       tasks,
       tickets,
       agentGroups,
+      failedRequests: failedRequests.length > 0 ? failedRequests : undefined,
     });
   }
 }

--- a/src/web/pages/trashcan/TrashCanPage.tsx
+++ b/src/web/pages/trashcan/TrashCanPage.tsx
@@ -4,7 +4,10 @@
  */
 
 import {useCallback, useEffect, useState} from 'react';
-import {showSuccessNotification} from '@greenbone/ui-lib';
+import {
+  showSuccessNotification,
+  showErrorNotification,
+} from '@greenbone/ui-lib';
 import styled from 'styled-components';
 import {type TrashCanGetData} from 'gmp/commands/trashcan';
 import type Rejection from 'gmp/http/rejection';
@@ -90,13 +93,25 @@ const TrashCan = () => {
       response => {
         setTrash(response.data);
         setIsLoading(false);
+
+        if (
+          response.data.failedRequests &&
+          response.data.failedRequests.length > 0
+        ) {
+          response.data.failedRequests.forEach(requestType => {
+            showErrorNotification(
+              '',
+              _('Failed to load {{type}} from trashcan', {type: requestType}),
+            );
+          });
+        }
       },
       error => {
         showError(error);
         setIsLoading(false);
       },
     );
-  }, [gmp, showError]);
+  }, [gmp, showError, _]);
 
   const handleRestore = async (entity: Model) => {
     try {


### PR DESCRIPTION
## What

- Improved the handling of requests in the TrashCanCommand.get() method to ensure that a failure in one request does not block the others.

## Why

- To ensure that the trashcan page remains functional even if one or more commands are unavailable or fail.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


