### PR TITLE
 Allow to download client certificate of a credential

### DIFF
--- a/src/web/pages/credentials/CredentialDownloadIcon.tsx
+++ b/src/web/pages/credentials/CredentialDownloadIcon.tsx
@@ -5,6 +5,7 @@
 
 import {type CredentialDownloadFormat} from 'gmp/commands/credential';
 import {
+  CERTIFICATE_CREDENTIAL_TYPE,
   type default as Credential,
   USERNAME_PASSWORD_CREDENTIAL_TYPE,
   USERNAME_SSH_KEY_CREDENTIAL_TYPE,
@@ -59,6 +60,15 @@ const CredentialDownloadIcon = ({
           value={credential}
           onClick={
             isDefined(onDownload) ? cred => onDownload(cred, 'key') : undefined
+          }
+        />
+      )}
+      {type === CERTIFICATE_CREDENTIAL_TYPE && (
+        <DownloadKeyIcon
+          title={_('Download Client Certificate')}
+          value={credential}
+          onClick={
+            isDefined(onDownload) ? cred => onDownload(cred, 'pem') : undefined
           }
         />
       )}

--- a/src/web/pages/credentials/__tests__/CredentialActions.test.tsx
+++ b/src/web/pages/credentials/__tests__/CredentialActions.test.tsx
@@ -7,6 +7,7 @@ import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWithTableRow, screen, fireEvent} from 'web/testing';
 import EverythingCapabilities from 'gmp/capabilities/everything';
 import Credential, {
+  CERTIFICATE_CREDENTIAL_TYPE,
   USERNAME_SSH_KEY_CREDENTIAL_TYPE,
 } from 'gmp/models/credential';
 import CredentialActions from 'web/pages/credentials/CredentialActions';
@@ -199,6 +200,30 @@ describe('CredentialActions tests', () => {
     });
     fireEvent.click(keyIcon);
     expect(handleDownloadInstaller).toHaveBeenCalledWith(credential, 'key');
+  });
+
+  test('should allow to download client certificate', () => {
+    const {render} = rendererWithTableRow({capabilities: true});
+    const credential = new Credential({
+      id: '1',
+      name: 'Test Credential',
+      credentialType: CERTIFICATE_CREDENTIAL_TYPE,
+      userCapabilities: new EverythingCapabilities(),
+    });
+    const handleDownloadInstaller = testing.fn();
+
+    render(
+      <CredentialActions
+        entity={credential}
+        onCredentialInstallerDownloadClick={handleDownloadInstaller}
+      />,
+    );
+
+    const clientCertDownloadIcon = screen.getByTitle(
+      'Download Client Certificate',
+    );
+    fireEvent.click(clientCertDownloadIcon);
+    expect(handleDownloadInstaller).toHaveBeenCalledWith(credential, 'pem');
   });
 
   test('should render user selection', () => {

--- a/src/web/pages/credentials/__tests__/CredentialDetailsPageToolBarIcons.test.tsx
+++ b/src/web/pages/credentials/__tests__/CredentialDetailsPageToolBarIcons.test.tsx
@@ -8,6 +8,7 @@ import {rendererWith, screen, fireEvent} from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import EverythingCapabilities from 'gmp/capabilities/everything';
 import Credential, {
+  CERTIFICATE_CREDENTIAL_TYPE,
   USERNAME_PASSWORD_CREDENTIAL_TYPE,
   USERNAME_SSH_KEY_CREDENTIAL_TYPE,
 } from 'gmp/models/credential';
@@ -297,6 +298,50 @@ describe('CredentialDetailsPageToolBarIcons tests', () => {
     expect(handleCredentialInstallerDownloadClick).toHaveBeenCalledWith(
       credential,
       'key',
+    );
+  });
+
+  test('should allow to download client certificate', () => {
+    const credential = new Credential({
+      id: '6575',
+      name: 'Credential 1',
+      credentialType: CERTIFICATE_CREDENTIAL_TYPE,
+      inUse: true,
+      userCapabilities: new EverythingCapabilities(),
+    });
+    const gmp = {settings: {manualUrl}};
+    const handleCredentialCloneClick = testing.fn();
+    const handleCredentialDeleteClick = testing.fn();
+    const handleCredentialDownloadClick = testing.fn();
+    const handleCredentialEditClick = testing.fn();
+    const handleCredentialCreateClick = testing.fn();
+    const handleCredentialInstallerDownloadClick = testing.fn();
+    const {render} = rendererWith({
+      gmp,
+      capabilities: true,
+      router: true,
+    });
+
+    render(
+      <CredentialDetailsPageToolBarIcons
+        entity={credential}
+        onCredentialCloneClick={handleCredentialCloneClick}
+        onCredentialCreateClick={handleCredentialCreateClick}
+        onCredentialDeleteClick={handleCredentialDeleteClick}
+        onCredentialDownloadClick={handleCredentialDownloadClick}
+        onCredentialEditClick={handleCredentialEditClick}
+        onCredentialInstallerDownloadClick={
+          handleCredentialInstallerDownloadClick
+        }
+      />,
+    );
+    const clientCertDownloadIcon = screen.getByTitle(
+      'Download Client Certificate',
+    );
+    fireEvent.click(clientCertDownloadIcon);
+    expect(handleCredentialInstallerDownloadClick).toHaveBeenCalledWith(
+      credential,
+      'pem',
     );
   });
 });


### PR DESCRIPTION

## What

 Allow to download client certificate of a credential

## Why

Add icon button for downloading the client certificate `.pem` file of a client certificate credential.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


