### PR TITLE
Allow to remove a scanner credential

### DIFF
--- a/src/gmp/commands/__tests__/scanner.test.ts
+++ b/src/gmp/commands/__tests__/scanner.test.ts
@@ -78,7 +78,7 @@ describe('ScannerCommand tests', () => {
     });
   });
 
-  test('should allow to keep credential when saving a scanner', async () => {
+  test('should remove a credential when saving a scanner', async () => {
     const response = createActionResultResponse({
       action: 'save_scanner',
       id: '123',
@@ -99,7 +99,7 @@ describe('ScannerCommand tests', () => {
       data: {
         cmd: 'save_scanner',
         ca_pub: 'updated-ca-pub',
-        credential_id: undefined,
+        credential_id: '',
         scanner_id: '123',
         name: 'Updated Scanner',
         comment: 'Updated comment',

--- a/src/gmp/commands/scanner.ts
+++ b/src/gmp/commands/scanner.ts
@@ -80,7 +80,8 @@ class ScannerCommand extends EntityCommand<Scanner, ScannerElement> {
       // send empty string if caCertificate is undefined to remove existing CA cert
       ca_pub: caCertificate ?? '',
       comment,
-      credential_id: credentialId,
+      // send empty string if credentialId is undefined to remove existing credential
+      credential_id: credentialId ?? '',
       id,
       name,
       port,

--- a/src/web/pages/scanners/ScannerDialog.tsx
+++ b/src/web/pages/scanners/ScannerDialog.tsx
@@ -167,6 +167,11 @@ const ScannerDialog = ({
     value: scannerType,
   }));
 
+  const credentialOptions = renderSelectItems(
+    credentials as RenderSelectItemProps[],
+    '',
+  );
+
   const isGreenboneSensorType = type === GREENBONE_SENSOR_SCANNER_TYPE;
   const isAgentControllerSensorScannerType =
     type === AGENT_CONTROLLER_SENSOR_SCANNER_TYPE;
@@ -257,11 +262,9 @@ const ScannerDialog = ({
                 <Select
                   aria-label={_('Credential')}
                   grow="1"
-                  items={renderSelectItems(
-                    credentials as RenderSelectItemProps[],
-                  )}
+                  items={credentialOptions}
                   name="credentialId"
-                  value={credentialId}
+                  value={credentialId ?? ''}
                   onChange={(value: string) =>
                     onCredentialChange && onCredentialChange(value)
                   }

--- a/src/web/pages/scanners/__tests__/ScannerDialog.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerDialog.test.tsx
@@ -119,7 +119,7 @@ describe('ScannerDialog tests', () => {
     const scannerType = screen.getByRole('textbox', {name: 'Scanner Type'});
     expect(scannerType).toHaveValue('Agent Controller');
     const credential = screen.getByRole('textbox', {name: 'Credential'});
-    expect(credential).toHaveValue('');
+    expect(credential).toHaveValue('--');
   });
 
   test('should display defaults when agent sensor is used', () => {


### PR DESCRIPTION

## What

Allow to remove a scanner credential

## Why

Use an empty string for a credential id to remove a credential from a scanner.

## References

https://jira.greenbone.net/browse/GEA-1314
Requires https://github.com/greenbone/gsad/pull/240

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


