### PR TITLE
Fix getting the existing tags when creating a new tag

### DIFF
--- a/src/web/entities/EntitiesContainer.tsx
+++ b/src/web/entities/EntitiesContainer.tsx
@@ -21,9 +21,9 @@ import type Tag from 'gmp/models/tag';
 import {map} from 'gmp/utils/array';
 import {
   getEntityType,
-  apiType,
   pluralizeType,
   type EntityType,
+  resourceType,
 } from 'gmp/utils/entity-type';
 import {isDefined} from 'gmp/utils/identity';
 import {
@@ -502,7 +502,7 @@ class EntitiesContainer<TModel extends Model> extends React.Component<
   }
 
   openTagsDialog() {
-    this.getTagsByType();
+    void this.getTagsByType();
     this.setState({
       tagsDialogVisible: true,
       multiTagEntitiesCount: this.getMultiTagEntitiesCount(),
@@ -517,16 +517,15 @@ class EntitiesContainer<TModel extends Model> extends React.Component<
     this.closeTagsDialog();
   }
 
-  getTagsByType() {
+  async getTagsByType() {
     const {gmp} = this.props;
     const {entities} = this.state as {entities: TModel[]};
 
     if (entities.length > 0) {
-      const filter = 'resource_type=' + apiType(getEntityType(entities[0]));
-      void gmp.tags.getAll({filter}).then(response => {
-        const {data: tags} = response;
-        this.setState({tags});
-      });
+      const filter = `resource_type=${resourceType(getEntityType(entities[0]))}`;
+      const response = await gmp.tags.getAll({filter});
+      const {data: tags} = response;
+      this.setState({tags});
     }
   }
 

--- a/src/web/entities/__tests__/EntitiesContainer.test.tsx
+++ b/src/web/entities/__tests__/EntitiesContainer.test.tsx
@@ -54,22 +54,37 @@ const setup = gmp => {
       updateFilter={updateFilter}
       onDownload={onDownload}
     >
-      {({onDownloadBulk}) => (
-        <button data-testid="button" onClick={() => onDownloadBulk()}>
-          Download Bulk
-        </button>
+      {({onDownloadBulk, onTagsBulk}) => (
+        <>
+          <button
+            data-testid="download-button"
+            onClick={() => onDownloadBulk()}
+          >
+            Download Bulk
+          </button>
+          <button data-testid="tags-button" onClick={() => onTagsBulk()}>
+            Open Tags
+          </button>
+        </>
       )}
     </EntitiesContainer>,
   );
-  return screen.getByRole('button', {name: /Download Bulk/i});
+  return {
+    downloadButton: screen.getByRole('button', {name: /Download Bulk/i}),
+    tagsButton: screen.getByRole('button', {name: /Open Tags/i}),
+  };
 };
 
 const createGmp = ({
   exportByFilter = testing.fn().mockResolvedValue({data: {id: '123'}}),
   currentSettings = testing.fn().mockResolvedValue(currentSettingsResponse),
+  getAllTags = testing.fn().mockResolvedValue({data: []}),
 } = {}) => ({
   portlists: {
     exportByFilter,
+  },
+  tags: {
+    getAll: getAllTags,
   },
   user: {currentSettings},
   session: createSession(),
@@ -78,7 +93,7 @@ const createGmp = ({
 describe('EntitiesContainer', () => {
   test('should allow downloading entities in bulk', async () => {
     const gmp = createGmp();
-    const downloadButton = setup(gmp);
+    const {downloadButton} = setup(gmp);
     await userEvent.click(downloadButton);
 
     await waitFor(() => expect(screen.getByText('Bulk download started.')));
@@ -97,7 +112,7 @@ describe('EntitiesContainer', () => {
     const originalConsoleError = console.error;
     console.error = testing.fn();
 
-    const downloadButton = setup(gmp);
+    const {downloadButton} = setup(gmp);
     fireEvent.click(downloadButton);
 
     await wait();
@@ -106,5 +121,25 @@ describe('EntitiesContainer', () => {
     expect(onDownloaded).not.toHaveBeenCalled();
 
     console.error = originalConsoleError;
+  });
+
+  test('should open tags dialog when onTagsBulk is triggered', async () => {
+    const getAllTags = testing.fn().mockResolvedValue({data: []});
+    const gmp = createGmp({getAllTags});
+    const {tagsButton} = setup(gmp);
+
+    await userEvent.click(tagsButton);
+
+    await waitFor(() => {
+      expect(getAllTags).toHaveBeenCalledWith({
+        filter: 'resource_type=port_list',
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getDialogTitle()).toHaveTextContent(
+        'Add Tag to Page Contents',
+      );
+    });
   });
 });


### PR DESCRIPTION

## What

Fix getting the existing tags when creating a new tag

## Why

When opening the create tag dialog for multiple entities from the button of the list page tables the list of existing tags was not loaded correctly. For loading the corresponding list of tags to the current entity type of the page it is required to use the resource type and not the api type. API type converts for example host to asset.


## References

https://jira.greenbone.net/browse/GEA-1690

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


