### PR TITLE
add: support agent control sensor creation in UI

### DIFF
--- a/src/web/pages/scanners/ScannerComponent.tsx
+++ b/src/web/pages/scanners/ScannerComponent.tsx
@@ -19,6 +19,7 @@ import {
   type default as Scanner,
   type ScannerType,
   AGENT_CONTROLLER_SCANNER_TYPE,
+  AGENT_CONTROLLER_SENSOR_SCANNER_TYPE,
   OPENVASD_SCANNER_TYPE,
   OPENVASD_SENSOR_SCANNER_TYPE,
 } from 'gmp/models/scanner';
@@ -148,7 +149,8 @@ const ScannerComponent = ({
       const credentialTypes: CredentialType[] =
         scanner.scannerType === OPENVASD_SCANNER_TYPE ||
         scanner.scannerType === AGENT_CONTROLLER_SCANNER_TYPE ||
-        scanner.scannerType === OPENVASD_SENSOR_SCANNER_TYPE
+        scanner.scannerType === OPENVASD_SENSOR_SCANNER_TYPE ||
+        scanner.scannerType === AGENT_CONTROLLER_SENSOR_SCANNER_TYPE
           ? [CERTIFICATE_CREDENTIAL_TYPE]
           : [];
       const credentialsPromise =

--- a/src/web/pages/scanners/ScannerDialog.tsx
+++ b/src/web/pages/scanners/ScannerDialog.tsx
@@ -141,8 +141,7 @@ const ScannerDialog = ({
       // don't allow selecting sensor types initially if the setting is disabled
       if (
         !gmp.settings.enableGreenboneSensor &&
-        (initialScannerType === GREENBONE_SENSOR_SCANNER_TYPE ||
-          initialScannerType === AGENT_CONTROLLER_SENSOR_SCANNER_TYPE)
+        initialScannerType === GREENBONE_SENSOR_SCANNER_TYPE
       ) {
         return undefined;
       }
@@ -191,8 +190,7 @@ const ScannerDialog = ({
   if (
     scannerType === AGENT_CONTROLLER_SENSOR_SCANNER_TYPE ||
     (features.featureEnabled('ENABLE_AGENTS') &&
-      capabilities.mayAccess('agent') &&
-      gmp.settings.enableGreenboneSensor)
+      capabilities.mayAccess('agent'))
   ) {
     scannerTypes.push(AGENT_CONTROLLER_SENSOR_SCANNER_TYPE);
   }

--- a/src/web/pages/scanners/__tests__/ScannerDialog.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerDialog.test.tsx
@@ -438,7 +438,7 @@ describe('ScannerDialog tests', () => {
     });
     expect(scannerType).toHaveValue('');
     const scannerTypeItems = await getSelectItemElementsForSelect(scannerType);
-    expect(scannerTypeItems.length).toBe(4); // OpenVAS Scanner, OpenVASD Scanner, OpenVASD Sensor, Agent Controller
+    expect(scannerTypeItems.length).toBe(5); // OpenVAS Scanner, OpenVASD Scanner, OpenVASD Sensor, Agent Controller, Agent Sensor
   });
 
   test('should not allow to change host, port and type if scanner is in use', () => {
@@ -568,9 +568,10 @@ describe('ScannerDialog tests', () => {
     });
     expect(scannerType).toHaveValue('Agent Controller');
     const scannerTypeItems = await getSelectItemElementsForSelect(scannerType);
-    expect(scannerTypeItems.length).toEqual(2); // OpenVAS Scanner and Agent Controller
+    expect(scannerTypeItems.length).toEqual(3); // OpenVAS Scanner, Agent Controller and Agent Sensor
     expect(scannerTypeItems[0]).toHaveTextContent('OpenVAS Scanner');
     expect(scannerTypeItems[1]).toHaveTextContent('Agent Controller');
+    expect(scannerTypeItems[2]).toHaveTextContent('Agent Sensor');
   });
 
   test('should allow to set a CA certificate of a scanner', async () => {


### PR DESCRIPTION
## What

- add UI support for creating agent control sensors  
- implement form and input handling  

## Why

- enable users to create agent control sensors from the UI  
- align frontend with the backend capabilities  

## References

GEA-1735

## Checklist

- [x] Tests


