### PR TITLE
Change: Prevent selection of container scanner for non-container tasks.

### DIFF
--- a/src/web/pages/tasks/TaskDialog.tsx
+++ b/src/web/pages/tasks/TaskDialog.tsx
@@ -11,6 +11,7 @@ import Scanner, {
   OPENVASD_SCANNER_TYPE,
   GREENBONE_SENSOR_SCANNER_TYPE,
   OPENVASD_SENSOR_SCANNER_TYPE,
+  CONTAINER_IMAGE_SCANNER_TYPE,
   type ScannerType,
 } from 'gmp/models/scanner';
 import {
@@ -158,6 +159,9 @@ const ScannerSelect = ({
   onChange,
 }: ScannerSelectProps) => {
   const [_] = useTranslation();
+  scanners = scanners?.filter(
+    scanner => scanner.scannerType !== CONTAINER_IMAGE_SCANNER_TYPE,
+  );
   return (
     <FormGroup title={_('Scanner')}>
       <Select


### PR DESCRIPTION
## What
Prevent selection of container image scanner in the task dialog for non-container tasks.

## Why
Container image tasks have a separate dialog.

## References
GEA-1638


