### PR TITLE
Session Hooks Improvements

### DIFF
--- a/src/web/components/observer/SessionObserver.tsx
+++ b/src/web/components/observer/SessionObserver.tsx
@@ -9,7 +9,7 @@ import date, {type Date} from 'gmp/models/date';
 import {isDefined} from 'gmp/utils/identity';
 import useGmp from 'web/hooks/useGmp';
 import useInstanceVariable from 'web/hooks/useInstanceVariable';
-import useUserSessionTimeout from 'web/hooks/useUserSessionTimeout';
+import useSessionTimeout from 'web/hooks/useSessionTimeout';
 
 interface PingProps {
   sessionTimeout: Date;
@@ -76,7 +76,7 @@ const Ping = ({sessionTimeout}: PingProps) => {
 };
 
 const SessionObserver = () => {
-  const [sessionTimeout] = useUserSessionTimeout();
+  const [sessionTimeout] = useSessionTimeout();
 
   if (!isDefined(sessionTimeout)) {
     return null;

--- a/src/web/components/observer/SessionTracker.tsx
+++ b/src/web/components/observer/SessionTracker.tsx
@@ -8,16 +8,16 @@ import {notifications} from '@mantine/notifications';
 import {showNotification} from '@greenbone/ui-lib';
 
 import date from 'gmp/models/date';
+import useSessionTimeout from 'web/hooks/useSessionTimeout';
 import useSessionTracker from 'web/hooks/useSessionTracker';
 import useTranslation from 'web/hooks/useTranslation';
-import useUserSessionTimeout from 'web/hooks/useUserSessionTimeout';
 
 export const NOTIFICATION_TIMEOUT = 3;
 const notificationId = 'session-expiration-warning';
 
 const SessionTracker = () => {
   const [_] = useTranslation();
-  const [sessionTimeout] = useUserSessionTimeout();
+  const [sessionTimeout] = useSessionTimeout();
   useSessionTracker();
 
   useEffect(() => {

--- a/src/web/components/observer/__tests__/SessionTracker.test.tsx
+++ b/src/web/components/observer/__tests__/SessionTracker.test.tsx
@@ -28,7 +28,7 @@ vi.mock('web/hooks/useSessionTracker', () => ({
 
 const mockUseUserSessionTimeout = testing.fn();
 
-vi.mock('web/hooks/useUserSessionTimeout', () => ({
+vi.mock('web/hooks/useSessionTimeout', () => ({
   __esModule: true,
   default: () => mockUseUserSessionTimeout(),
 }));

--- a/src/web/components/sessionTimer/SessionTimer.jsx
+++ b/src/web/components/sessionTimer/SessionTimer.jsx
@@ -8,11 +8,12 @@ import {ActionIcon} from '@mantine/core';
 import date from 'gmp/models/date';
 import {RefreshIcon} from 'web/components/icon';
 import Divider from 'web/components/layout/Divider';
+import useSessionTimeout from 'web/hooks/useSessionTimeout';
 import useTranslation from 'web/hooks/useTranslation';
-import useUserSessionTimeout from 'web/hooks/useUserSessionTimeout';
 import Theme from 'web/utils/Theme';
+
 const SessionTimer = () => {
-  const [sessionTimeout, renewSession] = useUserSessionTimeout();
+  const [sessionTimeout, renewSession] = useSessionTimeout();
   const [timeLeft, setTimeLeft] = useState('');
   const [_] = useTranslation();
 

--- a/src/web/hooks/__tests__/useSessionTimeout.test.tsx
+++ b/src/web/hooks/__tests__/useSessionTimeout.test.tsx
@@ -7,11 +7,11 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {fireEvent, rendererWith, wait} from 'web/testing';
 import {getFormattedDate} from 'gmp/locale/date';
 import date from 'gmp/models/date';
-import useUserSessionTimeout from 'web/hooks/useUserSessionTimeout';
+import useSessionTimeout from 'web/hooks/useSessionTimeout';
 import {setSessionTimeout as setSessionTimeoutAction} from 'web/store/usersettings/actions';
 
 const TestUserSessionTimeout = () => {
-  const [sessionTimeout, renewSessionTimeout] = useUserSessionTimeout();
+  const [sessionTimeout, renewSessionTimeout] = useSessionTimeout();
   return (
     <button onClick={() => renewSessionTimeout()} onKeyDown={() => {}}>
       {getFormattedDate(sessionTimeout, 'DD-MM-YY')}
@@ -19,7 +19,7 @@ const TestUserSessionTimeout = () => {
   );
 };
 
-describe('useUserSessionTimeout tests', () => {
+describe('useSessionTimeout tests', () => {
   test('should return the users session timeout', () => {
     const {render, store} = rendererWith({store: true, gmp: {}});
 

--- a/src/web/hooks/__tests__/useSessionTracker.test.tsx
+++ b/src/web/hooks/__tests__/useSessionTracker.test.tsx
@@ -10,6 +10,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {act, fireEvent, rendererWith, screen} from 'web/testing';
+import date from 'gmp/models/date';
 import useSessionTracker from 'web/hooks/useSessionTracker';
 
 const TestSessionTracker = ({onClick}: {onClick?: () => void}) => {
@@ -26,8 +27,8 @@ const runTimers = async () => {
 describe('useSessionTracker', () => {
   test('should renew session on mount and on user activity with cooldown', async () => {
     testing.useFakeTimers();
-    const renewSession = testing.fn().mockRejectedValueOnce({
-      data: new Date(),
+    const renewSession = testing.fn().mockResolvedValue({
+      data: date(),
     });
 
     const {render} = rendererWith({
@@ -50,17 +51,18 @@ describe('useSessionTracker', () => {
     renewSession.mockClear();
 
     fireEvent.click(btn);
-    expect(renewSession).not.toHaveBeenCalled();
+    expect(renewSession).toHaveBeenCalledOnce();
+    renewSession.mockClear();
 
     await runTimers();
     fireEvent.click(btn);
-    expect(renewSession).toHaveBeenCalledTimes(1);
+    expect(renewSession).toHaveBeenCalledOnce();
   });
 
   test('should not new session on non-button click', () => {
     testing.useFakeTimers();
-    const renewSession = testing.fn().mockRejectedValueOnce({
-      data: new Date(),
+    const renewSession = testing.fn().mockResolvedValue({
+      data: date(),
     });
 
     const {render} = rendererWith({
@@ -86,8 +88,8 @@ describe('useSessionTracker', () => {
 
   test('should  renew session on keypress, wheel, and drag events with cooldown resets', async () => {
     testing.useFakeTimers();
-    const renewSession = testing.fn().mockRejectedValueOnce({
-      data: new Date(),
+    const renewSession = testing.fn().mockResolvedValue({
+      data: date(),
     });
 
     const {render} = rendererWith({
@@ -102,18 +104,18 @@ describe('useSessionTracker', () => {
     renewSession.mockClear();
 
     fireEvent.keyPress(document, {key: 'Enter'});
-    expect(renewSession).toHaveBeenCalledTimes(1);
+    expect(renewSession).toHaveBeenCalledOnce();
 
     await runTimers();
     renewSession.mockClear();
 
     fireEvent.wheel(document);
-    expect(renewSession).toHaveBeenCalledTimes(1);
+    expect(renewSession).toHaveBeenCalledOnce();
 
     await runTimers();
     renewSession.mockClear();
 
     fireEvent.drag(document);
-    expect(renewSession).toHaveBeenCalledTimes(1);
+    expect(renewSession).toHaveBeenCalledOnce();
   });
 });

--- a/src/web/hooks/useSessionTimeout.ts
+++ b/src/web/hooks/useSessionTimeout.ts
@@ -20,7 +20,7 @@ import {getSessionTimeout} from 'web/store/usersettings/selectors';
  * @returns An array containing the current `sessionTimeout` as a Date object and the `renewSessionAndUpdateTimeout` function.
  */
 
-const useUserSessionTimeout = (): [Date, () => Promise<void>] => {
+const useSessionTimeout = (): [Date, () => Promise<void>] => {
   const gmp = useGmp();
   const dispatch = useDispatch();
   const sessionTimeout = useSelector(getSessionTimeout);
@@ -33,4 +33,4 @@ const useUserSessionTimeout = (): [Date, () => Promise<void>] => {
   return [sessionTimeout, renewSessionAndUpdateTimeout];
 };
 
-export default useUserSessionTimeout;
+export default useSessionTimeout;

--- a/src/web/hooks/useSessionTracker.ts
+++ b/src/web/hooks/useSessionTracker.ts
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {useCallback, useEffect} from 'react';
-import {useDispatch} from 'react-redux';
-import useGmp from 'web/hooks/useGmp';
-import {renewSessionTimeout} from 'web/store/usersettings/actions';
+import {useEffect} from 'react';
+import useUserSessionTimeout from 'web/hooks/useUserSessionTimeout';
 
 /**
  * Hook that automatically tracks user activity to renew the session timeout.
@@ -18,30 +16,24 @@ import {renewSessionTimeout} from 'web/store/usersettings/actions';
  */
 
 const useSessionTracker = () => {
-  const dispatch = useDispatch();
-  const gmp = useGmp();
-
-  const renewSession = useCallback(() => {
-    // @ts-expect-error
-    dispatch(renewSessionTimeout(gmp)());
-  }, [dispatch, gmp]);
+  const [, renewSession] = useUserSessionTimeout();
 
   useEffect(() => {
-    renewSession();
+    void renewSession();
 
     let isCooldown = false;
     let cooldownTimeoutId: ReturnType<typeof setTimeout>;
 
-    const handleUserActivity = () => {
+    const handleUserActivity = async () => {
       if (isCooldown) return;
-      renewSession();
+      await renewSession();
       isCooldown = true;
       cooldownTimeoutId = setTimeout(() => {
         isCooldown = false;
       }, 10000);
     };
 
-    const handleClick = (event: MouseEvent | KeyboardEvent) => {
+    const handleClick = async (event: MouseEvent | KeyboardEvent) => {
       if (isCooldown) return;
       if (!(event instanceof MouseEvent)) return;
       const path = event.composedPath?.() || [];
@@ -51,7 +43,7 @@ const useSessionTracker = () => {
           (el.tagName === 'BUTTON' || el.tagName === 'A'),
       );
       if (found) {
-        handleUserActivity();
+        await handleUserActivity();
       }
     };
 

--- a/src/web/hooks/useSessionTracker.ts
+++ b/src/web/hooks/useSessionTracker.ts
@@ -4,7 +4,7 @@
  */
 
 import {useEffect} from 'react';
-import useUserSessionTimeout from 'web/hooks/useUserSessionTimeout';
+import useSessionTimeout from 'web/hooks/useSessionTimeout';
 
 /**
  * Hook that automatically tracks user activity to renew the session timeout.
@@ -16,7 +16,7 @@ import useUserSessionTimeout from 'web/hooks/useUserSessionTimeout';
  */
 
 const useSessionTracker = () => {
-  const [, renewSession] = useUserSessionTimeout();
+  const [, renewSession] = useSessionTimeout();
 
   useEffect(() => {
     void renewSession();

--- a/src/web/hooks/useUserSessionTimeout.ts
+++ b/src/web/hooks/useUserSessionTimeout.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import {useCallback} from 'react';
 import {useSelector, useDispatch} from 'react-redux';
 import {type Date} from 'gmp/models/date';
 import useGmp from 'web/hooks/useGmp';
@@ -24,10 +25,10 @@ const useUserSessionTimeout = (): [Date, () => Promise<void>] => {
   const dispatch = useDispatch();
   const sessionTimeout = useSelector(getSessionTimeout);
 
-  const renewSessionAndUpdateTimeout = async () => {
+  const renewSessionAndUpdateTimeout = useCallback(async () => {
     const response = await gmp.user.renewSession();
     dispatch(setSessionTimeout(response.data));
-  };
+  }, [gmp, dispatch]);
 
   return [sessionTimeout, renewSessionAndUpdateTimeout];
 };


### PR DESCRIPTION
## What

* Rename useUserSessionTimeout to useSessionTimeout
* Use useSessionTimeout in useSessionTracker
* Avoid unnecessary re-rendering when using useSessionTimeout

## Why

Consistent naming of hooks regarding the session and single source of truth for the session information.


