### PR TITLE
Cleanup isLoggedIn status

### DIFF
--- a/src/gmp/__tests__/gmp.test.ts
+++ b/src/gmp/__tests__/gmp.test.ts
@@ -42,23 +42,6 @@ describe('Gmp tests', () => {
     globalThis.location = origLocation;
   });
 
-  test('should not be logged in if session is inactive', () => {
-    const storage = createStorage();
-    const settings = new Settings(storage);
-    const gmp = new Gmp(settings);
-
-    expect(gmp.isLoggedIn()).toEqual(false);
-  });
-
-  test('should be logged in if session is active', () => {
-    const storage = createStorage();
-    const settings = new Settings(storage);
-    settings.session.login({token: 'foo'});
-    const gmp = new Gmp(settings);
-
-    expect(gmp.isLoggedIn()).toEqual(true);
-  });
-
   test('should login user', async () => {
     const http = createHttp(createResponse({token: 'foo'}));
 
@@ -77,7 +60,7 @@ describe('Gmp tests', () => {
         },
       }),
     );
-    expect(gmp.isLoggedIn()).toEqual(true);
+    expect(settings.session.isLoggedIn()).toEqual(true);
   });
 
   test('should not login if request fails', async () => {
@@ -100,7 +83,7 @@ describe('Gmp tests', () => {
         }),
       );
       expect((error as Error).message).toEqual('An error');
-      expect(gmp.isLoggedIn()).toEqual(false);
+      expect(settings.session.isLoggedIn()).toEqual(false);
     }
   });
 
@@ -110,11 +93,11 @@ describe('Gmp tests', () => {
     settings.session.login({token: 'foo'});
     const gmp = new Gmp(settings);
 
-    expect(gmp.isLoggedIn()).toEqual(true);
+    expect(settings.session.isLoggedIn()).toEqual(true);
 
     gmp.logout();
 
-    expect(gmp.isLoggedIn()).toEqual(false);
+    expect(settings.session.isLoggedIn()).toEqual(false);
     expect(settings.session.token).toBeUndefined();
   });
 
@@ -126,11 +109,11 @@ describe('Gmp tests', () => {
     const handler = testing.fn();
     const unsub = gmp.subscribeToLogout(handler);
 
-    expect(gmp.isLoggedIn()).toEqual(true);
+    expect(settings.session.isLoggedIn()).toEqual(true);
 
     gmp.logout();
 
-    expect(gmp.isLoggedIn()).toEqual(false);
+    expect(settings.session.isLoggedIn()).toEqual(false);
     expect(handler).toHaveBeenCalled();
 
     unsub();
@@ -143,11 +126,11 @@ describe('Gmp tests', () => {
     const handler = testing.fn();
     const unsub = gmp.subscribeToLogout(handler);
 
-    expect(gmp.isLoggedIn()).toEqual(false);
+    expect(settings.session.isLoggedIn()).toEqual(false);
 
     gmp.logout();
 
-    expect(gmp.isLoggedIn()).toEqual(false);
+    expect(settings.session.isLoggedIn()).toEqual(false);
     expect(handler).toHaveBeenCalled();
 
     unsub();
@@ -160,7 +143,7 @@ describe('Gmp tests', () => {
     settings.session.login({token: 'foo'});
     const gmp = new Gmp(settings, http);
 
-    expect(gmp.isLoggedIn()).toEqual(true);
+    expect(settings.session.isLoggedIn()).toEqual(true);
 
     await gmp.doLogout();
     expect(http.request).toHaveBeenCalledWith('get', {
@@ -169,7 +152,7 @@ describe('Gmp tests', () => {
       },
       url: 'http://localhost/logout',
     });
-    expect(gmp.isLoggedIn()).toEqual(false);
+    expect(settings.session.isLoggedIn()).toEqual(false);
     expect(settings.session.token).toBeUndefined();
   });
 
@@ -184,10 +167,10 @@ describe('Gmp tests', () => {
 
     gmp.subscribeToLogout(handler);
 
-    expect(gmp.isLoggedIn()).toEqual(true);
+    expect(settings.session.isLoggedIn()).toEqual(true);
 
     await gmp.doLogout();
-    expect(gmp.isLoggedIn()).toEqual(false);
+    expect(settings.session.isLoggedIn()).toEqual(false);
     expect(settings.session.token).toBeUndefined();
     expect(handler).toHaveBeenCalled();
   });
@@ -206,10 +189,10 @@ describe('Gmp tests', () => {
 
     gmp.subscribeToLogout(handler);
 
-    expect(gmp.isLoggedIn()).toEqual(true);
+    expect(settings.session.isLoggedIn()).toEqual(true);
 
     await gmp.doLogout();
-    expect(gmp.isLoggedIn()).toEqual(false);
+    expect(settings.session.isLoggedIn()).toEqual(false);
     expect(settings.session.token).toBeUndefined();
     expect(handler).toHaveBeenCalled();
   });
@@ -224,10 +207,10 @@ describe('Gmp tests', () => {
 
     gmp.subscribeToLogout(handler);
 
-    expect(gmp.isLoggedIn()).toEqual(false);
+    expect(settings.session.isLoggedIn()).toEqual(false);
 
     await gmp.doLogout();
-    expect(gmp.isLoggedIn()).toEqual(false);
+    expect(settings.session.isLoggedIn()).toEqual(false);
     expect(settings.session.token).toBeUndefined();
     expect(handler).not.toHaveBeenCalled();
   });

--- a/src/gmp/gmp.ts
+++ b/src/gmp/gmp.ts
@@ -84,7 +84,6 @@ import {BROWSER_LANGUAGE} from 'gmp/locale/languages';
 import logger, {type RootLogger} from 'gmp/log';
 import type Settings from 'gmp/settings';
 import {isDefined} from 'gmp/utils/identity';
-import {isEmpty} from 'gmp/utils/string';
 
 type Listener = () => void;
 
@@ -263,7 +262,7 @@ class Gmp {
   }
 
   public async doLogout() {
-    if (this.isLoggedIn()) {
+    if (this.settings.session.isLoggedIn()) {
       const url = this.buildUrl('logout');
       const args = {token: this.settings.session.token};
 
@@ -288,10 +287,6 @@ class Gmp {
     for (const listener of this._logoutListeners) {
       listener();
     }
-  }
-
-  public isLoggedIn() {
-    return !isEmpty(this.settings.session.token);
   }
 
   public subscribeToLogout(listener: Listener) {

--- a/src/web/hooks/__tests__/useUserIsLoggedIn.test.tsx
+++ b/src/web/hooks/__tests__/useUserIsLoggedIn.test.tsx
@@ -5,16 +5,15 @@
 
 import {describe, test, expect} from '@gsa/testing';
 import {rendererWith} from 'web/testing';
+import {createSession} from 'gmp/testing';
 import useUserIsLoggedIn from 'web/hooks/useUserIsLoggedIn';
 
 describe('useUserIsLoggedIn tests', () => {
   test('should return the user logged-in state', () => {
+    const session = createSession();
     const gmp = {
       settings: {
-        session: {
-          isLoggedIn: () => true,
-          subscribeToChanges: () => () => {},
-        },
+        session,
       },
     };
     const {renderHook} = rendererWith({gmp});
@@ -22,5 +21,19 @@ describe('useUserIsLoggedIn tests', () => {
     const {result} = renderHook(() => useUserIsLoggedIn());
 
     expect(result.current).toBe(true);
+  });
+
+  test('should return the user logged-out state', () => {
+    const session = createSession({isLoggedIn: () => false});
+    const gmp = {
+      settings: {
+        session,
+      },
+    };
+    const {renderHook} = rendererWith({gmp});
+
+    const {result} = renderHook(() => useUserIsLoggedIn());
+
+    expect(result.current).toBe(false);
   });
 });

--- a/src/web/pages/login/__tests__/LoginPage.test.tsx
+++ b/src/web/pages/login/__tests__/LoginPage.test.tsx
@@ -32,7 +32,6 @@ vi.mock('react-router', async () => {
 });
 
 const createGmp = ({
-  isLoggedIn = false,
   clearToken = testing.fn(),
   login = testing.fn().mockResolvedValue({
     locale: 'locale',
@@ -49,7 +48,6 @@ const createGmp = ({
   guestUsername = undefined,
   guestPassword = undefined,
 }: {
-  isLoggedIn?: boolean;
   clearToken?: () => void;
   login?: (username: string, password: string) => Promise<void>;
   currentSettings?: () => Promise<unknown>;
@@ -171,7 +169,7 @@ describe('LoginPage tests', () => {
   });
 
   test('should redirect to main page if already logged in', () => {
-    const gmp = createGmp({isLoggedIn: true});
+    const gmp = createGmp();
 
     const {render} = rendererWith({gmp, router: true});
 


### PR DESCRIPTION

## What

Cleanup isLoggedIn status

## Why

Remove isLoggedIn method from Gmp class because it is unused.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


