### PR TITLE
fix: filter agents by selected agent controller

### DIFF
--- a/src/web/hooks/use-query/agents.ts
+++ b/src/web/hooks/use-query/agents.ts
@@ -44,11 +44,15 @@ export const useGetAgents = ({
 
   if (isDefined(scannerId)) {
     finalFilter = finalFilter ?? new Filter();
-    finalFilter = finalFilter.set('scanner', scannerId);
+    finalFilter = finalFilter.and(
+      Filter.fromString(`scanner_uuid=${scannerId}`),
+    );
   }
   if (isDefined(authorized)) {
     finalFilter = finalFilter ?? new Filter();
-    finalFilter = finalFilter.set('authorized', parseYesNo(authorized));
+    finalFilter = finalFilter.and(
+      Filter.fromString(`authorized=${parseYesNo(authorized)}`),
+    );
   }
 
   const gmp = useGmp();

--- a/src/web/pages/agent-groups/AgentGroupsDialog.tsx
+++ b/src/web/pages/agent-groups/AgentGroupsDialog.tsx
@@ -78,7 +78,8 @@ const AgentGroupsDialog = ({
 
   const allAgentsFilter = Filter.fromString('first=1 rows=-1');
   const {data: agentsData, isLoading: isLoadingAgents} = useGetAgents({
-    filter: selectedAgentController ? allAgentsFilter : undefined,
+    filter: allAgentsFilter,
+    scannerId: selectedAgentController,
     enabled: Boolean(selectedAgentController),
     authorized: true,
   });


### PR DESCRIPTION
## What

* Fixed the agent filter logic.
* Filter agents by the selected agent controller.

## Why

* The dialog should show only agents from the selected controller.
* Existing filters should not be replaced.


## References

GEA-1800


