### PR TITLE
Don't push edge images to the Greenbone container registry

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -50,8 +50,8 @@ jobs:
       suffix: ${{ matrix.build.suffix }}
       images: |
         ghcr.io/${{ github.repository }},enable=true
-        ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' }}
-        ${{ vars.GREENBONE_REGISTRY }}/openvas-scan-dev/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' && matrix.build.name == 'slim' }}
+        ${{ vars.GREENBONE_REGISTRY }}/community/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' && github.ref_type == 'tag' }}
+        ${{ vars.GREENBONE_REGISTRY }}/openvas-scan-dev/${{ github.event.repository.name }},enable=${{ github.event_name != 'pull_request' && github.ref_type == 'tag' && matrix.build.name == 'slim' }}
     secrets: inherit
 
   notify:


### PR DESCRIPTION


## What

Don't push edge images to the Greenbone container registry

## Why

The edge images should not be used by the community or any enterprise product. Their only purpose is for testing.
## References

https://jira.greenbone.net/browse/DOS-661


