### PR TITLE
fix:  severity handling in OverrideComponent and OverrideDialog to use isCVSSv3 for dynamic severity values

### DIFF
--- a/src/web/pages/overrides/Dialog.jsx
+++ b/src/web/pages/overrides/Dialog.jsx
@@ -41,7 +41,6 @@ import {
 import {
   FALSE_POSITIVE_VALUE,
   LOG_VALUE,
-  HIGH_VALUE,
   MEDIUM_VALUE,
   LOW_VALUE,
   _FALSE_POSITIVE,
@@ -50,8 +49,8 @@ import {
   _MEDIUM,
   _HIGH,
   translatedResultSeverityRiskFactor,
-  CRITICAL_VALUE,
   _CRITICAL,
+  getSeverityLevelBoundaries,
 } from 'web/utils/severity';
 
 const OverrideDialog = ({
@@ -85,7 +84,9 @@ const OverrideDialog = ({
   const [_] = useTranslation();
   const gmp = useGmp();
   const isEdit = isDefined(override);
-  const isCVSSv3 = gmp.settings.severityRating === 'CVSSv3';
+  const severityBoundaries = getSeverityLevelBoundaries(
+    gmp.settings.severityRating,
+  );
 
   title = title || _('New Override');
 
@@ -120,16 +121,16 @@ const OverrideDialog = ({
     });
   }
 
-  if (isCVSSv3) {
+  if (severityBoundaries.minCritical) {
     severityFromListItems.push({
-      value: CRITICAL_VALUE,
+      value: severityBoundaries.minCritical,
       label: `${_CRITICAL}`,
     });
   }
 
   severityFromListItems.push(
     {
-      value: HIGH_VALUE,
+      value: severityBoundaries.minHigh,
       label: `${_HIGH}`,
     },
     {
@@ -342,7 +343,7 @@ const OverrideDialog = ({
                     onChange={onValueChange}
                   />
                   <Radio
-                    checked={state.severity === 0.0}
+                    checked={state.severity === 0}
                     convert={parseFloat}
                     name="severity"
                     title={_('Log')}

--- a/src/web/pages/overrides/OverrideComponent.jsx
+++ b/src/web/pages/overrides/OverrideComponent.jsx
@@ -27,20 +27,10 @@ import PropTypes from 'web/utils/PropTypes';
 import {
   FALSE_POSITIVE_VALUE,
   LOG_VALUE,
-  HIGH_VALUE,
   MEDIUM_VALUE,
   LOW_VALUE,
-  CRITICAL_VALUE,
+  getSeverityLevelBoundaries,
 } from 'web/utils/severity';
-
-const SEVERITIES_LIST = [
-  CRITICAL_VALUE,
-  HIGH_VALUE,
-  MEDIUM_VALUE,
-  LOW_VALUE,
-  LOG_VALUE,
-  FALSE_POSITIVE_VALUE,
-];
 
 const OverrideComponent = ({
   children,
@@ -57,6 +47,19 @@ const OverrideComponent = ({
 }) => {
   const gmp = useGmp();
   const [_] = useTranslation();
+
+  const severityBoundaries = getSeverityLevelBoundaries(
+    gmp.settings.severityRating,
+  );
+
+  const SEVERITIES_LIST = new Set([
+    ...(severityBoundaries.minCritical ? [severityBoundaries.minCritical] : []),
+    severityBoundaries.minHigh,
+    MEDIUM_VALUE,
+    LOW_VALUE,
+    LOG_VALUE,
+    FALSE_POSITIVE_VALUE,
+  ]);
 
   const [dialogVisible, setDialogVisible] = useState(false);
 
@@ -118,7 +121,7 @@ const OverrideComponent = ({
       let newSeverityFromListValue;
       let newSeverityValue;
 
-      if (SEVERITIES_LIST.includes(overrideEntity.newSeverity)) {
+      if (SEVERITIES_LIST.has(overrideEntity.newSeverity)) {
         newSeverityFromListValue = overrideEntity.newSeverity;
       } else {
         customSeverityValue = YES_VALUE;

--- a/src/web/utils/severity.ts
+++ b/src/web/utils/severity.ts
@@ -224,8 +224,8 @@ export const getSeverityLevelBoundaries = (
 export const renderPercentile = (percentile?: number): string => {
   if (isNumber(percentile)) {
     const value = percentile.toFixed(0);
-    const rest1 = parseInt(value) % 10;
-    const rest2 = parseInt(value) % 100;
+    const rest1 = Number.parseInt(value) % 10;
+    const rest2 = Number.parseInt(value) % 100;
     if (rest1 === 1 && rest2 !== 11) {
       return `${value}st`;
     }


### PR DESCRIPTION
## What

- Fixed the severity mapping in the override creation dialog to ensure that selecting "High" sets the severity to 8.0 for CVSSv3, aligning with its severity range.
## Why

The previous implementation incorrectly set "High" to 9.0, which falls in the "Critical" range for CVSSv3, causing misclassification and confusion.

## References

GEA-1348

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


