### PR TITLE
Allow NumberField value to be an empty string

### DIFF
--- a/src/web/components/form/NumberField.tsx
+++ b/src/web/components/form/NumberField.tsx
@@ -26,7 +26,7 @@ export interface NumberFieldProps
   precision?: number | string;
   type?: 'int' | 'float';
   size?: 'sm' | 'md' | 'lg';
-  value?: number;
+  value?: number | '';
 }
 
 const getSize = (size: string) => (size === 'lg' ? '40px' : '32px');


### PR DESCRIPTION


## What

Allow NumberField value to be an empty string

## Why

If the NumberField allows for empty values the value is actually an empty string. Therefore the type information for value was not correct.
