### PR TITLE
Add scan config family MS Office LCSs as whole only

### DIFF
--- a/src/gmp/models/__tests__/scan-config.test.ts
+++ b/src/gmp/models/__tests__/scan-config.test.ts
@@ -7,6 +7,7 @@ import {describe, test, expect} from '@gsa/testing';
 import ScanConfig, {
   filterEmptyScanConfig,
   SCANCONFIG_TREND_DYNAMIC,
+  WHOLE_SELECTION_FAMILIES,
 } from 'gmp/models/scan-config';
 import {testModel} from 'gmp/models/testing';
 
@@ -207,6 +208,13 @@ describe('ScanConfig model tests', () => {
 
     expect(scanConfig.deprecated).toEqual(false);
     expect(scanConfig2.deprecated).toEqual(true);
+  });
+});
+
+describe('Whole Selection Family tests', () => {
+  test('should have whole selection families', () => {
+    // ensure that the whole selection families list is not empty and has the expected length
+    expect(WHOLE_SELECTION_FAMILIES.length).toEqual(25);
   });
 });
 

--- a/src/gmp/models/scan-config.ts
+++ b/src/gmp/models/scan-config.ts
@@ -114,6 +114,7 @@ export const WHOLE_SELECTION_FAMILIES = [
   'Huawei EulerOS Local Security Checks',
   'Mageia Linux Local Security Checks',
   'Mandrake Local Security Checks',
+  'Microsoft Office Local Security Checks',
   'openEuler Local Security Checks',
   'openSUSE Local Security Checks',
   'Oracle Linux Local Security Checks',


### PR DESCRIPTION


## What

Add scan config family MS Office LSCs as whole only

## Why

Only allow the scan config family `Microsoft Office Local Security Checks` as whole. It will not be possible single NVTs of this family anymore.

## References

https://jira.greenbone.net/browse/GEA-1576

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


