### PR TITLE
Fix getting the timezone for the override details

### DIFF
--- a/src/web/pages/notes/DetailsPage.jsx
+++ b/src/web/pages/notes/DetailsPage.jsx
@@ -44,7 +44,7 @@ import {renderYesNo} from 'web/utils/Render';
 import {formattedUserSettingLongDate} from 'web/utils/user-setting-time-date-formatters';
 
 const Details = ({entity, ...props}) => {
-  const timezone = useUserTimezone();
+  const [timezone] = useUserTimezone();
   const [_] = useTranslation();
   const {nvt} = entity;
   return (

--- a/src/web/pages/overrides/DetailsPage.jsx
+++ b/src/web/pages/overrides/DetailsPage.jsx
@@ -48,7 +48,7 @@ import {formattedUserSettingLongDate} from 'web/utils/user-setting-time-date-for
 
 const Details = ({entity, ...props}) => {
   const [_] = useTranslation();
-  const timezone = useUserTimezone();
+  const [timezone] = useUserTimezone();
   const {nvt} = entity;
   return (
     <Layout flex="column">


### PR DESCRIPTION




## What

Fix getting the timezone for the override details

## Why

Fix an issue introduced during timezone refactoring. `useUserTimezone` returns a tuple with the current applied timezone and a function for changing the timezone.

## References
Closes #5336
https://jira.greenbone.net/browse/GEA-1837