### PR TITLE
Add/report hosts command and report tabs

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -1665,6 +1665,7 @@
   "Report Formats": "Berichtformate",
   "Report Formats Filter": "Berichtformate-Filter",
   "Report Formats List": "Berichtformatliste",
+  "Report Host": "Berichtshost",
   "Report is selected for delta comparison": "Bericht ist für Delta-Vergleich ausgewählt",
   "Report Result Filter": "Ergebnisfilter für Bericht",
   "Report Type": "Berichtstyp",

--- a/public/locales/gsa-en.json
+++ b/public/locales/gsa-en.json
@@ -1665,6 +1665,7 @@
   "Report Formats": "Report Formats",
   "Report Formats Filter": "Report Formats Filter",
   "Report Formats List": "Report Formats List",
+  "Report Host": "Report Host",
   "Report is selected for delta comparison": "Report is selected for delta comparison",
   "Report Result Filter": "Report Result Filter",
   "Report Type": "Report Type",

--- a/public/locales/gsa-zh_CN.json
+++ b/public/locales/gsa-zh_CN.json
@@ -1665,6 +1665,7 @@
   "Report Formats": "报告格式",
   "Report Formats Filter": "报告格式筛选",
   "Report Formats List": "报告格式列表",
+  "Report Host": "",
   "Report is selected for delta comparison": "已添加对比",
   "Report Result Filter": "报告扫描结果筛选",
   "Report Type": "报告类型",

--- a/public/locales/gsa-zh_TW.json
+++ b/public/locales/gsa-zh_TW.json
@@ -1665,6 +1665,7 @@
   "Report Formats": "報告格式",
   "Report Formats Filter": "",
   "Report Formats List": "",
+  "Report Host": "",
   "Report is selected for delta comparison": "",
   "Report Result Filter": "",
   "Report Type": "",

--- a/src/gmp/commands/__tests__/report-hosts.test.ts
+++ b/src/gmp/commands/__tests__/report-hosts.test.ts
@@ -1,0 +1,134 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect} from '@gsa/testing';
+import ReportHostsCommand from 'gmp/commands/report-hosts';
+import {createHttp, createEntityResponse} from 'gmp/commands/testing';
+
+describe('ReportHostsCommand tests', () => {
+  test('should request report hosts with default options', async () => {
+    const response = createEntityResponse('get_report_hosts_response', {
+      host: {
+        ip: '127.0.0.1',
+      },
+      report_host_count: {
+        __text: 1,
+        filtered: 1,
+        page: 0,
+      },
+    });
+    const fakeHttp = createHttp(response);
+
+    const cmd = new ReportHostsCommand(fakeHttp);
+    await cmd.get({id: 'foo'});
+
+    expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+      args: {
+        cmd: 'get_report_hosts',
+        report_id: 'foo',
+        filter: undefined,
+        lean: 1,
+        ignore_pagination: 1,
+        details: 1,
+      },
+    });
+  });
+
+  test('should request report hosts with provided options', async () => {
+    const response = createEntityResponse('get_report_hosts_response', {
+      host: {
+        ip: '127.0.0.1',
+      },
+      report_host_count: {
+        __text: 1,
+        filtered: 1,
+        page: 0,
+      },
+    });
+    const fakeHttp = createHttp(response);
+
+    const cmd = new ReportHostsCommand(fakeHttp);
+    await cmd.get(
+      {id: 'foo'},
+      {
+        filter: 'rows=10 first=1',
+        lean: false,
+        ignorePagination: false,
+        details: false,
+      },
+    );
+
+    expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+      args: {
+        cmd: 'get_report_hosts',
+        report_id: 'foo',
+        filter: 'rows=10 first=1',
+        lean: 0,
+        ignore_pagination: 0,
+        details: 0,
+      },
+    });
+  });
+
+  test('should forward additional entity params and options', async () => {
+    const response = createEntityResponse('get_report_hosts_response', {
+      host: {
+        ip: '127.0.0.1',
+      },
+      report_host_count: {
+        __text: 1,
+        filtered: 1,
+        page: 0,
+      },
+    });
+    const fakeHttp = createHttp(response);
+
+    const cmd = new ReportHostsCommand(fakeHttp);
+    await cmd.get(
+      {
+        id: 'foo',
+        extraParam: 'bar',
+      } as never,
+      {
+        filter: 'rows=5',
+        extraOption: 'baz',
+      },
+    );
+
+    expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+      args: {
+        cmd: 'get_report_hosts',
+        report_id: 'foo',
+        filter: 'rows=5',
+        lean: 1,
+        ignore_pagination: 1,
+        details: 1,
+        extraParam: 'bar',
+        extraOption: 'baz',
+      },
+    });
+  });
+
+  test('getElementFromRoot should return report hosts response element', () => {
+    const fakeHttp = createHttp(
+      createEntityResponse('get_report_hosts_response'),
+    );
+    const cmd = new ReportHostsCommand(fakeHttp);
+
+    const element = cmd.getElementFromRoot({
+      get_report_hosts: {
+        get_report_hosts_response: {
+          _status: '200',
+          _status_text: 'OK',
+        },
+      },
+    } as never);
+
+    expect(element).toEqual({
+      _status: '200',
+      _status_text: 'OK',
+    });
+  });
+});

--- a/src/gmp/commands/report-hosts.ts
+++ b/src/gmp/commands/report-hosts.ts
@@ -1,0 +1,65 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import registerCommand from 'gmp/command';
+import EntityCommand, {type EntityCommandParams} from 'gmp/commands/entity';
+import type Http from 'gmp/http/http';
+import {type XmlResponseData} from 'gmp/http/transform/fast-xml';
+import ReportHostsResponse, {
+  type ReportHostsResponseElement,
+} from 'gmp/models/report-host';
+import {parseYesNo} from 'gmp/parser';
+
+interface ReportHostsCommandGetOptions {
+  filter?: string;
+  details?: boolean;
+  ignorePagination?: boolean;
+  lean?: boolean;
+  [key: string]: unknown;
+}
+
+class ReportHostsCommand extends EntityCommand<
+  ReportHostsResponse,
+  ReportHostsResponseElement
+> {
+  constructor(http: Http) {
+    super(http, 'report_hosts', ReportHostsResponse);
+  }
+
+  async get(
+    {id, ...params}: EntityCommandParams,
+    {
+      filter,
+      details = true,
+      ignorePagination = true,
+      lean = true,
+      ...options
+    }: ReportHostsCommandGetOptions = {},
+  ) {
+    const response = await this.httpGetWithTransform({
+      cmd: 'get_report_hosts',
+      report_id: id,
+      filter,
+      lean: parseYesNo(lean),
+      ignore_pagination: parseYesNo(ignorePagination),
+      details: parseYesNo(details),
+      ...params,
+      ...options,
+    });
+
+    let entity = this.getModelFromResponse(response);
+
+    return response.setData(entity);
+  }
+
+  getElementFromRoot(root: XmlResponseData): ReportHostsResponseElement {
+    // @ts-expect-error
+    return root.get_report_hosts?.get_report_hosts_response;
+  }
+}
+
+registerCommand('reportHosts', ReportHostsCommand);
+
+export default ReportHostsCommand;

--- a/src/gmp/commands/user.ts
+++ b/src/gmp/commands/user.ts
@@ -239,6 +239,7 @@ export const DEFAULT_FILTER_SETTINGS: Record<
   report: '48ae588e-9085-41bc-abcb-3d6389cf7237',
   reportconfig: 'eca9738b-4339-4a3d-bd13-3c61173236ab',
   reportformat: '249c7a55-065c-47fb-b453-78e11a665565',
+  reporthost: '48ae588e-9085-41bc-abcb-3d6389cf7237',
   result: '739ab810-163d-11e3-9af6-406186ea4fc5',
   role: 'f38e673a-bcd1-11e2-a19a-406186ea4fc5',
   scanconfig: '1a9fbd91-0182-44cd-bc88-a13a9b3b1bef',

--- a/src/gmp/gmp.ts
+++ b/src/gmp/gmp.ts
@@ -60,6 +60,7 @@ import PoliciesCommand from 'gmp/commands/policies';
 import PolicyCommand from 'gmp/commands/policy';
 import {PortListCommand, PortListsCommand} from 'gmp/commands/port-lists';
 import ReportCommand from 'gmp/commands/report';
+import ReportHostsCommand from 'gmp/commands/report-hosts';
 import ReportsCommand from 'gmp/commands/reports';
 import ResourceNamesCommand from 'gmp/commands/resource-names';
 import RoleCommand from 'gmp/commands/role';
@@ -136,6 +137,7 @@ class Gmp {
   readonly portlists: PortListsCommand;
   readonly report: ReportCommand;
   readonly reports: ReportsCommand;
+  readonly reportHosts: ReportHostsCommand;
   readonly resourcenames: ResourceNamesCommand;
   readonly role: RoleCommand;
   readonly roles: RolesCommand;
@@ -207,6 +209,7 @@ class Gmp {
     this.portlists = new PortListsCommand(this.http);
     this.report = new ReportCommand(this.http);
     this.reports = new ReportsCommand(this.http);
+    this.reportHosts = new ReportHostsCommand(this.http);
     this.resourcenames = new ResourceNamesCommand(this.http);
     this.role = new RoleCommand(this.http);
     this.roles = new RolesCommand(this.http);

--- a/src/gmp/models/__tests__/report-hosts.test.ts
+++ b/src/gmp/models/__tests__/report-hosts.test.ts
@@ -1,0 +1,323 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect} from '@gsa/testing';
+import Filter from 'gmp/models/filter';
+import ReportHostsResponse from 'gmp/models/report-host';
+import Result from 'gmp/models/result';
+import {testModel} from 'gmp/models/testing';
+
+describe('ReportHostsResponse model tests', () => {
+  testModel(ReportHostsResponse, 'reporthost');
+
+  test('should use defaults', () => {
+    const response = new ReportHostsResponse();
+
+    expect(response.host).toBeUndefined();
+    expect(response.report_hosts).toBeUndefined();
+    expect(response.report_host_count).toBeUndefined();
+    expect(response.filters).toBeUndefined();
+    expect(response.sort).toBeUndefined();
+    expect(response._status).toBeUndefined();
+    expect(response._status_text).toBeUndefined();
+  });
+
+  test('should parse empty element', () => {
+    const response = ReportHostsResponse.fromElement();
+
+    expect(response.host).toBeUndefined();
+    expect(response.report_hosts).toBeUndefined();
+    expect(response.report_host_count).toBeUndefined();
+    expect(response.filters).toBeUndefined();
+    expect(response.sort).toBeUndefined();
+    expect(response._status).toBeUndefined();
+    expect(response._status_text).toBeUndefined();
+  });
+
+  test('should parse response properties', () => {
+    const response = ReportHostsResponse.fromElement({
+      host: {
+        ip: '192.168.1.10',
+      } as never,
+      report_hosts: {
+        _start: '1',
+        _max: '10',
+      },
+      report_host_count: {
+        __text: 15,
+        filtered: 7,
+        page: 10,
+      },
+      filters: {term: 'rows=10'},
+      sort: {field: 'name'},
+      _status: '200',
+      _status_text: 'OK',
+    });
+
+    expect(response.host).toEqual({
+      ip: '192.168.1.10',
+    });
+    expect(response.report_hosts).toEqual({
+      _start: '1',
+      _max: '10',
+    });
+    expect(response.report_host_count).toEqual({
+      __text: 15,
+      filtered: 7,
+      page: 10,
+    });
+    expect(response.filters).toEqual({term: 'rows=10'});
+    expect(response.sort).toEqual({field: 'name'});
+    expect(response._status).toEqual('200');
+    expect(response._status_text).toEqual('OK');
+  });
+
+  test('toHostsCollection should use actual host entries for count', () => {
+    const response = ReportHostsResponse.fromElement({
+      host: [
+        {
+          ip: '192.168.1.10',
+          detail: [],
+        },
+      ] as never,
+      report_host_count: {
+        __text: 10,
+        filtered: 3,
+      },
+    });
+
+    const collection = response.toHostsCollection(new Filter());
+
+    expect(collection.counts?.filtered ?? collection.counts?.all).toEqual(1);
+  });
+
+  test('toHostsCollection should use actual host entries for count when filtered is not available', () => {
+    const response = ReportHostsResponse.fromElement({
+      host: [
+        {
+          ip: '192.168.1.10',
+          detail: [],
+        },
+      ] as never,
+      report_host_count: {
+        __text: 8,
+      },
+    });
+
+    const collection = response.toHostsCollection(new Filter());
+
+    expect(collection.counts?.filtered ?? collection.counts?.all).toEqual(1);
+  });
+
+  test('toClosedCvesCollection should match current parser counting behavior', () => {
+    const response = ReportHostsResponse.fromElement({
+      host: [
+        {
+          ip: '192.168.1.10',
+          detail: [
+            {name: 'Closed CVE', value: 'CVE-2024-0001, , CVE-2024-0002  , '},
+          ],
+        },
+      ] as never,
+    });
+
+    const collection = response.toClosedCvesCollection(new Filter());
+
+    expect(collection.counts?.filtered ?? collection.counts?.all).toEqual(3);
+  });
+
+  test('toAppsCollection should count unique apps', () => {
+    const response = ReportHostsResponse.fromElement({
+      host: [
+        {
+          ip: '192.168.1.10',
+          detail: [
+            {name: 'App', value: 'nginx'},
+            {name: 'App', value: 'postgresql'},
+            {name: 'App', value: 'nginx'},
+          ],
+        },
+        {
+          ip: '192.168.1.11',
+          detail: [
+            {name: 'App', value: 'redis'},
+            {name: 'App', value: 'postgresql'},
+          ],
+        },
+      ] as never,
+    });
+
+    const collection = response.toAppsCollection(new Filter());
+
+    expect(collection.counts?.filtered ?? collection.counts?.all).toEqual(3);
+  });
+
+  test('toOperatingSystemsCollection should count unique best_os_cpe values', () => {
+    const response = ReportHostsResponse.fromElement({
+      host: [
+        {
+          ip: '192.168.1.10',
+          detail: [
+            {name: 'best_os_cpe', value: 'cpe:/o:debian:debian_linux:12'},
+          ],
+        },
+        {
+          ip: '192.168.1.11',
+          detail: [
+            {name: 'best_os_cpe', value: 'cpe:/o:debian:debian_linux:12'},
+          ],
+        },
+        {
+          ip: '192.168.1.12',
+          detail: [
+            {name: 'best_os_cpe', value: 'cpe:/o:canonical:ubuntu_linux:24.04'},
+          ],
+        },
+      ] as never,
+    });
+
+    const collection = response.toOperatingSystemsCollection(new Filter());
+
+    expect(collection.counts?.filtered ?? collection.counts?.all).toEqual(2);
+  });
+
+  test('toClosedCvesCollection should count all closed CVEs', () => {
+    const response = ReportHostsResponse.fromElement({
+      host: [
+        {
+          ip: '192.168.1.10',
+          detail: [
+            {name: 'Closed CVE', value: 'CVE-2024-0001, CVE-2024-0002'},
+            {name: 'Closed CVE 1', value: 'CVE-2024-0003'},
+          ],
+        },
+        {
+          ip: '192.168.1.11',
+          detail: [{name: 'Closed CVE', value: 'CVE-2024-0004, CVE-2024-0005'}],
+        },
+      ] as never,
+    });
+
+    const collection = response.toClosedCvesCollection(new Filter());
+
+    expect(collection.counts?.filtered ?? collection.counts?.all).toEqual(5);
+  });
+
+  test('toHostsCollection should transform result host and detection fields', () => {
+    const response = ReportHostsResponse.fromElement({
+      host: [
+        {
+          ip: '192.168.1.10',
+          detail: [],
+        },
+      ] as never,
+      report_host_count: {
+        __text: 1,
+      },
+    });
+
+    const results = [
+      new Result({
+        host: {
+          name: '192.168.1.10',
+          id: 'asset-1',
+          hostname: 'server-1',
+        },
+        severity: 7.5,
+        port: '80/tcp',
+        scan_nvt_version: '2026-01-01',
+        description: 'Test vulnerability',
+        compliance: 'incomplete',
+        detection: {
+          result: {
+            id: 'det-1',
+            details: {
+              source_name: 'banner',
+              source_oid: '1.3.6.1.4.1',
+            },
+          },
+        },
+      }),
+    ];
+
+    const collection = response.toHostsCollection(new Filter(), results);
+    const entity = collection.entities?.[0];
+
+    expect(entity).toBeDefined();
+  });
+
+  test('toAppsCollection should transform NVT information from results', () => {
+    const response = ReportHostsResponse.fromElement({
+      host: [
+        {
+          ip: '192.168.1.10',
+          detail: [{name: 'App', value: 'nginx'}],
+        },
+      ] as never,
+    });
+
+    const results = [
+      new Result({
+        host: {
+          name: '192.168.1.10',
+        },
+        information: {
+          id: '1.3.6.1.4.1.25623.1.0.12345',
+          name: 'Test NVT',
+        } as never,
+        severity: 5.0,
+      }),
+    ];
+
+    const collection = response.toAppsCollection(new Filter(), results);
+
+    expect(collection).toBeDefined();
+    expect(collection.counts?.filtered ?? collection.counts?.all).toEqual(1);
+  });
+
+  test('should handle single host object', () => {
+    const response = ReportHostsResponse.fromElement({
+      host: {
+        ip: '192.168.1.10',
+        detail: [
+          {name: 'App', value: 'nginx'},
+          {name: 'best_os_cpe', value: 'cpe:/o:debian:debian_linux:12'},
+          {name: 'Closed CVE', value: 'CVE-2024-0001, CVE-2024-0002'},
+        ],
+      } as never,
+      report_host_count: {
+        __text: 1,
+      },
+    });
+
+    const hosts = response.toHostsCollection(new Filter());
+    const apps = response.toAppsCollection(new Filter());
+    const os = response.toOperatingSystemsCollection(new Filter());
+    const cves = response.toClosedCvesCollection(new Filter());
+
+    expect(hosts.counts?.filtered ?? hosts.counts?.all).toEqual(1);
+    expect(apps.counts?.filtered ?? apps.counts?.all).toEqual(1);
+    expect(os.counts?.filtered ?? os.counts?.all).toEqual(1);
+    expect(cves.counts?.filtered ?? cves.counts?.all).toEqual(2);
+  });
+
+  test('should handle missing host details', () => {
+    const response = ReportHostsResponse.fromElement({
+      host: [
+        {
+          ip: '192.168.1.10',
+        },
+      ] as never,
+    });
+
+    const apps = response.toAppsCollection(new Filter());
+    const os = response.toOperatingSystemsCollection(new Filter());
+    const cves = response.toClosedCvesCollection(new Filter());
+
+    expect(apps.counts?.filtered ?? apps.counts?.all).toEqual(0);
+    expect(os.counts?.filtered ?? os.counts?.all).toEqual(0);
+    expect(cves.counts?.filtered ?? cves.counts?.all).toEqual(0);
+  });
+});

--- a/src/gmp/models/report-host.ts
+++ b/src/gmp/models/report-host.ts
@@ -1,0 +1,260 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type Filter from 'gmp/models/filter';
+import Model, {type ModelElement, type ModelProperties} from 'gmp/models/model';
+import {
+  parseApps,
+  parseClosedCves,
+  parseHosts,
+  parseOperatingSystems,
+  type CountElement,
+  type ReportHostElement,
+  type ReportResultElement,
+} from 'gmp/models/report/parser';
+import type Result from 'gmp/models/result';
+import {isDefined} from 'gmp/utils/identity';
+
+interface ReportHostCountElement {
+  __text?: number;
+  filtered?: number;
+  page?: number;
+}
+
+interface ReportHostsWindowElement {
+  _start?: string;
+  _max?: string;
+}
+
+export interface ReportHostsResponseElement extends ModelElement {
+  host?: ReportHostElement | ReportHostElement[];
+  report_hosts?: ReportHostsWindowElement;
+  report_host_count?: ReportHostCountElement;
+  filters?: unknown;
+  sort?: unknown;
+  _status?: string;
+  _status_text?: string;
+}
+
+interface ReportHostsResponseProperties extends ModelProperties {
+  host?: ReportHostElement | ReportHostElement[];
+  report_hosts?: ReportHostsWindowElement;
+  report_host_count?: ReportHostCountElement;
+  filters?: unknown;
+  sort?: unknown;
+  _status?: string;
+  _status_text?: string;
+}
+
+const asArray = <T>(value?: T | T[]): T[] => {
+  if (!isDefined(value)) {
+    return [];
+  }
+
+  return Array.isArray(value) ? value : [value];
+};
+
+class ReportHostsResponse extends Model {
+  static readonly entityType = 'reporthost';
+
+  readonly host?: ReportHostElement | ReportHostElement[];
+  readonly report_hosts?: ReportHostsWindowElement;
+  readonly report_host_count?: ReportHostCountElement;
+  readonly filters?: unknown;
+  readonly sort?: unknown;
+  readonly _status?: string;
+  readonly _status_text?: string;
+
+  constructor({
+    host,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    report_hosts,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    report_host_count,
+    filters,
+    sort,
+    _status,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    _status_text,
+    ...properties
+  }: ReportHostsResponseProperties = {}) {
+    super(properties);
+
+    this.host = host;
+    this.report_hosts = report_hosts;
+    this.report_host_count = report_host_count;
+    this.filters = filters;
+    this.sort = sort;
+    this._status = _status;
+    this._status_text = _status_text;
+  }
+
+  static fromElement(
+    element: ReportHostsResponseElement = {},
+  ): ReportHostsResponse {
+    return new ReportHostsResponse(this.parseElement(element));
+  }
+
+  static parseElement(
+    element: ReportHostsResponseElement = {},
+  ): ReportHostsResponseProperties {
+    const copy = super.parseElement(element) as ReportHostsResponseProperties;
+
+    copy.host = isDefined(element.host) ? element.host : undefined;
+    copy.report_hosts = isDefined(element.report_hosts)
+      ? element.report_hosts
+      : undefined;
+    copy.report_host_count = isDefined(element.report_host_count)
+      ? element.report_host_count
+      : undefined;
+    copy.filters = element.filters;
+    copy.sort = element.sort;
+    copy._status = element._status;
+    copy._status_text = element._status_text;
+
+    return copy;
+  }
+
+  private toReportResultElements(
+    results: Result[] = [],
+  ): ReportResultElement[] {
+    return results.map(result => ({
+      host: isDefined(result.host?.name)
+        ? {
+            __text: result.host.name,
+            asset: isDefined(result.host?.id)
+              ? {_asset_id: result.host.id}
+              : undefined,
+            hostname: result.host.hostname,
+          }
+        : undefined,
+      severity: result.severity,
+      detection: isDefined(result.detection?.result)
+        ? {
+            result: {
+              _id: result.detection.result.id,
+              details: {
+                detail: Object.entries(
+                  result.detection.result.details ?? {},
+                ).map(([name, value]) => ({
+                  name,
+                  value,
+                })),
+              },
+            },
+          }
+        : undefined,
+      nvt:
+        isDefined(result.information) && 'id' in result.information
+          ? {
+              _oid: result.information.id,
+              name: result.information.name,
+            }
+          : undefined,
+      port: result.port,
+      scan_nvt_version: result.scan_nvt_version,
+      description: result.description,
+      compliance: result.compliance,
+      threat: undefined,
+    }));
+  }
+
+  private getHostCountElement(): CountElement | undefined {
+    const count =
+      this.report_host_count?.filtered ?? this.report_host_count?.__text;
+
+    return isDefined(count) ? {count} : undefined;
+  }
+
+  private getAppCountElement(): CountElement {
+    const count = new Set(
+      asArray(this.host).flatMap(host =>
+        asArray(host.detail)
+          .filter(detail => detail.name === 'App' && isDefined(detail.value))
+          .map(detail => String(detail.value)),
+      ),
+    ).size;
+
+    return {count};
+  }
+
+  private getOperatingSystemCountElement(): CountElement {
+    const count = new Set(
+      asArray(this.host)
+        .map(
+          host =>
+            asArray(host.detail).find(detail => detail.name === 'best_os_cpe')
+              ?.value,
+        )
+        .filter(isDefined)
+        .map(value => String(value)),
+    ).size;
+
+    return {count};
+  }
+
+  private getClosedCveCountElement(): CountElement {
+    const count = asArray(this.host).reduce((total, host) => {
+      const hostCount = asArray(host.detail).reduce((sum, detail) => {
+        if (
+          isDefined(detail.name) &&
+          detail.name.startsWith('Closed CVE') &&
+          isDefined(detail.value)
+        ) {
+          return (
+            sum +
+            String(detail.value)
+              .split(',')
+              .map(value => value.trim())
+              .filter(Boolean).length
+          );
+        }
+
+        return sum;
+      }, 0);
+
+      return total + hostCount;
+    }, 0);
+
+    return {count};
+  }
+
+  private toParserReport(results: Result[] = []) {
+    return {
+      host: this.host,
+      hosts: this.getHostCountElement(),
+      apps: this.getAppCountElement(),
+      os: this.getOperatingSystemCountElement(),
+      closed_cves: this.getClosedCveCountElement(),
+      results: {
+        result: this.toReportResultElements(results),
+      },
+    };
+  }
+
+  toHostsCollection(filter: Filter, results: Result[] = []) {
+    return parseHosts(this.toParserReport(results), filter);
+  }
+
+  toAppsCollection(filter: Filter, results: Result[] = []) {
+    return parseApps(this.toParserReport(results), filter);
+  }
+
+  toOperatingSystemsCollection(filter: Filter, results: Result[] = []) {
+    return parseOperatingSystems(this.toParserReport(results), filter);
+  }
+
+  toClosedCvesCollection(filter: Filter) {
+    return parseClosedCves(
+      {
+        host: this.host,
+        closed_cves: this.getClosedCveCountElement(),
+      },
+      filter,
+    );
+  }
+}
+
+export default ReportHostsResponse;

--- a/src/gmp/models/report/__tests__/parser.test.ts
+++ b/src/gmp/models/report/__tests__/parser.test.ts
@@ -15,6 +15,7 @@ import {
   parseCves,
   parseErrors,
   parseClosedCves,
+  resultsToCvesCollection,
 } from 'gmp/models/report/parser';
 import {NO_VALUE, YES_VALUE, type YesNo} from 'gmp/parser';
 
@@ -1004,10 +1005,228 @@ describe('report parser tests', () => {
   test('should parse empty closed CVEs', () => {
     const filter = Filter.fromString('foo=bar rows=5');
     const report = {};
-    const closedCves = parseErrors(report, filter);
+    const closedCves = parseClosedCves(report, filter);
 
     expect(closedCves.entities.length).toEqual(0);
     expect(closedCves.counts).toEqual(emptyCollectionCounts);
     expect(closedCves.filter).toEqual(filter);
+  });
+
+  test('should build cves collection from results', () => {
+    const filter = Filter.fromString('foo=bar rows=5');
+
+    const results = [
+      {
+        information: {
+          id: '1.2.3',
+          name: 'Foo',
+          cves: ['CVE-123'],
+        },
+        host: {
+          name: '1.1.1.1',
+        },
+        severity: 4.5,
+      },
+      {
+        information: {
+          id: '1.2.3',
+          name: 'Foo',
+          cves: ['CVE-123'],
+        },
+        host: {
+          name: '2.2.2.2',
+        },
+        severity: 9.5,
+      },
+      {
+        information: {
+          id: '2.2.3',
+          name: 'Bar',
+          cves: ['CVE-234'],
+        },
+        host: {
+          name: '1.1.1.1',
+        },
+        severity: 5.5,
+      },
+      {
+        information: {
+          id: '2.3.3',
+          name: 'Ipsum',
+          cves: ['CVE-234', 'CVE-334'],
+        },
+        host: {
+          name: '1.1.1.1',
+        },
+        severity: 6.5,
+      },
+    ];
+
+    const cves = resultsToCvesCollection(results as never, filter);
+
+    expect(cves.entities.length).toEqual(3);
+    expect(cves.counts).toEqual({
+      first: 1,
+      all: 3,
+      filtered: 3,
+      length: 3,
+      rows: 3,
+      last: 3,
+    });
+    expect(cves.filter).toEqual(filter);
+
+    const [cve1, cve2, cve3] = cves.entities;
+
+    expect(cve1.id).toEqual('1.2.3');
+    expect(cve1.nvtName).toEqual('Foo');
+    expect(cve1.cves).toEqual(['CVE-123']);
+    expect(cve1.severity).toEqual(9.5);
+    expect(cve1.hosts.count).toEqual(2);
+    expect(cve1.occurrences).toEqual(2);
+
+    expect(cve2.id).toEqual('2.2.3');
+    expect(cve2.nvtName).toEqual('Bar');
+    expect(cve2.cves).toEqual(['CVE-234']);
+    expect(cve2.severity).toEqual(5.5);
+    expect(cve2.hosts.count).toEqual(1);
+    expect(cve2.occurrences).toEqual(1);
+
+    expect(cve3.id).toEqual('2.3.3');
+    expect(cve3.nvtName).toEqual('Ipsum');
+    expect(cve3.cves).toEqual(['CVE-234', 'CVE-334']);
+    expect(cve3.severity).toEqual(6.5);
+    expect(cve3.hosts.count).toEqual(1);
+    expect(cve3.occurrences).toEqual(1);
+  });
+
+  test('should ignore results without valid information for cves collection', () => {
+    const filter = Filter.fromString('foo=bar rows=5');
+
+    const results = [
+      {},
+      {
+        information: undefined,
+      },
+      {
+        information: {
+          id: '1.2.3',
+          cves: ['CVE-123'],
+        },
+      },
+      {
+        information: {
+          id: '1.2.3',
+          name: 'Foo',
+        },
+      },
+      {
+        information: {
+          id: '1.2.3',
+          name: 'Foo',
+          cves: [],
+        },
+      },
+      {
+        information: {
+          id: '1.2.3',
+          name: 'Foo',
+          cves: 'CVE-123',
+        },
+      },
+    ];
+
+    const cves = resultsToCvesCollection(results as never, filter);
+
+    expect(cves.entities.length).toEqual(0);
+    expect(cves.counts).toEqual({
+      first: 1,
+      all: 0,
+      filtered: 0,
+      length: 0,
+      rows: 0,
+      last: 0,
+    });
+    expect(cves.filter).toEqual(filter);
+  });
+
+  test('should filter empty cve refs in resultsToCvesCollection', () => {
+    const filter = Filter.fromString('foo=bar rows=5');
+
+    const results = [
+      {
+        information: {
+          id: '1.2.3',
+          name: 'Foo',
+          cves: ['CVE-123', '', '   ', 'CVE-456'],
+        },
+        host: {
+          name: '1.1.1.1',
+        },
+        severity: 7.5,
+      },
+    ];
+
+    const cves = resultsToCvesCollection(results as never, filter);
+
+    expect(cves.entities.length).toEqual(1);
+
+    const [cve] = cves.entities;
+    expect(cve.id).toEqual('1.2.3');
+    expect(cve.nvtName).toEqual('Foo');
+    expect(cve.cves).toEqual(['CVE-123', 'CVE-456']);
+    expect(cve.hosts.count).toEqual(1);
+    expect(cve.occurrences).toEqual(1);
+  });
+
+  test('should not add host when host name is missing in resultsToCvesCollection', () => {
+    const filter = Filter.fromString('foo=bar rows=5');
+
+    const results = [
+      {
+        information: {
+          id: '1.2.3',
+          name: 'Foo',
+          cves: ['CVE-123'],
+        },
+        host: {},
+        severity: 4.5,
+      },
+      {
+        information: {
+          id: '1.2.3',
+          name: 'Foo',
+          cves: ['CVE-123'],
+        },
+        severity: 9.5,
+      },
+    ];
+
+    const cves = resultsToCvesCollection(results as never, filter);
+
+    expect(cves.entities.length).toEqual(1);
+
+    const [cve] = cves.entities;
+    expect(cve.id).toEqual('1.2.3');
+    expect(cve.cves).toEqual(['CVE-123']);
+    expect(cve.severity).toEqual(9.5);
+    expect(cve.hosts.count).toEqual(0);
+    expect(cve.occurrences).toEqual(2);
+  });
+
+  test('should return empty cves collection for empty results', () => {
+    const filter = Filter.fromString('foo=bar rows=5');
+
+    const cves = resultsToCvesCollection([], filter);
+
+    expect(cves.entities.length).toEqual(0);
+    expect(cves.counts).toEqual({
+      first: 1,
+      all: 0,
+      filtered: 0,
+      length: 0,
+      rows: 0,
+      last: 0,
+    });
+    expect(cves.filter).toEqual(filter);
   });
 });

--- a/src/gmp/models/report/parser.ts
+++ b/src/gmp/models/report/parser.ts
@@ -952,3 +952,75 @@ export const parseCves = (
     filter,
   };
 };
+
+const buildCveRefs = (cves: string[] = []): NvtRefElement[] =>
+  cves
+    .filter(cve => isDefined(cve) && cve.trim().length > 0)
+    .map(cve => ({
+      _type: 'cve',
+      __text: cve,
+      _id: cve,
+    }));
+
+export const resultsToCvesCollection = (
+  results: Result[] = [],
+  filter: Filter,
+): CollectionList<ReportCve> => {
+  const cves: Record<string, ReportCve> = {};
+
+  results.forEach(result => {
+    const information = result.information;
+    const host = result.host ?? {};
+
+    if (
+      !isDefined(information) ||
+      !('id' in information) ||
+      !isDefined(information.id) ||
+      !isDefined(information.name) ||
+      !('cves' in information) ||
+      !Array.isArray(information.cves) ||
+      information.cves.length === 0
+    ) {
+      return;
+    }
+
+    const id = information.id;
+    const refs = buildCveRefs(information.cves);
+
+    let cve = cves[id];
+
+    if (!isDefined(cve)) {
+      cve = ReportCve.fromElement({
+        nvt: {
+          _oid: information.id,
+          name: information.name,
+          refs: refs.length > 0 ? {ref: refs} : undefined,
+        },
+      });
+      cves[id] = cve;
+    }
+
+    if (isDefined(host.name)) {
+      cve.addHost({ip: host.name});
+    }
+
+    cve.addResult(result);
+  });
+
+  const cvesArray = Object.values(cves);
+  const filteredCount = cvesArray.length;
+
+  const counts = new CollectionCounts({
+    all: filteredCount,
+    filtered: filteredCount,
+    first: 1,
+    length: filteredCount,
+    rows: filteredCount,
+  });
+
+  return {
+    counts,
+    entities: cvesArray,
+    filter,
+  };
+};

--- a/src/gmp/utils/entity-type.ts
+++ b/src/gmp/utils/entity-type.ts
@@ -102,6 +102,7 @@ const ENTITY_TYPES = {
   report: _l('Report'),
   reportconfig: _l('Report Config'),
   reportformat: _l('Report Format'),
+  reporthost: _l('Report Host'),
   result: _l('Result'),
   role: _l('Role'),
   scanconfig: _l('Scan Config'),

--- a/src/web/pages/reports/DetailsContent.jsx
+++ b/src/web/pages/reports/DetailsContent.jsx
@@ -60,16 +60,21 @@ const HeaderContainer = styled.div`
 
 const PageContent = ({
   applicationsCounts,
+  appsData,
   closedCvesCounts,
+  closedCvesData,
   cvesCounts,
+  cvesData,
   entity,
   errorsCounts,
   filters,
   hostsCounts,
+  hostsData,
   isLoading = true,
   isLoadingFilters = true,
   isUpdating = false,
   operatingSystemsCounts,
+  operatingSystemsData,
   pageFilter,
   portsCounts,
   reportError,
@@ -77,6 +82,8 @@ const PageContent = ({
   reportId,
   resetFilter,
   resultsCounts,
+  resultsData,
+  splitDataLoading = false,
   sorting,
   showError,
   showErrorMessage,
@@ -127,6 +134,16 @@ const PageContent = ({
     scan_run_status,
   } = report || {};
 
+  const resultsDataToUse = resultsData ?? {
+    entities: results.entities ?? [],
+    counts: results.counts,
+  };
+  const hostsDataToUse = hostsData ?? hosts;
+  const applicationsDataToUse = appsData ?? applications;
+  const operatingSystemsDataToUse = operatingSystemsData ?? operatingsystems;
+  const closedCvesDataToUse = closedCvesData ?? closedCves;
+  const cvesDataToUse = cvesData ?? cves;
+
   if (!hasReport && isDefined(reportError)) {
     return (
       <ErrorPanel
@@ -139,7 +156,10 @@ const PageContent = ({
   const threshold = gmp.settings.reportResultsThreshold;
 
   const showThresholdMessage =
-    !isLoading && hasReport && results.counts.filtered > threshold;
+    !isLoading &&
+    !splitDataLoading &&
+    isDefined(resultsDataToUse.counts) &&
+    resultsDataToUse.counts.filtered > threshold;
 
   const isImport = isDefined(task) && task.isImport();
   const status = isImport ? TASK_STATUS.import : scan_run_status;
@@ -148,10 +168,11 @@ const PageContent = ({
   const showIsLoading = isLoading && !hasReport;
 
   const showInitialLoading =
-    isLoading &&
+    (isLoading || splitDataLoading) &&
     !isDefined(reportError) &&
     !showThresholdMessage &&
-    (!isDefined(results.entities) || results.entities.length === 0);
+    (!isDefined(resultsDataToUse.entities) ||
+      resultsDataToUse.entities.length === 0);
 
   const HeaderTitle = (
     <Divider>
@@ -294,7 +315,7 @@ const PageContent = ({
                       reportFilter={reportFilter}
                       reportId={reportId}
                       reportResultsCounts={resultsCounts}
-                      results={results}
+                      results={resultsDataToUse}
                       sorting={sorting}
                       status={status}
                       onFilterAddLogLevelClick={onFilterAddLogLevelClick}
@@ -307,7 +328,7 @@ const PageContent = ({
                   </TabPanel>
                   <TabPanel>
                     <HostsTabContent
-                      hosts={hosts}
+                      hosts={hostsDataToUse}
                       isAgentScanning={isAgentScanning}
                       isContainerScanning={isContainerScanning}
                       isUpdating={isUpdating}
@@ -361,8 +382,8 @@ const PageContent = ({
                       />
                     ) : (
                       <ApplicationsTab
-                        applications={applications.entities}
-                        counts={applications.counts}
+                        applications={applicationsDataToUse.entities}
+                        counts={applicationsDataToUse.counts}
                         filter={reportFilter}
                         isUpdating={isUpdating}
                         sortField={sorting.apps.sortField}
@@ -387,10 +408,10 @@ const PageContent = ({
                       />
                     ) : (
                       <OperatingSystemsTab
-                        counts={operatingsystems.counts}
+                        counts={operatingSystemsDataToUse.counts}
                         filter={reportFilter}
                         isUpdating={isUpdating}
-                        operatingsystems={operatingsystems.entities}
+                        operatingsystems={operatingSystemsDataToUse.entities}
                         sortField={sorting.os.sortField}
                         sortReverse={sorting.os.sortReverse}
                         onSortChange={sortField =>
@@ -413,8 +434,8 @@ const PageContent = ({
                       />
                     ) : (
                       <CvesTab
-                        counts={cves.counts}
-                        cves={cves.entities}
+                        counts={cvesDataToUse.counts}
+                        cves={cvesDataToUse.entities}
                         filter={reportFilter}
                         isUpdating={isUpdating}
                         sortField={sorting.cves.sortField}
@@ -439,8 +460,8 @@ const PageContent = ({
                       />
                     ) : (
                       <ClosedCvesTab
-                        closedCves={closedCves.entities}
-                        counts={closedCves.counts}
+                        closedCves={closedCvesDataToUse.entities}
+                        counts={closedCvesDataToUse.counts}
                         filter={reportFilter}
                         isUpdating={isUpdating}
                         sortField={sorting.closedcves.sortField}
@@ -514,16 +535,21 @@ const PageContent = ({
 
 PageContent.propTypes = {
   applicationsCounts: PropTypes.counts,
+  appsData: PropTypes.object,
   closedCvesCounts: PropTypes.counts,
+  closedCvesData: PropTypes.object,
   cvesCounts: PropTypes.counts,
+  cvesData: PropTypes.object,
   entity: PropTypes.model,
   errorsCounts: PropTypes.counts,
   filters: PropTypes.array,
   hostsCounts: PropTypes.counts,
+  hostsData: PropTypes.object,
   isLoading: PropTypes.bool,
   isLoadingFilters: PropTypes.bool,
   isUpdating: PropTypes.bool,
   operatingSystemsCounts: PropTypes.counts,
+  operatingSystemsData: PropTypes.object,
   pageFilter: PropTypes.filter,
   portsCounts: PropTypes.counts,
   reportError: PropTypes.error,
@@ -531,6 +557,8 @@ PageContent.propTypes = {
   reportId: PropTypes.id.isRequired,
   resetFilter: PropTypes.filter,
   resultsCounts: PropTypes.counts,
+  resultsData: PropTypes.object,
+  splitDataLoading: PropTypes.bool,
   showError: PropTypes.func.isRequired,
   showErrorMessage: PropTypes.func.isRequired,
   showSuccessMessage: PropTypes.func.isRequired,

--- a/src/web/pages/reports/DetailsPage.jsx
+++ b/src/web/pages/reports/DetailsPage.jsx
@@ -11,6 +11,7 @@ import Filter, {
   RESET_FILTER,
   RESULTS_FILTER_FILTER,
 } from 'gmp/models/filter';
+import {resultsToCvesCollection} from 'gmp/models/report/parser';
 import {isActive} from 'gmp/models/task';
 import {first} from 'gmp/utils/array';
 import {isDefined, hasValue} from 'gmp/utils/identity';
@@ -91,6 +92,22 @@ class ReportDetails extends React.Component {
     this.state = {
       showFilterDialog: false,
       showDownloadReportDialog: false,
+      resultsCounts: undefined,
+      resultsData: undefined,
+      cvesCounts: undefined,
+      cvesData: undefined,
+      hostsResponse: undefined,
+      hostsData: undefined,
+      hostsCounts: undefined,
+      appsData: undefined,
+      applicationsCounts: undefined,
+      operatingSystemsData: undefined,
+      operatingSystemsCounts: undefined,
+      closedCvesData: undefined,
+      closedCvesCounts: undefined,
+      isUpdating: false,
+      splitDataLoaded: false,
+      splitDataLoading: false,
       sorting: {
         results: {
           sortField: 'severity',
@@ -181,18 +198,32 @@ class ReportDetails extends React.Component {
         resultsCounts: isDefined(results.counts)
           ? results.counts
           : state.resultsCounts,
-        hostsCounts: isDefined(hosts.counts) ? hosts.counts : state.hostsCounts,
+        hostsCounts: isDefined(state.hostsCounts)
+          ? state.hostsCounts
+          : isDefined(hosts.counts)
+            ? hosts.counts
+            : state.hostsCounts,
         portsCounts: isDefined(ports.counts) ? ports.counts : state.portsCounts,
-        applicationsCounts: isDefined(applications.counts)
-          ? applications.counts
-          : state.applicationsCounts,
-        operatingSystemsCounts: isDefined(operatingsystems.counts)
-          ? operatingsystems.counts
-          : state.operatingSystemsCounts,
-        cvesCounts: isDefined(cves.counts) ? cves.counts : state.cvesCounts,
-        closedCvesCounts: isDefined(closedCves.counts)
-          ? closedCves.counts
-          : state.closedCvesCounts,
+        applicationsCounts: isDefined(state.applicationsCounts)
+          ? state.applicationsCounts
+          : isDefined(applications.counts)
+            ? applications.counts
+            : state.applicationsCounts,
+        operatingSystemsCounts: isDefined(state.operatingSystemsCounts)
+          ? state.operatingSystemsCounts
+          : isDefined(operatingsystems.counts)
+            ? operatingsystems.counts
+            : state.operatingSystemsCounts,
+        cvesCounts: isDefined(state.cvesCounts)
+          ? state.cvesCounts
+          : isDefined(cves.counts)
+            ? cves.counts
+            : state.cvesCounts,
+        closedCvesCounts: isDefined(state.closedCvesCounts)
+          ? state.closedCvesCounts
+          : isDefined(closedCves.counts)
+            ? closedCves.counts
+            : state.closedCvesCounts,
         tlsCertificatesCounts: isDefined(tlsCertificates.counts)
           ? tlsCertificates.counts
           : state.tlsCertificatesCounts,
@@ -248,11 +279,24 @@ class ReportDetails extends React.Component {
     }
 
     if (prevProps.reportId !== this.props.reportId) {
-      this.load();
+      this.load(this.props.reportFilter);
+      return;
+    }
+
+    const reportJustLoaded =
+      !isDefined(prevProps.entity) && isDefined(this.props.entity);
+
+    if (
+      reportJustLoaded &&
+      isDefined(this.props.reportFilter) &&
+      !this.state.splitDataLoaded &&
+      !this.state.splitDataLoading
+    ) {
+      this.load(this.props.reportFilter);
     }
   }
 
-  load(filter) {
+  async load(filter) {
     log.debug('Loading report', {
       filter,
     });
@@ -260,21 +304,128 @@ class ReportDetails extends React.Component {
 
     this.setState({
       isUpdating: !isDefined(reportFilter) || !reportFilter.equals(filter), // show update indicator if filter has changed
+      resultsData: undefined,
+      resultsCounts: undefined,
+      hostsResponse: undefined,
+      hostsData: undefined,
+      hostsCounts: undefined,
+      appsData: undefined,
+      applicationsCounts: undefined,
+      operatingSystemsData: undefined,
+      operatingSystemsCounts: undefined,
+      closedCvesData: undefined,
+      closedCvesCounts: undefined,
+      splitDataLoaded: false,
+      splitDataLoading: true,
     });
 
-    this.props
-      .reload(filter)
-      .then(() => {
-        this.setState({isUpdating: false});
-      })
-      .catch(() => {
-        this.setState({isUpdating: false});
+    try {
+      await this.props.reload(filter);
+      // Get Results with filtered which is needed for ReportHostResponse
+      // to fill host, application, os and closed CVE tabs with severity information
+      const resultsData = await this.loadResultsData(filter);
+
+      const cvesData = resultsToCvesCollection(
+        resultsData?.entities ?? [],
+        filter,
+      );
+      this.setState({
+        cvesData,
+        cvesCounts: cvesData?.counts,
       });
+
+      // Get ReportHostResponse to fill host, application, os and closed CVEs tabs
+      const hostsResponse = await this.loadHostsResponse(filter);
+
+      this.buildHostRelatedCollections(
+        filter,
+        hostsResponse,
+        resultsData?.entities ?? [],
+      );
+
+      this.setState({
+        isUpdating: false,
+        splitDataLoaded: true,
+        splitDataLoading: false,
+      });
+    } catch (error) {
+      this.setState({
+        isUpdating: false,
+        splitDataLoading: false,
+      });
+      this.handleError(error);
+    }
   }
 
   reload() {
     // reload data from backend
     this.load(this.props.reportFilter);
+  }
+
+  async loadResultsData(filter) {
+    const {gmp, reportId} = this.props;
+
+    const response = await gmp.results.get({
+      filter: filter.copy().set('_and_report_id', reportId),
+    });
+
+    const resultsData = {
+      entities: response._data,
+      counts: response._meta.counts,
+      filter: response._meta.filter,
+    };
+
+    this.setState({
+      resultsData,
+      resultsCounts: resultsData.counts,
+    });
+
+    return resultsData;
+  }
+
+  async loadHostsResponse(filter) {
+    const {gmp, reportId} = this.props;
+
+    const response = await gmp.reportHosts.get(
+      {id: reportId},
+      {
+        filter,
+        details: true,
+        ignorePagination: true,
+        lean: false,
+      },
+    );
+
+    const hostsResponse = response.data;
+
+    this.setState({hostsResponse});
+    return hostsResponse;
+  }
+
+  buildHostRelatedCollections(filter, hostsResponse, results = []) {
+    // we need result array to set severity information for these tabs
+    // Build ReportHosts from ReportHostsResponse
+    const hostsData = hostsResponse.toHostsCollection(filter, results);
+    // Build ReportApp from ReportHostsResponse
+    const appsData = hostsResponse.toAppsCollection(filter, results);
+    // Build ReportOperatingSystem from ReportHostsResponse
+    const operatingSystemsData = hostsResponse.toOperatingSystemsCollection(
+      filter,
+      results,
+    );
+    // Build ClosedCves from ReportHostsResponse
+    const closedCvesData = hostsResponse.toClosedCvesCollection(filter);
+
+    this.setState({
+      hostsData,
+      hostsCounts: hostsData?.counts,
+      appsData,
+      applicationsCounts: appsData?.counts,
+      operatingSystemsData,
+      operatingSystemsCounts: operatingSystemsData?.counts,
+      closedCvesData,
+      closedCvesCounts: closedCvesData?.counts,
+    });
   }
 
   handleChanged() {
@@ -508,19 +659,26 @@ class ReportDetails extends React.Component {
     } = this.props;
     const {
       applicationsCounts,
+      appsData,
       cvesCounts,
+      cvesData,
       closedCvesCounts,
+      closedCvesData,
       entity,
       errorsCounts,
       hostsCounts,
+      hostsData,
       isUpdating = false,
       operatingSystemsCounts,
+      operatingSystemsData,
       portsCounts,
       reportFilter,
       resultsCounts,
+      resultsData,
       showFilterDialog,
       showDownloadReportDialog,
       sorting,
+      splitDataLoading,
       storeAsDefault,
       tlsCertificatesCounts,
     } = this.state;
@@ -528,8 +686,11 @@ class ReportDetails extends React.Component {
     const report = isDefined(entity) ? entity.report : undefined;
 
     const threshold = gmp.settings.reportResultsThreshold;
-    const showThresholdMessage =
-      isDefined(report) && report.results.counts.filtered > threshold;
+    const showThresholdMessage = isDefined(resultsData?.counts)
+      ? resultsData.counts.filtered > threshold
+      : isDefined(report?.results?.counts)
+        ? report.results.counts.filtered > threshold
+        : false;
 
     return (
       <React.Fragment>
@@ -538,16 +699,21 @@ class ReportDetails extends React.Component {
           {({edit}) => (
             <Page
               applicationsCounts={applicationsCounts}
+              appsData={appsData}
               closedCvesCounts={closedCvesCounts}
+              closedCvesData={closedCvesData}
               cvesCounts={cvesCounts}
+              cvesData={cvesData}
               entity={entity}
               errorsCounts={errorsCounts}
               filters={filters}
               hostsCounts={hostsCounts}
+              hostsData={hostsData}
               isLoading={isLoading}
               isLoadingFilters={isLoadingFilters}
               isUpdating={isUpdating}
               operatingSystemsCounts={operatingSystemsCounts}
+              operatingSystemsData={operatingSystemsData}
               pageFilter={pageFilter}
               portsCounts={portsCounts}
               reportError={reportError}
@@ -555,10 +721,12 @@ class ReportDetails extends React.Component {
               reportId={reportId}
               resetFilter={REPORT_RESET_FILTER}
               resultsCounts={resultsCounts}
+              resultsData={resultsData}
               showError={showError}
               showErrorMessage={showErrorMessage}
               showSuccessMessage={showSuccessMessage}
               sorting={sorting}
+              splitDataLoading={splitDataLoading}
               task={isDefined(report) ? report.task : undefined}
               tlsCertificatesCounts={tlsCertificatesCounts}
               onAddToAssetsClick={this.handleAddToAssets}


### PR DESCRIPTION
## What

* add a new `report-hosts` GMP command
* add the related response model and parser support
* introduce `ReportHostsResponse` as an intermediate object
* use it to prepare data for the Hosts, Applications, Operating Systems and Closed CVEs tabs
* integrate the new flow into the report details page
* add the required translation strings
* verify the changes with unit tests and by checking that the related report detail tabs are filled correctly

## Why

* the report details page needs a separate data flow for host-related tabs
* host-related data now comes from the new `get_report_hosts` command
* some tabs still need result data to keep severity information
* `ReportHostsResponse` helps combine report host data with results in one place
* this makes the data flow clearer and prepares the report details page for the split request handling


## References

GEA-1710

## Checklist

- [x] Tests


