### PR TITLE
Fix displaying errors when importing of a report fails

### DIFF
--- a/src/gmp/commands/report.ts
+++ b/src/gmp/commands/report.ts
@@ -16,7 +16,7 @@ import {isDefined} from 'gmp/utils/identity';
 interface ReportCommandImportParams {
   task_id: string;
   in_assets?: YesNo;
-  xml_file?: string;
+  xml_file?: File;
 }
 
 interface ReportCommandAssetsParams {

--- a/src/web/pages/reports/ReportImportDialog.tsx
+++ b/src/web/pages/reports/ReportImportDialog.tsx
@@ -71,6 +71,7 @@ const ReportImportDialog = ({
           </FormGroup>
           <FormGroup direction="row" title={_('Import Task')}>
             <Select
+              disabled={tasks.length <= 1}
               grow="1"
               items={renderSelectItems(tasks as RenderSelectItemProps[])}
               name="task_id"

--- a/src/web/pages/reports/ReportListPage.tsx
+++ b/src/web/pages/reports/ReportListPage.tsx
@@ -129,7 +129,7 @@ const ReportListPage = ({
   const handleImportReport = (data: ReportImportDialogData) => {
     return gmp.report
       .import(data)
-      .then(onChanged, onError)
+      .then(onChanged)
       .then(() => closeImportDialog());
   };
 

--- a/src/web/pages/reports/ReportListPage.tsx
+++ b/src/web/pages/reports/ReportListPage.tsx
@@ -31,7 +31,9 @@ import ReportsDashboard, {
   REPORTS_DASHBOARD_ID,
 } from 'web/pages/reports/dashboard';
 import ReportFilterDialog from 'web/pages/reports/ReportFilterDialog';
-import ReportImportDialog from 'web/pages/reports/ReportImportDialog';
+import ReportImportDialog, {
+  type ReportImportDialogData,
+} from 'web/pages/reports/ReportImportDialog';
 import ReportsTable from 'web/pages/reports/ReportTable';
 import ImportTaskDialog from 'web/pages/tasks/ImportTaskDialog';
 import {
@@ -124,7 +126,7 @@ const ReportListPage = ({
     closeImportDialog();
   };
 
-  const handleImportReport = data => {
+  const handleImportReport = (data: ReportImportDialogData) => {
     return gmp.report
       .import(data)
       .then(onChanged, onError)

--- a/src/web/pages/reports/__tests__/ReportImportDialog.test.tsx
+++ b/src/web/pages/reports/__tests__/ReportImportDialog.test.tsx
@@ -30,8 +30,42 @@ describe('ReportImportDialog tests', () => {
     expect(screen.getByText('Import Report')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Import'})).toBeInTheDocument();
     expect(screen.getByName('task_id')).toHaveValue('1');
+    expect(screen.getByName('task_id')).toBeEnabled();
     expect(screen.getByTestId('new-import-task')).toBeInTheDocument();
     expect(screen.getByName('in_assets')).toBeChecked();
+  });
+
+  test('should disable task selection if there are no tasks', async () => {
+    const onSave = testing.fn();
+    const onClose = testing.fn();
+
+    render(
+      <ReportImportDialog
+        task_id=""
+        tasks={[]}
+        onClose={onClose}
+        onSave={onSave}
+      />,
+    );
+
+    expect(screen.getByName('task_id')).toBeDisabled();
+  });
+
+  test('should disable task selection if there is only one task', async () => {
+    const tasks = [new Task({id: '1', name: 'Task 1'})];
+    const onSave = testing.fn();
+    const onClose = testing.fn();
+
+    render(
+      <ReportImportDialog
+        task_id="1"
+        tasks={tasks}
+        onClose={onClose}
+        onSave={onSave}
+      />,
+    );
+
+    expect(screen.getByName('task_id')).toBeDisabled();
   });
 
   test('should call onSave', async () => {

--- a/src/web/pages/tasks/TaskComponent.tsx
+++ b/src/web/pages/tasks/TaskComponent.tsx
@@ -940,13 +940,10 @@ const TaskComponent = ({
   };
 
   const handleReportImport = (data: ReportImportDialogData) => {
-    return (
-      gmp.report
-        // @ts-expect-error
-        .import(data)
-        .then(onReportImported, onReportImportError)
-        .then(() => closeReportImportDialog())
-    );
+    return gmp.report
+      .import(data)
+      .then(onReportImported, onReportImportError)
+      .then(() => closeReportImportDialog());
   };
 
   const handleScanConfigChange = (configId?: string) => {


### PR DESCRIPTION
## What

Fix displaying errors when importing of a report fails

## Why

Don't use the onError handler and let the dialog handle the error cases
instead to show possible errors of the request in the dialog.

## References
https://jira.greenbone.net/browse/GEA-1751


