### PR TITLE
fix: handle undefined and falsy children in IconMenu component

### DIFF
--- a/src/web/components/menu/IconMenu.tsx
+++ b/src/web/components/menu/IconMenu.tsx
@@ -13,9 +13,10 @@ interface IconMenuProps {
 }
 
 const IconMenu = ({children, icon}: IconMenuProps) => {
-  const menuEntries = React.Children.map(children, child => (
-    <Menu.Item>{child}</Menu.Item>
-  ));
+  const menuEntries = React.Children.map(children, child => {
+    if (!child) return undefined;
+    return <Menu.Item>{child}</Menu.Item>;
+  })?.filter(Boolean);
 
   return (
     <Menu>

--- a/src/web/components/menu/__tests__/IconMenu.test.tsx
+++ b/src/web/components/menu/__tests__/IconMenu.test.tsx
@@ -41,4 +41,30 @@ describe('IconMenu', () => {
       expect(screen.getByText('Child')).toBeInTheDocument();
     });
   });
+
+  test('filters out null and falsy children', async () => {
+    const showHiddenChild = false;
+    render(
+      <IconMenu>
+        <div>Child 1</div>
+        {undefined}
+        {showHiddenChild && <div>Hidden Child</div>}
+        <div>Child 2</div>
+        {undefined}
+      </IconMenu>,
+    );
+
+    const button = screen.getByRole('button', {name: /menu/i});
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('Child 1')).toBeVisible();
+      expect(screen.getByText('Child 2')).toBeVisible();
+      expect(screen.queryByText('Hidden Child')).not.toBeInTheDocument();
+    });
+
+    // Verify only 2 menu items are rendered (not 5 including the falsy ones)
+    const menuItems = screen.getAllByRole('menuitem');
+    expect(menuItems).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
## What
- fix: handle `undefined` and falsy children in `IconMenu` component.
- Add test for `IconMenu` and `NewIconMenu`.

## Why

- If a component was `undefined`, `IconMenu` would render an empty button component.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


