### PR TITLE
Fix: Set LSC VT family Arch Linux as whole only

### DIFF
--- a/src/web/pages/scanconfigs/NvtFamilies.jsx
+++ b/src/web/pages/scanconfigs/NvtFamilies.jsx
@@ -29,6 +29,7 @@ const WHOLE_SELECTION_FAMILIES = [
   'AIX Local Security Checks',
   'AlmaLinux Local Security Checks',
   'Amazon Linux Local Security Checks',
+  'Arch Linux Local Security Checks',
   'CentOS Local Security Checks',
   'Debian Local Security Checks',
   'Fedora Local Security Checks',


### PR DESCRIPTION
## What
Add LSC VT family Arch Linux to whole only list.

## Why
Was added to the backend in https://github.com/greenbone/gvmd/pull/2555 but was missing in GSA

## References
GEA-1375