### PR TITLE
Make audit report component naming more consistent

### DIFF
--- a/src/web/Routes.tsx
+++ b/src/web/Routes.tsx
@@ -113,10 +113,10 @@ const ReportFormatsPage = lazy(
   () => import('web/pages/reportformats/ListPage'),
 );
 const DeltaAuditReportDetailsPage = lazy(
-  () => import('web/pages/reports/AuditDeltaDetailsPage'),
+  () => import('web/pages/reports/AuditDeltaReportDetailsPage'),
 );
 const AuditReportDetailsPage = lazy(
-  () => import('web/pages/reports/AuditDetailsPage'),
+  () => import('web/pages/reports/AuditReportDetailsPage'),
 );
 const AuditReportsPage = lazy(
   () => import('web/pages/reports/AuditReportsListPage'),

--- a/src/web/pages/reports/AuditReportDetailsContent.jsx
+++ b/src/web/pages/reports/AuditReportDetailsContent.jsx
@@ -39,11 +39,12 @@ import TabTitle from 'web/pages/reports/details/TabTitle';
 import TLSCertificatesTab from 'web/pages/reports/details/TlsCertificatesTab';
 import ToolBarIcons from 'web/pages/reports/details/ToolbarIcons';
 import PropTypes from 'web/utils/PropTypes';
+
 const Span = styled.span`
   margin-top: 2px;
 `;
 
-const PageContent = ({
+const AuditReportDetailsContent = ({
   entity,
   errorsCounts,
   filters,
@@ -73,7 +74,6 @@ const PageContent = ({
   onFilterEditClick,
   onFilterRemoveClick,
   onFilterResetClick,
-
   onRemoveFromAssetsClick,
   onReportDownloadClick,
   onSortChange,
@@ -371,7 +371,7 @@ const PageContent = ({
   );
 };
 
-PageContent.propTypes = {
+AuditReportDetailsContent.propTypes = {
   applicationsCounts: PropTypes.counts,
   closedCvesCounts: PropTypes.counts,
   cvesCounts: PropTypes.counts,
@@ -412,4 +412,4 @@ PageContent.propTypes = {
   onTlsCertificateDownloadClick: PropTypes.func.isRequired,
 };
 
-export default PageContent;
+export default AuditReportDetailsContent;

--- a/src/web/pages/reports/AuditReportRow.jsx
+++ b/src/web/pages/reports/AuditReportRow.jsx
@@ -22,7 +22,7 @@ import withEntitiesActions from 'web/entities/withEntitiesActions';
 import useTranslation from 'web/hooks/useTranslation';
 import PropTypes from 'web/utils/PropTypes';
 
-const Actions = withEntitiesActions(
+const AuditReportActions = withEntitiesActions(
   ({entity, selectedDeltaReport, onReportDeleteClick, onReportDeltaSelect}) => {
     const {report} = entity;
 
@@ -64,15 +64,15 @@ const Actions = withEntitiesActions(
   },
 );
 
-Actions.propTypes = {
+AuditReportActions.propTypes = {
   entity: PropTypes.model.isRequired,
   selectedDeltaReport: PropTypes.model,
   onReportDeleteClick: PropTypes.func.isRequired,
   onReportDeltaSelect: PropTypes.func.isRequired,
 };
 
-const AuditRow = ({
-  actionsComponent: ActionsComponent = Actions,
+const AuditReportRow = ({
+  actionsComponent: ActionsComponent = AuditReportActions,
   entity,
   links = true,
   ...props
@@ -127,10 +127,10 @@ const AuditRow = ({
   );
 };
 
-AuditRow.propTypes = {
+AuditReportRow.propTypes = {
   actionsComponent: PropTypes.component,
   entity: PropTypes.model.isRequired,
   links: PropTypes.bool,
 };
 
-export default AuditRow;
+export default AuditReportRow;

--- a/src/web/pages/reports/AuditReportTable.jsx
+++ b/src/web/pages/reports/AuditReportTable.jsx
@@ -16,7 +16,7 @@ import useTranslation from 'web/hooks/useTranslation';
 import AuditReportRow from 'web/pages/reports/AuditReportRow';
 import PropTypes from 'web/utils/PropTypes';
 
-const Header = ({
+const AuditReportTableHeader = ({
   actionsColumn,
   sort = true,
   currentSortBy,
@@ -101,7 +101,7 @@ const Header = ({
   );
 };
 
-Header.propTypes = {
+AuditReportTableHeader.propTypes = {
   actionsColumn: PropTypes.element,
   currentSortBy: PropTypes.string,
   currentSortDir: PropTypes.string,
@@ -109,15 +109,15 @@ Header.propTypes = {
   onSortChange: PropTypes.func,
 };
 
-const Footer = createEntitiesFooter({
+const AuditReportTableFooter = createEntitiesFooter({
   span: 10,
   delete: true,
 });
 
 export default createEntitiesTable({
   emptyTitle: _l('No reports available'),
-  header: Header,
-  footer: Footer,
+  header: AuditReportTableHeader,
+  footer: AuditReportTableFooter,
   row: AuditReportRow,
   toggleDetailsIcon: false,
 });

--- a/src/web/pages/reports/AuditReportsListPage.jsx
+++ b/src/web/pages/reports/AuditReportsListPage.jsx
@@ -24,7 +24,7 @@ import AuditReportsDashboard, {
   AUDIT_REPORTS_DASHBOARD_ID,
 } from 'web/pages/reports/auditdashboard';
 import AuditReportFilterDialog from 'web/pages/reports/AuditReportFilterDialog';
-import AuditReportsTable from 'web/pages/reports/AuditReportsTable';
+import AuditReportsTable from 'web/pages/reports/AuditReportTable';
 import {
   loadEntities,
   selector as entitiesSelector,
@@ -44,13 +44,7 @@ const ToolBarIcons = () => {
   );
 };
 
-const AuditReportsPage = ({
-  filter,
-  onFilterChanged,
-
-  onDelete,
-  ...props
-}) => {
+const AuditReportListPage = ({filter, onFilterChanged, onDelete, ...props}) => {
   const [selectedDeltaReport, setSelectedDeltaReport] = useState();
   const [beforeSelectFilter, setBeforeSelectFilter] = useState();
   const navigate = useNavigate();
@@ -122,7 +116,7 @@ const AuditReportsPage = ({
   );
 };
 
-AuditReportsPage.propTypes = {
+AuditReportListPage.propTypes = {
   filter: PropTypes.filter,
   navigate: PropTypes.func.isRequired,
   onChanged: PropTypes.func.isRequired,
@@ -145,4 +139,4 @@ export default withEntitiesContainer('auditreport', {
   entitiesSelector,
   loadEntities,
   reloadInterval: reportsReloadInterval,
-})(AuditReportsPage);
+})(AuditReportListPage);

--- a/src/web/pages/reports/DeltaDetailsContent.jsx
+++ b/src/web/pages/reports/DeltaDetailsContent.jsx
@@ -33,6 +33,7 @@ import Summary from 'web/pages/reports/details/Summary';
 import TabTitle from 'web/pages/reports/details/TabTitle';
 import ToolBarIcons from 'web/pages/reports/details/ToolbarIcons';
 import PropTypes from 'web/utils/PropTypes';
+
 const Span = styled.span`
   margin-top: 2px;
 `;

--- a/src/web/pages/reports/__tests__/AuditDetailsContent.test.jsx
+++ b/src/web/pages/reports/__tests__/AuditDetailsContent.test.jsx
@@ -9,7 +9,7 @@ import {screen, within, rendererWith, fireEvent} from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import Filter from 'gmp/models/filter';
 import {getMockAuditReport} from 'web/pages/reports/__mocks__/MockAuditReport';
-import DetailsContent from 'web/pages/reports/AuditDetailsContent';
+import AuditReportDetailsContent from 'web/pages/reports/AuditReportDetailsContent';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 
 const filter = Filter.fromString(
@@ -38,7 +38,7 @@ const getReportComposerDefaults = testing.fn().mockResolvedValue({
   foo: 'bar',
 });
 
-describe('Audit Report Details Content tests', () => {
+describe('AuditReportDetailsContent tests', () => {
   test('should render Audit Report Details Content', () => {
     const onAddToAssetsClick = testing.fn();
     const onError = testing.fn();
@@ -89,7 +89,7 @@ describe('Audit Report Details Content tests', () => {
     store.dispatch(setUsername('admin'));
 
     const {baseElement} = render(
-      <DetailsContent
+      <AuditReportDetailsContent
         applicationsCounts={{all: 4, filtered: 4}}
         closedCvesCounts={{all: 2, filtered: 2}}
         cvesCounts={{all: 2, filtered: 2}}
@@ -251,7 +251,7 @@ describe('Audit Report Details Content tests', () => {
     store.dispatch(setUsername('admin'));
 
     const {baseElement} = render(
-      <DetailsContent
+      <AuditReportDetailsContent
         applicationsCounts={{all: 4, filtered: 4}}
         closedCvesCounts={{all: 2, filtered: 2}}
         cvesCounts={{all: 2, filtered: 2}}

--- a/src/web/pages/reports/__tests__/AuditReportRow.test.jsx
+++ b/src/web/pages/reports/__tests__/AuditReportRow.test.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWithTableBody, screen} from 'web/testing';
 import {getMockAuditReport} from 'web/pages/reports/__mocks__/MockAuditReport';
-import AuditRow from 'web/pages/reports/AuditReportRow';
+import AuditReportRow from 'web/pages/reports/AuditReportRow';
 import {setTimezone} from 'web/store/usersettings/actions';
 
 describe('Audit report row', () => {
@@ -25,7 +25,7 @@ describe('Audit report row', () => {
     store.dispatch(setTimezone('CET'));
 
     const {baseElement} = render(
-      <AuditRow
+      <AuditReportRow
         entity={entity}
         onReportDeleteClick={onReportDeleteClick}
         onReportDeltaSelect={onReportDeltaSelect}

--- a/src/web/pages/reports/__tests__/AuditReportsListPage.test.jsx
+++ b/src/web/pages/reports/__tests__/AuditReportsListPage.test.jsx
@@ -17,7 +17,7 @@ import {
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Filter from 'gmp/models/filter';
 import {getMockAuditReport} from 'web/pages/reports/__mocks__/MockAuditReport';
-import AuditReportsPage from 'web/pages/reports/AuditReportsListPage';
+import AuditReportListPage from 'web/pages/reports/AuditReportsListPage';
 import {entitiesActions} from 'web/store/entities/auditreports';
 import {setTimezone, setUsername} from 'web/store/usersettings/actions';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
@@ -138,7 +138,7 @@ describe('AuditReportsPage tests', () => {
       entitiesActions.success([entity], filter, loadedFilter, counts),
     );
 
-    const {baseElement} = render(<AuditReportsPage />);
+    const {baseElement} = render(<AuditReportListPage />);
 
     await waitFor(() => baseElement.querySelectorAll('table'));
 
@@ -259,7 +259,7 @@ describe('AuditReportsPage tests', () => {
       entitiesActions.success([entity], filter, loadedFilter, counts),
     );
 
-    const {baseElement} = render(<AuditReportsPage />);
+    const {baseElement} = render(<AuditReportListPage />);
 
     await waitFor(() => baseElement.querySelectorAll('table'));
 


### PR DESCRIPTION


## What

Make audit report component naming more consistent

## Why

Use consistent names for the audit report components as it is difficult to understand the purpose of a component form its name.
