### PR TITLE
New login URL

### DIFF
--- a/src/gmp/__tests__/gmp.test.ts
+++ b/src/gmp/__tests__/gmp.test.ts
@@ -35,7 +35,10 @@ describe('Gmp tests', () => {
 
   test('should login user', async () => {
     const token = 'foo';
-    const http = createHttp(createResponse({token}));
+    const http = createHttp(createResponse({token}), {
+      apiServer: 'localhost',
+      apiProtocol: 'http:',
+    });
 
     const storage = createStorage();
     const session = createSession();
@@ -43,21 +46,21 @@ describe('Gmp tests', () => {
     const gmp = new Gmp({settings, http, session});
 
     await gmp.login('foo', 'bar');
-    expect(http.request).toHaveBeenCalledWith(
-      'post',
-      expect.objectContaining({
-        data: {
-          cmd: 'login',
-          login: 'foo',
-          password: 'bar',
-        },
-      }),
-    );
+    expect(http.request).toHaveBeenCalledWith('post', {
+      data: {
+        login: 'foo',
+        password: 'bar',
+      },
+      url: 'http://localhost/login',
+    });
     expect(session.login).toHaveBeenCalledWith({token, username: 'foo'});
   });
 
   test('should not login if request fails', async () => {
-    const http = createHttpError(new Error('An error'));
+    const http = createHttpError(new Error('An error'), {
+      apiServer: 'localhost',
+      apiProtocol: 'http:',
+    });
     const storage = createStorage();
     const session = createSession();
     const settings = new Settings(storage);
@@ -66,16 +69,13 @@ describe('Gmp tests', () => {
     try {
       return await gmp.login('foo', 'bar');
     } catch (error) {
-      expect(http.request).toHaveBeenCalledWith(
-        'post',
-        expect.objectContaining({
-          data: {
-            cmd: 'login',
-            login: 'foo',
-            password: 'bar',
-          },
-        }),
-      );
+      expect(http.request).toHaveBeenCalledWith('post', {
+        data: {
+          login: 'foo',
+          password: 'bar',
+        },
+        url: 'http://localhost/login',
+      });
       expect((error as Error).message).toEqual('An error');
       expect(session.login).not.toHaveBeenCalled();
     }

--- a/src/gmp/commands/__tests__/login.test.ts
+++ b/src/gmp/commands/__tests__/login.test.ts
@@ -1,0 +1,44 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect, testing} from '@gsa/testing';
+import LoginCommand from 'gmp/commands/login';
+import {createResponse, createHttp} from 'gmp/commands/testing';
+import {type Envelope} from 'gmp/http/transform/fast-xml';
+import date from 'gmp/models/date';
+
+describe('LoginCommand tests', () => {
+  test('should return Login model on successful login', async () => {
+    testing.useFakeTimers();
+    const response = createResponse<Envelope>({
+      token: 'abc123',
+      timezone: 'UTC',
+      i18n: 'en',
+      session: 3600,
+      jwt: 'jwt_token',
+      client_address: '127.0.0.123',
+    });
+    const fakeHttp = createHttp(response, {
+      apiProtocol: 'https',
+      apiServer: 'example.com',
+    });
+    const cmd = new LoginCommand(fakeHttp);
+    const loginModel = await cmd.login('user', 'pass');
+    expect(fakeHttp.request).toHaveBeenCalledWith('post', {
+      data: {
+        login: 'user',
+        password: 'pass',
+      },
+      url: 'https://example.com/login',
+    });
+    expect(loginModel.token).toEqual('abc123');
+    expect(loginModel.timezone).toEqual('UTC');
+    expect(loginModel.locale).toEqual('en');
+    expect(loginModel.sessionTimeout).toEqual(date('1970-01-01T01:00:00.000Z'));
+    expect(loginModel.jwt).toEqual('jwt_token');
+
+    testing.useRealTimers();
+  });
+});

--- a/src/gmp/commands/http.ts
+++ b/src/gmp/commands/http.ts
@@ -23,7 +23,7 @@ import type Filter from 'gmp/models/filter';
 import {filterString, isFilter} from 'gmp/models/filter/utils';
 import {hasValue, isDefined} from 'gmp/utils/identity';
 
-export interface HttpCommandOptions {
+export interface HttpCommandOptions extends RequestOptions {
   cancelToken?: CancelToken;
   force?: boolean;
   responseType?: ResponseType;

--- a/src/gmp/commands/login.ts
+++ b/src/gmp/commands/login.ts
@@ -6,22 +6,30 @@
 import HttpCommand from 'gmp/commands/http';
 import type Http from 'gmp/http/http';
 import {ResponseRejection} from 'gmp/http/rejection';
+import {buildServerUrl} from 'gmp/http/utils';
 import _ from 'gmp/locale';
 import Login from 'gmp/models/login';
 
 class LoginCommand extends HttpCommand {
   constructor(http: Http) {
-    super(http, {
-      cmd: 'login',
-    });
+    super(http);
   }
 
   async login(username: string, password: string) {
     try {
-      const response = await this.httpPostWithTransform({
-        login: username,
-        password,
-      });
+      const response = await this.httpPostWithTransform(
+        {
+          login: username,
+          password,
+        },
+        {
+          url: buildServerUrl(
+            this.http.apiServer,
+            'login',
+            this.http.apiProtocol,
+          ),
+        },
+      );
       return new Login(response);
     } catch (rej) {
       if (rej instanceof ResponseRejection) {

--- a/src/gmp/commands/testing.ts
+++ b/src/gmp/commands/testing.ts
@@ -4,7 +4,7 @@
  */
 
 import {testing} from '@gsa/testing';
-import type Http from 'gmp/http/http';
+import {type default as Http, type HttpOptions} from 'gmp/http/http';
 import Response, {type Meta} from 'gmp/http/response';
 import {type Element} from 'gmp/models/model';
 
@@ -113,14 +113,20 @@ export const createInfoEntitiesResponse = (entities: Element[]) =>
 
 export const createHttp = <TData = Element, TMeta extends Meta = Meta>(
   response?: TData | Response<TData, TMeta>,
+  options: Partial<HttpOptions> = {},
 ) =>
   ({
     request: testing.fn().mockResolvedValue(response),
+    ...options,
   }) as unknown as Http;
 
-export const createHttpError = (error: Error) =>
+export const createHttpError = (
+  error: Error,
+  options: Partial<HttpOptions> = {},
+) =>
   ({
     request: testing.fn().mockRejectedValue(error),
+    ...options,
   }) as unknown as Http;
 
 export const createHttpMany = (responses: Element[] | Response[]) => {

--- a/src/gmp/http/__tests__/http.test.ts
+++ b/src/gmp/http/__tests__/http.test.ts
@@ -36,6 +36,18 @@ const createXHR = (status: number, response = '') => {
 };
 
 describe('Http tests', () => {
+  test('should initialize with correct url and timeout', () => {
+    const http = createHttp({
+      apiServer: 'test.com',
+      apiProtocol: 'http:',
+      timeout: 5000,
+    });
+    expect(http.url).toEqual('http://test.com/gmp');
+    expect(http.timeout).toEqual(5000);
+    expect(http.apiServer).toEqual('test.com');
+    expect(http.apiProtocol).toEqual('http:');
+  });
+
   test('should handle response error without error handlers', async () => {
     const http = createHttp();
     const xhr = createXHR(500);

--- a/src/gmp/http/http.ts
+++ b/src/gmp/http/http.ts
@@ -50,6 +50,9 @@ const log = logger.getLogger('gmp.http');
 class Http {
   readonly url: string;
   readonly timeout?: number;
+  readonly apiServer: string;
+  readonly apiProtocol?: string;
+
   private errorHandlers: Array<ErrorHandler>;
   private readonly session: Session;
 
@@ -57,6 +60,9 @@ class Http {
 
   constructor(options: HttpOptions, session: Session) {
     const {timeout, apiServer, apiProtocol} = options;
+
+    this.apiServer = apiServer;
+    this.apiProtocol = apiProtocol;
 
     this.url = buildServerUrl(apiServer, 'gmp', apiProtocol);
     this.timeout = timeout;


### PR DESCRIPTION
## What

Use new login URL `/login` instead of `/gmp?cmd=login`.

## Why

The `/gmp?cmd=login` path contains special code in gsad only for the login and therefore should be separated from
other gmp commands.

## References

Requires https://github.com/greenbone/gsad/pull/403

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


