### PR TITLE
GEA-1698

### DIFF
--- a/src/web/pages/scanconfigs/ScanConfigComponent.tsx
+++ b/src/web/pages/scanconfigs/ScanConfigComponent.tsx
@@ -114,6 +114,10 @@ const ScanConfigComponent = ({
     ScanConfigFamilyNvt[] | undefined
   >();
   const [familySelectedNvts, setFamilySelectedNvts] = useState<SelectedNvts>();
+  const [familySelectionUpdate, setFamilySelectionUpdate] = useState<{
+    familyName: string;
+    select: YesNo;
+  }>();
   const [hasSelection, setHasSelection] = useState(false);
 
   const [nvt, setNvt] = useState<Nvt>();
@@ -365,6 +369,19 @@ const ScanConfigComponent = ({
       familyName: familyNameValue,
       selected,
     });
+
+    // Sync the parent dialog's family-level "select all" checkbox with the
+    // selection just saved in this family dialog, so saving the whole config
+    // does not overwrite these changes with a stale value.
+    const currentNvts = familyNvts ?? [];
+    const allSelected =
+      currentNvts.length > 0 &&
+      currentNvts.every(nvtItem => selected?.[nvtItem.oid] === YES_VALUE);
+    setFamilySelectionUpdate({
+      familyName: familyNameValue,
+      select: allSelected ? YES_VALUE : NO_VALUE,
+    });
+
     await loadEditScanConfigSettings(configId, true);
     closeEditConfigFamilyDialog();
   };
@@ -449,6 +466,7 @@ const ScanConfigComponent = ({
                   editNvtFamiliesTitle={_('Edit Scan Config Family')}
                   error={editScanConfigDialogError}
                   families={families}
+                  familySelectionUpdate={familySelectionUpdate}
                   isLoadingConfig={isLoadingConfig}
                   isLoadingFamilies={isLoadingFamilies}
                   name={config.name as string}

--- a/src/web/pages/scanconfigs/ScanConfigEditDialog.tsx
+++ b/src/web/pages/scanconfigs/ScanConfigEditDialog.tsx
@@ -24,7 +24,7 @@ import {
   type ScanConfigFamily,
   type ScanConfigTrend,
 } from 'gmp/models/scan-config';
-import {YES_VALUE, NO_VALUE} from 'gmp/parser';
+import {YES_VALUE, NO_VALUE, type YesNo} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import DialogInlineNotification from 'web/components/dialog/DialogInlineNotification';
 import SaveDialog from 'web/components/dialog/SaveDialog';
@@ -65,6 +65,11 @@ export type ScanConfigEditDialogData = ScanConfigEditDialogDefaultValues &
   ScanConfigEditDialogValues &
   Required<SyncData>;
 
+interface FamilySelectionUpdate {
+  familyName: string;
+  select: YesNo;
+}
+
 interface ScanConfigEditDialogProps {
   comment?: string;
   configId: string;
@@ -75,6 +80,7 @@ interface ScanConfigEditDialogProps {
   editNvtFamiliesTitle: string;
   error?: string;
   families?: ScanConfigFamily[];
+  familySelectionUpdate?: FamilySelectionUpdate;
   isLoadingConfig?: boolean;
   isLoadingFamilies?: boolean;
   isLoadingScanners?: boolean;
@@ -107,7 +113,8 @@ const createTrendAndSelect = (
       trend[name] = configFamily.trend as ScanConfigTrend;
       select[name] =
         isDefined(configFamily.nvts?.count) &&
-        configFamily.nvts.count === family.nvts?.max
+        isDefined(configFamily.nvts?.max) &&
+        configFamily.nvts.count === configFamily.nvts.max
           ? YES_VALUE
           : NO_VALUE;
     } else {
@@ -218,6 +225,7 @@ const ScanConfigEditDialog = ({
   editNvtFamiliesTitle,
   error,
   families,
+  familySelectionUpdate,
   isLoadingConfig = true,
   isLoadingFamilies = true,
   isLoadingScanners = true,
@@ -267,6 +275,25 @@ const ScanConfigEditDialog = ({
   useEffect(() => {
     setFilteredNvtPreferences(nvtPreferences ?? []);
   }, [nvtPreferences]);
+
+  // After a family's NVTs are edited and saved in the sub-dialog, sync the
+  // family-level "select all" checkbox for that family so it reflects the
+  // sub-dialog's selection. This keeps the parent value from overriding the
+  // sub-dialog's changes when the whole config is saved. Only the edited family
+  // is touched, so unsaved manual toggles for other families are preserved.
+  useEffect(() => {
+    if (!isDefined(familySelectionUpdate)) {
+      return;
+    }
+
+    const {familyName, select} = familySelectionUpdate;
+
+    setSelectValues(currentSelect =>
+      isDefined(currentSelect)
+        ? {...currentSelect, [familyName]: select}
+        : currentSelect,
+    );
+  }, [familySelectionUpdate]);
 
   // trend and select are created only once and only after the whole config is loaded
   if (!isDefined(trendValues) && !isDefined(selectValues) && !isLoadingConfig) {

--- a/src/web/pages/scanconfigs/ScanConfigEditFamilyDialog.tsx
+++ b/src/web/pages/scanconfigs/ScanConfigEditFamilyDialog.tsx
@@ -67,10 +67,10 @@ const EDIT_CONFIG_COLUMNS_SORT = {
   selected: 'selected',
 };
 
-const shouldNvtDisplayComponentUpdate = (
+const areNvtDisplayPropsEqual = (
   props: NvtDisplayProps,
   nextProps: NvtDisplayProps,
-) => nextProps.nvt !== props.nvt || nextProps.selected !== props.selected;
+) => nextProps.nvt === props.nvt && nextProps.selected === props.selected;
 
 const NvtDisplay = React.memo(
   ({
@@ -114,7 +114,7 @@ const NvtDisplay = React.memo(
       </TableRow>
     );
   },
-  shouldNvtDisplayComponentUpdate,
+  areNvtDisplayPropsEqual,
 );
 
 const sortFunctions = {

--- a/src/web/pages/scanconfigs/__tests__/ScanConfigComponent.test.tsx
+++ b/src/web/pages/scanconfigs/__tests__/ScanConfigComponent.test.tsx
@@ -559,6 +559,352 @@ describe('ScanConfigComponent', () => {
     });
   });
 
+  describe('family selection sync between parent and family dialog (regression)', () => {
+    test('should not let the parent overwrite a deselection made in the family dialog on save', async () => {
+      // family1 starts fully selected (2 of 2 NVTs)
+      const editScanConfigFamilySettings = testing.fn().mockResolvedValue({
+        data: {
+          nvts: [
+            {oid: 'nvt-1', name: 'NVT One', severity: 5, selected: YES_VALUE},
+            {oid: 'nvt-2', name: 'NVT Two', severity: 8, selected: YES_VALUE},
+          ],
+        },
+      });
+
+      const {gmp, mocks} = createGmp({editScanConfigFamilySettings});
+      const childFn = renderComponent(gmp);
+
+      const props = childFn.mock.calls[0]?.[0] as ScanConfigRenderProps;
+      props.edit(config);
+
+      await screen.findByText('Edit Scan Config Test Config');
+
+      const familyEditButtons = screen.getAllByTitle('Edit Scan Config Family');
+      fireEvent.click(familyEditButtons[0]);
+
+      await screen.findByText('Edit Scan Config Family family1');
+
+      // deselect one NVT in the family dialog
+      const nvtCheckbox = screen.getByName('nvt-2') as HTMLInputElement;
+      expect(nvtCheckbox).toBeChecked();
+      fireEvent.click(nvtCheckbox);
+      expect(nvtCheckbox).not.toBeChecked();
+
+      const familySaveButtons = screen.getAllByTestId('dialog-save-button');
+      fireEvent.click(familySaveButtons[familySaveButtons.length - 1]);
+
+      await waitFor(() => {
+        expect(mocks.saveScanConfigFamily).toHaveBeenCalledWith(
+          expect.objectContaining({
+            selected: {'nvt-1': YES_VALUE, 'nvt-2': NO_VALUE},
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Edit Scan Config Family family1'),
+        ).not.toBeInTheDocument();
+      });
+
+      // saving the parent config dialog must not overwrite the deselection
+      // with a stale "select all" value for family1
+      const parentSaveButton = screen.getByTestId('dialog-save-button');
+      fireEvent.click(parentSaveButton);
+
+      await waitFor(() => {
+        expect(mocks.saveScanConfig).toHaveBeenCalledWith(
+          expect.objectContaining({
+            select: expect.objectContaining({family1: NO_VALUE}),
+          }),
+        );
+      });
+    });
+
+    test('should reflect a full selection made in the family dialog on the parent select-all value on save', async () => {
+      // family2 starts partially selected (1 of 4 NVTs)
+      const editScanConfigFamilySettings = testing.fn().mockResolvedValue({
+        data: {
+          nvts: [
+            {oid: 'nvt-1', name: 'NVT One', severity: 5, selected: YES_VALUE},
+            {oid: 'nvt-2', name: 'NVT Two', severity: 8, selected: NO_VALUE},
+            {oid: 'nvt-3', name: 'NVT Three', severity: 3, selected: NO_VALUE},
+            {oid: 'nvt-4', name: 'NVT Four', severity: 1, selected: NO_VALUE},
+          ],
+        },
+      });
+
+      const {gmp, mocks} = createGmp({editScanConfigFamilySettings});
+      const childFn = renderComponent(gmp);
+
+      const props = childFn.mock.calls[0]?.[0] as ScanConfigRenderProps;
+      props.edit(config);
+
+      await screen.findByText('Edit Scan Config Test Config');
+
+      const familyEditButtons = screen.getAllByTitle('Edit Scan Config Family');
+      fireEvent.click(familyEditButtons[1]);
+
+      await screen.findByText('Edit Scan Config Family family2');
+
+      // select all remaining NVTs in the family dialog
+      fireEvent.click(screen.getByName('nvt-2'));
+      fireEvent.click(screen.getByName('nvt-3'));
+      fireEvent.click(screen.getByName('nvt-4'));
+      const familySaveButtons = screen.getAllByTestId('dialog-save-button');
+      fireEvent.click(familySaveButtons[familySaveButtons.length - 1]);
+
+      await waitFor(() => {
+        expect(mocks.saveScanConfigFamily).toHaveBeenCalledWith(
+          expect.objectContaining({
+            selected: {
+              'nvt-1': YES_VALUE,
+              'nvt-2': YES_VALUE,
+              'nvt-3': YES_VALUE,
+              'nvt-4': YES_VALUE,
+            },
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText('Edit Scan Config Family family2'),
+        ).not.toBeInTheDocument();
+      });
+
+      // saving the parent config dialog must reflect the full selection just
+      // made in the family dialog, not the stale "not all selected" value
+      const parentSaveButton = screen.getByTestId('dialog-save-button');
+      fireEvent.click(parentSaveButton);
+
+      await waitFor(() => {
+        expect(mocks.saveScanConfig).toHaveBeenCalledWith(
+          expect.objectContaining({
+            select: expect.objectContaining({family2: YES_VALUE}),
+          }),
+        );
+      });
+    });
+
+    describe('edge cases', () => {
+      test('should preserve updates to multiple families edited sequentially before the parent is saved', async () => {
+        const editScanConfigFamilySettings = testing
+          .fn()
+          .mockImplementation(({familyName}: {familyName: string}) => {
+            const nvts =
+              familyName === 'family1'
+                ? [
+                    {
+                      oid: 'nvt-1',
+                      name: 'NVT One',
+                      severity: 5,
+                      selected: YES_VALUE,
+                    },
+                    {
+                      oid: 'nvt-2',
+                      name: 'NVT Two',
+                      severity: 8,
+                      selected: YES_VALUE,
+                    },
+                  ]
+                : [
+                    {
+                      oid: 'nvt-1',
+                      name: 'NVT One',
+                      severity: 5,
+                      selected: YES_VALUE,
+                    },
+                    {
+                      oid: 'nvt-2',
+                      name: 'NVT Two',
+                      severity: 8,
+                      selected: NO_VALUE,
+                    },
+                    {
+                      oid: 'nvt-3',
+                      name: 'NVT Three',
+                      severity: 3,
+                      selected: NO_VALUE,
+                    },
+                    {
+                      oid: 'nvt-4',
+                      name: 'NVT Four',
+                      severity: 1,
+                      selected: NO_VALUE,
+                    },
+                  ];
+            return Promise.resolve({data: {nvts}});
+          });
+
+        const {gmp, mocks} = createGmp({editScanConfigFamilySettings});
+        const childFn = renderComponent(gmp);
+
+        const props = childFn.mock.calls[0]?.[0] as ScanConfigRenderProps;
+        props.edit(config);
+
+        await screen.findByText('Edit Scan Config Test Config');
+
+        // deselect one NVT in family1 (fully selected -> partially selected)
+        fireEvent.click(screen.getAllByTitle('Edit Scan Config Family')[0]);
+        await screen.findByText('Edit Scan Config Family family1');
+        fireEvent.click(screen.getByName('nvt-2'));
+        let familySaveButtons = screen.getAllByTestId('dialog-save-button');
+        fireEvent.click(familySaveButtons[familySaveButtons.length - 1]);
+        await waitFor(() => {
+          expect(
+            screen.queryByText('Edit Scan Config Family family1'),
+          ).not.toBeInTheDocument();
+        });
+
+        // select all remaining NVTs in family2 (partially selected -> fully selected)
+        fireEvent.click(screen.getAllByTitle('Edit Scan Config Family')[1]);
+        await screen.findByText('Edit Scan Config Family family2');
+        fireEvent.click(screen.getByName('nvt-2'));
+        fireEvent.click(screen.getByName('nvt-3'));
+        fireEvent.click(screen.getByName('nvt-4'));
+        familySaveButtons = screen.getAllByTestId('dialog-save-button');
+        fireEvent.click(familySaveButtons[familySaveButtons.length - 1]);
+        await waitFor(() => {
+          expect(
+            screen.queryByText('Edit Scan Config Family family2'),
+          ).not.toBeInTheDocument();
+        });
+
+        // both edits must be reflected when the parent config is saved
+        fireEvent.click(screen.getByTestId('dialog-save-button'));
+
+        await waitFor(() => {
+          expect(mocks.saveScanConfig).toHaveBeenCalledWith(
+            expect.objectContaining({
+              select: expect.objectContaining({
+                family1: NO_VALUE,
+                family2: YES_VALUE,
+              }),
+            }),
+          );
+        });
+      });
+
+      test('should not change the parent select value when the family dialog is closed without saving', async () => {
+        const {gmp, mocks} = createGmp();
+        const childFn = renderComponent(gmp);
+
+        const props = childFn.mock.calls[0]?.[0] as ScanConfigRenderProps;
+        props.edit(config);
+
+        await screen.findByText('Edit Scan Config Test Config');
+
+        const familyEditButtons = screen.getAllByTitle(
+          'Edit Scan Config Family',
+        );
+        fireEvent.click(familyEditButtons[0]);
+
+        await screen.findByText('Edit Scan Config Family family1');
+
+        // family1 starts fully selected (2 of 2); deselect one NVT but discard it
+        const nvtCheckbox = screen.getByName('nvt-2') as HTMLInputElement;
+        expect(nvtCheckbox).toBeChecked();
+        fireEvent.click(nvtCheckbox);
+
+        const closeButtons = screen.getAllByTestId('dialog-close-button');
+        fireEvent.click(closeButtons[closeButtons.length - 1]);
+
+        await waitFor(() => {
+          expect(
+            screen.queryByText('Edit Scan Config Family family1'),
+          ).not.toBeInTheDocument();
+        });
+        expect(mocks.saveScanConfigFamily).not.toHaveBeenCalled();
+
+        fireEvent.click(screen.getByTestId('dialog-save-button'));
+
+        await waitFor(() => {
+          expect(mocks.saveScanConfig).toHaveBeenCalledWith(
+            expect.objectContaining({
+              select: expect.objectContaining({family1: YES_VALUE}),
+            }),
+          );
+        });
+      });
+
+      test('should default to not selected when the edited family has no NVTs', async () => {
+        const emptyFamilyConfig = ScanConfig.fromElement({
+          _id: 'c1',
+          name: 'Test Config',
+          comment: 'A comment',
+          creation_time: '2024-01-01T00:00:00Z',
+          modification_time: '2024-01-02T00:00:00Z',
+          owner: {name: 'admin'},
+          writable: 1,
+          in_use: 0,
+          family_count: {__text: '1', growing: 0},
+          families: {
+            family: [
+              {
+                name: 'familyEmpty',
+                nvt_count: '0',
+                max_nvt_count: '0',
+                growing: 0,
+              },
+            ],
+          },
+          preferences,
+          permissions: {permission: [{name: 'everything'}]},
+          scanner: {name: 'scanner', type: '42'},
+          tasks: {task: []},
+        });
+
+        const {gmp, mocks} = createGmp({
+          getScanConfig: testing.fn().mockResolvedValue({
+            data: emptyFamilyConfig,
+          }),
+          editScanConfigFamilySettings: testing
+            .fn()
+            .mockResolvedValue({data: {nvts: []}}),
+          getNvtFamilies: testing
+            .fn()
+            .mockResolvedValue({data: [{name: 'familyEmpty', maxNvtCount: 0}]}),
+        });
+
+        const childFn = renderComponent(gmp);
+        const props = childFn.mock.calls[0]?.[0] as ScanConfigRenderProps;
+        props.edit(emptyFamilyConfig);
+
+        await screen.findByText('Edit Scan Config Test Config');
+
+        fireEvent.click(screen.getByTitle('Edit Scan Config Family'));
+
+        await screen.findByText('Edit Scan Config Family familyEmpty');
+
+        const familySaveButtons = screen.getAllByTestId('dialog-save-button');
+        fireEvent.click(familySaveButtons[familySaveButtons.length - 1]);
+
+        await waitFor(() => {
+          expect(mocks.saveScanConfigFamily).toHaveBeenCalledWith(
+            expect.objectContaining({selected: {}}),
+          );
+        });
+
+        await waitFor(() => {
+          expect(
+            screen.queryByText('Edit Scan Config Family familyEmpty'),
+          ).not.toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByTestId('dialog-save-button'));
+
+        await waitFor(() => {
+          expect(mocks.saveScanConfig).toHaveBeenCalledWith(
+            expect.objectContaining({
+              select: expect.objectContaining({familyEmpty: NO_VALUE}),
+            }),
+          );
+        });
+      });
+    });
+  });
+
   describe('handleSaveConfigNvt', () => {
     test('should save NVT, reload family, and close NVT dialog', async () => {
       const {gmp, mocks} = createGmp();

--- a/src/web/pages/scanconfigs/__tests__/ScanConfigEditDialog.test.tsx
+++ b/src/web/pages/scanconfigs/__tests__/ScanConfigEditDialog.test.tsx
@@ -19,6 +19,7 @@ import {
   type ScanConfigFamily,
   type ScanConfigPreference,
 } from 'gmp/models/scan-config';
+import {YES_VALUE, NO_VALUE} from 'gmp/parser';
 import ScanConfigEditDialog, {
   handleSearchChange,
 } from 'web/pages/scanconfigs/ScanConfigEditDialog';
@@ -403,6 +404,123 @@ describe('ScanConfigEditDialog tests', () => {
       select,
       trend,
     });
+  });
+
+  test('should mark a family as fully selected based on its own NVT count/max, independent of the families list shape (regression for GEA-1698)', () => {
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+
+    // families coming from gmp.nvtfamilies.get() only have `name` and
+    // `maxNvtCount`, not a `nvts.max` property. The select-all value must not
+    // depend on that shape, otherwise it always resolves to NO_VALUE.
+    const familiesWithoutNvtsMax = [
+      {name: 'family1'},
+      {name: 'family2'},
+    ] as unknown as ScanConfigFamily[];
+
+    const configFamiliesWithFullSelection: ScanConfigFamilies = {
+      family1: {
+        name: 'family1',
+        nvts: {count: 3, max: 3},
+        trend: SCANCONFIG_TREND_STATIC,
+      },
+      family2: {
+        name: 'family2',
+        nvts: {count: 1, max: 4},
+        trend: SCANCONFIG_TREND_STATIC,
+      },
+    };
+
+    const {render} = rendererWith({capabilities: true});
+    render(
+      <ScanConfigEditDialog
+        comment="bar"
+        configFamilies={configFamiliesWithFullSelection}
+        configId="c1"
+        configIsInUse={false}
+        editNvtDetailsTitle="Edit Scan Config NVT Details"
+        editNvtFamiliesTitle="Edit Scan Config Family"
+        families={familiesWithoutNvtsMax}
+        isLoadingConfig={false}
+        isLoadingFamilies={false}
+        isLoadingScanners={false}
+        name="Config"
+        title="Edit Scan Config"
+        onClose={handleClose}
+        onSave={handleSave}
+      />,
+    );
+
+    const saveButton = screen.getDialogSaveButton();
+    fireEvent.click(saveButton);
+
+    expect(handleSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({
+          family1: YES_VALUE, // fully selected: 3 of 3
+          family2: NO_VALUE, // partially selected: 1 of 4
+        }),
+      }),
+    );
+  });
+
+  test('should sync a single family select-all value from familySelectionUpdate without affecting other families (regression for GEA-1698)', () => {
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+
+    const {render} = rendererWith({capabilities: true});
+    const {rerender} = render(
+      <ScanConfigEditDialog
+        comment="bar"
+        configFamilies={configFamilies}
+        configId="c1"
+        configIsInUse={false}
+        editNvtDetailsTitle="Edit Scan Config NVT Details"
+        editNvtFamiliesTitle="Edit Scan Config Family"
+        families={families}
+        isLoadingConfig={false}
+        isLoadingFamilies={false}
+        isLoadingScanners={false}
+        name="Config"
+        title="Edit Scan Config"
+        onClose={handleClose}
+        onSave={handleSave}
+      />,
+    );
+
+    // family1 initially resolves to fully selected (count 1 === max 1)
+    // simulate the family dialog reporting a deselection was saved for family1
+    rerender(
+      <ScanConfigEditDialog
+        comment="bar"
+        configFamilies={configFamilies}
+        configId="c1"
+        configIsInUse={false}
+        editNvtDetailsTitle="Edit Scan Config NVT Details"
+        editNvtFamiliesTitle="Edit Scan Config Family"
+        families={families}
+        familySelectionUpdate={{familyName: 'family1', select: NO_VALUE}}
+        isLoadingConfig={false}
+        isLoadingFamilies={false}
+        isLoadingScanners={false}
+        name="Config"
+        title="Edit Scan Config"
+        onClose={handleClose}
+        onSave={handleSave}
+      />,
+    );
+
+    const saveButton = screen.getDialogSaveButton();
+    fireEvent.click(saveButton);
+
+    expect(handleSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: {
+          ...select,
+          family1: NO_VALUE, // updated via familySelectionUpdate
+        },
+      }),
+    );
   });
 
   test('should allow to edit nvt families for openvas configs', async () => {

--- a/src/web/pages/scanconfigs/__tests__/ScanConfigEditFamilyDialog.test.tsx
+++ b/src/web/pages/scanconfigs/__tests__/ScanConfigEditFamilyDialog.test.tsx
@@ -338,6 +338,8 @@ describe('ScanConfigEditFamilyDialog component tests', () => {
     expect(nvtCheckbox).not.toBeChecked();
 
     fireEvent.click(nvtCheckbox);
+    // the checkbox must visually reflect the new selection state
+    expect(nvtCheckbox).toBeChecked();
     fireEvent.click(screen.getDialogSaveButton());
 
     expect(handleSave).toHaveBeenCalledWith({
@@ -346,6 +348,52 @@ describe('ScanConfigEditFamilyDialog component tests', () => {
       selected: {
         1234: 1,
         5678: 0,
+      },
+    });
+  });
+
+  test('should allow deselecting an NVT', () => {
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+    const handleOpenEditNvtDetailsDialog = testing.fn();
+
+    const allSelected: ScanConfigNvtsSelected = {
+      1234: 1,
+      5678: 1,
+    };
+
+    const {render} = rendererWith({capabilities: true, gmp: createGmp()});
+    render(
+      <ScanConfigEditFamilyDialog
+        configId="c1"
+        configName="foo"
+        configNameLabel="Config"
+        familyName="family"
+        isLoadingFamily={false}
+        nvts={nvts}
+        selected={allSelected}
+        title="Foo title"
+        onClose={handleClose}
+        onEditNvtDetailsClick={handleOpenEditNvtDetailsDialog}
+        onSave={handleSave}
+      />,
+    );
+
+    const dialog = within(screen.getDialog());
+    const nvtCheckbox = dialog.getByName('1234') as HTMLInputElement;
+    expect(nvtCheckbox).toBeChecked();
+
+    fireEvent.click(nvtCheckbox);
+    // the checkbox must visually reflect the deselection
+    expect(nvtCheckbox).not.toBeChecked();
+    fireEvent.click(screen.getDialogSaveButton());
+
+    expect(handleSave).toHaveBeenCalledWith({
+      configId: 'c1',
+      familyName: 'family',
+      selected: {
+        1234: 0,
+        5678: 1,
       },
     });
   });


### PR DESCRIPTION
## What

- Fix: in edit scan configs the column of select is clickable.
- Fix: Avoid parent/child component overwriting the previous saved settings when closing dialog by clicking save.
- Added test to ensure that the values are clickable and parent/child updates are mantained.

## Why

- Refactoring made the column not clickable.
- When changes to a family were made via the child dialog it could be overwritten by the parent. 
  Example: parent has selected, child has all rows selected, one gets deselected, but the parent status was not updated,    therefore leaving it a selected, once save is clicked in the parent to close the dialog the values is overwritten.

## References

GEA-1698

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


