### PR TITLE
Allow to query tasks with schedules only param

### DIFF
--- a/src/gmp/commands/__tests__/tasks.test.ts
+++ b/src/gmp/commands/__tests__/tasks.test.ts
@@ -49,6 +49,24 @@ describe('TasksCommand tests', () => {
     expect(result.data).toEqual([new Task({id: '3', name: 'Custom Task'})]);
   });
 
+  test('should fetch tasks with schedules only', async () => {
+    const response = createEntitiesResponse('task', [
+      {_id: '3', name: 'Custom Task'},
+    ]);
+    const fakeHttp = createHttp(response);
+
+    const cmd = new TasksCommand(fakeHttp);
+    const result = await cmd.get({schedulesOnly: true});
+    expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+      args: {
+        cmd: 'get_tasks',
+        usage_type: 'scan',
+        schedules_only: 1,
+      },
+    });
+    expect(result.data).toEqual([new Task({id: '3', name: 'Custom Task'})]);
+  });
+
   test('should fetch all tasks', async () => {
     const response = createEntitiesResponse('task', [
       {_id: '4', name: 'All Tasks 1'},
@@ -60,6 +78,29 @@ describe('TasksCommand tests', () => {
     const result = await cmd.getAll();
     expect(fakeHttp.request).toHaveBeenCalledWith('get', {
       args: {cmd: 'get_tasks', filter: 'first=1 rows=-1', usage_type: 'scan'},
+    });
+    expect(result.data).toEqual([
+      new Task({id: '4', name: 'All Tasks 1'}),
+      new Task({id: '5', name: 'All Tasks 2'}),
+    ]);
+  });
+
+  test('should fetch all tasks with schedules only', async () => {
+    const response = createEntitiesResponse('task', [
+      {_id: '4', name: 'All Tasks 1'},
+      {_id: '5', name: 'All Tasks 2'},
+    ]);
+    const fakeHttp = createHttp(response);
+
+    const cmd = new TasksCommand(fakeHttp);
+    const result = await cmd.getAll({schedulesOnly: true});
+    expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+      args: {
+        cmd: 'get_tasks',
+        filter: 'first=1 rows=-1',
+        usage_type: 'scan',
+        schedules_only: 1,
+      },
     });
     expect(result.data).toEqual([
       new Task({id: '4', name: 'All Tasks 1'}),

--- a/src/gmp/commands/tasks.ts
+++ b/src/gmp/commands/tasks.ts
@@ -10,7 +10,8 @@ import type Http from 'gmp/http/http';
 import type Filter from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 import Task, {type TaskElement} from 'gmp/models/task';
-import {type YesNo} from 'gmp/parser';
+import {parseYesNo, type YesNo} from 'gmp/parser';
+import {isDefined} from 'gmp/utils/identity';
 
 interface GetTasksResponse extends Element {
   apply_overrides: YesNo;
@@ -39,6 +40,7 @@ interface TasksCommandWithFilterParam {
 
 interface TasksCommandGetParams {
   filter?: Filter | string;
+  schedulesOnly?: boolean;
 }
 
 class TasksCommand extends EntitiesCommand<Task, GetTasksResponse> {
@@ -52,10 +54,16 @@ class TasksCommand extends EntitiesCommand<Task, GetTasksResponse> {
   }
 
   async get(
-    {filter}: TasksCommandGetParams = {},
+    {filter, schedulesOnly}: TasksCommandGetParams = {},
     options?: HttpCommandOptions,
   ) {
-    const params = {filter, usage_type: 'scan'};
+    const params = {
+      filter,
+      usage_type: 'scan',
+      schedules_only: isDefined(schedulesOnly)
+        ? parseYesNo(schedulesOnly)
+        : undefined,
+    };
     const response = await this.httpGetWithTransform(params, options);
     const {
       entities,


### PR DESCRIPTION


## What

Allow to query tasks with schedules only param

## Why

Allow to limit the tasks response to only include id, name and schedule details. This will be used for getting the tasks of an alert.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


