### PR TITLE
Fix downloading an audit report from the audit list page

### DIFF
--- a/src/web/pages/audits/AuditComponent.jsx
+++ b/src/web/pages/audits/AuditComponent.jsx
@@ -63,7 +63,6 @@ const REPORT_FORMATS_FILTER = Filter.fromString(
 
 const AuditComponent = ({
   children,
-
   onStarted,
   onStartError,
   onStopped,
@@ -526,7 +525,6 @@ const AuditComponent = ({
         },
       );
 
-      const {data} = response;
       const filename = generateFilename({
         extension,
         fileNameFormat: reportExportFileName,
@@ -539,12 +537,8 @@ const AuditComponent = ({
 
       download({
         filename,
-        data: data.report,
+        data: response.data,
       });
-
-      if (onDownloaded) {
-        onDownloaded();
-      }
     } catch (error) {
       if (onDownloadError) {
         onDownloadError(error);


### PR DESCRIPTION

## What

Fix downloading an audit report from the audit list page

## Why

This change fixed two problems:
1. the wrong data was passed to the download handler function
2. the download handler was called twice and the second call missed even the required arguments

In this case the download handler onDownloaded is provided by the EntitiesContainer component. It implements the same behavior as the download handler from the useDownload hook. Therefore only one of these handlers need to be called.

## References

https://jira.greenbone.net/browse/GEA-1345

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


