### PR TITLE
Add a `addPrefix` function as an alternative to the withPrefix HOC

### DIFF
--- a/src/web/utils/__tests__/add-prefix.test.ts
+++ b/src/web/utils/__tests__/add-prefix.test.ts
@@ -1,0 +1,19 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect} from '@gsa/testing';
+import addPrefix from 'web/utils/add-prefix';
+
+describe('addPrefix tests', () => {
+  test('should add prefix when provided', () => {
+    const result = addPrefix('test');
+    expect(result('foo')).toBe('test_foo');
+  });
+
+  test('should return empty string when no prefix is provided', () => {
+    const result = addPrefix();
+    expect(result('foo')).toBe('foo');
+  });
+});

--- a/src/web/utils/add-prefix.ts
+++ b/src/web/utils/add-prefix.ts
@@ -1,0 +1,11 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+const addPrefix = (prefix?: string) => {
+  const newPrefix = prefix ? `${prefix}_` : '';
+  return (value: string) => `${newPrefix}${value}`;
+};
+
+export default addPrefix;


### PR DESCRIPTION


## What

Add a `addPrefix` function as an alternative to the withPrefix HOC
## Why

For function components it is better to use a dedicated function then to a HOC. The withPrefix HOC is used in the alert dialog for setting the names of the input fields.
## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


