### PR TITLE
Allow to include JWT in requests for authentication

### DIFF
--- a/src/gmp/http/__tests__/http.test.ts
+++ b/src/gmp/http/__tests__/http.test.ts
@@ -31,6 +31,7 @@ const createXHR = (status: number, response = '') => {
     onload: testing.fn(),
     onerror: testing.fn(),
     ontimeout: testing.fn(),
+    setRequestHeader: testing.fn(),
   } as unknown as XMLHttpRequest;
 };
 
@@ -70,6 +71,33 @@ describe('Http tests', () => {
     expect(http.getParams()).toEqual({
       token: '123',
     });
+  });
+
+  test('should allow to create requests with JWT', async () => {
+    const xhr = createXHR(200, 'some data');
+    // @ts-expect-error
+    Http.XHR = testing.fn().mockImplementation(function () {
+      return xhr;
+    });
+
+    const http = createHttp({}, {jwt: 'test-jwt'});
+    const promise = http.request('get', {args: {cmd: 'get_tasks'}});
+    // @ts-expect-error
+    xhr.onload();
+
+    const response = await promise;
+    expect(response.data).toEqual('some data');
+    expect(xhr.open).toHaveBeenCalledWith(
+      'GET',
+      'https://example.com/gmp?cmd=get_tasks',
+      true,
+    );
+    expect(xhr.withCredentials).toEqual(true);
+    expect(xhr.send).toHaveBeenCalledWith(undefined);
+    expect(xhr.setRequestHeader).toHaveBeenCalledWith(
+      'Authorization',
+      'Bearer test-jwt',
+    );
   });
 
   test('should allow to add error handlers and call them on error', async () => {

--- a/src/gmp/http/http.ts
+++ b/src/gmp/http/http.ts
@@ -81,6 +81,7 @@ class Http {
     let formdata: FormData | undefined;
 
     method = method.toUpperCase() as HttpMethod;
+    const {jwt} = this.session;
 
     if (args) {
       url = `${url}?${buildUrlParams({...this.getParams(), ...args})}`;
@@ -105,6 +106,10 @@ class Http {
       };
 
       xhr.open(method, url, true);
+
+      if (isDefined(jwt)) {
+        xhr.setRequestHeader('Authorization', `Bearer ${jwt}`);
+      }
 
       if (isDefined(self.timeout)) {
         xhr.timeout = self.timeout;


### PR DESCRIPTION


## What

Allow to include JWT in requests for authentication

## Why

Add JWT in Authorization header if available. This allows to use the JWT token for authentication.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


