### PR TITLE
FilterType Name and FilterType Methods

### DIFF
--- a/src/gmp/models/__tests__/filter.test.ts
+++ b/src/gmp/models/__tests__/filter.test.ts
@@ -430,6 +430,14 @@ describe('Filter fromResponseElement', () => {
     const filter3 = Filter.fromResponseElement({_id: UNKNOWN_FILTER_ID});
     expect(filter3.id).toBeUndefined();
   });
+
+  test('should parse name', () => {
+    const filter1 = Filter.fromResponseElement();
+    expect(filter1.name).toBeUndefined();
+
+    const filter2 = Filter.fromResponseElement({name: 'Test Filter'});
+    expect(filter2.name).toBe('Test Filter');
+  });
 });
 
 describe('Filter set', () => {

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -86,6 +86,7 @@ export interface FilterModelElement extends ModelElement {
  */
 export interface FilterResponseElement {
   _id?: string;
+  name?: string;
   keywords?: {
     keyword?: FilterKeyword | FilterKeyword[];
   };
@@ -110,6 +111,7 @@ type FilterForEachFunc = (
 export interface FilterType {
   id?: string;
   length: number;
+  name?: string;
   all(): Filter;
   and(filter?: Filter): Filter;
   copy(): Filter;
@@ -284,6 +286,8 @@ class Filter extends EntityModel implements FilterType {
         ? element._id
         : undefined;
 
+    const name = !isEmpty(element.name) ? element.name : undefined;
+
     let terms: FilterTerm[] = [];
     if (isDefined(element.keywords)) {
       terms = map(
@@ -295,7 +299,7 @@ class Filter extends EntityModel implements FilterType {
       terms = parseFilterTermsFromString(element.term);
     }
 
-    return new Filter({id, terms});
+    return new Filter({id, name, terms});
   }
 
   /**

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -112,12 +112,12 @@ export interface FilterType {
   id?: string;
   length: number;
   name?: string;
-  all(): Filter;
-  and(filter?: Filter): Filter;
-  copy(): Filter;
-  delete(key: string): Filter;
+  all(): FilterType;
+  and(filter?: FilterType): FilterType;
+  copy(): FilterType;
+  delete(key: string): FilterType;
   equals(filter?: FilterType): boolean;
-  first(first?: number): Filter;
+  first(first?: number): FilterType;
   forEach(func: FilterForEachFunc): void;
   getAllTerms(): readonly FilterTerm[];
   get(key: string, def?: string | number): string | number | undefined;
@@ -717,7 +717,7 @@ class Filter extends EntityModel implements FilterType {
    *
    * @return A shallow copy of this filter.
    */
-  copy(): Filter {
+  copy() {
     return this._copy();
   }
 
@@ -726,7 +726,7 @@ class Filter extends EntityModel implements FilterType {
    *
    * @return Copy of this filter but pointing to the next items.
    */
-  next(): Filter {
+  next() {
     const filter = this._copy();
     let first = parseInt(filter.get('first'));
     let rows = parseInt(filter.get('rows'));
@@ -752,7 +752,7 @@ class Filter extends EntityModel implements FilterType {
    *
    * @return Copy of this filter but pointing to the previous items.
    */
-  previous(): Filter {
+  previous() {
     const filter = this._copy();
     let first = parseInt(filter.get('first'));
     let rows = parseInt(filter.get('rows'));
@@ -785,7 +785,7 @@ class Filter extends EntityModel implements FilterType {
    *
    * @return Copy of this filter but pointing to the first items.
    */
-  first(first: number = 1): Filter {
+  first(first: number = 1) {
     return this.set('first', String(first), '=');
   }
 
@@ -796,7 +796,7 @@ class Filter extends EntityModel implements FilterType {
    *
    * @return Copy of this filter but removing the item count (rows) restriction.
    */
-  all(): Filter {
+  all() {
     const filter = this._copy();
 
     filter._set('first', '1', '=');
@@ -810,7 +810,7 @@ class Filter extends EntityModel implements FilterType {
    *
    * @return Copy of this filter but without first, rows and sort/sort-reverse terms.
    */
-  simple(): Filter {
+  simple() {
     const filter = this._copy();
 
     filter._delete('first');
@@ -827,7 +827,7 @@ class Filter extends EntityModel implements FilterType {
    *
    * @return A new filter if filter is defined, otherwise this filter is returned.
    */
-  and(filter: Filter | undefined | null): Filter {
+  and(filter: FilterType | undefined | null) {
     if (!hasValue(filter)) {
       return this;
     }
@@ -896,7 +896,7 @@ class Filter extends EntityModel implements FilterType {
    *
    * @return A new filter with merged terms if the filter has changed.
    */
-  merge(filter?: Filter) {
+  merge(filter?: FilterType) {
     if (!hasValue(filter) || filter.length === 0) {
       return this;
     }
@@ -914,7 +914,7 @@ class Filter extends EntityModel implements FilterType {
    * @return A new filter with merged terms if the filter has changed.
    */
 
-  mergeKeywords(filter?: Filter) {
+  mergeKeywords(filter?: FilterType) {
     if (!hasValue(filter)) {
       return this;
     }
@@ -935,7 +935,7 @@ class Filter extends EntityModel implements FilterType {
    *
    * @return A new filter with merged terms if changed.
    */
-  mergeExtraKeywords(filter?: Filter): Filter {
+  mergeExtraKeywords(filter?: FilterType) {
     if (!hasValue(filter)) {
       return this;
     }
@@ -976,7 +976,7 @@ class Filter extends EntityModel implements FilterType {
    *
    * @returns The new Filter
    */
-  static fromTerm(...term: FilterTerm[]): Filter {
+  static fromTerm(...term: FilterTerm[]) {
     return new Filter({
       terms: term,
     });

--- a/src/web/components/dashboard/display/DataDisplay.tsx
+++ b/src/web/components/dashboard/display/DataDisplay.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import equal from 'fast-deep-equal';
 import styled from 'styled-components';
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import {isDefined, isFunction} from 'gmp/utils/identity';
 import {excludeObjectProps} from 'gmp/utils/object';
 import DataDisplayIcons from 'web/components/dashboard/display/DataDisplayIcons';
@@ -74,7 +74,7 @@ export interface DataDisplayProps<
   dataRow: (data: TTransformedData) => string[];
   dataTitles: string[];
   dataTransform: TransformFunc<TData, TTransformedData, TTransformProps>;
-  filter?: Filter;
+  filter?: FilterType;
   height: number;
   icons: (props: IconsRenderProps<TState>) => React.ReactNode;
   children: (

--- a/src/web/components/dashboard/display/severity/SeverityClassDisplay.tsx
+++ b/src/web/components/dashboard/display/severity/SeverityClassDisplay.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import Filter from 'gmp/models/filter';
+import Filter, {type FilterType} from 'gmp/models/filter';
 import {isDefined} from 'gmp/utils/identity';
 import DonutChart from 'web/components/chart/Donut';
 import DataDisplay, {
@@ -24,8 +24,8 @@ interface SeverityClassDisplayProps extends DataDisplayProps<
   SeverityClassData,
   TransformSeverityDataProps
 > {
-  filter?: Filter;
-  onFilterChanged?: (filter: Filter) => void;
+  filter?: FilterType;
+  onFilterChanged?: (filter: FilterType) => void;
 }
 
 interface SeverityClassDisplayState {
@@ -56,7 +56,7 @@ const SeverityClassDisplay = ({
       return;
     }
 
-    let severityFilter: Filter;
+    let severityFilter: FilterType;
     const [startTerm, endTerm] = filterValueToFilterTerms(filterValue);
     if (!isDefined(startTerm)) {
       return;

--- a/src/web/pages/web-application-targets/WebApplicationTargetsListPage.tsx
+++ b/src/web/pages/web-application-targets/WebApplicationTargetsListPage.tsx
@@ -6,11 +6,7 @@
 import {useCallback, useMemo, useRef, useState} from 'react';
 import {showSuccessNotification} from '@greenbone/ui-lib';
 import type CollectionCounts from 'gmp/collection/collection-counts';
-import {
-  type default as Filter,
-  type FilterType,
-  TARGETS_FILTER_FILTER,
-} from 'gmp/models/filter';
+import {type FilterType, TARGETS_FILTER_FILTER} from 'gmp/models/filter';
 import type WebApplicationTarget from 'gmp/models/web-application-target';
 import {getEntityType, pluralizeType} from 'gmp/utils/entity-type';
 import Download from 'web/components/form/Download';
@@ -125,7 +121,7 @@ const WebApplicationTargetsListPage = () => {
   });
 
   const handleBulkDelete = useCallback(async () => {
-    let input: WebApplicationTarget[] | Filter;
+    let input: WebApplicationTarget[] | FilterType;
     if (selectionType === SelectionType.SELECTION_USER) {
       input = selectedEntities;
     } else if (selectionType === SelectionType.SELECTION_FILTER) {
@@ -149,7 +145,7 @@ const WebApplicationTargetsListPage = () => {
   ]);
 
   const handleBulkDownload = useCallback(async () => {
-    let input: WebApplicationTarget[] | Filter;
+    let input: WebApplicationTarget[] | FilterType;
     if (selectionType === SelectionType.SELECTION_USER) {
       input = selectedEntities;
     } else if (selectionType === SelectionType.SELECTION_FILTER) {


### PR DESCRIPTION
## What

* Add name to FilterType
* Expect and Return FilterType for all FilterType methods

## Why

Using the FilterType methods may return a different implementation then the current Filter class in future.
When querying some entity for example using `<get_tasks>` the returned filter may have an ID *and* a name.

## References

https://jira.greenbone.net/browse/GEA-1933

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


