### PR TITLE
fix(gmp): register VulnerabilitiesCommand to resolve gmp.vulns

### DIFF
--- a/src/gmp/gmp.ts
+++ b/src/gmp/gmp.ts
@@ -14,6 +14,7 @@ import 'gmp/commands/scan-configs';
 import 'gmp/commands/schedules';
 import 'gmp/commands/tickets';
 import 'gmp/commands/tls-certificates';
+import 'gmp/commands/vulns';
 
 import {getCommands} from 'gmp/command';
 import AgentCommand from 'gmp/commands/agent';


### PR DESCRIPTION
## What

Adds a missing side-effect import for gmp/commands/vulns in src/gmp/gmp.ts, fixing a crash that made the /vulnerabilities page completely unusable.
The fix was verified by navigating to /vulnerabilities before and after the change. 
Before: a React error boundary triggered with EntitiesContainer: gmp.vulns is not defined. 
After: the page loads correctly, showing the vulnerability list and dashboard charts.

## Why

EntitiesContainer resolves the GMP command to use by calling pluralizeType(gmpName) on the entity type passed to withEntitiesContainer. 

For 'vulnerability' this returns 'vulns', and it then accesses gmp['vulns'] at runtime.

gmp['vulns'] is populated lazily by _initCommands(), which iterates over commands registered via registerCommand(). 

VulnerabilityCommand and VulnerabilitiesCommand call registerCommand('vuln', ...) and registerCommand('vulns', ...) at module load time — but only if the module is imported.

src/gmp/gmp.ts imports 11 other self-registering command modules as side effects (notes, hosts, schedules, tickets, etc.) but gmp/commands/vulns was never included, so gmp.vulns was always undefined and the page always crashed.

## References

https://forum.greenbone.net/t/gmp-vulns-is-not-defined/22350

## Checklist

<!-- Remove this section if not applicable to your changes -->

- Tests - existing tests in src/gmp/models/__tests__/vulnerability.test.ts and src/web/store/entities/__tests__/vulns.test.js cover the model and store layers. No new test is required for this change: the fix is a missing module import.


