### PR TITLE
Don't return promises from http interceptor function

### DIFF
--- a/src/web/Authorized.tsx
+++ b/src/web/Authorized.tsx
@@ -28,9 +28,7 @@ const Authorized = ({children}: AuthorizedProps) => {
     (xhr: XMLHttpRequest) => {
       if (xhr.status === 401) {
         logout();
-        return Promise.resolve(xhr);
       }
-      return Promise.reject(xhr);
     },
     [logout],
   );


### PR DESCRIPTION


## What

Don't return promises from http interceptor function

## Why

The Authorized class handles responses with status != 2xx and issues a logout in case of a 401 response status. The interceptor function is expected to be of return type void.

Avoids some unnecessary error messages in the browser console.


