### PR TITLE
Change: Mark existing scanners for disabled features as disabled.

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -691,6 +691,7 @@
   "Diffuse": "Diffus",
   "Directory depth for indexer": "Verzeichnistiefe für Indexer",
   "Disable Tag": "Tag deaktivieren",
+  "Disabled": "Deaktiviert",
   "Distance": "Entfernung",
   "Do not automatically delete reports": "Berichte nicht automatisch löschen",
   "Do not change": "Nicht ändern",

--- a/public/locales/gsa-en.json
+++ b/public/locales/gsa-en.json
@@ -691,6 +691,7 @@
   "Diffuse": "Diffuse",
   "Directory depth for indexer": "",
   "Disable Tag": "Disable Tag",
+  "Disabled": "Disabled",
   "Distance": "Distance",
   "Do not automatically delete reports": "Do not automatically delete reports",
   "Do not change": "Do not change",

--- a/public/locales/gsa-zh_CN.json
+++ b/public/locales/gsa-zh_CN.json
@@ -691,6 +691,7 @@
   "Diffuse": "分散",
   "Directory depth for indexer": "",
   "Disable Tag": "禁用标签",
+  "Disabled": "",
   "Distance": "区域",
   "Do not automatically delete reports": "不自动删除报告",
   "Do not change": "不变更",

--- a/public/locales/gsa-zh_TW.json
+++ b/public/locales/gsa-zh_TW.json
@@ -691,6 +691,7 @@
   "Diffuse": "",
   "Directory depth for indexer": "",
   "Disable Tag": "",
+  "Disabled": "",
   "Distance": "",
   "Do not automatically delete reports": "",
   "Do not change": "沒有改變",

--- a/src/gmp/models/__tests__/scanner.test.ts
+++ b/src/gmp/models/__tests__/scanner.test.ts
@@ -36,6 +36,7 @@ describe('Scanner model tests', () => {
     expect(scanner.scannerType).toBeUndefined();
     expect(scanner.tasks).toEqual([]);
     expect(scanner.port).toBeUndefined();
+    expect(scanner.disabled).toBeUndefined();
   });
 
   test('should parse empty element', () => {
@@ -48,6 +49,7 @@ describe('Scanner model tests', () => {
     expect(scanner.scannerType).toBeUndefined();
     expect(scanner.tasks).toEqual([]);
     expect(scanner.port).toBeUndefined();
+    expect(scanner.disabled).toBeUndefined();
   });
 
   test('should parse type', () => {
@@ -200,6 +202,14 @@ describe('Scanner model tests', () => {
     expect(scanner2.port).toBeUndefined();
     expect(scanner3.port).toBeUndefined();
     expect(scanner4.port).toEqual(1234);
+  });
+
+  test('should parse disabled', () => {
+    const scanner = Scanner.fromElement({disabled: 0});
+    const scanner2 = Scanner.fromElement({disabled: 1});
+
+    expect(scanner.disabled).toEqual(false);
+    expect(scanner2.disabled).toEqual(true);
   });
 });
 

--- a/src/gmp/models/scanner.ts
+++ b/src/gmp/models/scanner.ts
@@ -109,6 +109,7 @@ export interface ScannerElement extends ModelElement {
     task?: ScannerTaskElement | ScannerTaskElement[];
   };
   agent_control_config_defaults?: AgentControlConfigElement;
+  disabled?: YesNo;
 }
 
 interface Info {
@@ -193,6 +194,7 @@ interface ScannerProperties extends ModelProperties {
   scannerType?: ScannerType;
   tasks?: ScannerTask[];
   agentControlConfig?: AgentControlConfig;
+  disabled?: boolean;
 }
 
 // Scanner type definitions - add new scanner types here with their display names
@@ -276,6 +278,7 @@ class Scanner extends Model {
   readonly scannerType?: ScannerType;
   readonly tasks: ScannerTask[];
   readonly agentControlConfig?: AgentControlConfig;
+  readonly disabled?: boolean;
 
   constructor({
     caPub,
@@ -287,6 +290,7 @@ class Scanner extends Model {
     scannerType,
     tasks = [],
     agentControlConfig,
+    disabled,
     ...properties
   }: ScannerProperties = {}) {
     super(properties);
@@ -300,6 +304,7 @@ class Scanner extends Model {
     this.scannerType = scannerType;
     this.tasks = tasks;
     this.agentControlConfig = agentControlConfig;
+    this.disabled = disabled;
   }
 
   static fromElement(element?: ScannerElement): Scanner {
@@ -414,6 +419,10 @@ class Scanner extends Model {
         };
       }
     }
+
+    ret.disabled = isDefined(element.disabled)
+      ? parseBoolean(element.disabled)
+      : undefined;
 
     return ret;
   }

--- a/src/web/entities/EntityNameTableData.tsx
+++ b/src/web/entities/EntityNameTableData.tsx
@@ -56,6 +56,9 @@ const EntityNameTableData = <TEntity extends Model>({
               >
                 {entity.name}
               </RowDetailsToggle>
+              {/* disabled is currently only supported for scanners. */}
+              {/* @ts-expect-error */}
+              {entity?.disabled && <b> ({_('Disabled')})</b>}
               {/* @ts-expect-error */}
               {entity?.deprecated && <b> ({_('Deprecated')})</b>}
             </span>
@@ -68,6 +71,8 @@ const EntityNameTableData = <TEntity extends Model>({
               >
                 {entity.name}
               </DetailsLink>
+              {/* @ts-expect-error */}
+              {entity?.disabled && <b> ({_('Disabled')})</b>}
               {/* @ts-expect-error */}
               {entity?.deprecated && <b> ({_('Deprecated')})</b>}
             </span>


### PR DESCRIPTION
## What
Mark existing scanners for disabled features as disabled.

## Why
`get_scanners` does not hide existing scanners for disabled features. They are now marked unusable if the corresponding feature is disabled.

## References
GEA-1722
