### PR TITLE
Refactor envelope parsing

### DIFF
--- a/src/gmp/http/transform/__tests__/fast-xml.test.ts
+++ b/src/gmp/http/transform/__tests__/fast-xml.test.ts
@@ -6,28 +6,38 @@
 import {describe, test, expect} from '@gsa/testing';
 import {ResponseRejection} from 'gmp/http/rejection';
 import Response, {type Meta} from 'gmp/http/response';
-import transform, {type XmlResponseData} from 'gmp/http/transform/fast-xml';
+import transform, {
+  type Envelope,
+  type XmlResponseData,
+} from 'gmp/http/transform/fast-xml';
 
 const createEnvelopedXml = (xmlStr: string) =>
   `
 <envelope>
-  <version>123</version>
-  <backend_operation>1</backend_operation>
-  <vendor_version>FooBar</vendor_version>
+  <client_address>1.2.3.4</client_address>
   <i18n>en</i18n>
-  <time></time>
+  <session>1234567890</session>
   <timezone>UTC</timezone>
+  <token>abc123</token>
+  <version>1.2.3</version>
   ${xmlStr}
 </envelope>
 `;
 
-const envelopeMeta = {
-  backendOperation: 1,
+const envelope: Envelope = {
+  client_address: '1.2.3.4',
   i18n: 'en',
-  time: '',
+  session: 1234567890,
   timezone: 'UTC',
-  version: 123,
-  vendorVersion: 'FooBar',
+  token: 'abc123',
+  version: '1.2.3',
+};
+
+const createExpectedData = (data: Record<string, unknown>) => {
+  return {
+    ...envelope,
+    ...data,
+  };
 };
 
 describe('fastxml transform tests', () => {
@@ -35,13 +45,12 @@ describe('fastxml transform tests', () => {
     const xmlStr = createEnvelopedXml(
       '<foo>foo&quot;&lt;&gt;&amp;&apos;&#x2F;&#x5C;</foo>',
     );
-    const expected = {
+    const expected = createExpectedData({
       foo: 'foo"<>&\'/\\',
-    };
+    });
     const response = new Response<string, Meta>(xmlStr, {});
     const transformedResponse = transform.success(response);
     expect(transformedResponse.data).toEqual(expected);
-    expect(transformedResponse.meta).toEqual(envelopeMeta);
   });
 
   test('should transform array buffer xml response successfully', () => {
@@ -50,41 +59,35 @@ describe('fastxml transform tests', () => {
     const xmlBuffer = encoder.encode(xmlStr).buffer;
     const response = new Response<ArrayBuffer, Meta>(xmlBuffer, {});
     const transformedResponse = transform.success(response);
-    expect(transformedResponse.data).toEqual({foo: 'bar'});
-    expect(transformedResponse.meta).toEqual(envelopeMeta);
+    expect(transformedResponse.data).toEqual(createExpectedData({foo: 'bar'}));
   });
 
   test('should transform xml object response successfully', () => {
     const xmlObj = {
       envelope: {
-        version: 123,
-        backend_operation: 1,
-        vendor_version: 'FooBar',
-        i18n: 'en',
-        time: '',
-        timezone: 'UTC',
+        ...envelope,
         foo: 'bar',
       },
     };
-    const response = new Response<XmlResponseData, Meta>(xmlObj, {});
+    const response = new Response<XmlResponseData>(xmlObj);
     const transformedResponse = transform.success(response);
-    expect(transformedResponse.data).toEqual({foo: 'bar'});
-    expect(transformedResponse.meta).toEqual(envelopeMeta);
+    expect(transformedResponse.data).toEqual(createExpectedData({foo: 'bar'}));
   });
 
   test('should transform xml encoded element attribute successfully', () => {
     const xmlStr = createEnvelopedXml(
       '<foo bar="foo&quot;&lt;&gt;&amp;&apos;&#x2F;&#x5C;"></foo>',
     );
-    const response = new Response<string, Meta>(xmlStr, {});
+    const response = new Response<string>(xmlStr);
 
     const transformedResponse = transform.success(response);
-    expect(transformedResponse.data).toEqual({
-      foo: {
-        _bar: 'foo"<>&\'/\\',
-      },
-    });
-    expect(transformedResponse.meta).toEqual(envelopeMeta);
+    expect(transformedResponse.data).toEqual(
+      createExpectedData({
+        foo: {
+          _bar: 'foo"<>&\'/\\',
+        },
+      }),
+    );
   });
 
   test('should create a rejection on parser errors', () => {
@@ -122,37 +125,13 @@ describe('fastxml transform tests', () => {
     expect(transformedRejection.message).toBe('bar');
   });
 
-  test('should drop unknown envelope information', () => {
-    const xmlStr = `
-<envelope>
-  <version>1.0.1</version>
-  <backend_operation>0.01</backend_operation>
-  <vendor_version>1.1.0</vendor_version>
-  <i18n>en</i18n>
-  <time>Fri Sep 14 11:26:40 2018 CEST</time>
-  <timezone>Europe/Berlin</timezone>
-  <foo>foo</foo>
-  <bar>bar</bar>
-</envelope>
-`;
-    const response = new Response<string>(xmlStr);
-    const transformedResponse = transform.success(response);
-    expect(transformedResponse.meta).toEqual({
-      version: '1.0.1',
-      backendOperation: 0.01,
-      vendorVersion: '1.1.0',
-      i18n: 'en',
-      time: 'Fri Sep 14 11:26:40 2018 CEST',
-      timezone: 'Europe/Berlin',
-    });
-  });
-
   test('should transform elements with long values', () => {
     const longValue = 'a'.repeat(100000);
     const xmlStr = createEnvelopedXml(`<foo>${longValue}</foo>`);
     const response = new Response<string, Meta>(xmlStr, {});
     const transformedResponse = transform.success(response);
-    expect(transformedResponse.data).toEqual({foo: longValue});
-    expect(transformedResponse.meta).toEqual(envelopeMeta);
+    expect(transformedResponse.data).toEqual(
+      createExpectedData({foo: longValue}),
+    );
   });
 });

--- a/src/gmp/http/transform/fast-xml.ts
+++ b/src/gmp/http/transform/fast-xml.ts
@@ -11,19 +11,20 @@ import {success, rejection} from 'gmp/http/transform/xml';
 import {parseXmlEncodedString} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 
-export interface XmlMeta {
-  version?: string;
-  backendOperation?: string;
-  vendorVersion?: string;
+export type XmlMeta = Meta;
+
+export interface Envelope {
+  client_address?: string;
   i18n?: string;
-  time?: string;
+  session?: number;
   timezone?: string;
-  [key: string]: string | undefined;
+  token?: string;
+  version?: string;
 }
 
-export type XmlResponseData = Record<string, unknown>;
-
-type Envelope = Record<string, string | undefined>;
+export interface XmlResponseData extends Envelope {
+  [key: string]: unknown;
+}
 
 type InputResponseData = string | ArrayBuffer | XmlResponseData;
 
@@ -39,25 +40,6 @@ const PARSER_OPTIONS = {
 };
 
 const xmlParser = new XMLParser(PARSER_OPTIONS);
-
-const ENVELOPE_PROPS = [
-  ['version', 'version'],
-  ['backend_operation', 'backendOperation'],
-  ['vendor_version', 'vendorVersion'],
-  ['i18n', 'i18n'],
-  ['time', 'time'],
-  ['timezone', 'timezone'],
-] as const;
-
-const parseEnvelopeMeta = (envelope: Envelope): XmlMeta => {
-  const meta: XmlMeta = {};
-
-  for (const [name, to] of ENVELOPE_PROPS) {
-    meta[to] = envelope[name];
-    delete envelope[name];
-  }
-  return meta;
-};
 
 const getStringFromData = (data: string | ArrayBuffer) => {
   if (typeof data === 'string') {
@@ -84,7 +66,7 @@ const transformXmlData = (
   if (!isDefined(envelope)) {
     throw new Error('No envelope found in response');
   }
-  return response.set(envelope, parseEnvelopeMeta(envelope));
+  return response.setData(envelope as XmlResponseData);
 };
 
 const transformRejection = (rej: ResponseRejection) => {

--- a/src/gmp/models/__tests__/login.test.ts
+++ b/src/gmp/models/__tests__/login.test.ts
@@ -6,33 +6,28 @@
 import {describe, test, expect} from '@gsa/testing';
 import Response from 'gmp/http/response';
 import {isDate} from 'gmp/models/date';
-import Login, {type LoginData, type LoginMeta} from 'gmp/models/login';
+import Login, {type LoginData} from 'gmp/models/login';
 
 describe('Login model tests', () => {
   test('should set all properties correctly', () => {
-    const response = new Response<LoginData, LoginMeta>(
-      {
-        client_address: '1.2.3.4',
-        guest: false,
-        severity: '8.5',
-        token: '123abc',
-        session: '12345',
-      },
-      {
-        i18n: 'en',
-        timezone: 'UTC',
-        version: '1337',
-      },
-    );
+    const response = new Response<LoginData>({
+      client_address: '1.2.3.4',
+      i18n: 'en',
+      session: 12345,
+      timezone: 'UTC',
+      token: '123abc',
+      version: '1337',
+    });
     const login = Login.fromElement(response);
-    const login2 = Login.fromElement(
-      {} as unknown as Response<LoginData, LoginMeta>,
-    );
 
+    expect(login.clientAddress).toEqual('1.2.3.4');
+    expect(login.gsadVersion).toEqual('1337');
     expect(login.locale).toEqual('en');
     expect(login.timezone).toEqual('UTC');
     expect(login.token).toEqual('123abc');
     expect(isDate(login.sessionTimeout)).toEqual(true);
+
+    const login2 = Login.fromElement({} as unknown as Response<LoginData>);
     expect(login2.sessionTimeout).toBeUndefined();
   });
 });

--- a/src/gmp/models/login.ts
+++ b/src/gmp/models/login.ts
@@ -3,39 +3,31 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {type default as Response, type Meta} from 'gmp/http/response';
+import {type default as Response} from 'gmp/http/response';
+import {type Envelope} from 'gmp/http/transform/fast-xml';
 import date, {type Date} from 'gmp/models/date';
 import {parseInt} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 
-export interface LoginData {
-  client_address?: string;
-  guest?: boolean;
-  role?: string;
-  severity?: string;
-  session?: string;
-  token?: string;
-}
-
-export interface LoginMeta extends Meta {
-  i18n?: string;
-  timezone?: string;
-  version?: string;
-}
-
-type LoginElement = Response<LoginData, LoginMeta>;
+export type LoginData = Envelope;
+type LoginElement = Response<LoginData>;
 
 class Login {
+  readonly clientAddress?: string;
+  readonly gsadVersion?: string;
   readonly locale?: string;
   readonly sessionTimeout?: Date;
   readonly timezone?: string;
   readonly token?: string;
 
   constructor(elem: LoginElement) {
-    const {data = {}, meta = {}} = elem;
-    this.locale = meta.i18n;
-    this.timezone = meta.timezone;
+    const {data = {}} = elem;
+    this.clientAddress = data.client_address;
+    this.gsadVersion = data.version;
+    this.locale = data.i18n;
+    this.timezone = data.timezone;
     this.token = data.token;
+
     const unixSeconds = parseInt(data.session);
 
     this.sessionTimeout = isDefined(unixSeconds)


### PR DESCRIPTION
## What

Refactor envelope parsing and adapt envelope to gsad changes (currently without jwt which will be added in another PR)

## Why

The final goal is to introduce a session object and to get rid of the Meta interface completely.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


