### PR TITLE
fix: set default scannerId to NO_VALUE_ID in TaskCommand

### DIFF
--- a/src/gmp/commands/__tests__/task.test.ts
+++ b/src/gmp/commands/__tests__/task.test.ts
@@ -874,7 +874,6 @@ describe('TaskCommand tests', () => {
       minQod: 70,
       name: 'foo',
       ociImageTargetId: 'oit1',
-      scannerId: 's1',
     });
 
     expect(fakeHttp.request).toHaveBeenCalledWith('post', {
@@ -892,9 +891,9 @@ describe('TaskCommand tests', () => {
         min_qod: 70,
         name: 'foo',
         oci_image_target_id: 'oit1',
-        scanner_id: 's1',
+        /* on edit scanner_id should be '0' */
+        scanner_id: '0',
         scanner_type: CONTAINER_IMAGE_SCANNER_TYPE,
-        schedule_id: undefined,
         schedule_periods: 0,
         task_id: 'task1',
         usage_type: 'scan',

--- a/src/gmp/commands/task.ts
+++ b/src/gmp/commands/task.ts
@@ -496,7 +496,7 @@ class TaskCommand extends EntityCommand<Task, TaskElement> {
     name,
     ociImageTargetId,
     registryAllowInsecure,
-    scannerId,
+    scannerId = NO_VALUE_ID,
     scheduleId,
     schedulePeriods,
   }: TaskCommandSaveContainerImageParams) {


### PR DESCRIPTION
## What

fix: set default scannerId to NO_VALUE_ID in TaskCommand
## Why

- Otherwise cannot edit task fields

## Reference

GEA-1442

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


