### PR TITLE
Change wording of search bar placeholder in scan config edit dialog

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -1849,7 +1849,7 @@
   "SCP to {{- url}}": "SCP nach {{- url}}",
   "Search": "Suche",
   "Search by content": "Suche nach Inhalt",
-  "Search for families, preferences, or NVTs": "Suche nach Familien, Vorgaben oder NVTs",
+  "Search for NVT families, Scanner preferences, or NVT preferences": "Suche nach NVT-Familien, Scanner-Vorgaben oder NVT-Vorgaben",
   "SecInfo": "Sicherheitsinfos",
   "SecInfo Displays": "SecInfo-Anzeigen",
   "Secret Key": "Geheimer Schlüssel",

--- a/public/locales/gsa-en.json
+++ b/public/locales/gsa-en.json
@@ -1849,7 +1849,7 @@
   "SCP to {{- url}}": "SCP to {{- url}}",
   "Search": "Search",
   "Search by content": "Search by content",
-  "Search for families, preferences, or NVTs": "Search for families, preferences, or NVTs",
+  "Search for NVT families, Scanner preferences, or NVT preferences": "Search for NVT families, Scanner preferences, or NVT preferences",
   "SecInfo": "SecInfo",
   "SecInfo Displays": "SecInfo Displays",
   "Secret Key": "Secret Key",

--- a/public/locales/gsa-zh_CN.json
+++ b/public/locales/gsa-zh_CN.json
@@ -1849,7 +1849,7 @@
   "SCP to {{- url}}": "SCP to {{- url}}",
   "Search": "搜索",
   "Search by content": "搜索内容",
-  "Search for families, preferences, or NVTs": "搜索系列、首选项或NVTs",
+  "Search for NVT families, Scanner preferences, or NVT preferences": "",
   "SecInfo": "安全信息",
   "SecInfo Displays": "安全信息图表",
   "Secret Key": "安全密钥",

--- a/public/locales/gsa-zh_TW.json
+++ b/public/locales/gsa-zh_TW.json
@@ -1849,7 +1849,7 @@
   "SCP to {{- url}}": "",
   "Search": "",
   "Search by content": "",
-  "Search for families, preferences, or NVTs": "",
+  "Search for NVT families, Scanner preferences, or NVT preferences": "",
   "SecInfo": "安全資訊",
   "SecInfo Displays": "",
   "Secret Key": "",

--- a/src/web/pages/scanconfigs/ScanConfigEditDialog.tsx
+++ b/src/web/pages/scanconfigs/ScanConfigEditDialog.tsx
@@ -367,7 +367,9 @@ const ScanConfigEditDialog = ({
 
           <SearchBar
             matchesCount={matchesCount}
-            placeholder={_('Search for families, preferences, or NVTs')}
+            placeholder={_(
+              'Search for NVT families, Scanner preferences, or NVT preferences',
+            )}
             onSearch={handleSearchChangeCallback}
           />
           {configIsInUse ? (

--- a/src/web/pages/scanconfigs/__tests__/ScanConfigEditDialog.test.tsx
+++ b/src/web/pages/scanconfigs/__tests__/ScanConfigEditDialog.test.tsx
@@ -560,7 +560,7 @@ describe('ScanConfigEditDialog tests', () => {
     );
 
     const searchBar = screen.getByPlaceholderText(
-      'Search for families, preferences, or NVTs',
+      'Search for NVT families, Scanner preferences, or NVT preferences',
     );
     fireEvent.change(searchBar, {target: {value: 'family4'}});
 
@@ -649,7 +649,7 @@ describe('ScanConfigEditDialog tests', () => {
       );
 
       const searchBar = screen.getByPlaceholderText(
-        'Search for families, preferences, or NVTs',
+        'Search for NVT families, Scanner preferences, or NVT preferences',
       );
 
       fireEvent.change(searchBar, {target: {value: 'family1'}});


### PR DESCRIPTION


## What

Change wording of search bar placeholder in scan config edit dialog

## Why

The placeholder text was misleading. It doesn't search for NVTs instead it searches only for NVT preferences.

## References

https://jira.greenbone.net/browse/GEA-1873
## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


