### PR TITLE
Fix extracting the en translation

### DIFF
--- a/i18next.config.ts
+++ b/i18next.config.ts
@@ -19,8 +19,8 @@ export default defineConfig({
     disablePlurals: true,
     generateBasePluralForms: false,
     removeUnusedKeys: true,
-    defaultValue: (locale, namespace, key, defaultValue) =>
-      locale === 'en' ? key : '',
+    defaultValue: (key, namespace, locale, defaultValue) =>
+      locale && locale.includes('en') ? key : '',
     functions: ['_', '_l'],
     useTranslationNames: ['useTranslation'],
   },


### PR DESCRIPTION

## What

Fix extracting the en translation

## Why

It seems the order of the arguments of the defaultValue function in the i18next config has changed and locale and key got interchanged. The en translation should always add the key also as the value.



