### PR TITLE
change: new scanner agent controller port disabled

### DIFF
--- a/src/web/pages/scanners/ScannerDialog.tsx
+++ b/src/web/pages/scanners/ScannerDialog.tsx
@@ -243,6 +243,8 @@ const ScannerDialog = ({
     scannerType === AGENT_CONTROLLER_SENSOR_SCANNER_TYPE;
   const showScannerDetails = isDefined(scannerType);
   const showPort = showScannerDetails && !isGreenboneSensorType;
+  const isPortDisabled =
+    scannerInUse || scannerType === AGENT_CONTROLLER_SCANNER_TYPE;
   const showCredentialField =
     !isGreenboneSensorType &&
     !isAgentControllerSensorScannerType &&
@@ -313,7 +315,7 @@ const ScannerDialog = ({
 
             {showPort && (
               <NumberField
-                disabled={scannerInUse}
+                disabled={isPortDisabled}
                 name="port"
                 placeholder={_('Insert a Port number')}
                 title={_('Port')}

--- a/src/web/pages/scanners/__tests__/ScannerDialog.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerDialog.test.tsx
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {describe, test, expect, testing} from '@gsa/testing';
+import {describe, expect, test, testing} from '@gsa/testing';
 import {
   changeInputValue,
-  screen,
-  rendererWith,
   fireEvent,
   getSelectItemElementsForSelect,
+  rendererWith,
+  screen,
   wait,
 } from 'web/testing';
 import Features from 'gmp/capabilities/features';
@@ -378,7 +378,7 @@ describe('ScannerDialog tests', () => {
         id="1234"
         name="john"
         port={22}
-        type={AGENT_CONTROLLER_SCANNER_TYPE}
+        type={OPENVAS_SCANNER_TYPE}
         onClose={handleClose}
         onCredentialChange={handleCredentialChange}
         onSave={handleSave}
@@ -402,7 +402,7 @@ describe('ScannerDialog tests', () => {
     const scannerType = screen.getByRole<HTMLSelectElement>('textbox', {
       name: 'Scanner Type',
     });
-    expect(scannerType).toHaveValue('Agent Controller');
+    expect(scannerType).toHaveValue('OpenVAS Scanner');
     const scannerTypeItems = await getSelectItemElementsForSelect(scannerType);
     fireEvent.click(scannerTypeItems[2]); // select Agent Sensor
     expect(scannerType).toHaveValue('Agent Sensor');
@@ -508,6 +508,21 @@ describe('ScannerDialog tests', () => {
     fireEvent.click(closeButton);
     expect(handleClose).toHaveBeenCalled();
     expect(handleSave).not.toHaveBeenCalled();
+  });
+
+  test('should disable port field for agent controller type because it always defaults to 8080', async () => {
+    const gmp = createGmp();
+    const {render} = rendererWith({
+      gmp,
+      capabilities: true,
+      features: new Features(['ENABLE_AGENTS']),
+    });
+
+    render(<ScannerDialog type={AGENT_CONTROLLER_SCANNER_TYPE} />);
+
+    const portInput = screen.getByName('port');
+    expect(portInput).toBeDisabled();
+    expect(portInput).toHaveValue('8080');
   });
 
   test('should not render agent controller in scanner selection if feature is disabled', async () => {


### PR DESCRIPTION
## What

- In the dialog for new scanner when selected type scanner is agent controller, port field is disabled because it's always 8080.

## Why

<!-- Describe why are these changes necessary? -->

## References

GEA-1815

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


