### PR TITLE
Display host and host exclude files in TargetDialog

### DIFF
--- a/src/gmp/commands/target.ts
+++ b/src/gmp/commands/target.ts
@@ -21,9 +21,9 @@ interface TargetCommandCreateParams {
   allowSimultaneousIPs?: boolean;
   comment?: string;
   esxiCredentialId?: string;
-  excludeFile?: string;
+  excludeFile?: File;
   excludeHosts?: string;
-  file?: string;
+  file?: File;
   hosts?: string;
   hostsFilter?: Filter;
   krb5CredentialId?: string;

--- a/src/web/pages/targets/TargetDialog.tsx
+++ b/src/web/pages/targets/TargetDialog.tsx
@@ -88,7 +88,9 @@ interface TargetDialogValues {
 interface TargetDialogDefaultValues {
   allowSimultaneousIPs: boolean;
   comment: string;
+  excludeFile?: File;
   excludeHosts: string;
+  file?: File;
   hosts: string;
   hostsCount?: number;
   hostsFilter?: Filter;
@@ -457,6 +459,7 @@ const TargetDialog = ({
                   disabled={inUse || state.targetSource !== 'file'}
                   grow="1"
                   name="file"
+                  value={state.file}
                   onChange={
                     onValueChange as (value?: File, name?: string) => void
                   }
@@ -508,6 +511,7 @@ const TargetDialog = ({
                   disabled={inUse || state.targetExcludeSource !== 'file'}
                   grow="1"
                   name="excludeFile"
+                  value={state.excludeFile}
                   onChange={
                     onValueChange as (value?: File, name?: string) => void
                   }


### PR DESCRIPTION


## What

Display host and host exclude files in TargetDialog

## Why

When uploading targets from a CSV in the create target dialog the files weren't visible to the user.
## References
https://jira.greenbone.net/browse/GEA-1449

