### PR TITLE
Introduce new FilterType interface

### DIFF
--- a/src/gmp/collection/parser.ts
+++ b/src/gmp/collection/parser.ts
@@ -7,7 +7,10 @@ import CollectionCounts, {
   type CollectionCountsOptions,
 } from 'gmp/collection/collection-counts';
 import logger from 'gmp/log';
-import Filter, {type FilterModelElement} from 'gmp/models/filter';
+import Filter, {
+  type FilterResponseElement,
+  type FilterType,
+} from 'gmp/models/filter';
 import Model, {type Element} from 'gmp/models/model';
 import {map} from 'gmp/utils/array';
 import {hasValue, isArray, isDefined} from 'gmp/utils/identity';
@@ -18,7 +21,7 @@ export interface ModelClass<TModel> {
 
 export interface CollectionList<TModel> {
   entities: TModel[];
-  filter: Filter;
+  filter: FilterType;
   counts: CollectionCounts;
 }
 

--- a/src/gmp/collection/parser.ts
+++ b/src/gmp/collection/parser.ts
@@ -39,7 +39,7 @@ interface ParseCollectionListOptions<TModel extends Model, TElement = Element> {
     name: string,
     pluralName?: string,
   ) => CollectionCounts;
-  filterParseFunc?: (element: FilterElement) => Filter;
+  filterParseFunc?: (element: FilterElement) => FilterType;
 }
 
 export interface InfoElement {
@@ -153,7 +153,7 @@ export function parseInfoCounts(response: InfoWithCounts) {
   return new CollectionCounts(counts);
 }
 
-export function parseFilter(element: FilterElement): Filter {
+export function parseFilter(element: FilterElement): FilterType {
   return Filter.fromElement(element.filters);
 }
 

--- a/src/gmp/collection/parser.ts
+++ b/src/gmp/collection/parser.ts
@@ -55,7 +55,7 @@ interface ResultsElement {
 }
 
 interface FilterElement {
-  filters?: FilterModelElement;
+  filters?: FilterResponseElement;
 }
 
 interface ElementStart {

--- a/src/gmp/commands/agent-groups.ts
+++ b/src/gmp/commands/agent-groups.ts
@@ -7,14 +7,14 @@ import EntitiesCommand from 'gmp/commands/entities';
 import type Http from 'gmp/http/http';
 import {type XmlResponseData} from 'gmp/http/transform/fast-xml';
 import AgentGroup from 'gmp/models/agent-group';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 
 class AgentGroupsCommand extends EntitiesCommand<AgentGroup> {
   constructor(http: Http) {
     super(http, 'agent_group', AgentGroup);
   }
 
-  getSeverityAggregates({filter}: {filter?: Filter} = {}) {
+  getSeverityAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'agent_group',
       group_column: 'severity',
@@ -22,7 +22,7 @@ class AgentGroupsCommand extends EntitiesCommand<AgentGroup> {
     });
   }
 
-  getNetworkAggregates({filter}: {filter?: Filter} = {}) {
+  getNetworkAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'agent_group',
       group_column: 'scanner',

--- a/src/gmp/commands/agents.ts
+++ b/src/gmp/commands/agents.ts
@@ -10,7 +10,7 @@ import type Response from 'gmp/http/response';
 import {type XmlMeta, type XmlResponseData} from 'gmp/http/transform/fast-xml';
 import logger from 'gmp/log';
 import Agent from 'gmp/models/agent';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import {
   AGENT_CONTROLLER_SCANNER_TYPE,
   AGENT_CONTROLLER_SENSOR_SCANNER_TYPE,
@@ -60,7 +60,7 @@ class AgentsCommand extends EntitiesCommand<Agent> {
     });
   }
 
-  async authorizeByFilter(filter: Filter) {
+  async authorizeByFilter(filter: FilterType) {
     const response = await this.get({filter});
     return this.authorize(response.data);
   }
@@ -74,12 +74,12 @@ class AgentsCommand extends EntitiesCommand<Agent> {
     });
   }
 
-  async revokeByFilter(filter: Filter) {
+  async revokeByFilter(filter: FilterType) {
     const response = await this.get({filter});
     return this.revoke(response.data);
   }
 
-  async enableUpdateToLatestByFilter(filter: Filter) {
+  async enableUpdateToLatestByFilter(filter: FilterType) {
     const response = await this.get({filter});
     return this.enableUpdateToLatest(response.data);
   }
@@ -93,7 +93,7 @@ class AgentsCommand extends EntitiesCommand<Agent> {
     });
   }
 
-  async disableUpdateToLatestByFilter(filter: Filter) {
+  async disableUpdateToLatestByFilter(filter: FilterType) {
     const response = await this.get({filter});
     return this.disableUpdateToLatest(response.data);
   }
@@ -107,7 +107,7 @@ class AgentsCommand extends EntitiesCommand<Agent> {
     });
   }
 
-  getSeverityAggregates({filter}: {filter?: Filter} = {}) {
+  getSeverityAggregates({filter}: {filter?: FilterType} = {}) {
     const combinedFilter = filter
       ? filter.and(AGENT_CONTROLLER_FILTER)
       : AGENT_CONTROLLER_FILTER;
@@ -120,7 +120,7 @@ class AgentsCommand extends EntitiesCommand<Agent> {
     });
   }
 
-  getNetworkAggregates({filter}: {filter?: Filter} = {}) {
+  getNetworkAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'agent',
       group_column: 'scanner',

--- a/src/gmp/commands/audit-report.ts
+++ b/src/gmp/commands/audit-report.ts
@@ -6,7 +6,7 @@
 import EntityCommand from 'gmp/commands/entity';
 import type Http from 'gmp/http/http';
 import AuditReport, {type AuditReportElement} from 'gmp/models/audit-report';
-import {type default as Filter, ALL_FILTER} from 'gmp/models/filter';
+import {ALL_FILTER, type FilterType} from 'gmp/models/filter';
 import {filterString} from 'gmp/models/filter/utils';
 import {type Element} from 'gmp/models/model';
 import {parseYesNo} from 'gmp/parser';
@@ -19,23 +19,23 @@ interface AuditReportCommandDownloadParams {
 interface AuditReportCommandDownloadOptions {
   reportFormatId: string;
   deltaReportId?: string;
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 interface AuditReportCommandAssetsParams {
   id: string;
-  filter?: Filter | string;
+  filter?: FilterType | string;
 }
 
 interface AuditReportCommandAlertParams {
   alert_id: string;
   report_id: string;
-  filter?: Filter | string;
+  filter?: FilterType | string;
 }
 
 interface AuditReportCommandGetParams {
   id?: string;
-  filter?: Filter | string;
+  filter?: FilterType | string;
   details?: boolean;
   ignorePagination?: boolean;
   lean?: boolean;
@@ -103,7 +103,7 @@ class AuditReportCommand extends EntityCommand<
       details = true,
       ...options
     }: {
-      filter?: Filter | string;
+      filter?: FilterType | string;
       details?: boolean;
       [key: string]: unknown;
     } = {},

--- a/src/gmp/commands/audit-reports.ts
+++ b/src/gmp/commands/audit-reports.ts
@@ -10,11 +10,11 @@ import {
 } from 'gmp/commands/http';
 import type Http from 'gmp/http/http';
 import AuditReport from 'gmp/models/audit-report';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 
 interface AuditReportAggregatesParams {
-  filter?: Filter | string;
+  filter?: FilterType | string;
 }
 
 class AuditReportsCommand extends EntitiesCommand<AuditReport> {

--- a/src/gmp/commands/audits.ts
+++ b/src/gmp/commands/audits.ts
@@ -4,16 +4,15 @@
  */
 
 import type CollectionCounts from 'gmp/collection/collection-counts';
-import AuditCommand from 'gmp/commands/audit';
 import EntitiesCommand from 'gmp/commands/entities';
 import {type HttpCommandOptions} from 'gmp/commands/http';
 import type Http from 'gmp/http/http';
 import Audit from 'gmp/models/audit';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 
 export interface AuditsCommandGetParams {
-  filter?: Filter | string;
+  filter?: FilterType | string;
 }
 
 class AuditsCommand extends EntitiesCommand<Audit> {
@@ -37,12 +36,11 @@ class AuditsCommand extends EntitiesCommand<Audit> {
       filter: responseFilter,
       counts,
     } = this.getCollectionListFromRoot(response.data);
-    return response.set<Audit[], {filter: Filter; counts: CollectionCounts}>(
-      entities,
-      {filter: responseFilter, counts},
-    );
+    return response.set<
+      Audit[],
+      {filter: FilterType; counts: CollectionCounts}
+    >(entities, {filter: responseFilter, counts});
   }
 }
 
 export default AuditsCommand;
-export {AuditCommand};

--- a/src/gmp/commands/cert-bund-advisories.ts
+++ b/src/gmp/commands/cert-bund-advisories.ts
@@ -6,7 +6,7 @@
 import InfoEntitiesCommand from 'gmp/commands/info-entities';
 import type Http from 'gmp/http/http';
 import CertBundAdv from 'gmp/models/cert-bund';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 import {isDefined} from 'gmp/utils/identity';
 
@@ -17,7 +17,7 @@ class CertBundAdvisoriesCommand extends InfoEntitiesCommand<CertBundAdv> {
     super(http, 'cert_bund_adv', CertBundAdv, infoFilter);
   }
 
-  getCreatedAggregates({filter}: {filter?: Filter} = {}) {
+  getCreatedAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'cert_bund_adv',
       group_column: 'created',
@@ -25,7 +25,7 @@ class CertBundAdvisoriesCommand extends InfoEntitiesCommand<CertBundAdv> {
     });
   }
 
-  getSeverityAggregates({filter}: {filter?: Filter} = {}) {
+  getSeverityAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'cert_bund_adv',
       group_column: 'severity',

--- a/src/gmp/commands/cpes.ts
+++ b/src/gmp/commands/cpes.ts
@@ -6,7 +6,7 @@
 import InfoEntitiesCommand from 'gmp/commands/info-entities';
 import type Http from 'gmp/http/http';
 import Cpe from 'gmp/models/cpe';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 import {isDefined} from 'gmp/utils/identity';
 
@@ -17,7 +17,7 @@ class CpesCommand extends InfoEntitiesCommand<Cpe> {
     super(http, 'cpe', Cpe, infoFilter);
   }
 
-  getCreatedAggregates({filter}: {filter?: Filter} = {}) {
+  getCreatedAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'cpe',
       group_column: 'created',
@@ -25,7 +25,7 @@ class CpesCommand extends InfoEntitiesCommand<Cpe> {
     });
   }
 
-  getSeverityAggregates({filter}: {filter?: Filter} = {}) {
+  getSeverityAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'cpe',
       group_column: 'severity',

--- a/src/gmp/commands/cves.ts
+++ b/src/gmp/commands/cves.ts
@@ -6,7 +6,7 @@
 import InfoEntitiesCommand from 'gmp/commands/info-entities';
 import type Http from 'gmp/http/http';
 import Cve from 'gmp/models/cve';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 import {isDefined} from 'gmp/utils/identity';
 
@@ -17,7 +17,7 @@ class CvesCommand extends InfoEntitiesCommand<Cve> {
     super(http, 'cve', Cve, infoFilter);
   }
 
-  getCreatedAggregates({filter}: {filter?: Filter} = {}) {
+  getCreatedAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'cve',
       group_column: 'created',
@@ -25,7 +25,7 @@ class CvesCommand extends InfoEntitiesCommand<Cve> {
     });
   }
 
-  getSeverityAggregates({filter}: {filter?: Filter} = {}) {
+  getSeverityAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'cve',
       group_column: 'severity',

--- a/src/gmp/commands/dfn-cert-advisories.ts
+++ b/src/gmp/commands/dfn-cert-advisories.ts
@@ -6,7 +6,7 @@
 import InfoEntitiesCommand from 'gmp/commands/info-entities';
 import type Http from 'gmp/http/http';
 import DfnCertAdv from 'gmp/models/dfn-cert';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 import {isDefined} from 'gmp/utils/identity';
 
@@ -17,7 +17,7 @@ class DfnCertAdvisoriesCommand extends InfoEntitiesCommand<DfnCertAdv> {
     super(http, 'dfn_cert_adv', DfnCertAdv, infoFilter);
   }
 
-  getCreatedAggregates({filter}: {filter?: Filter} = {}) {
+  getCreatedAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'dfn_cert_adv',
       group_column: 'created',
@@ -25,7 +25,7 @@ class DfnCertAdvisoriesCommand extends InfoEntitiesCommand<DfnCertAdv> {
     });
   }
 
-  getSeverityAggregates({filter}: {filter?: Filter} = {}) {
+  getSeverityAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'dfn_cert_adv',
       group_column: 'severity',

--- a/src/gmp/commands/entities.ts
+++ b/src/gmp/commands/entities.ts
@@ -21,8 +21,7 @@ import HttpCommand, {
 import type Http from 'gmp/http/http';
 import {type default as Response, type Meta} from 'gmp/http/response';
 import {type XmlMeta, type XmlResponseData} from 'gmp/http/transform/fast-xml';
-import Filter, {ALL_FILTER} from 'gmp/models/filter';
-import {filterString} from 'gmp/models/filter/utils';
+import Filter, {ALL_FILTER, type FilterType} from 'gmp/models/filter';
 import {type default as Model, type Element} from 'gmp/models/model';
 import {map, forEach} from 'gmp/utils/array';
 import {isDefined, isString} from 'gmp/utils/identity';
@@ -107,7 +106,7 @@ interface TransformedAggregatesResponseData {
 }
 
 export interface EntitiesMeta extends Meta {
-  filter: Filter;
+  filter: FilterType;
   counts: CollectionCounts;
 }
 
@@ -163,7 +162,7 @@ abstract class EntitiesCommand<
     } else if (isString(filter)) {
       params.filter = Filter.fromString(filter).all();
     } else {
-      params.filter = (filter as Filter).all();
+      params.filter = filter.all();
     }
     return this.get(params, options);
   }
@@ -186,13 +185,13 @@ abstract class EntitiesCommand<
     return this.httpRequestWithRejectionTransform('post', {data});
   }
 
-  exportByFilter(filter: Filter) {
+  exportByFilter(filter: FilterType) {
     return this.httpRequestWithRejectionTransform('post', {
       data: this.postParams({
         cmd: 'bulk_export',
         resource_type: this.name,
         bulk_select: BULK_SELECT_BY_FILTER,
-        filter: filterString(filter),
+        filter,
       }),
     });
   }
@@ -221,7 +220,10 @@ abstract class EntitiesCommand<
     return response.setData(ids);
   }
 
-  async deleteByFilter(filter: Filter, extraParams?: HttpCommandPostParams) {
+  async deleteByFilter(
+    filter: FilterType,
+    extraParams?: HttpCommandPostParams,
+  ) {
     // FIXME change gmp to allow deletion by filter
     const response = await this.get({filter});
     const deleted = response.data;

--- a/src/gmp/commands/entity.ts
+++ b/src/gmp/commands/entity.ts
@@ -16,7 +16,7 @@ import type Response from 'gmp/http/response';
 import {type XmlMeta, type XmlResponseData} from 'gmp/http/transform/fast-xml';
 import logger from 'gmp/log';
 import ActionResult from 'gmp/models/action-result';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type Model from 'gmp/models/model';
 import {isDefined} from 'gmp/utils/identity';
 
@@ -29,7 +29,7 @@ interface EntityCommandInputParams extends HttpCommandInputParams {
 }
 
 interface EntityCommandGetParams {
-  filter?: Filter | string;
+  filter?: FilterType | string;
 }
 
 export interface EntityCommandParams {

--- a/src/gmp/commands/hosts.ts
+++ b/src/gmp/commands/hosts.ts
@@ -6,12 +6,12 @@
 import EntitiesCommand from 'gmp/commands/entities';
 import {BULK_SELECT_BY_IDS} from 'gmp/commands/http';
 import type Http from 'gmp/http/http';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import Host from 'gmp/models/host';
 import {type Element} from 'gmp/models/model';
 
 interface HostAggregatesParams {
-  filter?: Filter | string;
+  filter?: FilterType | string;
 }
 
 interface HostVulnerabilityScoreAggregatesParams extends HostAggregatesParams {

--- a/src/gmp/commands/http.ts
+++ b/src/gmp/commands/http.ts
@@ -19,7 +19,7 @@ import type {
   UrlParams as Params,
   UrlParamValue as ParamValue,
 } from 'gmp/http/utils';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {filterString, isFilter} from 'gmp/models/filter/utils';
 import {hasValue, isDefined} from 'gmp/utils/identity';
 
@@ -45,7 +45,7 @@ export interface HttpCommandPostParams extends Data {
 
 export interface HttpCommandInputParams {
   cmd?: string;
-  filter?: Filter | string;
+  filter?: FilterType | string;
   [key: string]: unknown;
 }
 

--- a/src/gmp/commands/http.ts
+++ b/src/gmp/commands/http.ts
@@ -20,7 +20,7 @@ import type {
   UrlParamValue as ParamValue,
 } from 'gmp/http/utils';
 import {type FilterType} from 'gmp/models/filter';
-import {filterString, isFilter} from 'gmp/models/filter/utils';
+import {filterString, isFilterType} from 'gmp/models/filter/utils';
 import {hasValue, isDefined} from 'gmp/utils/identity';
 
 export interface HttpCommandOptions extends RequestOptions {
@@ -90,7 +90,7 @@ class HttpCommand {
       filter?: string;
     } = {};
     if (hasValue(filter)) {
-      if (isFilter(filter) && isDefined(filter.id)) {
+      if (isFilterType(filter) && isDefined(filter.id)) {
         filterParams.filter_id = filter.id;
       } else {
         filterParams.filter = filterString(filter);
@@ -116,7 +116,7 @@ class HttpCommand {
       filter?: string;
     } = {};
     if (hasValue(filter)) {
-      if (isFilter(filter) && isDefined(filter.id)) {
+      if (isFilterType(filter) && isDefined(filter.id)) {
         filterParams.filter_id = filter.id;
       } else {
         filterParams.filter = filterString(filter);

--- a/src/gmp/commands/notes.ts
+++ b/src/gmp/commands/notes.ts
@@ -5,12 +5,12 @@
 
 import EntitiesCommand from 'gmp/commands/entities';
 import type Http from 'gmp/http/http';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 import Note from 'gmp/models/note';
 
 interface NoteAggregateParams {
-  filter?: Filter | string;
+  filter?: FilterType | string;
 }
 
 class NotesCommand extends EntitiesCommand<Note> {

--- a/src/gmp/commands/nvts.ts
+++ b/src/gmp/commands/nvts.ts
@@ -5,7 +5,7 @@
 
 import InfoEntitiesCommand from 'gmp/commands/info-entities';
 import type Http from 'gmp/http/http';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 import Nvt from 'gmp/models/nvt';
 import {isDefined} from 'gmp/utils/identity';
@@ -17,7 +17,7 @@ class NvtsCommand extends InfoEntitiesCommand<Nvt> {
     super(http, 'nvt', Nvt, infoFilter);
   }
 
-  getFamilyAggregates({filter}: {filter?: Filter} = {}) {
+  getFamilyAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'nvt',
       group_column: 'family',
@@ -26,7 +26,7 @@ class NvtsCommand extends InfoEntitiesCommand<Nvt> {
     });
   }
 
-  getSeverityAggregates({filter}: {filter?: Filter} = {}) {
+  getSeverityAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'nvt',
       group_column: 'severity',
@@ -34,7 +34,7 @@ class NvtsCommand extends InfoEntitiesCommand<Nvt> {
     });
   }
 
-  getQodAggregates({filter}: {filter?: Filter} = {}) {
+  getQodAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'nvt',
       group_column: 'qod',
@@ -42,7 +42,7 @@ class NvtsCommand extends InfoEntitiesCommand<Nvt> {
     });
   }
 
-  getQodTypeAggregates({filter}: {filter?: Filter} = {}) {
+  getQodTypeAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'nvt',
       group_column: 'qod_type',
@@ -50,7 +50,7 @@ class NvtsCommand extends InfoEntitiesCommand<Nvt> {
     });
   }
 
-  getCreatedAggregates({filter}: {filter?: Filter} = {}) {
+  getCreatedAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'nvt',
       group_column: 'created',

--- a/src/gmp/commands/operatingsystems.ts
+++ b/src/gmp/commands/operatingsystems.ts
@@ -6,12 +6,12 @@
 import EntitiesCommand from 'gmp/commands/entities';
 import {BULK_SELECT_BY_IDS} from 'gmp/commands/http';
 import type Http from 'gmp/http/http';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 import OperatingSystem from 'gmp/models/os';
 
 interface OperatingSystemAggregatesParams {
-  filter?: Filter | string;
+  filter?: FilterType | string;
 }
 
 interface OperatingSystemVulnerabilityScoreAggregatesParams extends OperatingSystemAggregatesParams {

--- a/src/gmp/commands/overrides.ts
+++ b/src/gmp/commands/overrides.ts
@@ -5,12 +5,12 @@
 
 import EntitiesCommand from 'gmp/commands/entities';
 import type Http from 'gmp/http/http';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 import Override from 'gmp/models/override';
 
 interface OverrideAggregateParams {
-  filter?: Filter | string;
+  filter?: FilterType | string;
 }
 
 class OverridesCommand extends EntitiesCommand<Override> {

--- a/src/gmp/commands/policies.ts
+++ b/src/gmp/commands/policies.ts
@@ -6,14 +6,13 @@
 import type CollectionCounts from 'gmp/collection/collection-counts';
 import EntitiesCommand from 'gmp/commands/entities';
 import {type HttpCommandOptions} from 'gmp/commands/http';
-import PolicyCommand from 'gmp/commands/policy';
 import type Http from 'gmp/http/http';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 import Policy from 'gmp/models/policy';
 
 export interface PoliciesCommandGetParams {
-  filter?: Filter | string;
+  filter?: FilterType | string;
 }
 
 class PoliciesCommand extends EntitiesCommand<Policy> {
@@ -37,12 +36,11 @@ class PoliciesCommand extends EntitiesCommand<Policy> {
       filter: responseFilter,
       counts,
     } = this.getCollectionListFromRoot(response.data);
-    return response.set<Policy[], {filter: Filter; counts: CollectionCounts}>(
-      entities,
-      {filter: responseFilter, counts},
-    );
+    return response.set<
+      Policy[],
+      {filter: FilterType; counts: CollectionCounts}
+    >(entities, {filter: responseFilter, counts});
   }
 }
 
 export default PoliciesCommand;
-export {PolicyCommand};

--- a/src/gmp/commands/report.ts
+++ b/src/gmp/commands/report.ts
@@ -7,7 +7,7 @@ import EntityCommand from 'gmp/commands/entity';
 import type Http from 'gmp/http/http';
 import {type XmlResponseData} from 'gmp/http/transform/fast-xml';
 import logger from 'gmp/log';
-import {type default as Filter, ALL_FILTER} from 'gmp/models/filter';
+import {ALL_FILTER, type FilterType} from 'gmp/models/filter';
 import {filterString} from 'gmp/models/filter/utils';
 import Report, {type ReportElement} from 'gmp/models/report';
 import {parseYesNo, type YesNo} from 'gmp/parser';
@@ -21,18 +21,18 @@ interface ReportCommandImportParams {
 
 interface ReportCommandAssetsParams {
   id: string;
-  filter?: Filter | string;
+  filter?: FilterType | string;
 }
 
 interface ReportCommandAlertParams {
   alert_id: string;
   report_id: string;
-  filter?: Filter | string;
+  filter?: FilterType | string;
 }
 
 interface ReportCommandGetParams {
   id?: string;
-  filter?: Filter | string;
+  filter?: FilterType | string;
   details?: boolean;
   ignorePagination?: boolean;
   lean?: boolean;
@@ -47,7 +47,7 @@ interface ReportCommandDownloadOptions {
   reportFormatId: string;
   reportConfigId: string;
   deltaReportId?: string;
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const log = logger.getLogger('gmp.commands.reports');
@@ -127,7 +127,7 @@ class ReportCommand extends EntityCommand<Report, ReportElement> {
       details = true,
       ...options
     }: {
-      filter?: Filter | string;
+      filter?: FilterType | string;
       details?: boolean;
       [key: string]: unknown;
     } = {},

--- a/src/gmp/commands/reports.ts
+++ b/src/gmp/commands/reports.ts
@@ -6,7 +6,7 @@
 import EntitiesCommand from 'gmp/commands/entities';
 import type Http from 'gmp/http/http';
 import {type XmlResponseData} from 'gmp/http/transform/fast-xml';
-import Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import Report from 'gmp/models/report';
 
 interface ReportsCommandGetParams {
@@ -29,7 +29,7 @@ class ReportsCommand extends EntitiesCommand<Report> {
     return root.get_reports.get_reports_response;
   }
 
-  getSeverityAggregates({filter}: {filter: Filter} = {filter: new Filter()}) {
+  getSeverityAggregates({filter}: {filter?: FilterType}) {
     return this.getAggregates({
       aggregate_type: 'report',
       group_column: 'severity',
@@ -37,9 +37,7 @@ class ReportsCommand extends EntitiesCommand<Report> {
     });
   }
 
-  getHighResultsAggregates(
-    {filter}: {filter: Filter} = {filter: new Filter()},
-  ) {
+  getHighResultsAggregates({filter}: {filter?: FilterType}) {
     return this.getAggregates({
       aggregate_type: 'report',
       group_column: 'date',

--- a/src/gmp/commands/resource-names.ts
+++ b/src/gmp/commands/resource-names.ts
@@ -11,14 +11,14 @@ import {
 import {type EntitiesMeta} from 'gmp/commands/entities';
 import HttpCommand from 'gmp/commands/http';
 import type Http from 'gmp/http/http';
-import Filter, {ALL_FILTER} from 'gmp/models/filter';
+import Filter, {ALL_FILTER, type FilterType} from 'gmp/models/filter';
 import ResourceName from 'gmp/models/resource-name';
 import {resourceType, type EntityType} from 'gmp/utils/entity-type';
 import {isDefined, isString} from 'gmp/utils/identity';
 
 interface ResourceNamesGetParams {
   resourceType?: EntityType;
-  filter?: Filter | string;
+  filter?: FilterType | string;
 }
 
 class ResourceNamesCommand extends HttpCommand {
@@ -79,7 +79,7 @@ class ResourceNamesCommand extends HttpCommand {
     } else if (isString(filter)) {
       params.filter = Filter.fromString(filter).all();
     } else {
-      params.filter = (filter as Filter).all();
+      params.filter = filter.all();
     }
     return this.get(params);
   }

--- a/src/gmp/commands/results.ts
+++ b/src/gmp/commands/results.ts
@@ -9,12 +9,12 @@ import {
   type HttpCommandOptions,
 } from 'gmp/commands/http';
 import type Http from 'gmp/http/http';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 import Result from 'gmp/models/result';
 
 interface GetAggregatesParams {
-  filter?: Filter;
+  filter?: FilterType | string;
 }
 
 class ResultsCommand extends EntitiesCommand<Result> {

--- a/src/gmp/commands/tag.ts
+++ b/src/gmp/commands/tag.ts
@@ -6,7 +6,7 @@
 import EntityCommand, {type EntityCommandParams} from 'gmp/commands/entity';
 import type Http from 'gmp/http/http';
 import logger from 'gmp/log';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {filterString} from 'gmp/models/filter/utils';
 import {type Element} from 'gmp/models/model';
 import Tag, {type TagElement} from 'gmp/models/tag';
@@ -16,7 +16,7 @@ import {resourceType, type EntityType} from 'gmp/utils/entity-type';
 interface TagCommandCreateParams {
   active: boolean;
   comment?: string;
-  filter?: Filter | string;
+  filter?: FilterType | string;
   name: string;
   resourceIds?: string[];
   resourceType: EntityType;

--- a/src/gmp/commands/target.ts
+++ b/src/gmp/commands/target.ts
@@ -6,7 +6,7 @@
 import EntityCommand from 'gmp/commands/entity';
 import {feedStatusRejection} from 'gmp/commands/feed-status';
 import type Http from 'gmp/http/http';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {filterString} from 'gmp/models/filter/utils';
 import Target, {type AliveTest} from 'gmp/models/target';
 import {parseYesNo} from 'gmp/parser';
@@ -25,7 +25,7 @@ interface TargetCommandCreateParams {
   excludeHosts?: string;
   file?: File;
   hosts?: string;
-  hostsFilter?: Filter;
+  hostsFilter?: FilterType | string;
   krb5CredentialId?: string;
   name: string;
   port?: number;

--- a/src/gmp/commands/tasks.ts
+++ b/src/gmp/commands/tasks.ts
@@ -7,7 +7,7 @@ import type CollectionCounts from 'gmp/collection/collection-counts';
 import EntitiesCommand from 'gmp/commands/entities';
 import {type HttpCommandOptions} from 'gmp/commands/http';
 import type Http from 'gmp/http/http';
-import type Filter from 'gmp/models/filter';
+import {type default as Filter, type FilterType} from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 import Task, {type TaskElement} from 'gmp/models/task';
 import {parseYesNo, type YesNo} from 'gmp/parser';
@@ -35,11 +35,11 @@ interface GetTasksResponse extends Element {
 }
 
 interface TasksCommandWithFilterParam {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 interface TasksCommandGetParams {
-  filter?: Filter | string;
+  filter?: FilterType | string;
   schedulesOnly?: boolean;
 }
 
@@ -70,7 +70,7 @@ class TasksCommand extends EntitiesCommand<Task, GetTasksResponse> {
       filter: responseFilter,
       counts,
     } = this.getCollectionListFromRoot(response.data);
-    return response.set<Task[], {filter: Filter; counts: CollectionCounts}>(
+    return response.set<Task[], {filter: FilterType; counts: CollectionCounts}>(
       entities,
       {filter: responseFilter, counts},
     );

--- a/src/gmp/commands/tls-certificates.ts
+++ b/src/gmp/commands/tls-certificates.ts
@@ -5,12 +5,12 @@
 
 import EntitiesCommand from 'gmp/commands/entities';
 import type Http from 'gmp/http/http';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type Element} from 'gmp/models/model';
 import TlsCertificate from 'gmp/models/tls-certificate';
 
 interface TlsCertificateAggregatesParams {
-  filter?: Filter | string;
+  filter?: FilterType | string;
 }
 
 class TlsCertificatesCommand extends EntitiesCommand<TlsCertificate> {

--- a/src/gmp/commands/vulnerabilities.ts
+++ b/src/gmp/commands/vulnerabilities.ts
@@ -6,7 +6,7 @@
 import EntitiesCommand from 'gmp/commands/entities';
 import type Http from 'gmp/http/http';
 import type {XmlResponseData} from 'gmp/http/transform/fast-xml';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import Vulnerability from 'gmp/models/vulnerability';
 
 class VulnerabilitiesCommand extends EntitiesCommand<Vulnerability> {
@@ -21,7 +21,7 @@ class VulnerabilitiesCommand extends EntitiesCommand<Vulnerability> {
     );
   }
 
-  getSeverityAggregates({filter}: {filter?: Filter} = {}) {
+  getSeverityAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'vuln',
       group_column: 'severity',
@@ -29,7 +29,7 @@ class VulnerabilitiesCommand extends EntitiesCommand<Vulnerability> {
     });
   }
 
-  getHostAggregates({filter}: {filter?: Filter} = {}) {
+  getHostAggregates({filter}: {filter?: FilterType} = {}) {
     return this.getAggregates({
       aggregate_type: 'vuln',
       group_column: 'hosts',

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -62,7 +62,7 @@ export interface FilterType {
   first(first?: number): Filter;
   forEach(func: FilterForEachFunc): void;
   getAllTerms(): readonly FilterTerm[];
-  get(key: string, def?: string): string | number | undefined;
+  get(key: string, def?: string | number): string | number | undefined;
   getSortBy(): string | undefined;
   getSortOrder(): FilterSortOrder;
   getTerm(key?: string): FilterTerm | undefined;

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -58,7 +58,7 @@ export interface FilterType {
   and(filter?: Filter): Filter;
   copy(): Filter;
   delete(key: string): Filter;
-  equals(filter?: Filter): boolean;
+  equals(filter?: FilterType): boolean;
   first(first?: number): Filter;
   forEach(func: FilterForEachFunc): void;
   getAllTerms(): readonly FilterTerm[];
@@ -70,19 +70,19 @@ export interface FilterType {
   has(key: string): boolean;
   hasTerm(term?: FilterTerm): boolean;
   identifier(): string;
-  merge(filter?: Filter): Filter;
-  mergeExtraKeywords(filter?: Filter): Filter;
-  mergeKeywords(filter?: Filter): Filter;
-  next(): Filter;
-  previous(): Filter;
+  merge(filter?: FilterType): FilterType;
+  mergeExtraKeywords(filter?: FilterType): FilterType;
+  mergeKeywords(filter?: FilterType): FilterType;
+  next(): FilterType;
+  previous(): FilterType;
   set(
     keyword: string,
     value?: string | number | boolean,
     relation?: string,
-  ): Filter;
-  setSortBy(value: string): Filter;
-  setSortOrder(value: FilterSortOrder): Filter;
-  simple(): Filter;
+  ): FilterType;
+  setSortBy(value: string): FilterType;
+  setSortOrder(value: FilterSortOrder): FilterType;
+  simple(): FilterType;
   toFilterCriteriaString(): string;
   toFilterExtraString(): string;
   toFilterString(): string;
@@ -293,11 +293,12 @@ class Filter extends EntityModel implements FilterType {
    * @param filter Filter to get extra keywords from
    * @returns Array of FilterTerms with extra keywords from filter that are not included in this filter
    */
-  private _getExtraKeywords(filter: Filter | undefined | null) {
+  private _getExtraKeywords(filter: FilterType | undefined | null) {
     if (!hasValue(filter)) {
       return [];
     }
-    return filter.terms.filter(term => {
+    const terms = filter.getAllTerms();
+    return terms.filter(term => {
       const {keyword: key} = term;
       return (
         isDefined(key) &&
@@ -315,11 +316,12 @@ class Filter extends EntityModel implements FilterType {
    * @param filter Filter to get new keywords from
    * @returns Array of FilterTerms with new keywords from filter that are not included in this filter
    */
-  private _getNewKeywords(filter?: Filter) {
+  private _getNewKeywords(filter?: FilterType) {
     if (!hasValue(filter)) {
       return [];
     }
-    return filter.terms.filter(term => {
+    const terms = filter.getAllTerms();
+    return terms.filter(term => {
       const {keyword: key} = term;
       return isDefined(key) && !this.has(key);
     });
@@ -592,7 +594,7 @@ class Filter extends EntityModel implements FilterType {
    *
    * @return {bool} Returns true if this filter equals to the other filter
    */
-  equals(filter: Filter | undefined | null): boolean {
+  equals(filter: FilterType | undefined | null): boolean {
     if (!hasValue(filter)) {
       return false;
     }
@@ -884,7 +886,7 @@ class Filter extends EntityModel implements FilterType {
    *
    * @return New Filter with FilterTerms parsed from filterString.
    */
-  static fromString(filterString?: string, filter?: Filter): Filter {
+  static fromString(filterString?: string, filter?: FilterType): Filter {
     const f = new Filter({
       terms: parseFilterTermsFromString(filterString),
     });

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -53,6 +53,7 @@ type FilterForEachFunc = (
 
 export interface FilterType {
   id?: string;
+  length: number;
   all(): Filter;
   and(filter?: Filter): Filter;
   copy(): Filter;

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -29,6 +29,13 @@ export interface FilterModelElement extends ModelElement {
   term?: string;
 }
 
+export interface FilterResponseElement {
+  keywords?: {
+    keyword?: FilterKeyword | FilterKeyword[];
+  };
+  term?: string;
+}
+
 interface FilterModelProperties extends ModelProperties {
   _term?: string;
   alerts?: Model[];

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -44,6 +44,42 @@ type FilterForEachFunc = (
   array: FilterTerm[],
 ) => void;
 
+export interface FilterType {
+  id?: string;
+  all(): Filter;
+  and(filter?: Filter): Filter;
+  copy(): Filter;
+  delete(key: string): Filter;
+  equals(filter?: Filter): boolean;
+  first(first?: number): Filter;
+  forEach(func: FilterForEachFunc): void;
+  getAllTerms(): readonly FilterTerm[];
+  get(key: string, def?: string): string | number | undefined;
+  getSortBy(): string | undefined;
+  getSortOrder(): FilterSortOrder;
+  getTerm(key?: string): FilterTerm | undefined;
+  getTerms(key?: string): FilterTerm[];
+  has(key: string): boolean;
+  hasTerm(term?: FilterTerm): boolean;
+  identifier(): string;
+  merge(filter?: Filter): Filter;
+  mergeExtraKeywords(filter?: Filter): Filter;
+  mergeKeywords(filter?: Filter): Filter;
+  next(): Filter;
+  previous(): Filter;
+  set(
+    keyword: string,
+    value?: string | number | boolean,
+    relation?: string,
+  ): Filter;
+  setSortBy(value: string): Filter;
+  setSortOrder(value: FilterSortOrder): Filter;
+  simple(): Filter;
+  toFilterCriteriaString(): string;
+  toFilterExtraString(): string;
+  toFilterString(): string;
+}
+
 export const UNKNOWN_FILTER_ID = '0';
 const SORT_ORDER_ASC = 'sort';
 const SORT_ORDER_DESC = 'sort-reverse';
@@ -94,7 +130,7 @@ const parseFilterTermsFromString = (
 /**
  * Represents a filter
  */
-class Filter extends EntityModel {
+class Filter extends EntityModel implements FilterType {
   static readonly entityType = 'filter';
 
   readonly alerts: Model[];

--- a/src/gmp/models/filter/__tests__/utils.test.ts
+++ b/src/gmp/models/filter/__tests__/utils.test.ts
@@ -5,7 +5,7 @@
 
 import {describe, test, expect} from '@gsa/testing';
 import Filter from 'gmp/models/filter';
-import {filterString, isFilter} from 'gmp/models/filter/utils';
+import {filterString, isFilterType} from 'gmp/models/filter/utils';
 
 describe('filterString function tests', () => {
   test('should return undefined for undefined input', () => {
@@ -26,15 +26,15 @@ describe('filterString function tests', () => {
   });
 });
 
-describe('isFilter function tests', () => {
+describe('isFilterType function tests', () => {
   test('should return true for Filter objects', () => {
     const filter = Filter.fromString('foo bar');
-    expect(isFilter(filter)).toBe(true);
+    expect(isFilterType(filter)).toBe(true);
   });
 
   test('should return false for non-Filter objects', () => {
-    expect(isFilter(1)).toBe(false);
-    expect(isFilter('foo')).toBe(false);
-    expect(isFilter()).toBe(false);
+    expect(isFilterType(1)).toBe(false);
+    expect(isFilterType('foo')).toBe(false);
+    expect(isFilterType()).toBe(false);
   });
 });

--- a/src/gmp/models/filter/utils.ts
+++ b/src/gmp/models/filter/utils.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 
-export const isFilter = (filter?: unknown): filter is Filter =>
-  isDefined((filter as Filter)?.toFilterString);
+export const isFilter = (filter?: unknown): filter is FilterType =>
+  isDefined((filter as FilterType)?.toFilterString);
 
-export const filterString = (filter?: Filter | number | string) =>
+export const filterString = (filter?: FilterType | number | string) =>
   isFilter(filter)
     ? filter.toFilterString()
     : isDefined(filter)

--- a/src/gmp/models/filter/utils.ts
+++ b/src/gmp/models/filter/utils.ts
@@ -6,11 +6,11 @@
 import {type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 
-export const isFilter = (filter?: unknown): filter is FilterType =>
+export const isFilterType = (filter?: unknown): filter is FilterType =>
   isDefined((filter as FilterType)?.toFilterString);
 
 export const filterString = (filter?: FilterType | number | string) =>
-  isFilter(filter)
+  isFilterType(filter)
     ? filter.toFilterString()
     : isDefined(filter)
       ? String(filter)

--- a/src/gmp/models/report/audit-report.ts
+++ b/src/gmp/models/report/audit-report.ts
@@ -7,7 +7,7 @@ import {type CollectionList, parseFilter} from 'gmp/collection/parser';
 import {type AuditStatus} from 'gmp/models/audit';
 import {type ComplianceType} from 'gmp/models/compliance';
 import {type Date} from 'gmp/models/date';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import Model, {type ModelProperties} from 'gmp/models/model';
 import {
   parseResults,
@@ -62,7 +62,7 @@ interface AuditReportReportProperties extends ModelProperties {
   compliance?: AuditReportCompliance;
   complianceCounts?: AuditReportComplianceCounts;
   delta_report?: DeltaReport;
-  filter?: Filter;
+  filter?: FilterType;
   reportType?: ReportType;
   results?: CollectionList<Result>;
   task?: ReportTask;
@@ -79,7 +79,7 @@ class AuditReportReport extends Model {
   readonly compliance?: AuditReportCompliance;
   readonly complianceCounts?: AuditReportComplianceCounts;
   readonly delta_report?: DeltaReport;
-  readonly filter?: Filter;
+  readonly filter?: FilterType;
   readonly reportType?: ReportType;
   // used for delta reports only
   readonly results?: CollectionList<Result>;
@@ -138,9 +138,7 @@ class AuditReportReport extends Model {
     const {delta, compliance, compliance_count, scan_start, scan_end, task} =
       element;
 
-    const filter = parseFilter(element);
-
-    copy.filter = filter;
+    copy.filter = parseFilter(element);
 
     copy.reportType = element._type;
 

--- a/src/gmp/models/report/parser.ts
+++ b/src/gmp/models/report/parser.ts
@@ -10,7 +10,7 @@ import {
   type CollectionList,
 } from 'gmp/collection/parser';
 import {type ComplianceType} from 'gmp/models/compliance';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type NvtRefElement, type NvtSeveritiesElement} from 'gmp/models/nvt';
 import {type ReportTLSCertificateElement} from 'gmp/models/report/tls-certificate';
 import Result from 'gmp/models/result';
@@ -370,7 +370,7 @@ interface ResultsReportElement {
 // reports with details=1 always have a results element
 // (that can be empty) whereas reports with details=0
 // never have a results element
-export const emptyCollectionList = (filter: Filter) => {
+export const emptyCollectionList = (filter: FilterType) => {
   return {
     filter,
     entities: [],
@@ -405,7 +405,7 @@ export const parseHostSeverities = (results: ReportResultsElement = {}) => {
 
 export const parseErrors = (
   report: ErrorsReportElement,
-  filter: Filter,
+  filter: FilterType,
 ): CollectionList<ReportError> => {
   const {host: hosts, errors} = report;
 
@@ -505,7 +505,7 @@ const parseCveEndpointElements = (
 const buildCveCollectionList = (
   entities: ReportClosedCve[],
   container: CveEndpointContainer,
-  filter: Filter,
+  filter: FilterType,
 ): CollectionList<ReportClosedCve> => {
   const {length: filteredCount} = entities;
 
@@ -524,7 +524,7 @@ const buildCveCollectionList = (
 
 export const parseCvesFromEndpoint = (
   data: CvesEndpointData,
-  filter: Filter,
+  filter: FilterType,
 ): CollectionList<ReportActiveCve> => {
   const {cves: cvesContainer} = data;
 
@@ -539,7 +539,7 @@ export const parseCvesFromEndpoint = (
 
 export const parseClosedCvesFromEndpoint = (
   data: ClosedCvesEndpointData,
-  filter: Filter,
+  filter: FilterType,
 ): CollectionList<ReportClosedCve> => {
   const {closed_cves: closedCvesContainer} = data;
 

--- a/src/gmp/models/report/report.ts
+++ b/src/gmp/models/report/report.ts
@@ -5,7 +5,7 @@
 
 import {type CollectionList, parseFilter} from 'gmp/collection/parser';
 import {type Date} from 'gmp/models/date';
-import Filter, {type FilterKeyword} from 'gmp/models/filter';
+import {type FilterType, type FilterKeyword} from 'gmp/models/filter';
 import Model, {type ModelElement, type ModelProperties} from 'gmp/models/model';
 import {
   parseResults,
@@ -133,7 +133,7 @@ interface ReportResultCounts {
 
 interface ReportReportProperties extends ModelProperties {
   delta_report?: DeltaReport;
-  filter?: Filter;
+  filter?: FilterType;
   report_type?: ReportType;
   results?: CollectionList<Result>;
   result_count?: ReportResultCounts;
@@ -150,7 +150,7 @@ class ReportReport extends Model {
   static readonly entityType = 'report';
 
   readonly delta_report?: DeltaReport;
-  readonly filter?: Filter;
+  readonly filter?: FilterType;
   readonly report_type?: ReportType;
   // used for delta reports only
   readonly results?: CollectionList<Result>;
@@ -212,10 +212,7 @@ class ReportReport extends Model {
 
     const {delta, severity, scan_start, scan_end, task} = element;
 
-    const filter = isDefined(element.filters)
-      ? parseFilter(element)
-      : new Filter();
-    copy.filter = filter;
+    copy.filter = parseFilter(element);
 
     copy.report_type = element._type;
 

--- a/src/web/components/icon/ListIcon.tsx
+++ b/src/web/components/icon/ListIcon.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {ListSvgIcon} from 'web/components/icon';
 import {type ExtendedDynamicIconProps} from 'web/components/icon/createIconComponents';
 import Link from 'web/components/link/Link';
@@ -13,7 +13,7 @@ interface ListIconProps<
 > extends ExtendedDynamicIconProps<TValue> {
   'data-testid'?: string;
   page?: string;
-  filter?: string | Filter;
+  filter?: FilterType | string;
 }
 
 const ListIcon = <TValue = string,>({

--- a/src/web/components/link/Link.tsx
+++ b/src/web/components/link/Link.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import {type LinkProps as RLinkProps, Link as RLink} from 'react-router';
 import styled from 'styled-components';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isDefined, isString} from 'gmp/utils/identity';
 import Theme from 'web/utils/Theme';
 
@@ -24,7 +24,7 @@ interface WithTextOnlyComponentProps {
 interface LinkComponentProps extends Omit<RLinkProps, 'to'> {
   anchor?: string;
   to?: string;
-  filter?: string | Filter;
+  filter?: FilterType | string;
   query?: Record<string, string>;
 }
 

--- a/src/web/components/powerfilter/ApplyOverridesGroup.tsx
+++ b/src/web/components/powerfilter/ApplyOverridesGroup.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type YesNo} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import FormGroup from 'web/components/form/FormGroup';
@@ -11,7 +11,7 @@ import YesNoRadio from 'web/components/form/YesNoRadio';
 import useTranslation from 'web/hooks/useTranslation';
 
 interface ApplyOverridesGroupProps {
-  filter?: Filter;
+  filter?: FilterType;
   name?: string;
   overrides?: YesNo;
   onChange?: (value: YesNo, name: string) => void;

--- a/src/web/components/powerfilter/BooleanFilterGroup.tsx
+++ b/src/web/components/powerfilter/BooleanFilterGroup.tsx
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {parseYesNo, type YesNo} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import FormGroup from 'web/components/form/FormGroup';
 import YesNoRadio from 'web/components/form/YesNoRadio';
 
 interface BooleanFilterGroupProps {
-  filter?: Filter;
+  filter?: FilterType;
   name: string;
   title?: string;
   onChange?: (value: YesNo, name: string) => void;

--- a/src/web/components/powerfilter/ComplianceLevelsGroup.tsx
+++ b/src/web/components/powerfilter/ComplianceLevelsGroup.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import Checkbox from 'web/components/form/Checkbox';
 import FormGroup from 'web/components/form/FormGroup';
@@ -12,7 +12,7 @@ import IconDivider from 'web/components/layout/IconDivider';
 import useTranslation from 'web/hooks/useTranslation';
 
 interface ComplianceLevelsFilterGroupProps {
-  filter: Filter;
+  filter: FilterType;
   onChange: (value: string, field: string) => void;
   onRemove: () => void;
   isResult?: boolean;

--- a/src/web/components/powerfilter/DefaultFilterDialog.tsx
+++ b/src/web/components/powerfilter/DefaultFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {type default as Filter, type FilterSortOrder} from 'gmp/models/filter';
+import {type FilterType, type FilterSortOrder} from 'gmp/models/filter';
 import CreateNamedFilterGroup from 'web/components/powerfilter/CreateNamedFilterGroup';
 import FilterStringGroup from 'web/components/powerfilter/FilterStringGroup';
 import FirstResultGroup from 'web/components/powerfilter/FirstResultGroup';
@@ -14,7 +14,7 @@ import SortByGroup, {
 import useCapabilities from 'web/hooks/useCapabilities';
 
 interface DefaultFilterDialogProps {
-  filter?: Filter;
+  filter?: FilterType;
   filterName?: string;
   filterString: string;
   saveNamedFilter?: boolean;

--- a/src/web/components/powerfilter/FilterSearchGroup.tsx
+++ b/src/web/components/powerfilter/FilterSearchGroup.tsx
@@ -6,13 +6,13 @@
 /* this is experimental. trying to consolidate all filter terms whose
  * method should be ~'value' into one. */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import FormGroup from 'web/components/form/FormGroup';
 import TextField from 'web/components/form/TextField';
 
 interface FilterSearchGroupProps {
-  filter?: Filter;
+  filter?: FilterType;
   name: string;
   title?: string;
   onChange?: (value: string, name: string) => void;

--- a/src/web/components/powerfilter/FilterStringGroup.tsx
+++ b/src/web/components/powerfilter/FilterStringGroup.tsx
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isString} from 'gmp/utils/identity';
 import FormGroup from 'web/components/form/FormGroup';
 import TextField from 'web/components/form/TextField';
 import useTranslation from 'web/hooks/useTranslation';
 
 interface FilterStringGroupProps {
-  filter: string | Filter;
+  filter: FilterType | string;
   name?: string;
   onChange?: (value: string, name: string) => void;
 }

--- a/src/web/components/powerfilter/FirstResultGroup.tsx
+++ b/src/web/components/powerfilter/FirstResultGroup.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import FormGroup from 'web/components/form/FormGroup';
 import Spinner from 'web/components/form/Spinner';
@@ -11,7 +11,7 @@ import useTranslation from 'web/hooks/useTranslation';
 
 interface FirstResultGroupProps {
   first?: number;
-  filter?: Filter;
+  filter?: FilterType;
   name?: string;
   onChange?: (value: number, name: string) => void;
 }

--- a/src/web/components/powerfilter/MinQodGroup.tsx
+++ b/src/web/components/powerfilter/MinQodGroup.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import FormGroup from 'web/components/form/FormGroup';
 import Spinner from 'web/components/form/Spinner';
@@ -11,7 +11,7 @@ import useTranslation from 'web/hooks/useTranslation';
 
 interface MinQodGroupProps {
   qod?: number;
-  filter?: Filter;
+  filter?: FilterType;
   name?: string;
   onChange?: (value: number, name: string) => void;
 }

--- a/src/web/components/powerfilter/PowerFilter.tsx
+++ b/src/web/components/powerfilter/PowerFilter.tsx
@@ -8,7 +8,7 @@ import styled from 'styled-components';
 import type Capabilities from 'gmp/capabilities/capabilities';
 import type Gmp from 'gmp/gmp';
 import Filter, {RESET_FILTER} from 'gmp/models/filter';
-import {isFilter} from 'gmp/models/filter/utils';
+import {isFilterType} from 'gmp/models/filter/utils';
 import {KeyEvent} from 'gmp/utils/event';
 import {isDefined, isString} from 'gmp/utils/identity';
 import Select from 'web/components/form/Select';
@@ -61,7 +61,7 @@ const PowerFilterTextField = styled(TextField<string>)`
 `;
 
 const getUserFilterString = (filter?: Filter | string) => {
-  if (isFilter(filter)) {
+  if (isFilterType(filter)) {
     return filter.toFilterCriteriaString();
   }
   if (isString(filter)) {

--- a/src/web/components/powerfilter/PowerFilter.tsx
+++ b/src/web/components/powerfilter/PowerFilter.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import styled from 'styled-components';
 import type Capabilities from 'gmp/capabilities/capabilities';
 import type Gmp from 'gmp/gmp';
-import Filter, {RESET_FILTER} from 'gmp/models/filter';
+import Filter, {type FilterType, RESET_FILTER} from 'gmp/models/filter';
 import {isFilterType} from 'gmp/models/filter/utils';
 import {KeyEvent} from 'gmp/utils/event';
 import {isDefined, isString} from 'gmp/utils/identity';
@@ -27,21 +27,21 @@ import withTranslation from 'web/utils/withTranslation';
 
 interface PowerFilterState {
   userFilterString: string;
-  prevFilter?: Filter;
+  prevFilter?: FilterType;
 }
 
 interface PowerFilterProps {
   capabilities: Capabilities;
   createFilterType?: string;
-  filter?: Filter;
+  filter?: FilterType;
   filters?: Filter[];
   isLoading?: boolean;
   isLoadingFilters?: boolean;
-  resetFilter?: Filter;
+  resetFilter?: FilterType;
   gmp: Gmp;
   _: (key: string) => string;
   onEditClick?: () => void;
-  onUpdate?: (filter: Filter) => void;
+  onUpdate?: (filter: FilterType) => void;
   onRemoveClick?: () => void;
   onResetClick?: () => void;
 }
@@ -60,7 +60,7 @@ const PowerFilterTextField = styled(TextField<string>)`
   width: 30vw;
 `;
 
-const getUserFilterString = (filter?: Filter | string) => {
+const getUserFilterString = (filter?: FilterType | string) => {
   if (isFilterType(filter)) {
     return filter.toFilterCriteriaString();
   }
@@ -110,7 +110,7 @@ class PowerFilter extends React.Component<PowerFilterProps, PowerFilterState> {
     return null;
   }
 
-  updateFilter(filter: Filter) {
+  updateFilter(filter: FilterType) {
     const {onUpdate} = this.props;
 
     if (onUpdate) {
@@ -151,11 +151,8 @@ class PowerFilter extends React.Component<PowerFilterProps, PowerFilterState> {
   handleNamedFilterChange(value: string) {
     const {filters = [], resetFilter = RESET_FILTER} = this.props;
 
-    let filter = filters.find(f => f.id === value);
-    if (!isDefined(filter)) {
-      filter = resetFilter;
-    }
-    this.updateFilter(filter);
+    const filter: FilterType | undefined = filters.find(f => f.id === value);
+    this.updateFilter(filter ?? resetFilter);
   }
 
   handleRemoveClick() {

--- a/src/web/components/powerfilter/ResultsPerPageGroup.tsx
+++ b/src/web/components/powerfilter/ResultsPerPageGroup.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import FormGroup from 'web/components/form/FormGroup';
 import Spinner from 'web/components/form/Spinner';
@@ -11,7 +11,7 @@ import useTranslation from 'web/hooks/useTranslation';
 
 interface ResultsPerPageGroupProps {
   rows?: number;
-  filter?: Filter;
+  filter?: FilterType;
   name?: string;
   onChange?: (value: number, name: string) => void;
 }

--- a/src/web/components/powerfilter/SeverityLevelsGroup.tsx
+++ b/src/web/components/powerfilter/SeverityLevelsGroup.tsx
@@ -4,7 +4,7 @@
  */
 
 import {useCallback} from 'react';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
 import Checkbox from 'web/components/form/Checkbox';
@@ -15,7 +15,7 @@ import useGmp from 'web/hooks/useGmp';
 import useTranslation from 'web/hooks/useTranslation';
 
 interface SeverityLevelsFilterGroupProps {
-  filter: Filter;
+  filter: FilterType;
   onChange: (value: string, field: string) => void;
   onRemove: () => void;
 }

--- a/src/web/components/powerfilter/SeverityValuesGroup.tsx
+++ b/src/web/components/powerfilter/SeverityValuesGroup.tsx
@@ -4,7 +4,7 @@
  */
 
 import {useState} from 'react';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {parseSeverity} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import FormGroup from 'web/components/form/FormGroup';
@@ -13,7 +13,7 @@ import RelationSelector from 'web/components/powerfilter/RelationSelector';
 import {UNSET_VALUE} from 'web/utils/Render';
 
 interface SeverityValuesGroupProps {
-  filter: Filter;
+  filter: FilterType;
   name: string;
   title?: string;
   onChange?: (value: number, name: string, relation?: string) => void;

--- a/src/web/components/powerfilter/SolutionTypeGroup.tsx
+++ b/src/web/components/powerfilter/SolutionTypeGroup.tsx
@@ -4,7 +4,7 @@
  */
 
 import styled from 'styled-components';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import FormGroup from 'web/components/form/FormGroup';
 import Radio from 'web/components/form/Radio';
@@ -18,8 +18,8 @@ import TableRow from 'web/components/table/TableRow';
 import useTranslation from 'web/hooks/useTranslation';
 
 interface SolutionTypesFilterGroupProps {
-  filter: Filter;
-  onChange: (filter: Filter) => void;
+  filter: FilterType;
+  onChange: (filter: FilterType) => void;
 }
 
 const StyledLayout = styled(Layout)`

--- a/src/web/components/powerfilter/SortByGroup.tsx
+++ b/src/web/components/powerfilter/SortByGroup.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {type default as Filter, type FilterSortOrder} from 'gmp/models/filter';
+import {type FilterType, type FilterSortOrder} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import FormGroup from 'web/components/form/FormGroup';
 import Radio from 'web/components/form/Radio';
@@ -18,7 +18,7 @@ export interface SortByField {
 interface SortByGroupProps {
   by?: string;
   fields?: SortByField[];
-  filter?: Filter;
+  filter?: FilterType;
   order?: FilterSortOrder;
   onSortByChange?: (value: string) => void;
   onSortOrderChange?: (value: FilterSortOrder) => void;

--- a/src/web/components/powerfilter/TaskTrendGroup.tsx
+++ b/src/web/components/powerfilter/TaskTrendGroup.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {type TaskTrend} from 'gmp/models/task';
 import {isDefined} from 'gmp/utils/identity';
 import FormGroup from 'web/components/form/FormGroup';
@@ -13,7 +13,7 @@ import useTranslation from 'web/hooks/useTranslation';
 interface TaskTrendGroupProps {
   trend?: TaskTrend;
   name?: string;
-  filter?: Filter;
+  filter?: FilterType;
   onChange?: (value: TaskTrend, name: string) => void;
 }
 

--- a/src/web/components/powerfilter/TicketStatusGroup.tsx
+++ b/src/web/components/powerfilter/TicketStatusGroup.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {TICKET_STATUS, type TicketStatus} from 'gmp/models/ticket';
 import {isDefined} from 'gmp/utils/identity';
 import FormGroup from 'web/components/form/FormGroup';
@@ -12,7 +12,7 @@ import useTranslation from 'web/hooks/useTranslation';
 
 interface TicketStatusFilterGroupProps {
   status?: TicketStatus;
-  filter?: Filter;
+  filter?: FilterType;
   name?: string;
   onChange: (value: TicketStatus, name: string) => void;
 }

--- a/src/web/components/powerfilter/useFilterDialog.tsx
+++ b/src/web/components/powerfilter/useFilterDialog.tsx
@@ -4,7 +4,7 @@
  */
 
 import {useCallback, useState} from 'react';
-import Filter, {type FilterSortOrder} from 'gmp/models/filter';
+import Filter, {type FilterType, type FilterSortOrder} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 
 export interface FilterDialogState {
@@ -15,15 +15,15 @@ export interface FilterDialogState {
 /**
  * React hook for handling filter dialog state
  *
- * @param {Filter} initialFilter
+ * @param initialFilter Optional initial filter to be used in the dialog
  * @returns Object
  */
 const useFilterDialog = <TFilterDialogState extends FilterDialogState>(
-  initialFilter?: Filter,
+  initialFilter?: FilterType,
   initialFilterString?: string,
 ) => {
   const [originalFilter] = useState(initialFilter);
-  const [filter, setFilter] = useState<Filter>(() =>
+  const [filter, setFilter] = useState<FilterType>(() =>
     isDefined(initialFilter) ? initialFilter : new Filter(),
   );
   const [filterDialogState, setFilterDialogState] =
@@ -38,7 +38,7 @@ const useFilterDialog = <TFilterDialogState extends FilterDialogState>(
       : '';
   });
 
-  const handleFilterChange = useCallback((filter: Filter) => {
+  const handleFilterChange = useCallback((filter: FilterType) => {
     setFilter(filter);
   }, []);
 

--- a/src/web/components/powerfilter/useFilterDialogSave.tsx
+++ b/src/web/components/powerfilter/useFilterDialogSave.tsx
@@ -4,14 +4,14 @@
  */
 
 import {useCallback} from 'react';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import {type EntityType} from 'gmp/utils/entity-type';
 import {isDefined} from 'gmp/utils/identity';
 import useGmp from 'web/hooks/useGmp';
 import useTranslation from 'web/hooks/useTranslation';
 
 export type OnFilterCreatedFunc = (filter: Filter) => void;
-export type OnFilterChangedFunc = (filter: Filter) => void;
+export type OnFilterChangedFunc = (filter: FilterType) => void;
 
 export interface UseFilterDialogSaveProps {
   onClose?: () => void;
@@ -22,9 +22,9 @@ export interface UseFilterDialogSaveProps {
 export interface UseFilterDialogStateProps {
   filterName?: string;
   saveNamedFilter?: boolean;
-  filter: Filter;
+  filter: FilterType;
   filterString: string;
-  originalFilter: Filter;
+  originalFilter: FilterType;
 }
 
 interface UseFilterDialogReturn {
@@ -48,7 +48,7 @@ const useFilterDialogSave = (
   const gmp = useGmp();
 
   const createFilter = useCallback(
-    (newFilter: Filter, name: string) => {
+    (newFilter: FilterType, name: string) => {
       return gmp.filter
         .create({
           term: newFilter.toFilterString(),

--- a/src/web/entities/BulkTags.tsx
+++ b/src/web/entities/BulkTags.tsx
@@ -5,7 +5,7 @@
 
 import {useCallback, useEffect, useState} from 'react';
 import type CollectionCounts from 'gmp/collection/collection-counts';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type Model from 'gmp/models/model';
 import Tag from 'gmp/models/tag';
 import {apiType, type EntityType, getEntityType} from 'gmp/utils/entity-type';
@@ -19,7 +19,7 @@ import SelectionType, {type SelectionTypeType} from 'web/utils/SelectionType';
 interface BulkTagsProps<TEntity extends Model> {
   entities: TEntity[];
   selectedEntities: TEntity[];
-  filter: Filter;
+  filter: FilterType;
   selectionType: SelectionTypeType;
   entitiesCounts: CollectionCounts;
   onClose: () => void;

--- a/src/web/entities/EntitiesContainer.tsx
+++ b/src/web/entities/EntitiesContainer.tsx
@@ -15,7 +15,11 @@ import type Response from 'gmp/http/response';
 import {type XmlMeta} from 'gmp/http/transform/fast-xml';
 import {type TranslateOptions} from 'gmp/locale/lang';
 import logger from 'gmp/log';
-import {type default as Filter, RESET_FILTER} from 'gmp/models/filter';
+import {
+  type default as Filter,
+  type FilterType,
+  RESET_FILTER,
+} from 'gmp/models/filter';
 import type Model from 'gmp/models/model';
 import type Tag from 'gmp/models/tag';
 import {map} from 'gmp/utils/array';
@@ -53,7 +57,7 @@ export interface EntitiesContainerRenderProps<TModel extends Model = Model> {
   entitiesCounts?: CollectionCounts;
   entitiesError?: Error | Rejection;
   entitiesSelected?: Set<TModel>;
-  filter?: Filter;
+  filter?: FilterType;
   isLoading: boolean;
   isUpdating: boolean;
   selectionType: SelectionTypeType;
@@ -87,7 +91,7 @@ interface EntitiesContainerState<TModel extends Model = Model> {
   entitiesCounts?: CollectionCounts;
   entitiesError?: Error | Rejection;
   isUpdating: boolean;
-  loadedFilter?: Filter;
+  loadedFilter?: FilterType;
   multiTagEntitiesCount?: number;
   selected?: Set<TModel>;
   selectionType: SelectionTypeType;
@@ -102,17 +106,17 @@ interface EntitiesContainerProps<TModel extends Model = Model> {
   entities?: TModel[];
   entitiesCounts?: CollectionCounts;
   entitiesError?: Error | Rejection;
-  filter: Filter;
+  filter: FilterType;
   gmp: Gmp;
   gmpName: EntityType;
   isLoading?: boolean;
-  loadedFilter?: Filter;
+  loadedFilter?: FilterType;
   notify: (message: string) => () => void;
-  reload: (filter?: Filter) => void;
+  reload: (filter?: FilterType) => void;
   showError: (error: Error | Rejection) => void;
   showErrorMessage: (message: string) => void;
   showSuccessMessage: (message: string) => void;
-  updateFilter: (filter?: Filter) => void;
+  updateFilter: (filter?: FilterType) => void;
   onDownload: OnDownloadedFunc;
 }
 
@@ -237,7 +241,7 @@ class EntitiesContainer<TModel extends Model> extends React.Component<
     }
   }
 
-  updateFilter(filter?: Filter) {
+  updateFilter(filter?: FilterType) {
     this.props.updateFilter(filter);
     this.props.reload(filter);
   }
@@ -286,9 +290,11 @@ class EntitiesContainer<TModel extends Model> extends React.Component<
     if (selectionType === SelectionType.SELECTION_USER) {
       promise = entitiesCommand.export(Array.from(selected as Set<TModel>));
     } else if (selectionType === SelectionType.SELECTION_PAGE_CONTENTS) {
-      promise = entitiesCommand.exportByFilter(loadedFilter as Filter);
+      promise = entitiesCommand.exportByFilter(loadedFilter as FilterType);
     } else {
-      promise = entitiesCommand.exportByFilter((loadedFilter as Filter).all());
+      promise = entitiesCommand.exportByFilter(
+        (loadedFilter as FilterType).all(),
+      );
     }
 
     showSuccessNotification('', _('Bulk download started.'));
@@ -351,7 +357,7 @@ class EntitiesContainer<TModel extends Model> extends React.Component<
   }
 
   handleSortChange(field: string) {
-    const {loadedFilter} = this.state as {loadedFilter: Filter};
+    const {loadedFilter} = this.state as {loadedFilter: FilterType};
 
     let sort = 'sort';
     const sortField = loadedFilter.getSortBy();
@@ -373,31 +379,31 @@ class EntitiesContainer<TModel extends Model> extends React.Component<
     showError(error);
   }
 
-  changeFilter(filter?: Filter) {
+  changeFilter(filter?: FilterType) {
     this.updateFilter(filter);
   }
 
   handleFirst() {
-    const {loadedFilter: filter} = this.state as {loadedFilter: Filter};
+    const {loadedFilter: filter} = this.state as {loadedFilter: FilterType};
 
     this.changeFilter(filter.first());
   }
 
   handleNext() {
-    const {loadedFilter: filter} = this.state as {loadedFilter: Filter};
+    const {loadedFilter: filter} = this.state as {loadedFilter: FilterType};
 
     this.changeFilter(filter.next());
   }
 
   handlePrevious() {
-    const {loadedFilter: filter} = this.state as {loadedFilter: Filter};
+    const {loadedFilter: filter} = this.state as {loadedFilter: FilterType};
 
     this.changeFilter(filter.previous());
   }
 
   handleLast() {
     const {loadedFilter: filter, entitiesCounts: counts} = this.state as {
-      loadedFilter: Filter;
+      loadedFilter: FilterType;
       entitiesCounts: CollectionCounts;
     };
 
@@ -411,7 +417,7 @@ class EntitiesContainer<TModel extends Model> extends React.Component<
     this.changeFilter(filter);
   }
 
-  handleFilterChanged(filter: Filter) {
+  handleFilterChanged(filter: FilterType) {
     this.changeFilter(filter);
   }
 
@@ -476,14 +482,14 @@ class EntitiesContainer<TModel extends Model> extends React.Component<
     const entitiesType = getEntityType(entities[0]);
 
     let resourceIds: string[] | undefined;
-    let filter: Filter | undefined;
+    let filter: FilterType | undefined;
     if (selectionType === SelectionType.SELECTION_USER) {
       resourceIds = map(selected, res => res.id as string);
       filter = undefined;
     } else if (selectionType === SelectionType.SELECTION_PAGE_CONTENTS) {
       filter = loadedFilter;
     } else {
-      filter = (loadedFilter as Filter).all();
+      filter = (loadedFilter as FilterType).all();
     }
 
     return gmp.tag

--- a/src/web/entities/EntitiesPage.tsx
+++ b/src/web/entities/EntitiesPage.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {connect} from 'react-redux';
 import type CollectionCounts from 'gmp/collection/collection-counts';
 import type Gmp from 'gmp/gmp';
-import type Filter from 'gmp/models/filter';
+import {type default as Filter, type FilterType} from 'gmp/models/filter';
 import type Model from 'gmp/models/model';
 import {isDefined, hasValue} from 'gmp/utils/identity';
 import {excludeObjectProps} from 'gmp/utils/object';
@@ -25,20 +25,20 @@ import withTranslation from 'web/utils/withTranslation';
 
 interface FilterDialogComponentProps {
   createFilterType?: string;
-  filter?: Filter;
+  filter?: FilterType;
   onClose: () => void;
-  onFilterChanged: (filter: Filter) => void;
+  onFilterChanged: (filter: FilterType) => void;
   onFilterCreated: (filter: Filter) => void;
 }
 
 interface TableComponentProps<TModel extends Model = Model> {
   entities: TModel[];
   entitiesCounts?: CollectionCounts;
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 interface PowerFilterComponentProps {
-  filter?: Filter;
+  filter?: FilterType;
   filters?: Filter[];
   isLoading?: boolean;
   isLoadingFilters?: boolean;
@@ -46,7 +46,7 @@ interface PowerFilterComponentProps {
   onError?: (error: Error) => void;
   onRemoveClick?: () => void;
   onResetClick?: () => void;
-  onUpdate?: (filter: Filter) => void;
+  onUpdate?: (filter: FilterType) => void;
 }
 
 interface SectionComponentProps {
@@ -68,9 +68,9 @@ export interface EntitiesPageProps<TModel extends Model = Model, TProps = {}> {
   entities?: TModel[];
   entitiesCounts?: CollectionCounts;
   entitiesError?: Error;
-  filter?: Filter;
+  filter?: FilterType;
   filterEditDialog: React.ComponentType<FilterDialogComponentProps>;
-  filtersFilter: Filter;
+  filtersFilter: FilterType;
   isLoading?: boolean;
   powerfilter?: React.ComponentType<PowerFilterComponentProps>;
   section?: false | React.ComponentType<SectionComponentProps>;
@@ -81,7 +81,7 @@ export interface EntitiesPageProps<TModel extends Model = Model, TProps = {}> {
   title: string;
   toolBarIcons?: React.ComponentType<TProps> | React.ReactElement<TProps>;
   onError: (error: Error) => void;
-  onFilterChanged: (newFilter: Filter) => void;
+  onFilterChanged: (newFilter: FilterType) => void;
   onFilterCreated: (newFilter: Filter) => void;
   onFilterRemoved: () => void;
   onFilterReset: () => void;

--- a/src/web/entities/EntitiesTable.tsx
+++ b/src/web/entities/EntitiesTable.tsx
@@ -6,7 +6,7 @@
 import React, {useState} from 'react';
 import styled from 'styled-components';
 import type CollectionCounts from 'gmp/collection/collection-counts';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type Model from 'gmp/models/model';
 import {forEach} from 'gmp/utils/array';
 import {isDefined} from 'gmp/utils/identity';
@@ -24,7 +24,7 @@ import {type SortDirectionType} from 'web/utils/sort-direction';
 export interface FooterComponentProps<TEntity> {
   entities?: TEntity[];
   entitiesCounts?: CollectionCounts;
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 export interface HeaderComponentProps {
@@ -89,7 +89,7 @@ export interface EntitiesTableProps<
   emptyTitle?: string;
   entities?: TEntity[];
   entitiesCounts?: CollectionCounts;
-  filter?: Filter;
+  filter?: FilterType;
   footnote?: boolean;
   isUpdating?: boolean;
   links?: boolean;

--- a/src/web/entities/FilterProvider.tsx
+++ b/src/web/entities/FilterProvider.tsx
@@ -4,16 +4,16 @@
  */
 
 import React from 'react';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import Loading from 'web/components/loading/Loading';
 import usePageFilter from 'web/hooks/usePageFilter';
 
 interface FilterProviderRenderProps {
-  filter: Filter;
+  filter: FilterType;
 }
 
 interface FilterProviderProps {
-  fallbackFilter?: Filter;
+  fallbackFilter?: FilterType;
   gmpName: string;
   pageName?: string;
   children: (props: FilterProviderRenderProps) => React.ReactNode;

--- a/src/web/entities/withEntitiesContainer.tsx
+++ b/src/web/entities/withEntitiesContainer.tsx
@@ -7,7 +7,7 @@ import {connect} from 'react-redux';
 import type CollectionCounts from 'gmp/collection/collection-counts';
 import type Gmp from 'gmp/gmp';
 import type Rejection from 'gmp/http/rejection';
-import type Filter from 'gmp/models/filter';
+import {type default as Filter, type FilterType} from 'gmp/models/filter';
 import type Model from 'gmp/models/model';
 import {type EntityType} from 'gmp/utils/entity-type';
 import {type DownloadFunc} from 'web/components/form/useDownload';
@@ -30,24 +30,24 @@ import withGmp from 'web/utils/withGmp';
 
 interface ReduxMapProps {
   gmp: Gmp;
-  filter: Filter;
+  filter: FilterType;
 }
 
 interface EntitiesReloadOptions {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 interface EntitiesSelector<TEntity extends Model = Model> {
-  getEntities: (filter?: Filter) => TEntity[];
-  getEntitiesCounts: (filter?: Filter) => CollectionCounts;
-  getEntitiesError: (filter?: Filter) => Error | Rejection;
-  isLoadingEntities: (filter?: Filter) => boolean;
-  getLoadedFilter: (filter?: Filter) => Filter;
+  getEntities: (filter?: FilterType) => TEntity[];
+  getEntitiesCounts: (filter?: FilterType) => CollectionCounts;
+  getEntitiesError: (filter?: FilterType) => Error | Rejection;
+  isLoadingEntities: (filter?: FilterType) => boolean;
+  getLoadedFilter: (filter?: FilterType) => Filter;
 }
 
 interface EntitiesContainerWrapperProps {
-  filter: Filter;
-  loadEntities: (filter: Filter) => void;
+  filter: FilterType;
+  loadEntities: (filter: FilterType) => void;
   notify: NotifyFunc;
 }
 
@@ -58,11 +58,11 @@ interface OtherProps<
   entities: TEntity[];
   entitiesCounts: CollectionCounts;
   entitiesError?: Error | Rejection;
-  filter: Filter;
+  filter: FilterType;
   isLoading: boolean;
-  loadedFilter: Filter;
-  loadEntities: (filter?: Filter) => void;
-  updateFilter: (filter?: Filter) => void;
+  loadedFilter: FilterType;
+  loadEntities: (filter?: FilterType) => void;
+  updateFilter: (filter?: FilterType) => void;
   onDownload: DownloadFunc;
 }
 
@@ -84,9 +84,9 @@ export type WithEntitiesContainerComponentProps<TEntity extends Model> =
 
 interface WithEntitiesContainerOptions<TEntity extends Model = Model> {
   reloadInterval?: (props: ReloadIntervalProps<TEntity>) => number | void;
-  fallbackFilter?: Filter;
+  fallbackFilter?: FilterType;
   entitiesSelector: (state: unknown) => EntitiesSelector<TEntity>;
-  loadEntities: (gmp: Gmp) => (filter?: Filter) => void;
+  loadEntities: (gmp: Gmp) => (filter?: FilterType) => void;
 }
 
 const noop = () => {};
@@ -157,9 +157,10 @@ const withEntitiesContainer =
     };
 
     const mapDispatchToProps = (dispatch, {gmp}: ReduxMapProps) => ({
-      loadEntities: (filter?: Filter) =>
+      loadEntities: (filter?: FilterType) =>
         dispatch(loadEntitiesFunc(gmp)(filter)),
-      updateFilter: (filter?: Filter) => dispatch(pageFilter(gmpName, filter)),
+      updateFilter: (filter?: FilterType) =>
+        dispatch(pageFilter(gmpName, filter)),
     });
 
     const EntitiesContainerWrapper = compose(

--- a/src/web/entities/withEntitiesFooter.tsx
+++ b/src/web/entities/withEntitiesFooter.tsx
@@ -4,12 +4,12 @@
  */
 
 import type CollectionCounts from 'gmp/collection/collection-counts';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 
 interface EntitiesFooterWrapperProps<TEntity> {
   entities?: TEntity[];
   entitiesCounts?: CollectionCounts;
-  filter?: Filter;
+  filter?: FilterType;
   onDeleteBulk?: () => void;
   onDownloadBulk?: () => void;
   onTagsBulk?: () => void;
@@ -22,7 +22,7 @@ interface EntitiesFooterWrapperProps<TEntity> {
 export interface WithEntitiesFooterComponentProps<TEntity> {
   entities?: TEntity[];
   entitiesCounts?: CollectionCounts;
-  filter?: Filter;
+  filter?: FilterType;
   onDeleteClick?: () => void;
   onDownloadClick?: (filename: string) => void;
   onTagsClick?: () => void;

--- a/src/web/hooks/__tests__/useFilterSortBy.test.tsx
+++ b/src/web/hooks/__tests__/useFilterSortBy.test.tsx
@@ -6,12 +6,12 @@
 import {useState} from 'react';
 import {describe, test, expect, testing} from '@gsa/testing';
 import {fireEvent, render, screen} from 'web/testing';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import useFilterSortBy from 'web/hooks/useFilterSortBy';
 
 const TestComponent = ({filter: initialFilter, changeFilter}) => {
   const [filter, setFilter] = useState(initialFilter);
-  const handleChangeFilter = (newFilter: Filter) => {
+  const handleChangeFilter = (newFilter: FilterType) => {
     setFilter(newFilter);
     changeFilter(newFilter);
   };

--- a/src/web/hooks/use-query/agent-groups.ts
+++ b/src/web/hooks/use-query/agent-groups.ts
@@ -10,7 +10,7 @@ import {
 import {type EntityActionResponse} from 'gmp/commands/entity';
 import type Rejection from 'gmp/http/rejection';
 import AgentGroup from 'gmp/models/agent-group';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import useGmp from 'web/hooks/useGmp';
 import useCloneMutation from 'web/queries/useCloneMutation';
 import useCreateMutation from 'web/queries/useCreateMutation';
@@ -28,7 +28,7 @@ interface UseModifyAgentGroupParams {
   onError?: (error: Rejection) => void;
 }
 
-export const useGetAgentGroups = ({filter}: {filter?: Filter}) => {
+export const useGetAgentGroups = ({filter}: {filter?: FilterType}) => {
   const gmp = useGmp();
   return useGetEntities<AgentGroup>({
     queryId: 'get_agent_groups',

--- a/src/web/hooks/use-query/agent-installers.ts
+++ b/src/web/hooks/use-query/agent-installers.ts
@@ -4,12 +4,12 @@
  */
 
 import type AgentInstaller from 'gmp/models/agent-installer';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import useGmp from 'web/hooks/useGmp';
 import useGetEntities from 'web/queries/useGetEntities';
 
 interface UseGetAgentInstallersParams {
-  filter?: Filter;
+  filter?: FilterType;
   enabled?: boolean;
 }
 

--- a/src/web/hooks/use-query/agents.ts
+++ b/src/web/hooks/use-query/agents.ts
@@ -10,7 +10,7 @@ import type Response from 'gmp/http/response';
 import {type XmlMeta} from 'gmp/http/transform/fast-xml';
 import type Agent from 'gmp/models/agent';
 import Filter from 'gmp/models/filter';
-import {isFilter} from 'gmp/models/filter/utils';
+import {isFilterType} from 'gmp/models/filter/utils';
 import {parseYesNo} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import useGmp from 'web/hooks/useGmp';
@@ -120,7 +120,7 @@ export const useBulkDeleteAgents = ({
   const gmp = useGmp();
   return useGmpMutation<AgentBulkInput, Response<Agent[], XmlMeta>, Rejection>({
     gmpMethod: (input: AgentBulkInput) => {
-      return isFilter(input)
+      return isFilterType(input)
         ? gmp.agents.deleteByFilter(input)
         : gmp.agents.delete(input);
     },
@@ -139,7 +139,7 @@ export const useBulkAuthorizeAgents = ({
   const gmp = useGmp();
   return useGmpMutation<AgentBulkInput, void, Rejection>({
     gmpMethod: (input: AgentBulkInput) => {
-      return isFilter(input)
+      return isFilterType(input)
         ? gmp.agents.authorizeByFilter(input)
         : gmp.agents.authorize(input);
     },
@@ -158,7 +158,7 @@ export const useBulkRevokeAgents = ({
   const gmp = useGmp();
   return useGmpMutation<AgentBulkInput, void, Rejection>({
     gmpMethod: (input: AgentBulkInput) => {
-      return isFilter(input)
+      return isFilterType(input)
         ? gmp.agents.revokeByFilter(input)
         : gmp.agents.revoke(input);
     },
@@ -192,7 +192,7 @@ export const useBulkEnableUpdateToLatestAgents = ({
   const gmp = useGmp();
   return useGmpMutation<AgentBulkInput, void, Rejection>({
     gmpMethod: (input: AgentBulkInput) => {
-      return isFilter(input)
+      return isFilterType(input)
         ? gmp.agents.enableUpdateToLatestByFilter(input)
         : gmp.agents.enableUpdateToLatest(input);
     },
@@ -213,7 +213,7 @@ export const useBulkDisableUpdateToLatestAgents = ({
   const gmp = useGmp();
   return useGmpMutation<AgentBulkInput, void, Rejection>({
     gmpMethod: (input: AgentBulkInput) => {
-      return isFilter(input)
+      return isFilterType(input)
         ? gmp.agents.disableUpdateToLatestByFilter(input)
         : gmp.agents.disableUpdateToLatest(input);
     },

--- a/src/web/hooks/use-query/agents.ts
+++ b/src/web/hooks/use-query/agents.ts
@@ -9,7 +9,7 @@ import type Rejection from 'gmp/http/rejection';
 import type Response from 'gmp/http/response';
 import {type XmlMeta} from 'gmp/http/transform/fast-xml';
 import type Agent from 'gmp/models/agent';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import {isFilterType} from 'gmp/models/filter/utils';
 import {parseYesNo} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
@@ -21,7 +21,7 @@ import useGmpMutation from 'web/queries/useGmpMutation';
 import useSaveMutation from 'web/queries/useSaveMutation';
 
 interface UseGetAgentsParams {
-  filter?: Filter;
+  filter?: FilterType;
   scannerId?: string;
   authorized?: boolean;
   enabled?: boolean;
@@ -32,7 +32,7 @@ interface UseModifyAgentParams {
   onError?: (error: Rejection) => void;
 }
 
-type AgentBulkInput = Agent[] | Filter;
+type AgentBulkInput = Agent[] | FilterType;
 
 interface UseDownloadAgentSupportBundleParams {
   onSuccess?: (response: Response<ArrayBuffer>) => void;

--- a/src/web/hooks/use-query/audits.ts
+++ b/src/web/hooks/use-query/audits.ts
@@ -4,7 +4,7 @@
  */
 
 import type Audit from 'gmp/models/audit';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import useGmp from 'web/hooks/useGmp';
 import type {RefetchIntervalFn} from 'web/queries/helpers';
 import useGetEntities from 'web/queries/useGetEntities';
@@ -16,7 +16,7 @@ interface UseGetAuditParams {
 }
 
 interface UseGetAuditsParams {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 export const useGetAudit = ({id, refetchInterval}: UseGetAuditParams) => {

--- a/src/web/hooks/use-query/credential-store.ts
+++ b/src/web/hooks/use-query/credential-store.ts
@@ -7,7 +7,7 @@ import {type CredentialStoreModifyParams} from 'gmp/commands/credential-store';
 import type {EntityActionResponse} from 'gmp/commands/entity';
 import type Rejection from 'gmp/http/rejection';
 import type CredentialStore from 'gmp/models/credential-store';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import useGmp from 'web/hooks/useGmp';
 import useGetEntities from 'web/queries/useGetEntities';
 import useGmpMutation from 'web/queries/useGmpMutation';
@@ -22,7 +22,7 @@ interface UseVerifyCredentialStoreParams {
   onError?: (error: Error) => void;
 }
 
-export const useGetCredentialStores = ({filter}: {filter?: Filter}) => {
+export const useGetCredentialStores = ({filter}: {filter?: FilterType}) => {
   const gmp = useGmp();
   return useGetEntities<CredentialStore>({
     queryId: 'get_credential_stores',

--- a/src/web/hooks/use-query/oci-image-targets.ts
+++ b/src/web/hooks/use-query/oci-image-targets.ts
@@ -12,7 +12,7 @@ import type Rejection from 'gmp/http/rejection';
 import type Response from 'gmp/http/response';
 import {type XmlMeta} from 'gmp/http/transform/fast-xml';
 import type Filter from 'gmp/models/filter';
-import {isFilter} from 'gmp/models/filter/utils';
+import {isFilterType} from 'gmp/models/filter/utils';
 import type OciImageTarget from 'gmp/models/oci-image-target';
 import useGmp from 'web/hooks/useGmp';
 import useTranslation from 'web/hooks/useTranslation';
@@ -125,7 +125,7 @@ export const useBulkDeleteOciImageTargets = ({
     Rejection
   >({
     gmpMethod: (input: OciImageTargetBulkInput) => {
-      return isFilter(input)
+      return isFilterType(input)
         ? gmp.ociimagetargets.deleteByFilter(input)
         : gmp.ociimagetargets.delete(input);
     },
@@ -143,7 +143,7 @@ export const useBulkExportOciImageTargets = ({
   const gmp = useGmp();
   return useGmpMutation<OciImageTargetBulkInput, Response<string>, Rejection>({
     gmpMethod: (input: OciImageTargetBulkInput) => {
-      return isFilter(input)
+      return isFilterType(input)
         ? gmp.ociimagetargets.exportByFilter(input)
         : gmp.ociimagetargets.export(input);
     },

--- a/src/web/hooks/use-query/oci-image-targets.ts
+++ b/src/web/hooks/use-query/oci-image-targets.ts
@@ -11,7 +11,7 @@ import {
 import type Rejection from 'gmp/http/rejection';
 import type Response from 'gmp/http/response';
 import {type XmlMeta} from 'gmp/http/transform/fast-xml';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isFilterType} from 'gmp/models/filter/utils';
 import type OciImageTarget from 'gmp/models/oci-image-target';
 import useGmp from 'web/hooks/useGmp';
@@ -23,7 +23,7 @@ import useGmpMutation from 'web/queries/useGmpMutation';
 import useMoveToTrashCan from 'web/queries/useMoveToTrashCan';
 import useSaveMutation from 'web/queries/useSaveMutation';
 
-type OciImageTargetBulkInput = OciImageTarget[] | Filter;
+type OciImageTargetBulkInput = OciImageTarget[] | FilterType;
 
 interface UseCreateOciImageTargetParams {
   onSuccess?: (data: EntityActionResponse) => void;
@@ -35,7 +35,7 @@ interface UseModifyOciImageTargetParams {
   onError?: (error: Error) => void;
 }
 
-export const useGetOciImageTargets = ({filter}: {filter?: Filter}) => {
+export const useGetOciImageTargets = ({filter}: {filter?: FilterType}) => {
   const gmp = useGmp();
 
   return useGetEntities<OciImageTarget>({

--- a/src/web/hooks/use-query/permissions.ts
+++ b/src/web/hooks/use-query/permissions.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type Permission from 'gmp/models/permission';
 import useGmp from 'web/hooks/useGmp';
 import useGetEntities from 'web/queries/useGetEntities';
 
 interface UseGetPermissionsParams {
-  filter?: Filter;
+  filter?: FilterType;
   enabled?: boolean;
 }
 

--- a/src/web/hooks/use-query/policies.ts
+++ b/src/web/hooks/use-query/policies.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type Policy from 'gmp/models/policy';
 import useGmp from 'web/hooks/useGmp';
 import useGetEntities from 'web/queries/useGetEntities';
@@ -14,7 +14,7 @@ interface UseGetPolicyParams {
 }
 
 interface UseGetPoliciesParams {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 export const useGetPolicy = ({id}: UseGetPolicyParams) => {

--- a/src/web/hooks/use-query/report-applications.ts
+++ b/src/web/hooks/use-query/report-applications.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import useGmp from 'web/hooks/useGmp';
 import useGetEntities from 'web/queries/useGetEntities';
 
 interface UseGetReportApplicationsParams {
   reportId: string;
-  filter?: Filter;
+  filter?: FilterType;
   refetchInterval?: number | false;
 }
 

--- a/src/web/hooks/use-query/report-closed-cves.ts
+++ b/src/web/hooks/use-query/report-closed-cves.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import useGmp from 'web/hooks/useGmp';
 import useGetEntities from 'web/queries/useGetEntities';
 
 interface UseGetReportClosedCvesParams {
   reportId: string;
-  filter?: Filter;
+  filter?: FilterType;
   refetchInterval?: number | false;
 }
 

--- a/src/web/hooks/use-query/report-cves.ts
+++ b/src/web/hooks/use-query/report-cves.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import useGmp from 'web/hooks/useGmp';
 import useGetEntities from 'web/queries/useGetEntities';
 
 interface UseGetReportCvesParams {
   reportId: string;
-  filter?: Filter;
+  filter?: FilterType;
   refetchInterval?: number | false;
 }
 

--- a/src/web/hooks/use-query/report-errors.ts
+++ b/src/web/hooks/use-query/report-errors.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import useGmp from 'web/hooks/useGmp';
 import useGetEntities from 'web/queries/useGetEntities';
 
 interface UseGetReportErrorsParams {
   reportId: string;
-  filter?: Filter;
+  filter?: FilterType;
   refetchInterval?: number | false;
 }
 

--- a/src/web/hooks/use-query/report-hosts.ts
+++ b/src/web/hooks/use-query/report-hosts.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import useGmp from 'web/hooks/useGmp';
 import useGetEntities from 'web/queries/useGetEntities';
 
 interface UseGetReportHostsParams {
   reportId: string;
-  filter?: Filter;
+  filter?: FilterType;
   refetchInterval?: number | false;
 }
 

--- a/src/web/hooks/use-query/report-operating-system.ts
+++ b/src/web/hooks/use-query/report-operating-system.ts
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type ReportOperatingSystem from 'gmp/models/report/os';
 import useGmp from 'web/hooks/useGmp';
 import useGetEntities from 'web/queries/useGetEntities';
 
 interface UseGetReportOperatingSystemsParams {
   reportId: string;
-  filter?: Filter;
+  filter?: FilterType;
   refetchInterval?: number | false;
 }
 

--- a/src/web/hooks/use-query/report-ports.ts
+++ b/src/web/hooks/use-query/report-ports.ts
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type ReportPort from 'gmp/models/report/port';
 import useGmp from 'web/hooks/useGmp';
 import useGetEntities from 'web/queries/useGetEntities';
 
 interface UseGetReportPortsParams {
   reportId: string;
-  filter?: Filter;
+  filter?: FilterType;
   refetchInterval?: number | false;
 }
 

--- a/src/web/hooks/use-query/report-tls-certificates.ts
+++ b/src/web/hooks/use-query/report-tls-certificates.ts
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type ReportTLSCertificate from 'gmp/models/report/tls-certificate';
 import useGmp from 'web/hooks/useGmp';
 import useGetEntities from 'web/queries/useGetEntities';
 
 interface UseGetReportTlsCertificatesParams {
   reportId: string;
-  filter?: Filter;
+  filter?: FilterType;
   refetchInterval?: number | false;
 }
 

--- a/src/web/hooks/use-query/reports.ts
+++ b/src/web/hooks/use-query/reports.ts
@@ -4,7 +4,11 @@
  */
 
 import {useQuery} from '@tanstack/react-query';
-import Filter, {ALL_FILTER, RESULTS_FILTER_FILTER} from 'gmp/models/filter';
+import Filter, {
+  ALL_FILTER,
+  RESULTS_FILTER_FILTER,
+  type FilterType,
+} from 'gmp/models/filter';
 import type Report from 'gmp/models/report';
 import type ReportConfig from 'gmp/models/report-config';
 import type ReportFormat from 'gmp/models/report-format';
@@ -17,7 +21,7 @@ import useGetEntity from 'web/queries/useGetEntity';
 
 interface UseGetReportParams {
   id: string;
-  filter?: Filter;
+  filter?: FilterType;
   refetchInterval?: number | false | RefetchIntervalFn<Report>;
 }
 

--- a/src/web/hooks/use-query/results.ts
+++ b/src/web/hooks/use-query/results.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type Result from 'gmp/models/result';
 import useGmp from 'web/hooks/useGmp';
 import type {RefetchIntervalFn} from 'web/queries/helpers';
@@ -12,7 +12,7 @@ import useGetEntities, {
 } from 'web/queries/useGetEntities';
 
 interface UseGetResultsParams {
-  filter?: Filter;
+  filter?: FilterType;
   refetchInterval?:
     | number
     | false

--- a/src/web/hooks/use-query/tags.ts
+++ b/src/web/hooks/use-query/tags.ts
@@ -7,7 +7,7 @@ import {type EntityActionResponse} from 'gmp/commands/entity';
 import type Rejection from 'gmp/http/rejection';
 import type Response from 'gmp/http/response';
 import {type XmlMeta, type XmlResponseData} from 'gmp/http/transform/fast-xml';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isFilterType} from 'gmp/models/filter/utils';
 import type Tag from 'gmp/models/tag';
 import useGmp from 'web/hooks/useGmp';
@@ -26,7 +26,7 @@ interface UseGetTagParams {
 }
 
 interface UseGetTagsParams {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 interface UseMutationCallbacks {
@@ -44,7 +44,7 @@ interface UseModifyTagParams {
   onError?: (error: Error) => void;
 }
 
-type TagBulkInput = Tag[] | Filter;
+type TagBulkInput = Tag[] | FilterType;
 
 export const useGetTags = ({filter}: UseGetTagsParams) => {
   const gmp = useGmp();

--- a/src/web/hooks/use-query/tags.ts
+++ b/src/web/hooks/use-query/tags.ts
@@ -8,7 +8,7 @@ import type Rejection from 'gmp/http/rejection';
 import type Response from 'gmp/http/response';
 import {type XmlMeta, type XmlResponseData} from 'gmp/http/transform/fast-xml';
 import type Filter from 'gmp/models/filter';
-import {isFilter} from 'gmp/models/filter/utils';
+import {isFilterType} from 'gmp/models/filter/utils';
 import type Tag from 'gmp/models/tag';
 import useGmp from 'web/hooks/useGmp';
 import type {RefetchIntervalFn} from 'web/queries/helpers';
@@ -117,7 +117,7 @@ export const useBulkDeleteTags = ({
   const gmp = useGmp();
   return useGmpMutation<TagBulkInput, Response<Tag[], XmlMeta>, Rejection>({
     gmpMethod: (input: TagBulkInput) => {
-      return isFilter(input)
+      return isFilterType(input)
         ? gmp.tags.deleteByFilter(input)
         : gmp.tags.delete(input);
     },
@@ -134,7 +134,7 @@ export const useBulkExportTags = ({
   const gmp = useGmp();
   return useGmpMutation<TagBulkInput, Response<string>, Rejection>({
     gmpMethod: (input: TagBulkInput) => {
-      return isFilter(input)
+      return isFilterType(input)
         ? gmp.tags.exportByFilter(input)
         : gmp.tags.export(input);
     },

--- a/src/web/hooks/use-query/use-report-sub-entities.ts
+++ b/src/web/hooks/use-query/use-report-sub-entities.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {useGetReportApplications} from 'web/hooks/use-query/report-applications';
 import {useGetReportClosedCves} from 'web/hooks/use-query/report-closed-cves';
 import {useGetReportCves} from 'web/hooks/use-query/report-cves';
@@ -26,7 +26,7 @@ export interface ReportSubEntities {
 
 interface UseReportSubEntitiesParams {
   reportId: string;
-  filter?: Filter;
+  filter?: FilterType;
   refetchInterval?: number | false;
 }
 

--- a/src/web/hooks/use-query/web-application-targets.ts
+++ b/src/web/hooks/use-query/web-application-targets.ts
@@ -11,7 +11,7 @@ import {
 import type Rejection from 'gmp/http/rejection';
 import type Response from 'gmp/http/response';
 import {type XmlMeta} from 'gmp/http/transform/fast-xml';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isFilterType} from 'gmp/models/filter/utils';
 import type WebApplicationTarget from 'gmp/models/web-application-target';
 import useGmp from 'web/hooks/useGmp';
@@ -23,7 +23,7 @@ import useGmpMutation from 'web/queries/useGmpMutation';
 import useMoveToTrashCan from 'web/queries/useMoveToTrashCan';
 import useSaveMutation from 'web/queries/useSaveMutation';
 
-type WebApplicationTargetBulkInput = WebApplicationTarget[] | Filter;
+type WebApplicationTargetBulkInput = WebApplicationTarget[] | FilterType;
 
 interface UseCreateWebApplicationTargetParams {
   onSuccess?: (data: EntityActionResponse) => void;
@@ -35,7 +35,11 @@ interface UseModifyWebApplicationTargetParams {
   onError?: (error: Error) => void;
 }
 
-export const useGetWebApplicationTargets = ({filter}: {filter?: Filter}) => {
+export const useGetWebApplicationTargets = ({
+  filter,
+}: {
+  filter?: FilterType;
+}) => {
   const gmp = useGmp();
 
   return useGetEntities<WebApplicationTarget>({

--- a/src/web/hooks/use-query/web-application-targets.ts
+++ b/src/web/hooks/use-query/web-application-targets.ts
@@ -12,7 +12,7 @@ import type Rejection from 'gmp/http/rejection';
 import type Response from 'gmp/http/response';
 import {type XmlMeta} from 'gmp/http/transform/fast-xml';
 import type Filter from 'gmp/models/filter';
-import {isFilter} from 'gmp/models/filter/utils';
+import {isFilterType} from 'gmp/models/filter/utils';
 import type WebApplicationTarget from 'gmp/models/web-application-target';
 import useGmp from 'web/hooks/useGmp';
 import useTranslation from 'web/hooks/useTranslation';
@@ -125,7 +125,7 @@ export const useBulkDeleteWebApplicationTargets = ({
     Rejection
   >({
     gmpMethod: (input: WebApplicationTargetBulkInput) => {
-      return isFilter(input)
+      return isFilterType(input)
         ? gmp.webapplicationtargets.deleteByFilter(input)
         : gmp.webapplicationtargets.delete(input);
     },
@@ -147,7 +147,7 @@ export const useBulkExportWebApplicationTargets = ({
     Rejection
   >({
     gmpMethod: (input: WebApplicationTargetBulkInput) => {
-      return isFilter(input)
+      return isFilterType(input)
         ? gmp.webapplicationtargets.exportByFilter(input)
         : gmp.webapplicationtargets.export(input);
     },

--- a/src/web/hooks/useFilterSortBy.ts
+++ b/src/web/hooks/useFilterSortBy.ts
@@ -4,11 +4,11 @@
  */
 
 import {useCallback} from 'react';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import SortDirection, {type SortDirectionType} from 'web/utils/sort-direction';
 
-type ChangeFilterFunc = (filter: Filter) => void;
+type ChangeFilterFunc = (filter: FilterType) => void;
 type SortChangeFunc = (field: string) => void;
 
 /**
@@ -19,7 +19,7 @@ type SortChangeFunc = (field: string) => void;
  * @returns Array of the sort by field, sort direction and a function to change the sort by field
  */
 const useFilterSortBy = (
-  filter: Filter,
+  filter: FilterType,
   changeFilter: ChangeFilterFunc,
 ): [string | undefined, SortDirectionType, SortChangeFunc] => {
   const reverseField = isDefined(filter)

--- a/src/web/hooks/usePageFilter.ts
+++ b/src/web/hooks/usePageFilter.ts
@@ -10,6 +10,7 @@ import {ROWS_PER_PAGE_SETTING_ID} from 'gmp/commands/user';
 import Filter, {
   DEFAULT_FALLBACK_FILTER,
   DEFAULT_ROWS_PER_PAGE,
+  type FilterType,
   RESET_FILTER,
 } from 'gmp/models/filter';
 import {isDefined, hasValue} from 'gmp/utils/identity';
@@ -23,16 +24,16 @@ import {loadUserSettingDefault} from 'web/store/usersettings/defaults/actions';
 import {getUserSettingsDefaults} from 'web/store/usersettings/defaults/selectors';
 
 interface UsePageFilterOptions {
-  fallbackFilter?: Filter;
+  fallbackFilter?: FilterType;
 }
 
 interface UsePageFilterHandlers {
-  changeFilter: (filter?: Filter) => void;
+  changeFilter: (filter?: FilterType) => void;
   removeFilter: () => void;
   resetFilter: () => void;
 }
 
-type UsePageFilterReturn = [Filter, boolean, UsePageFilterHandlers];
+type UsePageFilterReturn = [FilterType, boolean, UsePageFilterHandlers];
 
 /**
  * Hook to get the default filter of a page from the store
@@ -110,7 +111,7 @@ const usePageFilter = (
     gmpName,
   ]);
 
-  let returnedFilter: Filter | undefined;
+  let returnedFilter: FilterType | undefined;
 
   useEffect(() => {
     if (!isDefined(rowsPerPage)) {
@@ -163,7 +164,7 @@ const usePageFilter = (
     isDefined(rowsPerPage);
 
   const changeFilter = useCallback(
-    (filter?: Filter) => {
+    (filter?: FilterType) => {
       dispatch(setPageFilter(pageName, filter));
     },
     [dispatch, pageName],
@@ -184,7 +185,7 @@ const usePageFilter = (
   }, [changeFilter, setSearchParams, searchParams]);
 
   return [
-    returnedFilter as Filter,
+    returnedFilter as FilterType,
     !finishedLoading,
     {
       changeFilter,

--- a/src/web/hooks/usePagination.ts
+++ b/src/web/hooks/usePagination.ts
@@ -5,10 +5,10 @@
 
 import {useCallback} from 'react';
 import type CollectionCounts from 'gmp/collection/collection-counts';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 
 interface ChangeFilterFunc {
-  (filter: Filter): void;
+  (filter: FilterType): void;
 }
 
 /**
@@ -18,10 +18,10 @@ interface ChangeFilterFunc {
  * @example
  *
  * const gmp = useGmp();
- * const [filter, setFilter] = useState(new Filter());
+ * const [filter, setFilter] = useState<FilterType>(new Filter());
  * const [entities, setEntities] = useState([]);
  * const [counts, setCounts] = useState({});
- * const updateFilter = useCallback(filter => {
+ * const updateFilter = useCallback((filter: FilterType) => {
  *   setFilter(filter);
  *   gmp.tasks.get(filter).then(response => {setEntities(response.data);setCounts(response.meta.counts)});
  * }, [gmp.tasks]);
@@ -35,7 +35,7 @@ interface ChangeFilterFunc {
  *   next and previous page.
  */
 const usePagination = (
-  filter: Filter,
+  filter: FilterType,
   counts: CollectionCounts,
   changeFilter: ChangeFilterFunc,
 ): [() => void, () => void, () => void, () => void] => {

--- a/src/web/pages/agent-groups/AgentGroupsListPage.tsx
+++ b/src/web/pages/agent-groups/AgentGroupsListPage.tsx
@@ -6,10 +6,7 @@
 import {useCallback, useMemo, useRef, useState} from 'react';
 import type CollectionCounts from 'gmp/collection/collection-counts';
 import type AgentGroup from 'gmp/models/agent-group';
-import {
-  type default as Filter,
-  AGENT_GROUPS_FILTER_FILTER,
-} from 'gmp/models/filter';
+import {AGENT_GROUPS_FILTER_FILTER, type FilterType} from 'gmp/models/filter';
 import {HatAndGlassesIcon} from 'web/components/icon';
 import PageTitle from 'web/components/layout/PageTitle';
 import DialogNotification from 'web/components/notification/DialogNotification';
@@ -92,7 +89,7 @@ const AgentGroupsListPage = () => {
   }, [selectionType, selectedEntities, allEntities, showError]);
 
   const handleFilterChanged = useCallback(
-    (newFilter?: Filter) => {
+    (newFilter?: FilterType) => {
       changeFilter(newFilter);
     },
     [changeFilter],

--- a/src/web/pages/agents/AgentListPage.tsx
+++ b/src/web/pages/agents/AgentListPage.tsx
@@ -6,7 +6,7 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 import type CollectionCounts from 'gmp/collection/collection-counts';
 import type Agent from 'gmp/models/agent';
-import {type default as Filter, AGENTS_FILTER_FILTER} from 'gmp/models/filter';
+import {AGENTS_FILTER_FILTER, type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import ConfirmationDialog from 'web/components/dialog/ConfirmationDialog';
 import {DELETE_ACTION} from 'web/components/dialog/DialogTwoButtonFooter';
@@ -113,7 +113,7 @@ const AgentListPage = () => {
   });
 
   const handleBulkDelete = useCallback(async () => {
-    let input: Agent[] | Filter;
+    let input: Agent[] | FilterType;
     if (selectionType === SelectionType.SELECTION_USER) {
       input = selectedEntities;
     } else if (selectionType === SelectionType.SELECTION_FILTER) {
@@ -215,7 +215,7 @@ const AgentListPage = () => {
   };
 
   const handleFilterChanged = useCallback(
-    (newFilter?: Filter) => {
+    (newFilter?: FilterType) => {
       changeFilter(newFilter);
     },
     [changeFilter],

--- a/src/web/pages/container-image-targets/ContainerImageTargetsListPage.tsx
+++ b/src/web/pages/container-image-targets/ContainerImageTargetsListPage.tsx
@@ -6,7 +6,7 @@
 import {useCallback, useMemo, useRef, useState} from 'react';
 import {showSuccessNotification} from '@greenbone/ui-lib';
 import type CollectionCounts from 'gmp/collection/collection-counts';
-import {type default as Filter, TARGETS_FILTER_FILTER} from 'gmp/models/filter';
+import {type FilterType, TARGETS_FILTER_FILTER} from 'gmp/models/filter';
 import type OciImageTarget from 'gmp/models/oci-image-target';
 import {getEntityType, pluralizeType} from 'gmp/utils/entity-type';
 import Download from 'web/components/form/Download';
@@ -118,7 +118,7 @@ const ContainerImageTargetsListPage = () => {
   });
 
   const handleBulkDelete = useCallback(async () => {
-    let input: OciImageTarget[] | Filter;
+    let input: OciImageTarget[] | FilterType;
     if (selectionType === SelectionType.SELECTION_USER) {
       input = selectedEntities;
     } else if (selectionType === SelectionType.SELECTION_FILTER) {
@@ -142,7 +142,7 @@ const ContainerImageTargetsListPage = () => {
   ]);
 
   const handleBulkDownload = useCallback(async () => {
-    let input: OciImageTarget[] | Filter;
+    let input: OciImageTarget[] | FilterType;
     if (selectionType === SelectionType.SELECTION_USER) {
       input = selectedEntities;
     } else if (selectionType === SelectionType.SELECTION_FILTER) {
@@ -177,7 +177,7 @@ const ContainerImageTargetsListPage = () => {
   ]);
 
   const handleFilterChanged = useCallback(
-    (newFilter?: Filter) => {
+    (newFilter?: FilterType) => {
       changeFilter(newFilter);
     },
     [changeFilter],

--- a/src/web/pages/credentials/CredentialFilterDialog.tsx
+++ b/src/web/pages/credentials/CredentialFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import DefaultFilterDialog from 'web/components/powerfilter/DefaultFilterDialog';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
 import useFilterDialog from 'web/components/powerfilter/useFilterDialog';
@@ -14,7 +14,7 @@ import useFilterDialogSave, {
 import useTranslation from 'web/hooks/useTranslation';
 
 interface CredentialFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const CredentialFilterDialog = ({

--- a/src/web/pages/permissions/PermissionFilterDialog.tsx
+++ b/src/web/pages/permissions/PermissionFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import DefaultFilterDialog from 'web/components/powerfilter/DefaultFilterDialog';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
 import useFilterDialog from 'web/components/powerfilter/useFilterDialog';
@@ -14,7 +14,7 @@ import useFilterDialogSave, {
 import useTranslation from 'web/hooks/useTranslation';
 
 interface PermissionFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const PermissionFilterDialog = ({

--- a/src/web/pages/portlists/PortListFilterDialog.tsx
+++ b/src/web/pages/portlists/PortListFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import DefaultFilterDialog from 'web/components/powerfilter/DefaultFilterDialog';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
 import useFilterDialog from 'web/components/powerfilter/useFilterDialog';
@@ -14,7 +14,7 @@ import useFilterDialogSave, {
 import useTranslation from 'web/hooks/useTranslation';
 
 interface PortListsFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const PortListsFilterDialog = ({

--- a/src/web/pages/portlists/PortListListPage.tsx
+++ b/src/web/pages/portlists/PortListListPage.tsx
@@ -6,7 +6,7 @@
 import {useCallback, useEffect, useState} from 'react';
 import {useDispatch} from 'react-redux';
 import {
-  type default as Filter,
+  type FilterType,
   PORTLISTS_FILTER_FILTER,
   RESET_FILTER,
 } from 'gmp/models/filter';
@@ -40,7 +40,7 @@ import {getUserSettingsDefaults} from 'web/store/usersettings/defaults/selectors
 import {generateFilename} from 'web/utils/Render';
 import SelectionType from 'web/utils/SelectionType';
 
-const getData = (filter: Filter, eSelector: EntitiesSelector) => {
+const getData = (filter: FilterType, eSelector: EntitiesSelector) => {
   const entities = eSelector.getEntities(filter);
   return {
     entities,
@@ -61,7 +61,7 @@ const PortListsPage = () => {
   const [filter, isLoadingFilter, {changeFilter, resetFilter, removeFilter}] =
     usePageFilter('portlist', 'portlist');
   const [requestedFilter, setRequestedFilter] = useInstanceVariable<
-    Filter | undefined
+    FilterType | undefined
   >(undefined);
   const portListsSelector = useShallowEqualSelector(selector);
   const listExportFileName = useShallowEqualSelector(state =>
@@ -86,7 +86,7 @@ const PortListsPage = () => {
 
   // fetch port lists
   const fetch = useCallback(
-    (withFilter?: Filter) => {
+    (withFilter?: FilterType) => {
       setRequestedFilter(withFilter);
       // @ts-expect-error
       dispatch(loadEntities(gmp)(withFilter));
@@ -106,7 +106,7 @@ const PortListsPage = () => {
   );
 
   const handleFilterChanged = useCallback(
-    (newFilter?: Filter) => {
+    (newFilter?: FilterType) => {
       changeFilter(newFilter);
       fetch(newFilter);
     },

--- a/src/web/pages/reports/AuditReportDetailsContent.tsx
+++ b/src/web/pages/reports/AuditReportDetailsContent.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import type AuditReport from 'gmp/models/audit-report';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import type ReportReport from 'gmp/models/report/report';
 import type ReportTask from 'gmp/models/report/task';
 import type ReportTLSCertificate from 'gmp/models/report/tls-certificate';
@@ -51,18 +51,18 @@ interface AuditReportDetailsContentProps {
   isLoading?: boolean;
   isLoadingFilters?: boolean;
   isUpdating?: boolean;
-  pageFilter?: Filter;
+  pageFilter?: FilterType;
   reportError?: Error;
-  reportFilter?: Filter;
+  reportFilter?: FilterType;
   reportId: string;
-  resetFilter?: Filter;
+  resetFilter?: FilterType;
   showError: (error: Error) => void;
   showErrorMessage: (message: string) => void;
   showSuccessMessage: (message: string) => void;
   task?: ReportTask;
   onAddToAssetsClick: () => void;
   onError: (error: Error) => void;
-  onFilterChanged: (filter: Filter) => void;
+  onFilterChanged: (filter: FilterType) => void;
   onFilterCreated: (filter: Filter) => void;
   onFilterDecreaseMinQoDClick: () => void;
   onFilterEditClick: () => void;
@@ -86,8 +86,8 @@ const renderWithThreshold = (
     showThresholdMessage: boolean;
     isUpdating: boolean;
     threshold: number;
-    reportFilter: Filter;
-    onFilterChanged: (filter: Filter) => void;
+    reportFilter: FilterType;
+    onFilterChanged: (filter: FilterType) => void;
     onFilterEditClick: () => void;
   },
   content: React.ReactNode,
@@ -99,6 +99,7 @@ const renderWithThreshold = (
     return (
       <AuditThresholdPanel
         entityType={entityType}
+        // @ts-expect-error
         filter={config.reportFilter}
         isUpdating={config.isUpdating}
         threshold={config.threshold}

--- a/src/web/pages/reports/AuditReportDetailsPage.tsx
+++ b/src/web/pages/reports/AuditReportDetailsPage.tsx
@@ -10,7 +10,7 @@ import type Response from 'gmp/http/response';
 import type {XmlMeta} from 'gmp/http/transform/fast-xml';
 import logger from 'gmp/log';
 import type AuditReport from 'gmp/models/audit-report';
-import Filter, {RESET_FILTER} from 'gmp/models/filter';
+import Filter, {type FilterType, RESET_FILTER} from 'gmp/models/filter';
 import type ReportTLSCertificate from 'gmp/models/report/tls-certificate';
 import {isActive, type TaskStatus} from 'gmp/models/task';
 import {isDefined} from 'gmp/utils/identity';
@@ -63,7 +63,7 @@ interface AuditReportCommand {
   removeAssets: (params: {id: string; filter?: string}) => Promise<unknown>;
   download: (
     params: {id: string},
-    options: {reportFormatId: string; filter: Filter},
+    options: {reportFormatId: string; filter: FilterType},
   ) => Promise<{data: string | ArrayBuffer}>;
 }
 
@@ -102,17 +102,15 @@ const useGetAuditReport = ({
   refetchInterval,
 }: {
   id: string;
-  filter?: Filter;
+  filter?: FilterType;
   refetchInterval?: number | false | ((data?: AuditReport) => number | false);
 }) => {
   const gmp = useGmp();
-  const auditreport = (gmp as unknown as {auditreport: AuditReportCommand})
-    .auditreport;
   const filterString = filter?.toFilterString();
 
   return useGetEntity<AuditReport>({
     gmpMethod: async ({id}) => {
-      return auditreport.get({id}, {filter: filterString, details: false});
+      return gmp.auditreport.get({id}, {filter, details: false});
     },
     queryId: 'get_audit_report',
     queryKeyParts: [filterString],
@@ -238,7 +236,7 @@ const AuditReportDetailsPage = () => {
 
   // Handlers
   const handleFilterChange = useCallback(
-    (filter: Filter) => {
+    (filter: FilterType) => {
       changeFilter(filter);
     },
     [changeFilter],

--- a/src/web/pages/reports/DeltaDetailsPage.tsx
+++ b/src/web/pages/reports/DeltaDetailsPage.tsx
@@ -10,6 +10,7 @@ import type Gmp from 'gmp/gmp';
 import logger from 'gmp/log';
 import Filter, {
   ALL_FILTER,
+  type FilterType,
   RESET_FILTER,
   RESULTS_FILTER_FILTER,
 } from 'gmp/models/filter';
@@ -78,8 +79,8 @@ const DEFAULT_FILTER = Filter.fromString(
 const REPORT_FORMATS_FILTER = Filter.fromString('active=1 and trust=1 rows=-1');
 
 const getFilter = (
-  entity: {report?: {filter?: Filter}} | undefined = {},
-): Filter | undefined => {
+  entity: {report?: {filter?: FilterType}} | undefined = {},
+): FilterType | undefined => {
   const {report = {}} = entity;
   return report.filter;
 };
@@ -118,7 +119,7 @@ const useReportDispatch = (gmp: Gmp, params: UseReportStateParams) => {
       saveReportComposerDefaults: reportComposerDefaults =>
         // @ts-expect-error
         dispatch(saveReportComposerDefaults(gmp)(reportComposerDefaults)),
-      updateFilter: (f: Filter) => {
+      updateFilter: (f: FilterType) => {
         return dispatch(
           setPageFilter(getReportPageName(params.id as string), f),
         );
@@ -183,7 +184,7 @@ const useReportState = (params: UseReportStateParams) => {
 
 const loadFilteredReport =
   ({reportId, deltaReportId, loadReport, loadReportIfNeeded, reportFilter}) =>
-  (filter: Filter) => {
+  (filter: FilterType) => {
     if (!hasValue(filter)) {
       // use loaded filter after initial loading
       filter = reportFilter;
@@ -289,7 +290,7 @@ const DeltaReportDetails = () => {
 
   const [isUpdating, setIsUpdating] = useState(false);
 
-  const [lastFilter, setLastFilter] = useState<Filter | undefined>();
+  const [lastFilter, setLastFilter] = useState<FilterType>();
 
   const [storeAsDefault] = useState(false);
 
@@ -298,7 +299,7 @@ const DeltaReportDetails = () => {
   const [initialLoaded, setInitialLoaded] = useState(false);
 
   const reload = useCallback(
-    (filter: Filter) => reloadFunc(filter),
+    (filter: FilterType) => reloadFunc(filter),
     [reloadFunc],
   );
 
@@ -336,7 +337,7 @@ const DeltaReportDetails = () => {
 
   // Load function
 
-  const load = async (filter?: Filter) => {
+  const load = async (filter?: FilterType) => {
     log.debug('Loading delta report', {filter});
     setIsUpdating(isDefined(lastFilter) && !lastFilter?.equals?.(filter));
     setLastFilter(filter);

--- a/src/web/pages/reports/DeltaReportDetailsContent.tsx
+++ b/src/web/pages/reports/DeltaReportDetailsContent.tsx
@@ -6,7 +6,7 @@
 import styled from 'styled-components';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import type AuditReport from 'gmp/models/audit-report';
-import type Filter from 'gmp/models/filter';
+import {type default as Filter, type FilterType} from 'gmp/models/filter';
 import type Report from 'gmp/models/report';
 import {
   type default as AuditReportReport,
@@ -46,7 +46,7 @@ interface DeltaReportDetailsContentProps {
   audit?: boolean;
   entity?: Report | AuditReport;
   entityError?: Error;
-  filter?: Filter;
+  filter?: FilterType;
   filters?: Filter[];
   isLoading?: boolean;
   isUpdating?: boolean;
@@ -60,7 +60,7 @@ interface DeltaReportDetailsContentProps {
   onAddToAssetsClick?: () => void;
   onError?: (error: Error) => void;
   onFilterAddLogLevelClick?: () => void;
-  onFilterChanged?: (filter: Filter) => void;
+  onFilterChanged?: (filter: FilterType) => void;
   onFilterCreated?: (filter: Filter) => void;
   onFilterDecreaseMinQoDClick?: () => void;
   onFilterEditClick?: () => void;

--- a/src/web/pages/reports/DownloadReportDialog.tsx
+++ b/src/web/pages/reports/DownloadReportDialog.tsx
@@ -4,7 +4,7 @@
  */
 
 import {useState} from 'react';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type ReportConfig from 'gmp/models/report-config';
 import type ReportFormat from 'gmp/models/report-format';
 import {CONTAINER_SCANNING_RESULTS_THRESHOLD} from 'gmp/settings';
@@ -26,7 +26,7 @@ interface DownloadReportDialogProps {
   audit?: boolean;
   defaultReportConfigId?: string;
   defaultReportFormatId?: string;
-  filter: Filter | string;
+  filter: FilterType | string;
   includeNotes?: boolean;
   includeOverrides?: boolean;
   isContainerScanning?: boolean;

--- a/src/web/pages/reports/ReportDetailsContent.tsx
+++ b/src/web/pages/reports/ReportDetailsContent.tsx
@@ -4,7 +4,7 @@
  */
 
 import styled from 'styled-components';
-import type Filter from 'gmp/models/filter';
+import {type default as Filter, type FilterType} from 'gmp/models/filter';
 import type Report from 'gmp/models/report';
 import type ReportTask from 'gmp/models/report/task';
 import type ReportTLSCertificate from 'gmp/models/report/tls-certificate';
@@ -42,7 +42,7 @@ interface ThresholdConfig {
   showThresholdMessage: boolean;
   isUpdating: boolean;
   threshold: number;
-  onFilterChanged: (filter: Filter) => void;
+  onFilterChanged: (filter: FilterType) => void;
   onFilterEditClick: () => void;
 }
 
@@ -52,11 +52,11 @@ interface ReportDetailsContentProps {
   isLoading?: boolean;
   isLoadingFilters?: boolean;
   isUpdating?: boolean;
-  pageFilter?: Filter;
+  pageFilter?: FilterType;
   reportError?: Error;
-  reportFilter?: Filter;
+  reportFilter?: FilterType;
   reportId: string;
-  resetFilter?: Filter;
+  resetFilter?: FilterType;
   resultsCounts?: {filtered?: number; full?: number};
   showError: (...args: unknown[]) => void;
   showErrorMessage: (message: string) => void;
@@ -65,7 +65,7 @@ interface ReportDetailsContentProps {
   onAddToAssetsClick: () => void;
   onError: (error: Error) => void;
   onFilterAddLogLevelClick: () => void;
-  onFilterChanged: (filter: Filter) => void;
+  onFilterChanged: (filter: FilterType) => void;
   onFilterDecreaseMinQoDClick: () => void;
   onFilterEditClick: () => void;
   onFilterRemoveClick: () => void;

--- a/src/web/pages/reports/ReportDetailsFilterDialog.tsx
+++ b/src/web/pages/reports/ReportDetailsFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import Checkbox from 'web/components/form/Checkbox';
 import BooleanFilterGroup from 'web/components/powerfilter/BooleanFilterGroup';
 import ComplianceLevelsFilterGroup from 'web/components/powerfilter/ComplianceLevelsGroup';
@@ -29,7 +29,7 @@ import DeltaResultsFilterGroup from 'web/pages/reports/DeltaResultsFilterGroup';
 interface ReportDetailsFilterDialogProps extends UseFilterDialogSaveProps {
   audit?: boolean;
   delta?: boolean;
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const ReportDetailsFilterDialog = ({

--- a/src/web/pages/reports/ReportDetailsPage.tsx
+++ b/src/web/pages/reports/ReportDetailsPage.tsx
@@ -7,7 +7,7 @@ import {useCallback, useEffect, useState} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
 import {useParams} from 'react-router';
 import logger from 'gmp/log';
-import Filter, {RESET_FILTER} from 'gmp/models/filter';
+import Filter, {type FilterType, RESET_FILTER} from 'gmp/models/filter';
 import type Report from 'gmp/models/report';
 import type ReportTLSCertificate from 'gmp/models/report/tls-certificate';
 import {isActive} from 'gmp/models/task';
@@ -201,7 +201,7 @@ const ReportDetailsPage = () => {
 
   // Handlers
   const handleFilterChange = useCallback(
-    (filter: Filter) => {
+    (filter: FilterType) => {
       changeFilter(filter);
     },
     [changeFilter],

--- a/src/web/pages/reports/ReportFilterDialog.tsx
+++ b/src/web/pages/reports/ReportFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import BooleanFilterGroup from 'web/components/powerfilter/BooleanFilterGroup';
 import CreateNamedFilterGroup from 'web/components/powerfilter/CreateNamedFilterGroup';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
@@ -23,7 +23,7 @@ import useCapabilities from 'web/hooks/useCapabilities';
 import useTranslation from 'web/hooks/useTranslation';
 
 interface ReportFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const ReportFilterDialog = ({

--- a/src/web/pages/reports/ReportListPage.tsx
+++ b/src/web/pages/reports/ReportListPage.tsx
@@ -7,7 +7,10 @@ import {useEffect, useState} from 'react';
 import {useDispatch} from 'react-redux';
 import {useNavigate} from 'react-router';
 import {type TaskCommandCreateImportTaskParams} from 'gmp/commands/task';
-import Filter, {REPORTS_FILTER_FILTER} from 'gmp/models/filter';
+import Filter, {
+  type FilterType,
+  REPORTS_FILTER_FILTER,
+} from 'gmp/models/filter';
 import type Report from 'gmp/models/report';
 import {isActive} from 'gmp/models/task';
 import {isDefined} from 'gmp/utils/identity';
@@ -87,7 +90,7 @@ const ReportListPage = ({
   >(undefined);
   const [taskId, setTaskId] = useState<string | undefined>(undefined);
   const [beforeSelectFilter, setBeforeSelectFilter] = useState<
-    Filter | undefined
+    FilterType | undefined
   >(undefined);
   const dispatch = useDispatch();
   const tasks = useShallowEqualSelector(state =>

--- a/src/web/pages/reports/details/DeltaResultsTab.tsx
+++ b/src/web/pages/reports/details/DeltaResultsTab.tsx
@@ -4,7 +4,7 @@
  */
 
 import type CollectionCounts from 'gmp/collection/collection-counts';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type Nvt from 'gmp/models/nvt';
 import type Result from 'gmp/models/result';
 import {type TaskStatus} from 'gmp/models/task';
@@ -24,7 +24,7 @@ interface DeltaResultsTabProps {
   audit?: boolean;
   counts: CollectionCounts;
   delta?: boolean;
-  filter?: Filter;
+  filter?: FilterType;
   hasTarget?: boolean;
   isUpdating?: boolean;
   progress: number;

--- a/src/web/pages/reports/details/EmptyResultsReport.tsx
+++ b/src/web/pages/reports/details/EmptyResultsReport.tsx
@@ -4,7 +4,7 @@
  */
 
 import styled from 'styled-components';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import {CircleXDeleteIcon, EditIcon, FilterIcon} from 'web/components/icon';
 import Divider from 'web/components/layout/Divider';
@@ -15,7 +15,7 @@ import ReportPanel from 'web/pages/reports/details/ReportPanel';
 
 interface EmptyResultsReportProps {
   all: number;
-  filter?: Filter;
+  filter?: FilterType;
   onFilterAddLogLevelClick?: () => void;
   onFilterEditClick?: () => void;
   onFilterDecreaseMinQoDClick?: () => void;

--- a/src/web/pages/reports/details/ReportDetailsPageToolBar.tsx
+++ b/src/web/pages/reports/details/ReportDetailsPageToolBar.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type default as Filter, type FilterType} from 'gmp/models/filter';
 import type ReportReport from 'gmp/models/report/report';
 import type ReportTask from 'gmp/models/report/task';
 import ToolBar from 'web/components/bar/Toolbar';
@@ -17,11 +17,11 @@ export interface DetailsToolbarProps {
   isLoading?: boolean;
   isLoadingFilters?: boolean;
   isUpdating?: boolean;
-  pageFilter?: Filter;
+  pageFilter?: FilterType;
   report?: ReportReport;
-  reportFilter?: Filter;
+  reportFilter?: FilterType;
   reportId: string;
-  resetFilter?: Filter;
+  resetFilter?: FilterType;
   showError: (error: Error) => void;
   showErrorMessage: (message: string) => void;
   showSuccessMessage: (message: string) => void;
@@ -29,7 +29,7 @@ export interface DetailsToolbarProps {
   task?: ReportTask;
   threshold?: number;
   onAddToAssetsClick?: () => void;
-  onFilterChanged?: (filter: Filter) => void;
+  onFilterChanged?: (filter: FilterType) => void;
   onFilterEditClick?: () => void;
   onFilterRemoveClick?: () => void;
   onFilterResetClick?: () => void;

--- a/src/web/pages/reports/details/ReportDetailsPageToolBarIcons.tsx
+++ b/src/web/pages/reports/details/ReportDetailsPageToolBarIcons.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type AuditReportReport from 'gmp/models/report/audit-report';
 import type ReportReport from 'gmp/models/report/report';
 import type ReportTask from 'gmp/models/report/task';
@@ -30,7 +30,7 @@ import AlertActions from 'web/pages/reports/details/AlertActions';
 interface ReportDetailsToolBarIconsProps {
   audit?: boolean;
   delta?: boolean;
-  filter?: Filter;
+  filter?: FilterType;
   isLoading?: boolean;
   report?: ReportReport | AuditReportReport;
   reportId: string;

--- a/src/web/pages/reports/details/ReportEntitiesContainer.tsx
+++ b/src/web/pages/reports/details/ReportEntitiesContainer.tsx
@@ -5,7 +5,7 @@
 
 import React, {useEffect, useMemo, useState} from 'react';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import Loading from 'web/components/loading/Loading';
 import SortDirection, {type SortDirectionType} from 'web/utils/sort-direction';
@@ -33,7 +33,7 @@ interface ReportEntitiesContainerProps<TEntity> {
   children: (
     props: ReportEntitiesContainerRenderProps<TEntity>,
   ) => React.JSX.Element;
-  filter?: Filter;
+  filter?: FilterType;
   counts?: CollectionCounts;
   entities?: TEntity[];
   sortField: string;
@@ -64,7 +64,7 @@ const sortEntities = <TEntity,>({
   return [...entities].sort(compare);
 };
 
-const getRows = (filter?: Filter, counts?: CollectionCounts) => {
+const getRows = (filter?: FilterType, counts?: CollectionCounts) => {
   let rows = isDefined(filter) ? (filter.get('rows') as number) : undefined;
 
   if (!isDefined(rows)) {

--- a/src/web/pages/reports/details/ReportTabDefinitions.tsx
+++ b/src/web/pages/reports/details/ReportTabDefinitions.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import _ from 'gmp/locale';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type ReportReport from 'gmp/models/report/report';
 import type ReportTLSCertificate from 'gmp/models/report/tls-certificate';
 import {type TaskStatus} from 'gmp/models/task';
@@ -30,7 +30,7 @@ export interface ThresholdConfig {
   showThresholdMessage: boolean;
   isUpdating: boolean;
   threshold: number;
-  onFilterChanged: (filter: Filter) => void;
+  onFilterChanged: (filter: FilterType) => void;
   onFilterEditClick: () => void;
 }
 
@@ -42,7 +42,7 @@ interface TabDefinition {
 
 interface BuildReportTabDefinitionsParams {
   activeReport: ReportReport;
-  activeFilter: Filter;
+  activeFilter: FilterType;
   reportId: string;
   isImport: boolean;
   isAgentScanning: boolean;
@@ -94,7 +94,7 @@ const EXCLUDED_WEBAPP_TAB_KEY_SET = new Set<string>(
 
 export const renderWithThreshold = (
   entityType: string,
-  activeFilter: Filter,
+  activeFilter: FilterType,
   config: ThresholdConfig,
   content: React.ReactNode,
 ): React.ReactNode => {

--- a/src/web/pages/reports/details/ReportThresholdPanel.tsx
+++ b/src/web/pages/reports/details/ReportThresholdPanel.tsx
@@ -4,7 +4,7 @@
  */
 
 import styled from 'styled-components';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import FootNote from 'web/components/footnote/Footnote';
 import {EditIcon, FilterIcon} from 'web/components/icon';
@@ -19,10 +19,10 @@ import ReportPanel from 'web/pages/reports/details/ReportPanel';
 
 interface ThresholdPanelProps {
   entityType: string;
-  filter: Filter;
+  filter: FilterType;
   isUpdating?: boolean;
   threshold: number;
-  onFilterChanged?: (filter: Filter) => void;
+  onFilterChanged?: (filter: FilterType) => void;
   onFilterEditClick?: () => void;
 }
 

--- a/src/web/pages/reports/details/Summary.tsx
+++ b/src/web/pages/reports/details/Summary.tsx
@@ -9,7 +9,7 @@ import {
   type Date as GmpDate,
   duration as createDuration,
 } from 'gmp/models/date';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type AuditReportReport from 'gmp/models/report/audit-report';
 import type ReportReport from 'gmp/models/report/report';
 import {TASK_STATUS} from 'gmp/models/task';
@@ -30,7 +30,7 @@ import useTranslation from 'web/hooks/useTranslation';
 
 interface SummaryProps {
   audit?: boolean;
-  filter?: Filter;
+  filter?: FilterType;
   isUpdating?: boolean;
   links?: boolean;
   report: ReportReport | AuditReportReport;

--- a/src/web/pages/reports/details/application/ApplicationsTab.tsx
+++ b/src/web/pages/reports/details/application/ApplicationsTab.tsx
@@ -5,7 +5,7 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import type ReportApp from 'gmp/models/report/app';
 import {isDefined} from 'gmp/utils/identity';
 import ErrorPanel from 'web/components/error/ErrorPanel';
@@ -21,7 +21,7 @@ import {
 } from 'web/utils/Sort';
 
 interface ApplicationsTabProps {
-  filter?: Filter;
+  filter?: FilterType;
   reportId: string;
   applicationsData?: UseGetEntitiesReturn<ReportApp>;
   isApplicationsFetching?: boolean;
@@ -30,8 +30,10 @@ interface ApplicationsTabProps {
 
 export const appsSortFunctions = {
   name: makeCompareString('name'),
-  hosts: makeCompareNumber(entity => entity.hosts.count),
-  occurrences: makeCompareNumber(entity => entity.occurrences.total),
+  hosts: makeCompareNumber((entity: ReportApp) => entity.hosts.count),
+  occurrences: makeCompareNumber(
+    (entity: ReportApp) => entity.occurrences.total,
+  ),
   severity: makeCompareSeverity(),
 };
 
@@ -48,7 +50,7 @@ const ApplicationsTabWrapper = ({
     return isDefined(filter) ? filter : new Filter();
   }, [filter]);
 
-  const [appsFilter, setAppsFilter] = useState<Filter>(baseFilter);
+  const [appsFilter, setAppsFilter] = useState<FilterType>(baseFilter);
 
   useEffect(() => {
     setAppsFilter(baseFilter);
@@ -59,7 +61,7 @@ const ApplicationsTabWrapper = ({
   const isLoading = !data && isFetching;
   const isError = isApplicationsError ?? false;
 
-  const updateFilter = (newFilter: Filter) => {
+  const updateFilter = (newFilter: FilterType) => {
     setAppsFilter(newFilter);
   };
 

--- a/src/web/pages/reports/details/cve/ClosedCvesTab.tsx
+++ b/src/web/pages/reports/details/cve/ClosedCvesTab.tsx
@@ -5,7 +5,7 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import {type ReportClosedCve} from 'gmp/models/report/parser';
 import {isDefined} from 'gmp/utils/identity';
 import ErrorPanel from 'web/components/error/ErrorPanel';
@@ -21,7 +21,7 @@ import {
 } from 'web/utils/Sort';
 
 interface ClosedCvesTabProps {
-  filter?: Filter;
+  filter?: FilterType;
   reportId: string;
   closedCvesData?: UseGetEntitiesReturn<ReportClosedCve>;
   isClosedCvesFetching?: boolean;
@@ -30,8 +30,10 @@ interface ClosedCvesTabProps {
 
 export const closedCvesSortFunctions = {
   cve: makeCompareString('cveId'),
-  host: makeCompareIp(entity => entity.host.ip),
-  nvt: makeCompareString(entity => entity.source?.description),
+  host: makeCompareIp((entity: ReportClosedCve) => entity.host?.ip),
+  nvt: makeCompareString(
+    (entity: ReportClosedCve) => entity.source?.description,
+  ),
   severity: makeCompareSeverity(),
 };
 
@@ -48,7 +50,8 @@ const ClosedCvesTabWrapper = ({
     return isDefined(filter) ? filter : new Filter();
   }, [filter]);
 
-  const [closedCvesFilter, setClosedCvesFilter] = useState<Filter>(baseFilter);
+  const [closedCvesFilter, setClosedCvesFilter] =
+    useState<FilterType>(baseFilter);
 
   useEffect(() => {
     setClosedCvesFilter(baseFilter);
@@ -58,7 +61,7 @@ const ClosedCvesTabWrapper = ({
   const isFetching = isClosedCvesFetching ?? false;
   const isLoading = !data && isFetching;
   const isError = isClosedCvesError ?? false;
-  const updateFilter = (newFilter: Filter) => {
+  const updateFilter = (newFilter: FilterType) => {
     setClosedCvesFilter(newFilter);
   };
 

--- a/src/web/pages/reports/details/cve/CvesTab.tsx
+++ b/src/web/pages/reports/details/cve/CvesTab.tsx
@@ -5,7 +5,7 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import {type ReportActiveCve} from 'gmp/models/report/parser';
 import {isDefined} from 'gmp/utils/identity';
 import ErrorPanel from 'web/components/error/ErrorPanel';
@@ -21,7 +21,7 @@ import {
 } from 'web/utils/Sort';
 
 interface CvesTabProps {
-  filter?: Filter;
+  filter?: FilterType;
   reportId: string;
   cvesData?: UseGetEntitiesReturn<ReportActiveCve>;
   isCvesFetching?: boolean;
@@ -30,8 +30,10 @@ interface CvesTabProps {
 
 export const cvesSortFunctions = {
   cve: makeCompareString('cveId'),
-  host: makeCompareIp(entity => entity.host.ip),
-  nvt: makeCompareString(entity => entity.source?.description),
+  host: makeCompareIp((entity: ReportActiveCve) => entity.host?.ip),
+  nvt: makeCompareString(
+    (entity: ReportActiveCve) => entity.source?.description,
+  ),
   severity: makeCompareSeverity(),
 };
 
@@ -48,7 +50,7 @@ const CvesTabWrapper = ({
     return isDefined(filter) ? filter : new Filter();
   }, [filter]);
 
-  const [cvesFilter, setCvesFilter] = useState<Filter>(baseFilter);
+  const [cvesFilter, setCvesFilter] = useState<FilterType>(baseFilter);
 
   useEffect(() => {
     setCvesFilter(baseFilter);
@@ -58,7 +60,7 @@ const CvesTabWrapper = ({
   const isFetching = isCvesFetching ?? false;
   const isLoading = !data && isFetching;
   const isError = isCvesError ?? false;
-  const updateFilter = (newFilter: Filter) => {
+  const updateFilter = (newFilter: FilterType) => {
     setCvesFilter(newFilter);
   };
 

--- a/src/web/pages/reports/details/error/ErrorsTab.tsx
+++ b/src/web/pages/reports/details/error/ErrorsTab.tsx
@@ -4,7 +4,7 @@
  */
 
 import {useEffect, useMemo, useState} from 'react';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import {type ReportError} from 'gmp/models/report/parser';
 import {isDefined} from 'gmp/utils/identity';
 import ErrorPanel from 'web/components/error/ErrorPanel';
@@ -17,7 +17,7 @@ import {type UseGetEntitiesReturn} from 'web/queries/useGetEntities';
 import {makeCompareIp, makeCompareString} from 'web/utils/Sort';
 
 interface ErrorsTabWrapperProps {
-  filter?: Filter;
+  filter?: FilterType;
   reportId: string;
   errorsData?: UseGetEntitiesReturn<ReportError>;
   isErrorsFetching?: boolean;
@@ -26,9 +26,9 @@ interface ErrorsTabWrapperProps {
 
 export const errorsSortFunctions = {
   error: makeCompareString('description'),
-  host: makeCompareIp(entity => entity.host.ip),
-  hostname: makeCompareString(entity => entity.host.name),
-  nvt: makeCompareString(entity => entity.nvt.name),
+  host: makeCompareIp((entity: ReportError) => entity.host?.ip),
+  hostname: makeCompareString((entity: ReportError) => entity.host?.name),
+  nvt: makeCompareString((entity: ReportError) => entity.nvt?.name),
   port: makeCompareString('port'),
 };
 
@@ -48,7 +48,7 @@ const ErrorsTabWrapper = ({
     return f.set('sort-reverse', 'error');
   }, [filter]);
 
-  const [errorsFilter, setErrorsFilter] = useState<Filter>(baseFilter);
+  const [errorsFilter, setErrorsFilter] = useState<FilterType>(baseFilter);
 
   useEffect(() => {
     setErrorsFilter(baseFilter);
@@ -58,7 +58,7 @@ const ErrorsTabWrapper = ({
   const isFetching = isErrorsFetching ?? false;
   const isLoading = !data && isFetching;
   const isError = isErrorsError ?? false;
-  const updateFilter = (newFilter: Filter) => {
+  const updateFilter = (newFilter: FilterType) => {
     setErrorsFilter(newFilter);
   };
 

--- a/src/web/pages/reports/details/host/AgentScanningHostsTab.tsx
+++ b/src/web/pages/reports/details/host/AgentScanningHostsTab.tsx
@@ -4,7 +4,7 @@
  */
 
 import type CollectionCounts from 'gmp/collection/collection-counts';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type ReportHost from 'gmp/models/report/host';
 import AgentScanningHostsTable from 'web/pages/reports/details/host/AgentScanningHostsTable';
 import ReportEntitiesContainer from 'web/pages/reports/details/ReportEntitiesContainer';
@@ -19,7 +19,7 @@ interface AgentScanningHostsTabProps {
   audit?: boolean;
   counts?: CollectionCounts;
   hosts?: ReportHost[];
-  filter: Filter;
+  filter: FilterType;
   isUpdating?: boolean;
   sortField: string;
   sortReverse: boolean;

--- a/src/web/pages/reports/details/host/ContainerScanningHostsTab.tsx
+++ b/src/web/pages/reports/details/host/ContainerScanningHostsTab.tsx
@@ -4,7 +4,7 @@
  */
 
 import type CollectionCounts from 'gmp/collection/collection-counts';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type ReportHost from 'gmp/models/report/host';
 import ContainerScanningHostsTable from 'web/pages/reports/details/host/ContainerScanningHostsTable';
 import ReportEntitiesContainer from 'web/pages/reports/details/ReportEntitiesContainer';
@@ -20,7 +20,7 @@ interface ContainerScanningHostsTabProps {
   audit?: boolean;
   counts?: CollectionCounts;
   hosts?: ReportHost[];
-  filter: Filter;
+  filter: FilterType;
   isUpdating?: boolean;
   sortField: string;
   sortReverse: boolean;

--- a/src/web/pages/reports/details/host/HostsTab.tsx
+++ b/src/web/pages/reports/details/host/HostsTab.tsx
@@ -4,7 +4,7 @@
  */
 
 import type CollectionCounts from 'gmp/collection/collection-counts';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type ReportHost from 'gmp/models/report/host';
 import HostsTable from 'web/pages/reports/details/host/HostsTable';
 import ReportEntitiesContainer from 'web/pages/reports/details/ReportEntitiesContainer';
@@ -20,7 +20,7 @@ interface HostsTabProps {
   audit?: boolean;
   counts?: CollectionCounts;
   hosts?: ReportHost[];
-  filter: Filter;
+  filter: FilterType;
   isUpdating?: boolean;
   sortField: string;
   sortReverse: boolean;

--- a/src/web/pages/reports/details/host/HostsTabContent.tsx
+++ b/src/web/pages/reports/details/host/HostsTabContent.tsx
@@ -4,7 +4,7 @@
  */
 
 import {useState} from 'react';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type ReportHost from 'gmp/models/report/host';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
@@ -21,7 +21,7 @@ export interface HostsTabContentProps {
   isAgentScanning?: boolean;
   isContainerScanning: boolean;
   isWebApplicationScanning?: boolean;
-  reportFilter: Filter;
+  reportFilter: FilterType;
   hostsData?: UseGetEntitiesReturn<ReportHost>;
   isHostsFetching?: boolean;
   isHostsError?: boolean;

--- a/src/web/pages/reports/details/host/WebApplicationHostsTab.tsx
+++ b/src/web/pages/reports/details/host/WebApplicationHostsTab.tsx
@@ -4,7 +4,7 @@
  */
 
 import type CollectionCounts from 'gmp/collection/collection-counts';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type ReportHost from 'gmp/models/report/host';
 import WebApplicationHostsTable from 'web/pages/reports/details/host/WebApplicationHostsTable';
 import ReportEntitiesContainer from 'web/pages/reports/details/ReportEntitiesContainer';
@@ -20,7 +20,7 @@ interface WebApplicationHostsTabProps {
   audit?: boolean;
   counts?: CollectionCounts;
   hosts?: ReportHost[];
-  filter: Filter;
+  filter: FilterType;
   isUpdating?: boolean;
   sortField: string;
   sortReverse: boolean;

--- a/src/web/pages/reports/details/operating-system/OperatingSystemsTab.tsx
+++ b/src/web/pages/reports/details/operating-system/OperatingSystemsTab.tsx
@@ -5,7 +5,7 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import type ReportOperatingSystem from 'gmp/models/report/os';
 import {isDefined} from 'gmp/utils/identity';
 import Loading from 'web/components/loading/Loading';
@@ -17,7 +17,7 @@ import {makeCompareNumber, makeCompareString} from 'web/utils/Sort';
 
 interface OperatingSystemsTabWrapperProps {
   audit?: boolean;
-  filter?: Filter;
+  filter?: FilterType;
   reportId: string;
   operatingSystemsData?: UseGetEntitiesReturn<ReportOperatingSystem>;
   isOperatingSystemsFetching?: boolean;
@@ -61,7 +61,7 @@ const OperatingSystemsTabWrapper = ({
   }, [filter]);
 
   const [operatingSystemsFilter, setOperatingSystemsFilter] =
-    useState<Filter>(baseFilter);
+    useState<FilterType>(baseFilter);
 
   useEffect(() => {
     setOperatingSystemsFilter(baseFilter);
@@ -72,7 +72,7 @@ const OperatingSystemsTabWrapper = ({
   const isLoading = !data && isFetching;
   const isError = isOperatingSystemsError ?? false;
 
-  const updateFilter = (newFilter: Filter) => {
+  const updateFilter = (newFilter: FilterType) => {
     setOperatingSystemsFilter(newFilter);
   };
 

--- a/src/web/pages/reports/details/port/PortsTab.tsx
+++ b/src/web/pages/reports/details/port/PortsTab.tsx
@@ -4,7 +4,7 @@
  */
 
 import {useEffect, useMemo, useState} from 'react';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import type ReportPort from 'gmp/models/report/port';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
@@ -17,7 +17,7 @@ import {makeCompareNumber, makeCompareSeverity} from 'web/utils/Sort';
 
 interface PortsTabProps {
   reportId: string;
-  reportFilter: Filter;
+  reportFilter: FilterType;
   portsData?: UseGetEntitiesReturn<ReportPort>;
   isPortsFetching?: boolean;
   isPortsError?: boolean;
@@ -43,7 +43,7 @@ const PortsTab = ({
     return Filter.fromString(reportFilterString);
   }, [reportFilterString]);
 
-  const [portsFilter, setPortsFilter] = useState<Filter>(baseFilter);
+  const [portsFilter, setPortsFilter] = useState<FilterType>(baseFilter);
 
   useEffect(() => {
     setPortsFilter(baseFilter);
@@ -54,7 +54,7 @@ const PortsTab = ({
   const isLoading = !data && isFetching;
   const isError = isPortsError ?? false;
 
-  const updateFilter = (newFilter: Filter) => {
+  const updateFilter = (newFilter: FilterType) => {
     setPortsFilter(newFilter);
   };
 

--- a/src/web/pages/reports/details/result/ContainerScanningResultsTab.tsx
+++ b/src/web/pages/reports/details/result/ContainerScanningResultsTab.tsx
@@ -5,7 +5,7 @@
 
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import {isActive, type TaskStatus} from 'gmp/models/task';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
@@ -21,7 +21,7 @@ import ContainerScanningResultsTable from 'web/pages/reports/details/result/Cont
 
 interface ContainerScanningResultsTabProps {
   reportId: string;
-  reportFilter: Filter;
+  reportFilter: FilterType;
   status: TaskStatus;
 }
 
@@ -40,7 +40,7 @@ const ContainerScanningResultsTab = ({
     return filter.set('_and_report_id', reportId);
   }, [reportFilterString, reportId]);
 
-  const [resultsFilter, setResultsFilter] = useState<Filter>(baseFilter);
+  const [resultsFilter, setResultsFilter] = useState<FilterType>(baseFilter);
 
   useEffect(() => {
     setResultsFilter(baseFilter);
@@ -54,7 +54,7 @@ const ContainerScanningResultsTab = ({
   });
 
   const updateFilter = useCallback(
-    (newFilter: Filter) => {
+    (newFilter: FilterType) => {
       setResultsFilter(newFilter.set('_and_report_id', reportId));
     },
     [reportId],

--- a/src/web/pages/reports/details/result/ResultsTab.tsx
+++ b/src/web/pages/reports/details/result/ResultsTab.tsx
@@ -5,7 +5,7 @@
 
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import {isActive, type TaskStatus} from 'gmp/models/task';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
@@ -30,7 +30,7 @@ interface ResultsTabWrapperProps {
   audit?: boolean;
   hasTarget: boolean;
   progress: number;
-  reportFilter: Filter;
+  reportFilter: FilterType;
   reportId: string;
   reportResultsCounts?: ResultsCounts;
   status: TaskStatus;
@@ -68,7 +68,7 @@ const ResultsTabWrapper = ({
     return filter.set('_and_report_id', reportId);
   }, [reportFilterString, reportId]);
 
-  const [resultsFilter, setResultsFilter] = useState<Filter>(baseFilter);
+  const [resultsFilter, setResultsFilter] = useState<FilterType>(baseFilter);
 
   useEffect(() => {
     setResultsFilter(baseFilter);
@@ -82,7 +82,7 @@ const ResultsTabWrapper = ({
   });
 
   const updateFilter = useCallback(
-    (newFilter: Filter) => {
+    (newFilter: FilterType) => {
       setResultsFilter(newFilter.set('_and_report_id', reportId));
     },
     [reportId],

--- a/src/web/pages/reports/details/result/ResultsTabContent.tsx
+++ b/src/web/pages/reports/details/result/ResultsTabContent.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import type {TaskStatus} from 'gmp/models/task';
 import EmptyReport from 'web/pages/reports/details/EmptyReport';
 import EmptyResultsReport from 'web/pages/reports/details/EmptyResultsReport';
@@ -21,7 +21,7 @@ interface ResultsTabContentProps {
   isWebApplicationScanning: boolean;
   hasTarget: boolean;
   progress: number;
-  reportFilter: Filter;
+  reportFilter: FilterType;
   reportId: string;
   reportResultsCounts?: ResultsCounts;
   status: TaskStatus;

--- a/src/web/pages/reports/details/result/WebApplicationScanningResultsTab.tsx
+++ b/src/web/pages/reports/details/result/WebApplicationScanningResultsTab.tsx
@@ -5,7 +5,7 @@
 
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import {isActive, type TaskStatus} from 'gmp/models/task';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
@@ -21,7 +21,7 @@ import WebApplicationScanningResultsTable from 'web/pages/reports/details/result
 
 interface WebApplicationScanningResultsTabProps {
   reportId: string;
-  reportFilter: Filter;
+  reportFilter: FilterType;
   status: TaskStatus;
 }
 
@@ -40,7 +40,7 @@ const WebApplicationScanningResultsTab = ({
     return filter.set('_and_report_id', reportId);
   }, [reportFilterString, reportId]);
 
-  const [resultsFilter, setResultsFilter] = useState<Filter>(baseFilter);
+  const [resultsFilter, setResultsFilter] = useState<FilterType>(baseFilter);
 
   useEffect(() => {
     setResultsFilter(baseFilter);
@@ -54,7 +54,7 @@ const WebApplicationScanningResultsTab = ({
   });
 
   const updateFilter = useCallback(
-    (newFilter: Filter) => {
+    (newFilter: FilterType) => {
       setResultsFilter(newFilter.set('_and_report_id', reportId));
     },
     [reportId],

--- a/src/web/pages/reports/details/tls-certificate/TlsCertificatesTab.tsx
+++ b/src/web/pages/reports/details/tls-certificate/TlsCertificatesTab.tsx
@@ -4,7 +4,7 @@
  */
 
 import {useEffect, useMemo, useState} from 'react';
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import type ReportTLSCertificate from 'gmp/models/report/tls-certificate';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
@@ -19,9 +19,10 @@ import {
   makeComparePort,
   makeCompareString,
 } from 'web/utils/Sort';
+
 interface TLSCertificatesTabProps {
   reportId: string;
-  reportFilter: Filter;
+  reportFilter: FilterType;
   onTlsCertificateDownloadClick: (entity: ReportTLSCertificate) => void;
   tlsCertificatesData?: UseGetEntitiesReturn<ReportTLSCertificate>;
   isTlsCertificatesFetching?: boolean;
@@ -58,7 +59,7 @@ const TLSCertificatesTab = ({
   }, [reportFilterString]);
 
   const [tlsCertificatesFilter, setTlsCertificatesFilter] =
-    useState<Filter>(baseFilter);
+    useState<FilterType>(baseFilter);
 
   useEffect(() => {
     setTlsCertificatesFilter(baseFilter);
@@ -68,7 +69,7 @@ const TLSCertificatesTab = ({
   const isFetching = isTlsCertificatesFetching ?? false;
   const isLoading = !data && isFetching;
   const isError = isTlsCertificatesError ?? false;
-  const updateFilter = (newFilter: Filter) => {
+  const updateFilter = (newFilter: FilterType) => {
     setTlsCertificatesFilter(newFilter);
   };
 

--- a/src/web/pages/roles/RoleFilterDialog.tsx
+++ b/src/web/pages/roles/RoleFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import DefaultFilterDialog from 'web/components/powerfilter/DefaultFilterDialog';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
 import useFilterDialog from 'web/components/powerfilter/useFilterDialog';
@@ -14,7 +14,7 @@ import useFilterDialogSave, {
 import useTranslation from 'web/hooks/useTranslation';
 
 interface RoleFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const RoleFilterDialog = ({

--- a/src/web/pages/scanners/ScannerFilterDialog.tsx
+++ b/src/web/pages/scanners/ScannerFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {
   AGENT_CONTROLLER_SCANNER_TYPE,
   AGENT_CONTROLLER_SENSOR_SCANNER_TYPE,
@@ -33,11 +33,11 @@ import useGmp from 'web/hooks/useGmp';
 import useTranslation from 'web/hooks/useTranslation';
 
 interface ScannerFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 interface ScannerTypeGroupProps {
-  filter?: Filter;
+  filter?: FilterType;
   onFilterValueChange: (value: string, name: string) => void;
 }
 

--- a/src/web/pages/tags/TagListPage.tsx
+++ b/src/web/pages/tags/TagListPage.tsx
@@ -6,7 +6,7 @@
 import {useCallback, useMemo, useRef, useState} from 'react';
 import {showSuccessNotification} from '@greenbone/ui-lib';
 import type CollectionCounts from 'gmp/collection/collection-counts';
-import {type default as Filter, TAGS_FILTER_FILTER} from 'gmp/models/filter';
+import {type FilterType, TAGS_FILTER_FILTER} from 'gmp/models/filter';
 import type Tag from 'gmp/models/tag';
 import {getEntityType, pluralizeType} from 'gmp/utils/entity-type';
 import Download from 'web/components/form/Download';
@@ -114,7 +114,7 @@ const TagsPage = () => {
   });
 
   const handleBulkDelete = useCallback(async () => {
-    let input: Tag[] | Filter;
+    let input: Tag[] | FilterType;
     if (selectionType === SelectionType.SELECTION_USER) {
       input = selectedEntities;
     } else if (selectionType === SelectionType.SELECTION_FILTER) {
@@ -138,7 +138,7 @@ const TagsPage = () => {
   ]);
 
   const handleBulkDownload = useCallback(async () => {
-    let input: Tag[] | Filter;
+    let input: Tag[] | FilterType;
     if (selectionType === SelectionType.SELECTION_USER) {
       input = selectedEntities;
     } else if (selectionType === SelectionType.SELECTION_FILTER) {
@@ -173,7 +173,7 @@ const TagsPage = () => {
   ]);
 
   const handleFilterChanged = useCallback(
-    (newFilter?: Filter) => {
+    (newFilter?: FilterType) => {
       changeFilter(newFilter);
     },
     [changeFilter],

--- a/src/web/pages/targets/TargetFilterDialog.tsx
+++ b/src/web/pages/targets/TargetFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import DefaultFilterDialog from 'web/components/powerfilter/DefaultFilterDialog';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
 import useFilterDialog from 'web/components/powerfilter/useFilterDialog';
@@ -15,7 +15,7 @@ import useGmp from 'web/hooks/useGmp';
 import useTranslation from 'web/hooks/useTranslation';
 
 interface TargetFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const TargetFilterDialog = ({

--- a/src/web/pages/tasks/TaskFilterDialog.tsx
+++ b/src/web/pages/tasks/TaskFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import BooleanFilterGroup from 'web/components/powerfilter/BooleanFilterGroup';
 import CreateNamedFilterGroup from 'web/components/powerfilter/CreateNamedFilterGroup';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
@@ -24,7 +24,7 @@ import useCapabilities from 'web/hooks/useCapabilities';
 import useTranslation from 'web/hooks/useTranslation';
 
 interface TaskFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const TaskFilterDialog = ({

--- a/src/web/pages/web-application-targets/WebApplicationTargetsListPage.tsx
+++ b/src/web/pages/web-application-targets/WebApplicationTargetsListPage.tsx
@@ -6,7 +6,11 @@
 import {useCallback, useMemo, useRef, useState} from 'react';
 import {showSuccessNotification} from '@greenbone/ui-lib';
 import type CollectionCounts from 'gmp/collection/collection-counts';
-import {type default as Filter, TARGETS_FILTER_FILTER} from 'gmp/models/filter';
+import {
+  type default as Filter,
+  type FilterType,
+  TARGETS_FILTER_FILTER,
+} from 'gmp/models/filter';
 import type WebApplicationTarget from 'gmp/models/web-application-target';
 import {getEntityType, pluralizeType} from 'gmp/utils/entity-type';
 import Download from 'web/components/form/Download';
@@ -180,7 +184,7 @@ const WebApplicationTargetsListPage = () => {
   ]);
 
   const handleFilterChanged = useCallback(
-    (newFilter?: Filter) => {
+    (newFilter?: FilterType) => {
       changeFilter(newFilter);
     },
     [changeFilter],

--- a/src/web/queries/useGetEntities.ts
+++ b/src/web/queries/useGetEntities.ts
@@ -22,7 +22,7 @@ type GmpMethodParams = HttpCommandInputParams;
 export interface UseGetEntitiesReturn<T> {
   entities: T[];
   entitiesCounts: CollectionCounts;
-  filter?: Filter;
+  filterType?: Filter;
 }
 
 interface UseGetEntitiesParams<

--- a/src/web/queries/useGetEntities.ts
+++ b/src/web/queries/useGetEntities.ts
@@ -8,7 +8,7 @@ import type CollectionCounts from 'gmp/collection/collection-counts';
 import {type EntitiesMeta} from 'gmp/commands/entities';
 import {type HttpCommandInputParams} from 'gmp/commands/http';
 import type Response from 'gmp/http/response';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import useGmp from 'web/hooks/useGmp';
 import useSessionToken from 'web/hooks/useSessionToken';
 import {
@@ -22,7 +22,7 @@ type GmpMethodParams = HttpCommandInputParams;
 export interface UseGetEntitiesReturn<T> {
   entities: T[];
   entitiesCounts: CollectionCounts;
-  filterType?: Filter;
+  filterType?: FilterType;
 }
 
 interface UseGetEntitiesParams<
@@ -31,7 +31,7 @@ interface UseGetEntitiesParams<
 > {
   gmpMethod: (input: TInput) => Promise<Response<TModel[], EntitiesMeta>>;
   queryId: string;
-  filter?: Filter;
+  filter?: FilterType;
   enabled?: boolean;
   refetchInterval?:
     | number


### PR DESCRIPTION


## What

Introduce new FilterType interface

## Why

Extract a FilterType interface from the Filter class. The Filter class has several purposes and mixes responsibilities. Introducing a FilterType is the first step for splitting up the responsibilities.

## References

https://jira.greenbone.net/browse/GEA-1933

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


