### PR TITLE
Remove onReportImportError handler from TaskComponent

### DIFF
--- a/src/web/pages/tasks/TaskComponent.tsx
+++ b/src/web/pages/tasks/TaskComponent.tsx
@@ -135,7 +135,6 @@ interface TaskComponentProps {
   onModifyTaskWizardError?: (error: Error) => void;
   onModifyTaskWizardSaved?: () => void;
   onReportImported?: () => void;
-  onReportImportError?: (error: Error) => void;
   onResumed?: (response: Response<Task, XmlMeta>) => void;
   onResumeError?: (error: Error) => void;
   onSaved?: () => void;
@@ -169,7 +168,6 @@ const TaskComponent = ({
   onModifyTaskWizardError,
   onModifyTaskWizardSaved,
   onReportImported,
-  onReportImportError,
   onResumed,
   onResumeError,
   onSaved,
@@ -939,11 +937,10 @@ const TaskComponent = ({
     setReportImportDialogVisible(false);
   };
 
-  const handleReportImport = (data: ReportImportDialogData) => {
-    return gmp.report
-      .import(data)
-      .then(onReportImported, onReportImportError)
-      .then(() => closeReportImportDialog());
+  const handleReportImport = async (data: ReportImportDialogData) => {
+    await gmp.report.import(data);
+    onReportImported?.();
+    closeReportImportDialog();
   };
 
   const handleScanConfigChange = (configId?: string) => {


### PR DESCRIPTION


## What

Remove onReportImportError handler from TaskComponent

## Why
Setting the onReportImportError handler may result in an unexpected behavior of the ReportImportDialog because it would close despite of an error occurred and maybe no error is displayed. Therefore it is better to always let the dialog handle and display the error by removing the callback prop completely.

