### PR TITLE
Allow to remove a scanner CA Certificate

### DIFF
--- a/src/gmp/commands/__tests__/scanner.test.ts
+++ b/src/gmp/commands/__tests__/scanner.test.ts
@@ -45,7 +45,7 @@ describe('ScannerCommand tests', () => {
     expect(result.data.id).toEqual('123');
   });
 
-  test('should send the correct data to save a scanner', async () => {
+  test('should save a scanner', async () => {
     const response = createActionResultResponse({
       action: 'save_scanner',
       id: '123',
@@ -78,7 +78,7 @@ describe('ScannerCommand tests', () => {
     });
   });
 
-  test('should allow to keep credential and cert unchanged when saving a scanner', async () => {
+  test('should allow to keep credential when saving a scanner', async () => {
     const response = createActionResultResponse({
       action: 'save_scanner',
       id: '123',
@@ -93,12 +93,45 @@ describe('ScannerCommand tests', () => {
       port: 9390,
       type: OPENVASD_SCANNER_TYPE,
       comment: 'Updated comment',
+      caCertificate: 'updated-ca-pub' as unknown as File,
     });
     expect(fakeHttp.request).toHaveBeenCalledWith('post', {
       data: {
         cmd: 'save_scanner',
-        ca_pub: undefined,
+        ca_pub: 'updated-ca-pub',
         credential_id: undefined,
+        scanner_id: '123',
+        name: 'Updated Scanner',
+        comment: 'Updated comment',
+        scanner_host: '127.0.0.1',
+        scanner_type: OPENVASD_SCANNER_TYPE,
+        port: 9390,
+      },
+    });
+  });
+
+  test('should remove ca cert when saving a scanner', async () => {
+    const response = createActionResultResponse({
+      action: 'save_scanner',
+      id: '123',
+      message: 'Scanner updated successfully',
+    });
+    const fakeHttp = createHttp(response);
+    const cmd = new ScannerCommand(fakeHttp);
+    await cmd.save({
+      id: '123',
+      name: 'Updated Scanner',
+      host: '127.0.0.1',
+      port: 9390,
+      type: OPENVASD_SCANNER_TYPE,
+      comment: 'Updated comment',
+      credentialId: '123',
+    });
+    expect(fakeHttp.request).toHaveBeenCalledWith('post', {
+      data: {
+        cmd: 'save_scanner',
+        ca_pub: '',
+        credential_id: '123',
         scanner_id: '123',
         name: 'Updated Scanner',
         comment: 'Updated comment',

--- a/src/gmp/commands/scanner.ts
+++ b/src/gmp/commands/scanner.ts
@@ -77,7 +77,8 @@ class ScannerCommand extends EntityCommand<Scanner, ScannerElement> {
   }: ScannerCommandSaveParams) {
     const data = {
       cmd: 'save_scanner',
-      ca_pub: caCertificate,
+      // send empty string if caCertificate is undefined to remove existing CA cert
+      ca_pub: caCertificate ?? '',
       comment,
       credential_id: credentialId,
       id,

--- a/src/web/pages/scanners/ScannerDialog.tsx
+++ b/src/web/pages/scanners/ScannerDialog.tsx
@@ -30,6 +30,7 @@ import {type RenderSelectItemProps, renderSelectItems} from 'web/utils/Render';
 
 interface ScannerDialogProps {
   comment?: string;
+  caCertificate?: File;
   credentialId?: string;
   credentials?: Credential[];
   host?: string;
@@ -83,6 +84,7 @@ const updatePort = (scannerType: ScannerType | undefined) => {
 const ScannerDialog = ({
   comment = '',
   scannerInUse = false,
+  caCertificate: initialCaCertificate,
   credentials = [],
   credentialId,
   host = 'localhost',
@@ -101,7 +103,7 @@ const ScannerDialog = ({
   const features = useFeatures();
   const gmp = useGmp();
   const [caCertificate, setCaCertificate] = useState<File | undefined>(
-    undefined,
+    initialCaCertificate,
   );
   const [error, setError] = useState<string | undefined>();
   const [scannerType, setScannerType] = useState<ScannerType | undefined>(type);


### PR DESCRIPTION


## What

Allow to remove a scanner CA Certificate

## Why

With this change it is possible to remove a scanner CA Certificate when editing an existing scanner.
## References
https://jira.greenbone.net/browse/GEA-1314

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


