### PR TITLE
Parse usage type for Scanner model tasks

### DIFF
--- a/src/gmp/models/__tests__/scanner.test.ts
+++ b/src/gmp/models/__tests__/scanner.test.ts
@@ -20,11 +20,11 @@ import Scanner, {
 import {testModel} from 'gmp/models/testing';
 import {YES_VALUE} from 'gmp/parser';
 
-testModel(Scanner, 'scanner', {
-  testType: false,
-});
-
 describe('Scanner model tests', () => {
+  testModel(Scanner, 'scanner', {
+    testType: false,
+  });
+
   test('should use defaults', () => {
     const scanner = new Scanner();
     expect(scanner.caPub).toBeUndefined();
@@ -101,12 +101,20 @@ describe('Scanner model tests', () => {
   test('should parse tasks', () => {
     const scanner = Scanner.fromElement({
       tasks: {
-        task: [{_id: '123'}],
+        task: [
+          {_id: '123', usage_type: 'scan'},
+          {_id: '456', name: 'foo', usage_type: 'audit'},
+        ],
       },
     });
 
-    expect(scanner.tasks[0].entityType).toEqual('task');
+    expect(scanner.tasks.length).toEqual(2);
     expect(scanner.tasks[0].id).toEqual('123');
+    expect(scanner.tasks[0].name).toBeUndefined();
+    expect(scanner.tasks[0].usageType).toEqual('scan');
+    expect(scanner.tasks[1].id).toEqual('456');
+    expect(scanner.tasks[1].name).toEqual('foo');
+    expect(scanner.tasks[1].usageType).toEqual('audit');
   });
 
   test('should parse scan configs', () => {

--- a/src/gmp/models/scanner.ts
+++ b/src/gmp/models/scanner.ts
@@ -34,6 +34,12 @@ interface ScannerParamElement {
   paramType?: string;
 }
 
+interface ScannerTaskElement {
+  _id: string;
+  name?: string;
+  usage_type: 'scan' | 'audit';
+}
+
 export interface ScannerElement extends ModelElement {
   ca_pub?: string;
   ca_pub_info?: {
@@ -58,7 +64,7 @@ export interface ScannerElement extends ModelElement {
   relay_host?: string;
   relay_port?: number;
   tasks?: {
-    task?: ModelElement | ModelElement[];
+    task?: ScannerTaskElement | ScannerTaskElement[];
   };
 }
 
@@ -91,6 +97,12 @@ interface CaPub {
   };
 }
 
+interface ScannerTask {
+  id: string;
+  name?: string;
+  usageType: 'scan' | 'audit';
+}
+
 interface ScannerProperties extends ModelProperties {
   caPub?: CaPub;
   configs?: Model[];
@@ -99,7 +111,7 @@ interface ScannerProperties extends ModelProperties {
   host?: string;
   port?: number;
   scannerType?: ScannerType;
-  tasks?: Model[];
+  tasks?: ScannerTask[];
 }
 
 export const OPENVAS_SCANNER_TYPE = '2';
@@ -157,7 +169,7 @@ class Scanner extends Model {
   readonly host?: string;
   readonly port?: number;
   readonly scannerType?: ScannerType;
-  readonly tasks: Model[];
+  readonly tasks: ScannerTask[];
 
   constructor({
     caPub,
@@ -214,9 +226,13 @@ class Scanner extends Model {
       }
     }
 
-    ret.tasks = map(element.tasks?.task, task =>
-      Model.fromElement(task, 'task'),
-    );
+    ret.tasks = map(element.tasks?.task, task => {
+      return {
+        id: task._id as string,
+        name: task.name,
+        usageType: task.usage_type as 'scan' | 'audit',
+      };
+    });
     ret.configs = map(element.configs?.config, config =>
       Model.fromElement(config, 'scanconfig'),
     );

--- a/src/web/pages/scanners/ScannerDetails.tsx
+++ b/src/web/pages/scanners/ScannerDetails.tsx
@@ -105,7 +105,10 @@ const ScannerDetails = ({
                 {tasks.map(task => {
                   return (
                     <span key={task.id}>
-                      <DetailsLink id={task.id as string} type="task">
+                      <DetailsLink
+                        id={task.id as string}
+                        type={task.usageType === 'audit' ? 'audit' : 'task'}
+                      >
                         {task.name}
                       </DetailsLink>
                     </span>

--- a/src/web/pages/scanners/__tests__/ScannerDetails.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerDetails.test.tsx
@@ -12,7 +12,6 @@ import Scanner, {
   OPENVAS_SCANNER_TYPE,
   OPENVASD_SCANNER_TYPE,
 } from 'gmp/models/scanner';
-import Task from 'gmp/models/task';
 import ScannerDetails from 'web/pages/scanners/ScannerDetails';
 
 describe('ScannerDetails tests', () => {
@@ -26,8 +25,8 @@ describe('ScannerDetails tests', () => {
       caPub: {certificate: 'Test CA Certificate'},
       credential: new Credential({id: '5678', name: 'Test Credential'}),
       tasks: [
-        new Task({id: '1', name: 'Task 1'}),
-        new Task({id: '2', name: 'Task 2'}),
+        {id: '1', name: 'Task 1', usageType: 'scan'},
+        {id: '2', name: 'Task 2', usageType: 'scan'},
       ],
       configs: [
         new ScanConfig({id: '1', name: 'Config 1'}),
@@ -76,8 +75,8 @@ describe('ScannerDetails tests', () => {
         certificate_info: {issuer: 'Test Issuer'},
       }),
       tasks: [
-        new Task({id: '1', name: 'Task 1'}),
-        new Task({id: '2', name: 'Task 2'}),
+        {id: '1', name: 'Task 1', usageType: 'scan'},
+        {id: '2', name: 'Task 2', usageType: 'scan'},
       ],
       configs: [
         new ScanConfig({id: '1', name: 'Config 1'}),
@@ -119,8 +118,8 @@ describe('ScannerDetails tests', () => {
       name: 'Test Scanner',
       scannerType: CVE_SCANNER_TYPE,
       tasks: [
-        new Task({id: '1', name: 'Task 1'}),
-        new Task({id: '2', name: 'Task 2'}),
+        {id: '1', name: 'Task 1', usageType: 'scan'},
+        {id: '2', name: 'Task 2', usageType: 'scan'},
       ],
       configs: [
         new ScanConfig({id: '1', name: 'Config 1'}),


### PR DESCRIPTION

## What

Parse usage type for Scanner model tasks

## Why

Change Scanner tasks to be parsed as a simple JS object instead of a Model instance and parse the usage type of the tasks. This is required to be able to create correct links either to the task or audit details page.

## References

https://jira.greenbone.net/browse/GEA-1321
Requires https://github.com/greenbone/gvmd/pull/2611

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


