### PR TITLE
Fix binary report downloads

### DIFF
--- a/src/gmp/commands/__tests__/report.test.ts
+++ b/src/gmp/commands/__tests__/report.test.ts
@@ -5,7 +5,12 @@
 
 import {describe, test, expect} from '@gsa/testing';
 import ReportCommand from 'gmp/commands/report';
-import {createHttp, createEntityResponse} from 'gmp/commands/testing';
+import {
+  createHttp,
+  createEntityResponse,
+  createHttpError,
+} from 'gmp/commands/testing';
+import {ResponseRejection} from 'gmp/http/rejection';
 
 describe('ReportCommand tests', () => {
   test('should request single report', async () => {
@@ -25,5 +30,50 @@ describe('ReportCommand tests', () => {
     });
     const {data} = resp;
     expect(data.id).toEqual('foo');
+  });
+
+  test('should allow to download a report', async () => {
+    const data = new ArrayBuffer(8);
+    const fakeHttp = createHttp(data);
+    const cmd = new ReportCommand(fakeHttp);
+    const response = await cmd.download(
+      {id: 'report-uuid'},
+      {
+        reportConfigId: 'config-uuid',
+        reportFormatId: 'format-uuid',
+      },
+    );
+    expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+      args: {
+        cmd: 'get_report',
+        details: 1,
+        report_id: 'report-uuid',
+        delta_report_id: undefined,
+        report_config_id: 'config-uuid',
+        report_format_id: 'format-uuid',
+        filter: 'first=1 rows=-1',
+      },
+      responseType: 'arraybuffer',
+    });
+    expect(response).toBe(data);
+  });
+
+  test('should transform error during report download', async () => {
+    const error = new ResponseRejection<string>(
+      {status: 500} as XMLHttpRequest,
+      'some error',
+      '<gsad_message>Some error</gsad_message>',
+    );
+    const http = createHttpError(error);
+    const cmd = new ReportCommand(http);
+    await expect(
+      cmd.download(
+        {id: 'report-uuid'},
+        {
+          reportConfigId: 'config-uuid',
+          reportFormatId: 'format-uuid',
+        },
+      ),
+    ).rejects.toThrow('some error');
   });
 });

--- a/src/gmp/commands/report.ts
+++ b/src/gmp/commands/report.ts
@@ -92,8 +92,8 @@ class ReportCommand extends EntityCommand<Report, ReportElement> {
         report_config_id: reportConfigId,
         report_format_id: reportFormatId,
         filter: filterString(allFilter),
-        responseType: 'arraybuffer',
       },
+      responseType: 'arraybuffer',
     });
   }
 


### PR DESCRIPTION


## What

Fix binary report downloads

## Why

Ensure the data is provided as binary data and no string encoding is applied by setting the expected response type correctly. Currently downloads for binary format like PDF are broken.

## References

https://jira.greenbone.net/browse/GEA-1354

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


