### PR TITLE
Change: Update GSA commands to use import_task instead of container_task

### DIFF
--- a/src/gmp/commands/__tests__/task.test.ts
+++ b/src/gmp/commands/__tests__/task.test.ts
@@ -238,13 +238,36 @@ describe('TaskCommand tests', () => {
     expect(fakeHttp.request).toHaveBeenCalledWith('post', {
       data: {
         auto_delete_data: AUTO_DELETE_KEEP_DEFAULT_VALUE,
-        cmd: 'create_container_task',
+        cmd: 'create_import_task',
         comment: 'comment',
         name: 'foo',
         usage_type: 'scan',
       },
     });
     expect(response.data).toEqual({id: 'foo'});
+  });
+
+  test('should update the import task', async () => {
+    const mockResponse = createActionResultResponse();
+    const fakeHttp = createHttp(mockResponse);
+    const cmd = new TaskCommand(fakeHttp);
+    await cmd.saveImportTask({
+      name: 'foo',
+      comment: 'comment',
+      id: 'test',
+    });
+    expect(fakeHttp.request).toHaveBeenCalledWith('post', {
+      data: {
+        cmd: 'save_import_task',
+        comment: 'comment',
+        name: 'foo',
+        auto_delete: 'no',
+        auto_delete_data: AUTO_DELETE_KEEP_DEFAULT_VALUE,
+        task_id: 'test',
+        usage_type: 'scan',
+        in_assets: 1,
+      },
+    });
   });
 
   test('should save task', async () => {

--- a/src/gmp/commands/task.ts
+++ b/src/gmp/commands/task.ts
@@ -372,7 +372,7 @@ class TaskCommand extends EntityCommand<Task, TaskElement> {
   }: TaskCommandCreateImportTaskParams) {
     log.debug('Creating import task', name, comment);
     return await this.entityAction({
-      cmd: 'create_container_task',
+      cmd: 'create_import_task',
       auto_delete_data: AUTO_DELETE_KEEP_DEFAULT_VALUE,
       name,
       comment,
@@ -539,7 +539,7 @@ class TaskCommand extends EntityCommand<Task, TaskElement> {
   }: TaskCommandSaveImportTaskParams) {
     log.debug('Saving import task', {name, comment, in_assets, id});
     await this.httpPostWithTransform({
-      cmd: 'save_container_task',
+      cmd: 'save_import_task',
       name,
       comment,
       in_assets,


### PR DESCRIPTION
## What

Update GSA commands to use import_task instead of container_task

## Why

These changes are needed after the gsad PR merged.
PR: https://github.com/greenbone/gsad/pull/272

## References

GEA-1406


## Checklist

- [x] Tests


