### PR TITLE
Fix returning the same timeout date object from the session

### DIFF
--- a/src/gmp/session/__tests__/user-session-state.test.ts
+++ b/src/gmp/session/__tests__/user-session-state.test.ts
@@ -118,6 +118,13 @@ describe('UserSessionState tests', () => {
 
     const session = new UserSessionState(storage);
 
+    expect(session.locale).toBe('en-US');
+    expect(session.sessionTimeout?.toISOString()).toBe(
+      '2024-12-31T23:59:59.000Z',
+    );
+    expect(session.timezone).toBe('UTC');
+    expect(session.username).toBe('test-user');
+
     session.locale = undefined;
     session.sessionTimeout = undefined;
     session.timezone = undefined;
@@ -213,5 +220,39 @@ describe('UserSessionState tests', () => {
     expect(newState.locale).toBe('de-DE');
     expect(newState.timezone).toBe('CET');
     expect(newState.username).toBe('test-user1');
+  });
+
+  test("should return same session timeout instance if it's not changed", () => {
+    const storage = createStorage({
+      sessionTimeout: '2024-12-31T23:59:59.000Z',
+    });
+
+    const session = new UserSessionState(storage);
+
+    const firstTimeout = session.sessionTimeout;
+    const secondTimeout = session.sessionTimeout;
+
+    expect(firstTimeout).toBe(secondTimeout);
+  });
+
+  test("should return new session timeout instance if it's changed", () => {
+    const storage = createStorage({
+      sessionTimeout: '2024-12-31T23:59:59.000Z',
+    });
+
+    const session = new UserSessionState(storage);
+
+    const firstTimeout = session.sessionTimeout;
+
+    session.sessionTimeout = date('2025-01-01T00:00:00Z');
+
+    const secondTimeout = session.sessionTimeout;
+
+    expect(firstTimeout).not.toBe(secondTimeout);
+    expect(secondTimeout?.toISOString()).toBe('2025-01-01T00:00:00.000Z');
+
+    session.sessionTimeout = undefined;
+
+    expect(session.sessionTimeout).toBeUndefined();
   });
 });

--- a/src/gmp/session/user-session-state.ts
+++ b/src/gmp/session/user-session-state.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import memoizeOne from 'memoize-one';
 import date, {type Date} from 'gmp/models/date';
 import NoSessionState from 'gmp/session/no-session-state';
 import {
@@ -14,6 +15,8 @@ import {
   setSessionValue,
 } from 'gmp/session/session-storage';
 import {hasValue, isDefined} from 'gmp/utils/identity';
+
+const memoizedDate = memoizeOne((value: string): Date => date(value));
 
 /**
  * UserSession class manages the user's session data, including JWT, token,
@@ -60,7 +63,7 @@ class UserSessionState implements SessionState {
 
   get sessionTimeout(): Date | undefined {
     const value = this.storage.getItem('sessionTimeout');
-    return hasValue(value) ? date(value) : undefined;
+    return hasValue(value) ? memoizedDate(value) : undefined;
   }
 
   set token(value: string | undefined) {


### PR DESCRIPTION


## What

Fix returning the same timeout date object from the session

## Why

If the session timeout has not changed the same date object has to be returned. Otherwise react would re-render very often.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


