### PR TITLE
fix: number of max items per row in dashboard

### DIFF
--- a/src/web/components/dashboard/Dashboard.jsx
+++ b/src/web/components/dashboard/Dashboard.jsx
@@ -37,8 +37,8 @@ import withTranslation from 'web/utils/withTranslation';
 
 const log = Logger.getLogger('web.components.dashboard');
 
-const DEFAULT_MAX_ITEMS_PER_ROW = 4;
-const DEFAULT_MAX_ROWS = 4;
+export const DEFAULT_MAX_ITEMS_PER_ROW = 4;
+export const DEFAULT_MAX_ROWS = 4;
 
 const ownPropNames = [
   'defaultDisplays',

--- a/src/web/pages/start/StartPage.tsx
+++ b/src/web/pages/start/StartPage.tsx
@@ -8,6 +8,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import styled from 'styled-components';
 import {v4 as uuid} from 'uuid';
 import {isDefined} from 'gmp/utils/identity';
+import {DEFAULT_MAX_ITEMS_PER_ROW} from 'web/components/dashboard/Dashboard';
 import {
   addDisplayToSettings,
   canAddDisplay,
@@ -120,7 +121,11 @@ const StartPage = () => {
     if (!dashboardSelector) {
       return {};
     }
-    return dashboardSelector.getById(dashboardId);
+
+    return {
+      maxItemsPerRow: DEFAULT_MAX_ITEMS_PER_ROW,
+      ...dashboardSelector.getById(dashboardId),
+    };
   };
 
   const [showConfirmRemoveDialog, setShowConfirmRemoveDialog] = useState(false);


### PR DESCRIPTION
## What

- Add max displays items per row in the dashboard 

## Why

- If more than 4 items are added, they overflow the row instead of creating a new row.

## References

GEA- 1327

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


