### PR TITLE
Immutable Filter Class

### DIFF
--- a/src/gmp/commands/agents.ts
+++ b/src/gmp/commands/agents.ts
@@ -109,8 +109,8 @@ class AgentsCommand extends EntitiesCommand<Agent> {
 
   getSeverityAggregates({filter}: {filter?: Filter} = {}) {
     const combinedFilter = filter
-      ? filter.copy().and(AGENT_CONTROLLER_FILTER)
-      : AGENT_CONTROLLER_FILTER.copy();
+      ? filter.and(AGENT_CONTROLLER_FILTER)
+      : AGENT_CONTROLLER_FILTER;
 
     return this.getAggregates({
       aggregate_type: 'task',

--- a/src/gmp/models/__tests__/filter.test.ts
+++ b/src/gmp/models/__tests__/filter.test.ts
@@ -12,13 +12,14 @@ describe('Filter parse filter terms from string', () => {
   test('should parse terms from string', () => {
     const filter = Filter.fromString('foo=bar lorem~ipsum');
     expect(filter.toFilterString()).toEqual('foo=bar lorem~ipsum');
-    expect(filter.terms.length).toBe(2);
-    expect(filter.terms[0]).toEqual({
+    expect(filter.length).toBe(2);
+    const terms = filter.getAllTerms();
+    expect(terms[0]).toEqual({
       keyword: 'foo',
       relation: '=',
       value: 'bar',
     });
-    expect(filter.terms[1]).toEqual({
+    expect(terms[1]).toEqual({
       keyword: 'lorem',
       relation: '~',
       value: 'ipsum',
@@ -29,18 +30,19 @@ describe('Filter parse filter terms from string', () => {
     // should parse filter strings with and
     let filter = Filter.fromString('foo=bar and lorem~ipsum');
     expect(filter.toFilterString()).toEqual('foo=bar and lorem~ipsum');
-    expect(filter.terms.length).toBe(3);
-    expect(filter.terms[0]).toEqual({
+    expect(filter.length).toBe(3);
+    let terms = filter.getAllTerms();
+    expect(terms[0]).toEqual({
       keyword: 'foo',
       relation: '=',
       value: 'bar',
     });
-    expect(filter.terms[1]).toEqual({
+    expect(terms[1]).toEqual({
       keyword: undefined,
       relation: undefined,
       value: 'and',
     });
-    expect(filter.terms[2]).toEqual({
+    expect(terms[2]).toEqual({
       keyword: 'lorem',
       relation: '~',
       value: 'ipsum',
@@ -49,18 +51,19 @@ describe('Filter parse filter terms from string', () => {
     // should parse filter strings with or
     filter = Filter.fromString('foo=bar or lorem~ipsum');
     expect(filter.toFilterString()).toEqual('foo=bar or lorem~ipsum');
-    expect(filter.terms.length).toBe(3);
-    expect(filter.terms[0]).toEqual({
+    expect(filter.length).toBe(3);
+    terms = filter.getAllTerms();
+    expect(terms[0]).toEqual({
       keyword: 'foo',
       relation: '=',
       value: 'bar',
     });
-    expect(filter.terms[1]).toEqual({
+    expect(terms[1]).toEqual({
       keyword: undefined,
       relation: undefined,
       value: 'or',
     });
-    expect(filter.terms[2]).toEqual({
+    expect(terms[2]).toEqual({
       keyword: 'lorem',
       relation: '~',
       value: 'ipsum',
@@ -69,13 +72,14 @@ describe('Filter parse filter terms from string', () => {
     // should parse filter strings with not
     filter = Filter.fromString('not foo=bar');
     expect(filter.toFilterString()).toEqual('not foo=bar');
-    expect(filter.terms.length).toBe(2);
-    expect(filter.terms[0]).toEqual({
+    expect(filter.length).toBe(2);
+    terms = filter.getAllTerms();
+    expect(terms[0]).toEqual({
       keyword: undefined,
       relation: undefined,
       value: 'not',
     });
-    expect(filter.terms[1]).toEqual({
+    expect(terms[1]).toEqual({
       keyword: 'foo',
       relation: '=',
       value: 'bar',
@@ -87,14 +91,15 @@ describe('Filter parse filter terms from string', () => {
     expect(filter.toFilterString()).toEqual(
       'name="foo bar" comment~"lorem ipsum"',
     );
-    expect(filter.terms.length).toBe(2);
-    expect(filter.terms[0]).toEqual({
+    expect(filter.length).toBe(2);
+    const terms = filter.getAllTerms();
+    expect(terms[0]).toEqual({
       keyword: 'name',
       relation: '=',
       value: '"foo bar"',
     });
-    expect(filter.terms.length).toBe(2);
-    expect(filter.terms[1]).toEqual({
+    expect(terms.length).toBe(2);
+    expect(terms[1]).toEqual({
       keyword: 'comment',
       relation: '~',
       value: '"lorem ipsum"',
@@ -104,14 +109,15 @@ describe('Filter parse filter terms from string', () => {
   test('should parse strings with double quotes and without columns', () => {
     const filter = Filter.fromString('="foo bar" ~"lorem ipsum"');
     expect(filter.toFilterString()).toEqual('="foo bar" ~"lorem ipsum"');
-    expect(filter.terms.length).toBe(2);
-    expect(filter.terms[0]).toEqual({
+    expect(filter.length).toBe(2);
+    const terms = filter.getAllTerms();
+    expect(terms[0]).toEqual({
       keyword: undefined,
       relation: '=',
       value: '"foo bar"',
     });
-    expect(filter.terms.length).toBe(2);
-    expect(filter.terms[1]).toEqual({
+    expect(terms.length).toBe(2);
+    expect(terms[1]).toEqual({
       keyword: undefined,
       relation: '~',
       value: '"lorem ipsum"',
@@ -125,23 +131,24 @@ describe('Filter parse filter terms from string', () => {
     expect(filter.toFilterString()).toEqual(
       'name="foo <= bar" ~"foo & bar" and comment="hello : world ?"',
     );
-    expect(filter.terms.length).toBe(4);
-    expect(filter.terms[0]).toEqual({
+    expect(filter.length).toBe(4);
+    const terms = filter.getAllTerms();
+    expect(terms[0]).toEqual({
       keyword: 'name',
       relation: '=',
       value: '"foo <= bar"',
     });
-    expect(filter.terms[1]).toEqual({
+    expect(terms[1]).toEqual({
       keyword: undefined,
       relation: '~',
       value: '"foo & bar"',
     });
-    expect(filter.terms[2]).toEqual({
+    expect(terms[2]).toEqual({
       keyword: undefined,
       relation: undefined,
       value: 'and',
     });
-    expect(filter.terms[3]).toEqual({
+    expect(terms[3]).toEqual({
       keyword: 'comment',
       relation: '=',
       value: '"hello : world ?"',

--- a/src/gmp/models/__tests__/filter.test.ts
+++ b/src/gmp/models/__tests__/filter.test.ts
@@ -420,66 +420,74 @@ describe('Filter set', () => {
     expect(filter.set('abc', '1', '=').toFilterString()).toEqual('abc=1');
   });
 
+  test('should not mutate the filter when setting a filter term', () => {
+    const filter = new Filter();
+    const newFilter = filter.set('abc', '1', '=');
+    expect(filter).not.toBe(newFilter);
+    expect(filter.toFilterString()).toEqual('');
+    expect(newFilter.toFilterString()).toEqual('abc=1');
+  });
+
   test('should allow to change a filter term', () => {
     const filter = Filter.fromString('abc=1');
-    expect(filter.set('abc', '2', '=').toFilterString()).toEqual('abc=2');
+    const newFilter = filter.set('abc', '2', '=');
+    expect(newFilter.toFilterString()).toEqual('abc=2');
   });
 
   test('should remove sort-reverse when adding sort filter term', () => {
     const filter = new Filter();
 
-    filter.set('sort-reverse', 'foo', '=');
-    expect(filter.has('sort-reverse')).toEqual(true);
-    expect(filter.has('sort')).toEqual(false);
+    let newFilter = filter.set('sort-reverse', 'foo', '=');
+    expect(newFilter.has('sort-reverse')).toEqual(true);
+    expect(newFilter.has('sort')).toEqual(false);
 
-    filter.set('sort', 'foo', '=');
-    expect(filter.has('sort-reverse')).toEqual(false);
-    expect(filter.has('sort')).toEqual(true);
+    newFilter = filter.set('sort', 'foo', '=');
+    expect(newFilter.has('sort-reverse')).toEqual(false);
+    expect(newFilter.has('sort')).toEqual(true);
   });
 
   test('should remove sort when adding sort-reverse filter term', () => {
     const filter = new Filter();
 
-    filter.set('sort', 'foo', '=');
-    expect(filter.has('sort')).toEqual(true);
-    expect(filter.has('sort-reverse')).toEqual(false);
+    let newFilter = filter.set('sort', 'foo', '=');
+    expect(newFilter.has('sort')).toEqual(true);
+    expect(newFilter.has('sort-reverse')).toEqual(false);
 
-    filter.set('sort-reverse', 'foo', '=');
-    expect(filter.has('sort')).toEqual(false);
-    expect(filter.has('sort-reverse')).toEqual(true);
+    newFilter = filter.set('sort-reverse', 'foo', '=');
+    expect(newFilter.has('sort')).toEqual(false);
+    expect(newFilter.has('sort-reverse')).toEqual(true);
   });
 
   test('should allow to set first keyword', () => {
     const filter = new Filter();
-    filter.set('first', 123);
-    expect(filter.get('first')).toEqual(123);
+    let newFilter = filter.set('first', 123);
+    expect(newFilter.get('first')).toEqual(123);
 
-    filter.set('first', '0');
-    expect(filter.get('first')).toEqual(1);
+    newFilter = filter.set('first', '0');
+    expect(newFilter.get('first')).toEqual(1);
 
-    filter.set('first', '-666');
-    expect(filter.get('first')).toEqual(1);
+    newFilter = filter.set('first', '-666');
+    expect(newFilter.get('first')).toEqual(1);
   });
 
   test('should allow to set name keyword', () => {
     const filter = new Filter();
-    filter.set('name', 'Test Task');
-    expect(filter.get('name')).toEqual('Test Task');
+    let newFilter = filter.set('name', 'Test Task');
+    expect(newFilter.get('name')).toEqual('Test Task');
 
-    filter.set('name', '');
-    expect(filter.get('name')).toBeUndefined();
+    newFilter = filter.set('name', '');
+    expect(newFilter.get('name')).toBeUndefined();
 
-    filter.set('name', 123);
-    expect(filter.get('name')).toEqual('123');
+    newFilter = filter.set('name', 123);
+    expect(newFilter.get('name')).toEqual('123');
   });
 
   test('should reset filter id', () => {
     const filter = new Filter({id: 'foo'});
-
     expect(filter.id).toEqual('foo');
 
-    filter.set('first', '0');
-    expect(filter.id).toBeUndefined();
+    const newFilter = filter.set('first', '0');
+    expect(newFilter.id).toBeUndefined();
   });
 
   test('should allow to set a filter term with underscore', () => {
@@ -519,6 +527,23 @@ describe('Filter delete', () => {
     expect(filter.delete('abc').toFilterString()).toEqual('def=1');
   });
 
+  test('should not mutate filter when deleting a term', () => {
+    const filter = Filter.fromString('abc=1 def=1');
+    const newFilter = filter.delete('abc');
+
+    expect(newFilter).not.toBe(filter);
+    expect(filter.toFilterString()).toEqual('abc=1 def=1');
+    expect(newFilter.toFilterString()).toEqual('def=1');
+  });
+
+  test("should not create new filter if filter term doesn't exist", () => {
+    const filter = Filter.fromString('abc=1 def=1');
+    const newFilter = filter.delete('xyz');
+
+    expect(newFilter).toBe(filter);
+    expect(filter.toFilterString()).toEqual('abc=1 def=1');
+  });
+
   test('should ignore unknown filter term to delete', () => {
     const filter = Filter.fromString('abc=1');
     expect(filter.delete('def').toFilterString()).toEqual('abc=1');
@@ -534,9 +559,10 @@ describe('Filter delete', () => {
     const filter = Filter.fromString('abc=1');
     // @ts-expect-error
     filter.id = 'foo';
-    filter.delete('abc');
+    const newFilter = filter.delete('abc');
 
-    expect(filter.id).toBeUndefined();
+    expect(filter.id).toEqual('foo');
+    expect(newFilter.id).toBeUndefined();
   });
 });
 
@@ -820,6 +846,8 @@ describe('Filter copy', () => {
     expect(filter1).not.toBe(filter2);
     expect(filter2.get('abc')).toBe('1');
     expect(filter2.get('def')).toBe('2');
+    expect(filter1.toFilterString()).toBe('abc=1 def=2');
+    expect(filter2.toFilterString()).toBe('abc=1 def=2');
   });
 
   test('should copy public properties', () => {
@@ -834,19 +862,6 @@ describe('Filter copy', () => {
     expect(filter2.id).toBe('100');
     expect(filter2.filter_type).toBe('foo');
   });
-
-  test('should shallow copy terms', () => {
-    const filter1 = Filter.fromString('abc=1 def=2');
-    const filter2 = filter1.copy();
-
-    expect(filter1).not.toBe(filter2);
-    expect(filter1.equals(filter2)).toBe(true);
-
-    filter2.set('foo', 'bar', '=');
-    expect(filter1.equals(filter2)).toBe(false);
-    expect(filter1.toFilterString()).toBe('abc=1 def=2');
-    expect(filter2.toFilterString()).toBe('abc=1 def=2 foo=bar');
-  });
 });
 
 describe('Filter next', () => {
@@ -860,6 +875,17 @@ describe('Filter next', () => {
 
     expect(filter.get('first')).toEqual(1);
     expect(filter.get('rows')).toEqual(10);
+  });
+
+  test('should not mutate original filter when calling next', () => {
+    let filter = Filter.fromString('first=1 rows=10');
+    const copy = filter.next();
+
+    expect(filter).not.toBe(copy);
+    expect(filter.get('first')).toBe(1);
+    expect(filter.get('rows')).toBe(10);
+    expect(copy.get('first')).toBe(11);
+    expect(copy.get('rows')).toBe(10);
   });
 
   test('should change first and rows', () => {
@@ -896,6 +922,15 @@ describe('Filter first', () => {
     expect(filter.get('first')).toEqual(1);
   });
 
+  test('should not mutate original filter when calling first', () => {
+    let filter = Filter.fromString('first=99');
+    const copy = filter.first();
+
+    expect(filter).not.toBe(copy);
+    expect(filter.get('first')).toBe(99);
+    expect(copy.get('first')).toBe(1);
+  });
+
   test('should change first to 1', () => {
     let filter = Filter.fromString('first=99');
     expect(filter.get('first')).toBe(99);
@@ -928,6 +963,17 @@ describe('Filter previous', () => {
 
     expect(filter.get('first')).toEqual(1);
     expect(filter.get('rows')).toEqual(10);
+  });
+
+  test('should not mutate original filter when calling previous', () => {
+    let filter = Filter.fromString('first=11 rows=10');
+    const copy = filter.previous();
+
+    expect(filter).not.toBe(copy);
+    expect(filter.get('first')).toBe(11);
+    expect(filter.get('rows')).toBe(10);
+    expect(copy.get('first')).toBe(1);
+    expect(copy.get('rows')).toBe(10);
   });
 
   test('should change first and rows', () => {
@@ -990,27 +1036,40 @@ describe('Filter getSortBy', () => {
 describe('Filter setSortOrder', () => {
   test('should keep sort by if order changes to sort', () => {
     const filter = Filter.fromString('sort-reverse=foo');
-    filter.setSortOrder('sort');
+    const newFilter = filter.setSortOrder('sort');
 
-    expect(filter.has('sort-reverse')).toEqual(false);
-    expect(filter.get('sort')).toEqual('foo');
+    expect(newFilter.has('sort-reverse')).toEqual(false);
+    expect(newFilter.get('sort')).toEqual('foo');
+  });
+
+  test('should not mutate the filter when changing sort order', () => {
+    const filter = Filter.fromString('sort-reverse=foo');
+    const newFilter = filter.setSortOrder('sort');
+
+    expect(filter).not.toBe(newFilter);
+
+    expect(filter.has('sort-reverse')).toEqual(true);
+    expect(filter.has('sort')).toEqual(false);
+
+    expect(newFilter.has('sort-reverse')).toEqual(false);
+    expect(newFilter.has('sort')).toEqual(true);
   });
 
   test('should keep sort by if order changes to sort-reverse', () => {
     const filter = Filter.fromString('sort=foo');
-    filter.setSortOrder('sort-reverse');
+    const newFilter = filter.setSortOrder('sort-reverse');
 
-    expect(filter.has('sort')).toEqual(false);
-    expect(filter.get('sort-reverse')).toEqual('foo');
+    expect(newFilter.has('sort')).toEqual(false);
+    expect(newFilter.get('sort-reverse')).toEqual('foo');
   });
 
   test('should set sort for unknown orders', () => {
     const filter = Filter.fromString('sort-reverse=foo');
     // @ts-expect-error
-    filter.setSortOrder('foo');
+    const newFilter = filter.setSortOrder('foo');
 
-    expect(filter.has('sort-reverse')).toEqual(false);
-    expect(filter.get('sort')).toEqual('foo');
+    expect(newFilter.has('sort-reverse')).toEqual(false);
+    expect(newFilter.get('sort')).toEqual('foo');
   });
 
   test('should reset filter id', () => {
@@ -1020,35 +1079,46 @@ describe('Filter setSortOrder', () => {
 
     expect(filter.id).toEqual('foo');
 
-    filter.setSortOrder('sort');
-    expect(filter.id).toBeUndefined();
+    const newFilter = filter.setSortOrder('sort');
+    expect(newFilter.id).toBeUndefined();
   });
 });
 
 describe('Filter setSortBy', () => {
   test('should set sort if not order is set', () => {
     const filter = Filter.fromString('');
-    filter.setSortBy('foo');
+    const newFilter = filter.setSortBy('foo');
 
-    expect(filter.get('sort')).toEqual('foo');
+    expect(newFilter.get('sort')).toEqual('foo');
+  });
+
+  test('should not mutate the filter when changing sort by if order is not set', () => {
+    const filter = Filter.fromString('');
+    const newFilter = filter.setSortBy('foo');
+
+    expect(filter).not.toBe(newFilter);
+
+    expect(filter.has('sort')).toEqual(false);
+    expect(filter.has('sort-reverse')).toEqual(false);
+
+    expect(newFilter.has('sort')).toEqual(true);
+    expect(newFilter.get('sort')).toEqual('foo');
   });
 
   test('should change sort by if order is sort', () => {
     const filter = Filter.fromString('sort=bar');
     expect(filter.get('sort')).toEqual('bar');
 
-    filter.setSortBy('foo');
-
-    expect(filter.get('sort')).toEqual('foo');
+    const newFilter = filter.setSortBy('foo');
+    expect(newFilter.get('sort')).toEqual('foo');
   });
 
   test('should change sort by if order is sort-reverse', () => {
     const filter = Filter.fromString('sort-reverse=bar');
     expect(filter.get('sort-reverse')).toEqual('bar');
 
-    filter.setSortBy('foo');
-
-    expect(filter.get('sort-reverse')).toEqual('foo');
+    const newFilter = filter.setSortBy('foo');
+    expect(newFilter.get('sort-reverse')).toEqual('foo');
   });
 
   test('should reset filter id', () => {
@@ -1057,9 +1127,8 @@ describe('Filter setSortBy', () => {
     filter.id = 'foo';
 
     expect(filter.id).toEqual('foo');
-
-    filter.setSortBy('foo');
-    expect(filter.id).toBeUndefined();
+    const newFilter = filter.setSortBy('foo');
+    expect(newFilter.id).toBeUndefined();
   });
 });
 
@@ -1070,6 +1139,20 @@ describe('Filter simple', () => {
 
     expect(filter).not.toBe(simple);
     expect(filter.equals(simple)).toBe(true);
+  });
+
+  test('should not mutate original filter when calling simple', () => {
+    const filter = Filter.fromString('first=1 rows=10 sort=foo foo=bar');
+    const simple = filter.simple();
+
+    expect(filter).not.toBe(simple);
+    expect(filter.has('first')).toEqual(true);
+    expect(filter.has('rows')).toEqual(true);
+    expect(filter.has('sort')).toEqual(true);
+
+    expect(simple.has('first')).toEqual(false);
+    expect(simple.has('rows')).toEqual(false);
+    expect(simple.has('sort')).toEqual(false);
   });
 
   test('should remove first, rows and sort terms', () => {
@@ -1117,9 +1200,7 @@ describe('Filter merge extra keywords', () => {
     filter1.id = 'f1';
     const filter2 = filter1.mergeExtraKeywords();
 
-    expect(filter1).not.toBe(filter2);
-    expect(filter2.get('abc')).toEqual('1');
-    expect(filter2.id).toBeUndefined();
+    expect(filter1).toBe(filter2);
   });
 
   test('should merge extra keywords', () => {
@@ -1243,12 +1324,29 @@ describe('Filter merge extra keywords', () => {
 describe('filter and', () => {
   test('should ignore undefined', () => {
     const filter = Filter.fromString('foo=1');
-    expect(filter.and(undefined).toFilterString()).toEqual('foo=1');
+    const newFilter = filter.and(undefined);
+    expect(newFilter).toBe(filter);
+    expect(newFilter.toFilterString()).toEqual('foo=1');
   });
 
   test('should ignore null', () => {
     const filter = Filter.fromString('foo=1');
-    expect(filter.and(null).toFilterString()).toEqual('foo=1');
+    const newFilter = filter.and(null);
+    expect(newFilter).toBe(filter);
+    expect(newFilter.toFilterString()).toEqual('foo=1');
+  });
+
+  test("should not mutate filter when concatenating with 'and'", () => {
+    const filter1 = Filter.fromString('foo=1');
+    const filter2 = Filter.fromString('bar=2');
+    const filter3 = filter1.and(filter2);
+
+    expect(filter1).not.toBe(filter2);
+    expect(filter3).not.toBe(filter1);
+    expect(filter3).not.toBe(filter2);
+    expect(filter1.toFilterString()).toBe('foo=1');
+    expect(filter2.toFilterString()).toBe('bar=2');
+    expect(filter3.toFilterString()).toBe('foo=1 and bar=2');
   });
 
   test('filters should be concatenated with and', () => {
@@ -1455,12 +1553,16 @@ describe('Filter merge', () => {
     expect(filter2.get('foo')).toEqual('bar');
   });
 
-  test('should merge filter', () => {
+  test('should not mutate filter while merging', () => {
     const filter1 = Filter.fromString('foo=bar');
     const filter2 = Filter.fromString('rows=10 first=1');
     const filter3 = filter1.merge(filter2);
 
-    expect(filter1).toBe(filter3);
+    expect(filter1).not.toBe(filter2);
+    expect(filter3).not.toBe(filter1);
+    expect(filter3).not.toBe(filter2);
+    expect(filter1.toFilterString()).toEqual('foo=bar');
+    expect(filter2.toFilterString()).toEqual('rows=10 first=1');
     expect(filter3.toFilterString()).toEqual('foo=bar rows=10 first=1');
   });
 });

--- a/src/gmp/models/__tests__/filter.test.ts
+++ b/src/gmp/models/__tests__/filter.test.ts
@@ -1210,6 +1210,18 @@ describe('Filter merge extra keywords', () => {
     expect(filter1).toBe(filter2);
   });
 
+  test('should return a new filter', () => {
+    const filter1 = Filter.fromString('abc=1');
+    const filter2 = Filter.fromString('rows=1');
+
+    const filter3 = filter1.mergeExtraKeywords(filter2);
+
+    expect(filter1).not.toBe(filter3);
+    expect(filter2).not.toBe(filter3);
+    expect(filter3.get('abc')).toBe('1');
+    expect(filter3.get('rows')).toBe(1);
+  });
+
   test('should merge extra keywords', () => {
     const filter1 = Filter.fromString('abc=1');
     const filter2 = Filter.fromString(
@@ -1234,19 +1246,6 @@ describe('Filter merge extra keywords', () => {
     expect(filter3.get('timezone')).toBe('CET');
   });
 
-  test('should merge new keywords', () => {
-    const filter1 = Filter.fromString('abc=1 trend=more');
-    const filter2 = Filter.fromString('delta_states=1 severity>3 sort=name');
-
-    const filter3 = filter2.mergeKeywords(filter1);
-
-    expect(filter3.get('abc')).toBe('1');
-    expect(filter3.get('delta_states')).toBe('1');
-    expect(filter3.get('sort')).toBe('name');
-    expect(filter3.get('severity')).toBe('3');
-    expect(filter3.get('trend')).toBe('more');
-  });
-
   test('should not merge non extra keywords', () => {
     const filter1 = Filter.fromString('abc=1');
     const filter2 = Filter.fromString('apply_overrides=1 def=1');
@@ -1256,6 +1255,15 @@ describe('Filter merge extra keywords', () => {
     expect(filter3.get('abc')).toBe('1');
     expect(filter3.get('apply_overrides')).toBe(1);
     expect(filter3.get('def')).toBeUndefined();
+  });
+
+  test('should return same filter if no extra keywords to merge', () => {
+    const filter1 = Filter.fromString('abc=1');
+    const filter2 = Filter.fromString('def=1');
+
+    const filter3 = filter1.mergeExtraKeywords(filter2);
+
+    expect(filter3).toBe(filter1);
   });
 
   test('should not merge existing extra keywords', () => {
@@ -1328,7 +1336,126 @@ describe('Filter merge extra keywords', () => {
   });
 });
 
-describe('filter and', () => {
+describe('Filter mergeKeywords', () => {
+  test('should merge keywords', () => {
+    const filter1 = Filter.fromString('abc=1 trend=more');
+    const filter2 = Filter.fromString('delta_states=1 severity>3 sort=name');
+
+    const filter3 = filter2.mergeKeywords(filter1);
+
+    expect(filter3.get('abc')).toBe('1');
+    expect(filter3.get('delta_states')).toBe('1');
+    expect(filter3.get('sort')).toBe('name');
+    expect(filter3.get('severity')).toBe('3');
+    expect(filter3.get('trend')).toBe('more');
+  });
+
+  test('should return new filter', () => {
+    const filter1 = Filter.fromString('abc=1');
+    const filter2 = Filter.fromString('def=1');
+
+    const filter3 = filter2.mergeKeywords(filter1);
+
+    expect(filter3).not.toBe(filter1);
+    expect(filter3).not.toBe(filter2);
+
+    expect(filter3.get('abc')).toBe('1');
+    expect(filter3.get('def')).toBe('1');
+  });
+
+  test('should return same filter if no keywords to merge', () => {
+    const filter1 = Filter.fromString('abc=1');
+    const filter2 = Filter.fromString('abc=1');
+
+    expect(filter1).not.toBe(filter2);
+
+    const filter3 = filter1.mergeKeywords(filter2);
+
+    expect(filter3).toBe(filter1);
+  });
+
+  test('should return same filter if no filter to merge', () => {
+    const filter1 = Filter.fromString('abc=1');
+    const filter2 = filter1.mergeKeywords();
+
+    expect(filter2).toBe(filter1);
+  });
+
+  test('should reset filter id', () => {
+    const filter1 = Filter.fromString('abc=1');
+    // @ts-expect-error
+    filter1.id = 'f1';
+    const filter2 = Filter.fromString('def=1');
+    // @ts-expect-error
+    filter2.id = 'f2';
+
+    const filter3 = filter2.mergeKeywords(filter1);
+    expect(filter3.id).toBeUndefined();
+  });
+});
+
+describe('Filter merge', () => {
+  test('should merge undefined', () => {
+    const filter1 = Filter.fromString('foo=bar');
+    const filter2 = filter1.merge(undefined);
+
+    expect(filter1).toBe(filter2);
+    expect(filter2.get('foo')).toEqual('bar');
+  });
+
+  test('should not mutate filter while merging', () => {
+    const filter1 = Filter.fromString('foo=bar');
+    const filter2 = Filter.fromString('rows=10 first=1');
+
+    expect(filter1).not.toBe(filter2);
+
+    const filter3 = filter1.merge(filter2);
+
+    expect(filter3).not.toBe(filter1);
+    expect(filter3).not.toBe(filter2);
+    expect(filter1.toFilterString()).toEqual('foo=bar');
+    expect(filter2.toFilterString()).toEqual('rows=10 first=1');
+    expect(filter3.toFilterString()).toEqual('foo=bar rows=10 first=1');
+  });
+
+  test('should return same filter when merging an empty filter', () => {
+    const filter1 = Filter.fromString('foo=bar');
+    const emptyFilter = new Filter();
+    const merged = filter1.merge(emptyFilter);
+
+    expect(merged).toBe(filter1);
+    expect(merged.toFilterString()).toEqual('foo=bar');
+    expect(filter1.toFilterString()).toEqual('foo=bar');
+    expect(emptyFilter.toFilterString()).toEqual('');
+  });
+
+  test('should keep duplicate keywords and preserve term order while merging', () => {
+    const filter1 = Filter.fromString('foo=bar');
+    const filter2 = Filter.fromString('foo=baz rows=10');
+    const merged = filter1.merge(filter2);
+
+    expect(merged.toFilterString()).toEqual('foo=bar foo=baz rows=10');
+    expect(merged.getTerms('foo')).toHaveLength(2);
+  });
+
+  test('should merge operator terms as-is', () => {
+    const filter1 = Filter.fromString('name~ssh');
+    const filter2 = Filter.fromString('and severity>7');
+    const merged = filter1.merge(filter2);
+
+    expect(merged.toFilterString()).toEqual('name~ssh and severity>7');
+  });
+
+  test('should merge duplicate terms', () => {
+    const filter1 = Filter.fromString('foo=bar');
+    const filter2 = Filter.fromString('foo=bar');
+    const merged = filter1.merge(filter2);
+
+    expect(merged.toFilterString()).toEqual('foo=bar foo=bar');
+  });
+});
+
+describe('Filter and', () => {
   test('should ignore undefined', () => {
     const filter = Filter.fromString('foo=1');
     const newFilter = filter.and(undefined);
@@ -1389,7 +1516,7 @@ describe('filter and', () => {
   });
 });
 
-describe('filter hasTerm', () => {
+describe('Filter hasTerm', () => {
   test('filter should include terms', () => {
     const filter = Filter.fromString('apply_overrides=1 min_qod=70 severity>0');
 
@@ -1540,37 +1667,6 @@ describe('should lower the case of capitalized keywords', () => {
   test('just a value', () => {
     const filter2 = Filter.fromString('~AbC');
     expect(filter2.toFilterString()).toEqual('~AbC');
-  });
-});
-
-describe('Filter merge', () => {
-  test('should merge undefined', () => {
-    const filter1 = Filter.fromString('foo=bar');
-    const filter2 = filter1.merge(undefined);
-
-    expect(filter1).toBe(filter2);
-    expect(filter2.get('foo')).toEqual('bar');
-  });
-
-  test('should merge null', () => {
-    const filter1 = Filter.fromString('foo=bar');
-    const filter2 = filter1.merge(null);
-
-    expect(filter1).toBe(filter2);
-    expect(filter2.get('foo')).toEqual('bar');
-  });
-
-  test('should not mutate filter while merging', () => {
-    const filter1 = Filter.fromString('foo=bar');
-    const filter2 = Filter.fromString('rows=10 first=1');
-    const filter3 = filter1.merge(filter2);
-
-    expect(filter1).not.toBe(filter2);
-    expect(filter3).not.toBe(filter1);
-    expect(filter3).not.toBe(filter2);
-    expect(filter1.toFilterString()).toEqual('foo=bar');
-    expect(filter2.toFilterString()).toEqual('rows=10 first=1');
-    expect(filter3.toFilterString()).toEqual('foo=bar rows=10 first=1');
   });
 });
 

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -99,7 +99,7 @@ class Filter extends EntityModel {
 
   readonly alerts: Model[];
   readonly filter_type?: string;
-  readonly terms: FilterTerm[];
+  private terms: FilterTerm[];
 
   constructor({
     _type,
@@ -359,7 +359,7 @@ class Filter extends EntityModel {
     const index = this._getIndex(key);
     const hasKey = index !== -1;
     if (hasKey) {
-      this.terms.splice(index, 1);
+      this.terms = this.terms.filter((_, i) => i !== index);
       this._resetFilterId(); // filter has changed
     }
     return hasKey;
@@ -477,7 +477,7 @@ class Filter extends EntityModel {
    *
    * @returns Returns the array of all FilterTerms in this filter
    */
-  getAllTerms(): FilterTerm[] {
+  getAllTerms(): readonly FilterTerm[] {
     return this.terms;
   }
 

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -199,10 +199,10 @@ class Filter extends EntityModel {
     // special handling of sort. should be put into a more generic solution in
     // future
     if (key === 'sort' && this.has('sort-reverse')) {
-      this.delete('sort-reverse');
+      this._delete('sort-reverse');
     }
     if (key === 'sort-reverse' && this.has('sort')) {
-      this.delete('sort');
+      this._delete('sort');
     }
 
     const {keyword} = term;
@@ -308,6 +308,61 @@ class Filter extends EntityModel {
     // @ts-expect-error
     this.id = undefined;
     return this;
+  }
+
+  /**
+   * Creates a copy of this filter
+   *
+   * The returned copy is only a shallow copy of this filter.
+   * FilterTerms are copied only by reference.
+   *
+   * @return A shallow copy of this filter.
+   */
+  private _copy(): Filter {
+    return new Filter({
+      id: this.id,
+      filter_type: this.filter_type,
+      terms: [...this.getAllTerms()],
+      userCapabilities: this.userCapabilities,
+      userTags: this.userTags,
+    });
+  }
+
+  /**
+   * Creates a new FilterTerm from key, value and relation
+   *
+   * @param keyword   FilterTerm keyword
+   * @param value     FilterTerm value
+   * @param relation  FilterTerm relation (Default: '=').
+   *
+   * @return This filter
+   */
+  private _set(
+    keyword: string,
+    value?: string | number | boolean,
+    relation: string = '=',
+  ) {
+    this._resetFilterId(); // reset id because the filter has changed
+    const converted = convert(keyword, value, relation);
+    this._setTerm(new FilterTerm(converted));
+    return this;
+  }
+
+  /**
+   * Remove all FilterTerms with this key
+   *
+   * @param key Filter term key to remove
+   *
+   * @return True if a FilterTerm with this key has been removed from this Filter.
+   */
+  private _delete(key: string) {
+    const index = this._getIndex(key);
+    const hasKey = index !== -1;
+    if (hasKey) {
+      this.terms.splice(index, 1);
+      this._resetFilterId(); // filter has changed
+    }
+    return hasKey;
   }
 
   /**
@@ -445,25 +500,22 @@ class Filter extends EntityModel {
   }
 
   /**
-   * Creates a new FilterTerm from key, value and relation
-   *
-   * Creates a new FilterTerm from key, value and relation.
+   * Creates a new Filter with passed keyword, value and relation set
    *
    * @param keyword   FilterTerm keyword
    * @param value     FilterTerm value
    * @param relation  FilterTerm relation (Default: '=').
    *
-   * @return This filter
+   * @return A new Filter
    */
   set(
     keyword: string,
     value?: string | number | boolean,
     relation: string = '=',
   ) {
-    this._resetFilterId(); // reset id because the filter has changed
-    const converted = convert(keyword, value, relation);
-    this._setTerm(new FilterTerm(converted));
-    return this;
+    const filter = this._copy();
+    filter._set(keyword, value, relation);
+    return filter;
   }
 
   /**
@@ -485,13 +537,13 @@ class Filter extends EntityModel {
    *
    * @param key Filter term key to remove
    *
-   * @return This filter
+   * @return New filter with the FilterTerm removed or this filter if no FilterTerm with this key exists.
    */
   delete(key: string) {
-    const index = this._getIndex(key);
-    if (index !== -1) {
-      this.terms.splice(index, 1);
-      this._resetFilterId(); // filter has changed
+    if (this.has(key)) {
+      const filter = this._copy();
+      filter._delete(key);
+      return filter;
     }
     return this;
   }
@@ -557,16 +609,14 @@ class Filter extends EntityModel {
    * The returned copy is only a shallow copy of this filter.
    * FilterTerms are copied only by reference.
    *
+   * @deprecated All methods that mutate the filter now return a new filter instead
+   * of mutating the current filter. Therefore this method is no longer needed
+   * and will be removed in a future version.
+   *
    * @return A shallow copy of this filter.
    */
   copy(): Filter {
-    return new Filter({
-      id: this.id,
-      filter_type: this.filter_type,
-      terms: [...this.getAllTerms()],
-      userCapabilities: this.userCapabilities,
-      userTags: this.userTags,
-    });
+    return this._copy();
   }
 
   /**
@@ -575,7 +625,7 @@ class Filter extends EntityModel {
    * @return Copy of this filter but pointing to the next items.
    */
   next(): Filter {
-    const filter = this.copy();
+    const filter = this._copy();
     let first = parseInt(filter.get('first'));
     let rows = parseInt(filter.get('rows'));
 
@@ -589,8 +639,8 @@ class Filter extends EntityModel {
       first = 1;
     }
 
-    filter.set('first', String(first), '=');
-    filter.set('rows', String(rows), '=');
+    filter._set('first', String(first), '=');
+    filter._set('rows', String(rows), '=');
 
     return filter;
   }
@@ -601,7 +651,7 @@ class Filter extends EntityModel {
    * @return Copy of this filter but pointing to the previous items.
    */
   previous(): Filter {
-    const filter = this.copy();
+    const filter = this._copy();
     let first = parseInt(filter.get('first'));
     let rows = parseInt(filter.get('rows'));
 
@@ -619,8 +669,8 @@ class Filter extends EntityModel {
       first = 1;
     }
 
-    filter.set('first', String(first), '=');
-    filter.set('rows', String(rows), '=');
+    filter._set('first', String(first), '=');
+    filter._set('rows', String(rows), '=');
 
     return filter;
   }
@@ -634,11 +684,7 @@ class Filter extends EntityModel {
    * @return Copy of this filter but pointing to the first items.
    */
   first(first: number = 1): Filter {
-    const filter = this.copy();
-
-    filter.set('first', String(first), '=');
-
-    return filter;
+    return this.set('first', String(first), '=');
   }
 
   /**
@@ -649,10 +695,10 @@ class Filter extends EntityModel {
    * @return Copy of this filter but removing the item count (rows) restriction.
    */
   all(): Filter {
-    const filter = this.copy();
+    const filter = this._copy();
 
-    filter.set('first', '1', '=');
-    filter.set('rows', '-1', '=');
+    filter._set('first', '1', '=');
+    filter._set('rows', '-1', '=');
 
     return filter;
   }
@@ -663,11 +709,11 @@ class Filter extends EntityModel {
    * @return Copy of this filter but without first, rows and sort/sort-reverse terms.
    */
   simple(): Filter {
-    const filter = this.copy();
+    const filter = this._copy();
 
-    filter.delete('first');
-    filter.delete('rows');
-    filter.delete(filter.getSortOrder());
+    filter._delete('first');
+    filter._delete('rows');
+    filter._delete(filter.getSortOrder());
 
     return filter;
   }
@@ -677,7 +723,7 @@ class Filter extends EntityModel {
    *
    * @param filter  Filter to be merged with and operation
    *
-   * @return This filter
+   * @return A new filter if filter is defined, otherwise this filter is returned.
    */
   and(filter: Filter | undefined | null): Filter {
     if (!hasValue(filter)) {
@@ -688,12 +734,13 @@ class Filter extends EntityModel {
       term => isDefined(term.keyword) && !EXTRA_KEYWORDS.includes(term.keyword),
     );
 
+    const copy = this._copy();
     if (nonExtraTerms.length > 0) {
-      this._addTerm(AND);
+      copy._addTerm(AND);
     }
-
-    this._resetFilterId(); // filter has changed
-    return this.merge(filter);
+    copy._resetFilterId(); // filter has changed
+    copy._addTerm(...filter.getAllTerms());
+    return copy;
   }
 
   /**
@@ -716,44 +763,44 @@ class Filter extends EntityModel {
   }
 
   /**
-   * Set the current sort order
+   * Create a new filter with the current sort order
    *
    * @param value  New sort order. 'sort' or 'sort-reverse'.
    *
-   * @return This filter.
+   * @return A new filter with the current sort order.
    */
   setSortOrder(value: FilterSortOrder) {
     const sortby = this.getSortBy();
     value = value === SORT_ORDER_DESC ? SORT_ORDER_DESC : SORT_ORDER_ASC;
-    this.set(value, sortby);
-    return this;
+    return this.set(value, sortby);
   }
 
   /**
-   * Set the current sort field
+   * Create a new filter with the current sort field
    *
    * @param value  New sort field
    *
-   * @return This filter.
+   * @return A new filter with the current sort field.
    */
   setSortBy(value: string) {
     const order = this.getSortOrder();
-    this.set(order, value);
-    return this;
+    return this.set(order, value);
   }
 
   /**
-   * Merges all terms from filter into this Filter
+   * Merges all terms from filter into a Filter
    *
    * @param filter Terms from filter to be merged.
    *
-   * @return This filter with merged terms.
+   * @return A new filter with merged terms if the filter has changed.
    */
   merge(filter: Filter | undefined | null) {
-    if (hasValue(filter)) {
-      this._addTerm(...filter.getAllTerms());
+    if (!hasValue(filter)) {
+      return this;
     }
-    return this;
+    const copy = this._copy();
+    copy._addTerm(...filter.getAllTerms());
+    return copy;
   }
 
   /**
@@ -761,33 +808,34 @@ class Filter extends EntityModel {
    *
    * @param filter Terms from filter to be merged.
    *
-   * @return This filter with merged terms.
+   * @return A new filter with merged terms if the filter has changed.
    */
 
   mergeKeywords(filter: Filter | undefined | null) {
-    if (hasValue(filter)) {
-      this._resetFilterId();
-
-      this._mergeNewKeywords(filter);
+    if (!hasValue(filter)) {
+      return this;
     }
-    return this;
+    const copy = this._copy();
+    copy._resetFilterId();
+    copy._mergeNewKeywords(filter);
+    return copy;
   }
 
   /**
-   * Merges additional EXTRA KEYWORD terms from filter into this Filter
-   *
-   * This filter will not be changed. Instead a copy with merged terms will be
-   * created and returned. Only extra keywords not included in this filter will
-   * be merged.
+   * Merges additional EXTRA KEYWORD terms from filter into a Filter
    *
    * @param filter Use extra params terms filter to be merged.
    *
-   * @return A new filter with merged terms.
+   * @return A new filter with merged terms if changed.
    */
   mergeExtraKeywords(filter?: Filter): Filter {
-    const f = this.copy();
-    f._resetFilterId();
-    return f._mergeExtraKeywords(filter);
+    if (!hasValue(filter)) {
+      return this;
+    }
+    const copy = this._copy();
+    copy._resetFilterId();
+    copy._mergeExtraKeywords(filter);
+    return copy;
   }
 
   /**

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -244,57 +244,41 @@ class Filter extends EntityModel {
   }
 
   /**
-   * Merges additional EXTRA KEYWORD terms from filter into this Filter
+   * Returns extra keywords filter terms from the given filter that are not included in this filter
    *
-   * Only extra keywords not included in this filter will be merged.
-   *
-   * @private
-   *
-   * @param filter Use extra params terms filter to be merged.
-   *
-   * @return This filter with merged terms.
+   * @param filter Filter to get extra keywords from
+   * @returns Array of FilterTerms with extra keywords from filter that are not included in this filter
    */
-
-  private _mergeExtraKeywords(filter: Filter | undefined | null) {
-    if (hasValue(filter)) {
-      filter.forEach(term => {
-        const {keyword: key} = term;
-        if (!isDefined(key) || !EXTRA_KEYWORDS.includes(key) || this.has(key)) {
-          return;
-        }
-        if (
-          (key === 'sort' && this.has('sort-reverse')) ||
-          (key === 'sort-reverse' && this.has('sort'))
-        ) {
-          return;
-        }
-        this._addTerm(term);
-      });
+  private _getExtraKeywords(filter: Filter | undefined | null) {
+    if (!hasValue(filter)) {
+      return [];
     }
-    return this;
+    return filter.terms.filter(term => {
+      const {keyword: key} = term;
+      return (
+        isDefined(key) &&
+        EXTRA_KEYWORDS.includes(key) &&
+        !this.has(key) &&
+        !(key === 'sort' && this.has('sort-reverse')) &&
+        !(key === 'sort-reverse' && this.has('sort'))
+      );
+    });
   }
 
   /**
-   * Merges terms with new keywords from filter into this Filter
+   * Returns new keywords filter terms from the given filter that are not included in this filter
    *
-   * @private
-   *
-   * @param filter  Use extra params terms filter to be merged.
-   *
-   * @return This filter with merged terms.
+   * @param filter Filter to get new keywords from
+   * @returns Array of FilterTerms with new keywords from filter that are not included in this filter
    */
-  private _mergeNewKeywords(filter: Filter | undefined) {
-    if (hasValue(filter)) {
-      filter.forEach(term => {
-        const {keyword: key} = term;
-        if (isDefined(key)) {
-          if (!this.has(key)) {
-            this._addTerm(term);
-          }
-        }
-      });
+  private _getNewKeywords(filter?: Filter) {
+    if (!hasValue(filter)) {
+      return [];
     }
-    return this;
+    return filter.terms.filter(term => {
+      const {keyword: key} = term;
+      return isDefined(key) && !this.has(key);
+    });
   }
 
   /**
@@ -794,11 +778,12 @@ class Filter extends EntityModel {
    *
    * @return A new filter with merged terms if the filter has changed.
    */
-  merge(filter: Filter | undefined | null) {
-    if (!hasValue(filter)) {
+  merge(filter?: Filter) {
+    if (!hasValue(filter) || filter.length === 0) {
       return this;
     }
     const copy = this._copy();
+    // currently this method also adds duplicate terms. this may change in future.
     copy._addTerm(...filter.getAllTerms());
     return copy;
   }
@@ -811,13 +796,17 @@ class Filter extends EntityModel {
    * @return A new filter with merged terms if the filter has changed.
    */
 
-  mergeKeywords(filter: Filter | undefined | null) {
+  mergeKeywords(filter?: Filter) {
     if (!hasValue(filter)) {
+      return this;
+    }
+    const newKeywords = this._getNewKeywords(filter);
+    if (newKeywords.length === 0) {
       return this;
     }
     const copy = this._copy();
     copy._resetFilterId();
-    copy._mergeNewKeywords(filter);
+    copy._addTerm(...newKeywords);
     return copy;
   }
 
@@ -832,9 +821,13 @@ class Filter extends EntityModel {
     if (!hasValue(filter)) {
       return this;
     }
+    const extraKeywords = this._getExtraKeywords(filter);
+    if (extraKeywords.length === 0) {
+      return this;
+    }
     const copy = this._copy();
     copy._resetFilterId();
-    copy._mergeExtraKeywords(filter);
+    copy._addTerm(...extraKeywords);
     return copy;
   }
 
@@ -852,7 +845,8 @@ class Filter extends EntityModel {
       terms: parseFilterTermsFromString(filterString),
     });
 
-    f._mergeExtraKeywords(filter);
+    const extraKeywords = f._getExtraKeywords(filter);
+    f._addTerm(...extraKeywords);
 
     return f;
   }

--- a/src/gmp/models/filter/filterterm.ts
+++ b/src/gmp/models/filter/filterterm.ts
@@ -19,9 +19,9 @@ const RELATIONS = ['=', ':', '~', '>', '<'];
  * value or relation after creation. This can lead to unexpected behavior.
  */
 class FilterTerm {
-  keyword?: string;
-  value?: string | number;
-  relation?: string;
+  readonly keyword?: string;
+  readonly value?: string | number;
+  readonly relation?: string;
 
   /**
    * @param keyword  Filter keyword

--- a/src/web/components/dashboard/display/DataDisplay.tsx
+++ b/src/web/components/dashboard/display/DataDisplay.tsx
@@ -485,9 +485,7 @@ class DataDisplay<
             {showFilterString && isDefined(filter) && (
               <FilterString>
                 ({_('Applied filter: ')}
-                {/* @ts-ignore-error */}
                 <b>{filter.name}</b>&nbsp;
-                {/* @ts-ignore-error */}
                 <i>{filter.simple().toFilterString()}</i>)
               </FilterString>
             )}

--- a/src/web/components/dashboard/display/severity/SeverityClassDisplay.tsx
+++ b/src/web/components/dashboard/display/severity/SeverityClassDisplay.tsx
@@ -81,7 +81,7 @@ const SeverityClassDisplay = ({
     }
 
     const newFilter = isDefined(filter)
-      ? filter.copy().and(severityFilter)
+      ? filter.and(severityFilter)
       : severityFilter;
 
     onFilterChanged(newFilter);

--- a/src/web/components/powerfilter/SolutionTypeGroup.tsx
+++ b/src/web/components/powerfilter/SolutionTypeGroup.tsx
@@ -36,9 +36,9 @@ const SolutionTypesFilterGroup = ({
     const filteredSolutionType = filter.get('solution_type');
 
     if (!isDefined(solutionType) || solutionType === 'All') {
-      onChange(filter.copy().delete('solution_type'));
+      onChange(filter.delete('solution_type'));
     } else if (solutionType !== filteredSolutionType) {
-      onChange(filter.copy().set('solution_type', solutionType));
+      onChange(filter.set('solution_type', solutionType));
     }
   };
 

--- a/src/web/components/powerfilter/__tests__/useFilterDialog.test.tsx
+++ b/src/web/components/powerfilter/__tests__/useFilterDialog.test.tsx
@@ -42,9 +42,7 @@ describe('useFilterDialog', () => {
     const {result} = renderHook(() => useFilterDialog(initialFilter));
 
     act(() => {
-      result.current.handleFilterChange(
-        initialFilter.copy().set('status', 'active'),
-      );
+      result.current.handleFilterChange(initialFilter.set('status', 'active'));
     });
 
     expect(result.current.filter.toFilterString()).toEqual(

--- a/src/web/components/powerfilter/useFilterDialog.tsx
+++ b/src/web/components/powerfilter/useFilterDialog.tsx
@@ -24,7 +24,7 @@ const useFilterDialog = <TFilterDialogState extends FilterDialogState>(
 ) => {
   const [originalFilter] = useState(initialFilter);
   const [filter, setFilter] = useState<Filter>(() =>
-    isDefined(initialFilter) ? initialFilter.copy() : new Filter(),
+    isDefined(initialFilter) ? initialFilter : new Filter(),
   );
   const [filterDialogState, setFilterDialogState] =
     useState<TFilterDialogState>({} as TFilterDialogState);
@@ -44,14 +44,14 @@ const useFilterDialog = <TFilterDialogState extends FilterDialogState>(
 
   const handleFilterValueChange = useCallback(
     (value: string | number, name: string, relation: string = '=') => {
-      setFilter(filter => filter.copy().set(name, value, relation));
+      setFilter(filter => filter.set(name, value, relation));
     },
     [],
   );
 
   const handleSearchTermChange = useCallback(
     (value: string, name: string, relation: string = '~') => {
-      setFilter(filter => filter.copy().set(name, `"${value}"`, relation));
+      setFilter(filter => filter.set(name, `"${value}"`, relation));
     },
     [],
   );
@@ -61,11 +61,11 @@ const useFilterDialog = <TFilterDialogState extends FilterDialogState>(
   }, []);
 
   const handleSortByChange = useCallback((value: string) => {
-    setFilter(filter => filter.copy().setSortBy(value));
+    setFilter(filter => filter.setSortBy(value));
   }, []);
 
   const handleSortOrderChange = useCallback((value: FilterSortOrder) => {
-    setFilter(filter => filter.copy().setSortOrder(value));
+    setFilter(filter => filter.setSortOrder(value));
   }, []);
 
   const handleChange = useCallback(

--- a/src/web/components/powerfilter/useFilterDialogSave.tsx
+++ b/src/web/components/powerfilter/useFilterDialogSave.tsx
@@ -72,9 +72,7 @@ const useFilterDialogSave = (
   );
 
   const handleSave: () => Promise<void> = useCallback(() => {
-    const newFilter = filter
-      .copy()
-      .mergeKeywords(Filter.fromString(filterString));
+    const newFilter = filter.mergeKeywords(Filter.fromString(filterString));
 
     if (saveNamedFilter) {
       if (isDefined(filterName) && filterName.trim().length > 0) {

--- a/src/web/entities/EntitiesContainer.tsx
+++ b/src/web/entities/EntitiesContainer.tsx
@@ -356,13 +356,13 @@ class EntitiesContainer<TModel extends Model> extends React.Component<
     let sort = 'sort';
     const sortField = loadedFilter.getSortBy();
 
-    const filter = loadedFilter.first();
+    let filter = loadedFilter.first();
 
     if (sortField && sortField === field) {
       sort = filter.getSortOrder() === 'sort' ? 'sort-reverse' : 'sort';
     }
 
-    filter.set(sort, field);
+    filter = filter.set(sort, field);
 
     this.changeFilter(filter);
   }

--- a/src/web/entities/__tests__/FilterProvider.test.tsx
+++ b/src/web/entities/__tests__/FilterProvider.test.tsx
@@ -250,7 +250,7 @@ describe('FilterProvider component tests', () => {
   });
 
   test('should use default fallbackFilter as last resort', async () => {
-    const resultingFilter = DEFAULT_FALLBACK_FILTER.copy().set('rows', 42);
+    const resultingFilter = DEFAULT_FALLBACK_FILTER.set('rows', 42);
 
     const getSetting = testing.fn().mockResolvedValue({});
     const subscribe = testing.fn();

--- a/src/web/hooks/__tests__/usePageFilter.test.tsx
+++ b/src/web/hooks/__tests__/usePageFilter.test.tsx
@@ -65,7 +65,7 @@ describe('usePageFilter tests', () => {
 
     const {result} = renderHook(() => usePageFilter('somePage2', 'somePage'));
     const [filter] = result.current;
-    expect(filter.equals(pFilter.copy().set('rows', '42'))).toEqual(true);
+    expect(filter.equals(pFilter.set('rows', '42'))).toEqual(true);
   });
 
   test('should use defaultSettingFilter', async () => {
@@ -160,7 +160,7 @@ describe('usePageFilter tests', () => {
   });
 
   test('should use default fallback filter as last resort', async () => {
-    const resultingFilter = DEFAULT_FALLBACK_FILTER.copy().set('rows', '42');
+    const resultingFilter = DEFAULT_FALLBACK_FILTER.set('rows', '42');
 
     const getSetting = testing.fn().mockResolvedValue({});
     const subscribe = testing.fn();
@@ -275,7 +275,7 @@ describe('usePageFilter tests', () => {
       usePageFilter(undefined, 'somePage', {fallbackFilter}),
     );
     const [filter] = result.current;
-    const expectedFilter = defaultSettingFilter.copy().set('rows', '42');
+    const expectedFilter = defaultSettingFilter.set('rows', '42');
     expect(filter.equals(expectedFilter)).toEqual(true);
   });
 
@@ -311,7 +311,7 @@ describe('usePageFilter tests', () => {
     await wait();
 
     const [resetFilterResult] = result.current;
-    const expectedFilter = defaultSettingFilter.copy().set('rows', '42');
+    const expectedFilter = defaultSettingFilter.set('rows', '42');
     expect(resetFilterResult.equals(expectedFilter)).toEqual(true);
   });
 

--- a/src/web/hooks/useFilterSortBy.ts
+++ b/src/web/hooks/useFilterSortBy.ts
@@ -35,14 +35,14 @@ const useFilterSortBy = (
   const sortChange = useCallback(
     (field: string) => {
       let sort = 'sort';
-      const newFilter = filter.copy().first();
+      let newFilter = filter.first();
       const sortField = filter.getSortBy();
 
       if (sortField && sortField === field) {
         sort = filter.getSortOrder() === 'sort' ? 'sort-reverse' : 'sort';
       }
 
-      newFilter.set(sort, field);
+      newFilter = newFilter.set(sort, field);
 
       changeFilter(newFilter);
     },

--- a/src/web/hooks/usePageFilter.ts
+++ b/src/web/hooks/usePageFilter.ts
@@ -153,7 +153,7 @@ const usePageFilter = (
     !returnedFilter.has('rows') &&
     isDefined(rowsPerPage)
   ) {
-    returnedFilter = returnedFilter.copy().set('rows', rowsPerPage);
+    returnedFilter = returnedFilter.set('rows', rowsPerPage);
   }
 
   const finishedLoading =

--- a/src/web/pages/reports/AuditReportDetailsPage.tsx
+++ b/src/web/pages/reports/AuditReportDetailsPage.tsx
@@ -73,9 +73,8 @@ const DEFAULT_FILTER = Filter.fromString(
   'levels=hmlg rows=100 min_qod=70 first=1 compliance_levels=yniu sort=compliant',
 );
 
-export const AUDIT_REPORT_RESET_FILTER = RESET_FILTER.copy()
-  .setSortOrder('sort')
-  .setSortBy('compliant');
+export const AUDIT_REPORT_RESET_FILTER =
+  RESET_FILTER.setSortOrder('sort').setSortBy('compliant');
 
 const hasTargetId = (value: unknown): value is ReportTargetRef => {
   return (
@@ -326,9 +325,9 @@ const AuditReportDetailsPage = () => {
       const {includeNotes, includeOverrides, reportFormatId, storeAsDefault} =
         state;
 
-      const newFilter = reportFilter.copy();
-      newFilter.set('notes', includeNotes);
-      newFilter.set('overrides', includeOverrides);
+      const newFilter = reportFilter
+        .set('notes', includeNotes)
+        .set('overrides', includeOverrides);
 
       if (storeAsDefault) {
         const defaults = {
@@ -419,8 +418,7 @@ const AuditReportDetailsPage = () => {
     if (!reportFilter) return;
 
     if (reportFilter.has('min_qod')) {
-      const levelFilter = reportFilter.copy();
-      levelFilter.set('min_qod', 30);
+      const levelFilter = reportFilter.set('min_qod', 30);
       handleFilterChange(levelFilter);
     }
   }, [reportFilter, handleFilterChange]);

--- a/src/web/pages/reports/DeltaDetailsPage.tsx
+++ b/src/web/pages/reports/DeltaDetailsPage.tsx
@@ -201,7 +201,7 @@ const loadFilteredReport =
 
     // Ensure the filter respects the sortField set by the user
     if (!filter.has('sort') && !filter.has('sort-reverse')) {
-      filter.set('sort', 'name');
+      filter = filter.set('sort', 'name');
     }
 
     return loadReportIfNeeded(reportId, deltaReportId, filter).then(() =>
@@ -410,10 +410,9 @@ const DeltaReportDetails = () => {
     } = state;
 
     const baseFilter = reportFilter ?? DEFAULT_FILTER;
-    const newFilter = baseFilter.copy();
-
-    newFilter.set('notes', includeNotes);
-    newFilter.set('overrides', includeOverrides);
+    const newFilter = baseFilter
+      .set('notes', includeNotes)
+      .set('overrides', includeOverrides);
 
     if (storeDefault) {
       const defaults = {
@@ -479,24 +478,21 @@ const DeltaReportDetails = () => {
     if (!levelsStr.includes('g')) {
       const newLevels = levelsStr + 'g';
 
-      const copiedReportFilter = reportFilter.copy();
-      copiedReportFilter.set('levels', newLevels);
+      const copiedReportFilter = reportFilter.set('levels', newLevels);
       void load(copiedReportFilter);
     }
   };
 
   const handleFilterRemoveSeverity = () => {
     if (reportFilter?.has('severity')) {
-      const copiedReportFilter = reportFilter.copy();
-      copiedReportFilter.delete('severity');
+      const copiedReportFilter = reportFilter.delete('severity');
       void load(copiedReportFilter);
     }
   };
 
   const handleFilterDecreaseMinQoD = () => {
     if (reportFilter?.has('min_qod')) {
-      const copiedReportFilter = reportFilter.copy();
-      copiedReportFilter.set('min_qod', 30);
+      const copiedReportFilter = reportFilter.set('min_qod', 30);
       void load(copiedReportFilter);
     }
   };

--- a/src/web/pages/reports/ReportDetailsFilterDialog.tsx
+++ b/src/web/pages/reports/ReportDetailsFilterDialog.tsx
@@ -65,8 +65,7 @@ const ReportDetailsFilterDialog = ({
     onValueChange,
   } = filterDialogProps;
   const resultHostsOnly = filter.get('result_hosts_only');
-  const handleRemoveLevels = () =>
-    onFilterChange(filter.copy().delete('levels'));
+  const handleRemoveLevels = () => onFilterChange(filter.delete('levels'));
   const handleRemoveCompliance = () =>
     onFilterChange(filter.delete('compliance_levels'));
   return (

--- a/src/web/pages/reports/ReportDetailsPage.tsx
+++ b/src/web/pages/reports/ReportDetailsPage.tsx
@@ -60,9 +60,8 @@ const DEFAULT_FILTER = Filter.fromString(
   'levels=chml rows=100 min_qod=70 first=1 sort-reverse=severity result_hosts_only=0',
 );
 
-export const REPORT_RESET_FILTER = RESET_FILTER.copy()
-  .setSortOrder('sort-reverse')
-  .setSortBy('severity');
+export const REPORT_RESET_FILTER =
+  RESET_FILTER.setSortOrder('sort-reverse').setSortBy('severity');
 
 const hasTargetId = (value: unknown): value is ReportTargetRef => {
   return (
@@ -294,9 +293,9 @@ const ReportDetailsPage = () => {
         storeAsDefault,
       } = state;
 
-      const newFilter = reportFilter.copy();
-      newFilter.set('notes', includeNotes);
-      newFilter.set('overrides', includeOverrides);
+      const newFilter = reportFilter
+        .set('notes', includeNotes)
+        .set('overrides', includeOverrides);
 
       if (storeAsDefault) {
         const defaults = {
@@ -390,8 +389,7 @@ const ReportDetailsPage = () => {
 
     if (!levels.includes('g')) {
       levels += 'g';
-      const levelFilter = reportFilter.copy();
-      levelFilter.set('levels', levels);
+      const levelFilter = reportFilter.set('levels', levels);
       handleFilterChange(levelFilter);
     }
   }, [reportFilter, handleFilterChange]);
@@ -400,8 +398,7 @@ const ReportDetailsPage = () => {
     if (!reportFilter) return;
 
     if (reportFilter.has('severity')) {
-      const levelFilter = reportFilter.copy();
-      levelFilter.delete('severity');
+      const levelFilter = reportFilter.delete('severity');
       handleFilterChange(levelFilter);
     }
   }, [reportFilter, handleFilterChange]);
@@ -410,8 +407,7 @@ const ReportDetailsPage = () => {
     if (!reportFilter) return;
 
     if (reportFilter.has('min_qod')) {
-      const levelFilter = reportFilter.copy();
-      levelFilter.set('min_qod', 30);
+      const levelFilter = reportFilter.set('min_qod', 30);
       handleFilterChange(levelFilter);
     }
   }, [reportFilter, handleFilterChange]);

--- a/src/web/pages/reports/ReportListPage.tsx
+++ b/src/web/pages/reports/ReportListPage.tsx
@@ -159,12 +159,11 @@ const ReportListPage = ({
         replace: true,
       });
     } else {
-      const newFilter = filter || new Filter();
+      const newFilter = filter ?? new Filter();
 
       isDefined(onFilterChanged) &&
         onFilterChanged(
           newFilter
-            .copy()
             .set('first', 1) // reset to first page
             .set('task_id', report?.task?.id),
         );

--- a/src/web/pages/reports/details/ThresholdPanel.jsx
+++ b/src/web/pages/reports/details/ThresholdPanel.jsx
@@ -32,37 +32,33 @@ const ThresholdPanel = ({
   const handleRemoveLogLevel = () => {
     if (levels.includes('g')) {
       const newLevels = levels.replace('g', '');
-      const lfilter = filter.copy();
-      lfilter.set('levels', newLevels);
+      const levelsFilter = filter.set('levels', newLevels);
 
-      onFilterChanged(lfilter);
+      onFilterChanged(levelsFilter);
     }
   };
 
   const handleRemoveLowLevel = () => {
     if (levels.includes('l')) {
       const newLevels = levels.replace('l', '');
-      const lfilter = filter.copy();
-      lfilter.set('levels', newLevels);
+      const levelsFilter = filter.set('levels', newLevels);
 
-      onFilterChanged(lfilter);
+      onFilterChanged(levelsFilter);
     }
   };
 
   const handleRemoveMediumLevel = () => {
     if (levels.includes('m')) {
       const newLevels = levels.replace('m', '');
-      const lfilter = filter.copy();
-      lfilter.set('levels', newLevels);
+      const levelsFilter = filter.set('levels', newLevels);
 
-      onFilterChanged(lfilter);
+      onFilterChanged(levelsFilter);
     }
   };
   const handleSetMinimumSeverity = () => {
-    const lfilter = filter.copy();
-    lfilter.set('severity', 7.0, '>');
+    const severityFilter = filter.set('severity', 7.0, '>');
 
-    onFilterChanged(lfilter);
+    onFilterChanged(severityFilter);
   };
   return (
     <UpdatingDivider

--- a/src/web/pages/reports/details/__tests__/ThresholdPanel.test.jsx
+++ b/src/web/pages/reports/details/__tests__/ThresholdPanel.test.jsx
@@ -131,9 +131,7 @@ describe('Report Threshold Panel tests', () => {
 
     const filterMinSeverity = Filter.fromString(
       'apply_overrides=0 rows=2 first=1 sort-reverse=severity',
-    );
-
-    filterMinSeverity.set('severity', 7.0, '>');
+    ).set('severity', 7.0, '>');
 
     const {baseElement} = render(
       <Thresholdpanel

--- a/src/web/pages/reports/details/application/ApplicationsTab.tsx
+++ b/src/web/pages/reports/details/application/ApplicationsTab.tsx
@@ -45,7 +45,7 @@ const ApplicationsTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    return isDefined(filter) ? filter.copy() : new Filter();
+    return isDefined(filter) ? filter : new Filter();
   }, [filter]);
 
   const [appsFilter, setAppsFilter] = useState<Filter>(baseFilter);

--- a/src/web/pages/reports/details/cve/ClosedCvesTab.tsx
+++ b/src/web/pages/reports/details/cve/ClosedCvesTab.tsx
@@ -45,7 +45,7 @@ const ClosedCvesTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    return isDefined(filter) ? filter.copy() : new Filter();
+    return isDefined(filter) ? filter : new Filter();
   }, [filter]);
 
   const [closedCvesFilter, setClosedCvesFilter] = useState<Filter>(baseFilter);

--- a/src/web/pages/reports/details/cve/CvesTab.tsx
+++ b/src/web/pages/reports/details/cve/CvesTab.tsx
@@ -45,7 +45,7 @@ const CvesTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    return isDefined(filter) ? filter.copy() : new Filter();
+    return isDefined(filter) ? filter : new Filter();
   }, [filter]);
 
   const [cvesFilter, setCvesFilter] = useState<Filter>(baseFilter);

--- a/src/web/pages/reports/details/error/ErrorsTab.tsx
+++ b/src/web/pages/reports/details/error/ErrorsTab.tsx
@@ -42,11 +42,10 @@ const ErrorsTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    const f = isDefined(filter) ? filter.copy() : new Filter();
+    const f = isDefined(filter) ? filter : new Filter();
     // Override sort: 'sort-reverse=error' maps to ascending A→Z via the
     // sortReverse=(sortDir==='asc') convention used in ReportEntitiesContainer
-    f.set('sort-reverse', 'error');
-    return f;
+    return f.set('sort-reverse', 'error');
   }, [filter]);
 
   const [errorsFilter, setErrorsFilter] = useState<Filter>(baseFilter);

--- a/src/web/pages/reports/details/operating-system/OperatingSystemsTab.tsx
+++ b/src/web/pages/reports/details/operating-system/OperatingSystemsTab.tsx
@@ -57,7 +57,7 @@ const OperatingSystemsTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    return isDefined(filter) ? filter.copy() : new Filter();
+    return isDefined(filter) ? filter : new Filter();
   }, [filter]);
 
   const [operatingSystemsFilter, setOperatingSystemsFilter] =

--- a/src/web/pages/reports/details/result/ResultsTab.tsx
+++ b/src/web/pages/reports/details/result/ResultsTab.tsx
@@ -121,7 +121,7 @@ const ResultsTabWrapper = ({
 
   const {entities: results = [], entitiesCounts: resultsCounts} = data || {};
 
-  const displayedFilter = resultsFilter.copy().delete('_and_report_id');
+  const displayedFilter = resultsFilter.delete('_and_report_id');
 
   if (reportResultsCounts?.filtered === 0) {
     if ((reportResultsCounts.full ?? 0) === 0) {

--- a/src/web/pages/reports/details/tls-certificate/TlsCertificatesTab.tsx
+++ b/src/web/pages/reports/details/tls-certificate/TlsCertificatesTab.tsx
@@ -54,8 +54,7 @@ const TLSCertificatesTab = ({
     const f = Filter.fromString(reportFilterString);
     // Override sort: 'sort-reverse=dn' maps to ascending A→Z via the
     // sortReverse=(sortDir==='asc') convention used in ReportEntitiesContainer
-    f.set('sort-reverse', 'dn');
-    return f;
+    return f.set('sort-reverse', 'dn');
   }, [reportFilterString]);
 
   const [tlsCertificatesFilter, setTlsCertificatesFilter] =

--- a/src/web/pages/results/ResultFilterDialog.tsx
+++ b/src/web/pages/results/ResultFilterDialog.tsx
@@ -109,8 +109,7 @@ const ResultFilterDialog = ({
     onValueChange,
   } = filterDialogProps;
 
-  const handleRemoveLevels = () =>
-    onFilterChange(filter.copy().delete('levels'));
+  const handleRemoveLevels = () => onFilterChange(filter.delete('levels'));
   return (
     <FilterDialog onClose={onClose} onSave={handleSave}>
       <FilterStringGroup

--- a/src/web/pages/scanners/ScannerFilterDialog.tsx
+++ b/src/web/pages/scanners/ScannerFilterDialog.tsx
@@ -96,7 +96,7 @@ const ScannerFilterDialog = ({
   const [_] = useTranslation();
   const capabilities = useCapabilities();
   const initialFilterString = isDefined(initialFilter)
-    ? initialFilter.copy().delete('type').toFilterCriteriaString()
+    ? initialFilter.delete('type').toFilterCriteriaString()
     : '';
   const filterDialogProps = useFilterDialog<UseFilterDialogStateProps>(
     initialFilter,

--- a/src/web/pages/scanners/__tests__/ScannerFilterDialog.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerFilterDialog.test.tsx
@@ -59,7 +59,7 @@ describe('ScannerFilterDialog tests', () => {
       terms: [new FilterTerm({keyword: 'name', value: 'test'})],
     });
     const newFilter = new Filter({id: 'new-filter'});
-    const newFilterWithDetails = newFilter.copy().set('rows', 10);
+    const newFilterWithDetails = newFilter.set('rows', 10);
     const gmp = {
       settings: {enableGreenboneSensor: true},
       filter: {

--- a/src/web/pages/tasks/TaskComponent.tsx
+++ b/src/web/pages/tasks/TaskComponent.tsx
@@ -147,7 +147,7 @@ interface TaskComponentProps {
   onTaskWizardSaved?: () => void;
 }
 
-const TAGS_FILTER = ALL_FILTER.copy().set('resource_type', 'task');
+const TAGS_FILTER = ALL_FILTER.set('resource_type', 'task');
 
 const TaskComponent = ({
   children,

--- a/src/web/pages/tasks/__tests__/TaskFilterDialog.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskFilterDialog.test.tsx
@@ -47,7 +47,7 @@ describe('TaskFilterDialog tests', () => {
       terms: [new FilterTerm({keyword: 'name', value: 'test'})],
     });
     const newFilter = new Filter({id: 'new-filter'});
-    const newFilterWithDetails = newFilter.copy().set('rows', 10);
+    const newFilterWithDetails = newFilter.set('rows', 10);
     const gmp = {
       filter: {
         create: testing.fn().mockResolvedValue({data: newFilter}),


### PR DESCRIPTION
## What

Make Filter class in GSA immutable

## Why

Don't allow to change the internal data of a Filter instance. This avoids issues with frameworks depending on equality checks for comparing the identity. For example react decides to re-render if the identity has changed only. Also redux heavily relies on the identity.

## References

https://jira.greenbone.net/browse/GEA-848

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


