### PR TITLE
Add a test for using a Radio with boolean values

### DIFF
--- a/src/web/components/form/__tests__/Radio.test.tsx
+++ b/src/web/components/form/__tests__/Radio.test.tsx
@@ -5,6 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {render, fireEvent, screen} from 'web/testing';
+import {parseBoolean} from 'gmp/parser';
 import Radio from 'web/components/form/Radio';
 
 describe('Radio tests', () => {
@@ -125,5 +126,39 @@ describe('Radio tests', () => {
     fireEvent.click(element);
 
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('should call change handler with booleans', () => {
+    const onChange = testing.fn();
+
+    const {rerender} = render(
+      <Radio
+        convert={parseBoolean}
+        data-testid="input"
+        value={true}
+        onChange={onChange}
+      />,
+    );
+
+    const element = screen.getByTestId('input');
+
+    fireEvent.click(element);
+
+    expect(onChange).toHaveBeenCalledWith(true, undefined);
+
+    onChange.mockClear();
+
+    rerender(
+      <Radio
+        convert={parseBoolean}
+        data-testid="input"
+        value={false}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(element);
+
+    expect(onChange).toHaveBeenCalledWith(false, undefined);
   });
 });


### PR DESCRIPTION


## What

Add a test for using a Radio with boolean values

## Why

Ensure the component works as expected when being used with boolean values. Actually it requires a convert function because boolean values of true/false will be string values "true"/"false" on the callback handler otherwise.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


