### PR TITLE
Remove unnecessary properties from AgentInstaller model

### DIFF
--- a/src/gmp/models/__tests__/agent-installer.test.ts
+++ b/src/gmp/models/__tests__/agent-installer.test.ts
@@ -5,12 +5,11 @@
 
 import {describe, test, expect} from '@gsa/testing';
 import AgentInstaller from 'gmp/models/agent-installer';
-import date from 'gmp/models/date';
 import {testModel} from 'gmp/models/testing';
 
-testModel(AgentInstaller, 'agentinstaller');
-
 describe('AgentInstaller model tests', () => {
+  testModel(AgentInstaller, 'agentinstaller');
+
   test('should use defaults', () => {
     const agentInstaller = new AgentInstaller();
 
@@ -23,10 +22,6 @@ describe('AgentInstaller model tests', () => {
     expect(agentInstaller.fileExtension).toBeUndefined();
     expect(agentInstaller.version).toBeUndefined();
     expect(agentInstaller.checksum).toBeUndefined();
-    expect(agentInstaller.fileSize).toBeUndefined();
-    expect(agentInstaller.fileValidity).toBeUndefined();
-    expect(agentInstaller.lastUpdate).toBeUndefined();
-    expect(agentInstaller.cpes).toEqual([]);
   });
 
   test('should parse contentType', () => {
@@ -67,93 +62,5 @@ describe('AgentInstaller model tests', () => {
     });
 
     expect(agentInstaller.checksum).toBe('abc123');
-  });
-
-  test('should parse fileSize', () => {
-    const agentInstaller = AgentInstaller.fromElement({
-      file_size: 2048,
-    });
-
-    expect(agentInstaller.fileSize).toBe(2048);
-  });
-
-  test('should parse fileValidity', () => {
-    const agentInstallerValid = AgentInstaller.fromElement({
-      file_validity: 'valid',
-    });
-    expect(agentInstallerValid.fileValidity).toBe('valid');
-
-    const agentInstallerInvalid = AgentInstaller.fromElement({
-      file_validity: 'invalid',
-    });
-    expect(agentInstallerInvalid.fileValidity).toBe('invalid');
-
-    const agentInstallerUnknown = AgentInstaller.fromElement({
-      file_validity: 'unknown',
-    });
-    expect(agentInstallerUnknown.fileValidity).toBe('unknown');
-
-    const agentInstallerUndefined = AgentInstaller.fromElement({});
-    expect(agentInstallerUndefined.fileValidity).toBeUndefined();
-  });
-
-  test('should parse lastUpdate', () => {
-    const agentInstaller = AgentInstaller.fromElement({
-      last_update: '2023-10-01T12:34:56Z',
-    });
-
-    expect(agentInstaller.lastUpdate).toEqual(date('2023-10-01T12:34:56Z'));
-  });
-
-  test('should parse cpes', () => {
-    const agentInstaller = AgentInstaller.fromElement({
-      cpes: [
-        {
-          criteria: 'cpe:/a:vendor:product:1.0',
-          version_start_incl: '1.0',
-          version_end_excl: '2.0',
-        },
-        {
-          criteria: 'cpe:/a:vendor:product:2.0',
-          version_start_excl: '2.0',
-          version_end_incl: '3.0',
-        },
-      ],
-    });
-
-    expect(agentInstaller.cpes).toEqual([
-      {
-        criteria: 'cpe:/a:vendor:product:1.0',
-        versionStartIncluding: '1.0',
-        versionStartExcluding: undefined,
-        versionEndIncluding: undefined,
-        versionEndExcluding: '2.0',
-      },
-      {
-        criteria: 'cpe:/a:vendor:product:2.0',
-        versionStartIncluding: undefined,
-        versionStartExcluding: '2.0',
-        versionEndIncluding: '3.0',
-        versionEndExcluding: undefined,
-      },
-    ]);
-
-    const agentInstaller2 = AgentInstaller.fromElement({
-      cpes: {
-        criteria: 'cpe:/a:vendor:product:1.0',
-        version_start_incl: '1.0',
-        version_end_excl: '2.0',
-      },
-    });
-
-    expect(agentInstaller2.cpes).toEqual([
-      {
-        criteria: 'cpe:/a:vendor:product:1.0',
-        versionStartIncluding: '1.0',
-        versionStartExcluding: undefined,
-        versionEndIncluding: undefined,
-        versionEndExcluding: '2.0',
-      },
-    ]);
   });
 });

--- a/src/gmp/models/agent-installer.ts
+++ b/src/gmp/models/agent-installer.ts
@@ -3,22 +3,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type {Date as GmpDate} from 'gmp/models/date';
 import Model, {type ModelElement, type ModelProperties} from 'gmp/models/model';
-import {parseDate, parseInt, parseToString} from 'gmp/parser';
-import {map} from 'gmp/utils/array';
+import {parseToString} from 'gmp/parser';
 import {type EntityType} from 'gmp/utils/entity-type';
-
-// Possible values for file_validity are 'valid' or a string describing why the file is not valid
-type FileValidity = 'valid' | string;
-
-interface CpeElement {
-  criteria: string;
-  version_start_incl?: string;
-  version_start_excl?: string;
-  version_end_incl?: string;
-  version_end_excl?: string;
-}
 
 export interface AgentInstallerElement extends ModelElement {
   content_type?: string;
@@ -26,18 +13,6 @@ export interface AgentInstallerElement extends ModelElement {
   file_extension?: string;
   version?: string;
   checksum?: string;
-  file_size?: number;
-  file_validity?: string;
-  last_update?: string;
-  cpes?: CpeElement | CpeElement[];
-}
-
-interface Cpe {
-  criteria: string;
-  versionStartIncluding?: string;
-  versionStartExcluding?: string;
-  versionEndIncluding?: string;
-  versionEndExcluding?: string;
 }
 
 interface AgentInstallerProperties extends ModelProperties {
@@ -46,10 +21,6 @@ interface AgentInstallerProperties extends ModelProperties {
   fileExtension?: string;
   version?: string;
   checksum?: string;
-  fileSize?: number;
-  fileValidity?: FileValidity;
-  lastUpdate?: GmpDate;
-  cpes?: Cpe[];
 }
 
 class AgentInstaller extends Model {
@@ -60,10 +31,6 @@ class AgentInstaller extends Model {
   readonly fileExtension?: string;
   readonly version?: string;
   readonly checksum?: string;
-  readonly fileSize?: number;
-  readonly fileValidity?: FileValidity;
-  readonly lastUpdate?: GmpDate;
-  readonly cpes: Cpe[];
 
   constructor({
     contentType,
@@ -71,10 +38,6 @@ class AgentInstaller extends Model {
     fileExtension,
     version,
     checksum,
-    fileSize,
-    fileValidity,
-    lastUpdate,
-    cpes = [],
     ...properties
   }: AgentInstallerProperties = {}) {
     super(properties);
@@ -84,10 +47,6 @@ class AgentInstaller extends Model {
     this.fileExtension = fileExtension;
     this.version = version;
     this.checksum = checksum;
-    this.fileSize = fileSize;
-    this.fileValidity = fileValidity;
-    this.lastUpdate = lastUpdate;
-    this.cpes = cpes;
   }
 
   static fromElement(element: AgentInstallerElement = {}): AgentInstaller {
@@ -105,18 +64,7 @@ class AgentInstaller extends Model {
     copy.fileExtension = element.file_extension;
     copy.version = parseToString(element.version);
     copy.checksum = element.checksum;
-    copy.fileSize = parseInt(element.file_size);
-    copy.fileValidity = element.file_validity;
-    copy.lastUpdate = parseDate(element.last_update);
-    copy.cpes = map(element.cpes, cpe => {
-      return {
-        criteria: cpe.criteria,
-        versionStartIncluding: cpe.version_start_incl,
-        versionStartExcluding: cpe.version_start_excl,
-        versionEndIncluding: cpe.version_end_incl,
-        versionEndExcluding: cpe.version_end_excl,
-      };
-    });
+
     return copy;
   }
 }


### PR DESCRIPTION


## What

Remove unnecessary properties from AgentInstaller model

## Why

The properties are removed from GMP now because they aren't necessary.

## References

https://jira.greenbone.net/browse/GEA-1311

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


