### PR TITLE
fix: fetching container image tasks filters update

### DIFF
--- a/src/web/pages/container-image-targets/ContainerImageTargetsDialog.tsx
+++ b/src/web/pages/container-image-targets/ContainerImageTargetsDialog.tsx
@@ -278,7 +278,7 @@ const ContainerImageTargetsDialog = ({
 
             <FormGroup title={_('Reverse Lookup Only')}>
               <YesNoRadio
-                convert={val => (val === 'true' ? true : false)}
+                convert={val => val === 'true'}
                 disabled={inUse}
                 name="reverseLookupOnly"
                 noValue={false}
@@ -290,7 +290,7 @@ const ContainerImageTargetsDialog = ({
 
             <FormGroup title={_('Reverse Lookup Unify')}>
               <YesNoRadio
-                convert={val => (val === 'true' ? true : false)}
+                convert={val => val === 'true'}
                 disabled={inUse}
                 name="reverseLookupUnify"
                 noValue={false}

--- a/src/web/pages/container-image-targets/ContainerImageTargetsListPage.tsx
+++ b/src/web/pages/container-image-targets/ContainerImageTargetsListPage.tsx
@@ -270,6 +270,10 @@ const ContainerImageTargetsListPage = () => {
                   onDownloadBulk={handleBulkDownload}
                   onEntityDeselected={deselect}
                   onEntitySelected={select}
+                  onFirstClick={getFirst}
+                  onLastClick={getLast}
+                  onNextClick={getNext}
+                  onPreviousClick={getPrevious}
                   onSelectionTypeChange={changeSelectionType}
                   onSortChange={handleSortChange}
                   onTagsBulk={openTagsDialog}
@@ -288,10 +292,6 @@ const ContainerImageTargetsListPage = () => {
               onFilterCreated={handleFilterChanged}
               onFilterRemoved={handleFilterRemoved}
               onFilterReset={handleFilterReset}
-              onFirstClick={getFirst}
-              onLastClick={getLast}
-              onNextClick={getNext}
-              onPreviousClick={getPrevious}
               onTagsBulk={openTagsDialog}
             />
             <Download ref={downloadRef} />

--- a/src/web/pages/tasks/ContainerImageTaskDialog.tsx
+++ b/src/web/pages/tasks/ContainerImageTaskDialog.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import {ALL_FILTER} from 'gmp/models/filter';
 import {CONTAINER_IMAGE_DEFAULT_SCANNER_ID} from 'gmp/models/scanner';
 import {
   type default as Task,
@@ -137,7 +138,9 @@ const ContainerImageTaskDialog = ({
   const isEdit = isDefined(task);
 
   const {data: ociImageTargetsData, isLoading: isOciImageTargetsLoading} =
-    useGetOciImageTargets({});
+    useGetOciImageTargets({
+      filter: ALL_FILTER,
+    });
 
   title = title || _('New Container Image Task');
 


### PR DESCRIPTION
## What

- Pagination was not working on the container image table page.
- Not all image targets being fetched in the component task dialog.

## Why

- Props not being passed
- Missing filter

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


