### PR TITLE
Update error parameter type of task details page render props onError

### DIFF
--- a/src/web/pages/tasks/TaskDetailsPage.tsx
+++ b/src/web/pages/tasks/TaskDetailsPage.tsx
@@ -83,7 +83,7 @@ interface TaskDetailsPageProps {
   isLoading?: boolean;
   onChanged?: () => void;
   onDownloaded?: OnDownloadedFunc;
-  onError?: (error: unknown) => void;
+  onError?: (error: Error) => void;
 }
 
 const Details = ({entity, links}: DetailsProps) => {


### PR DESCRIPTION


## What

Update error parameter type of task details page render props onError

## Why

All our error callbacks get an Error instance as parameter nowadays.