### PR TITLE
GEA-1730 report details hosts

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -809,6 +809,7 @@
   "Error while loading Applications for Report {{reportId}}": "Fehler beim Laden der Anwendungen für Bericht {{reportId}}",
   "Error while loading Container Scanning Results for Report {{reportId}}": "Fehler beim Laden der Container-Scan-Ergebnisse für Bericht {{reportId}}",
   "Error while loading Errors for Report {{reportId}}": "Fehler beim Laden der Fehler für Bericht {{reportId}}",
+  "Error while loading Hosts for Report {{reportId}}": "Fehler beim Laden der Hosts für Bericht {{reportId}}",
   "Error while loading Operating Systems for Report {{reportId}}": "Fehler beim Laden der Betriebssysteme für Bericht {{reportId}}",
   "Error while loading Ports for Report {{reportId}}": "Fehler beim Laden der Ports für Bericht {{reportId}}",
   "Error while loading Report {{reportId}}": "Fehler beim Laden des Berichts {{reportId}}",

--- a/public/locales/gsa-en.json
+++ b/public/locales/gsa-en.json
@@ -809,6 +809,7 @@
   "Error while loading Applications for Report {{reportId}}": "",
   "Error while loading Container Scanning Results for Report {{reportId}}": "",
   "Error while loading Errors for Report {{reportId}}": "",
+  "Error while loading Hosts for Report {{reportId}}": "",
   "Error while loading Operating Systems for Report {{reportId}}": "",
   "Error while loading Ports for Report {{reportId}}": "",
   "Error while loading Report {{reportId}}": "Error while loading Report {{reportId}}",

--- a/public/locales/gsa-zh_CN.json
+++ b/public/locales/gsa-zh_CN.json
@@ -809,6 +809,7 @@
   "Error while loading Applications for Report {{reportId}}": "",
   "Error while loading Container Scanning Results for Report {{reportId}}": "",
   "Error while loading Errors for Report {{reportId}}": "",
+  "Error while loading Hosts for Report {{reportId}}": "",
   "Error while loading Operating Systems for Report {{reportId}}": "",
   "Error while loading Ports for Report {{reportId}}": "",
   "Error while loading Report {{reportId}}": "加载报告 {{reportId}} 时出错",

--- a/public/locales/gsa-zh_TW.json
+++ b/public/locales/gsa-zh_TW.json
@@ -809,6 +809,7 @@
   "Error while loading Applications for Report {{reportId}}": "",
   "Error while loading Container Scanning Results for Report {{reportId}}": "",
   "Error while loading Errors for Report {{reportId}}": "",
+  "Error while loading Hosts for Report {{reportId}}": "",
   "Error while loading Operating Systems for Report {{reportId}}": "",
   "Error while loading Ports for Report {{reportId}}": "",
   "Error while loading Report {{reportId}}": "",

--- a/src/gmp/commands/__tests__/report-hosts.test.ts
+++ b/src/gmp/commands/__tests__/report-hosts.test.ts
@@ -1,0 +1,273 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect} from '@gsa/testing';
+import ReportHostsCommand from 'gmp/commands/report-hosts';
+import {createResponse, createHttp} from 'gmp/commands/testing';
+
+describe('ReportHostsCommand tests', () => {
+  test('should return report hosts', async () => {
+    const response = createResponse({
+      get_report_hosts: {
+        get_report_hosts_response: {
+          host: [
+            {
+              _id: 'host-1',
+              ip: '192.168.1.1',
+              hostname: 'host1.example.com',
+              start: '2019-06-03T11:00:00Z',
+              end: '2019-06-03T11:15:00Z',
+              result_count: {
+                page: 1,
+                high: {__text: 5, page: 1},
+                medium: {__text: 3, page: 1},
+                low: {__text: 0, page: 1},
+                log: {__text: 0, page: 1},
+                false_positive: {__text: 0, page: 1},
+              },
+              detail: [
+                {name: 'hostname', value: 'host1.example.com'},
+                {name: 'best_os_cpe', value: 'cpe:/o:linux'},
+              ],
+            },
+            {
+              _id: 'host-2',
+              ip: '192.168.1.2',
+              hostname: 'host2.example.com',
+              start: '2019-06-03T11:00:00Z',
+              end: '2019-06-03T11:15:00Z',
+              result_count: {
+                page: 1,
+                high: {__text: 2, page: 1},
+                medium: {__text: 1, page: 1},
+                low: {__text: 0, page: 1},
+                log: {__text: 0, page: 1},
+                false_positive: {__text: 0, page: 1},
+              },
+              detail: [{name: 'hostname', value: 'host2.example.com'}],
+            },
+          ],
+          results: {
+            result: [
+              {
+                host: {__text: '192.168.1.1'},
+                severity: {__text: '8.5', _type: 'CVE'},
+              },
+              {
+                host: {__text: '192.168.1.2'},
+                severity: {__text: '5.0', _type: 'CVE'},
+              },
+            ],
+          },
+          hosts: {count: 2},
+          filters: {
+            term: 'first=1 rows=100 sort=severity',
+            filter: {_id: ''},
+            keywords: {
+              keyword: [
+                {column: 'first', relation: '=', value: '1'},
+                {column: 'rows', relation: '=', value: '100'},
+                {column: 'sort', relation: '=', value: 'severity'},
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const fakeHttp = createHttp(response);
+    const cmd = new ReportHostsCommand(fakeHttp);
+    const resp = await cmd.get({report_id: 'r1'});
+
+    expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+      args: {
+        cmd: 'get_report_hosts',
+        details: 1,
+        report_id: 'r1',
+      },
+    });
+
+    const {data} = resp;
+    expect(data).toHaveLength(2);
+    expect(data[0]).toBeDefined();
+    expect(data[1]).toBeDefined();
+  });
+
+  test('should handle single host element', async () => {
+    const response = createResponse({
+      get_report_hosts: {
+        get_report_hosts_response: {
+          host: {
+            _id: 'host-single',
+            ip: '10.0.0.1',
+            hostname: 'single.example.com',
+            start: '2019-06-03T11:00:00Z',
+            end: '2019-06-03T11:15:00Z',
+            result_count: {
+              page: 1,
+              high: {__text: 1, page: 1},
+              medium: {__text: 0, page: 1},
+              low: {__text: 0, page: 1},
+              log: {__text: 0, page: 1},
+              false_positive: {__text: 0, page: 1},
+            },
+            detail: [{name: 'hostname', value: 'single.example.com'}],
+          },
+          results: {
+            result: [
+              {
+                host: {__text: '10.0.0.1'},
+                severity: {__text: '3.0', _type: 'CVE'},
+              },
+            ],
+          },
+          hosts: {count: 1},
+          filters: {
+            term: 'first=1 rows=100',
+            filter: {_id: ''},
+            keywords: {
+              keyword: [
+                {column: 'first', relation: '=', value: '1'},
+                {column: 'rows', relation: '=', value: '100'},
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const fakeHttp = createHttp(response);
+    const cmd = new ReportHostsCommand(fakeHttp);
+    const resp = await cmd.get({report_id: 'r2'});
+
+    const {data} = resp;
+    expect(data).toHaveLength(1);
+  });
+
+  test('should handle empty hosts', async () => {
+    const response = createResponse({
+      get_report_hosts: {
+        get_report_hosts_response: {
+          hosts: {count: 0},
+          results: {},
+          filters: {
+            term: 'first=1 rows=100',
+            filter: {_id: ''},
+            keywords: {
+              keyword: [
+                {column: 'first', relation: '=', value: '1'},
+                {column: 'rows', relation: '=', value: '100'},
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const fakeHttp = createHttp(response);
+    const cmd = new ReportHostsCommand(fakeHttp);
+    const resp = await cmd.get({report_id: 'r3'});
+
+    const {data} = resp;
+    expect(data).toHaveLength(0);
+  });
+
+  test('should throw error for invalid response', async () => {
+    const response = createResponse({});
+
+    const fakeHttp = createHttp(response);
+    const cmd = new ReportHostsCommand(fakeHttp);
+
+    await expect(cmd.get({report_id: 'r4'})).rejects.toThrow(
+      'Invalid response: get_report_hosts not found in response',
+    );
+  });
+
+  test('should pass filter parameter', async () => {
+    const response = createResponse({
+      get_report_hosts: {
+        get_report_hosts_response: {
+          hosts: {count: 0},
+          results: {},
+          filters: {
+            term: 'first=1 rows=100',
+            filter: {_id: ''},
+            keywords: {
+              keyword: [
+                {column: 'first', relation: '=', value: '1'},
+                {column: 'rows', relation: '=', value: '100'},
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const fakeHttp = createHttp(response);
+    const cmd = new ReportHostsCommand(fakeHttp);
+    await cmd.get({report_id: 'r5', filter: 'rows=50 first=1'});
+
+    expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+      args: {
+        cmd: 'get_report_hosts',
+        details: 1,
+        report_id: 'r5',
+        filter: 'rows=50 first=1',
+      },
+    });
+  });
+
+  test('should include filter in meta', async () => {
+    const response = createResponse({
+      get_report_hosts: {
+        get_report_hosts_response: {
+          host: {
+            _id: 'host-meta',
+            ip: '10.0.0.1',
+            hostname: 'meta.example.com',
+            start: '2019-06-03T11:00:00Z',
+            end: '2019-06-03T11:15:00Z',
+            result_count: {
+              page: 1,
+              high: {__text: 0, page: 1},
+              medium: {__text: 0, page: 1},
+              low: {__text: 0, page: 1},
+              log: {__text: 0, page: 1},
+              false_positive: {__text: 0, page: 1},
+            },
+            detail: [{name: 'hostname', value: 'meta.example.com'}],
+          },
+          results: {
+            result: [
+              {
+                host: {__text: '10.0.0.1'},
+                severity: {__text: '2.0', _type: 'CVE'},
+              },
+            ],
+          },
+          hosts: {count: 1},
+          filters: {
+            term: 'rows=50 first=1 sort=ip',
+            filter: {_id: ''},
+            keywords: {
+              keyword: [
+                {column: 'rows', relation: '=', value: '50'},
+                {column: 'first', relation: '=', value: '1'},
+                {column: 'sort', relation: '=', value: 'ip'},
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const fakeHttp = createHttp(response);
+    const cmd = new ReportHostsCommand(fakeHttp);
+    const resp = await cmd.get({report_id: 'r6'});
+
+    const {filter} = resp.meta;
+    expect(filter).toBeDefined();
+  });
+});

--- a/src/gmp/commands/report-hosts.ts
+++ b/src/gmp/commands/report-hosts.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import CollectionCounts from 'gmp/collection/collection-counts';
 import {parseFilter} from 'gmp/collection/parser';
 import type {EntitiesMeta} from 'gmp/commands/entities';
 import HttpCommand, {
@@ -13,17 +14,12 @@ import type Http from 'gmp/http/http';
 import type Response from 'gmp/http/response';
 import type {XmlResponseData} from 'gmp/http/transform/fast-xml';
 import type {FilterModelElement} from 'gmp/models/filter';
-import type ReportHost from 'gmp/models/report/host';
-import {
-  parseHosts,
-  type ReportHostElement,
-  type ReportResultsElement,
-} from 'gmp/models/report/parser';
+import ReportHost from 'gmp/models/report/host';
+import {type ReportHostElement} from 'gmp/models/report/parser';
+import {map} from 'gmp/utils/array';
 
 interface ReportHostsData {
-  hosts?: {count?: number};
   host?: ReportHostElement | ReportHostElement[];
-  results?: ReportResultsElement;
   filters?: FilterModelElement;
   [key: string]: unknown;
 }
@@ -58,9 +54,17 @@ class ReportHostsCommand extends HttpCommand {
 
     const data = root.get_report_hosts.get_report_hosts_response;
     const filter = parseFilter(data);
-    const {entities: hosts, counts} = parseHosts(data, filter);
 
-    return response.set<ReportHost[], EntitiesMeta>(hosts, {
+    const hostsArray = map(data.host, host => ReportHost.fromElement(host));
+
+    const counts = new CollectionCounts({
+      first: 1,
+      filtered: hostsArray.length,
+      length: hostsArray.length,
+      rows: hostsArray.length,
+    });
+
+    return response.set<ReportHost[], EntitiesMeta>(hostsArray, {
       filter,
       counts,
     });

--- a/src/gmp/commands/report-hosts.ts
+++ b/src/gmp/commands/report-hosts.ts
@@ -1,0 +1,70 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {parseFilter} from 'gmp/collection/parser';
+import type {EntitiesMeta} from 'gmp/commands/entities';
+import HttpCommand, {
+  type HttpCommandInputParams,
+  type HttpCommandOptions,
+} from 'gmp/commands/http';
+import type Http from 'gmp/http/http';
+import type Response from 'gmp/http/response';
+import type {XmlResponseData} from 'gmp/http/transform/fast-xml';
+import type {FilterModelElement} from 'gmp/models/filter';
+import type ReportHost from 'gmp/models/report/host';
+import {
+  parseHosts,
+  type ReportHostElement,
+  type ReportResultsElement,
+} from 'gmp/models/report/parser';
+
+interface ReportHostsData {
+  hosts?: {count?: number};
+  host?: ReportHostElement | ReportHostElement[];
+  results?: ReportResultsElement;
+  filters?: FilterModelElement;
+  [key: string]: unknown;
+}
+
+interface ReportHostsResponseData extends XmlResponseData {
+  get_report_hosts?: {
+    get_report_hosts_response: ReportHostsData;
+  };
+}
+
+class ReportHostsCommand extends HttpCommand {
+  constructor(http: Http) {
+    super(http, {cmd: 'get_report_hosts'});
+  }
+
+  async get(
+    params: HttpCommandInputParams = {},
+    options?: HttpCommandOptions,
+  ): Promise<Response<ReportHost[], EntitiesMeta>> {
+    const response = await this.httpGetWithTransform(
+      {details: 1, ...params},
+      options,
+    );
+
+    const root = response.data as ReportHostsResponseData;
+
+    if (!root.get_report_hosts) {
+      throw new Error(
+        'Invalid response: get_report_hosts not found in response',
+      );
+    }
+
+    const data = root.get_report_hosts.get_report_hosts_response;
+    const filter = parseFilter(data);
+    const {entities: hosts, counts} = parseHosts(data, filter);
+
+    return response.set<ReportHost[], EntitiesMeta>(hosts, {
+      filter,
+      counts,
+    });
+  }
+}
+
+export default ReportHostsCommand;

--- a/src/gmp/gmp.ts
+++ b/src/gmp/gmp.ts
@@ -62,6 +62,7 @@ import ReportConfigsCommand from 'gmp/commands/report-configs';
 import ReportsErrorsCommand from 'gmp/commands/report-errors';
 import ReportFormatCommand from 'gmp/commands/report-format';
 import ReportFormatsCommand from 'gmp/commands/report-formats';
+import ReportHostsCommand from 'gmp/commands/report-hosts';
 import ReportOperatingSystemsCommand from 'gmp/commands/report-operating-system';
 import ReportPortsCommand from 'gmp/commands/report-ports';
 import ReportTlsCertificatesCommand from 'gmp/commands/report-tls-certificates';
@@ -151,6 +152,7 @@ class Gmp {
   public readonly reporterrors: ReportsErrorsCommand;
   public readonly reportformat: ReportFormatCommand;
   public readonly reportformats: ReportFormatsCommand;
+  public readonly reporthosts: ReportHostsCommand;
   public readonly reports: ReportsCommand;
   public readonly reportports: ReportPortsCommand;
   public readonly reportoperatingsystems: ReportOperatingSystemsCommand;
@@ -240,6 +242,7 @@ class Gmp {
     this.report = new ReportCommand(this.http);
     this.reportconfig = new ReportConfigCommand(this.http);
     this.reportapplications = new ReportApplicationsCommand(this.http);
+    this.reporthosts = new ReportHostsCommand(this.http);
     this.reportconfigs = new ReportConfigsCommand(this.http);
     this.reporterrors = new ReportsErrorsCommand(this.http);
     this.reportformat = new ReportFormatCommand(this.http);

--- a/src/web/hooks/use-query/report-hosts.ts
+++ b/src/web/hooks/use-query/report-hosts.ts
@@ -1,0 +1,37 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type Filter from 'gmp/models/filter';
+import useGmp from 'web/hooks/useGmp';
+import useGetEntities from 'web/queries/useGetEntities';
+
+interface UseGetReportHostsParams {
+  reportId: string;
+  filter?: Filter;
+  refetchInterval?: number | false;
+}
+
+export const useGetReportHosts = ({
+  reportId,
+  filter = undefined,
+  refetchInterval = undefined,
+}: UseGetReportHostsParams) => {
+  const gmp = useGmp();
+
+  return useGetEntities({
+    gmpMethod: ({filter: reportFilter}) =>
+      gmp.reporthosts.get({
+        report_id: reportId,
+        filter: reportFilter,
+      }),
+    queryId: `get_report_hosts_${reportId}`,
+    filter,
+    refetchInterval,
+    enabled: Boolean(reportId),
+    keepPreviousData: true,
+  });
+};
+
+export default useGetReportHosts;

--- a/src/web/pages/reports/DetailsContent.tsx
+++ b/src/web/pages/reports/DetailsContent.tsx
@@ -211,8 +211,7 @@ const PageContent = ({
 
   const userTagsCount = report?.userTags?.length ?? 0;
 
-  const {closedCves, cves, hosts, results, timestamp, scan_run_status} =
-    report ?? {};
+  const {closedCves, cves, results, timestamp, scan_run_status} = report ?? {};
 
   if (!hasReport && isDefined(reportError)) {
     return (
@@ -318,22 +317,19 @@ const PageContent = ({
     {
       key: 'hosts',
       renderTab: () => <TabTitle counts={hostsCounts} title={_('Hosts')} />,
-      renderPanel: () => (
-        <HostsTabContent
-          hosts={hosts ?? {entities: [], counts: undefined}}
-          isAgentScanning={isAgentScanning}
-          isContainerScanning={isContainerScanning}
-          isUpdating={isUpdating}
-          reportFilter={activeFilter}
-          showInitialLoading={showInitialLoading}
-          showThresholdMessage={showThresholdMessage}
-          sorting={sorting}
-          threshold={threshold}
-          onFilterChanged={onFilterChanged}
-          onFilterEditClick={onFilterEditClick}
-          onSortChange={onSortChange}
-        />
-      ),
+      renderPanel: () =>
+        renderWithThreshold(
+          _('Hosts'),
+          activeFilter,
+          thresholdConfig,
+          <HostsTabContent
+            isAgentScanning={isAgentScanning}
+            isContainerScanning={isContainerScanning}
+            reportFilter={activeFilter}
+            reportId={reportId}
+            status={status}
+          />,
+        ),
     },
     {
       key: 'ports',

--- a/src/web/pages/reports/details/HostsTab.tsx
+++ b/src/web/pages/reports/details/HostsTab.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
- import type CollectionCounts from 'gmp/collection/collection-counts';
+import type CollectionCounts from 'gmp/collection/collection-counts';
 import type Filter from 'gmp/models/filter';
 import type ReportHost from 'gmp/models/report/host';
 import HostsTable from 'web/pages/reports/details/HostsTable';

--- a/src/web/pages/reports/details/HostsTab.tsx
+++ b/src/web/pages/reports/details/HostsTab.tsx
@@ -1,12 +1,13 @@
-/* SPDX-FileCopyrightText: 2024 Greenbone AG
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
+ import type CollectionCounts from 'gmp/collection/collection-counts';
+import type Filter from 'gmp/models/filter';
+import type ReportHost from 'gmp/models/report/host';
 import HostsTable from 'web/pages/reports/details/HostsTable';
 import ReportEntitiesContainer from 'web/pages/reports/details/ReportEntitiesContainer';
-import PropTypes from 'web/utils/PropTypes';
 import {
   makeCompareDate,
   makeCompareIp,
@@ -14,6 +15,17 @@ import {
   makeCompareSeverity,
   makeCompareString,
 } from 'web/utils/Sort';
+
+interface HostsTabProps {
+  audit?: boolean;
+  counts?: CollectionCounts;
+  hosts?: ReportHost[];
+  filter: Filter;
+  isUpdating?: boolean;
+  sortField: string;
+  sortReverse: boolean;
+  onSortChange: (sortField: string) => void;
+}
 
 const hostsSortFunctions = {
   ip: makeCompareIp('ip'),
@@ -52,7 +64,7 @@ const HostsTab = ({
   sortField,
   sortReverse,
   onSortChange,
-}) => (
+}: HostsTabProps) => (
   <ReportEntitiesContainer
     counts={counts}
     entities={hosts}
@@ -73,6 +85,7 @@ const HostsTab = ({
     }) => (
       <HostsTable
         audit={audit}
+        // @ts-expect-error
         entities={entities}
         entitiesCounts={entitiesCounts}
         filter={filter}
@@ -89,16 +102,5 @@ const HostsTab = ({
     )}
   </ReportEntitiesContainer>
 );
-
-HostsTab.propTypes = {
-  audit: PropTypes.bool,
-  counts: PropTypes.object,
-  filter: PropTypes.filter.isRequired,
-  hosts: PropTypes.array,
-  isUpdating: PropTypes.bool,
-  sortField: PropTypes.string.isRequired,
-  sortReverse: PropTypes.bool.isRequired,
-  onSortChange: PropTypes.func.isRequired,
-};
 
 export default HostsTab;

--- a/src/web/pages/reports/details/HostsTabContent.tsx
+++ b/src/web/pages/reports/details/HostsTabContent.tsx
@@ -1,79 +1,80 @@
-/* SPDX-FileCopyrightText: 2025 Greenbone AG
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type CollectionCounts from 'gmp/collection/collection-counts';
+import {useState} from 'react';
 import type Filter from 'gmp/models/filter';
-import type ReportHost from 'gmp/models/report/host';
+import {isActive, type TaskStatus} from 'gmp/models/task';
+import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
+import {
+  NO_RELOAD,
+  USE_DEFAULT_RELOAD_INTERVAL_ACTIVE,
+} from 'web/components/loading/Reload';
+import useGetReportHosts from 'web/hooks/use-query/report-hosts';
 import useTranslation from 'web/hooks/useTranslation';
 import AgentScanningHostsTab from 'web/pages/reports/details/AgentScanningHostsTab';
 import ContainerScanningHostsTab from 'web/pages/reports/details/ContainerScanningHostsTab';
 import HostsTab from 'web/pages/reports/details/HostsTab';
-import ThresholdPanel from 'web/pages/reports/details/ThresholdPanel';
 
-interface HostsData {
-  counts?: CollectionCounts;
-  entities?: ReportHost[];
-}
-
-interface SortingData {
-  hosts: {
-    sortField: string;
-    sortReverse: boolean;
-  };
-}
-
-interface HostsTabContentProps {
+export interface HostsTabContentProps {
   audit?: boolean;
-  hosts: HostsData;
+  reportId: string;
+  status: TaskStatus;
   isAgentScanning?: boolean;
   isContainerScanning: boolean;
   reportFilter: Filter;
-  isUpdating: boolean;
-  showInitialLoading: boolean;
-  showThresholdMessage: boolean;
-  sorting: SortingData;
-  threshold: number;
-  onFilterChanged: (filter: Filter) => void;
-  onFilterEditClick: () => void;
-  onSortChange: (type: string, sortField: string) => void;
 }
 
 const HostsTabContent = ({
   audit = false,
-  hosts,
+  reportId,
+  status,
   isAgentScanning,
   isContainerScanning,
   reportFilter,
-  isUpdating,
-  showInitialLoading,
-  showThresholdMessage,
-  sorting,
-  threshold,
-  onFilterChanged,
-  onFilterEditClick,
-  onSortChange,
 }: HostsTabContentProps) => {
   const [_] = useTranslation();
+  const [{sortField, sortReverse}, setSorting] = useState({
+    sortField: 'severity',
+    sortReverse: true,
+  });
 
-  if (showInitialLoading) {
+  const {data, isLoading, isFetching, isError, error} = useGetReportHosts({
+    reportId,
+    filter: reportFilter,
+    refetchInterval: isActive(status)
+      ? USE_DEFAULT_RELOAD_INTERVAL_ACTIVE
+      : NO_RELOAD,
+  });
+
+  const handleSortChange = (newSortField: string) => {
+    setSorting(prev => ({
+      sortField: newSortField,
+      sortReverse: newSortField === prev.sortField ? !prev.sortReverse : false,
+    }));
+  };
+
+  if (isLoading && !data) {
     return <Loading />;
   }
 
-  if (showThresholdMessage) {
+  if (isError) {
     return (
-      <ThresholdPanel
-        entityType={_('Hosts')}
-        filter={reportFilter}
-        isUpdating={isUpdating}
-        threshold={threshold}
-        onFilterChanged={onFilterChanged}
-        onFilterEditClick={onFilterEditClick}
+      <ErrorPanel
+        error={error}
+        message={_('Error while loading Hosts for Report {{reportId}}', {
+          reportId,
+        })}
       />
     );
   }
+
+  const hosts = {
+    counts: data?.entitiesCounts,
+    entities: data?.entities ?? [],
+  };
 
   if (isAgentScanning) {
     return (
@@ -82,10 +83,10 @@ const HostsTabContent = ({
         counts={hosts.counts}
         filter={reportFilter}
         hosts={hosts.entities}
-        isUpdating={isUpdating}
-        sortField={sorting.hosts.sortField}
-        sortReverse={sorting.hosts.sortReverse}
-        onSortChange={(sortField: string) => onSortChange('hosts', sortField)}
+        isUpdating={isFetching}
+        sortField={sortField}
+        sortReverse={sortReverse}
+        onSortChange={handleSortChange}
       />
     );
   }
@@ -97,10 +98,10 @@ const HostsTabContent = ({
         counts={hosts.counts}
         filter={reportFilter}
         hosts={hosts.entities}
-        isUpdating={isUpdating}
-        sortField={sorting.hosts.sortField}
-        sortReverse={sorting.hosts.sortReverse}
-        onSortChange={(sortField: string) => onSortChange('hosts', sortField)}
+        isUpdating={isFetching}
+        sortField={sortField}
+        sortReverse={sortReverse}
+        onSortChange={handleSortChange}
       />
     );
   }
@@ -111,10 +112,10 @@ const HostsTabContent = ({
       counts={hosts.counts}
       filter={reportFilter}
       hosts={hosts.entities}
-      isUpdating={isUpdating}
-      sortField={sorting.hosts.sortField}
-      sortReverse={sorting.hosts.sortReverse}
-      onSortChange={(sortField: string) => onSortChange('hosts', sortField)}
+      isUpdating={isFetching}
+      sortField={sortField}
+      sortReverse={sortReverse}
+      onSortChange={handleSortChange}
     />
   );
 };

--- a/src/web/pages/reports/details/__tests__/HostsTabContent.test.tsx
+++ b/src/web/pages/reports/details/__tests__/HostsTabContent.test.tsx
@@ -1,205 +1,196 @@
-/* SPDX-FileCopyrightText: 2025 Greenbone AG
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 import {describe, test, expect, testing} from '@gsa/testing';
-import {screen, rendererWith} from 'web/testing';
+import {screen, rendererWith, within} from 'web/testing';
+import CollectionCounts from 'gmp/collection/collection-counts';
 import Filter from 'gmp/models/filter';
 import {createSession} from 'gmp/testing';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
 import {getMockReport} from 'web/pages/reports/__fixtures__/MockReport';
-import HostsTabContent from 'web/pages/reports/details/HostsTabContent';
+import HostsTabContent, {
+  type HostsTabContentProps,
+} from 'web/pages/reports/details/HostsTabContent';
 
-const createMockProps = (overrides = {}) => {
-  const {hosts} = getMockReport();
-  if (!hosts?.entities) {
-    throw new Error('Mock report did not return hosts or hosts.entities');
-  }
-  const filter = Filter.fromString(
-    'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
-  );
+const filter = Filter.fromString(
+  'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
+);
 
-  return {
-    hosts: {
-      counts: hosts.counts,
-      entities: hosts.entities,
+const reportId = 'report-123';
+
+const {hosts: mockReportHosts} = getMockReport();
+const mockHosts = mockReportHosts?.entities ?? [];
+const mockHostsCounts =
+  mockReportHosts?.counts ??
+  new CollectionCounts({filtered: 0, all: 0, first: 1, rows: 2});
+
+const createGmp = ({
+  getReportHosts = testing.fn().mockResolvedValue({
+    data: mockHosts,
+    meta: {
+      filter,
+      counts: mockHostsCounts,
     },
-    isContainerScanning: false,
-    reportFilter: filter,
-    isUpdating: false,
-    showInitialLoading: false,
-    showThresholdMessage: false,
-    sorting: {
-      hosts: {
-        sortField: 'severity',
-        sortReverse: true,
-      },
-    },
-    threshold: 1000,
-    onFilterChanged: testing.fn(),
-    onFilterEditClick: testing.fn(),
-    onSortChange: testing.fn(),
-    ...overrides,
-  };
-};
-
-const createGmp = ({severityRating = SEVERITY_RATING_CVSS_3} = {}) => ({
+  }),
+  severityRating = SEVERITY_RATING_CVSS_3,
+} = {}) => ({
+  reporthosts: {
+    get: getReportHosts,
+  },
   settings: {
     severityRating,
+    reloadInterval: 5000,
+    reloadIntervalActive: 2000,
+    reloadIntervalInactive: 10000,
   },
   session: createSession({
     timezone: 'CET',
+    token: 'test-token',
+    username: 'admin',
   }),
 });
 
+const createMockProps = (
+  overrides: Partial<HostsTabContentProps> = {},
+): HostsTabContentProps => ({
+  reportId,
+  status: 'Done',
+  isContainerScanning: false,
+  reportFilter: filter,
+  ...overrides,
+});
+
 describe('HostsTabContent', () => {
-  test('should render Loading component when showInitialLoading is true', () => {
-    const props = createMockProps({
-      showInitialLoading: true,
-    });
-    const {render} = rendererWith({
-      gmp: createGmp(),
-      capabilities: true,
-      router: true,
-    });
-
-    render(<HostsTabContent {...props} />);
-
-    expect(screen.getByTestId('loading')).toBeInTheDocument();
-  });
-
-  test('should render ThresholdPanel when showThresholdMessage is true', () => {
-    const props = createMockProps({
-      showThresholdMessage: true,
-    });
-    const {render} = rendererWith({
-      gmp: createGmp(),
-      capabilities: true,
-      router: true,
-    });
-
-    render(<HostsTabContent {...props} />);
-
-    expect(
-      screen.getByText(/cannot be displayed.*performance.*threshold of 1000/i),
-    ).toBeInTheDocument();
-    expect(screen.getAllByTestId('filter-icon')).toHaveLength(2);
-  });
-
-  test('should render ContainerScanningHostsTab when isContainerScanning is true', () => {
+  test('should render ContainerScanningHostsTab when isContainerScanning is true', async () => {
+    const gmp = createGmp();
     const props = createMockProps({
       isContainerScanning: true,
     });
     const {render} = rendererWith({
-      gmp: createGmp(),
+      gmp,
       capabilities: true,
       router: true,
     });
 
     render(<HostsTabContent {...props} />);
 
-    // Check for container scanning specific elements
-    const table = screen.getByRole('table');
+    const table = await screen.findByRole('table');
     expect(table).toBeInTheDocument();
-
-    // Check for pagination (which confirms ContainerScanningHostsTab is rendered)
     expect(screen.getAllByText('1 - 2 of 2')).toHaveLength(2);
   });
 
-  test('should render HostsTab when isContainerScanning is false', () => {
+  test('should render HostsTab when isContainerScanning is false', async () => {
+    const gmp = createGmp();
     const props = createMockProps({
       isContainerScanning: false,
     });
     const {render} = rendererWith({
-      gmp: createGmp(),
+      gmp,
       capabilities: true,
       router: true,
     });
 
     render(<HostsTabContent {...props} />);
 
-    // Check for regular hosts tab elements
-    const table = screen.getByRole('table');
+    const table = await screen.findByRole('table');
     expect(table).toBeInTheDocument();
-    // Check that we have the standard hosts table
     expect(screen.getByText(/123\.456\.78\.910/)).toBeInTheDocument();
   });
 
-  test('should pass correct props to ContainerScanningHostsTab', () => {
-    const mockOnSortChange = testing.fn();
+  test('should pass correct props to ContainerScanningHostsTab', async () => {
+    const gmp = createGmp();
     const props = createMockProps({
       isContainerScanning: true,
-      onSortChange: mockOnSortChange,
     });
     const {render} = rendererWith({
-      gmp: createGmp(),
+      gmp,
       capabilities: true,
       router: true,
     });
 
     render(<HostsTabContent {...props} />);
 
-    // Verify the component is rendered with expected data
-    expect(screen.getByRole('table')).toBeInTheDocument();
+    await screen.findByRole('table');
     expect(screen.getAllByTestId('progressbar-box')).toHaveLength(2);
   });
 
-  test('should pass correct props to HostsTab', () => {
-    const mockOnSortChange = testing.fn();
+  test('should pass correct props to HostsTab', async () => {
+    const gmp = createGmp();
     const props = createMockProps({
       isContainerScanning: false,
-      onSortChange: mockOnSortChange,
     });
     const {render} = rendererWith({
-      gmp: createGmp(),
+      gmp,
       capabilities: true,
       router: true,
     });
 
     render(<HostsTabContent {...props} />);
 
-    // Verify the component is rendered with expected data
-    expect(screen.getByRole('table')).toBeInTheDocument();
+    await screen.findByRole('table');
   });
 
-  test('should prioritize showInitialLoading over other conditions', () => {
-    const props = createMockProps({
-      showInitialLoading: true,
-      showThresholdMessage: true,
-      isContainerScanning: true,
-    });
-    const {render} = rendererWith({
-      capabilities: true,
-      router: true,
-      gmp: createGmp(),
-    });
+  // Hook-based assertions
+  test('should show Loading spinner while hook is fetching', () => {
+    const gmp = createGmp();
+    const props = createMockProps();
+    const {render} = rendererWith({gmp, capabilities: true, router: true});
 
     render(<HostsTabContent {...props} />);
 
     expect(screen.getByTestId('loading')).toBeInTheDocument();
-    expect(screen.queryByText(/threshold/i)).not.toBeInTheDocument();
-    expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 
-  test('should prioritize showThresholdMessage over tab rendering', () => {
-    const props = createMockProps({
-      showInitialLoading: false,
-      showThresholdMessage: true,
-      isContainerScanning: true,
+  test('should render ErrorPanel on fetch failure', async () => {
+    const gmp = createGmp({
+      getReportHosts: testing
+        .fn()
+        .mockRejectedValue(new Error('Failed to fetch hosts')),
     });
-    const {render} = rendererWith({
-      gmp: createGmp(),
-      capabilities: true,
-      router: true,
-    });
+    const props = createMockProps();
+    const {render} = rendererWith({gmp, capabilities: true, router: true});
 
     render(<HostsTabContent {...props} />);
 
     expect(
-      screen.getByText(/cannot be displayed.*performance.*threshold of 1000/i),
+      await screen.findByText(/Error while loading Hosts for Report/),
     ).toBeInTheDocument();
-    expect(screen.getAllByTestId('filter-icon')).toHaveLength(2);
-    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  test('should call API with reportId and filter', async () => {
+    const getReportHosts = testing.fn().mockResolvedValue({
+      data: mockHosts,
+      meta: {filter, counts: mockHostsCounts},
+    });
+    const gmp = createGmp({getReportHosts});
+    const props = createMockProps();
+    const {render} = rendererWith({gmp, capabilities: true, router: true});
+
+    render(<HostsTabContent {...props} />);
+
+    await screen.findByRole('table');
+
+    expect(getReportHosts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        report_id: reportId,
+        filter: expect.objectContaining({}),
+      }),
+    );
+  });
+
+  test('should render table with host rows once data resolves', async () => {
+    const gmp = createGmp();
+    const props = createMockProps();
+    const {render} = rendererWith({gmp, capabilities: true, router: true});
+
+    render(<HostsTabContent {...props} />);
+
+    const table = await screen.findByRole('table');
+    expect(table).toBeInTheDocument();
+
+    const rows = within(table).getAllByRole('row');
+    expect(rows.length).toBeGreaterThan(1);
   });
 });


### PR DESCRIPTION
## What

- Use new gmp command `get_report_hosts`
- Refactor report details hosts files to Typescript.

## Why

<!-- Describe why are these changes necessary? -->

## References

GEA-1730

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


