### PR TITLE
Allow the display critical severity level for override new severity

### DIFF
--- a/src/web/pages/overrides/OverrideComponent.jsx
+++ b/src/web/pages/overrides/OverrideComponent.jsx
@@ -30,9 +30,11 @@ import {
   HIGH_VALUE,
   MEDIUM_VALUE,
   LOW_VALUE,
+  CRITICAL_VALUE,
 } from 'web/utils/severity';
 
 const SEVERITIES_LIST = [
+  CRITICAL_VALUE,
   HIGH_VALUE,
   MEDIUM_VALUE,
   LOW_VALUE,


### PR DESCRIPTION


## What
Allow the display critical severity level for override new severity

## Why

Adapt the override create and edit dialog to allow selecting critical severity lever for the new severity.

## References

https://jira.greenbone.net/browse/GEA-1335


