### PR TITLE
GEA-1764

### DIFF
--- a/src/gmp/commands/__tests__/result.test.js
+++ b/src/gmp/commands/__tests__/result.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import {ResultCommand} from 'gmp/commands/results';
+import {ResultCommand} from 'gmp/commands/result';
 import {createEntityResponse, createHttp} from 'gmp/commands/testing';
 
 describe('ResultCommand tests', () => {

--- a/src/gmp/commands/result.ts
+++ b/src/gmp/commands/result.ts
@@ -1,0 +1,23 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import registerCommand from 'gmp/command';
+import EntityCommand from 'gmp/commands/entity';
+import type Http from 'gmp/http/http';
+import {type Element} from 'gmp/models/model';
+import Result from 'gmp/models/result';
+
+export class ResultCommand extends EntityCommand<Result> {
+  constructor(http: Http) {
+    super(http, 'result', Result);
+  }
+
+  getElementFromRoot(root: Element): Element {
+    // @ts-expect-error
+    return root.get_result.get_results_response.result;
+  }
+}
+
+registerCommand('result', ResultCommand);

--- a/src/gmp/commands/result.ts
+++ b/src/gmp/commands/result.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import registerCommand from 'gmp/command';
 import EntityCommand from 'gmp/commands/entity';
 import type Http from 'gmp/http/http';
 import {type Element} from 'gmp/models/model';
@@ -19,5 +18,3 @@ export class ResultCommand extends EntityCommand<Result> {
     return root.get_result.get_results_response.result;
   }
 }
-
-registerCommand('result', ResultCommand);

--- a/src/gmp/commands/results.ts
+++ b/src/gmp/commands/results.ts
@@ -1,27 +1,38 @@
-/* SPDX-FileCopyrightText: 2024 Greenbone AG
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 import registerCommand from 'gmp/command';
 import EntitiesCommand from 'gmp/commands/entities';
-import EntityCommand from 'gmp/commands/entity';
+import {
+  type HttpCommandInputParams,
+  type HttpCommandOptions,
+} from 'gmp/commands/http';
+import type Http from 'gmp/http/http';
+import type Filter from 'gmp/models/filter';
+import {type Element} from 'gmp/models/model';
 import Result from 'gmp/models/result';
 
-export class ResultsCommand extends EntitiesCommand {
-  constructor(http) {
+interface GetAggregatesParams {
+  filter?: Filter;
+}
+
+export class ResultsCommand extends EntitiesCommand<Result> {
+  constructor(http: Http) {
     super(http, 'result', Result);
   }
 
-  getEntitiesResponse(root) {
+  getEntitiesResponse(root: Element): Element {
+    // @ts-expect-error
     return root.get_results.get_results_response;
   }
 
-  get(params = {}, options) {
+  get(params: HttpCommandInputParams = {}, options?: HttpCommandOptions) {
     return super.get({details: 1, ...params}, options);
   }
 
-  getDescriptionWordCountsAggregates({filter} = {}) {
+  getDescriptionWordCountsAggregates({filter}: GetAggregatesParams = {}) {
     return this.getAggregates({
       aggregate_type: 'result',
       group_column: 'description',
@@ -31,7 +42,7 @@ export class ResultsCommand extends EntitiesCommand {
     });
   }
 
-  getWordCountsAggregates({filter} = {}) {
+  getWordCountsAggregates({filter}: GetAggregatesParams = {}) {
     return this.getAggregates({
       aggregate_type: 'result',
       group_column: 'vulnerability',
@@ -41,7 +52,7 @@ export class ResultsCommand extends EntitiesCommand {
     });
   }
 
-  getSeverityAggregates({filter} = {}) {
+  getSeverityAggregates({filter}: GetAggregatesParams = {}) {
     return this.getAggregates({
       aggregate_type: 'result',
       group_column: 'severity',
@@ -50,15 +61,4 @@ export class ResultsCommand extends EntitiesCommand {
   }
 }
 
-export class ResultCommand extends EntityCommand {
-  constructor(http) {
-    super(http, 'result', Result);
-  }
-
-  getElementFromRoot(root) {
-    return root.get_result.get_results_response.result;
-  }
-}
-
-registerCommand('result', ResultCommand);
 registerCommand('results', ResultsCommand);

--- a/src/gmp/commands/results.ts
+++ b/src/gmp/commands/results.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import registerCommand from 'gmp/command';
 import EntitiesCommand from 'gmp/commands/entities';
 import {
   type HttpCommandInputParams,
@@ -60,5 +59,3 @@ export class ResultsCommand extends EntitiesCommand<Result> {
     });
   }
 }
-
-registerCommand('results', ResultsCommand);

--- a/src/gmp/gmp.ts
+++ b/src/gmp/gmp.ts
@@ -10,8 +10,6 @@ import 'gmp/commands/license';
 import 'gmp/commands/notes';
 import 'gmp/commands/os';
 import 'gmp/commands/overrides';
-
-import 'gmp/commands/results';
 import 'gmp/commands/scan-configs';
 import 'gmp/commands/schedules';
 import 'gmp/commands/tickets';
@@ -66,6 +64,8 @@ import ReportFormatsCommand from 'gmp/commands/report-formats';
 import ReportPortsCommand from 'gmp/commands/report-ports';
 import ReportsCommand from 'gmp/commands/reports';
 import ResourceNamesCommand from 'gmp/commands/resource-names';
+import {ResultCommand} from 'gmp/commands/result';
+import {ResultsCommand} from 'gmp/commands/results';
 import RoleCommand from 'gmp/commands/role';
 import RolesCommand from 'gmp/commands/roles';
 import ScannerCommand from 'gmp/commands/scanner';
@@ -148,6 +148,8 @@ class Gmp {
   public readonly reportformats: ReportFormatsCommand;
   public readonly reports: ReportsCommand;
   public readonly reportports: ReportPortsCommand;
+  public readonly result: ResultCommand;
+  public readonly results: ResultsCommand;
   public readonly resourcenames: ResourceNamesCommand;
   public readonly role: RoleCommand;
   public readonly roles: RolesCommand;
@@ -235,6 +237,8 @@ class Gmp {
     this.reportformats = new ReportFormatsCommand(this.http);
     this.reports = new ReportsCommand(this.http);
     this.reportports = new ReportPortsCommand(this.http);
+    this.result = new ResultCommand(this.http);
+    this.results = new ResultsCommand(this.http);
     this.resourcenames = new ResourceNamesCommand(this.http);
     this.role = new RoleCommand(this.http);
     this.roles = new RolesCommand(this.http);

--- a/src/web/hooks/use-query/results.ts
+++ b/src/web/hooks/use-query/results.ts
@@ -6,20 +6,26 @@
 import type Filter from 'gmp/models/filter';
 import type Result from 'gmp/models/result';
 import useGmp from 'web/hooks/useGmp';
-import useGetEntities from 'web/queries/useGetEntities';
+import type {RefetchIntervalFn} from 'web/queries/helpers';
+import useGetEntities, {
+  type UseGetEntitiesReturn,
+} from 'web/queries/useGetEntities';
 
 interface UseGetResultsParams {
   filter?: Filter;
+  refetchInterval?: number | RefetchIntervalFn<UseGetEntitiesReturn<Result>>;
 }
 
 /**
  * Hook to fetch results using TanStack Query
  *
  * @param filter The filter to apply to the results query
+ * @param refetchInterval Override the refetch interval (supports NO_RELOAD, USE_DEFAULT_RELOAD_INTERVAL_ACTIVE, etc.)
  * @returns Query result with entities, entitiesCounts, and filter
  */
 export const useGetResults = ({
   filter = undefined,
+  refetchInterval = undefined,
 }: UseGetResultsParams = {}) => {
   const gmp = useGmp();
 
@@ -29,6 +35,7 @@ export const useGetResults = ({
     queryId: 'get_results',
     filter,
     keepPreviousData: true,
+    refetchInterval,
   });
 };
 

--- a/src/web/hooks/use-query/results.ts
+++ b/src/web/hooks/use-query/results.ts
@@ -13,7 +13,10 @@ import useGetEntities, {
 
 interface UseGetResultsParams {
   filter?: Filter;
-  refetchInterval?: number | RefetchIntervalFn<UseGetEntitiesReturn<Result>>;
+  refetchInterval?:
+    | number
+    | false
+    | RefetchIntervalFn<UseGetEntitiesReturn<Result>>;
 }
 
 /**
@@ -30,7 +33,6 @@ export const useGetResults = ({
   const gmp = useGmp();
 
   return useGetEntities<Result>({
-    // @ts-expect-error results command is dynamically added via getCommands()
     gmpMethod: gmp.results.get.bind(gmp.results),
     queryId: 'get_results',
     filter,

--- a/src/web/pages/reports/details/ContainerScanningResultsTab.tsx
+++ b/src/web/pages/reports/details/ContainerScanningResultsTab.tsx
@@ -6,8 +6,13 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Filter from 'gmp/models/filter';
+import {isActive, type TaskStatus} from 'gmp/models/task';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
+import {
+  NO_RELOAD,
+  USE_DEFAULT_RELOAD_INTERVAL_ACTIVE,
+} from 'web/components/loading/Reload';
 import useGetResults from 'web/hooks/use-query/results';
 import useFilterSortBy from 'web/hooks/useFilterSortBy';
 import usePagination from 'web/hooks/usePagination';
@@ -17,11 +22,13 @@ import ContainerScanningResultsTable from 'web/pages/reports/details/ContainerSc
 interface ContainerScanningResultsTabProps {
   reportId: string;
   reportFilter: Filter;
+  status: TaskStatus;
 }
 
 const ContainerScanningResultsTab = ({
   reportId,
   reportFilter,
+  status,
 }: ContainerScanningResultsTabProps) => {
   const [_] = useTranslation();
   const reportFilterString = reportFilter.toFilterString();
@@ -41,6 +48,9 @@ const ContainerScanningResultsTab = ({
 
   const {data, isLoading, isFetching, isError, error} = useGetResults({
     filter: resultsFilter,
+    refetchInterval: isActive(status)
+      ? USE_DEFAULT_RELOAD_INTERVAL_ACTIVE
+      : NO_RELOAD,
   });
 
   const updateFilter = useCallback(

--- a/src/web/pages/reports/details/ResultsTab.tsx
+++ b/src/web/pages/reports/details/ResultsTab.tsx
@@ -6,9 +6,13 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Filter from 'gmp/models/filter';
-import type {TaskStatus} from 'gmp/models/task';
+import {isActive, type TaskStatus} from 'gmp/models/task';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
+import {
+  NO_RELOAD,
+  USE_DEFAULT_RELOAD_INTERVAL_ACTIVE,
+} from 'web/components/loading/Reload';
 import useGetResults from 'web/hooks/use-query/results';
 import useFilterSortBy from 'web/hooks/useFilterSortBy';
 import usePagination from 'web/hooks/usePagination';
@@ -67,6 +71,9 @@ const ResultsTabWrapper = ({
 
   const {data, isLoading, isFetching, isError, error} = useGetResults({
     filter: resultsFilter,
+    refetchInterval: isActive(status)
+      ? USE_DEFAULT_RELOAD_INTERVAL_ACTIVE
+      : NO_RELOAD,
   });
 
   const updateFilter = useCallback(

--- a/src/web/pages/reports/details/ResultsTabContent.tsx
+++ b/src/web/pages/reports/details/ResultsTabContent.tsx
@@ -95,6 +95,7 @@ const ResultsTabContent = ({
       <ContainerScanningResultsTab
         reportFilter={reportFilter}
         reportId={reportId}
+        status={status}
       />
     );
   }

--- a/src/web/pages/reports/details/__tests__/ContainerScanningResultsTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ContainerScanningResultsTab.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect, testing} from '@gsa/testing';
-import {rendererWith} from 'web/testing';
+import {act, rendererWith} from 'web/testing';
 import {waitFor, screen} from '@testing-library/react';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Filter from 'gmp/models/filter';
@@ -17,6 +17,8 @@ const result = Result.fromElement({
   name: 'Test Result',
   severity: 7.5,
 });
+
+const reloadIntervalActive = 100; // short value for timer tests
 
 const createGmp = ({
   get = testing.fn().mockResolvedValue({
@@ -31,6 +33,9 @@ const createGmp = ({
     get,
   },
   settings: {
+    reloadInterval: 15000,
+    reloadIntervalActive,
+    reloadIntervalInactive: 60000,
     enableEPSS: false,
   },
   session: createSession({token: 'test-token'}),
@@ -46,7 +51,11 @@ describe('ContainerScanningResultsTab', () => {
     const {render} = rendererWith({gmp});
 
     render(
-      <ContainerScanningResultsTab reportFilter={filter} reportId={reportId} />,
+      <ContainerScanningResultsTab
+        reportFilter={filter}
+        reportId={reportId}
+        status={'Running'}
+      />,
     );
 
     expect(screen.getByTestId('loading')).toBeInTheDocument();
@@ -60,7 +69,11 @@ describe('ContainerScanningResultsTab', () => {
     const {render} = rendererWith({gmp});
 
     render(
-      <ContainerScanningResultsTab reportFilter={filter} reportId={reportId} />,
+      <ContainerScanningResultsTab
+        reportFilter={filter}
+        reportId={reportId}
+        status={'Running'}
+      />,
     );
 
     await waitFor(() => {
@@ -108,7 +121,11 @@ describe('ContainerScanningResultsTab', () => {
     const {render} = rendererWith({gmp});
 
     const {userEvent} = render(
-      <ContainerScanningResultsTab reportFilter={filter} reportId={reportId} />,
+      <ContainerScanningResultsTab
+        reportFilter={filter}
+        reportId={reportId}
+        status={'Stopped'}
+      />,
     );
 
     await waitFor(() => {
@@ -155,7 +172,11 @@ describe('ContainerScanningResultsTab', () => {
     const {render} = rendererWith({gmp});
 
     const {userEvent} = render(
-      <ContainerScanningResultsTab reportFilter={filter} reportId={reportId} />,
+      <ContainerScanningResultsTab
+        reportFilter={filter}
+        reportId={reportId}
+        status={'Stopped'}
+      />,
     );
 
     await waitFor(() => {
@@ -203,7 +224,11 @@ describe('ContainerScanningResultsTab', () => {
     const {render} = rendererWith({gmp});
 
     const {userEvent} = render(
-      <ContainerScanningResultsTab reportFilter={filter} reportId={reportId} />,
+      <ContainerScanningResultsTab
+        reportFilter={filter}
+        reportId={reportId}
+        status={'Stopped'}
+      />,
     );
 
     await waitFor(() => {
@@ -251,7 +276,11 @@ describe('ContainerScanningResultsTab', () => {
     const {render} = rendererWith({gmp});
 
     const {userEvent} = render(
-      <ContainerScanningResultsTab reportFilter={filter} reportId={reportId} />,
+      <ContainerScanningResultsTab
+        reportFilter={filter}
+        reportId={reportId}
+        status={'Stopped'}
+      />,
     );
 
     await waitFor(() => {
@@ -299,7 +328,11 @@ describe('ContainerScanningResultsTab', () => {
     const {render} = rendererWith({gmp});
 
     const {userEvent} = render(
-      <ContainerScanningResultsTab reportFilter={filter} reportId={reportId} />,
+      <ContainerScanningResultsTab
+        reportFilter={filter}
+        reportId={reportId}
+        status={'Stopped'}
+      />,
     );
 
     await waitFor(() => {
@@ -351,6 +384,7 @@ describe('ContainerScanningResultsTab', () => {
       <ContainerScanningResultsTab
         reportFilter={filter1}
         reportId={reportId}
+        status={'Stopped'}
       />,
     );
 
@@ -362,6 +396,7 @@ describe('ContainerScanningResultsTab', () => {
       <ContainerScanningResultsTab
         reportFilter={filter2}
         reportId={reportId}
+        status={'Stopped'}
       />,
     );
 
@@ -384,7 +419,11 @@ describe('ContainerScanningResultsTab', () => {
     const {render} = rendererWith({gmp});
 
     render(
-      <ContainerScanningResultsTab reportFilter={filter} reportId={reportId} />,
+      <ContainerScanningResultsTab
+        reportFilter={filter}
+        reportId={reportId}
+        status={'Running'}
+      />,
     );
 
     await waitFor(() => {
@@ -429,7 +468,11 @@ describe('ContainerScanningResultsTab', () => {
     const {render} = rendererWith({gmp});
 
     const {userEvent} = render(
-      <ContainerScanningResultsTab reportFilter={filter} reportId={reportId} />,
+      <ContainerScanningResultsTab
+        reportFilter={filter}
+        reportId={reportId}
+        status={'Stopped'}
+      />,
     );
 
     if (resolveFirstQuery) {
@@ -474,6 +517,60 @@ describe('ContainerScanningResultsTab', () => {
 
     await waitFor(() => {
       expect(gmp.results.get).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('Results polling behavior isActive status', () => {
+    test.each([
+      [
+        'should poll results when task status is active',
+        'Running' as const,
+        reloadIntervalActive + 50,
+        2,
+      ],
+      [
+        'should not poll results when task status is not active',
+        'Stopped' as const,
+        reloadIntervalActive * 10,
+        1,
+      ],
+    ])('%s', async (_, status, timeToAdvance, expectedCallCount) => {
+      testing.useFakeTimers();
+
+      const getMock = testing.fn().mockResolvedValue({
+        data: [result],
+        meta: {
+          counts: new CollectionCounts({
+            filtered: 1,
+            all: 1,
+            first: 1,
+            rows: 10,
+          }),
+          filter: Filter.fromString(''),
+        },
+      });
+
+      const gmp = createGmp({get: getMock});
+      const {render} = rendererWith({gmp});
+
+      render(
+        <ContainerScanningResultsTab
+          reportFilter={Filter.fromString('')}
+          reportId={'report-123'}
+          status={status}
+        />,
+      );
+
+      await act(async () => {});
+      expect(getMock).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await testing.advanceTimersByTimeAsync(timeToAdvance);
+      });
+
+      expect(getMock).toHaveBeenCalledTimes(expectedCallCount);
+
+      testing.useRealTimers();
     });
   });
 });

--- a/src/web/pages/reports/details/__tests__/ResultsTab.test.jsx
+++ b/src/web/pages/reports/details/__tests__/ResultsTab.test.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import {describe, test, expect, testing} from '@gsa/testing';
-import {rendererWith, wait} from 'web/testing';
+import {act, rendererWith, wait} from 'web/testing';
 import {waitFor, screen} from '@testing-library/react';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Filter from 'gmp/models/filter';
@@ -17,6 +17,7 @@ import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters
 import {loadingActions} from 'web/store/usersettings/defaults/actions';
 
 const reloadInterval = 60000;
+const reloadIntervalActive = 100; // short value for timer tests
 const manualUrl = 'test/';
 
 // mock entities
@@ -138,6 +139,7 @@ const createGmp = ({
   settings: {
     manualUrl,
     reloadInterval,
+    reloadIntervalActive,
     severityRating: SEVERITY_RATING_CVSS_3,
   },
   session: createSession({token: 'test-token', timezone: 'CET'}),
@@ -369,5 +371,78 @@ describe('Report Results Tab tests', () => {
     expect(row[4]).toHaveTextContent(
       'Mon, Jun 3, 2019 1:06 PM Central European Summer Time',
     );
+  });
+
+  describe('Results polling behavior isActive status', () => {
+    test.each([
+      [
+        'should poll results when task status is active',
+        'Running',
+        50,
+        reloadIntervalActive + 50,
+        2,
+      ],
+      [
+        'should not poll results when task status is not active',
+        'Stopped',
+        100,
+        reloadIntervalActive * 10,
+        1,
+      ],
+    ])('%s', async (_, status, progress, timeToAdvance, expectedCallCount) => {
+      testing.useFakeTimers();
+
+      const getResults = testing.fn().mockResolvedValue({
+        data: results,
+        meta: {
+          filter: Filter.fromString(),
+          counts: new CollectionCounts({
+            first: 1,
+            all: 3,
+            filtered: 3,
+            length: 3,
+            rows: 10,
+          }),
+        },
+      });
+
+      const gmp = createGmp({getResults});
+      const {render, store} = rendererWith({
+        gmp,
+        capabilities: true,
+        store: true,
+        router: true,
+      });
+
+      store.dispatch(loadingActions.success({rowsperpage: {value: '10'}}));
+
+      render(
+        <ResultsTab
+          hasTarget={true}
+          progress={progress}
+          reportFilter={Filter.fromString('first=1 rows=10')}
+          reportId={'123'}
+          reportResultsCounts={
+            new CollectionCounts({first: 1, all: 3, filtered: 3, rows: 10})
+          }
+          status={status}
+          onFilterDecreaseMinQoDClick={testing.fn()}
+          onFilterEditClick={testing.fn()}
+          onFilterRemoveClick={testing.fn()}
+          onTargetEditClick={testing.fn()}
+        />,
+      );
+
+      await act(async () => {});
+      expect(getResults).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await testing.advanceTimersByTimeAsync(timeToAdvance);
+      });
+
+      expect(getResults).toHaveBeenCalledTimes(expectedCallCount);
+
+      testing.useRealTimers();
+    });
   });
 });

--- a/src/web/pages/reports/details/__tests__/ResultsTab.test.jsx
+++ b/src/web/pages/reports/details/__tests__/ResultsTab.test.jsx
@@ -5,8 +5,8 @@
 
 import React from 'react';
 import {describe, test, expect, testing} from '@gsa/testing';
-import {act, rendererWith, wait} from 'web/testing';
-import {waitFor, screen} from '@testing-library/react';
+import {act, rendererWith} from 'web/testing';
+import {screen} from '@testing-library/react';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Filter from 'gmp/models/filter';
 import Result from 'gmp/models/result';
@@ -147,231 +147,126 @@ const createGmp = ({
 });
 
 describe('Report Results Tab tests', () => {
-  test('should render Results Tab with compliance information', async () => {
-    const onFilterAddLogLevelClick = testing.fn();
-    const onFilterDecreaseMinQoDClick = testing.fn();
-    const onFilterEditClick = testing.fn();
-    const onFilterRemoveClick = testing.fn();
-    const onFilterRemoveSeverityClick = testing.fn();
-    const onTargetEditClick = testing.fn();
+  test.each([
+    ['compliance information', true, 'Compliant', 'Yes', 'No', 'Incomplete'],
+    [
+      'severity information',
+      false,
+      'Severity',
+      '10.0 (Critical)',
+      '5.0 (Medium)',
+      '5.0 (Medium)',
+    ],
+  ])(
+    'should render Results Tab with %s',
+    async (_, audit, header2Text, row2Val, row3Val, row4Val) => {
+      const onFilterAddLogLevelClick = testing.fn();
+      const onFilterDecreaseMinQoDClick = testing.fn();
+      const onFilterEditClick = testing.fn();
+      const onFilterRemoveClick = testing.fn();
+      const onFilterRemoveSeverityClick = testing.fn();
+      const onTargetEditClick = testing.fn();
 
-    const getResults = testing.fn().mockResolvedValue({
-      data: results,
-      meta: {
-        filter: Filter.fromString(),
-        counts: new CollectionCounts({
-          first: 1,
-          all: 3,
-          filtered: 3,
-          length: 3,
-          rows: 10,
-        }),
-      },
-    });
+      const getResults = testing.fn().mockResolvedValue({
+        data: results,
+        meta: {
+          filter: Filter.fromString(),
+          counts: new CollectionCounts({
+            first: 1,
+            all: 3,
+            filtered: 3,
+            length: 3,
+            rows: 10,
+          }),
+        },
+      });
 
-    const gmp = createGmp({getResults});
+      const gmp = createGmp({getResults});
 
-    const {render, store} = rendererWith({
-      gmp,
-      capabilities: true,
-      store: true,
-      router: true,
-    });
+      const {render, store} = rendererWith({
+        gmp,
+        capabilities: true,
+        store: true,
+        router: true,
+      });
 
-    const defaultSettingFilter = Filter.fromString('foo=bar');
-    store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
-    store.dispatch(
-      defaultFilterLoadingActions.success('result', defaultSettingFilter),
-    );
+      const defaultSettingFilter = Filter.fromString('foo=bar');
+      store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
+      store.dispatch(
+        defaultFilterLoadingActions.success('result', defaultSettingFilter),
+      );
 
-    const filter = Filter.fromString('first=1 rows=10');
-    const reportResultsCounts = new CollectionCounts({
-      first: 1,
-      all: 3,
-      filtered: 3,
-      length: 3,
-      rows: 10,
-    });
+      const filter = Filter.fromString('first=1 rows=10');
+      const reportResultsCounts = new CollectionCounts({
+        first: 1,
+        all: 3,
+        filtered: 3,
+        length: 3,
+        rows: 10,
+      });
 
-    const {baseElement} = render(
-      <ResultsTab
-        audit={true}
-        hasTarget={true}
-        progress={100}
-        reportFilter={filter}
-        reportId={'123'}
-        reportResultsCounts={reportResultsCounts}
-        status={'Stopped'}
-        onFilterAddLogLevelClick={onFilterAddLogLevelClick}
-        onFilterDecreaseMinQoDClick={onFilterDecreaseMinQoDClick}
-        onFilterEditClick={onFilterEditClick}
-        onFilterRemoveClick={onFilterRemoveClick}
-        onFilterRemoveSeverityClick={onFilterRemoveSeverityClick}
-        onTargetEditClick={onTargetEditClick}
-      />,
-    );
+      render(
+        <ResultsTab
+          audit={audit}
+          hasTarget={true}
+          progress={100}
+          reportFilter={filter}
+          reportId={'123'}
+          reportResultsCounts={reportResultsCounts}
+          status={'Stopped'}
+          onFilterAddLogLevelClick={onFilterAddLogLevelClick}
+          onFilterDecreaseMinQoDClick={onFilterDecreaseMinQoDClick}
+          onFilterEditClick={onFilterEditClick}
+          onFilterRemoveClick={onFilterRemoveClick}
+          onFilterRemoveSeverityClick={onFilterRemoveSeverityClick}
+          onTargetEditClick={onTargetEditClick}
+        />,
+      );
 
-    await wait();
+      await screen.findByTestId('entities-table');
 
-    // Wait for the table to be rendered
-    await waitFor(() => {
-      expect(screen.getByTestId('entities-table')).toBeInTheDocument();
-    });
+      const headers = screen.getAllByRole('columnheader');
+      const rows = screen.getAllByRole('row');
 
-    const header = baseElement.querySelectorAll('th');
-    const row = baseElement.querySelectorAll('tr');
+      expect(headers[0]).toHaveTextContent('Vulnerability');
+      expect(headers[2]).toHaveTextContent(header2Text);
+      expect(headers[3]).toHaveTextContent('QoD');
+      expect(headers[4]).toHaveTextContent('Host');
+      expect(headers[5]).toHaveTextContent('Location');
+      expect(headers[6]).toHaveTextContent('Created');
+      expect(headers[7]).toHaveTextContent('IP');
+      expect(headers[8]).toHaveTextContent('Name');
 
-    expect(header[0]).toHaveTextContent('Vulnerability');
-    expect(header[2]).toHaveTextContent('Compliant');
-    expect(header[3]).toHaveTextContent('QoD');
-    expect(header[4]).toHaveTextContent('Host');
-    expect(header[5]).toHaveTextContent('Location');
-    expect(header[6]).toHaveTextContent('Created');
-    expect(header[7]).toHaveTextContent('IP');
-    expect(header[8]).toHaveTextContent('Name');
+      expect(rows[2]).toHaveTextContent('Result 1');
+      expect(rows[2]).toHaveTextContent(row2Val);
+      expect(rows[2]).toHaveTextContent('80 %');
+      expect(rows[2]).toHaveTextContent('123.456.78.910');
+      expect(rows[2]).toHaveTextContent('foo');
+      expect(rows[2]).toHaveTextContent('80/tcp');
+      expect(rows[2]).toHaveTextContent(
+        'Mon, Jun 3, 2019 1:06 PM Central European Summer Time',
+      );
 
-    expect(row[2]).toHaveTextContent('Result 1');
-    expect(row[2]).toHaveTextContent('Yes');
-    expect(row[2]).toHaveTextContent('80 %');
-    expect(row[2]).toHaveTextContent('123.456.78.910');
-    expect(row[2]).toHaveTextContent('foo');
-    expect(row[2]).toHaveTextContent('80/tcp');
-    expect(row[2]).toHaveTextContent(
-      'Mon, Jun 3, 2019 1:06 PM Central European Summer Time',
-    );
+      expect(rows[3]).toHaveTextContent('Result 2');
+      expect(rows[3]).toHaveTextContent(row3Val);
+      expect(rows[3]).toHaveTextContent('70 %');
+      expect(rows[3]).toHaveTextContent('109.876.54.321');
+      expect(rows[3]).toHaveTextContent('80/tcp');
+      expect(rows[3]).toHaveTextContent(
+        'Mon, Jun 3, 2019 1:06 PM Central European Summer Time',
+      );
 
-    expect(row[3]).toHaveTextContent('Result 2');
-    expect(row[3]).toHaveTextContent('No');
-    expect(row[3]).toHaveTextContent('70 %');
-    expect(row[3]).toHaveTextContent('109.876.54.321');
-    expect(row[3]).toHaveTextContent('80/tcp');
-    expect(row[3]).toHaveTextContent(
-      'Mon, Jun 3, 2019 1:06 PM Central European Summer Time',
-    );
-
-    expect(row[4]).toHaveTextContent('Result 3');
-    expect(row[4]).toHaveTextContent('Incomplete');
-    expect(row[4]).toHaveTextContent('80 %');
-    expect(row[4]).toHaveTextContent('109.876.54.321');
-    expect(row[4]).toHaveTextContent('bar');
-    expect(row[4]).toHaveTextContent('80/tcp');
-    expect(row[4]).toHaveTextContent(
-      'Mon, Jun 3, 2019 1:06 PM Central European Summer Time',
-    );
-  });
-
-  test('should render Results Tab with severity information', async () => {
-    const onFilterAddLogLevelClick = testing.fn();
-    const onFilterDecreaseMinQoDClick = testing.fn();
-    const onFilterEditClick = testing.fn();
-    const onFilterRemoveClick = testing.fn();
-    const onFilterRemoveSeverityClick = testing.fn();
-    const onTargetEditClick = testing.fn();
-
-    const getResults = testing.fn().mockResolvedValue({
-      data: results,
-      meta: {
-        filter: Filter.fromString(),
-        counts: new CollectionCounts({
-          first: 1,
-          all: 3,
-          filtered: 3,
-          length: 3,
-          rows: 10,
-        }),
-      },
-    });
-
-    const gmp = createGmp({getResults});
-
-    const {render, store} = rendererWith({
-      gmp,
-      capabilities: true,
-      store: true,
-      router: true,
-    });
-
-    const defaultSettingFilter = Filter.fromString('foo=bar');
-    store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
-    store.dispatch(
-      defaultFilterLoadingActions.success('result', defaultSettingFilter),
-    );
-
-    const filter = Filter.fromString('first=1 rows=10');
-    const reportResultsCounts = new CollectionCounts({
-      first: 1,
-      all: 3,
-      filtered: 3,
-      length: 3,
-      rows: 10,
-    });
-
-    const {baseElement} = render(
-      <ResultsTab
-        audit={false}
-        hasTarget={true}
-        progress={100}
-        reportFilter={filter}
-        reportId={'123'}
-        reportResultsCounts={reportResultsCounts}
-        status={'Stopped'}
-        onFilterAddLogLevelClick={onFilterAddLogLevelClick}
-        onFilterDecreaseMinQoDClick={onFilterDecreaseMinQoDClick}
-        onFilterEditClick={onFilterEditClick}
-        onFilterRemoveClick={onFilterRemoveClick}
-        onFilterRemoveSeverityClick={onFilterRemoveSeverityClick}
-        onTargetEditClick={onTargetEditClick}
-      />,
-    );
-
-    await wait();
-
-    // Wait for the table to be rendered
-    await waitFor(() => {
-      expect(screen.getByTestId('entities-table')).toBeInTheDocument();
-    });
-
-    const header = baseElement.querySelectorAll('th');
-    const row = baseElement.querySelectorAll('tr');
-
-    expect(header[0]).toHaveTextContent('Vulnerability');
-    expect(header[2]).toHaveTextContent('Severity');
-    expect(header[3]).toHaveTextContent('QoD');
-    expect(header[4]).toHaveTextContent('Host');
-    expect(header[5]).toHaveTextContent('Location');
-    expect(header[6]).toHaveTextContent('Created');
-    expect(header[7]).toHaveTextContent('IP');
-    expect(header[8]).toHaveTextContent('Name');
-
-    expect(row[2]).toHaveTextContent('Result 1');
-    expect(row[2]).toHaveTextContent('10.0 (Critical)');
-    expect(row[2]).toHaveTextContent('80 %');
-    expect(row[2]).toHaveTextContent('123.456.78.910');
-    expect(row[2]).toHaveTextContent('foo');
-    expect(row[2]).toHaveTextContent('80/tcp');
-    expect(row[2]).toHaveTextContent(
-      'Mon, Jun 3, 2019 1:06 PM Central European Summer Time',
-    );
-
-    expect(row[3]).toHaveTextContent('Result 2');
-    expect(row[3]).toHaveTextContent('5.0 (Medium)');
-    expect(row[3]).toHaveTextContent('70 %');
-    expect(row[3]).toHaveTextContent('109.876.54.321');
-    expect(row[3]).toHaveTextContent('80/tcp');
-    expect(row[3]).toHaveTextContent(
-      'Mon, Jun 3, 2019 1:06 PM Central European Summer Time',
-    );
-
-    expect(row[4]).toHaveTextContent('Result 3');
-    expect(row[4]).toHaveTextContent('5.0 (Medium)');
-    expect(row[4]).toHaveTextContent('80 %');
-    expect(row[4]).toHaveTextContent('109.876.54.321');
-    expect(row[4]).toHaveTextContent('bar');
-    expect(row[4]).toHaveTextContent('80/tcp');
-    expect(row[4]).toHaveTextContent(
-      'Mon, Jun 3, 2019 1:06 PM Central European Summer Time',
-    );
-  });
+      expect(rows[4]).toHaveTextContent('Result 3');
+      expect(rows[4]).toHaveTextContent(row4Val);
+      expect(rows[4]).toHaveTextContent('80 %');
+      expect(rows[4]).toHaveTextContent('109.876.54.321');
+      expect(rows[4]).toHaveTextContent('bar');
+      expect(rows[4]).toHaveTextContent('80/tcp');
+      expect(rows[4]).toHaveTextContent(
+        'Mon, Jun 3, 2019 1:06 PM Central European Summer Time',
+      );
+    },
+  );
 
   describe('Results polling behavior isActive status', () => {
     test.each([

--- a/src/web/queries/__tests__/helpers.test.ts
+++ b/src/web/queries/__tests__/helpers.test.ts
@@ -22,60 +22,58 @@ const settings = {
 };
 
 describe('resolveRefetchInterval', () => {
-  test('returns false for NO_RELOAD (0)', () => {
-    expect(resolveRefetchInterval(NO_RELOAD, settings)).toBe(false);
-  });
-
-  test('returns false for boolean false', () => {
-    expect(resolveRefetchInterval(false, settings)).toBe(false);
-  });
-
-  test('returns reloadIntervalActive for USE_DEFAULT_RELOAD_INTERVAL_ACTIVE', () => {
-    expect(
-      resolveRefetchInterval(USE_DEFAULT_RELOAD_INTERVAL_ACTIVE, settings),
-    ).toBe(settings.reloadIntervalActive);
-  });
-
-  test('returns reloadIntervalInactive for USE_DEFAULT_RELOAD_INTERVAL_INACTIVE', () => {
-    expect(
-      resolveRefetchInterval(USE_DEFAULT_RELOAD_INTERVAL_INACTIVE, settings),
-    ).toBe(settings.reloadIntervalInactive);
-  });
-
-  test('returns reloadInterval for USE_DEFAULT_RELOAD_INTERVAL', () => {
-    expect(
-      resolveRefetchInterval(USE_DEFAULT_RELOAD_INTERVAL, settings),
-    ).toBe(settings.reloadInterval);
-  });
-
-  test('returns reloadInterval for undefined', () => {
-    expect(resolveRefetchInterval(undefined, settings)).toBe(
+  test.each<[string, number | false | undefined, number | false]>([
+    ['returns false for NO_RELOAD (0)', NO_RELOAD, false],
+    ['returns false for boolean false', false, false],
+    [
+      'returns reloadIntervalActive for USE_DEFAULT_RELOAD_INTERVAL_ACTIVE',
+      USE_DEFAULT_RELOAD_INTERVAL_ACTIVE,
+      settings.reloadIntervalActive,
+    ],
+    [
+      'returns reloadIntervalInactive for USE_DEFAULT_RELOAD_INTERVAL_INACTIVE',
+      USE_DEFAULT_RELOAD_INTERVAL_INACTIVE,
+      settings.reloadIntervalInactive,
+    ],
+    [
+      'returns reloadInterval for USE_DEFAULT_RELOAD_INTERVAL',
+      USE_DEFAULT_RELOAD_INTERVAL,
       settings.reloadInterval,
-    );
-  });
-
-  test('returns reloadInterval for unknown negative numbers', () => {
-    expect(resolveRefetchInterval(-99, settings)).toBe(settings.reloadInterval);
-  });
-
-  test('passes through positive numeric intervals unchanged', () => {
-    expect(resolveRefetchInterval(30000, settings)).toBe(30000);
+    ],
+    [
+      'returns reloadInterval for undefined',
+      undefined,
+      settings.reloadInterval,
+    ],
+    [
+      'returns reloadInterval for unknown negative numbers',
+      -99,
+      settings.reloadInterval,
+    ],
+    ['passes through positive numeric intervals unchanged', 30000, 30000],
+  ])('%s', (_, interval, expected) => {
+    expect(resolveRefetchInterval(interval, settings)).toBe(expected);
   });
 });
 
 describe('transformRefetchIntervalFn', () => {
-  test('resolves USE_DEFAULT_RELOAD_INTERVAL_ACTIVE returned by the wrapped function', () => {
-    const fn = () => USE_DEFAULT_RELOAD_INTERVAL_ACTIVE;
-    const transformed = transformRefetchIntervalFn(fn, settings);
-    expect(transformed({state: {data: undefined}})).toBe(
+  test.each<[string, number | false, number | false]>([
+    [
+      'resolves USE_DEFAULT_RELOAD_INTERVAL_ACTIVE to reloadIntervalActive',
+      USE_DEFAULT_RELOAD_INTERVAL_ACTIVE,
       settings.reloadIntervalActive,
-    );
-  });
-
-  test('resolves NO_RELOAD returned by the wrapped function to false', () => {
-    const fn = () => NO_RELOAD;
+    ],
+    ['resolves NO_RELOAD to false', NO_RELOAD, false],
+    [
+      'resolves USE_DEFAULT_RELOAD_INTERVAL to reloadInterval',
+      USE_DEFAULT_RELOAD_INTERVAL,
+      settings.reloadInterval,
+    ],
+    ['passes through positive numeric intervals unchanged', 15000, 15000],
+  ])('%s', (_, returnValue, expected) => {
+    const fn = () => returnValue;
     const transformed = transformRefetchIntervalFn(fn, settings);
-    expect(transformed({state: {data: undefined}})).toBe(false);
+    expect(transformed({state: {data: undefined}})).toBe(expected);
   });
 
   test('passes data from query state to the wrapped function', () => {
@@ -87,17 +85,5 @@ describe('transformRefetchIntervalFn', () => {
       settings.reloadIntervalActive,
     );
     expect(transformed({state: {data: 'done'}})).toBe(false);
-  });
-
-  test('resolves USE_DEFAULT_RELOAD_INTERVAL returned by the wrapped function', () => {
-    const fn = () => USE_DEFAULT_RELOAD_INTERVAL;
-    const transformed = transformRefetchIntervalFn(fn, settings);
-    expect(transformed({state: {data: undefined}})).toBe(settings.reloadInterval);
-  });
-
-  test('passes through positive numeric intervals returned by the wrapped function', () => {
-    const fn = () => 15000;
-    const transformed = transformRefetchIntervalFn(fn, settings);
-    expect(transformed({state: {data: undefined}})).toBe(15000);
   });
 });

--- a/src/web/queries/__tests__/helpers.test.ts
+++ b/src/web/queries/__tests__/helpers.test.ts
@@ -1,0 +1,103 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect} from '@gsa/testing';
+import {
+  NO_RELOAD,
+  USE_DEFAULT_RELOAD_INTERVAL,
+  USE_DEFAULT_RELOAD_INTERVAL_ACTIVE,
+  USE_DEFAULT_RELOAD_INTERVAL_INACTIVE,
+} from 'web/components/loading/Reload';
+import {
+  resolveRefetchInterval,
+  transformRefetchIntervalFn,
+} from 'web/queries/helpers';
+
+const settings = {
+  reloadInterval: 60000,
+  reloadIntervalActive: 5000,
+  reloadIntervalInactive: 120000,
+};
+
+describe('resolveRefetchInterval', () => {
+  test('returns false for NO_RELOAD (0)', () => {
+    expect(resolveRefetchInterval(NO_RELOAD, settings)).toBe(false);
+  });
+
+  test('returns false for boolean false', () => {
+    expect(resolveRefetchInterval(false, settings)).toBe(false);
+  });
+
+  test('returns reloadIntervalActive for USE_DEFAULT_RELOAD_INTERVAL_ACTIVE', () => {
+    expect(
+      resolveRefetchInterval(USE_DEFAULT_RELOAD_INTERVAL_ACTIVE, settings),
+    ).toBe(settings.reloadIntervalActive);
+  });
+
+  test('returns reloadIntervalInactive for USE_DEFAULT_RELOAD_INTERVAL_INACTIVE', () => {
+    expect(
+      resolveRefetchInterval(USE_DEFAULT_RELOAD_INTERVAL_INACTIVE, settings),
+    ).toBe(settings.reloadIntervalInactive);
+  });
+
+  test('returns reloadInterval for USE_DEFAULT_RELOAD_INTERVAL', () => {
+    expect(
+      resolveRefetchInterval(USE_DEFAULT_RELOAD_INTERVAL, settings),
+    ).toBe(settings.reloadInterval);
+  });
+
+  test('returns reloadInterval for undefined', () => {
+    expect(resolveRefetchInterval(undefined, settings)).toBe(
+      settings.reloadInterval,
+    );
+  });
+
+  test('returns reloadInterval for unknown negative numbers', () => {
+    expect(resolveRefetchInterval(-99, settings)).toBe(settings.reloadInterval);
+  });
+
+  test('passes through positive numeric intervals unchanged', () => {
+    expect(resolveRefetchInterval(30000, settings)).toBe(30000);
+  });
+});
+
+describe('transformRefetchIntervalFn', () => {
+  test('resolves USE_DEFAULT_RELOAD_INTERVAL_ACTIVE returned by the wrapped function', () => {
+    const fn = () => USE_DEFAULT_RELOAD_INTERVAL_ACTIVE;
+    const transformed = transformRefetchIntervalFn(fn, settings);
+    expect(transformed({state: {data: undefined}})).toBe(
+      settings.reloadIntervalActive,
+    );
+  });
+
+  test('resolves NO_RELOAD returned by the wrapped function to false', () => {
+    const fn = () => NO_RELOAD;
+    const transformed = transformRefetchIntervalFn(fn, settings);
+    expect(transformed({state: {data: undefined}})).toBe(false);
+  });
+
+  test('passes data from query state to the wrapped function', () => {
+    const fn = (data: string | undefined) =>
+      data === 'active' ? USE_DEFAULT_RELOAD_INTERVAL_ACTIVE : NO_RELOAD;
+    const transformed = transformRefetchIntervalFn(fn, settings);
+
+    expect(transformed({state: {data: 'active'}})).toBe(
+      settings.reloadIntervalActive,
+    );
+    expect(transformed({state: {data: 'done'}})).toBe(false);
+  });
+
+  test('resolves USE_DEFAULT_RELOAD_INTERVAL returned by the wrapped function', () => {
+    const fn = () => USE_DEFAULT_RELOAD_INTERVAL;
+    const transformed = transformRefetchIntervalFn(fn, settings);
+    expect(transformed({state: {data: undefined}})).toBe(settings.reloadInterval);
+  });
+
+  test('passes through positive numeric intervals returned by the wrapped function', () => {
+    const fn = () => 15000;
+    const transformed = transformRefetchIntervalFn(fn, settings);
+    expect(transformed({state: {data: undefined}})).toBe(15000);
+  });
+});

--- a/src/web/queries/helpers.ts
+++ b/src/web/queries/helpers.ts
@@ -3,11 +3,59 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import {
+  NO_RELOAD,
+  USE_DEFAULT_RELOAD_INTERVAL,
+  USE_DEFAULT_RELOAD_INTERVAL_ACTIVE,
+  USE_DEFAULT_RELOAD_INTERVAL_INACTIVE,
+} from 'web/components/loading/Reload';
+
 export type RefetchIntervalFn<TData> = (
   data: TData | undefined,
 ) => number | false;
 
-export const transformRefetchInterval =
-  <TData>(refetchInterval: RefetchIntervalFn<TData>) =>
-  (query: {state: {data: TData | undefined}}) =>
-    refetchInterval(query.state.data);
+interface ReloadSettings {
+  reloadInterval: number;
+  reloadIntervalActive: number;
+  reloadIntervalInactive: number;
+}
+
+/**
+ * Resolves a reload interval value (which may be a special constant like
+ * NO_RELOAD, USE_DEFAULT_RELOAD_INTERVAL_ACTIVE, etc.) into an actual
+ * millisecond interval or `false` for React Query's refetchInterval.
+ */
+export const resolveRefetchInterval = (
+  interval: number | false | undefined,
+  settings: ReloadSettings,
+): number | false => {
+  switch (interval) {
+    case false:
+    case NO_RELOAD:
+      return false;
+    case USE_DEFAULT_RELOAD_INTERVAL_ACTIVE:
+      return settings.reloadIntervalActive;
+    case USE_DEFAULT_RELOAD_INTERVAL_INACTIVE:
+      return settings.reloadIntervalInactive;
+    case undefined:
+    case USE_DEFAULT_RELOAD_INTERVAL:
+      return settings.reloadInterval;
+    default:
+      if (typeof interval === 'number' && interval < 0) {
+        return settings.reloadInterval;
+      }
+      return interval;
+  }
+};
+
+/**
+ * Wraps a RefetchIntervalFn so that its return values (which may be special
+ * constants) are resolved into actual millisecond intervals for React Query.
+ */
+export const transformRefetchIntervalFn =
+  <TData>(
+    refetchInterval: RefetchIntervalFn<TData>,
+    settings: ReloadSettings,
+  ) =>
+  (query: {state: {data: TData | undefined}}): number | false =>
+    resolveRefetchInterval(refetchInterval(query.state.data), settings);

--- a/src/web/queries/useGetEntities.ts
+++ b/src/web/queries/useGetEntities.ts
@@ -12,7 +12,8 @@ import type Filter from 'gmp/models/filter';
 import useGmp from 'web/hooks/useGmp';
 import useSessionToken from 'web/hooks/useSessionToken';
 import {
-  transformRefetchInterval,
+  resolveRefetchInterval,
+  transformRefetchIntervalFn,
   type RefetchIntervalFn,
 } from 'web/queries/helpers';
 
@@ -53,11 +54,11 @@ const useGetEntities = <
   const gmp = useGmp();
   const token = useSessionToken();
 
-  const interval = refetchInterval ?? gmp.settings.reloadInterval;
+  const settings = gmp.settings;
   const resolvedRefetchInterval =
-    typeof interval === 'function'
-      ? transformRefetchInterval(interval)
-      : interval;
+    typeof refetchInterval === 'function'
+      ? transformRefetchIntervalFn(refetchInterval, settings)
+      : resolveRefetchInterval(refetchInterval, settings);
 
   return useQuery<UseGetEntitiesReturn<TModel>>({
     enabled: enabled && Boolean(token),

--- a/src/web/queries/useGetEntity.ts
+++ b/src/web/queries/useGetEntity.ts
@@ -10,7 +10,8 @@ import type Model from 'gmp/models/model';
 import useGmp from 'web/hooks/useGmp';
 import useSessionToken from 'web/hooks/useSessionToken';
 import {
-  transformRefetchInterval,
+  resolveRefetchInterval,
+  transformRefetchIntervalFn,
   type RefetchIntervalFn,
 } from 'web/queries/helpers';
 
@@ -32,11 +33,11 @@ const useGetEntity = <TModel extends Model>({
   const gmp = useGmp();
   const token = useSessionToken();
 
-  const interval = refetchInterval ?? gmp.settings.reloadInterval;
+  const settings = gmp.settings;
   const resolvedRefetchInterval =
-    typeof interval === 'function'
-      ? transformRefetchInterval(interval)
-      : interval;
+    typeof refetchInterval === 'function'
+      ? transformRefetchIntervalFn(refetchInterval, settings)
+      : resolveRefetchInterval(refetchInterval, settings);
 
   return useQuery<TModel>({
     enabled: Boolean(token) && Boolean(id),


### PR DESCRIPTION
## What

- Fix refetch interval for active results
- Create a more general approach for refetch intervals
- Improve tests and cases for `isActive`
- Convert to Typescript results command

## Why

- If a result was finished it would continue to fetch

## References

GEA-1764

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


