### PR TITLE
Rename feature `OPENVASD` to `ENABLE_OPENVASD`

### DIFF
--- a/src/gmp/capabilities/__tests__/features.test.ts
+++ b/src/gmp/capabilities/__tests__/features.test.ts
@@ -8,13 +8,13 @@ import Features, {type Feature} from 'gmp/capabilities/features';
 
 describe('Features tests', () => {
   test('should check feature enabled', () => {
-    const featureList: Feature[] = ['CVSS3_RATINGS', 'OPENVASD'];
+    const featureList: Feature[] = ['CVSS3_RATINGS', 'ENABLE_OPENVASD'];
     const features = new Features(featureList);
 
     expect(features.featureEnabled('CVSS3_RATINGS')).toBe(true);
-    expect(features.featureEnabled('OPENVASD')).toBe(true);
+    expect(features.featureEnabled('ENABLE_OPENVASD')).toBe(true);
     // @ts-expect-error
-    expect(features.featureEnabled('openvasd')).toBe(true);
+    expect(features.featureEnabled('enable_openvasd')).toBe(true);
     expect(features.featureEnabled('FEED_VT_METADATA')).toBe(false);
     expect(features.featureEnabled('ENABLE_AGENTS')).toBe(false);
     // @ts-expect-error
@@ -38,7 +38,7 @@ describe('Features tests', () => {
   });
 
   test('should allow iterating', () => {
-    const featureList: Feature[] = ['CVSS3_RATINGS', 'OPENVASD'];
+    const featureList: Feature[] = ['CVSS3_RATINGS', 'ENABLE_OPENVASD'];
     const features = new Features(featureList);
 
     expect(features.length).toEqual(2);
@@ -52,11 +52,11 @@ describe('Features tests', () => {
   });
 
   test('should allow mapping', () => {
-    const features = new Features(['CVSS3_RATINGS', 'OPENVASD']);
+    const features = new Features(['CVSS3_RATINGS', 'ENABLE_OPENVASD']);
 
     expect(features.map(feature => feature)).toEqual([
       'CVSS3_RATINGS',
-      'OPENVASD',
+      'ENABLE_OPENVASD',
     ]);
   });
 });

--- a/src/gmp/capabilities/features.ts
+++ b/src/gmp/capabilities/features.ts
@@ -8,7 +8,7 @@ import {map} from 'gmp/utils/array';
 export type Feature =
   | 'CVSS3_RATINGS'
   | 'FEED_VT_METADATA'
-  | 'OPENVASD'
+  | 'ENABLE_OPENVASD'
   | 'ENABLE_AGENTS'
   | 'ENABLE_CONTAINER_SCANNING'
   | 'ENABLE_CREDENTIAL_STORES';

--- a/src/gmp/commands/__tests__/user.test.ts
+++ b/src/gmp/commands/__tests__/user.test.ts
@@ -179,7 +179,7 @@ test('should get features', async () => {
           },
           {
             _enabled: 1,
-            name: 'OPENVASD',
+            name: 'ENABLE_OPENVASD',
           },
         ],
       },
@@ -197,7 +197,7 @@ test('should get features', async () => {
 
   expect(features.length).toEqual(2);
   expect(features.featureEnabled('ENABLE_AGENTS')).toBe(true);
-  expect(features.featureEnabled('OPENVASD')).toBe(true);
+  expect(features.featureEnabled('ENABLE_OPENVASD')).toBe(true);
   expect(features.featureEnabled('CVSS3_RATINGS')).toBe(false);
 });
 

--- a/src/web/hooks/__tests__/useLoadFeatures.test.tsx
+++ b/src/web/hooks/__tests__/useLoadFeatures.test.tsx
@@ -26,7 +26,7 @@ const TestComponent = () => {
 
 describe('useLoadFeatures tests', () => {
   test('should load features', async () => {
-    const features = new Features(['CVSS3_RATINGS', 'OPENVASD']);
+    const features = new Features(['CVSS3_RATINGS', 'ENABLE_OPENVASD']);
     const response = {data: features};
     const gmp = {
       user: {

--- a/src/web/pages/scanners/ScannerDialog.tsx
+++ b/src/web/pages/scanners/ScannerDialog.tsx
@@ -129,7 +129,7 @@ const ScannerDialog = ({
       }
 
       if (
-        !features.featureEnabled('OPENVASD') &&
+        !features.featureEnabled('ENABLE_OPENVASD') &&
         type === OPENVASD_SCANNER_TYPE
       ) {
         return undefined;
@@ -147,7 +147,7 @@ const ScannerDialog = ({
 
   const scannerTypes: ScannerType[] = [OPENVAS_SCANNER_TYPE];
 
-  if (features.featureEnabled('OPENVASD')) {
+  if (features.featureEnabled('ENABLE_OPENVASD')) {
     scannerTypes.push(OPENVASD_SCANNER_TYPE);
   }
 

--- a/src/web/pages/scanners/__tests__/ScannerDialog.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerDialog.test.tsx
@@ -288,7 +288,7 @@ describe('ScannerDialog tests', () => {
     const {render} = rendererWith({
       gmp,
       capabilities: true,
-      features: new Features(['ENABLE_AGENTS', 'OPENVASD']),
+      features: new Features(['ENABLE_AGENTS', 'ENABLE_OPENVASD']),
     });
 
     render(<ScannerDialog />);
@@ -474,7 +474,7 @@ describe('ScannerDialog tests', () => {
     const {render} = rendererWith({
       gmp: {settings: {enableGreenboneSensor: false}}, // no sensor
       capabilities: true,
-      features: new Features(['OPENVASD']),
+      features: new Features(['ENABLE_OPENVASD']),
     });
 
     render(<ScannerDialog type={OPENVASD_SCANNER_TYPE} />);


### PR DESCRIPTION


## What

Rename feature `OPENVASD` to `ENABLE_OPENVASD`

## Why
Use consistent naming of the features.

## References

This change requires https://github.com/greenbone/gvmd/pull/2655

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


