### PR TITLE
Fix: Change DetailLinks type to "audit" in AuditReportRow.jsx

### DIFF
--- a/src/web/pages/reports/AuditReportRow.jsx
+++ b/src/web/pages/reports/AuditReportRow.jsx
@@ -109,7 +109,7 @@ const AuditRow = ({
       </TableData>
       <TableData>
         <span>
-          <DetailsLink id={entity.task.id} textOnly={!links} type="task">
+          <DetailsLink id={entity.task.id} textOnly={!links} type="audit">
             {entity.task.name}
           </DetailsLink>
         </span>

--- a/src/web/pages/reports/__tests__/AuditReportRow.test.jsx
+++ b/src/web/pages/reports/__tests__/AuditReportRow.test.jsx
@@ -41,7 +41,7 @@ describe('Audit report row', () => {
     expect(bars[0]).toHaveAttribute('title', 'Done');
     expect(bars[0]).toHaveTextContent('Done');
     expect(rows[0]).toHaveTextContent('foo');
-    expect(links[1]).toHaveAttribute('href', '/task/314');
+    expect(links[1]).toHaveAttribute('href', '/audit/314');
     expect(bars[1]).toHaveAttribute('title', 'No');
     expect(bars[1]).toHaveTextContent('No');
     expect(rows[0]).toHaveTextContent('321'); // yes: 3, no: 2, incomplete: 1


### PR DESCRIPTION
## What

This changes the DetailLinks type in AuditReportRow.jsx so that compliance report links use /audit instead of /task.

## Why

The previous implementation produced wrong URLs, and this fix corrects the regression so audit links point

## References

GEA-1356

## Checklist

- [x] Tests


