### PR TITLE
Raise error if desired select element has no aria-control

### DIFF
--- a/src/web/components/form/FormGroup.tsx
+++ b/src/web/components/form/FormGroup.tsx
@@ -14,6 +14,7 @@ interface FormGroupProps {
   'data-testid'?: string;
   direction?: 'row' | 'column';
   gap?: StyleProp<MantineSpacing>;
+  htmlFor?: string;
   title?: React.ReactNode;
 }
 
@@ -33,6 +34,7 @@ const StyledLabel = styled.label`
 
 const FormGroup = ({
   children,
+  htmlFor,
   title,
   gap = 'md',
   direction = 'column',
@@ -42,7 +44,9 @@ const FormGroup = ({
   return (
     <Wrapper data-testid={dataTestId}>
       {isDefined(title) && (
-        <StyledLabel data-testid={`${dataTestId}-label`}>{title}</StyledLabel>
+        <StyledLabel data-testid={`${dataTestId}-label`} htmlFor={htmlFor}>
+          {title}
+        </StyledLabel>
       )}
       <Layout gap={gap}>{children}</Layout>
     </Wrapper>

--- a/src/web/components/form/__tests__/FormGroup.test.tsx
+++ b/src/web/components/form/__tests__/FormGroup.test.tsx
@@ -30,4 +30,17 @@ describe('FormGroup tests', () => {
     const content = screen.getByTestId('inner');
     expect(content).toHaveTextContent('Foo');
   });
+
+  test("should render with htmlFor and label's htmlFor should match", () => {
+    render(
+      <FormGroup htmlFor="input-id" title="Some Label">
+        <input id="input-id" name="input-name" />
+      </FormGroup>,
+    );
+
+    const input = screen.getByLabelText('Some Label');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('id', 'input-id');
+    expect(input).toHaveAttribute('name', 'input-name');
+  });
 });

--- a/src/web/pages/agent-groups/__tests__/AgentGroupsDialog.test.tsx
+++ b/src/web/pages/agent-groups/__tests__/AgentGroupsDialog.test.tsx
@@ -5,6 +5,7 @@
 
 import {describe, expect, test, testing} from '@gsa/testing';
 import {
+  changeInputValue,
   fireEvent,
   getSelectItemElementsForSelect,
   rendererWith,
@@ -98,7 +99,10 @@ describe('AgentGroupsDialog tests', () => {
     render(<AgentGroupsDialog onClose={onClose} onSave={onSave} />);
 
     // open agent controller select and choose controller
-    const select = screen.getByName('agentController') as HTMLSelectElement;
+    const select = screen.getByRole<HTMLSelectElement>('textbox', {
+      name: 'Agent Controller',
+    });
+
     const items = await getSelectItemElementsForSelect(select);
     const item = items.find(i =>
       i.textContent?.includes('Controller One'),
@@ -151,7 +155,9 @@ describe('AgentGroupsDialog tests', () => {
 
     render(<AgentGroupsDialog onClose={onClose} onSave={onSave} />);
 
-    const select = screen.getByName('agentController') as HTMLSelectElement;
+    const select = screen.getByRole<HTMLSelectElement>('textbox', {
+      name: 'Agent Controller',
+    });
     const items = await getSelectItemElementsForSelect(select);
     const item = items.find(i =>
       i.textContent?.includes('Controller One'),
@@ -190,10 +196,12 @@ describe('AgentGroupsDialog tests', () => {
 
     // type a custom name
     const nameField = screen.getByName('name');
-    fireEvent.change(nameField, {target: {value: 'Custom Group'}});
+    changeInputValue(nameField, 'Custom Group');
 
     // select a controller
-    const select = screen.getByName('agentController') as HTMLSelectElement;
+    const select = screen.getByRole<HTMLSelectElement>('textbox', {
+      name: 'Agent Controller',
+    });
     const items = await getSelectItemElementsForSelect(select);
     const item = items.find(i =>
       i.textContent?.includes('Controller One'),

--- a/src/web/pages/permissions/PermissionDialog.tsx
+++ b/src/web/pages/permissions/PermissionDialog.tsx
@@ -256,9 +256,10 @@ const PermissionDialog = ({
 
         return (
           <>
-            <FormGroup title={_('Name')}>
+            <FormGroup htmlFor="permission-name" title={_('Name')}>
               <Select
                 grow="1"
+                id="permission-name"
                 items={permItems}
                 name="name"
                 value={state.name}
@@ -266,9 +267,10 @@ const PermissionDialog = ({
               />
             </FormGroup>
 
-            <FormGroup title={_('Comment')}>
+            <FormGroup htmlFor="permission-comment" title={_('Comment')}>
               <TextField
                 grow="1"
+                id="permission-comment"
                 name="comment"
                 value={state.comment}
                 onChange={onValueChange}
@@ -334,9 +336,13 @@ const PermissionDialog = ({
             </FormGroup>
 
             {state.name === 'Super' && (
-              <FormGroup title={_('Resource Type')}>
+              <FormGroup
+                htmlFor="permission-resource-type"
+                title={_('Resource Type')}
+              >
                 <Select
                   grow="1"
+                  id="permission-resource-type"
                   items={[
                     {
                       value: '',
@@ -362,10 +368,14 @@ const PermissionDialog = ({
               </FormGroup>
             )}
             {showResourceId && (
-              <FormGroup title={resourceIdTitle}>
+              <FormGroup
+                htmlFor="permission-resource-id"
+                title={resourceIdTitle}
+              >
                 <TextField
                   disabled={fixedResource}
                   grow="1"
+                  id="permission-resource-id"
                   name="resourceId"
                   value={state.resourceId}
                   onChange={onValueChange}

--- a/src/web/pages/permissions/__tests__/PermissionDialog.test.tsx
+++ b/src/web/pages/permissions/__tests__/PermissionDialog.test.tsx
@@ -101,8 +101,9 @@ describe('PermissionDialog tests', () => {
     render(<PermissionDialog onClose={onClose} onSave={onSave} />);
 
     const dialog = within(screen.getDialog());
-    const nameSelect = dialog.getByName('name') as HTMLSelectElement;
-
+    const nameSelect = dialog.getByRole<HTMLSelectElement>('textbox', {
+      name: 'Name',
+    });
     const selectItems = await getSelectItemElementsForSelect(nameSelect);
 
     const getTasksOption = selectItems.find(item =>
@@ -372,10 +373,10 @@ describe('PermissionDialog tests', () => {
     const dialog = within(screen.getDialog());
 
     // Check that resource type select is visible for Super permission
-    const resourceTypeSelect = dialog.getByName(
-      'resourceType',
-    ) as HTMLSelectElement;
-    expect(resourceTypeSelect.value).toBe('user');
+    const resourceTypeSelect = dialog.getByRole<HTMLSelectElement>('textbox', {
+      name: 'Resource Type',
+    });
+    expect(resourceTypeSelect.value).toBe('User');
 
     // Open the select dropdown and get available options
     const selectItems =
@@ -558,8 +559,9 @@ describe('PermissionDialog tests', () => {
 
     const dialog = within(screen.getDialog());
 
-    const nameSelect = dialog.getByName('name') as HTMLSelectElement;
-
+    const nameSelect = dialog.getByRole<HTMLSelectElement>('textbox', {
+      name: 'Name',
+    });
     const selectItems = await getSelectItemElementsForSelect(nameSelect);
 
     const getTasksOption = selectItems.find(item =>

--- a/src/web/pages/tasks/AgentTaskDialog.tsx
+++ b/src/web/pages/tasks/AgentTaskDialog.tsx
@@ -209,7 +209,11 @@ const AgentTaskDialog = ({
 
             {capabilities.mayAccess('agentgroup') &&
               capabilities.mayCreate('agentgroup') && (
-                <FormGroup direction="row" title={_('Scan Agent Groups')}>
+                <FormGroup
+                  direction="row"
+                  htmlFor="agent-group"
+                  title={_('Scan Agent Groups')}
+                >
                   <Title
                     title={
                       changeTask
@@ -221,6 +225,7 @@ const AgentTaskDialog = ({
                   >
                     <Select
                       disabled={!changeTask}
+                      id="agent-group"
                       isLoading={isLoadingAgentGroups}
                       items={agentGroupItems}
                       name="agentGroupId"
@@ -239,9 +244,10 @@ const AgentTaskDialog = ({
 
             {capabilities.mayAccess('alert') &&
               capabilities.mayCreate('alert') && (
-                <FormGroup direction="row" title={_('Alerts')}>
+                <FormGroup direction="row" htmlFor="alerts" title={_('Alerts')}>
                   <MultiSelect
                     grow="1"
+                    id="alerts"
                     isLoading={isLoadingAlerts}
                     items={alertItems}
                     name="alertIds"
@@ -263,9 +269,14 @@ const AgentTaskDialog = ({
                     'Note that the Agent Task refers to generating the report with stored data.\nIf you want to change when the Scan Agents scan, go to the Agent Groups page.',
                   )}
                   slot={
-                    <FormGroup direction="row" title={_('Schedule')}>
+                    <FormGroup
+                      direction="row"
+                      htmlFor="schedule"
+                      title={_('Schedule')}
+                    >
                       <Select
                         grow="1"
+                        id="schedule"
                         isLoading={isLoadingSchedules}
                         items={scheduleItems}
                         name="scheduleId"
@@ -303,9 +314,10 @@ const AgentTaskDialog = ({
               />
             </FormGroup>
 
-            <FormGroup title={_('Min QoD')}>
+            <FormGroup htmlFor="min-qod" title={_('Min QoD')}>
               <Spinner
                 disabled={state.inAssets !== YES_VALUE}
+                id="min-qod"
                 max={100}
                 min={0}
                 name="minQod"

--- a/src/web/pages/tasks/__tests__/AgentTaskDialog.test.tsx
+++ b/src/web/pages/tasks/__tests__/AgentTaskDialog.test.tsx
@@ -76,10 +76,11 @@ describe('AgentTaskDialog component tests', () => {
     const {onAgentGroupChange} = commonHandlers();
     renderDialog({onAgentGroupChange});
 
-    const agentGroupSelect = screen.getByName('agentGroupId');
+    const agentGroupSelect = screen.getByRole<HTMLSelectElement>('textbox', {
+      name: 'Scan Agent Groups',
+    });
     fireEvent.click(agentGroupSelect);
 
-    //@ts-expect-error
     const items = await getSelectItemElementsForSelect(agentGroupSelect);
     expect(items[0]).toHaveTextContent('Group A');
     fireEvent.click(items[0]);

--- a/src/web/testing/actions.ts
+++ b/src/web/testing/actions.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import {prettyDOM} from '@testing-library/react';
 import {PointerEventsCheckLevel} from '@testing-library/user-event';
 import {isDefined} from 'gmp/utils/identity';
 import {
@@ -25,6 +26,12 @@ export const getSelectItemElementsForSelect = async (
   element = isDefined(element) ? element : getSelectElement();
   await openSelectElement(element);
   const selectItemsId = element.getAttribute('aria-controls');
+  if (!selectItemsId) {
+    throw new Error(
+      'Select element does not have aria-controls attribute\n ' +
+        prettyDOM(element),
+    );
+  }
   const itemsContainer =
     document.body.querySelector<HTMLElement>('#' + selectItemsId) || undefined;
   return getSelectItemElements(itemsContainer);


### PR DESCRIPTION

## What
Raise error if desired select element has no aria-control

## Why
Extend `getSelectItemElementsForSelect` to raise an error if the desired select element has not `aria-control` attribute. Otherwise wrong item elements are returned.


