### PR TITLE
Split Filter into two classes

### DIFF
--- a/src/gmp/collection/parser.ts
+++ b/src/gmp/collection/parser.ts
@@ -7,10 +7,10 @@ import CollectionCounts, {
   type CollectionCountsOptions,
 } from 'gmp/collection/collection-counts';
 import logger from 'gmp/log';
-import Filter, {
+import BaseFilter, {
   type FilterResponseElement,
-  type FilterType,
-} from 'gmp/models/filter';
+} from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import Model, {type Element} from 'gmp/models/model';
 import {map} from 'gmp/utils/array';
 import {hasValue, isArray, isDefined} from 'gmp/utils/identity';
@@ -154,7 +154,7 @@ export function parseInfoCounts(response: InfoWithCounts) {
 }
 
 export function parseFilter(element: FilterElement): FilterType {
-  return Filter.fromResponseElement(element.filters);
+  return BaseFilter.fromResponseElement(element.filters);
 }
 
 export function parseCounts<TElement = Element>(

--- a/src/gmp/commands/filters.ts
+++ b/src/gmp/commands/filters.ts
@@ -9,6 +9,7 @@ import EntitiesCommand from 'gmp/commands/entities';
 import type Http from 'gmp/http/http';
 import {type XmlResponseData} from 'gmp/http/transform/fast-xml';
 import Filter, {type FilterModelElement} from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import type {Element} from 'gmp/models/model';
 import {isArray, isDefined} from 'gmp/utils/identity';
 
@@ -45,15 +46,15 @@ const isPaginationElement = (
   );
 };
 
-const parseFilterFromResponse = (element: FiltersResponseElement): Filter => {
+const parseFilterFromResponse = (element: FiltersResponseElement) => {
   const firstFilter =
     isDefined(element.filters) && isArray(element.filters)
       ? element.filters[0]
       : undefined;
 
   return isDefined(firstFilter) && !isPaginationElement(firstFilter)
-    ? Filter.fromElement(firstFilter)
-    : Filter.fromElement();
+    ? BaseFilter.fromResponseElement(firstFilter)
+    : BaseFilter.fromResponseElement();
 };
 
 const parseCollectionCountsFromResponse = (

--- a/src/gmp/models/__tests__/filter.test.ts
+++ b/src/gmp/models/__tests__/filter.test.ts
@@ -4,1710 +4,1315 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import Filter, {UNKNOWN_FILTER_ID} from 'gmp/models/filter';
-import FilterTerm from 'gmp/models/filter/filter-term';
+import Capabilities from 'gmp/capabilities/capabilities';
+import date from 'gmp/models/date';
+import Filter from 'gmp/models/filter';
+import FilterTerm, {
+  parseFilterTermsFromString,
+} from 'gmp/models/filter/filter-term';
+import type FilterType from 'gmp/models/filter/filter-type';
+import Model from 'gmp/models/model';
+import UserTag from 'gmp/models/user-tag';
+import {YES_VALUE} from 'gmp/parser';
 import {isArray} from 'gmp/utils/identity';
 
-describe('Filter parse filter terms from string', () => {
-  test('should parse terms from string', () => {
-    const filter = Filter.fromString('foo=bar lorem~ipsum');
-    expect(filter.toFilterString()).toEqual('foo=bar lorem~ipsum');
-    expect(filter.length).toBe(2);
-    const terms = filter.getAllTerms();
-    expect(terms[0]).toEqual({
-      keyword: 'foo',
-      relation: '=',
-      value: 'bar',
-    });
-    expect(terms[1]).toEqual({
-      keyword: 'lorem',
-      relation: '~',
-      value: 'ipsum',
-    });
+const createFilterWithTerms = (terms: string, id: string = 'foo'): Filter => {
+  return new Filter({
+    id,
+    terms: parseFilterTermsFromString(terms),
   });
+};
 
-  test('should parse filter strings with compound statements', () => {
-    // should parse filter strings with and
-    let filter = Filter.fromString('foo=bar and lorem~ipsum');
-    expect(filter.toFilterString()).toEqual('foo=bar and lorem~ipsum');
-    expect(filter.length).toBe(3);
-    let terms = filter.getAllTerms();
-    expect(terms[0]).toEqual({
-      keyword: 'foo',
-      relation: '=',
-      value: 'bar',
-    });
-    expect(terms[1]).toEqual({
-      keyword: undefined,
-      relation: undefined,
-      value: 'and',
-    });
-    expect(terms[2]).toEqual({
-      keyword: 'lorem',
-      relation: '~',
-      value: 'ipsum',
+describe('Filter tests', () => {
+  describe('Filter set', () => {
+    test('should allow to set a filter term', () => {
+      const filter = new Filter({id: 'foo'});
+      expect(filter.set('abc', '1', '=').toFilterString()).toEqual('abc=1');
     });
 
-    // should parse filter strings with or
-    filter = Filter.fromString('foo=bar or lorem~ipsum');
-    expect(filter.toFilterString()).toEqual('foo=bar or lorem~ipsum');
-    expect(filter.length).toBe(3);
-    terms = filter.getAllTerms();
-    expect(terms[0]).toEqual({
-      keyword: 'foo',
-      relation: '=',
-      value: 'bar',
-    });
-    expect(terms[1]).toEqual({
-      keyword: undefined,
-      relation: undefined,
-      value: 'or',
-    });
-    expect(terms[2]).toEqual({
-      keyword: 'lorem',
-      relation: '~',
-      value: 'ipsum',
+    test('should not mutate the filter when setting a filter term', () => {
+      const filter = new Filter({id: 'foo'});
+      const newFilter = filter.set('abc', '1', '=');
+      expect(filter).not.toBe(newFilter);
+      expect(filter.toFilterString()).toEqual('');
+      expect(newFilter.toFilterString()).toEqual('abc=1');
     });
 
-    // should parse filter strings with not
-    filter = Filter.fromString('not foo=bar');
-    expect(filter.toFilterString()).toEqual('not foo=bar');
-    expect(filter.length).toBe(2);
-    terms = filter.getAllTerms();
-    expect(terms[0]).toEqual({
-      keyword: undefined,
-      relation: undefined,
-      value: 'not',
+    test('should allow to change a filter term', () => {
+      const filter = createFilterWithTerms('abc=1');
+      const newFilter = filter.set('abc', '2', '=');
+      expect(newFilter.toFilterString()).toEqual('abc=2');
     });
-    expect(terms[1]).toEqual({
-      keyword: 'foo',
-      relation: '=',
-      value: 'bar',
-    });
-  });
 
-  test('should parse strings with double quotes', () => {
-    const filter = Filter.fromString('name="foo bar" comment~"lorem ipsum"');
-    expect(filter.toFilterString()).toEqual(
-      'name="foo bar" comment~"lorem ipsum"',
-    );
-    expect(filter.length).toBe(2);
-    const terms = filter.getAllTerms();
-    expect(terms[0]).toEqual({
-      keyword: 'name',
-      relation: '=',
-      value: '"foo bar"',
+    test('should remove sort-reverse when adding sort filter term', () => {
+      const filter = new Filter({id: 'foo'});
+
+      let newFilter = filter.set('sort-reverse', 'foo', '=');
+      expect(newFilter.has('sort-reverse')).toEqual(true);
+      expect(newFilter.has('sort')).toEqual(false);
+
+      newFilter = filter.set('sort', 'foo', '=');
+      expect(newFilter.has('sort-reverse')).toEqual(false);
+      expect(newFilter.has('sort')).toEqual(true);
     });
-    expect(terms.length).toBe(2);
-    expect(terms[1]).toEqual({
-      keyword: 'comment',
-      relation: '~',
-      value: '"lorem ipsum"',
+
+    test('should remove sort when adding sort-reverse filter term', () => {
+      const filter = new Filter({id: 'foo'});
+
+      let newFilter = filter.set('sort', 'foo', '=');
+      expect(newFilter.has('sort')).toEqual(true);
+      expect(newFilter.has('sort-reverse')).toEqual(false);
+
+      newFilter = filter.set('sort-reverse', 'foo', '=');
+      expect(newFilter.has('sort')).toEqual(false);
+      expect(newFilter.has('sort-reverse')).toEqual(true);
+    });
+
+    test('should allow to set first keyword', () => {
+      const filter = new Filter({id: 'foo'});
+      let newFilter = filter.set('first', 123);
+      expect(newFilter.get('first')).toEqual(123);
+
+      newFilter = filter.set('first', '0');
+      expect(newFilter.get('first')).toEqual(1);
+
+      newFilter = filter.set('first', '-666');
+      expect(newFilter.get('first')).toEqual(1);
+    });
+
+    test('should allow to set name keyword', () => {
+      const filter = new Filter({id: 'foo'});
+      let newFilter = filter.set('name', 'Test Task');
+      expect(newFilter.get('name')).toEqual('Test Task');
+
+      newFilter = filter.set('name', '');
+      expect(newFilter.get('name')).toBeUndefined();
+
+      newFilter = filter.set('name', 123);
+      expect(newFilter.get('name')).toEqual('123');
+    });
+
+    test('should reset filter id', () => {
+      const filter = new Filter({id: 'foo'});
+      expect(filter.id).toEqual('foo');
+
+      const newFilter = filter.set('first', '0');
+      expect(newFilter.id).toBeUndefined();
+    });
+
+    test('should allow to set a filter term with underscore', () => {
+      const filter = new Filter({id: 'foo'});
+      expect(filter.set('_foo', '1', '=').toFilterString()).toEqual('_foo=1');
     });
   });
 
-  test('should parse strings with double quotes and without columns', () => {
-    const filter = Filter.fromString('="foo bar" ~"lorem ipsum"');
-    expect(filter.toFilterString()).toEqual('="foo bar" ~"lorem ipsum"');
-    expect(filter.length).toBe(2);
-    const terms = filter.getAllTerms();
-    expect(terms[0]).toEqual({
-      keyword: undefined,
-      relation: '=',
-      value: '"foo bar"',
+  describe('Filter has', () => {
+    test('should have filter terms', () => {
+      const filter = createFilterWithTerms('abc=1 def=1');
+      expect(filter.has('abc')).toEqual(true);
+      expect(filter.has('def')).toEqual(true);
     });
-    expect(terms.length).toBe(2);
-    expect(terms[1]).toEqual({
-      keyword: undefined,
-      relation: '~',
-      value: '"lorem ipsum"',
+
+    test('should not have unknown filter term', () => {
+      const filter = createFilterWithTerms('abc=1');
+      expect(filter.has('def')).toEqual(false);
     });
-  });
 
-  test('should parse strings with double quotes and special characters', () => {
-    const filter = Filter.fromString(
-      'name="foo <= bar" ~"foo & bar" and comment="hello : world ?"',
-    );
-    expect(filter.toFilterString()).toEqual(
-      'name="foo <= bar" ~"foo & bar" and comment="hello : world ?"',
-    );
-    expect(filter.length).toBe(4);
-    const terms = filter.getAllTerms();
-    expect(terms[0]).toEqual({
-      keyword: 'name',
-      relation: '=',
-      value: '"foo <= bar"',
+    test('should not have filter terms without keyword', () => {
+      const filter = createFilterWithTerms('abc=1 ~def');
+      expect(filter.has('def')).toEqual(false);
+      expect(filter.has('~def')).toEqual(false);
     });
-    expect(terms[1]).toEqual({
-      keyword: undefined,
-      relation: '~',
-      value: '"foo & bar"',
-    });
-    expect(terms[2]).toEqual({
-      keyword: undefined,
-      relation: undefined,
-      value: 'and',
-    });
-    expect(terms[3]).toEqual({
-      keyword: 'comment',
-      relation: '=',
-      value: '"hello : world ?"',
-    });
-  });
-});
 
-describe('Filter parse from string tests', () => {
-  test('should parse approx relation without column', () => {
-    const filter = Filter.fromString('~abc');
-    expect(filter.toFilterString()).toEqual('~abc');
-  });
-
-  test('should parse approx relation without relation and column', () => {
-    const filter = Filter.fromString('abc');
-    expect(filter.toFilterString()).toEqual('abc');
-  });
-
-  test('should parse equal relation without column', () => {
-    const filter = Filter.fromString('=abc');
-    expect(filter.toFilterString()).toEqual('=abc');
-  });
-
-  test('should parse equal relation without column and with quotes', () => {
-    const filter = Filter.fromString('="abc def"');
-    expect(filter.toFilterString()).toEqual('="abc def"');
-  });
-
-  test('should parse equal relation without column and with special characters in quotes', () => {
-    const filter = Filter.fromString('="abc : def"');
-    expect(filter.toFilterString()).toEqual('="abc : def"');
-  });
-
-  test('should parse above relation without column', () => {
-    const filter = Filter.fromString('>1.0');
-    expect(filter.toFilterString()).toEqual('>1.0');
-  });
-
-  test('should parse below relation without column', () => {
-    const filter = Filter.fromString('<1.0');
-    expect(filter.toFilterString()).toEqual('<1.0');
-  });
-
-  test('should parse below relation without column', () => {
-    const filter = Filter.fromString(':abc');
-    expect(filter.toFilterString()).toEqual(':abc');
-  });
-
-  test('should parse and keep sequence order', () => {
-    const fStrings = [
-      'abc and not def',
-      '~abc and not ~def',
-      'abc and not def rows=10 first=1 sort=name',
-      'family=FTP severity>4 and severity<9', // severity range
-      'apply_overrides=0 min_qod=70 vulnerability~"Reporting" and ' +
-        'vulnerability~"SSH" and severity>6.9 first=1 rows=10 sort=name',
-    ];
-
-    fStrings.forEach(fString => {
-      expect(Filter.fromString(fString).toFilterString()).toEqual(fString);
+    test('should return false for undefined key', () => {
+      const filter = createFilterWithTerms('');
+      // @ts-expect-error
+      expect(filter.has()).toEqual(false);
     });
   });
 
-  test('should convert first if less then 1', () => {
-    let filter = Filter.fromString('first=0');
-    expect(filter.toFilterString()).toEqual('first=1');
+  describe('Filter delete', () => {
+    test('should allow to delete a filter term', () => {
+      const filter = createFilterWithTerms('abc=1 def=1');
+      expect(filter.delete('abc').toFilterString()).toEqual('def=1');
+    });
 
-    filter = Filter.fromString('first=-1');
-    expect(filter.toFilterString()).toEqual('first=1');
+    test('should not mutate filter when deleting a term', () => {
+      const filter = createFilterWithTerms('abc=1 def=1');
+      const newFilter = filter.delete('abc');
 
-    filter = Filter.fromString('first=-666');
-    expect(filter.toFilterString()).toEqual('first=1');
+      expect(newFilter).not.toBe(filter);
+      expect(filter.toFilterString()).toEqual('abc=1 def=1');
+      expect(newFilter.toFilterString()).toEqual('def=1');
+    });
+
+    test("should not create new filter if filter term doesn't exist", () => {
+      const filter = createFilterWithTerms('abc=1 def=1');
+      const newFilter = filter.delete('xyz');
+
+      expect(newFilter).toBe(filter);
+      expect(filter.toFilterString()).toEqual('abc=1 def=1');
+    });
+
+    test('should ignore unknown filter term to delete', () => {
+      const filter = createFilterWithTerms('abc=1');
+      expect(filter.delete('def').toFilterString()).toEqual('abc=1');
+    });
+
+    test('should not delete filter terms without keyword', () => {
+      const filter = createFilterWithTerms('abc=1 ~def');
+      expect(filter.delete('def').toFilterString()).toEqual('abc=1 ~def');
+      expect(filter.delete('~def').toFilterString()).toEqual('abc=1 ~def');
+    });
+
+    test('should reset filter id', () => {
+      const filter = createFilterWithTerms('abc=1');
+      const newFilter = filter.delete('abc');
+
+      expect(filter.id).toEqual('foo');
+      expect(newFilter.id).toBeUndefined();
+    });
   });
 
-  test('should always use equal relation for first keyword', () => {
-    let filter = Filter.fromString('first>1');
-    expect(filter.toFilterString()).toEqual('first=1');
+  describe('Filter equal', () => {
+    test('should not equal undefined', () => {
+      const filter = createFilterWithTerms('');
+      // @ts-expect-error
+      expect(filter.equals()).toEqual(false);
+    });
 
-    filter = Filter.fromString('first<1');
-    expect(filter.toFilterString()).toEqual('first=1');
+    test('should not equal null', () => {
+      const filter = createFilterWithTerms('');
+      expect(filter.equals(null)).toEqual(false);
+    });
 
-    filter = Filter.fromString('first>1');
-    expect(filter.toFilterString()).toEqual('first=1');
+    test('empty filter should equal itself', () => {
+      let filter: FilterType = createFilterWithTerms('');
+      expect(filter.equals(filter)).toEqual(true);
+      filter = new Filter({id: 'foo'});
+      expect(filter.equals(filter)).toEqual(true);
+    });
+
+    test('filter should equal itself', () => {
+      const filter = createFilterWithTerms('abc=1 def=1');
+      expect(filter.equals(filter)).toEqual(true);
+    });
+
+    test('filter with number of terms should not equal', () => {
+      const filter1 = createFilterWithTerms('abc=1 def=1');
+      const filter2 = createFilterWithTerms('abc=1 def=1 hij=1');
+      expect(filter1.equals(filter2)).toEqual(false);
+    });
+
+    test('filter with same keywords in other order should equal', () => {
+      const filter1 = createFilterWithTerms('abc=1 def=1');
+      const filter2 = createFilterWithTerms('def=1 abc=1');
+      expect(filter1.equals(filter2)).toEqual(true);
+    });
+
+    test('filter with different keywords should not equal', () => {
+      const filter1 = createFilterWithTerms('abc=1');
+      const filter2 = createFilterWithTerms('def=1');
+      expect(filter1.equals(filter2)).toEqual(false);
+    });
+
+    test('filter with different relations should not equal', () => {
+      const filter1 = createFilterWithTerms('abc=1');
+      const filter2 = createFilterWithTerms('abc~1');
+      expect(filter1.equals(filter2)).toEqual(false);
+    });
+
+    test('filter with different values should not equal', () => {
+      const filter1 = createFilterWithTerms('abc=1');
+      const filter2 = createFilterWithTerms('abc=2');
+      expect(filter1.equals(filter2)).toEqual(false);
+    });
+
+    test('filter without keywords in other order should not equal', () => {
+      // this is not completely correct but currently required for and, or, ...
+      const filter1 = createFilterWithTerms('abc def');
+      const filter2 = createFilterWithTerms('def abc');
+      expect(filter1.equals(filter2)).toEqual(false);
+    });
+
+    test('filter with severity range should equal', () => {
+      // this is not completely correct but currently required for and, or, ...
+      const filter1 = createFilterWithTerms('severity>3.9 and severity<7');
+      const filter2 = createFilterWithTerms('severity>3.9 and severity<7');
+      expect(filter1.equals(filter2)).toEqual(true);
+    });
+
+    test('filter with severity range in different order should equal', () => {
+      // this is not completely correct but currently required for and, or, ...
+      const filter1 = createFilterWithTerms('severity<7 and severity>3.9');
+      const filter2 = createFilterWithTerms('severity>3.9 and severity<7');
+      expect(filter1.equals(filter2)).toEqual(true);
+    });
+
+    test('filter with an and term should not equal', () => {
+      const filter1 = createFilterWithTerms(
+        'min_qod=70 apply_overrides=1 rows=10 first=1 sort=name',
+      );
+      const filter2 = createFilterWithTerms(
+        'min_qod=70 apply_overrides=1 rows=10 first=1 sort=name and',
+      );
+      expect(filter1.equals(filter2)).toEqual(false);
+    });
+
+    test('filter with different realistic terms should not equal', () => {
+      const filter1 = createFilterWithTerms(
+        'min_qod=70 apply_overrides=1 rows=10 first=1 sort=name',
+      );
+      const filter2 = createFilterWithTerms(
+        'min_qod=70 apply_overrides=1 rows=10 first=1 sort=name ' +
+          'and status="Stopped"',
+      );
+      expect(filter1.equals(filter2)).toEqual(false);
+    });
+
+    test('filter with realistic more complex term should equal', () => {
+      const filter1 = createFilterWithTerms(
+        'min_qod=70 apply_overrides=1 rows=10 first=1 sort=name ' +
+          'and status="Stopped"',
+      );
+      const filter2 = createFilterWithTerms(
+        'min_qod=70 apply_overrides=1 rows=10 first=1 sort=name ' +
+          'and status="Stopped"',
+      );
+      expect(filter1.equals(filter2)).toEqual(true);
+    });
   });
 
-  test('should always use equal relation for rows keyword', () => {
-    let filter = Filter.fromString('rows>1');
-    expect(filter.toFilterString()).toEqual('rows=1');
+  describe('Filter get', () => {
+    test('should get value', () => {
+      let filter = createFilterWithTerms('abc=1');
+      expect(filter.get('abc')).toEqual('1');
 
-    filter = Filter.fromString('rows<1');
-    expect(filter.toFilterString()).toEqual('rows=1');
+      filter = createFilterWithTerms('abc=1 def=2');
+      expect(filter.get('abc')).toEqual('1');
+      expect(filter.get('def')).toEqual('2');
+    });
 
-    filter = Filter.fromString('rows>1');
-    expect(filter.toFilterString()).toEqual('rows=1');
+    test('should not get value', () => {
+      const filter = createFilterWithTerms('abc=1');
+      expect(filter.get('def')).toBeUndefined();
+    });
+
+    test('should not get value without keyword', () => {
+      let filter = createFilterWithTerms('abc');
+      expect(filter.get('abc')).toBeUndefined();
+
+      filter = createFilterWithTerms('~abc');
+      expect(filter.get('abc')).toBeUndefined();
+      expect(filter.get('~abc')).toBeUndefined();
+    });
   });
 
-  test('should ignore null as filter argument', () => {
-    // @ts-expect-error
-    const filter = Filter.fromString('foo=1', null);
-    expect(filter.toFilterString()).toEqual('foo=1');
+  describe('Filter getTerm', () => {
+    test('should return undefined', () => {
+      const filter = createFilterWithTerms('');
+      // @ts-expect-error
+      expect(filter.getTerm()).toBeUndefined();
+    });
+
+    test('should get term', () => {
+      let filter = createFilterWithTerms('abc=1');
+      expect(filter.getTerm('abc')).toBeDefined();
+
+      filter = createFilterWithTerms('abc=1 def=2');
+      expect(filter.getTerm('abc')).toBeDefined();
+      expect(filter.getTerm('def')).toBeDefined();
+    });
+
+    test('should not get term', () => {
+      const filter = createFilterWithTerms('abc=1');
+      expect(filter.getTerm('def')).toBeUndefined();
+    });
+
+    test('should not get term without keyword', () => {
+      let filter = createFilterWithTerms('abc');
+      expect(filter.getTerm('abc')).toBeUndefined();
+
+      filter = createFilterWithTerms('~abc');
+      expect(filter.getTerm('abc')).toBeUndefined();
+      expect(filter.getTerm('~abc')).toBeUndefined();
+    });
+
+    test('should match term', () => {
+      let filter = createFilterWithTerms('abc=1');
+      let term = filter.getTerm('abc');
+      expect(term?.keyword).toBe('abc');
+      expect(term?.relation).toBe('=');
+      expect(term?.value).toBe('1');
+
+      filter = createFilterWithTerms('abc<1 def~2');
+      term = filter.getTerm('abc');
+      expect(term?.keyword).toBe('abc');
+      expect(term?.relation).toBe('<');
+      expect(term?.value).toBe('1');
+
+      term = filter.getTerm('def');
+      expect(term?.keyword).toBe('def');
+      expect(term?.relation).toBe('~');
+      expect(term?.value).toBe('2');
+    });
   });
 
-  test('should ignore filter terms starting with _', () => {
-    let filter = Filter.fromString('rows=100 _foo=bar');
-    expect(filter.toFilterString()).toEqual('rows=100');
+  describe('Filter getTerms', () => {
+    test('should return empty array for unknown keyword', () => {
+      const filter = createFilterWithTerms('abc=1');
+      const terms = filter.getTerms('def');
 
-    filter = Filter.fromString('_bar=foo rows=100');
-    expect(filter.toFilterString()).toEqual('rows=100');
+      expect(terms.length).toBe(0);
+    });
 
-    filter = Filter.fromString('_foo rows=100');
-    expect(filter.toFilterString()).toEqual('rows=100');
+    test('should return empty array for undefined keyword', () => {
+      const filter = createFilterWithTerms('abc=1');
+      const terms = filter.getTerms(undefined);
+
+      expect(terms.length).toBe(0);
+    });
+
+    test('should return single term as array', () => {
+      const filter = createFilterWithTerms('abc=1');
+      const terms = filter.getTerms('abc');
+
+      expect(terms.length).toBe(1);
+
+      const [term] = terms;
+      expect(term.keyword).toBe('abc');
+    });
+
+    test('should return all terms in an array', () => {
+      const filter = createFilterWithTerms('abc=1 abc=2');
+      const terms = filter.getTerms('abc');
+
+      expect(terms.length).toBe(2);
+    });
+
+    test('should return only terms with same keyword', () => {
+      const filter = createFilterWithTerms('abc=1 def=2 abc=3');
+      const terms1 = filter.getTerms('abc');
+      const terms2 = filter.getTerms('def');
+
+      expect(terms1.length).toBe(2);
+      expect(terms2.length).toBe(1);
+    });
   });
-});
 
-describe('Filter fromResponseElement', () => {
-  test('should parse approx relation without column', () => {
-    const elem = {
-      keywords: {
-        keyword: [
-          {
-            column: '',
-            relation: '~',
-            value: 'abc',
-          },
+  describe('Filter fromElement', () => {
+    test('Should parse public properties', () => {
+      const filter1 = Filter.fromElement({
+        _id: '100',
+        type: 'foo',
+      });
+
+      expect(filter1.id).toBe('100');
+      expect(filter1.filter_type).toBe('foo');
+    });
+
+    test('Should not parse term as public property', () => {
+      const filter1 = Filter.fromElement({
+        term: 'abc=1',
+      });
+
+      // @ts-expect-error
+      expect(filter1.term).toBeUndefined();
+    });
+
+    test('should parse alerts', () => {
+      const filter1 = Filter.fromElement({
+        term: 'abc=1',
+        alerts: {
+          alert: [
+            {
+              _id: 'a1',
+            },
+            {
+              _id: 'a2',
+            },
+          ],
+        },
+      });
+
+      expect(isArray(filter1.alerts)).toEqual(true);
+      expect(filter1.alerts).toHaveLength(2);
+      expect(filter1.alerts[0].id).toEqual('a1');
+      expect(filter1.alerts[1].id).toEqual('a2');
+    });
+  });
+
+  describe('Filter copy', () => {
+    test('should copy all values', () => {
+      const filter1 = createFilterWithTerms('abc=1 def=2');
+      const filter2 = filter1.copy();
+      expect(filter1).not.toBe(filter2);
+      expect(filter2.get('abc')).toBe('1');
+      expect(filter2.get('def')).toBe('2');
+      expect(filter1.toFilterString()).toBe('abc=1 def=2');
+      expect(filter2.toFilterString()).toBe('abc=1 def=2');
+    });
+
+    test('should copy public properties', () => {
+      const filter1 = new Filter({
+        alerts: [new Model({id: 'a1'}), new Model({id: 'a2'})],
+        comment: 'Test Filter',
+        creationTime: date('2024-01-01T00:00:00Z'),
+        filter_type: 'foo',
+        id: '100',
+        inUse: true,
+        modificationTime: date('2024-01-02T00:00:00Z'),
+        name: 'Test Filter',
+        owner: {name: 'user1'},
+        terms: [new FilterTerm({keyword: 'abc', value: '1', relation: '='})],
+        userCapabilities: new Capabilities(['create_task', 'delete_task']),
+        userTags: [
+          new UserTag({id: 'tag1', name: 'tag1', value: 'value1'}),
+          new UserTag({id: 'tag2', name: 'tag2', value: 'value2'}),
         ],
-      },
-    };
-    const filter = Filter.fromResponseElement(elem);
-    expect(filter.toFilterString()).toEqual('~abc');
+        writable: YES_VALUE,
+      });
+      const filter2 = filter1.copy();
+
+      expect(filter2.get('abc')).toBe('1');
+      expect(filter2.alerts).toHaveLength(2);
+      expect(filter2.comment).toBe('Test Filter');
+      expect(filter2.creationTime?.toISOString()).toBe(
+        '2024-01-01T00:00:00.000Z',
+      );
+      expect(filter2.inUse).toBe(true);
+      expect(filter2.modificationTime?.toISOString()).toBe(
+        '2024-01-02T00:00:00.000Z',
+      );
+      expect(filter2.name).toBe('Test Filter');
+      expect(filter2.owner?.name).toBe('user1');
+      expect(filter2.userCapabilities?.mayCreate('task')).toBe(true);
+      expect(filter2.userCapabilities?.mayDelete('task')).toBe(true);
+      expect(filter2.userTags).toHaveLength(2);
+      expect(filter2.userTags[0].id).toBe('tag1');
+      expect(filter2.userTags[0].name).toBe('tag1');
+      expect(filter2.userTags[0].value).toBe('value1');
+      expect(filter2.userTags[1].id).toBe('tag2');
+      expect(filter2.userTags[1].name).toBe('tag2');
+      expect(filter2.userTags[1].value).toBe('value2');
+      expect(filter2.writable).toBe(YES_VALUE);
+      expect(filter2.toFilterString()).toBe('abc=1');
+      expect(filter2.id).toBe('100');
+      expect(filter2.filter_type).toBe('foo');
+    });
   });
 
-  test('should parse and keep sequence order', () => {
-    let elem = {
-      keywords: {
-        keyword: [
-          {
-            column: '',
-            relation: '~',
-            value: 'abc',
-          },
-          {
-            column: '',
-            relation: '~',
-            value: 'and',
-          },
-          {
-            column: '',
-            relation: '~',
-            value: 'not',
-          },
-          {
-            column: '',
-            relation: '~',
-            value: 'def',
-          },
-        ],
-      },
-    };
-    let filter = Filter.fromResponseElement(elem);
-    expect(filter.toFilterString()).toEqual('~abc and not ~def');
+  describe('Filter next', () => {
+    test('should return defaults', () => {
+      let filter: FilterType = createFilterWithTerms('');
 
-    elem = {
-      keywords: {
-        keyword: [
-          {
-            column: '',
-            relation: '~',
-            value: 'abc',
-          },
-          {
-            column: '',
-            relation: '~',
-            value: 'and',
-          },
-          {
-            column: '',
-            relation: '~',
-            value: 'not',
-          },
-          {
-            column: '',
-            relation: '~',
-            value: 'def',
-          },
-          {
-            column: 'rows',
-            relation: '=',
-            value: '10',
-          },
-          {
-            column: 'first',
-            relation: '=',
-            value: '1',
-          },
-          {
-            column: 'sort',
-            relation: '=',
-            value: 'name',
-          },
-        ],
-      },
-    };
-    filter = Filter.fromResponseElement(elem);
-    expect(filter.toFilterString()).toEqual(
-      '~abc and not ~def rows=10 first=1 sort=name',
-    );
-  });
+      expect(filter.get('first')).toBeUndefined();
+      expect(filter.get('rows')).toBeUndefined();
 
-  test('should parse keywords with severity range', () => {
-    const elem = {
-      keywords: {
-        keyword: [
-          {
-            column: 'severity',
-            relation: '>',
-            value: '3.9',
-          },
-          {
-            column: '',
-            relation: '',
-            value: 'and',
-          },
-          {
-            column: 'severity',
-            relation: '<',
-            value: '7',
-          },
-          {
-            column: 'first',
-            relation: '=',
-            value: '1',
-          },
-          {
-            column: 'rows',
-            relation: '=',
-            value: '10',
-          },
-          {
-            column: 'sort',
-            relation: '=',
-            value: 'name',
-          },
-        ],
-      },
-    };
+      filter = filter.next();
 
-    const filter = Filter.fromResponseElement(elem);
-    const filterString =
-      'severity>3.9 and severity<7 first=1 rows=10 sort=name';
-    expect(filter.toFilterString()).toEqual(filterString);
-
-    const filter2 = Filter.fromString(filterString);
-    expect(filter.equals(filter2)).toEqual(true);
-  });
-
-  test('should parse columns with underscore', () => {
-    const elem = {
-      keywords: {
-        keyword: [
-          {
-            column: '_foo',
-            relation: '=',
-            value: 'abc',
-          },
-        ],
-      },
-    };
-    const filter = Filter.fromResponseElement(elem);
-    expect(filter.toFilterString()).toEqual('_foo=abc');
-  });
-
-  test('should parse id', () => {
-    const filter1 = Filter.fromResponseElement();
-    expect(filter1.id).toBeUndefined();
-
-    const filter2 = Filter.fromResponseElement({_id: '123'});
-    expect(filter2.id).toBe('123');
-
-    const filter3 = Filter.fromResponseElement({_id: UNKNOWN_FILTER_ID});
-    expect(filter3.id).toBeUndefined();
-  });
-
-  test('should parse name', () => {
-    const filter1 = Filter.fromResponseElement();
-    expect(filter1.name).toBeUndefined();
-
-    const filter2 = Filter.fromResponseElement({name: 'Test Filter'});
-    expect(filter2.name).toBe('Test Filter');
-  });
-});
-
-describe('Filter set', () => {
-  test('should allow to set a filter term', () => {
-    const filter = new Filter();
-    expect(filter.set('abc', '1', '=').toFilterString()).toEqual('abc=1');
-  });
-
-  test('should not mutate the filter when setting a filter term', () => {
-    const filter = new Filter();
-    const newFilter = filter.set('abc', '1', '=');
-    expect(filter).not.toBe(newFilter);
-    expect(filter.toFilterString()).toEqual('');
-    expect(newFilter.toFilterString()).toEqual('abc=1');
-  });
-
-  test('should allow to change a filter term', () => {
-    const filter = Filter.fromString('abc=1');
-    const newFilter = filter.set('abc', '2', '=');
-    expect(newFilter.toFilterString()).toEqual('abc=2');
-  });
-
-  test('should remove sort-reverse when adding sort filter term', () => {
-    const filter = new Filter();
-
-    let newFilter = filter.set('sort-reverse', 'foo', '=');
-    expect(newFilter.has('sort-reverse')).toEqual(true);
-    expect(newFilter.has('sort')).toEqual(false);
-
-    newFilter = filter.set('sort', 'foo', '=');
-    expect(newFilter.has('sort-reverse')).toEqual(false);
-    expect(newFilter.has('sort')).toEqual(true);
-  });
-
-  test('should remove sort when adding sort-reverse filter term', () => {
-    const filter = new Filter();
-
-    let newFilter = filter.set('sort', 'foo', '=');
-    expect(newFilter.has('sort')).toEqual(true);
-    expect(newFilter.has('sort-reverse')).toEqual(false);
-
-    newFilter = filter.set('sort-reverse', 'foo', '=');
-    expect(newFilter.has('sort')).toEqual(false);
-    expect(newFilter.has('sort-reverse')).toEqual(true);
-  });
-
-  test('should allow to set first keyword', () => {
-    const filter = new Filter();
-    let newFilter = filter.set('first', 123);
-    expect(newFilter.get('first')).toEqual(123);
-
-    newFilter = filter.set('first', '0');
-    expect(newFilter.get('first')).toEqual(1);
-
-    newFilter = filter.set('first', '-666');
-    expect(newFilter.get('first')).toEqual(1);
-  });
-
-  test('should allow to set name keyword', () => {
-    const filter = new Filter();
-    let newFilter = filter.set('name', 'Test Task');
-    expect(newFilter.get('name')).toEqual('Test Task');
-
-    newFilter = filter.set('name', '');
-    expect(newFilter.get('name')).toBeUndefined();
-
-    newFilter = filter.set('name', 123);
-    expect(newFilter.get('name')).toEqual('123');
-  });
-
-  test('should reset filter id', () => {
-    const filter = new Filter({id: 'foo'});
-    expect(filter.id).toEqual('foo');
-
-    const newFilter = filter.set('first', '0');
-    expect(newFilter.id).toBeUndefined();
-  });
-
-  test('should allow to set a filter term with underscore', () => {
-    const filter = new Filter();
-    expect(filter.set('_foo', '1', '=').toFilterString()).toEqual('_foo=1');
-  });
-});
-
-describe('Filter has', () => {
-  test('should have filter terms', () => {
-    const filter = Filter.fromString('abc=1 def=1');
-    expect(filter.has('abc')).toEqual(true);
-    expect(filter.has('def')).toEqual(true);
-  });
-
-  test('should not have unknown filter term', () => {
-    const filter = Filter.fromString('abc=1');
-    expect(filter.has('def')).toEqual(false);
-  });
-
-  test('should not have filter terms without keyword', () => {
-    const filter = Filter.fromString('abc=1 ~def');
-    expect(filter.has('def')).toEqual(false);
-    expect(filter.has('~def')).toEqual(false);
-  });
-
-  test('should return false for undefined key', () => {
-    const filter = Filter.fromString('');
-    // @ts-expect-error
-    expect(filter.has()).toEqual(false);
-  });
-});
-
-describe('Filter delete', () => {
-  test('should allow to delete a filter term', () => {
-    const filter = Filter.fromString('abc=1 def=1');
-    expect(filter.delete('abc').toFilterString()).toEqual('def=1');
-  });
-
-  test('should not mutate filter when deleting a term', () => {
-    const filter = Filter.fromString('abc=1 def=1');
-    const newFilter = filter.delete('abc');
-
-    expect(newFilter).not.toBe(filter);
-    expect(filter.toFilterString()).toEqual('abc=1 def=1');
-    expect(newFilter.toFilterString()).toEqual('def=1');
-  });
-
-  test("should not create new filter if filter term doesn't exist", () => {
-    const filter = Filter.fromString('abc=1 def=1');
-    const newFilter = filter.delete('xyz');
-
-    expect(newFilter).toBe(filter);
-    expect(filter.toFilterString()).toEqual('abc=1 def=1');
-  });
-
-  test('should ignore unknown filter term to delete', () => {
-    const filter = Filter.fromString('abc=1');
-    expect(filter.delete('def').toFilterString()).toEqual('abc=1');
-  });
-
-  test('should not delete filter terms without keyword', () => {
-    const filter = Filter.fromString('abc=1 ~def');
-    expect(filter.delete('def').toFilterString()).toEqual('abc=1 ~def');
-    expect(filter.delete('~def').toFilterString()).toEqual('abc=1 ~def');
-  });
-
-  test('should reset filter id', () => {
-    const filter = Filter.fromString('abc=1');
-    // @ts-expect-error
-    filter.id = 'foo';
-    const newFilter = filter.delete('abc');
-
-    expect(filter.id).toEqual('foo');
-    expect(newFilter.id).toBeUndefined();
-  });
-});
-
-describe('Filter equal', () => {
-  test('should not equal undefined', () => {
-    const filter = Filter.fromString('');
-    // @ts-expect-error
-    expect(filter.equals()).toEqual(false);
-  });
-
-  test('should not equal null', () => {
-    const filter = Filter.fromString('');
-    expect(filter.equals(null)).toEqual(false);
-  });
-
-  test('empty filter should equal itself', () => {
-    let filter = Filter.fromString('');
-    expect(filter.equals(filter)).toEqual(true);
-    filter = Filter.fromElement();
-    expect(filter.equals(filter)).toEqual(true);
-  });
-
-  test('filter should equal itself', () => {
-    const filter = Filter.fromString('abc=1 def=1');
-    expect(filter.equals(filter)).toEqual(true);
-  });
-
-  test('filter with number of terms should not equal', () => {
-    const filter1 = Filter.fromString('abc=1 def=1');
-    const filter2 = Filter.fromString('abc=1 def=1 hij=1');
-    expect(filter1.equals(filter2)).toEqual(false);
-  });
-
-  test('filter with same keywords in other order should equal', () => {
-    const filter1 = Filter.fromString('abc=1 def=1');
-    const filter2 = Filter.fromString('def=1 abc=1');
-    expect(filter1.equals(filter2)).toEqual(true);
-  });
-
-  test('filter with different keywords should not equal', () => {
-    const filter1 = Filter.fromString('abc=1');
-    const filter2 = Filter.fromString('def=1');
-    expect(filter1.equals(filter2)).toEqual(false);
-  });
-
-  test('filter with different relations should not equal', () => {
-    const filter1 = Filter.fromString('abc=1');
-    const filter2 = Filter.fromString('abc~1');
-    expect(filter1.equals(filter2)).toEqual(false);
-  });
-
-  test('filter with different values should not equal', () => {
-    const filter1 = Filter.fromString('abc=1');
-    const filter2 = Filter.fromString('abc=2');
-    expect(filter1.equals(filter2)).toEqual(false);
-  });
-
-  test('filter without keywords in other order should not equal', () => {
-    // this is not completely correct but currently required for and, or, ...
-    const filter1 = Filter.fromString('abc def');
-    const filter2 = Filter.fromString('def abc');
-    expect(filter1.equals(filter2)).toEqual(false);
-  });
-
-  test('filter with severity range should equal', () => {
-    // this is not completely correct but currently required for and, or, ...
-    const filter1 = Filter.fromString('severity>3.9 and severity<7');
-    const filter2 = Filter.fromString('severity>3.9 and severity<7');
-    expect(filter1.equals(filter2)).toEqual(true);
-  });
-
-  test('filter with severity range in different order should equal', () => {
-    // this is not completely correct but currently required for and, or, ...
-    const filter1 = Filter.fromString('severity<7 and severity>3.9');
-    const filter2 = Filter.fromString('severity>3.9 and severity<7');
-    expect(filter1.equals(filter2)).toEqual(true);
-  });
-
-  test('filter with an and term should not equal', () => {
-    const filter1 = Filter.fromString(
-      'min_qod=70 apply_overrides=1 rows=10 first=1 sort=name',
-    );
-    const filter2 = Filter.fromString(
-      'min_qod=70 apply_overrides=1 rows=10 first=1 sort=name and',
-    );
-    expect(filter1.equals(filter2)).toEqual(false);
-  });
-
-  test('filter with different realistic terms should not equal', () => {
-    const filter1 = Filter.fromString(
-      'min_qod=70 apply_overrides=1 rows=10 first=1 sort=name',
-    );
-    const filter2 = Filter.fromString(
-      'min_qod=70 apply_overrides=1 rows=10 first=1 sort=name ' +
-        'and status="Stopped"',
-    );
-    expect(filter1.equals(filter2)).toEqual(false);
-  });
-
-  test('filter with realistic more complex term should equal', () => {
-    const filter1 = Filter.fromString(
-      'min_qod=70 apply_overrides=1 rows=10 first=1 sort=name ' +
-        'and status="Stopped"',
-    );
-    const filter2 = Filter.fromString(
-      'min_qod=70 apply_overrides=1 rows=10 first=1 sort=name ' +
-        'and status="Stopped"',
-    );
-    expect(filter1.equals(filter2)).toEqual(true);
-  });
-});
-
-describe('Filter get', () => {
-  test('should get value', () => {
-    let filter = Filter.fromString('abc=1');
-    expect(filter.get('abc')).toEqual('1');
-
-    filter = Filter.fromString('abc=1 def=2');
-    expect(filter.get('abc')).toEqual('1');
-    expect(filter.get('def')).toEqual('2');
-  });
-
-  test('should not get value', () => {
-    const filter = Filter.fromString('abc=1');
-    expect(filter.get('def')).toBeUndefined();
-  });
-
-  test('should not get value without keyword', () => {
-    let filter = Filter.fromString('abc');
-    expect(filter.get('abc')).toBeUndefined();
-
-    filter = Filter.fromString('~abc');
-    expect(filter.get('abc')).toBeUndefined();
-    expect(filter.get('~abc')).toBeUndefined();
-  });
-});
-
-describe('Filter getTerm', () => {
-  test('should return undefined', () => {
-    const filter = Filter.fromString('');
-    // @ts-expect-error
-    expect(filter.getTerm()).toBeUndefined();
-  });
-
-  test('should get term', () => {
-    let filter = Filter.fromString('abc=1');
-    expect(filter.getTerm('abc')).toBeDefined();
-
-    filter = Filter.fromString('abc=1 def=2');
-    expect(filter.getTerm('abc')).toBeDefined();
-    expect(filter.getTerm('def')).toBeDefined();
-  });
-
-  test('should not get term', () => {
-    const filter = Filter.fromString('abc=1');
-    expect(filter.getTerm('def')).toBeUndefined();
-  });
-
-  test('should not get term without keyword', () => {
-    let filter = Filter.fromString('abc');
-    expect(filter.getTerm('abc')).toBeUndefined();
-
-    filter = Filter.fromString('~abc');
-    expect(filter.getTerm('abc')).toBeUndefined();
-    expect(filter.getTerm('~abc')).toBeUndefined();
-  });
-
-  test('should match term', () => {
-    let filter = Filter.fromString('abc=1');
-    let term = filter.getTerm('abc');
-    expect(term?.keyword).toBe('abc');
-    expect(term?.relation).toBe('=');
-    expect(term?.value).toBe('1');
-
-    filter = Filter.fromString('abc<1 def~2');
-    term = filter.getTerm('abc');
-    expect(term?.keyword).toBe('abc');
-    expect(term?.relation).toBe('<');
-    expect(term?.value).toBe('1');
-
-    term = filter.getTerm('def');
-    expect(term?.keyword).toBe('def');
-    expect(term?.relation).toBe('~');
-    expect(term?.value).toBe('2');
-  });
-});
-
-describe('Filter getTerms', () => {
-  test('should return empty array for unknown keyword', () => {
-    const filter = Filter.fromString('abc=1');
-    const terms = filter.getTerms('def');
-
-    expect(terms.length).toBe(0);
-  });
-
-  test('should return empty array for undefined keyword', () => {
-    const filter = Filter.fromString('abc=1');
-    const terms = filter.getTerms(undefined);
-
-    expect(terms.length).toBe(0);
-  });
-
-  test('should return single term as array', () => {
-    const filter = Filter.fromString('abc=1');
-    const terms = filter.getTerms('abc');
-
-    expect(terms.length).toBe(1);
-
-    const [term] = terms;
-    expect(term.keyword).toBe('abc');
-  });
-
-  test('should return all terms in an array', () => {
-    const filter = Filter.fromString('abc=1 abc=2');
-    const terms = filter.getTerms('abc');
-
-    expect(terms.length).toBe(2);
-  });
-
-  test('should return only terms with same keyword', () => {
-    const filter = Filter.fromString('abc=1 def=2 abc=3');
-    const terms1 = filter.getTerms('abc');
-    const terms2 = filter.getTerms('def');
-
-    expect(terms1.length).toBe(2);
-    expect(terms2.length).toBe(1);
-  });
-});
-
-describe('Filter parse elem', () => {
-  test('Should parse public properties', () => {
-    const filter1 = Filter.fromElement({
-      _id: '100',
-      type: 'foo',
+      expect(filter.get('first')).toEqual(1);
+      expect(filter.get('rows')).toEqual(10);
     });
 
-    expect(filter1.id).toBe('100');
-    expect(filter1.filter_type).toBe('foo');
-  });
+    test('should not mutate original filter when calling next', () => {
+      let filter: FilterType = createFilterWithTerms('first=1 rows=10');
+      const copy = filter.next();
 
-  test('Should not parse term as public property', () => {
-    const filter1 = Filter.fromElement({
-      term: 'abc=1',
+      expect(filter).not.toBe(copy);
+      expect(filter.get('first')).toBe(1);
+      expect(filter.get('rows')).toBe(10);
+      expect(copy.get('first')).toBe(11);
+      expect(copy.get('rows')).toBe(10);
     });
 
-    // @ts-expect-error
-    expect(filter1.term).toBeUndefined();
-  });
+    test('should change first and rows', () => {
+      let filter: FilterType = createFilterWithTerms('first=1 rows=10');
+      expect(filter.get('first')).toBe(1);
+      expect(filter.get('rows')).toBe(10);
 
-  test('should parse alerts', () => {
-    const filter1 = Filter.fromElement({
-      term: 'abc=1',
-      alerts: {
-        alert: [
-          {
-            _id: 'a1',
-          },
-          {
-            _id: 'a2',
-          },
-        ],
-      },
+      filter = filter.next();
+
+      expect(filter.get('first')).toBe(11);
+      expect(filter.get('rows')).toBe(10);
     });
 
-    expect(isArray(filter1.alerts)).toEqual(true);
-    expect(filter1.alerts).toHaveLength(2);
-    expect(filter1.alerts[0].id).toEqual('a1');
-    expect(filter1.alerts[1].id).toEqual('a2');
-  });
+    test('should reset filter id', () => {
+      let filter: FilterType = createFilterWithTerms('first=1 rows=10');
+      expect(filter.id).toEqual('foo');
 
-  test('should parse id of zero as undefined id', () => {
-    const filter = Filter.fromElement({_id: UNKNOWN_FILTER_ID});
-    expect(filter.id).toBeUndefined();
-  });
-});
-
-describe('Filter copy', () => {
-  test('should copy all values', () => {
-    const filter1 = Filter.fromString('abc=1 def=2');
-    const filter2 = filter1.copy();
-    expect(filter1).not.toBe(filter2);
-    expect(filter2.get('abc')).toBe('1');
-    expect(filter2.get('def')).toBe('2');
-    expect(filter1.toFilterString()).toBe('abc=1 def=2');
-    expect(filter2.toFilterString()).toBe('abc=1 def=2');
-  });
-
-  test('should copy public properties', () => {
-    const filter1 = Filter.fromElement({
-      term: 'abc=1',
-      _id: '100',
-      type: 'foo',
+      filter = filter.next();
+      expect(filter.id).toBeUndefined();
     });
-    const filter2 = filter1.copy();
-
-    expect(filter2.get('abc')).toBe('1');
-    expect(filter2.id).toBe('100');
-    expect(filter2.filter_type).toBe('foo');
-  });
-});
-
-describe('Filter next', () => {
-  test('should return defaults', () => {
-    let filter = Filter.fromString('');
-
-    expect(filter.get('first')).toBeUndefined();
-    expect(filter.get('rows')).toBeUndefined();
-
-    filter = filter.next();
-
-    expect(filter.get('first')).toEqual(1);
-    expect(filter.get('rows')).toEqual(10);
   });
 
-  test('should not mutate original filter when calling next', () => {
-    let filter = Filter.fromString('first=1 rows=10');
-    const copy = filter.next();
+  describe('Filter first', () => {
+    test('should set first if undefined', () => {
+      let filter: FilterType = createFilterWithTerms('');
 
-    expect(filter).not.toBe(copy);
-    expect(filter.get('first')).toBe(1);
-    expect(filter.get('rows')).toBe(10);
-    expect(copy.get('first')).toBe(11);
-    expect(copy.get('rows')).toBe(10);
-  });
+      expect(filter.get('first')).toBeUndefined();
 
-  test('should change first and rows', () => {
-    let filter = Filter.fromString('first=1 rows=10');
-    expect(filter.get('first')).toBe(1);
-    expect(filter.get('rows')).toBe(10);
+      filter = filter.first();
 
-    filter = filter.next();
-
-    expect(filter.get('first')).toBe(11);
-    expect(filter.get('rows')).toBe(10);
-  });
-
-  test('should reset filter id', () => {
-    let filter = Filter.fromString('first=1 rows=10');
-    // @ts-expect-error
-    filter.id = 'foo';
-
-    expect(filter.id).toEqual('foo');
-
-    filter = filter.next();
-    expect(filter.id).toBeUndefined();
-  });
-});
-
-describe('Filter first', () => {
-  test('should set first if undefined', () => {
-    let filter = Filter.fromString('');
-
-    expect(filter.get('first')).toBeUndefined();
-
-    filter = filter.first();
-
-    expect(filter.get('first')).toEqual(1);
-  });
-
-  test('should not mutate original filter when calling first', () => {
-    let filter = Filter.fromString('first=99');
-    const copy = filter.first();
-
-    expect(filter).not.toBe(copy);
-    expect(filter.get('first')).toBe(99);
-    expect(copy.get('first')).toBe(1);
-  });
-
-  test('should change first to 1', () => {
-    let filter = Filter.fromString('first=99');
-    expect(filter.get('first')).toBe(99);
-
-    filter = filter.first();
-
-    expect(filter.get('first')).toBe(1);
-  });
-
-  test('should reset filter id', () => {
-    let filter = Filter.fromString('first=1 rows=10');
-    // @ts-expect-error
-    filter.id = 'foo';
-
-    expect(filter.id).toEqual('foo');
-
-    filter = filter.first();
-    expect(filter.id).toBeUndefined();
-  });
-});
-
-describe('Filter previous', () => {
-  test('should return defaults', () => {
-    let filter = Filter.fromString('');
-
-    expect(filter.get('first')).toBeUndefined();
-    expect(filter.get('rows')).toBeUndefined();
-
-    filter = filter.previous();
-
-    expect(filter.get('first')).toEqual(1);
-    expect(filter.get('rows')).toEqual(10);
-  });
-
-  test('should not mutate original filter when calling previous', () => {
-    let filter = Filter.fromString('first=11 rows=10');
-    const copy = filter.previous();
-
-    expect(filter).not.toBe(copy);
-    expect(filter.get('first')).toBe(11);
-    expect(filter.get('rows')).toBe(10);
-    expect(copy.get('first')).toBe(1);
-    expect(copy.get('rows')).toBe(10);
-  });
-
-  test('should change first and rows', () => {
-    let filter = Filter.fromString('first=11 rows=10');
-    expect(filter.get('first')).toBe(11);
-    expect(filter.get('rows')).toBe(10);
-
-    filter = filter.previous();
-
-    expect(filter.get('first')).toBe(1);
-    expect(filter.get('rows')).toBe(10);
-  });
-
-  test('should reset filter id', () => {
-    let filter = Filter.fromString('first=1 rows=10');
-    // @ts-expect-error
-    filter.id = 'foo';
-
-    expect(filter.id).toEqual('foo');
-
-    filter = filter.previous();
-    expect(filter.id).toBeUndefined();
-  });
-});
-
-describe('Filter getSortOrder', () => {
-  test('should return sort if not set', () => {
-    const filter = Filter.fromString('');
-    expect(filter.getSortOrder()).toEqual('sort');
-  });
-
-  test('should return sort if sort is set', () => {
-    const filter = Filter.fromString('sort=foo');
-    expect(filter.getSortOrder()).toEqual('sort');
-  });
-
-  test('should return sort-reverse if sort-reverse is set', () => {
-    const filter = Filter.fromString('sort-reverse=foo');
-    expect(filter.getSortOrder()).toEqual('sort-reverse');
-  });
-});
-
-describe('Filter getSortBy', () => {
-  test('should return undefined if not set', () => {
-    const filter = Filter.fromString('');
-    expect(filter.getSortBy()).toBeUndefined();
-  });
-
-  test('should return order from sort', () => {
-    const filter = Filter.fromString('sort=foo');
-    expect(filter.getSortBy()).toEqual('foo');
-  });
-
-  test('should return order from sort-reverse', () => {
-    const filter = Filter.fromString('sort-reverse=foo');
-    expect(filter.getSortBy()).toEqual('foo');
-  });
-});
-
-describe('Filter setSortOrder', () => {
-  test('should keep sort by if order changes to sort', () => {
-    const filter = Filter.fromString('sort-reverse=foo');
-    const newFilter = filter.setSortOrder('sort');
-
-    expect(newFilter.has('sort-reverse')).toEqual(false);
-    expect(newFilter.get('sort')).toEqual('foo');
-  });
-
-  test('should not mutate the filter when changing sort order', () => {
-    const filter = Filter.fromString('sort-reverse=foo');
-    const newFilter = filter.setSortOrder('sort');
-
-    expect(filter).not.toBe(newFilter);
-
-    expect(filter.has('sort-reverse')).toEqual(true);
-    expect(filter.has('sort')).toEqual(false);
-
-    expect(newFilter.has('sort-reverse')).toEqual(false);
-    expect(newFilter.has('sort')).toEqual(true);
-  });
-
-  test('should keep sort by if order changes to sort-reverse', () => {
-    const filter = Filter.fromString('sort=foo');
-    const newFilter = filter.setSortOrder('sort-reverse');
-
-    expect(newFilter.has('sort')).toEqual(false);
-    expect(newFilter.get('sort-reverse')).toEqual('foo');
-  });
-
-  test('should set sort for unknown orders', () => {
-    const filter = Filter.fromString('sort-reverse=foo');
-    // @ts-expect-error
-    const newFilter = filter.setSortOrder('foo');
-
-    expect(newFilter.has('sort-reverse')).toEqual(false);
-    expect(newFilter.get('sort')).toEqual('foo');
-  });
-
-  test('should reset filter id', () => {
-    const filter = Filter.fromString('sort-reverse=foo');
-    // @ts-expect-error
-    filter.id = 'foo';
-
-    expect(filter.id).toEqual('foo');
-
-    const newFilter = filter.setSortOrder('sort');
-    expect(newFilter.id).toBeUndefined();
-  });
-});
-
-describe('Filter setSortBy', () => {
-  test('should set sort if not order is set', () => {
-    const filter = Filter.fromString('');
-    const newFilter = filter.setSortBy('foo');
-
-    expect(newFilter.get('sort')).toEqual('foo');
-  });
-
-  test('should not mutate the filter when changing sort by if order is not set', () => {
-    const filter = Filter.fromString('');
-    const newFilter = filter.setSortBy('foo');
-
-    expect(filter).not.toBe(newFilter);
-
-    expect(filter.has('sort')).toEqual(false);
-    expect(filter.has('sort-reverse')).toEqual(false);
-
-    expect(newFilter.has('sort')).toEqual(true);
-    expect(newFilter.get('sort')).toEqual('foo');
-  });
-
-  test('should change sort by if order is sort', () => {
-    const filter = Filter.fromString('sort=bar');
-    expect(filter.get('sort')).toEqual('bar');
-
-    const newFilter = filter.setSortBy('foo');
-    expect(newFilter.get('sort')).toEqual('foo');
-  });
-
-  test('should change sort by if order is sort-reverse', () => {
-    const filter = Filter.fromString('sort-reverse=bar');
-    expect(filter.get('sort-reverse')).toEqual('bar');
-
-    const newFilter = filter.setSortBy('foo');
-    expect(newFilter.get('sort-reverse')).toEqual('foo');
-  });
-
-  test('should reset filter id', () => {
-    const filter = Filter.fromString('sort-reverse=bar');
-    // @ts-expect-error
-    filter.id = 'foo';
-
-    expect(filter.id).toEqual('foo');
-    const newFilter = filter.setSortBy('foo');
-    expect(newFilter.id).toBeUndefined();
-  });
-});
-
-describe('Filter simple', () => {
-  test('should return copy if first, rows and sort not set', () => {
-    const filter = Filter.fromString('foo=bar');
-    const simple = filter.simple();
-
-    expect(filter).not.toBe(simple);
-    expect(filter.equals(simple)).toBe(true);
-  });
-
-  test('should not mutate original filter when calling simple', () => {
-    const filter = Filter.fromString('first=1 rows=10 sort=foo foo=bar');
-    const simple = filter.simple();
-
-    expect(filter).not.toBe(simple);
-    expect(filter.has('first')).toEqual(true);
-    expect(filter.has('rows')).toEqual(true);
-    expect(filter.has('sort')).toEqual(true);
-
-    expect(simple.has('first')).toEqual(false);
-    expect(simple.has('rows')).toEqual(false);
-    expect(simple.has('sort')).toEqual(false);
-  });
-
-  test('should remove first, rows and sort terms', () => {
-    const filter = Filter.fromString('first=1 rows=10 sort=foo foo=bar');
-
-    expect(filter.has('first')).toEqual(true);
-    expect(filter.has('rows')).toEqual(true);
-    expect(filter.has('sort')).toEqual(true);
-
-    const simple = filter.simple();
-
-    expect(filter).not.toBe(simple);
-    expect(simple.has('first')).toEqual(false);
-    expect(simple.has('rows')).toEqual(false);
-    expect(simple.has('sort')).toEqual(false);
-  });
-
-  test('should remove sort-reverse term', () => {
-    const filter = Filter.fromString('sort-reverse=foo foo=bar');
-
-    expect(filter.has('sort-reverse')).toEqual(true);
-
-    const simple = filter.simple();
-
-    expect(filter).not.toBe(simple);
-    expect(simple.has('sort-reverse')).toEqual(false);
-  });
-
-  test('should reset filter id', () => {
-    const filter = Filter.fromString('sort-reverse=foo foo=bar');
-    // @ts-expect-error
-    filter.id = 'foo';
-
-    expect(filter.id).toEqual('foo');
-
-    const simple = filter.simple();
-    expect(simple.id).toBeUndefined();
-  });
-});
-
-describe('Filter merge extra keywords', () => {
-  test('should handle merging undefined filter', () => {
-    const filter1 = Filter.fromString('abc=1');
-    // @ts-expect-error
-    filter1.id = 'f1';
-    const filter2 = filter1.mergeExtraKeywords();
-
-    expect(filter1).toBe(filter2);
-  });
-
-  test('should return a new filter', () => {
-    const filter1 = Filter.fromString('abc=1');
-    const filter2 = Filter.fromString('rows=1');
-
-    const filter3 = filter1.mergeExtraKeywords(filter2);
-
-    expect(filter1).not.toBe(filter3);
-    expect(filter2).not.toBe(filter3);
-    expect(filter3.get('abc')).toBe('1');
-    expect(filter3.get('rows')).toBe(1);
-  });
-
-  test('should merge extra keywords', () => {
-    const filter1 = Filter.fromString('abc=1');
-    const filter2 = Filter.fromString(
-      'apply_overrides=1 overrides=1 ' +
-        'delta_states=1 first=1 levels=hml min_qod=70 notes=1 ' +
-        'result_hosts_only=1 rows=10 sort=name timezone=CET',
-    );
-
-    const filter3 = filter1.mergeExtraKeywords(filter2);
-
-    expect(filter3.get('abc')).toBe('1');
-    expect(filter3.get('apply_overrides')).toBe(1);
-    expect(filter3.get('overrides')).toBe(1);
-    expect(filter3.get('delta_states')).toBe('1');
-    expect(filter3.get('first')).toBe(1);
-    expect(filter3.get('levels')).toBe('hml');
-    expect(filter3.get('min_qod')).toBe(70);
-    expect(filter3.get('notes')).toBe(1);
-    expect(filter3.get('result_hosts_only')).toBe(1);
-    expect(filter3.get('rows')).toBe(10);
-    expect(filter3.get('sort')).toBe('name');
-    expect(filter3.get('timezone')).toBe('CET');
-  });
-
-  test('should not merge non extra keywords', () => {
-    const filter1 = Filter.fromString('abc=1');
-    const filter2 = Filter.fromString('apply_overrides=1 def=1');
-
-    const filter3 = filter1.mergeExtraKeywords(filter2);
-
-    expect(filter3.get('abc')).toBe('1');
-    expect(filter3.get('apply_overrides')).toBe(1);
-    expect(filter3.get('def')).toBeUndefined();
-  });
-
-  test('should return same filter if no extra keywords to merge', () => {
-    const filter1 = Filter.fromString('abc=1');
-    const filter2 = Filter.fromString('def=1');
-
-    const filter3 = filter1.mergeExtraKeywords(filter2);
-
-    expect(filter3).toBe(filter1);
-  });
-
-  test('should not merge existing extra keywords', () => {
-    const filter1 = Filter.fromString('abc=1 min_qod=80');
-    const filter2 = Filter.fromString('apply_overrides=1 min_qod=70');
-
-    const filter3 = filter1.mergeExtraKeywords(filter2);
-
-    expect(filter3.get('abc')).toBe('1');
-    expect(filter3.get('apply_overrides')).toBe(1);
-    expect(filter3.get('min_qod')).toBe(80);
-  });
-
-  test('should not merge sort or sort-reverse if already exists', () => {
-    let filter1 = Filter.fromString('sort=foo');
-    let filter2 = Filter.fromString('sort=bar');
-
-    let filter3 = filter1.mergeExtraKeywords(filter2);
-
-    expect(filter3.getSortOrder()).toEqual('sort');
-    expect(filter3.getSortBy()).toEqual('foo');
-
-    expect(filter3.toFilterString()).toEqual('sort=foo');
-
-    filter1 = Filter.fromString('sort=foo');
-    filter2 = Filter.fromString('sort-reverse=bar');
-
-    filter3 = filter1.mergeExtraKeywords(filter2);
-
-    expect(filter3.getSortOrder()).toEqual('sort');
-    expect(filter3.getSortBy()).toEqual('foo');
-
-    expect(filter3.toFilterString()).toEqual('sort=foo');
-
-    filter1 = Filter.fromString('sort-reverse=foo');
-    filter2 = Filter.fromString('sort-reverse=bar');
-
-    filter3 = filter1.mergeExtraKeywords(filter2);
-
-    expect(filter3.getSortOrder()).toEqual('sort-reverse');
-    expect(filter3.getSortBy()).toEqual('foo');
-
-    expect(filter3.toFilterString()).toEqual('sort-reverse=foo');
-
-    filter1 = Filter.fromString('sort-reverse=foo');
-    filter2 = Filter.fromString('sort=bar');
-
-    filter3 = filter1.mergeExtraKeywords(filter2);
-
-    expect(filter3.getSortOrder()).toEqual('sort-reverse');
-    expect(filter3.getSortBy()).toEqual('foo');
-
-    expect(filter3.toFilterString()).toEqual('sort-reverse=foo');
-  });
-
-  test('should reset filter id', () => {
-    const filter1 = Filter.fromString('abc=1');
-    // @ts-expect-error
-    filter1.id = 'f1';
-    const filter2 = Filter.fromString(
-      'apply_overrides=1 overrides=1 ' +
-        'delta_states=1 first=1 levels=hml min_qod=70 notes=1 ' +
-        'result_hosts_only=1 rows=10 sort=name timezone=CET',
-    );
-    // @ts-expect-error
-    filter2.id = 'f2';
-
-    const filter3 = filter1.mergeExtraKeywords(filter2);
-    expect(filter3.id).toBeUndefined();
-  });
-});
-
-describe('Filter mergeKeywords', () => {
-  test('should merge keywords', () => {
-    const filter1 = Filter.fromString('abc=1 trend=more');
-    const filter2 = Filter.fromString('delta_states=1 severity>3 sort=name');
-
-    const filter3 = filter2.mergeKeywords(filter1);
-
-    expect(filter3.get('abc')).toBe('1');
-    expect(filter3.get('delta_states')).toBe('1');
-    expect(filter3.get('sort')).toBe('name');
-    expect(filter3.get('severity')).toBe('3');
-    expect(filter3.get('trend')).toBe('more');
-  });
-
-  test('should return new filter', () => {
-    const filter1 = Filter.fromString('abc=1');
-    const filter2 = Filter.fromString('def=1');
-
-    const filter3 = filter2.mergeKeywords(filter1);
-
-    expect(filter3).not.toBe(filter1);
-    expect(filter3).not.toBe(filter2);
-
-    expect(filter3.get('abc')).toBe('1');
-    expect(filter3.get('def')).toBe('1');
-  });
-
-  test('should return same filter if no keywords to merge', () => {
-    const filter1 = Filter.fromString('abc=1');
-    const filter2 = Filter.fromString('abc=1');
-
-    expect(filter1).not.toBe(filter2);
-
-    const filter3 = filter1.mergeKeywords(filter2);
-
-    expect(filter3).toBe(filter1);
-  });
-
-  test('should return same filter if no filter to merge', () => {
-    const filter1 = Filter.fromString('abc=1');
-    const filter2 = filter1.mergeKeywords();
-
-    expect(filter2).toBe(filter1);
-  });
-
-  test('should reset filter id', () => {
-    const filter1 = Filter.fromString('abc=1');
-    // @ts-expect-error
-    filter1.id = 'f1';
-    const filter2 = Filter.fromString('def=1');
-    // @ts-expect-error
-    filter2.id = 'f2';
-
-    const filter3 = filter2.mergeKeywords(filter1);
-    expect(filter3.id).toBeUndefined();
-  });
-});
-
-describe('Filter merge', () => {
-  test('should merge undefined', () => {
-    const filter1 = Filter.fromString('foo=bar');
-    const filter2 = filter1.merge(undefined);
-
-    expect(filter1).toBe(filter2);
-    expect(filter2.get('foo')).toEqual('bar');
-  });
-
-  test('should not mutate filter while merging', () => {
-    const filter1 = Filter.fromString('foo=bar');
-    const filter2 = Filter.fromString('rows=10 first=1');
-
-    expect(filter1).not.toBe(filter2);
-
-    const filter3 = filter1.merge(filter2);
-
-    expect(filter3).not.toBe(filter1);
-    expect(filter3).not.toBe(filter2);
-    expect(filter1.toFilterString()).toEqual('foo=bar');
-    expect(filter2.toFilterString()).toEqual('rows=10 first=1');
-    expect(filter3.toFilterString()).toEqual('foo=bar rows=10 first=1');
-  });
-
-  test('should return same filter when merging an empty filter', () => {
-    const filter1 = Filter.fromString('foo=bar');
-    const emptyFilter = new Filter();
-    const merged = filter1.merge(emptyFilter);
-
-    expect(merged).toBe(filter1);
-    expect(merged.toFilterString()).toEqual('foo=bar');
-    expect(filter1.toFilterString()).toEqual('foo=bar');
-    expect(emptyFilter.toFilterString()).toEqual('');
-  });
-
-  test('should keep duplicate keywords and preserve term order while merging', () => {
-    const filter1 = Filter.fromString('foo=bar');
-    const filter2 = Filter.fromString('foo=baz rows=10');
-    const merged = filter1.merge(filter2);
-
-    expect(merged.toFilterString()).toEqual('foo=bar foo=baz rows=10');
-    expect(merged.getTerms('foo')).toHaveLength(2);
-  });
-
-  test('should merge operator terms as-is', () => {
-    const filter1 = Filter.fromString('name~ssh');
-    const filter2 = Filter.fromString('and severity>7');
-    const merged = filter1.merge(filter2);
-
-    expect(merged.toFilterString()).toEqual('name~ssh and severity>7');
-  });
-
-  test('should merge duplicate terms', () => {
-    const filter1 = Filter.fromString('foo=bar');
-    const filter2 = Filter.fromString('foo=bar');
-    const merged = filter1.merge(filter2);
-
-    expect(merged.toFilterString()).toEqual('foo=bar foo=bar');
-  });
-});
-
-describe('Filter and', () => {
-  test('should ignore undefined', () => {
-    const filter = Filter.fromString('foo=1');
-    const newFilter = filter.and(undefined);
-    expect(newFilter).toBe(filter);
-    expect(newFilter.toFilterString()).toEqual('foo=1');
-  });
-
-  test('should ignore null', () => {
-    const filter = Filter.fromString('foo=1');
-    const newFilter = filter.and(null);
-    expect(newFilter).toBe(filter);
-    expect(newFilter.toFilterString()).toEqual('foo=1');
-  });
-
-  test("should not mutate filter when concatenating with 'and'", () => {
-    const filter1 = Filter.fromString('foo=1');
-    const filter2 = Filter.fromString('bar=2');
-    const filter3 = filter1.and(filter2);
-
-    expect(filter1).not.toBe(filter2);
-    expect(filter3).not.toBe(filter1);
-    expect(filter3).not.toBe(filter2);
-    expect(filter1.toFilterString()).toBe('foo=1');
-    expect(filter2.toFilterString()).toBe('bar=2');
-    expect(filter3.toFilterString()).toBe('foo=1 and bar=2');
-  });
-
-  test('filters should be concatenated with and', () => {
-    const filter1 = Filter.fromString('foo=1');
-    const filter2 = Filter.fromString('bar=2');
-    expect(filter1.and(filter2).toFilterString()).toBe('foo=1 and bar=2');
-  });
-
-  test('empty filters should be concatenated without and', () => {
-    const filter1 = Filter.fromString('');
-    const filter2 = Filter.fromString('bar=2');
-    expect(filter1.and(filter2).toFilterString()).toBe('bar=2');
-  });
-
-  test('filters with only extra keywords should be concatenated without and', () => {
-    const filter1 = Filter.fromString('apply_overrides=1 min_qod=70');
-    const filter2 = Filter.fromString('bar=2');
-    expect(filter1.and(filter2).toFilterString()).toBe(
-      'apply_overrides=1 min_qod=70 bar=2',
-    );
-  });
-
-  test('should reset filter id', () => {
-    const filter1 = Filter.fromString('foo=1');
-    // @ts-expect-error
-    filter1.id = 'f1';
-    const filter2 = Filter.fromString('bar=2');
-    // @ts-expect-error
-    filter2.id = 'f2';
-    const filter3 = filter1.and(filter2);
-
-    expect(filter3.id).toBeUndefined();
-  });
-});
-
-describe('Filter hasTerm', () => {
-  test('filter should include terms', () => {
-    const filter = Filter.fromString('apply_overrides=1 min_qod=70 severity>0');
-
-    const term1 = FilterTerm.fromString('apply_overrides=1');
-    const term2 = FilterTerm.fromString('min_qod=70');
-    const term3 = FilterTerm.fromString('severity>0');
-    const term4 = FilterTerm.fromString('apply_overrides=666'); // special keyword
-
-    expect(filter.hasTerm(term1)).toBe(true);
-    expect(filter.hasTerm(term2)).toBe(true);
-    expect(filter.hasTerm(term3)).toBe(true);
-    expect(filter.hasTerm(term4)).toBe(true);
-  });
-
-  test('filter should not include terms', () => {
-    const filter = Filter.fromString('apply_overrides=1 min_qod=70 severity>0');
-
-    const term1 = FilterTerm.fromString('apply_overrides>1'); // special keyword
-    const term2 = FilterTerm.fromString('min_qod=78');
-    const term3 = FilterTerm.fromString('severity>1');
-    const term4 = FilterTerm.fromString('abc=70');
-    const term5 = FilterTerm.fromString('severity<0');
-
-    expect(filter.hasTerm(term1)).toBe(false);
-    expect(filter.hasTerm(term2)).toBe(false);
-    expect(filter.hasTerm(term3)).toBe(false);
-    expect(filter.hasTerm(term4)).toBe(false);
-    expect(filter.hasTerm(term5)).toBe(false);
-  });
-
-  test('should return false for undefined term', () => {
-    const filter = Filter.fromString('apply_overrides=1 min_qod=70 severity>0');
-    expect(filter.hasTerm(undefined)).toBe(false);
-  });
-});
-
-describe('Filter fromTerm', () => {
-  test('should add FilterTerm to the Filter.fromElement', () => {
-    const term = new FilterTerm({
-      keyword: 'abc',
-      relation: '=',
-      value: '1',
+      expect(filter.get('first')).toEqual(1);
     });
-    const filter = Filter.fromTerm(term);
 
-    expect(filter.toFilterString()).toEqual('abc=1');
-  });
+    test('should not mutate original filter when calling first', () => {
+      let filter = createFilterWithTerms('first=99');
+      const copy = filter.first();
 
-  test('should add several FilterTerms to the Filter.fromElement', () => {
-    const term1 = new FilterTerm({
-      keyword: 'abc',
-      relation: '=',
-      value: '1',
+      expect(filter).not.toBe(copy);
+      expect(filter.get('first')).toBe(99);
+      expect(copy.get('first')).toBe(1);
     });
-    const term2 = new FilterTerm({
-      keyword: 'def',
-      relation: '>',
-      value: '666',
+
+    test('should change first to 1', () => {
+      let filter: FilterType = createFilterWithTerms('first=99');
+      expect(filter.get('first')).toBe(99);
+
+      filter = filter.first();
+
+      expect(filter.get('first')).toBe(1);
     });
-    const filter = Filter.fromTerm(term1, term2);
 
-    expect(filter.toFilterString()).toEqual('abc=1 def>666');
-  });
-});
+    test('should reset filter id', () => {
+      let filter: FilterType = createFilterWithTerms('first=1 rows=10');
+      expect(filter.id).toEqual('foo');
 
-describe('Filter toFilterCriteriaString', () => {
-  test('should return string representation', () => {
-    const filter1 = Filter.fromString('foo=bar and lorem=ipsum');
-    expect(filter1.toFilterCriteriaString()).toEqual('foo=bar and lorem=ipsum');
+      filter = filter.first();
+      expect(filter.id).toBeUndefined();
+    });
   });
 
-  test('should ignore extra keywords', () => {
-    const filter1 = Filter.fromString('foo=bar first=1 rows=66');
-    expect(filter1.toFilterCriteriaString()).toEqual('foo=bar');
-  });
-});
+  describe('Filter previous', () => {
+    test('should return defaults', () => {
+      let filter: FilterType = createFilterWithTerms('');
 
-describe('Filter toFilterExtraString', () => {
-  test('should empty string if no extra keywords are present', () => {
-    const filter1 = Filter.fromString('foo=bar and lorem=ipsum');
-    expect(filter1.toFilterExtraString()).toEqual('');
-  });
+      expect(filter.get('first')).toBeUndefined();
+      expect(filter.get('rows')).toBeUndefined();
 
-  test('should ignore non extra keywords', () => {
-    const filter1 = Filter.fromString('foo=bar first=1 rows=66');
-    expect(filter1.toFilterExtraString()).toEqual('first=1 rows=66');
-  });
-});
+      filter = filter.previous();
 
-describe('should lower the case of capitalized keywords', () => {
-  test('should lower the case of multiple keywords', () => {
-    const filter = Filter.fromString('sevErIty>3.9 and Qod_MIN=70 RoWs=14');
-    expect(filter.toFilterString()).toEqual(
-      'severity>3.9 and qod_min=70 rows=14',
-    );
-  });
+      expect(filter.get('first')).toEqual(1);
+      expect(filter.get('rows')).toEqual(10);
+    });
 
-  test('should do the same for filters from arrays', () => {
-    const element = {
-      keywords: {
-        keyword: [
-          {
-            column: '',
-            relation: '~',
-            value: 'abc',
-          },
-          {
-            column: '',
-            relation: '~',
-            value: 'and',
-          },
-          {
-            column: '',
-            relation: '~',
-            value: 'not',
-          },
-          {
-            column: '',
-            relation: '~',
-            value: 'def',
-          },
-          {
-            column: 'ROWS',
-            relation: '=',
-            value: '10',
-          },
-          {
-            column: 'fiRsT',
-            relation: '=',
-            value: '1',
-          },
-          {
-            column: 'sORt',
-            relation: '=',
-            value: 'name',
-          },
-        ],
-      },
-    };
-    const filter = Filter.fromResponseElement(element);
-    expect(filter.toFilterString()).toEqual(
-      '~abc and not ~def rows=10 first=1 sort=name',
-    );
+    test('should not mutate original filter when calling previous', () => {
+      let filter = createFilterWithTerms('first=11 rows=10');
+      const copy = filter.previous();
+
+      expect(filter).not.toBe(copy);
+      expect(filter.get('first')).toBe(11);
+      expect(filter.get('rows')).toBe(10);
+      expect(copy.get('first')).toBe(1);
+      expect(copy.get('rows')).toBe(10);
+    });
+
+    test('should change first and rows', () => {
+      let filter: FilterType = createFilterWithTerms('first=11 rows=10');
+      expect(filter.get('first')).toBe(11);
+      expect(filter.get('rows')).toBe(10);
+
+      filter = filter.previous();
+
+      expect(filter.get('first')).toBe(1);
+      expect(filter.get('rows')).toBe(10);
+    });
+
+    test('should reset filter id', () => {
+      let filter: FilterType = createFilterWithTerms('first=1 rows=10');
+      expect(filter.id).toEqual('foo');
+
+      filter = filter.previous();
+      expect(filter.id).toBeUndefined();
+    });
   });
 
-  test('a more wacky scenario', () => {
-    const filter1 = Filter.fromString('~abc SorT=name');
-    expect(filter1.toFilterString()).toEqual('~abc sort=name');
+  describe('Filter getSortOrder', () => {
+    test('should return sort if not set', () => {
+      const filter = createFilterWithTerms('');
+      expect(filter.getSortOrder()).toEqual('sort');
+    });
+
+    test('should return sort if sort is set', () => {
+      const filter = createFilterWithTerms('sort=foo');
+      expect(filter.getSortOrder()).toEqual('sort');
+    });
+
+    test('should return sort-reverse if sort-reverse is set', () => {
+      const filter = createFilterWithTerms('sort-reverse=foo');
+      expect(filter.getSortOrder()).toEqual('sort-reverse');
+    });
   });
 
-  test('just a value', () => {
-    const filter2 = Filter.fromString('~AbC');
-    expect(filter2.toFilterString()).toEqual('~AbC');
-  });
-});
+  describe('Filter getSortBy', () => {
+    test('should return undefined if not set', () => {
+      const filter = createFilterWithTerms('');
+      expect(filter.getSortBy()).toBeUndefined();
+    });
 
-describe('Filter identifier', () => {
-  test('should return identifier', () => {
-    const filter = Filter.fromString('foo=bar');
-    expect(filter.identifier()).toEqual('foo=bar');
+    test('should return order from sort', () => {
+      const filter = createFilterWithTerms('sort=foo');
+      expect(filter.getSortBy()).toEqual('foo');
+    });
+
+    test('should return order from sort-reverse', () => {
+      const filter = createFilterWithTerms('sort-reverse=foo');
+      expect(filter.getSortBy()).toEqual('foo');
+    });
   });
 
-  test('should use filter terms for identifier', () => {
-    const filter = Filter.fromString('foo=bar first=1 rows=10');
-    expect(filter.identifier()).toEqual('foo=bar first=1 rows=10');
+  describe('Filter setSortOrder', () => {
+    test('should keep sort by if order changes to sort', () => {
+      const filter = createFilterWithTerms('sort-reverse=foo');
+      const newFilter = filter.setSortOrder('sort');
+
+      expect(newFilter.has('sort-reverse')).toEqual(false);
+      expect(newFilter.get('sort')).toEqual('foo');
+    });
+
+    test('should not mutate the filter when changing sort order', () => {
+      const filter = createFilterWithTerms('sort-reverse=foo');
+      const newFilter = filter.setSortOrder('sort');
+
+      expect(filter).not.toBe(newFilter);
+
+      expect(filter.has('sort-reverse')).toEqual(true);
+      expect(filter.has('sort')).toEqual(false);
+
+      expect(newFilter.has('sort-reverse')).toEqual(false);
+      expect(newFilter.has('sort')).toEqual(true);
+    });
+
+    test('should keep sort by if order changes to sort-reverse', () => {
+      const filter = createFilterWithTerms('sort=foo');
+      const newFilter = filter.setSortOrder('sort-reverse');
+
+      expect(newFilter.has('sort')).toEqual(false);
+      expect(newFilter.get('sort-reverse')).toEqual('foo');
+    });
+
+    test('should set sort for unknown orders', () => {
+      const filter = createFilterWithTerms('sort-reverse=foo');
+      // @ts-expect-error
+      const newFilter = filter.setSortOrder('foo');
+
+      expect(newFilter.has('sort-reverse')).toEqual(false);
+      expect(newFilter.get('sort')).toEqual('foo');
+    });
+
+    test('should reset filter id', () => {
+      const filter = createFilterWithTerms('sort-reverse=foo');
+      expect(filter.id).toEqual('foo');
+
+      const newFilter = filter.setSortOrder('sort');
+      expect(newFilter.id).toBeUndefined();
+    });
   });
 
-  test('should use different identifiers for different filter term order', () => {
-    const filter1 = Filter.fromString('foo=bar first=1 rows=10');
-    const filter2 = Filter.fromString('rows=10 first=1 foo=bar');
-    expect(filter1.identifier()).toEqual('foo=bar first=1 rows=10');
-    expect(filter2.identifier()).toEqual('rows=10 first=1 foo=bar');
-    expect(filter1.identifier()).not.toEqual(filter2.identifier());
+  describe('Filter setSortBy', () => {
+    test('should set sort if not order is set', () => {
+      const filter = createFilterWithTerms('');
+      const newFilter = filter.setSortBy('foo');
+
+      expect(newFilter.get('sort')).toEqual('foo');
+    });
+
+    test('should not mutate the filter when changing sort by if order is not set', () => {
+      const filter = createFilterWithTerms('');
+      const newFilter = filter.setSortBy('foo');
+
+      expect(filter).not.toBe(newFilter);
+
+      expect(filter.has('sort')).toEqual(false);
+      expect(filter.has('sort-reverse')).toEqual(false);
+
+      expect(newFilter.has('sort')).toEqual(true);
+      expect(newFilter.get('sort')).toEqual('foo');
+    });
+
+    test('should change sort by if order is sort', () => {
+      const filter = createFilterWithTerms('sort=bar');
+      expect(filter.get('sort')).toEqual('bar');
+
+      const newFilter = filter.setSortBy('foo');
+      expect(newFilter.get('sort')).toEqual('foo');
+    });
+
+    test('should change sort by if order is sort-reverse', () => {
+      const filter = createFilterWithTerms('sort-reverse=bar');
+      expect(filter.get('sort-reverse')).toEqual('bar');
+
+      const newFilter = filter.setSortBy('foo');
+      expect(newFilter.get('sort-reverse')).toEqual('foo');
+    });
+
+    test('should reset filter id', () => {
+      const filter = createFilterWithTerms('sort-reverse=bar');
+      expect(filter.id).toEqual('foo');
+
+      const newFilter = filter.setSortBy('foo');
+      expect(newFilter.id).toBeUndefined();
+    });
+  });
+
+  describe('Filter simple', () => {
+    test('should return copy if first, rows and sort not set', () => {
+      const filter = createFilterWithTerms('foo=bar');
+      const simple = filter.simple();
+
+      expect(filter).not.toBe(simple);
+      expect(filter.equals(simple)).toBe(true);
+    });
+
+    test('should not mutate original filter when calling simple', () => {
+      const filter = createFilterWithTerms('first=1 rows=10 sort=foo foo=bar');
+      const simple = filter.simple();
+
+      expect(filter).not.toBe(simple);
+      expect(filter.has('first')).toEqual(true);
+      expect(filter.has('rows')).toEqual(true);
+      expect(filter.has('sort')).toEqual(true);
+
+      expect(simple.has('first')).toEqual(false);
+      expect(simple.has('rows')).toEqual(false);
+      expect(simple.has('sort')).toEqual(false);
+    });
+
+    test('should remove first, rows and sort terms', () => {
+      const filter = createFilterWithTerms('first=1 rows=10 sort=foo foo=bar');
+
+      expect(filter.has('first')).toEqual(true);
+      expect(filter.has('rows')).toEqual(true);
+      expect(filter.has('sort')).toEqual(true);
+
+      const simple = filter.simple();
+
+      expect(filter).not.toBe(simple);
+      expect(simple.has('first')).toEqual(false);
+      expect(simple.has('rows')).toEqual(false);
+      expect(simple.has('sort')).toEqual(false);
+    });
+
+    test('should remove sort-reverse term', () => {
+      const filter = createFilterWithTerms('sort-reverse=foo foo=bar');
+
+      expect(filter.has('sort-reverse')).toEqual(true);
+
+      const simple = filter.simple();
+
+      expect(filter).not.toBe(simple);
+      expect(simple.has('sort-reverse')).toEqual(false);
+    });
+
+    test('should reset filter id', () => {
+      const filter = createFilterWithTerms('sort-reverse=foo foo=bar');
+      expect(filter.id).toEqual('foo');
+
+      const simple = filter.simple();
+      expect(simple.id).toBeUndefined();
+    });
+  });
+
+  describe('Filter merge extra keywords', () => {
+    test('should handle merging undefined filter', () => {
+      const filter1 = createFilterWithTerms('abc=1');
+      expect(filter1.id).toBe('foo');
+
+      const filter2 = filter1.mergeExtraKeywords();
+      expect(filter1).toBe(filter2);
+    });
+
+    test('should return a new filter', () => {
+      const filter1 = createFilterWithTerms('abc=1');
+      const filter2 = createFilterWithTerms('rows=1');
+
+      const filter3 = filter1.mergeExtraKeywords(filter2);
+
+      expect(filter1).not.toBe(filter3);
+      expect(filter2).not.toBe(filter3);
+      expect(filter3.get('abc')).toBe('1');
+      expect(filter3.get('rows')).toBe(1);
+    });
+
+    test('should merge extra keywords', () => {
+      const filter1 = createFilterWithTerms('abc=1');
+      const filter2 = createFilterWithTerms(
+        'apply_overrides=1 overrides=1 ' +
+          'delta_states=1 first=1 levels=hml min_qod=70 notes=1 ' +
+          'result_hosts_only=1 rows=10 sort=name timezone=CET',
+      );
+
+      const filter3 = filter1.mergeExtraKeywords(filter2);
+
+      expect(filter3.get('abc')).toBe('1');
+      expect(filter3.get('apply_overrides')).toBe(1);
+      expect(filter3.get('overrides')).toBe(1);
+      expect(filter3.get('delta_states')).toBe('1');
+      expect(filter3.get('first')).toBe(1);
+      expect(filter3.get('levels')).toBe('hml');
+      expect(filter3.get('min_qod')).toBe(70);
+      expect(filter3.get('notes')).toBe(1);
+      expect(filter3.get('result_hosts_only')).toBe(1);
+      expect(filter3.get('rows')).toBe(10);
+      expect(filter3.get('sort')).toBe('name');
+      expect(filter3.get('timezone')).toBe('CET');
+    });
+
+    test('should not merge non extra keywords', () => {
+      const filter1 = createFilterWithTerms('abc=1');
+      const filter2 = createFilterWithTerms('apply_overrides=1 def=1');
+
+      const filter3 = filter1.mergeExtraKeywords(filter2);
+
+      expect(filter3.get('abc')).toBe('1');
+      expect(filter3.get('apply_overrides')).toBe(1);
+      expect(filter3.get('def')).toBeUndefined();
+    });
+
+    test('should return same filter if no extra keywords to merge', () => {
+      const filter1 = createFilterWithTerms('abc=1');
+      const filter2 = createFilterWithTerms('def=1');
+
+      const filter3 = filter1.mergeExtraKeywords(filter2);
+
+      expect(filter3).toBe(filter1);
+    });
+
+    test('should not merge existing extra keywords', () => {
+      const filter1 = createFilterWithTerms('abc=1 min_qod=80');
+      const filter2 = createFilterWithTerms('apply_overrides=1 min_qod=70');
+
+      const filter3 = filter1.mergeExtraKeywords(filter2);
+
+      expect(filter3.get('abc')).toBe('1');
+      expect(filter3.get('apply_overrides')).toBe(1);
+      expect(filter3.get('min_qod')).toBe(80);
+    });
+
+    test('should not merge sort or sort-reverse if already exists', () => {
+      let filter1 = createFilterWithTerms('sort=foo');
+      let filter2 = createFilterWithTerms('sort=bar');
+
+      let filter3 = filter1.mergeExtraKeywords(filter2);
+
+      expect(filter3.getSortOrder()).toEqual('sort');
+      expect(filter3.getSortBy()).toEqual('foo');
+
+      expect(filter3.toFilterString()).toEqual('sort=foo');
+
+      filter1 = createFilterWithTerms('sort=foo');
+      filter2 = createFilterWithTerms('sort-reverse=bar');
+
+      filter3 = filter1.mergeExtraKeywords(filter2);
+
+      expect(filter3.getSortOrder()).toEqual('sort');
+      expect(filter3.getSortBy()).toEqual('foo');
+
+      expect(filter3.toFilterString()).toEqual('sort=foo');
+
+      filter1 = createFilterWithTerms('sort-reverse=foo');
+      filter2 = createFilterWithTerms('sort-reverse=bar');
+
+      filter3 = filter1.mergeExtraKeywords(filter2);
+
+      expect(filter3.getSortOrder()).toEqual('sort-reverse');
+      expect(filter3.getSortBy()).toEqual('foo');
+
+      expect(filter3.toFilterString()).toEqual('sort-reverse=foo');
+
+      filter1 = createFilterWithTerms('sort-reverse=foo');
+      filter2 = createFilterWithTerms('sort=bar');
+
+      filter3 = filter1.mergeExtraKeywords(filter2);
+
+      expect(filter3.getSortOrder()).toEqual('sort-reverse');
+      expect(filter3.getSortBy()).toEqual('foo');
+
+      expect(filter3.toFilterString()).toEqual('sort-reverse=foo');
+    });
+
+    test('should reset filter id', () => {
+      const filter1 = createFilterWithTerms('abc=1', 'f1');
+      expect(filter1.id).toBe('f1');
+
+      const filter2 = createFilterWithTerms(
+        'apply_overrides=1 overrides=1 ' +
+          'delta_states=1 first=1 levels=hml min_qod=70 notes=1 ' +
+          'result_hosts_only=1 rows=10 sort=name timezone=CET',
+        'f2',
+      );
+      expect(filter2.id).toBe('f2');
+
+      const filter3 = filter1.mergeExtraKeywords(filter2);
+      expect(filter3.id).toBeUndefined();
+    });
+  });
+
+  describe('Filter mergeKeywords', () => {
+    test('should merge keywords', () => {
+      const filter1 = createFilterWithTerms('abc=1 trend=more');
+      const filter2 = createFilterWithTerms(
+        'delta_states=1 severity>3 sort=name',
+      );
+
+      const filter3 = filter2.mergeKeywords(filter1);
+
+      expect(filter3.get('abc')).toBe('1');
+      expect(filter3.get('delta_states')).toBe('1');
+      expect(filter3.get('sort')).toBe('name');
+      expect(filter3.get('severity')).toBe('3');
+      expect(filter3.get('trend')).toBe('more');
+    });
+
+    test('should return new filter', () => {
+      const filter1 = createFilterWithTerms('abc=1');
+      const filter2 = createFilterWithTerms('def=1');
+
+      const filter3 = filter2.mergeKeywords(filter1);
+
+      expect(filter3).not.toBe(filter1);
+      expect(filter3).not.toBe(filter2);
+
+      expect(filter3.get('abc')).toBe('1');
+      expect(filter3.get('def')).toBe('1');
+    });
+
+    test('should return same filter if no keywords to merge', () => {
+      const filter1 = createFilterWithTerms('abc=1');
+      const filter2 = createFilterWithTerms('abc=1');
+
+      expect(filter1).not.toBe(filter2);
+
+      const filter3 = filter1.mergeKeywords(filter2);
+
+      expect(filter3).toBe(filter1);
+    });
+
+    test('should return same filter if no filter to merge', () => {
+      const filter1 = createFilterWithTerms('abc=1');
+      const filter2 = filter1.mergeKeywords();
+
+      expect(filter2).toBe(filter1);
+    });
+
+    test('should reset filter id', () => {
+      const filter1 = createFilterWithTerms('abc=1', 'f1');
+      expect(filter1.id).toBe('f1');
+
+      const filter2 = createFilterWithTerms('def=1', 'f2');
+      expect(filter2.id).toBe('f2');
+
+      const filter3 = filter2.mergeKeywords(filter1);
+      expect(filter3.id).toBeUndefined();
+    });
+  });
+
+  describe('Filter merge', () => {
+    test('should merge undefined', () => {
+      const filter1 = createFilterWithTerms('foo=bar');
+      const filter2 = filter1.merge(undefined);
+
+      expect(filter1).toBe(filter2);
+      expect(filter2.get('foo')).toEqual('bar');
+    });
+
+    test('should not mutate filter while merging', () => {
+      const filter1 = createFilterWithTerms('foo=bar');
+      const filter2 = createFilterWithTerms('rows=10 first=1');
+
+      expect(filter1).not.toBe(filter2);
+
+      const filter3 = filter1.merge(filter2);
+
+      expect(filter3).not.toBe(filter1);
+      expect(filter3).not.toBe(filter2);
+      expect(filter1.toFilterString()).toEqual('foo=bar');
+      expect(filter2.toFilterString()).toEqual('rows=10 first=1');
+      expect(filter3.toFilterString()).toEqual('foo=bar rows=10 first=1');
+    });
+
+    test('should return same filter when merging an empty filter', () => {
+      const filter1 = createFilterWithTerms('foo=bar');
+      const emptyFilter = new Filter({id: 'foo'});
+      const merged = filter1.merge(emptyFilter);
+
+      expect(merged).toBe(filter1);
+      expect(merged.toFilterString()).toEqual('foo=bar');
+      expect(filter1.toFilterString()).toEqual('foo=bar');
+      expect(emptyFilter.toFilterString()).toEqual('');
+    });
+
+    test('should keep duplicate keywords and preserve term order while merging', () => {
+      const filter1 = createFilterWithTerms('foo=bar');
+      const filter2 = createFilterWithTerms('foo=baz rows=10');
+      const merged = filter1.merge(filter2);
+
+      expect(merged.toFilterString()).toEqual('foo=bar foo=baz rows=10');
+      expect(merged.getTerms('foo')).toHaveLength(2);
+    });
+
+    test('should merge operator terms as-is', () => {
+      const filter1 = createFilterWithTerms('name~ssh');
+      const filter2 = createFilterWithTerms('and severity>7');
+      const merged = filter1.merge(filter2);
+
+      expect(merged.toFilterString()).toEqual('name~ssh and severity>7');
+    });
+
+    test('should merge duplicate terms', () => {
+      const filter1 = createFilterWithTerms('foo=bar');
+      const filter2 = createFilterWithTerms('foo=bar');
+      const merged = filter1.merge(filter2);
+
+      expect(merged.toFilterString()).toEqual('foo=bar foo=bar');
+    });
+  });
+
+  describe('Filter and', () => {
+    test('should ignore undefined', () => {
+      const filter = createFilterWithTerms('foo=1');
+      const newFilter = filter.and(undefined);
+      expect(newFilter).toBe(filter);
+      expect(newFilter.toFilterString()).toEqual('foo=1');
+    });
+
+    test('should ignore null', () => {
+      const filter = createFilterWithTerms('foo=1');
+      const newFilter = filter.and(null);
+      expect(newFilter).toBe(filter);
+      expect(newFilter.toFilterString()).toEqual('foo=1');
+    });
+
+    test("should not mutate filter when concatenating with 'and'", () => {
+      const filter1 = createFilterWithTerms('foo=1');
+      const filter2 = createFilterWithTerms('bar=2');
+      const filter3 = filter1.and(filter2);
+
+      expect(filter1).not.toBe(filter2);
+      expect(filter3).not.toBe(filter1);
+      expect(filter3).not.toBe(filter2);
+      expect(filter1.toFilterString()).toBe('foo=1');
+      expect(filter2.toFilterString()).toBe('bar=2');
+      expect(filter3.toFilterString()).toBe('foo=1 and bar=2');
+    });
+
+    test('filters should be concatenated with and', () => {
+      const filter1 = createFilterWithTerms('foo=1');
+      const filter2 = createFilterWithTerms('bar=2');
+      expect(filter1.and(filter2).toFilterString()).toBe('foo=1 and bar=2');
+    });
+
+    test('empty filters should be concatenated without and', () => {
+      const filter1 = createFilterWithTerms('');
+      const filter2 = createFilterWithTerms('bar=2');
+      expect(filter1.and(filter2).toFilterString()).toBe('bar=2');
+    });
+
+    test('filters with only extra keywords should be concatenated without and', () => {
+      const filter1 = createFilterWithTerms('apply_overrides=1 min_qod=70');
+      const filter2 = createFilterWithTerms('bar=2');
+      expect(filter1.and(filter2).toFilterString()).toBe(
+        'apply_overrides=1 min_qod=70 bar=2',
+      );
+    });
+
+    test('should reset filter id', () => {
+      const filter1 = createFilterWithTerms('foo=1', 'f1');
+      expect(filter1.id).toBe('f1');
+
+      const filter2 = createFilterWithTerms('bar=2', 'f2');
+      expect(filter2.id).toBe('f2');
+
+      const filter3 = filter1.and(filter2);
+      expect(filter3.id).toBeUndefined();
+    });
+  });
+
+  describe('Filter hasTerm', () => {
+    test('filter should include terms', () => {
+      const filter = createFilterWithTerms(
+        'apply_overrides=1 min_qod=70 severity>0',
+      );
+
+      const term1 = FilterTerm.fromString('apply_overrides=1');
+      const term2 = FilterTerm.fromString('min_qod=70');
+      const term3 = FilterTerm.fromString('severity>0');
+      const term4 = FilterTerm.fromString('apply_overrides=666'); // special keyword
+
+      expect(filter.hasTerm(term1)).toBe(true);
+      expect(filter.hasTerm(term2)).toBe(true);
+      expect(filter.hasTerm(term3)).toBe(true);
+      expect(filter.hasTerm(term4)).toBe(true);
+    });
+
+    test('filter should not include terms', () => {
+      const filter = createFilterWithTerms(
+        'apply_overrides=1 min_qod=70 severity>0',
+      );
+
+      const term1 = FilterTerm.fromString('apply_overrides>1'); // special keyword
+      const term2 = FilterTerm.fromString('min_qod=78');
+      const term3 = FilterTerm.fromString('severity>1');
+      const term4 = FilterTerm.fromString('abc=70');
+      const term5 = FilterTerm.fromString('severity<0');
+
+      expect(filter.hasTerm(term1)).toBe(false);
+      expect(filter.hasTerm(term2)).toBe(false);
+      expect(filter.hasTerm(term3)).toBe(false);
+      expect(filter.hasTerm(term4)).toBe(false);
+      expect(filter.hasTerm(term5)).toBe(false);
+    });
+
+    test('should return false for undefined term', () => {
+      const filter = createFilterWithTerms(
+        'apply_overrides=1 min_qod=70 severity>0',
+      );
+      expect(filter.hasTerm(undefined)).toBe(false);
+    });
+  });
+
+  describe('Filter fromTerm', () => {
+    test('should add FilterTerm to the Filter.fromElement', () => {
+      const term = new FilterTerm({
+        keyword: 'abc',
+        relation: '=',
+        value: '1',
+      });
+      const filter = Filter.fromTerm(term);
+
+      expect(filter.toFilterString()).toEqual('abc=1');
+    });
+
+    test('should add several FilterTerms to the Filter.fromElement', () => {
+      const term1 = new FilterTerm({
+        keyword: 'abc',
+        relation: '=',
+        value: '1',
+      });
+      const term2 = new FilterTerm({
+        keyword: 'def',
+        relation: '>',
+        value: '666',
+      });
+      const filter = Filter.fromTerm(term1, term2);
+
+      expect(filter.toFilterString()).toEqual('abc=1 def>666');
+    });
+  });
+
+  describe('Filter toFilterCriteriaString', () => {
+    test('should return string representation', () => {
+      const filter1 = createFilterWithTerms('foo=bar and lorem=ipsum');
+      expect(filter1.toFilterCriteriaString()).toEqual(
+        'foo=bar and lorem=ipsum',
+      );
+    });
+
+    test('should ignore extra keywords', () => {
+      const filter1 = createFilterWithTerms('foo=bar first=1 rows=66');
+      expect(filter1.toFilterCriteriaString()).toEqual('foo=bar');
+    });
+  });
+
+  describe('Filter toFilterExtraString', () => {
+    test('should empty string if no extra keywords are present', () => {
+      const filter1 = createFilterWithTerms('foo=bar and lorem=ipsum');
+      expect(filter1.toFilterExtraString()).toEqual('');
+    });
+
+    test('should ignore non extra keywords', () => {
+      const filter1 = createFilterWithTerms('foo=bar first=1 rows=66');
+      expect(filter1.toFilterExtraString()).toEqual('first=1 rows=66');
+    });
+  });
+
+  describe('should lower the case of capitalized keywords', () => {
+    test('should lower the case of multiple keywords', () => {
+      const filter = createFilterWithTerms(
+        'sevErIty>3.9 and Qod_MIN=70 RoWs=14',
+      );
+      expect(filter.toFilterString()).toEqual(
+        'severity>3.9 and qod_min=70 rows=14',
+      );
+    });
+
+    test('should do the same for filters from arrays', () => {
+      const element = {
+        keywords: {
+          keyword: [
+            {
+              column: '',
+              relation: '~',
+              value: 'abc',
+            },
+            {
+              column: '',
+              relation: '~',
+              value: 'and',
+            },
+            {
+              column: '',
+              relation: '~',
+              value: 'not',
+            },
+            {
+              column: '',
+              relation: '~',
+              value: 'def',
+            },
+            {
+              column: 'ROWS',
+              relation: '=',
+              value: '10',
+            },
+            {
+              column: 'fiRsT',
+              relation: '=',
+              value: '1',
+            },
+            {
+              column: 'sORt',
+              relation: '=',
+              value: 'name',
+            },
+          ],
+        },
+      };
+      const filter = Filter.fromResponseElement(element);
+      expect(filter.toFilterString()).toEqual(
+        '~abc and not ~def rows=10 first=1 sort=name',
+      );
+    });
+
+    test('a more wacky scenario', () => {
+      const filter1 = createFilterWithTerms('~abc SorT=name');
+      expect(filter1.toFilterString()).toEqual('~abc sort=name');
+    });
+
+    test('just a value', () => {
+      const filter2 = createFilterWithTerms('~AbC');
+      expect(filter2.toFilterString()).toEqual('~AbC');
+    });
+  });
+
+  describe('Filter identifier', () => {
+    test('should return identifier', () => {
+      const filter = createFilterWithTerms('foo=bar');
+      expect(filter.identifier()).toEqual('foo=bar');
+    });
+
+    test('should use filter terms for identifier', () => {
+      const filter = createFilterWithTerms('foo=bar first=1 rows=10');
+      expect(filter.identifier()).toEqual('foo=bar first=1 rows=10');
+    });
+
+    test('should use different identifiers for different filter term order', () => {
+      const filter1 = createFilterWithTerms('foo=bar first=1 rows=10');
+      const filter2 = createFilterWithTerms('rows=10 first=1 foo=bar');
+      expect(filter1.identifier()).toEqual('foo=bar first=1 rows=10');
+      expect(filter2.identifier()).toEqual('rows=10 first=1 foo=bar');
+      expect(filter1.identifier()).not.toEqual(filter2.identifier());
+    });
   });
 });

--- a/src/gmp/models/__tests__/filter.test.ts
+++ b/src/gmp/models/__tests__/filter.test.ts
@@ -628,6 +628,18 @@ describe('Filter tests', () => {
     });
   });
 
+  describe('Filter all', () => {
+    test('should set first and rows for all items', () => {
+      const filter = createFilterWithTerms('first=3 rows=10');
+      const updated = filter.all();
+
+      expect(filter.get('first')).toBe(3);
+      expect(filter.get('rows')).toBe(10);
+      expect(updated.get('first')).toBe(1);
+      expect(updated.get('rows')).toBe(-1);
+    });
+  });
+
   describe('Filter getSortOrder', () => {
     test('should return sort if not set', () => {
       const filter = createFilterWithTerms('');

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -158,6 +158,8 @@ class Filter extends EntityModel implements FilterType {
   /**
    * Create a new Filter from the passed response element.
    *
+   * @deprecated Use `BaseFilter.fromResponseElement` instead.
+   *
    * @param element Response element to parse properties from.
    *
    * @returns A new Filter model instance.
@@ -168,6 +170,8 @@ class Filter extends EntityModel implements FilterType {
 
   /**
    * Creates a new Filter from filterString
+   *
+   * @deprecated Use `BaseFilter.fromString` instead.
    *
    * @param filterString String to parse FilterTerms from.
    * @param filter Use extra terms from filter if not already
@@ -181,6 +185,8 @@ class Filter extends EntityModel implements FilterType {
 
   /**
    * Creates a new Filter from FilterTerms
+   *
+   * @deprecated Use `BaseFilter.fromTerm` instead.
    *
    * @param term FilterTerms to set for the new Filter
    *

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -4,8 +4,13 @@
  */
 
 import EntityModel, {parseEntityModelProperties} from 'gmp/models/entity-model';
-import convert from 'gmp/models/filter/convert';
-import FilterTerm from 'gmp/models/filter/filter-term';
+import BaseFilter, {
+  type FilterResponseElement,
+} from 'gmp/models/filter/base-filter';
+import {
+  type default as FilterTerm,
+  parseFilterTermsFromString,
+} from 'gmp/models/filter/filter-term';
 import FilterTerms from 'gmp/models/filter/filter-terms';
 import {
   type default as FilterType,
@@ -13,14 +18,7 @@ import {
 } from 'gmp/models/filter/filter-type';
 import Model, {type ModelElement, type ModelProperties} from 'gmp/models/model';
 import {map} from 'gmp/utils/array';
-import {isDefined, isString, isArray} from 'gmp/utils/identity';
-import {isEmpty} from 'gmp/utils/string';
-
-export interface FilterKeyword {
-  column?: string;
-  relation?: string;
-  value?: string;
-}
+import {isDefined} from 'gmp/utils/identity';
 
 /**
  * XML Structure of a filter model element as returned by `<get_filters>`
@@ -44,58 +42,6 @@ export interface FilterModelElement extends ModelElement {
   term?: string;
 }
 
-/**
- * XML Structure of a filter response element
- * as returned by all `<get_xyz>` queries, for example `<get_tasks>`.
- *
- * Example XML Structure:
- * ```xml
- * <get_tasks_response>
- *   <task>
- *     ...
- *   </task>
- *   <filters id="">
- *     <term>apply_overrides=0 min_qod=70 sort=name first=1 rows=1</term>
- *     <keywords>
- *       <keyword>
- *         <column>apply_overrides</column>
- *         <relation>=</relation>
- *         <value>0</value>
- *       </keyword>
- *       <keyword>
- *         <column>min_qod</column>
- *         <relation>=</relation>
- *         <value>70</value>
- *       </keyword>
- *       <keyword>
- *         <column>sort</column>
- *         <relation>=</relation>
- *         <value>name</value>
- *       </keyword>
- *       <keyword>
- *         <column>first</column>
- *         <relation>=</relation>
- *         <value>1</value>
- *       </keyword>
- *       <keyword>
- *         <column>rows</column>
- *         <relation>=</relation>
- *         <value>1</value>
- *       </keyword>
- *     </keywords>
- *   </filters>
- * </get_tasks_response>
- * ```
- */
-export interface FilterResponseElement {
-  _id?: string;
-  name?: string;
-  keywords?: {
-    keyword?: FilterKeyword | FilterKeyword[];
-  };
-  term?: string;
-}
-
 interface FilterModelProperties extends ModelProperties {
   _term?: string;
   alerts?: Model[];
@@ -107,110 +53,6 @@ export type {
   default as FilterType,
   FilterSortOrder,
 } from 'gmp/models/filter/filter-type';
-
-/**
- * XML Structure of a filter model element as returned by `<get_filters>`
- * queries.
- *
- * Example XML Structure:
- * ```xml
- * <get_filters_response status="200" status_text="OK">
- *   <filter id="0c239c16-d597-48a1-9f51-347627a23dac">
- *     ...
- *     <term>apply_overrides=0 min_qod=70 sort=name first=1 rows=1</term>
- *   </filter>
- * </get_filters_response>
- * ```
- */
-
-/**
- * XML Structure of a filter response element
- * as returned by all `<get_xyz>` queries, for example `<get_tasks>`.
- *
- * Example XML Structure:
- * ```xml
- * <get_tasks_response>
- *   <task>
- *     ...
- *   </task>
- *   <filters id="">
- *     <term>apply_overrides=0 min_qod=70 sort=name first=1 rows=1</term>
- *     <keywords>
- *       <keyword>
- *         <column>apply_overrides</column>
- *         <relation>=</relation>
- *         <value>0</value>
- *       </keyword>
- *       <keyword>
- *         <column>min_qod</column>
- *         <relation>=</relation>
- *         <value>70</value>
- *       </keyword>
- *       <keyword>
- *         <column>sort</column>
- *         <relation>=</relation>
- *         <value>name</value>
- *       </keyword>
- *       <keyword>
- *         <column>first</column>
- *         <relation>=</relation>
- *         <value>1</value>
- *       </keyword>
- *       <keyword>
- *         <column>rows</column>
- *         <relation>=</relation>
- *         <value>1</value>
- *       </keyword>
- *     </keywords>
- *   </filters>
- * </get_tasks_response>
- * ```
- */
-
-export const UNKNOWN_FILTER_ID = '0';
-
-/**
- * Parses FilterTerms from filterString
- *
- * @param filterString  Filter representation as a string
- *
- * @returns Array of parsed FilterTerms
- */
-const parseFilterTermsFromString = (
-  filterString: string | undefined,
-): FilterTerm[] => {
-  const terms: FilterTerm[] = [];
-  if (isString(filterString)) {
-    // replace whitespace between double quotes with placeholders
-    let modifiedFilterString = filterString;
-    const quotes = filterString.match(/".+?"/g); // find all substrings between double quotes
-    if (isArray(quotes)) {
-      for (const quotedString of quotes) {
-        const newQuotedString = quotedString.replace(/\s/g, '####'); // replace all " " with "####"
-        modifiedFilterString = modifiedFilterString.replace(
-          quotedString,
-          newQuotedString,
-        );
-      }
-    }
-
-    // get filter terms by splitting at whitespace
-    const filterTerms = modifiedFilterString.split(' ');
-
-    for (let filterTerm of filterTerms) {
-      // strip whitespace
-      filterTerm = filterTerm.trim();
-
-      // remove placeholders
-      filterTerm = filterTerm.replace(/####/g, ' '); // replace all "####" with " "
-
-      if (filterTerm.length > 0 && !filterTerm.startsWith('_')) {
-        terms.push(FilterTerm.fromString(filterTerm));
-      }
-    }
-  }
-  return terms;
-};
 
 /**
  * Represents a filter
@@ -238,7 +80,7 @@ class Filter extends EntityModel implements FilterType {
     userCapabilities,
     userTags = [],
     writable,
-  }: FilterModelProperties = {}) {
+  }: FilterModelProperties) {
     super({
       _type,
       comment,
@@ -270,16 +112,13 @@ class Filter extends EntityModel implements FilterType {
    *
    * @returns A new Filter if the FilterTerms are different, otherwise the current Filter.
    */
-  private _delegate(terms: FilterTerms, keepId = false): Filter {
+  private _delegate(terms: FilterTerms, keepId = false) {
     return terms === this.filterTerms
       ? this
-      : new Filter({
+      : new BaseFilter({
           id: keepId ? this.id : undefined,
           name: this.name,
-          filter_type: this.filter_type,
           terms: [...terms.getAllTerms()],
-          userCapabilities: this.userCapabilities,
-          userTags: this.userTags,
         });
   }
 
@@ -290,14 +129,11 @@ class Filter extends EntityModel implements FilterType {
    *
    * @returns An object with properties for the new Filter model
    */
-  static fromElement(element: FilterModelElement = {}): Filter {
+  static fromElement(element: FilterModelElement): Filter {
     const ret = parseEntityModelProperties(element) as FilterModelProperties;
 
     ret.filter_type = ret._type;
 
-    if (ret.id === UNKNOWN_FILTER_ID) {
-      ret.id = undefined;
-    }
     if (isDefined(element.term)) {
       ret.terms = parseFilterTermsFromString(element.term);
 
@@ -326,26 +162,8 @@ class Filter extends EntityModel implements FilterType {
    *
    * @returns A new Filter model instance.
    */
-  static fromResponseElement(element: FilterResponseElement = {}): Filter {
-    const id =
-      !isEmpty(element._id) && element._id !== UNKNOWN_FILTER_ID
-        ? element._id
-        : undefined;
-
-    const name = !isEmpty(element.name) ? element.name : undefined;
-
-    let terms: FilterTerm[] = [];
-    if (isDefined(element.keywords)) {
-      terms = map(
-        element.keywords.keyword,
-        ({relation, value, column: key}: FilterKeyword) =>
-          new FilterTerm(convert(key, value, relation)),
-      );
-    } else if (isDefined(element.term)) {
-      terms = parseFilterTermsFromString(element.term);
-    }
-
-    return new Filter({id, name, terms});
+  static fromResponseElement(element: FilterResponseElement = {}) {
+    return BaseFilter.fromResponseElement(element);
   }
 
   /**
@@ -357,14 +175,8 @@ class Filter extends EntityModel implements FilterType {
    *
    * @returns New Filter with FilterTerms parsed from filterString.
    */
-  static fromString(filterString?: string, filter?: FilterType): Filter {
-    const filterTerms = new FilterTerms({
-      terms: parseFilterTermsFromString(filterString),
-    }).mergeExtraKeywords(filter) as FilterTerms;
-
-    return new Filter({
-      terms: [...filterTerms.getAllTerms()],
-    });
+  static fromString(filterString?: string, filter?: FilterType) {
+    return BaseFilter.fromString(filterString, filter);
   }
 
   /**
@@ -375,9 +187,7 @@ class Filter extends EntityModel implements FilterType {
    * @returns The new Filter
    */
   static fromTerm(...term: FilterTerm[]) {
-    return new Filter({
-      terms: [...term],
-    });
+    return BaseFilter.fromTerm(...term);
   }
 
   toFilterString(): string {
@@ -419,7 +229,7 @@ class Filter extends EntityModel implements FilterType {
     keyword: string,
     value?: string | number | boolean,
     relation: string = '=',
-  ): Filter {
+  ) {
     return this._delegate(this.filterTerms.set(keyword, value, relation));
   }
 
@@ -427,7 +237,7 @@ class Filter extends EntityModel implements FilterType {
     return this.filterTerms.has(key);
   }
 
-  delete(key: string): Filter {
+  delete(key: string) {
     return this._delegate(this.filterTerms.delete(key));
   }
 
@@ -439,31 +249,45 @@ class Filter extends EntityModel implements FilterType {
     return this.filterTerms.equals(filter);
   }
 
-  copy(): Filter {
-    return this._delegate(this.filterTerms.copy(), true);
+  copy() {
+    return new Filter({
+      alerts: [...this.alerts],
+      comment: this.comment,
+      creationTime: this.creationTime,
+      filter_type: this.filter_type,
+      id: this.id,
+      inUse: this.inUse,
+      modificationTime: this.modificationTime,
+      name: this.name,
+      owner: this.owner,
+      terms: [...this.filterTerms.getAllTerms()],
+      userCapabilities: this.userCapabilities,
+      userTags: [...this.userTags],
+      writable: this.writable,
+    });
   }
 
-  next(): Filter {
+  next() {
     return this._delegate(this.filterTerms.next());
   }
 
-  previous(): Filter {
+  previous() {
     return this._delegate(this.filterTerms.previous());
   }
 
-  first(first: number = 1): Filter {
+  first(first: number = 1) {
     return this._delegate(this.filterTerms.first(first));
   }
 
-  all(): Filter {
+  all() {
     return this._delegate(this.filterTerms.all());
   }
 
-  simple(): Filter {
+  simple() {
     return this._delegate(this.filterTerms.simple());
   }
 
-  and(filter: FilterType | undefined | null): Filter {
+  and(filter: FilterType | undefined | null) {
     return this._delegate(this.filterTerms.and(filter));
   }
 
@@ -475,28 +299,28 @@ class Filter extends EntityModel implements FilterType {
     return this.filterTerms.getSortBy();
   }
 
-  setSortOrder(value: FilterSortOrder): Filter {
+  setSortOrder(value: FilterSortOrder) {
     return this._delegate(this.filterTerms.setSortOrder(value));
   }
 
-  setSortBy(value: string): Filter {
+  setSortBy(value: string) {
     return this._delegate(this.filterTerms.setSortBy(value));
   }
 
-  merge(filter?: FilterType): Filter {
+  merge(filter?: FilterType) {
     return this._delegate(this.filterTerms.merge(filter));
   }
 
-  mergeKeywords(filter?: FilterType): Filter {
+  mergeKeywords(filter?: FilterType) {
     return this._delegate(this.filterTerms.mergeKeywords(filter));
   }
 
-  mergeExtraKeywords(filter?: FilterType): Filter {
+  mergeExtraKeywords(filter?: FilterType) {
     return this._delegate(this.filterTerms.mergeExtraKeywords(filter));
   }
 }
 
-export const ALL_FILTER = new Filter().all();
+export const ALL_FILTER = new BaseFilter().all();
 export const AGENTS_FILTER_FILTER = Filter.fromString('type=agent');
 export const AGENT_GROUPS_FILTER_FILTER = Filter.fromString('type=agent_group');
 export const AGENT_INSTALLERS_FILTER_FILTER = Filter.fromString(

--- a/src/gmp/models/filter/__tests__/base-filter.test.ts
+++ b/src/gmp/models/filter/__tests__/base-filter.test.ts
@@ -1,0 +1,659 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect} from '@gsa/testing';
+import BaseFilter, {UNKNOWN_FILTER_ID} from 'gmp/models/filter/base-filter';
+import FilterTerm from 'gmp/models/filter/filter-term';
+
+describe('BaseFilter tests', () => {
+  describe('BaseFilter constructor', () => {
+    test('should create a filter with id and name', () => {
+      const filter = new BaseFilter({id: '123', name: 'Test Filter'});
+      expect(filter.id).toBe('123');
+      expect(filter.name).toBe('Test Filter');
+    });
+
+    test('should create a filter with id, name and terms', () => {
+      const filter = new BaseFilter({
+        id: '123',
+        name: 'Test Filter',
+        terms: [
+          new FilterTerm({keyword: 'foo', relation: '=', value: 'bar'}),
+          new FilterTerm({keyword: 'lorem', relation: '~', value: 'ipsum'}),
+        ],
+      });
+      expect(filter.id).toBe('123');
+      expect(filter.name).toBe('Test Filter');
+      expect(filter.length).toBe(2);
+      const terms = filter.getAllTerms();
+      expect(terms[0]).toEqual({
+        keyword: 'foo',
+        relation: '=',
+        value: 'bar',
+      });
+      expect(terms[1]).toEqual({
+        keyword: 'lorem',
+        relation: '~',
+        value: 'ipsum',
+      });
+    });
+
+    test('should create a filter with no id and name', () => {
+      const filter = new BaseFilter();
+      expect(filter.id).toBeUndefined();
+      expect(filter.name).toBeUndefined();
+    });
+  });
+
+  describe('BaseFilter fromString', () => {
+    test('should parse terms from string', () => {
+      const filter = BaseFilter.fromString('foo=bar lorem~ipsum');
+      expect(filter.toFilterString()).toEqual('foo=bar lorem~ipsum');
+      expect(filter.length).toBe(2);
+      const terms = filter.getAllTerms();
+      expect(terms[0]).toEqual({
+        keyword: 'foo',
+        relation: '=',
+        value: 'bar',
+      });
+      expect(terms[1]).toEqual({
+        keyword: 'lorem',
+        relation: '~',
+        value: 'ipsum',
+      });
+    });
+
+    test('should parse filter strings with compound statements', () => {
+      // should parse filter strings with and
+      let filter = BaseFilter.fromString('foo=bar and lorem~ipsum');
+      expect(filter.toFilterString()).toEqual('foo=bar and lorem~ipsum');
+      expect(filter.length).toBe(3);
+      let terms = filter.getAllTerms();
+      expect(terms[0]).toEqual({
+        keyword: 'foo',
+        relation: '=',
+        value: 'bar',
+      });
+      expect(terms[1]).toEqual({
+        keyword: undefined,
+        relation: undefined,
+        value: 'and',
+      });
+      expect(terms[2]).toEqual({
+        keyword: 'lorem',
+        relation: '~',
+        value: 'ipsum',
+      });
+
+      // should parse filter strings with or
+      filter = BaseFilter.fromString('foo=bar or lorem~ipsum');
+      expect(filter.toFilterString()).toEqual('foo=bar or lorem~ipsum');
+      expect(filter.length).toBe(3);
+      terms = filter.getAllTerms();
+      expect(terms[0]).toEqual({
+        keyword: 'foo',
+        relation: '=',
+        value: 'bar',
+      });
+      expect(terms[1]).toEqual({
+        keyword: undefined,
+        relation: undefined,
+        value: 'or',
+      });
+      expect(terms[2]).toEqual({
+        keyword: 'lorem',
+        relation: '~',
+        value: 'ipsum',
+      });
+
+      // should parse filter strings with not
+      filter = BaseFilter.fromString('not foo=bar');
+      expect(filter.toFilterString()).toEqual('not foo=bar');
+      expect(filter.length).toBe(2);
+      terms = filter.getAllTerms();
+      expect(terms[0]).toEqual({
+        keyword: undefined,
+        relation: undefined,
+        value: 'not',
+      });
+      expect(terms[1]).toEqual({
+        keyword: 'foo',
+        relation: '=',
+        value: 'bar',
+      });
+    });
+
+    test('should parse strings with double quotes', () => {
+      const filter = BaseFilter.fromString(
+        'name="foo bar" comment~"lorem ipsum"',
+      );
+      expect(filter.toFilterString()).toEqual(
+        'name="foo bar" comment~"lorem ipsum"',
+      );
+      expect(filter.length).toBe(2);
+      const terms = filter.getAllTerms();
+      expect(terms[0]).toEqual({
+        keyword: 'name',
+        relation: '=',
+        value: '"foo bar"',
+      });
+      expect(terms.length).toBe(2);
+      expect(terms[1]).toEqual({
+        keyword: 'comment',
+        relation: '~',
+        value: '"lorem ipsum"',
+      });
+    });
+
+    test('should parse strings with double quotes and without columns', () => {
+      const filter = BaseFilter.fromString('="foo bar" ~"lorem ipsum"');
+      expect(filter.toFilterString()).toEqual('="foo bar" ~"lorem ipsum"');
+      expect(filter.length).toBe(2);
+      const terms = filter.getAllTerms();
+      expect(terms[0]).toEqual({
+        keyword: undefined,
+        relation: '=',
+        value: '"foo bar"',
+      });
+      expect(terms.length).toBe(2);
+      expect(terms[1]).toEqual({
+        keyword: undefined,
+        relation: '~',
+        value: '"lorem ipsum"',
+      });
+    });
+
+    test('should parse strings with double quotes and special characters', () => {
+      const filter = BaseFilter.fromString(
+        'name="foo <= bar" ~"foo & bar" and comment="hello : world ?"',
+      );
+      expect(filter.toFilterString()).toEqual(
+        'name="foo <= bar" ~"foo & bar" and comment="hello : world ?"',
+      );
+      expect(filter.length).toBe(4);
+      const terms = filter.getAllTerms();
+      expect(terms[0]).toEqual({
+        keyword: 'name',
+        relation: '=',
+        value: '"foo <= bar"',
+      });
+      expect(terms[1]).toEqual({
+        keyword: undefined,
+        relation: '~',
+        value: '"foo & bar"',
+      });
+      expect(terms[2]).toEqual({
+        keyword: undefined,
+        relation: undefined,
+        value: 'and',
+      });
+      expect(terms[3]).toEqual({
+        keyword: 'comment',
+        relation: '=',
+        value: '"hello : world ?"',
+      });
+    });
+
+    test('should parse approx relation without column', () => {
+      const filter = BaseFilter.fromString('~abc');
+      expect(filter.toFilterString()).toEqual('~abc');
+    });
+
+    test('should parse approx relation without relation and column', () => {
+      const filter = BaseFilter.fromString('abc');
+      expect(filter.toFilterString()).toEqual('abc');
+    });
+
+    test('should parse equal relation without column', () => {
+      const filter = BaseFilter.fromString('=abc');
+      expect(filter.toFilterString()).toEqual('=abc');
+    });
+
+    test('should parse equal relation without column and with quotes', () => {
+      const filter = BaseFilter.fromString('="abc def"');
+      expect(filter.toFilterString()).toEqual('="abc def"');
+    });
+
+    test('should parse equal relation without column and with special characters in quotes', () => {
+      const filter = BaseFilter.fromString('="abc : def"');
+      expect(filter.toFilterString()).toEqual('="abc : def"');
+    });
+
+    test('should parse above relation without column', () => {
+      const filter = BaseFilter.fromString('>1.0');
+      expect(filter.toFilterString()).toEqual('>1.0');
+    });
+
+    test('should parse below relation without column', () => {
+      const filter = BaseFilter.fromString('<1.0');
+      expect(filter.toFilterString()).toEqual('<1.0');
+    });
+
+    test('should parse below relation without column', () => {
+      const filter = BaseFilter.fromString(':abc');
+      expect(filter.toFilterString()).toEqual(':abc');
+    });
+
+    test('should parse and keep sequence order', () => {
+      const fStrings = [
+        'abc and not def',
+        '~abc and not ~def',
+        'abc and not def rows=10 first=1 sort=name',
+        'family=FTP severity>4 and severity<9', // severity range
+        'apply_overrides=0 min_qod=70 vulnerability~"Reporting" and ' +
+          'vulnerability~"SSH" and severity>6.9 first=1 rows=10 sort=name',
+      ];
+
+      fStrings.forEach(fString => {
+        expect(BaseFilter.fromString(fString).toFilterString()).toEqual(
+          fString,
+        );
+      });
+    });
+
+    test('should convert first if less then 1', () => {
+      let filter = BaseFilter.fromString('first=0');
+      expect(filter.toFilterString()).toEqual('first=1');
+
+      filter = BaseFilter.fromString('first=-1');
+      expect(filter.toFilterString()).toEqual('first=1');
+
+      filter = BaseFilter.fromString('first=-666');
+      expect(filter.toFilterString()).toEqual('first=1');
+    });
+
+    test('should always use equal relation for first keyword', () => {
+      let filter = BaseFilter.fromString('first>1');
+      expect(filter.toFilterString()).toEqual('first=1');
+
+      filter = BaseFilter.fromString('first<1');
+      expect(filter.toFilterString()).toEqual('first=1');
+
+      filter = BaseFilter.fromString('first>1');
+      expect(filter.toFilterString()).toEqual('first=1');
+    });
+
+    test('should always use equal relation for rows keyword', () => {
+      let filter = BaseFilter.fromString('rows>1');
+      expect(filter.toFilterString()).toEqual('rows=1');
+
+      filter = BaseFilter.fromString('rows<1');
+      expect(filter.toFilterString()).toEqual('rows=1');
+
+      filter = BaseFilter.fromString('rows>1');
+      expect(filter.toFilterString()).toEqual('rows=1');
+    });
+
+    test('should ignore null as filter argument', () => {
+      // @ts-expect-error
+      const filter = BaseFilter.fromString('foo=1', null);
+      expect(filter.toFilterString()).toEqual('foo=1');
+    });
+
+    test('should ignore filter terms starting with _', () => {
+      let filter = BaseFilter.fromString('rows=100 _foo=bar');
+      expect(filter.toFilterString()).toEqual('rows=100');
+
+      filter = BaseFilter.fromString('_bar=foo rows=100');
+      expect(filter.toFilterString()).toEqual('rows=100');
+
+      filter = BaseFilter.fromString('_foo rows=100');
+      expect(filter.toFilterString()).toEqual('rows=100');
+    });
+  });
+
+  describe('BaseFilter fromResponseElement', () => {
+    test('should parse approx relation without column', () => {
+      const elem = {
+        keywords: {
+          keyword: [
+            {
+              column: '',
+              relation: '~',
+              value: 'abc',
+            },
+          ],
+        },
+      };
+      const filter = BaseFilter.fromResponseElement(elem);
+      expect(filter.toFilterString()).toEqual('~abc');
+    });
+
+    test('should parse and keep sequence order', () => {
+      let elem = {
+        keywords: {
+          keyword: [
+            {
+              column: '',
+              relation: '~',
+              value: 'abc',
+            },
+            {
+              column: '',
+              relation: '~',
+              value: 'and',
+            },
+            {
+              column: '',
+              relation: '~',
+              value: 'not',
+            },
+            {
+              column: '',
+              relation: '~',
+              value: 'def',
+            },
+          ],
+        },
+      };
+      let filter = BaseFilter.fromResponseElement(elem);
+      expect(filter.toFilterString()).toEqual('~abc and not ~def');
+
+      elem = {
+        keywords: {
+          keyword: [
+            {
+              column: '',
+              relation: '~',
+              value: 'abc',
+            },
+            {
+              column: '',
+              relation: '~',
+              value: 'and',
+            },
+            {
+              column: '',
+              relation: '~',
+              value: 'not',
+            },
+            {
+              column: '',
+              relation: '~',
+              value: 'def',
+            },
+            {
+              column: 'rows',
+              relation: '=',
+              value: '10',
+            },
+            {
+              column: 'first',
+              relation: '=',
+              value: '1',
+            },
+            {
+              column: 'sort',
+              relation: '=',
+              value: 'name',
+            },
+          ],
+        },
+      };
+      filter = BaseFilter.fromResponseElement(elem);
+      expect(filter.toFilterString()).toEqual(
+        '~abc and not ~def rows=10 first=1 sort=name',
+      );
+    });
+
+    test('should parse keywords with severity range', () => {
+      const elem = {
+        keywords: {
+          keyword: [
+            {
+              column: 'severity',
+              relation: '>',
+              value: '3.9',
+            },
+            {
+              column: '',
+              relation: '',
+              value: 'and',
+            },
+            {
+              column: 'severity',
+              relation: '<',
+              value: '7',
+            },
+            {
+              column: 'first',
+              relation: '=',
+              value: '1',
+            },
+            {
+              column: 'rows',
+              relation: '=',
+              value: '10',
+            },
+            {
+              column: 'sort',
+              relation: '=',
+              value: 'name',
+            },
+          ],
+        },
+      };
+
+      const filter = BaseFilter.fromResponseElement(elem);
+      const filterString =
+        'severity>3.9 and severity<7 first=1 rows=10 sort=name';
+      expect(filter.toFilterString()).toEqual(filterString);
+
+      const filter2 = BaseFilter.fromString(filterString);
+      expect(filter.equals(filter2)).toEqual(true);
+    });
+
+    test('should parse columns with underscore', () => {
+      const elem = {
+        keywords: {
+          keyword: [
+            {
+              column: '_foo',
+              relation: '=',
+              value: 'abc',
+            },
+          ],
+        },
+      };
+      const filter = BaseFilter.fromResponseElement(elem);
+      expect(filter.toFilterString()).toEqual('_foo=abc');
+    });
+
+    test('should parse id', () => {
+      const filter1 = BaseFilter.fromResponseElement();
+      expect(filter1.id).toBeUndefined();
+
+      const filter2 = BaseFilter.fromResponseElement({_id: '123'});
+      expect(filter2.id).toBe('123');
+
+      const filter3 = BaseFilter.fromResponseElement({
+        _id: UNKNOWN_FILTER_ID,
+      });
+      expect(filter3.id).toBeUndefined();
+    });
+
+    test('should parse name', () => {
+      const filter1 = BaseFilter.fromResponseElement();
+      expect(filter1.name).toBeUndefined();
+
+      const filter2 = BaseFilter.fromResponseElement({name: 'Test Filter'});
+      expect(filter2.name).toBe('Test Filter');
+    });
+
+    test('should parse term string', () => {
+      const filter = BaseFilter.fromResponseElement({
+        term: 'foo=bar and lorem~ipsum',
+      });
+      expect(filter.toFilterString()).toEqual('foo=bar and lorem~ipsum');
+      expect(filter.length).toBe(3);
+      const terms = filter.getAllTerms();
+      expect(terms[0]).toEqual({
+        keyword: 'foo',
+        relation: '=',
+        value: 'bar',
+      });
+      expect(terms[1]).toEqual({
+        keyword: undefined,
+        relation: undefined,
+        value: 'and',
+      });
+      expect(terms[2]).toEqual({
+        keyword: 'lorem',
+        relation: '~',
+        value: 'ipsum',
+      });
+    });
+  });
+
+  describe('BaseFilter fromTerm', () => {
+    test('should create filter from single term', () => {
+      const filter = BaseFilter.fromTerm(FilterTerm.fromString('foo=1'));
+
+      expect(filter.toFilterString()).toBe('foo=1');
+      expect(filter.length).toBe(1);
+    });
+
+    test('should create filter from multiple terms', () => {
+      const filter = BaseFilter.fromTerm(
+        FilterTerm.fromString('foo=1'),
+        FilterTerm.fromString('bar=2'),
+      );
+
+      expect(filter.toFilterString()).toBe('foo=1 bar=2');
+      expect(filter.length).toBe(2);
+    });
+  });
+
+  describe('BaseFilter set', () => {
+    test('should return new filter and not mutate original', () => {
+      const filter = new BaseFilter({
+        id: '123',
+        name: 'Test Filter',
+        terms: [FilterTerm.fromString('foo=1')],
+      });
+
+      const updated = filter.set('bar', '2');
+
+      expect(filter.toFilterString()).toBe('foo=1');
+      expect(filter.id).toBe('123');
+      expect(updated).not.toBe(filter);
+      expect(updated.toFilterString()).toBe('foo=1 bar=2');
+      expect(updated.id).toBeUndefined();
+      expect(updated.name).toBe('Test Filter');
+    });
+  });
+
+  describe('BaseFilter copy', () => {
+    test('should keep id and create equal filter', () => {
+      const filter = new BaseFilter({
+        id: '123',
+        name: 'Test Filter',
+        terms: [FilterTerm.fromString('foo=1')],
+      });
+
+      const copied = filter.copy();
+
+      expect(filter.id).toBe('123');
+      expect(filter.name).toBe('Test Filter');
+      expect(copied).not.toBe(filter);
+      expect(copied.equals(filter)).toBe(true);
+      expect(copied.id).toBe('123');
+      expect(copied.name).toBe('Test Filter');
+    });
+  });
+
+  describe('BaseFilter delete', () => {
+    test('should return same instance for unknown key', () => {
+      const filter = BaseFilter.fromString('foo=1');
+      const updated = filter.delete('bar');
+
+      expect(updated).toBe(filter);
+    });
+  });
+
+  describe('BaseFilter get/has terms api', () => {
+    test('should delegate get, has, getTerm, getTerms and hasTerm', () => {
+      const filter = BaseFilter.fromString('foo=1 foo=2 bar=3');
+
+      expect(filter.has('foo')).toBe(true);
+      expect(filter.get('foo')).toBe('1');
+      expect(filter.get('missing', 'fallback')).toBe('fallback');
+      expect(filter.getTerm('foo')?.value).toBe('1');
+      expect(filter.getTerms('foo')).toHaveLength(2);
+      expect(filter.hasTerm(FilterTerm.fromString('bar=3'))).toBe(true);
+    });
+  });
+
+  describe('BaseFilter toFilterCriteriaString', () => {
+    test('should split terms into criteria and extra strings', () => {
+      const filter = BaseFilter.fromString('foo=1 rows=10 sort=name');
+
+      expect(filter.toFilterCriteriaString()).toBe('foo=1');
+      expect(filter.toFilterExtraString()).toBe('rows=10 sort=name');
+      expect(filter.identifier()).toEqual('foo=1 rows=10 sort=name');
+    });
+  });
+
+  describe('BaseFilter paging helpers', () => {
+    test('next, previous, first and all should update paging terms', () => {
+      const filter = BaseFilter.fromString('first=1 rows=10');
+
+      expect(filter.next().toFilterString()).toBe('first=11 rows=10');
+      expect(filter.next().previous().toFilterString()).toBe('first=1 rows=10');
+      expect(filter.first(5).toFilterString()).toBe('first=5 rows=10');
+      expect(filter.all().toFilterString()).toBe('first=1 rows=-1');
+    });
+  });
+
+  describe('BaseFilter simple', () => {
+    test('should remove paging and sorting terms', () => {
+      const filter = BaseFilter.fromString('foo=1 first=1 rows=10 sort=name');
+
+      expect(filter.simple().toFilterString()).toBe('foo=1');
+    });
+  });
+
+  describe('BaseFilter sort helpers', () => {
+    test('setSortOrder and setSortBy should delegate sort updates', () => {
+      const filter = BaseFilter.fromString('sort=name');
+
+      const reverse = filter.setSortOrder('sort-reverse');
+      expect(reverse.getSortOrder()).toBe('sort-reverse');
+      expect(reverse.getSortBy()).toBe('name');
+
+      const updated = reverse.setSortBy('severity');
+      expect(updated.getSortOrder()).toBe('sort-reverse');
+      expect(updated.getSortBy()).toBe('severity');
+    });
+  });
+
+  describe('BaseFilter merge/and/equals', () => {
+    test('should delegate merge variants and and', () => {
+      const filter = BaseFilter.fromString('foo=1 sort=name');
+
+      expect(filter.merge(undefined)).toBe(filter);
+      expect(
+        filter.merge(BaseFilter.fromString('bar=2')).toFilterString(),
+      ).toBe('foo=1 sort=name bar=2');
+      expect(
+        filter
+          .mergeKeywords(BaseFilter.fromString('foo=2 severity>3'))
+          .toFilterString(),
+      ).toBe('foo=1 sort=name severity>3');
+      expect(
+        filter
+          .mergeExtraKeywords(BaseFilter.fromString('bar=2 rows=50'))
+          .toFilterString(),
+      ).toBe('foo=1 sort=name rows=50');
+      expect(filter.and(BaseFilter.fromString('bar=2')).toFilterString()).toBe(
+        'foo=1 sort=name and bar=2',
+      );
+      expect(filter.and(undefined)).toBe(filter);
+      expect(filter.equals(BaseFilter.fromString('sort=name foo=1'))).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/src/gmp/models/filter/__tests__/filter-term.test.ts
+++ b/src/gmp/models/filter/__tests__/filter-term.test.ts
@@ -4,193 +4,329 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import FilterTerm from 'gmp/models/filter/filter-term';
+import FilterTerm, {
+  parseFilterTermsFromString,
+} from 'gmp/models/filter/filter-term';
 
-describe('FilterTerm equals', () => {
-  test('should not equal object', () => {
-    const term = new FilterTerm({});
-    // @ts-expect-error
-    expect(term.equals({})).toBe(false);
-  });
-
-  test('should equal self', () => {
-    const term = new FilterTerm({});
-    expect(term.equals(term)).toBe(true);
-  });
-
-  test('empty terms should be equal', () => {
-    const term1 = new FilterTerm({});
-    const term2 = new FilterTerm({});
-    expect(term1.equals(term2)).toBe(true);
-  });
-
-  test('terms with different keywords should not be equal', () => {
-    const term1 = new FilterTerm({
-      keyword: 'abc',
-      relation: '=',
-      value: '1',
+describe('FilterTerm tests', () => {
+  describe('FilterTerm equals', () => {
+    test('should not equal object', () => {
+      const term = new FilterTerm({});
+      // @ts-expect-error
+      expect(term.equals({})).toBe(false);
     });
-    const term2 = new FilterTerm({
-      keyword: 'def',
-      relation: '=',
-      value: '1',
+
+    test('should equal self', () => {
+      const term = new FilterTerm({});
+      expect(term.equals(term)).toBe(true);
     });
-    expect(term1.equals(term2)).toBe(false);
+
+    test('empty terms should be equal', () => {
+      const term1 = new FilterTerm({});
+      const term2 = new FilterTerm({});
+      expect(term1.equals(term2)).toBe(true);
+    });
+
+    test('terms with different keywords should not be equal', () => {
+      const term1 = new FilterTerm({
+        keyword: 'abc',
+        relation: '=',
+        value: '1',
+      });
+      const term2 = new FilterTerm({
+        keyword: 'def',
+        relation: '=',
+        value: '1',
+      });
+      expect(term1.equals(term2)).toBe(false);
+    });
+
+    test('terms with different relations should not be equal', () => {
+      const term1 = new FilterTerm({
+        keyword: 'abc',
+        relation: '=',
+        value: '1',
+      });
+      const term2 = new FilterTerm({
+        keyword: 'abc',
+        relation: '~',
+        value: '1',
+      });
+      expect(term1.equals(term2)).toBe(false);
+    });
+
+    test('terms with different values should not be equal', () => {
+      const term1 = new FilterTerm({
+        keyword: 'abc',
+        relation: '=',
+        value: '1',
+      });
+      const term2 = new FilterTerm({
+        keyword: 'abc',
+        relation: '=',
+        value: '2',
+      });
+      expect(term1.equals(term2)).toBe(false);
+    });
+
+    test('terms should be equal', () => {
+      const term1 = new FilterTerm({
+        keyword: 'abc',
+        relation: '=',
+        value: '1',
+      });
+      const term2 = new FilterTerm({
+        keyword: 'abc',
+        relation: '=',
+        value: '1',
+      });
+      expect(term1.equals(term2)).toBe(true);
+    });
   });
 
-  test('terms with different relations should not be equal', () => {
-    const term1 = new FilterTerm({
-      keyword: 'abc',
-      relation: '=',
-      value: '1',
+  describe('FilterTerm fromString', () => {
+    test('should parse single value', () => {
+      const term = FilterTerm.fromString('abc');
+
+      expect(term.keyword).toBeUndefined();
+      expect(term.value).toEqual('abc');
+      expect(term.relation).toBeUndefined();
     });
-    const term2 = new FilterTerm({
-      keyword: 'abc',
+
+    test('should parse term with relation', () => {
+      const term = FilterTerm.fromString('abc=22');
+
+      expect(term.keyword).toEqual('abc');
+      expect(term.value).toEqual('22');
+      expect(term.relation).toEqual('=');
+    });
+
+    test('should parse special keywords', () => {
+      const term1 = FilterTerm.fromString('apply_overrides=22');
+
+      expect(term1.keyword).toEqual('apply_overrides');
+      expect(term1.value).toEqual(1);
+      expect(term1.relation).toEqual('=');
+
+      const term2 = FilterTerm.fromString('notes>4');
+
+      expect(term2.keyword).toEqual('notes');
+      expect(term2.value).toEqual(1);
+      expect(term2.relation).toEqual('>');
+    });
+
+    test('should parse value with double quotes', () => {
+      const term = FilterTerm.fromString('foo="abc def"');
+
+      expect(term.keyword).toEqual('foo');
+      expect(term.value).toEqual('"abc def"');
+      expect(term.relation).toEqual('=');
+    });
+
+    test('should parse value with double quotes and special characters', () => {
+      const term = FilterTerm.fromString('foo="abc : def"');
+
+      expect(term.keyword).toEqual('foo');
+      expect(term.value).toEqual('"abc : def"');
+      expect(term.relation).toEqual('=');
+    });
+
+    test('should parse correct relation with double quotes and special characters', () => {
+      const term = FilterTerm.fromString('foo~"abc = def"');
+
+      expect(term.keyword).toEqual('foo');
+      expect(term.value).toEqual('"abc = def"');
+      expect(term.relation).toEqual('~');
+    });
+  });
+
+  describe('Compound statement parsing', () => {
+    test('should parse and', () => {
+      const term = FilterTerm.fromString('and');
+
+      expect(term.keyword).toBeUndefined();
+      expect(term.value).toBe('and');
+      expect(term.relation).toBeUndefined();
+    });
+
+    test('should parse or', () => {
+      const term = FilterTerm.fromString('or');
+
+      expect(term.keyword).toBeUndefined();
+      expect(term.value).toBe('or');
+      expect(term.relation).toBeUndefined();
+    });
+
+    test('should parse not', () => {
+      const term = FilterTerm.fromString('not');
+
+      expect(term.keyword).toBeUndefined();
+      expect(term.value).toBe('not');
+      expect(term.relation).toBeUndefined();
+    });
+  });
+
+  describe('FilterTerm toString tests', () => {
+    test('should combine keyword, relation and value', () => {
+      const term = FilterTerm.fromString('apply_overrides=22');
+
+      expect(term.keyword).toBeDefined();
+      expect(term.value).toBeDefined();
+      expect(term.relation).toBeDefined();
+
+      expect(term.toString()).toEqual('apply_overrides=1');
+    });
+
+    test('should print value', () => {
+      const term = FilterTerm.fromString('not');
+
+      expect(term.keyword).toBeUndefined();
+      expect(term.value).toBeDefined();
+      expect(term.relation).toBeUndefined();
+
+      expect(term.toString()).toEqual('not');
+    });
+  });
+
+  describe('FilterTerm keywords should be lowercase', () => {
+    test('should lower keyword case from string', () => {
+      const term = FilterTerm.fromString('timEZOne=CET');
+
+      expect(term.keyword).toBe('timezone');
+      expect(term.value).toBe('CET');
+      expect(term.relation).toBe('=');
+    });
+  });
+});
+
+describe('parseFilterTermsFromString tests', () => {
+  test('should parse terms from string', () => {
+    const terms = parseFilterTermsFromString('foo=bar lorem~ipsum');
+    expect(terms.length).toBe(2);
+    expect(terms[0]).toEqual({
+      keyword: 'foo',
+      relation: '=',
+      value: 'bar',
+    });
+    expect(terms[1]).toEqual({
+      keyword: 'lorem',
       relation: '~',
-      value: '1',
+      value: 'ipsum',
     });
-    expect(term1.equals(term2)).toBe(false);
   });
 
-  test('terms with different values should not be equal', () => {
-    const term1 = new FilterTerm({
-      keyword: 'abc',
+  test('should parse filter strings with compound statements', () => {
+    // should parse filter strings with and
+    let terms = parseFilterTermsFromString('foo=bar and lorem~ipsum');
+    expect(terms.length).toBe(3);
+    expect(terms[0]).toEqual({
+      keyword: 'foo',
       relation: '=',
-      value: '1',
+      value: 'bar',
     });
-    const term2 = new FilterTerm({
-      keyword: 'abc',
+    expect(terms[1]).toEqual({
+      keyword: undefined,
+      relation: undefined,
+      value: 'and',
+    });
+    expect(terms[2]).toEqual({
+      keyword: 'lorem',
+      relation: '~',
+      value: 'ipsum',
+    });
+
+    // should parse filter strings with or
+    terms = parseFilterTermsFromString('foo=bar or lorem~ipsum');
+    expect(terms.length).toBe(3);
+    expect(terms[0]).toEqual({
+      keyword: 'foo',
       relation: '=',
-      value: '2',
+      value: 'bar',
     });
-    expect(term1.equals(term2)).toBe(false);
-  });
+    expect(terms[1]).toEqual({
+      keyword: undefined,
+      relation: undefined,
+      value: 'or',
+    });
+    expect(terms[2]).toEqual({
+      keyword: 'lorem',
+      relation: '~',
+      value: 'ipsum',
+    });
 
-  test('terms should be equal', () => {
-    const term1 = new FilterTerm({
-      keyword: 'abc',
+    // should parse filter strings with not
+    terms = parseFilterTermsFromString('not foo=bar');
+    expect(terms.length).toBe(2);
+    expect(terms[0]).toEqual({
+      keyword: undefined,
+      relation: undefined,
+      value: 'not',
+    });
+    expect(terms[1]).toEqual({
+      keyword: 'foo',
       relation: '=',
-      value: '1',
+      value: 'bar',
     });
-    const term2 = new FilterTerm({
-      keyword: 'abc',
+  });
+
+  test('should parse strings with double quotes', () => {
+    const terms = parseFilterTermsFromString(
+      'name="foo bar" comment~"lorem ipsum"',
+    );
+    expect(terms.length).toBe(2);
+    expect(terms[0]).toEqual({
+      keyword: 'name',
       relation: '=',
-      value: '1',
+      value: '"foo bar"',
     });
-    expect(term1.equals(term2)).toBe(true);
-  });
-});
-
-describe('FilterTerm fromString', () => {
-  test('should parse single value', () => {
-    const term = FilterTerm.fromString('abc');
-
-    expect(term.keyword).toBeUndefined();
-    expect(term.value).toEqual('abc');
-    expect(term.relation).toBeUndefined();
+    expect(terms.length).toBe(2);
+    expect(terms[1]).toEqual({
+      keyword: 'comment',
+      relation: '~',
+      value: '"lorem ipsum"',
+    });
   });
 
-  test('should parse term with relation', () => {
-    const term = FilterTerm.fromString('abc=22');
-
-    expect(term.keyword).toEqual('abc');
-    expect(term.value).toEqual('22');
-    expect(term.relation).toEqual('=');
+  test('should parse strings with double quotes and without columns', () => {
+    const terms = parseFilterTermsFromString('="foo bar" ~"lorem ipsum"');
+    expect(terms.length).toBe(2);
+    expect(terms[0]).toEqual({
+      keyword: undefined,
+      relation: '=',
+      value: '"foo bar"',
+    });
+    expect(terms.length).toBe(2);
+    expect(terms[1]).toEqual({
+      keyword: undefined,
+      relation: '~',
+      value: '"lorem ipsum"',
+    });
   });
 
-  test('should parse special keywords', () => {
-    const term1 = FilterTerm.fromString('apply_overrides=22');
-
-    expect(term1.keyword).toEqual('apply_overrides');
-    expect(term1.value).toEqual(1);
-    expect(term1.relation).toEqual('=');
-
-    const term2 = FilterTerm.fromString('notes>4');
-
-    expect(term2.keyword).toEqual('notes');
-    expect(term2.value).toEqual(1);
-    expect(term2.relation).toEqual('>');
-  });
-
-  test('should parse value with double quotes', () => {
-    const term = FilterTerm.fromString('foo="abc def"');
-
-    expect(term.keyword).toEqual('foo');
-    expect(term.value).toEqual('"abc def"');
-    expect(term.relation).toEqual('=');
-  });
-
-  test('should parse value with double quotes and special characters', () => {
-    const term = FilterTerm.fromString('foo="abc : def"');
-
-    expect(term.keyword).toEqual('foo');
-    expect(term.value).toEqual('"abc : def"');
-    expect(term.relation).toEqual('=');
-  });
-
-  test('should parse correct relation with double quotes and special characters', () => {
-    const term = FilterTerm.fromString('foo~"abc = def"');
-
-    expect(term.keyword).toEqual('foo');
-    expect(term.value).toEqual('"abc = def"');
-    expect(term.relation).toEqual('~');
-  });
-});
-
-describe('Compound statement parsing', () => {
-  test('should parse and', () => {
-    const term = FilterTerm.fromString('and');
-
-    expect(term.keyword).toBeUndefined();
-    expect(term.value).toBe('and');
-    expect(term.relation).toBeUndefined();
-  });
-
-  test('should parse or', () => {
-    const term = FilterTerm.fromString('or');
-
-    expect(term.keyword).toBeUndefined();
-    expect(term.value).toBe('or');
-    expect(term.relation).toBeUndefined();
-  });
-
-  test('should parse not', () => {
-    const term = FilterTerm.fromString('not');
-
-    expect(term.keyword).toBeUndefined();
-    expect(term.value).toBe('not');
-    expect(term.relation).toBeUndefined();
-  });
-});
-
-describe('FilterTerm toString tests', () => {
-  test('should combine keyword, relation and value', () => {
-    const term = FilterTerm.fromString('apply_overrides=22');
-
-    expect(term.keyword).toBeDefined();
-    expect(term.value).toBeDefined();
-    expect(term.relation).toBeDefined();
-
-    expect(term.toString()).toEqual('apply_overrides=1');
-  });
-
-  test('should print value', () => {
-    const term = FilterTerm.fromString('not');
-
-    expect(term.keyword).toBeUndefined();
-    expect(term.value).toBeDefined();
-    expect(term.relation).toBeUndefined();
-
-    expect(term.toString()).toEqual('not');
-  });
-});
-
-describe('keywords should be lowercase', () => {
-  test('should lower keyword case from string', () => {
-    const term = FilterTerm.fromString('timEZOne=CET');
-
-    expect(term.keyword).toBe('timezone');
-    expect(term.value).toBe('CET');
-    expect(term.relation).toBe('=');
+  test('should parse strings with double quotes and special characters', () => {
+    const terms = parseFilterTermsFromString(
+      'name="foo <= bar" ~"foo & bar" and comment="hello : world ?"',
+    );
+    expect(terms.length).toBe(4);
+    expect(terms[0]).toEqual({
+      keyword: 'name',
+      relation: '=',
+      value: '"foo <= bar"',
+    });
+    expect(terms[1]).toEqual({
+      keyword: undefined,
+      relation: '~',
+      value: '"foo & bar"',
+    });
+    expect(terms[2]).toEqual({
+      keyword: undefined,
+      relation: undefined,
+      value: 'and',
+    });
+    expect(terms[3]).toEqual({
+      keyword: 'comment',
+      relation: '=',
+      value: '"hello : world ?"',
+    });
   });
 });

--- a/src/gmp/models/filter/__tests__/filter-terms.test.ts
+++ b/src/gmp/models/filter/__tests__/filter-terms.test.ts
@@ -125,6 +125,15 @@ describe('FilterTerms tests', () => {
       expect(updated.get('rows')).toBe(10);
       expect(filterTerms.get('first')).toBe(1);
     });
+
+    test('should keep other keywords when moving to next page', () => {
+      const filterTerms = fromTerms('first=1', 'rows=10', 'sort=name');
+      const updated = filterTerms.next();
+
+      expect(updated.get('first')).toBe(11);
+      expect(updated.get('rows')).toBe(10);
+      expect(updated.get('sort')).toBe('name');
+    });
   });
 
   describe('FilterTerms previous', () => {
@@ -135,14 +144,46 @@ describe('FilterTerms tests', () => {
       expect(updated.get('first')).toBe(1);
       expect(updated.get('rows')).toBe(10);
     });
+
+    test('should keep other keywords when moving to previous page', () => {
+      const filterTerms = fromTerms('first=15', 'rows=10', 'sort=name');
+      const updated = filterTerms.previous();
+
+      expect(updated.get('first')).toBe(5);
+      expect(updated.get('rows')).toBe(10);
+      expect(updated.get('sort')).toBe('name');
+    });
   });
 
   describe('FilterTerms first', () => {
+    test('should set first', () => {
+      const filterTerms = fromTerms('first=9');
+      const updated = filterTerms.first();
+
+      expect(updated.get('first')).toBe(1);
+      expect(filterTerms.get('first')).toBe(9);
+    });
+
     test('should set first to provided value', () => {
       const filterTerms = fromTerms('first=9');
       const updated = filterTerms.first(3);
       expect(updated.get('first')).toBe(3);
       expect(filterTerms.get('first')).toBe(9);
+    });
+
+    test('should keep other keywords when setting first', () => {
+      const filterTerms = fromTerms('first=9', 'rows=10', 'sort=name');
+      const updated = filterTerms.first(1);
+
+      expect(updated.get('first')).toBe(1);
+      expect(updated.get('rows')).toBe(10);
+      expect(updated.get('sort')).toBe('name');
+    });
+
+    test('should set first to 1 when provided value is less than 1', () => {
+      const filterTerms = fromTerms('first=9');
+      const updated = filterTerms.first(0);
+      expect(updated.get('first')).toBe(1);
     });
   });
 

--- a/src/gmp/models/filter/base-filter.ts
+++ b/src/gmp/models/filter/base-filter.ts
@@ -1,0 +1,295 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import convert from 'gmp/models/filter/convert';
+import FilterTerm, {
+  parseFilterTermsFromString,
+} from 'gmp/models/filter/filter-term';
+import FilterTerms from 'gmp/models/filter/filter-terms';
+import {
+  type default as FilterType,
+  type FilterSortOrder,
+} from 'gmp/models/filter/filter-type';
+import {map} from 'gmp/utils/array';
+import {isDefined} from 'gmp/utils/identity';
+import {isEmpty} from 'gmp/utils/string';
+
+export interface FilterKeyword {
+  column?: string;
+  relation?: string;
+  value?: string;
+}
+
+/**
+ * XML Structure of a filter response element
+ * as returned by all `<get_xyz>` queries, for example `<get_tasks>`.
+ *
+ * Example XML Structure:
+ * ```xml
+ * <get_tasks_response>
+ *   <task>
+ *     ...
+ *   </task>
+ *   <filters id="">
+ *     <term>apply_overrides=0 min_qod=70 sort=name first=1 rows=1</term>
+ *     <keywords>
+ *       <keyword>
+ *         <column>apply_overrides</column>
+ *         <relation>=</relation>
+ *         <value>0</value>
+ *       </keyword>
+ *       <keyword>
+ *         <column>min_qod</column>
+ *         <relation>=</relation>
+ *         <value>70</value>
+ *       </keyword>
+ *       <keyword>
+ *         <column>sort</column>
+ *         <relation>=</relation>
+ *         <value>name</value>
+ *       </keyword>
+ *       <keyword>
+ *         <column>first</column>
+ *         <relation>=</relation>
+ *         <value>1</value>
+ *       </keyword>
+ *       <keyword>
+ *         <column>rows</column>
+ *         <relation>=</relation>
+ *         <value>1</value>
+ *       </keyword>
+ *     </keywords>
+ *   </filters>
+ * </get_tasks_response>
+ * ```
+ */
+export interface FilterResponseElement {
+  _id?: string;
+  name?: string;
+  keywords?: {
+    keyword?: FilterKeyword | FilterKeyword[];
+  };
+  term?: string;
+}
+
+interface BaseFilterParams {
+  id?: string;
+  name?: string;
+  terms?: FilterTerm[];
+}
+
+export const UNKNOWN_FILTER_ID = '0';
+
+class BaseFilter implements FilterType {
+  public readonly id?: string;
+  public readonly name?: string;
+  private readonly filterTerms: FilterTerms;
+
+  constructor({id, name, terms = []}: BaseFilterParams = {}) {
+    this.id = id;
+    this.name = name;
+    this.filterTerms = new FilterTerms({terms});
+  }
+
+  get length() {
+    return this.filterTerms.length;
+  }
+
+  /**
+   * Create a new Filter from the passed FilterTerms if they are different from the current ones.
+   *
+   * @param terms The FilterTerms to use for creating the new Filter.
+   * @param keepId Whether to keep the current Filter's ID.
+   *
+   * @returns A new Filter if the FilterTerms are different, otherwise the current Filter.
+   */
+  private _delegate(terms: FilterTerms, keepId = false) {
+    return terms === this.filterTerms
+      ? this
+      : new BaseFilter({
+          id: keepId ? this.id : undefined,
+          name: this.name,
+          terms: [...terms.getAllTerms()],
+        });
+  }
+
+  /**
+   * Create a new Filter from the passed response element.
+   *
+   * @param element Response element to parse properties from.
+   *
+   * @returns A new Filter model instance.
+   */
+  static fromResponseElement(element: FilterResponseElement = {}) {
+    const id =
+      !isEmpty(element._id) && element._id !== UNKNOWN_FILTER_ID
+        ? element._id
+        : undefined;
+
+    const name = !isEmpty(element.name) ? element.name : undefined;
+
+    let terms: FilterTerm[] = [];
+    if (isDefined(element.keywords)) {
+      terms = map(
+        element.keywords.keyword,
+        ({relation, value, column: key}: FilterKeyword) =>
+          new FilterTerm(convert(key, value, relation)),
+      );
+    } else if (isDefined(element.term)) {
+      terms = parseFilterTermsFromString(element.term);
+    }
+
+    return new BaseFilter({id, name, terms});
+  }
+
+  /**
+   * Creates a new Filter from filterString
+   *
+   * @param filterString String to parse FilterTerms from.
+   * @param filter Use extra terms from filter if not already
+   *               parsed from filterString.
+   *
+   * @returns New Filter with FilterTerms parsed from filterString.
+   */
+  static fromString(filterString?: string, filter?: FilterType) {
+    const filterTerms = new FilterTerms({
+      terms: parseFilterTermsFromString(filterString),
+    }).mergeExtraKeywords(filter) as FilterTerms;
+
+    return new BaseFilter({
+      terms: [...filterTerms.getAllTerms()],
+    });
+  }
+
+  /**
+   * Creates a new Filter from FilterTerms
+   *
+   * @param term FilterTerms to set for the new Filter
+   *
+   * @returns The new Filter
+   */
+  static fromTerm(...term: FilterTerm[]) {
+    return new BaseFilter({
+      terms: [...term],
+    });
+  }
+
+  toFilterString(): string {
+    return this.filterTerms.toFilterString();
+  }
+
+  toFilterCriteriaString(): string {
+    return this.filterTerms.toFilterCriteriaString();
+  }
+
+  toFilterExtraString(): string {
+    return this.filterTerms.toFilterExtraString();
+  }
+
+  getTerm(key: string | undefined): FilterTerm | undefined {
+    return this.filterTerms.getTerm(key);
+  }
+
+  hasTerm(term: FilterTerm | undefined): boolean {
+    return this.filterTerms.hasTerm(term);
+  }
+
+  getTerms(key: string | undefined): FilterTerm[] {
+    return this.filterTerms.getTerms(key);
+  }
+
+  getAllTerms(): readonly FilterTerm[] {
+    return this.filterTerms.getAllTerms();
+  }
+
+  get(
+    key: string,
+    def: string | number | undefined = undefined,
+  ): string | number | undefined {
+    return this.filterTerms.get(key, def);
+  }
+
+  set(
+    keyword: string,
+    value?: string | number | boolean,
+    relation: string = '=',
+  ) {
+    return this._delegate(this.filterTerms.set(keyword, value, relation));
+  }
+
+  has(key: string): boolean {
+    return this.filterTerms.has(key);
+  }
+
+  delete(key: string) {
+    return this._delegate(this.filterTerms.delete(key));
+  }
+
+  identifier() {
+    return this.filterTerms.identifier();
+  }
+
+  equals(filter: FilterType | undefined | null): boolean {
+    return this.filterTerms.equals(filter);
+  }
+
+  copy() {
+    return this._delegate(this.filterTerms.copy(), true);
+  }
+
+  next() {
+    return this._delegate(this.filterTerms.next());
+  }
+
+  previous() {
+    return this._delegate(this.filterTerms.previous());
+  }
+
+  first(first: number = 1) {
+    return this._delegate(this.filterTerms.first(first));
+  }
+
+  all() {
+    return this._delegate(this.filterTerms.all());
+  }
+
+  simple() {
+    return this._delegate(this.filterTerms.simple());
+  }
+
+  and(filter: FilterType | undefined | null) {
+    return this._delegate(this.filterTerms.and(filter));
+  }
+
+  getSortOrder(): FilterSortOrder {
+    return this.filterTerms.getSortOrder();
+  }
+
+  getSortBy(): string | undefined {
+    return this.filterTerms.getSortBy();
+  }
+
+  setSortOrder(value: FilterSortOrder) {
+    return this._delegate(this.filterTerms.setSortOrder(value));
+  }
+
+  setSortBy(value: string) {
+    return this._delegate(this.filterTerms.setSortBy(value));
+  }
+
+  merge(filter?: FilterType) {
+    return this._delegate(this.filterTerms.merge(filter));
+  }
+
+  mergeKeywords(filter?: FilterType) {
+    return this._delegate(this.filterTerms.mergeKeywords(filter));
+  }
+
+  mergeExtraKeywords(filter?: FilterType) {
+    return this._delegate(this.filterTerms.mergeExtraKeywords(filter));
+  }
+}
+
+export default BaseFilter;

--- a/src/gmp/models/filter/filter-term.ts
+++ b/src/gmp/models/filter/filter-term.ts
@@ -4,9 +4,52 @@
  */
 
 import convert, {type FilterTermObject} from 'gmp/models/filter/convert';
-import {isDefined} from 'gmp/utils/identity';
+import {isDefined, isString, isArray} from 'gmp/utils/identity';
 
 const RELATIONS = ['=', ':', '~', '>', '<'];
+
+/**
+ * Parses FilterTerms from a filter string
+ *
+ * @param filterString Filter representation as a string
+ *
+ * @returns Array of parsed FilterTerms
+ */
+export const parseFilterTermsFromString = (
+  filterString: string | undefined,
+): FilterTerm[] => {
+  const terms: FilterTerm[] = [];
+  if (isString(filterString)) {
+    // replace whitespace between double quotes with placeholders
+    let modifiedFilterString = filterString;
+    const quotes = filterString.match(/".+?"/g); // find all substrings between double quotes
+    if (isArray(quotes)) {
+      for (const quotedString of quotes) {
+        const newQuotedString = quotedString.replace(/\s/g, '####'); // replace all " " with "####"
+        modifiedFilterString = modifiedFilterString.replace(
+          quotedString,
+          newQuotedString,
+        );
+      }
+    }
+
+    // get filter terms by splitting at whitespace
+    const filterTerms = modifiedFilterString.split(' ');
+
+    for (let filterTerm of filterTerms) {
+      // strip whitespace
+      filterTerm = filterTerm.trim();
+
+      // remove placeholders
+      filterTerm = filterTerm.replace(/####/g, ' '); // replace all "####" with " "
+
+      if (filterTerm.length > 0 && !filterTerm.startsWith('_')) {
+        terms.push(FilterTerm.fromString(filterTerm));
+      }
+    }
+  }
+  return terms;
+};
 
 /**
  * Represents a filter term

--- a/src/gmp/models/report/report.ts
+++ b/src/gmp/models/report/report.ts
@@ -5,7 +5,8 @@
 
 import {type CollectionList, parseFilter} from 'gmp/collection/parser';
 import {type Date} from 'gmp/models/date';
-import {type FilterType, type FilterKeyword} from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
+import {type FilterKeyword} from 'gmp/models/filter/base-filter';
 import Model, {type ModelElement, type ModelProperties} from 'gmp/models/model';
 import {
   parseResults,

--- a/src/web/components/powerfilter/__tests__/useFilterDialog.test.tsx
+++ b/src/web/components/powerfilter/__tests__/useFilterDialog.test.tsx
@@ -10,6 +10,8 @@ import useFilterDialog, {
   type FilterDialogState,
 } from 'web/components/powerfilter/useFilterDialog';
 
+const createInitialFilter = () => new Filter({id: 'foo'}).set('name', 'test');
+
 describe('useFilterDialog', () => {
   test('should initialize with default values', () => {
     const {result} = renderHook(() => useFilterDialog());
@@ -20,7 +22,7 @@ describe('useFilterDialog', () => {
   });
 
   test('should initialize with provided filter and filter string', () => {
-    const initialFilter = new Filter().set('name', 'test');
+    const initialFilter = createInitialFilter();
     const {result} = renderHook(() =>
       useFilterDialog(initialFilter, 'foo=bar'),
     );
@@ -31,14 +33,14 @@ describe('useFilterDialog', () => {
   });
 
   test("should use criteria string from filter if initial filter string isn't provided", () => {
-    const initialFilter = new Filter().set('name', 'test');
+    const initialFilter = createInitialFilter();
     const {result} = renderHook(() => useFilterDialog(initialFilter));
 
     expect(result.current.filterString).toEqual('name=test');
   });
 
   test('should handle filter changes', () => {
-    const initialFilter = new Filter().set('name', 'test');
+    const initialFilter = createInitialFilter();
     const {result} = renderHook(() => useFilterDialog(initialFilter));
 
     act(() => {
@@ -51,7 +53,7 @@ describe('useFilterDialog', () => {
   });
 
   test('should handle filter value changes', () => {
-    const initialFilter = new Filter().set('name', 'test');
+    const initialFilter = createInitialFilter();
     const {result} = renderHook(() => useFilterDialog(initialFilter));
 
     act(() => {
@@ -64,7 +66,7 @@ describe('useFilterDialog', () => {
   });
 
   test('should handle search term changes', () => {
-    const initialFilter = new Filter().set('name', 'test');
+    const initialFilter = createInitialFilter();
     const {result} = renderHook(() => useFilterDialog(initialFilter));
 
     act(() => {
@@ -77,7 +79,7 @@ describe('useFilterDialog', () => {
   });
 
   test('should handle filter string changes', () => {
-    const initialFilter = new Filter().set('name', 'test');
+    const initialFilter = createInitialFilter();
     const {result} = renderHook(() => useFilterDialog(initialFilter));
 
     act(() => {
@@ -89,7 +91,7 @@ describe('useFilterDialog', () => {
   });
 
   test('should handle sort by changes', () => {
-    const initialFilter = new Filter().set('name', 'test');
+    const initialFilter = createInitialFilter();
     const {result} = renderHook(() => useFilterDialog(initialFilter));
 
     act(() => {
@@ -102,7 +104,7 @@ describe('useFilterDialog', () => {
   });
 
   test('should handle sort order changes', () => {
-    const initialFilter = new Filter().set('name', 'test').setSortBy('name');
+    const initialFilter = createInitialFilter().setSortBy('name');
     const {result} = renderHook(() => useFilterDialog(initialFilter));
 
     act(() => {
@@ -115,7 +117,7 @@ describe('useFilterDialog', () => {
   });
 
   test('should handle dialog state changes', () => {
-    const initialFilter = new Filter().set('name', 'test');
+    const initialFilter = createInitialFilter();
     const {result} = renderHook(() =>
       useFilterDialog<FilterDialogState>(initialFilter),
     );

--- a/src/web/components/powerfilter/useFilterDialog.tsx
+++ b/src/web/components/powerfilter/useFilterDialog.tsx
@@ -4,7 +4,11 @@
  */
 
 import {useCallback, useState} from 'react';
-import Filter, {type FilterType, type FilterSortOrder} from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import {
+  type default as FilterType,
+  type FilterSortOrder,
+} from 'gmp/models/filter/filter-type';
 import {isDefined} from 'gmp/utils/identity';
 
 export interface FilterDialogState {
@@ -24,7 +28,7 @@ const useFilterDialog = <TFilterDialogState extends FilterDialogState>(
 ) => {
   const [originalFilter] = useState(initialFilter);
   const [filter, setFilter] = useState<FilterType>(() =>
-    isDefined(initialFilter) ? initialFilter : new Filter(),
+    isDefined(initialFilter) ? initialFilter : new BaseFilter(),
   );
   const [filterDialogState, setFilterDialogState] =
     useState<TFilterDialogState>({} as TFilterDialogState);

--- a/src/web/entities/__tests__/EntitiesContainer.test.tsx
+++ b/src/web/entities/__tests__/EntitiesContainer.test.tsx
@@ -12,7 +12,7 @@ import {
   fireEvent,
   wait,
 } from 'web/testing';
-import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import PortList from 'gmp/models/port-list';
 import {createSession} from 'gmp/testing';
 import EntitiesContainer from 'web/entities/EntitiesContainer';
@@ -38,7 +38,7 @@ const onDownload = testing.fn();
 
 const setup = gmp => {
   const {render} = rendererWith({gmp, store: true, router: true});
-  const initialFilter = new Filter();
+  const initialFilter = new BaseFilter();
   render(
     <EntitiesContainer
       entities={[new PortList()]}

--- a/src/web/entities/__tests__/withEntitiesFooter.test.tsx
+++ b/src/web/entities/__tests__/withEntitiesFooter.test.tsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {render, screen} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import Task from 'gmp/models/task';
 import withEntitiesFooter, {
   type WithEntitiesFooterComponentProps,
@@ -29,7 +29,7 @@ describe('withEntitiesFooter tests', () => {
     const mockProps = {
       entities: [new Task({id: '1'}), new Task({id: '2'})],
       entitiesCounts: new CollectionCounts({all: 2, filtered: 2, length: 2}),
-      filter: new Filter(),
+      filter: new BaseFilter(),
       onDeleteBulk: testing.fn(),
       onDownloadBulk: testing.fn(),
       onTagsBulk: testing.fn(),

--- a/src/web/hooks/use-query/__tests__/Audits.test.tsx
+++ b/src/web/hooks/use-query/__tests__/Audits.test.tsx
@@ -7,7 +7,8 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, screen, waitFor} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
-import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import {createSession} from 'gmp/testing';
 import {useGetAudit, useGetAudits} from 'web/hooks/use-query/audits';
 
@@ -27,7 +28,7 @@ const audit2 = Audit.fromElement({
   permissions: {permission: [{name: 'everything'}]},
 });
 
-const filter = Filter.fromString('name~test');
+const filter = BaseFilter.fromString('name~test');
 
 const SingleAuditComponent = ({id}: {id: string}) => {
   const {data, isLoading, isError} = useGetAudit({id});
@@ -50,7 +51,7 @@ const SingleAuditComponent = ({id}: {id: string}) => {
   );
 };
 
-const AuditListComponent = ({filter}: {filter?: Filter}) => {
+const AuditListComponent = ({filter}: {filter?: FilterType}) => {
   const {data, isLoading, isError} = useGetAudits({filter});
 
   if (isLoading) {

--- a/src/web/hooks/use-query/__tests__/Permissions.test.tsx
+++ b/src/web/hooks/use-query/__tests__/Permissions.test.tsx
@@ -6,7 +6,8 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, screen, waitFor} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import Permission from 'gmp/models/permission';
 import {createSession} from 'gmp/testing';
 import {useGetPermissions} from 'web/hooks/use-query/permissions';
@@ -25,9 +26,9 @@ const permission2 = Permission.fromElement({
   subject: {_id: 'user-1', type: 'user'},
 });
 
-const filter = Filter.fromString('resource_uuid=task-1').all();
+const filter = BaseFilter.fromString('resource_uuid=task-1').all();
 
-const TestComponent = ({filter}: {filter?: Filter}) => {
+const TestComponent = ({filter}: {filter?: FilterType}) => {
   const {data, isLoading, isError} = useGetPermissions({filter});
 
   if (isLoading) {

--- a/src/web/hooks/use-query/__tests__/Policies.test.tsx
+++ b/src/web/hooks/use-query/__tests__/Policies.test.tsx
@@ -6,7 +6,8 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, screen, waitFor} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import Policy from 'gmp/models/policy';
 import {createSession} from 'gmp/testing';
 import {useGetPolicy, useGetPolicies} from 'web/hooks/use-query/policies';
@@ -29,7 +30,7 @@ const policy2 = Policy.fromElement({
   permissions: {permission: [{name: 'everything'}]},
 });
 
-const filter = Filter.fromString('name~test');
+const filter = BaseFilter.fromString('name~test');
 
 const SinglePolicyComponent = ({id}: {id: string}) => {
   const {data, isLoading, isError} = useGetPolicy({id});
@@ -52,7 +53,7 @@ const SinglePolicyComponent = ({id}: {id: string}) => {
   );
 };
 
-const PolicyListComponent = ({filter}: {filter?: Filter}) => {
+const PolicyListComponent = ({filter}: {filter?: FilterType}) => {
   const {data, isLoading, isError} = useGetPolicies({filter});
 
   if (isLoading) {

--- a/src/web/hooks/use-query/__tests__/ReportOperatingSystem.test.tsx
+++ b/src/web/hooks/use-query/__tests__/ReportOperatingSystem.test.tsx
@@ -6,7 +6,8 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, screen, waitFor} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import ReportOperatingSystem from 'gmp/models/report/os';
 import {createSession} from 'gmp/testing';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
@@ -24,14 +25,14 @@ const os2 = ReportOperatingSystem.fromElement({
 });
 os2.hosts.count = 5;
 
-const filter = Filter.fromString('rows=10 first=1');
+const filter = BaseFilter.fromString('rows=10 first=1');
 
 const TestComponent = ({
   reportId,
   filter: testFilter,
 }: {
   reportId: string;
-  filter?: Filter;
+  filter?: FilterType;
 }) => {
   const {data, isLoading, isError} = useGetReportOperatingSystems({
     reportId,

--- a/src/web/hooks/use-query/agents.ts
+++ b/src/web/hooks/use-query/agents.ts
@@ -9,7 +9,8 @@ import type Rejection from 'gmp/http/rejection';
 import type Response from 'gmp/http/response';
 import {type XmlMeta} from 'gmp/http/transform/fast-xml';
 import type Agent from 'gmp/models/agent';
-import Filter, {type FilterType} from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import {isFilterType} from 'gmp/models/filter/utils';
 import {parseYesNo} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
@@ -48,15 +49,15 @@ export const useGetAgents = ({
   let finalFilter = filter;
 
   if (isDefined(scannerId)) {
-    finalFilter = finalFilter ?? new Filter();
+    finalFilter = finalFilter ?? new BaseFilter();
     finalFilter = finalFilter.and(
-      Filter.fromString(`scanner_uuid=${scannerId}`),
+      BaseFilter.fromString(`scanner_uuid=${scannerId}`),
     );
   }
   if (isDefined(authorized)) {
-    finalFilter = finalFilter ?? new Filter();
+    finalFilter = finalFilter ?? new BaseFilter();
     finalFilter = finalFilter.and(
-      Filter.fromString(`authorized=${parseYesNo(authorized)}`),
+      BaseFilter.fromString(`authorized=${parseYesNo(authorized)}`),
     );
   }
 

--- a/src/web/pages/agent-groups/AgentGroupsFilterDialog.tsx
+++ b/src/web/pages/agent-groups/AgentGroupsFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import DefaultFilterDialog from 'web/components/powerfilter/DefaultFilterDialog';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
 import useFilterDialog from 'web/components/powerfilter/useFilterDialog';
@@ -14,7 +14,7 @@ import useFilterDialogSave, {
 import useTranslation from 'web/hooks/useTranslation';
 
 interface AgentGroupsFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const AgentGroupsFilterDialog = ({

--- a/src/web/pages/agent-installers/AgentInstallerFilterDialog.tsx
+++ b/src/web/pages/agent-installers/AgentInstallerFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import DefaultFilterDialog from 'web/components/powerfilter/DefaultFilterDialog';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
 import useFilterDialog from 'web/components/powerfilter/useFilterDialog';
@@ -14,7 +14,7 @@ import useFilterDialogSave, {
 import useTranslation from 'web/hooks/useTranslation';
 
 interface AgentInstallersFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const AgentInstallersFilterDialog = ({

--- a/src/web/pages/agents/AgentFilterDialog.tsx
+++ b/src/web/pages/agents/AgentFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import DefaultFilterDialog from 'web/components/powerfilter/DefaultFilterDialog';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
 import useFilterDialog from 'web/components/powerfilter/useFilterDialog';
@@ -14,7 +14,7 @@ import useFilterDialogSave, {
 import useTranslation from 'web/hooks/useTranslation';
 
 interface AgentsFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const AgentsFilterDialog = ({

--- a/src/web/pages/container-image-targets/ContainerImageTargetFilterDialog.tsx
+++ b/src/web/pages/container-image-targets/ContainerImageTargetFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import DefaultFilterDialog from 'web/components/powerfilter/DefaultFilterDialog';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
 import useFilterDialog from 'web/components/powerfilter/useFilterDialog';
@@ -14,7 +14,7 @@ import useFilterDialogSave, {
 import useTranslation from 'web/hooks/useTranslation';
 
 interface ContainerImageTargetFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const ContainerImageTargetFilterDialog = ({

--- a/src/web/pages/container-image-targets/__tests__/ContainerImageTargetFilterDialog.test.tsx
+++ b/src/web/pages/container-image-targets/__tests__/ContainerImageTargetFilterDialog.test.tsx
@@ -12,11 +12,12 @@ import {
   wait,
 } from 'web/testing';
 import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import ContainerImageTargetFilterDialog from 'web/pages/container-image-targets/ContainerImageTargetFilterDialog';
 
 describe('ContainerImageTargetFilterDialog tests', () => {
   test('should render dialog with default fields', () => {
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const gmp = {filter: {}};
     const {render} = rendererWith({capabilities: true, gmp});
     render(<ContainerImageTargetFilterDialog filter={filter} />);
@@ -35,7 +36,7 @@ describe('ContainerImageTargetFilterDialog tests', () => {
   });
 
   test('should call onFilterChanged when filter is updated', () => {
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const handleFilterChanged = testing.fn();
     const gmp = {filter: {}};
     const {render} = rendererWith({capabilities: true, gmp});
@@ -55,7 +56,7 @@ describe('ContainerImageTargetFilterDialog tests', () => {
   });
 
   test('should call onFilterCreated when a new filter is saved', async () => {
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const newFilter = new Filter({
       id: 'new-filter-id',
       name: 'New Filter',

--- a/src/web/pages/credentials/__tests__/CredentialListPage.test.tsx
+++ b/src/web/pages/credentials/__tests__/CredentialListPage.test.tsx
@@ -15,7 +15,7 @@ import {
 } from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Credential from 'gmp/models/credential';
-import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
 import CredentialPage from 'web/pages/credentials/CredentialListPage';
@@ -52,11 +52,11 @@ const createGmp = ({
   getCredentialResponse = {data: credential},
   getCredentialsResponse = {
     data: [credential],
-    meta: {filter: new Filter(), counts: new CollectionCounts()},
+    meta: {filter: new BaseFilter(), counts: new CollectionCounts()},
   },
   getFiltersResponse = {
     data: [],
-    meta: {filter: new Filter(), counts: new CollectionCounts()},
+    meta: {filter: new BaseFilter(), counts: new CollectionCounts()},
   },
   cloneCredential = testing.fn().mockResolvedValue(cloneCredentialResponse),
   deleteCredential = testing.fn().mockResolvedValue(undefined),
@@ -111,7 +111,7 @@ const createGmp = ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: Filter.fromString(),
+        filter: new BaseFilter(),
         counts: new CollectionCounts(),
       },
     }),
@@ -128,7 +128,7 @@ describe('CredentialListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = Filter.fromString('foo=bar');
+    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('credential', defaultSettingFilter),
@@ -200,7 +200,7 @@ describe('CredentialListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = Filter.fromString('foo=bar');
+    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('credential', defaultSettingFilter),
@@ -230,7 +230,7 @@ describe('CredentialListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = Filter.fromString('foo=bar');
+    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('credential', defaultSettingFilter),
@@ -273,7 +273,7 @@ describe('CredentialListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = Filter.fromString('foo=bar');
+    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('credential', defaultSettingFilter),

--- a/src/web/pages/portlists/__tests__/PortListFilterDialog.test.tsx
+++ b/src/web/pages/portlists/__tests__/PortListFilterDialog.test.tsx
@@ -12,6 +12,7 @@ import {
   wait,
 } from 'web/testing';
 import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import PortListsFilterDialog from 'web/pages/portlists/PortListFilterDialog';
 
 const newFilter = new Filter({
@@ -33,7 +34,7 @@ const gmp = {
 
 describe('PortListsFilterDialog tests', () => {
   test('should render dialog', () => {
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const {render} = rendererWith({capabilities: true, gmp});
     render(<PortListsFilterDialog filter={filter} />);
 
@@ -54,7 +55,7 @@ describe('PortListsFilterDialog tests', () => {
   });
 
   test('should call onFilterChanged when a filter is updated', async () => {
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const {render} = rendererWith({capabilities: true, gmp});
     const handleFilterChanged = testing.fn();
     render(
@@ -69,12 +70,12 @@ describe('PortListsFilterDialog tests', () => {
     const saveButton = screen.getDialogSaveButton();
     fireEvent.click(saveButton);
     expect(handleFilterChanged).toHaveBeenCalledWith(
-      Filter.fromString('foo=bar'),
+      BaseFilter.fromString('foo=bar'),
     );
   });
 
   test('should call onFilterCreated when a new filter is saved', async () => {
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const {render} = rendererWith({capabilities: true, gmp});
     const handleFilterCreated = testing.fn();
     render(

--- a/src/web/pages/reports/AuditReportDetailsContent.tsx
+++ b/src/web/pages/reports/AuditReportDetailsContent.tsx
@@ -6,7 +6,9 @@
 import React from 'react';
 import styled from 'styled-components';
 import type AuditReport from 'gmp/models/audit-report';
-import Filter, {type FilterType} from 'gmp/models/filter';
+import type Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import type ReportReport from 'gmp/models/report/report';
 import type ReportTask from 'gmp/models/report/task';
 import type ReportTLSCertificate from 'gmp/models/report/tls-certificate';
@@ -182,7 +184,7 @@ const AuditReportDetailsContent = ({
 
   const progress = task?.progress ?? 0;
 
-  const effectiveReportFilter = reportFilter ?? pageFilter ?? new Filter();
+  const effectiveReportFilter = reportFilter ?? pageFilter ?? new BaseFilter();
 
   const showIsLoading = isLoading && !hasReport;
 

--- a/src/web/pages/reports/AuditReportFilterDialog.tsx
+++ b/src/web/pages/reports/AuditReportFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import ComplianceLevelFilterGroup from 'web/components/powerfilter/ComplianceLevelsGroup';
 import CreateNamedFilterGroup from 'web/components/powerfilter/CreateNamedFilterGroup';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
@@ -22,7 +22,7 @@ import useCapabilities from 'web/hooks/useCapabilities';
 import useTranslation from 'web/hooks/useTranslation';
 
 interface AuditReportFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const AuditReportFilterDialog = ({

--- a/src/web/pages/reports/ReportListPage.tsx
+++ b/src/web/pages/reports/ReportListPage.tsx
@@ -7,10 +7,9 @@ import {useEffect, useState} from 'react';
 import {useDispatch} from 'react-redux';
 import {useNavigate} from 'react-router';
 import {type TaskCommandCreateImportTaskParams} from 'gmp/commands/task';
-import Filter, {
-  type FilterType,
-  REPORTS_FILTER_FILTER,
-} from 'gmp/models/filter';
+import {REPORTS_FILTER_FILTER} from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import type Report from 'gmp/models/report';
 import {isActive} from 'gmp/models/task';
 import {isDefined} from 'gmp/utils/identity';
@@ -54,7 +53,7 @@ interface ToolBarIconsProps {
 
 type ReportListPageProps = WithEntitiesContainerComponentProps<Report>;
 
-const CONTAINER_TASK_FILTER = Filter.fromString('target=""');
+const CONTAINER_TASK_FILTER = BaseFilter.fromString('target=""');
 
 const ToolBarIcons = ({onUploadReportClick}: ToolBarIconsProps) => {
   const [_] = useTranslation();
@@ -157,19 +156,14 @@ const ReportListPage = ({
   const handleReportDeltaSelect = (report: Report) => {
     if (isDefined(selectedDeltaReport)) {
       isDefined(onFilterChanged) &&
-        onFilterChanged(beforeSelectFilter as Filter);
+        onFilterChanged(beforeSelectFilter as FilterType);
       void navigate(`/report/delta/${selectedDeltaReport.id}/${report.id}`, {
         replace: true,
       });
     } else {
-      const newFilter = filter ?? new Filter();
-
+      const newFilter = filter ?? new BaseFilter();
       isDefined(onFilterChanged) &&
-        onFilterChanged(
-          newFilter
-            .set('first', 1) // reset to first page
-            .set('task_id', report?.task?.id),
-        );
+        onFilterChanged(newFilter.first().set('task_id', report?.task?.id));
       setBeforeSelectFilter(newFilter);
       setSelectedDeltaReport(report);
     }
@@ -242,7 +236,7 @@ const reportsReloadInterval = ({entities = []}: {entities: Report[]}) =>
     ? USE_DEFAULT_RELOAD_INTERVAL_ACTIVE
     : USE_DEFAULT_RELOAD_INTERVAL;
 
-const FALLBACK_REPORT_LIST_FILTER = Filter.fromString(
+const FALLBACK_REPORT_LIST_FILTER = BaseFilter.fromString(
   'sort-reverse=date first=1',
 );
 

--- a/src/web/pages/reports/__tests__/AuditReportDetailsPage.test.tsx
+++ b/src/web/pages/reports/__tests__/AuditReportDetailsPage.test.tsx
@@ -9,6 +9,8 @@ import {Route, Routes} from 'react-router';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import {ROWS_PER_PAGE_SETTING_ID} from 'gmp/commands/user';
 import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
 import {getMockAuditReport} from 'web/pages/reports/__fixtures__/MockAuditReport';
@@ -17,7 +19,7 @@ import AuditReportDetailsPage from 'web/pages/reports/AuditReportDetailsPage';
 interface CollectionResponse {
   data: unknown[];
   meta: {
-    filter: Filter;
+    filter: FilterType;
     counts: CollectionCounts;
   };
 }
@@ -30,7 +32,7 @@ const reportId = entity.report?.id ?? '';
 const emptyCollectionResponse: CollectionResponse = {
   data: [],
   meta: {
-    filter: Filter.fromString(''),
+    filter: new BaseFilter(),
     counts: new CollectionCounts(),
   },
 };

--- a/src/web/pages/reports/__tests__/ReportDetailsPage.test.tsx
+++ b/src/web/pages/reports/__tests__/ReportDetailsPage.test.tsx
@@ -8,7 +8,8 @@ import {rendererWith, fireEvent, screen, within, waitFor} from 'web/testing';
 import {Route, Routes} from 'react-router';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import {ROWS_PER_PAGE_SETTING_ID} from 'gmp/commands/user';
-import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
 import {getMockReport} from 'web/pages/reports/__fixtures__/MockReport';
@@ -17,7 +18,7 @@ import ReportDetailsPage from 'web/pages/reports/ReportDetailsPage';
 interface CollectionResponse {
   data: unknown[];
   meta: {
-    filter: Filter;
+    filter: FilterType;
     counts: CollectionCounts;
   };
 }
@@ -30,7 +31,7 @@ const reportId = entity.report?.id ?? '';
 const emptyCollectionResponse: CollectionResponse = {
   data: [],
   meta: {
-    filter: Filter.fromString(''),
+    filter: new BaseFilter(),
     counts: new CollectionCounts(),
   },
 };
@@ -74,7 +75,9 @@ const createGmp = () => ({
     getSetting: createGetSettingMock(),
   },
   filter: {
-    get: testing.fn().mockResolvedValue({data: Filter.fromString('rows=100')}),
+    get: testing
+      .fn()
+      .mockResolvedValue({data: BaseFilter.fromString('rows=100')}),
   },
   filters: {
     get: testing.fn().mockResolvedValue(emptyCollectionResponse),
@@ -103,7 +106,7 @@ const createGmp = () => ({
         },
       ],
       meta: {
-        filter: Filter.fromString(''),
+        filter: new BaseFilter(),
         counts: new CollectionCounts({
           first: 1,
           all: 1,
@@ -118,7 +121,7 @@ const createGmp = () => ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: Filter.fromString(''),
+        filter: new BaseFilter(),
         counts: new CollectionCounts(),
       },
     }),

--- a/src/web/pages/reports/details/EmptyResultsReport.tsx
+++ b/src/web/pages/reports/details/EmptyResultsReport.tsx
@@ -4,7 +4,8 @@
  */
 
 import styled from 'styled-components';
-import Filter, {type FilterType} from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import {isDefined} from 'gmp/utils/identity';
 import {CircleXDeleteIcon, EditIcon, FilterIcon} from 'web/components/icon';
 import Divider from 'web/components/layout/Divider';
@@ -38,7 +39,7 @@ const EmptyResultsReport = ({
   onFilterRemoveClick,
 }: EmptyResultsReportProps) => {
   const [_] = useTranslation();
-  filter = filter ?? new Filter();
+  filter = filter ?? new BaseFilter();
   const levels = filter.get('levels', '') as string | undefined;
   const severity = filter.getTerm('severity');
   const minQod = filter.get('min_qod') as number | undefined;

--- a/src/web/pages/reports/details/application/ApplicationsTab.tsx
+++ b/src/web/pages/reports/details/application/ApplicationsTab.tsx
@@ -5,7 +5,8 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import Filter, {type FilterType} from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import type ReportApp from 'gmp/models/report/app';
 import {isDefined} from 'gmp/utils/identity';
 import ErrorPanel from 'web/components/error/ErrorPanel';
@@ -47,7 +48,7 @@ const ApplicationsTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    return isDefined(filter) ? filter : new Filter();
+    return isDefined(filter) ? filter : new BaseFilter();
   }, [filter]);
 
   const [appsFilter, setAppsFilter] = useState<FilterType>(baseFilter);

--- a/src/web/pages/reports/details/cve/ClosedCvesTab.tsx
+++ b/src/web/pages/reports/details/cve/ClosedCvesTab.tsx
@@ -5,7 +5,8 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import Filter, {type FilterType} from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import {type ReportClosedCve} from 'gmp/models/report/parser';
 import {isDefined} from 'gmp/utils/identity';
 import ErrorPanel from 'web/components/error/ErrorPanel';
@@ -47,7 +48,7 @@ const ClosedCvesTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    return isDefined(filter) ? filter : new Filter();
+    return isDefined(filter) ? filter : new BaseFilter();
   }, [filter]);
 
   const [closedCvesFilter, setClosedCvesFilter] =

--- a/src/web/pages/reports/details/cve/CvesTab.tsx
+++ b/src/web/pages/reports/details/cve/CvesTab.tsx
@@ -5,7 +5,8 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import Filter, {type FilterType} from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import {type ReportActiveCve} from 'gmp/models/report/parser';
 import {isDefined} from 'gmp/utils/identity';
 import ErrorPanel from 'web/components/error/ErrorPanel';
@@ -47,7 +48,7 @@ const CvesTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    return isDefined(filter) ? filter : new Filter();
+    return isDefined(filter) ? filter : new BaseFilter();
   }, [filter]);
 
   const [cvesFilter, setCvesFilter] = useState<FilterType>(baseFilter);

--- a/src/web/pages/reports/details/error/ErrorsTab.tsx
+++ b/src/web/pages/reports/details/error/ErrorsTab.tsx
@@ -4,7 +4,8 @@
  */
 
 import {useEffect, useMemo, useState} from 'react';
-import Filter, {type FilterType} from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import {type ReportError} from 'gmp/models/report/parser';
 import {isDefined} from 'gmp/utils/identity';
 import ErrorPanel from 'web/components/error/ErrorPanel';
@@ -42,7 +43,7 @@ const ErrorsTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    const f = isDefined(filter) ? filter : new Filter();
+    const f = isDefined(filter) ? filter : new BaseFilter();
     // Override sort: 'sort-reverse=error' maps to ascending A→Z via the
     // sortReverse=(sortDir==='asc') convention used in ReportEntitiesContainer
     return f.set('sort-reverse', 'error');

--- a/src/web/pages/reports/details/operating-system/OperatingSystemsTab.tsx
+++ b/src/web/pages/reports/details/operating-system/OperatingSystemsTab.tsx
@@ -5,7 +5,8 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import Filter, {type FilterType} from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import type ReportOperatingSystem from 'gmp/models/report/os';
 import {isDefined} from 'gmp/utils/identity';
 import Loading from 'web/components/loading/Loading';
@@ -57,7 +58,7 @@ const OperatingSystemsTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    return isDefined(filter) ? filter : new Filter();
+    return isDefined(filter) ? filter : new BaseFilter();
   }, [filter]);
 
   const [operatingSystemsFilter, setOperatingSystemsFilter] =

--- a/src/web/pages/reports/details/result/ContainerScanningResultsTab.tsx
+++ b/src/web/pages/reports/details/result/ContainerScanningResultsTab.tsx
@@ -5,7 +5,8 @@
 
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import Filter, {type FilterType} from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import {isActive, type TaskStatus} from 'gmp/models/task';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
@@ -35,8 +36,8 @@ const ContainerScanningResultsTab = ({
 
   const baseFilter = useMemo(() => {
     const filter = reportFilterString
-      ? Filter.fromString(reportFilterString)
-      : new Filter();
+      ? BaseFilter.fromString(reportFilterString)
+      : new BaseFilter();
     return filter.set('_and_report_id', reportId);
   }, [reportFilterString, reportId]);
 

--- a/src/web/pages/reports/details/result/ResultsTab.tsx
+++ b/src/web/pages/reports/details/result/ResultsTab.tsx
@@ -5,7 +5,8 @@
 
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import Filter, {type FilterType} from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import {isActive, type TaskStatus} from 'gmp/models/task';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
@@ -63,8 +64,8 @@ const ResultsTabWrapper = ({
   // Create filter with report ID
   const baseFilter = useMemo(() => {
     const filter = reportFilterString
-      ? Filter.fromString(reportFilterString)
-      : new Filter();
+      ? BaseFilter.fromString(reportFilterString)
+      : new BaseFilter();
     return filter.set('_and_report_id', reportId);
   }, [reportFilterString, reportId]);
 

--- a/src/web/pages/reports/details/result/WebApplicationScanningResultsTab.tsx
+++ b/src/web/pages/reports/details/result/WebApplicationScanningResultsTab.tsx
@@ -5,7 +5,8 @@
 
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import Filter, {type FilterType} from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import {isActive, type TaskStatus} from 'gmp/models/task';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
@@ -35,8 +36,8 @@ const WebApplicationScanningResultsTab = ({
 
   const baseFilter = useMemo(() => {
     const filter = reportFilterString
-      ? Filter.fromString(reportFilterString)
-      : new Filter();
+      ? BaseFilter.fromString(reportFilterString)
+      : new BaseFilter();
     return filter.set('_and_report_id', reportId);
   }, [reportFilterString, reportId]);
 

--- a/src/web/pages/scanners/ScannerComponent.tsx
+++ b/src/web/pages/scanners/ScannerComponent.tsx
@@ -13,7 +13,7 @@ import {
   type CredentialType,
   CERTIFICATE_CREDENTIAL_TYPE,
 } from 'gmp/models/credential';
-import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
 import {
   type default as Scanner,
@@ -84,7 +84,7 @@ const createCaCertificateFile = (name: string, certificate: string) =>
   new File([certificate], name, {type: MIME_TYPE_PEM});
 
 const createCredentialsFilter = (types: CredentialType[]) => {
-  return new Filter({
+  return new BaseFilter({
     terms: types.map(
       credentialType =>
         new FilterTerm({

--- a/src/web/pages/scanners/__tests__/ScannerComponent.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerComponent.test.tsx
@@ -5,7 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, fireEvent, rendererWith, wait} from 'web/testing';
-import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import Scanner, {
   GREENBONE_SENSOR_SCANNER_TYPE,
   OPENVASD_SCANNER_TYPE,
@@ -209,7 +209,7 @@ describe('ScannerComponent tests', () => {
     fireEvent.click(button);
     expect(gmp.scanner.get).toHaveBeenCalledWith({id: '1234'});
     expect(gmp.credentials.getAll).toHaveBeenCalledWith({
-      filter: Filter.fromString('type=cc'),
+      filter: BaseFilter.fromString('type=cc'),
     });
 
     await wait();

--- a/src/web/pages/scanners/__tests__/ScannerFilterDialog.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerFilterDialog.test.tsx
@@ -14,6 +14,7 @@ import {
 } from 'web/testing';
 import Features from 'gmp/capabilities/features';
 import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
 import {OPENVASD_SCANNER_TYPE, scannerTypeName} from 'gmp/models/scanner';
 import ScannerFilterDialog from 'web/pages/scanners/ScannerFilterDialog';
@@ -55,7 +56,7 @@ describe('ScannerFilterDialog tests', () => {
   });
 
   test('should allow to create a new filter', async () => {
-    const filter = new Filter({
+    const filter = new BaseFilter({
       terms: [new FilterTerm({keyword: 'name', value: 'test'})],
     });
     const newFilter = new Filter({id: 'new-filter'});
@@ -105,11 +106,11 @@ describe('ScannerFilterDialog tests', () => {
   });
 
   test('should not render create named filter group if not allowed', () => {
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const gmp = {
       settings: {enableGreenboneSensor: true},
       filter: {
-        create: testing.fn().mockResolvedValue(new Filter()),
+        create: testing.fn().mockResolvedValue(new Filter({id: 'new-filter'})),
       },
     };
     const handleClose = testing.fn();

--- a/src/web/pages/tags/TagFilterDialog.tsx
+++ b/src/web/pages/tags/TagFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import DefaultFilterDialog from 'web/components/powerfilter/DefaultFilterDialog';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
 import useFilterDialog from 'web/components/powerfilter/useFilterDialog';
@@ -14,7 +14,7 @@ import useFilterDialogSave, {
 import useTranslation from 'web/hooks/useTranslation';
 
 interface TagFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const TagFilterDialog = ({

--- a/src/web/pages/tags/__tests__/TagFilterDialog.test.tsx
+++ b/src/web/pages/tags/__tests__/TagFilterDialog.test.tsx
@@ -5,12 +5,12 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {changeInputValue, fireEvent, rendererWith, screen} from 'web/testing';
-import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import TagFilterDialog from 'web/pages/tags/TagFilterDialog';
 
 describe('TagFilterDialog tests', () => {
   test('should render dialog', () => {
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const gmp = {filter: {}};
     const {render} = rendererWith({capabilities: true, gmp});
 
@@ -37,7 +37,7 @@ describe('TagFilterDialog tests', () => {
   test('should call onFilterChanged on save', () => {
     const handleClose = testing.fn();
     const handleFilterChanged = testing.fn();
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const gmp = {filter: {}};
     const {render} = rendererWith({capabilities: true, gmp});
 
@@ -54,7 +54,7 @@ describe('TagFilterDialog tests', () => {
     fireEvent.click(screen.getDialogSaveButton());
 
     expect(handleFilterChanged).toHaveBeenCalledWith(
-      Filter.fromString('foo=bar'),
+      BaseFilter.fromString('foo=bar'),
     );
   });
 });

--- a/src/web/pages/tasks/__tests__/TaskFilterDialog.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskFilterDialog.test.tsx
@@ -13,6 +13,7 @@ import {
 } from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
 import TaskFilterDialog from 'web/pages/tasks/TaskFilterDialog';
 
@@ -24,7 +25,7 @@ describe('TaskFilterDialog tests', () => {
     const gmp = {
       filter: {},
     };
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const {render} = rendererWith({capabilities: true, gmp});
 
     render(
@@ -92,10 +93,10 @@ describe('TaskFilterDialog tests', () => {
     const handleClose = testing.fn();
     const handleFilterChanged = testing.fn();
     const handleFilterCreated = testing.fn();
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const gmp = {
       filter: {
-        create: testing.fn().mockResolvedValue(new Filter()),
+        create: testing.fn().mockResolvedValue(new Filter({id: 'new-filter'})),
       },
     };
     const {render} = rendererWith({capabilities: new Capabilities(), gmp});

--- a/src/web/pages/users/__tests__/UsersListsPage.test.tsx
+++ b/src/web/pages/users/__tests__/UsersListsPage.test.tsx
@@ -14,7 +14,7 @@ import {
 } from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import User from 'gmp/models/user';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -55,15 +55,15 @@ const createGmp = ({
   getUserResponse = {data: user},
   getUsersResponse = {
     data: [user],
-    meta: {filter: new Filter(), counts: new CollectionCounts()},
+    meta: {filter: new BaseFilter(), counts: new CollectionCounts()},
   },
   getAllUsersResponse = {
     data: [user],
-    meta: {filter: new Filter(), counts: new CollectionCounts()},
+    meta: {filter: new BaseFilter(), counts: new CollectionCounts()},
   },
   getFiltersResponse = {
     data: [],
-    meta: {filter: new Filter(), counts: new CollectionCounts()},
+    meta: {filter: new BaseFilter(), counts: new CollectionCounts()},
   },
   cloneUser = testing.fn().mockResolvedValue(cloneUserResponse),
   deleteUser = testing.fn().mockResolvedValue(deleteUserResponse),
@@ -116,7 +116,7 @@ const createGmp = ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: Filter.fromString(),
+        filter: new BaseFilter(),
         counts: new CollectionCounts(),
       },
     }),
@@ -135,7 +135,7 @@ describe('UsersListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = Filter.fromString('foo=bar');
+    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('user', defaultSettingFilter),
@@ -207,7 +207,7 @@ describe('UsersListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = Filter.fromString('foo=bar');
+    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('user', defaultSettingFilter),
@@ -238,7 +238,7 @@ describe('UsersListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = Filter.fromString('foo=bar');
+    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('user', defaultSettingFilter),
@@ -282,7 +282,7 @@ describe('UsersListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = Filter.fromString('foo=bar');
+    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('user', defaultSettingFilter),
@@ -323,7 +323,7 @@ describe('UsersListPage tests', () => {
     const gmp = createGmp({
       getUsersResponse: {
         data: [user],
-        meta: {filter: new Filter(), counts},
+        meta: {filter: new BaseFilter(), counts},
       },
     });
 
@@ -334,7 +334,7 @@ describe('UsersListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = Filter.fromString('foo=bar');
+    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '10'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('user', defaultSettingFilter),
@@ -362,14 +362,14 @@ describe('UsersListPage tests', () => {
 
     const getUsers = testing.fn().mockResolvedValue({
       data: [user],
-      meta: {filter: Filter.fromString('first=1 rows=10'), counts},
+      meta: {filter: BaseFilter.fromString('first=1 rows=10'), counts},
     });
 
     const gmp = createGmp({
       getUsers,
       getUsersResponse: {
         data: [user],
-        meta: {filter: Filter.fromString('first=1 rows=10'), counts},
+        meta: {filter: BaseFilter.fromString('first=1 rows=10'), counts},
       },
     });
 
@@ -380,7 +380,7 @@ describe('UsersListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = Filter.fromString('first=1 rows=10');
+    const defaultSettingFilter = BaseFilter.fromString('first=1 rows=10');
     store.dispatch(loadingActions.success({rowsperpage: {value: '10'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('user', defaultSettingFilter),

--- a/src/web/pages/web-application-targets/WebApplicationTargetFilterDialog.tsx
+++ b/src/web/pages/web-application-targets/WebApplicationTargetFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import type FilterType from 'gmp/models/filter/filter-type';
 import DefaultFilterDialog from 'web/components/powerfilter/DefaultFilterDialog';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
 import useFilterDialog from 'web/components/powerfilter/useFilterDialog';
@@ -14,7 +14,7 @@ import useFilterDialogSave, {
 import useTranslation from 'web/hooks/useTranslation';
 
 interface WebApplicationTargetFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const WebApplicationTargetFilterDialog = ({

--- a/src/web/pages/web-application-targets/__tests__/WebApplicationTargetFilterDialog.test.tsx
+++ b/src/web/pages/web-application-targets/__tests__/WebApplicationTargetFilterDialog.test.tsx
@@ -12,11 +12,12 @@ import {
   wait,
 } from 'web/testing';
 import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import WebApplicationTargetFilterDialog from 'web/pages/web-application-targets/WebApplicationTargetFilterDialog';
 
 describe('WebApplicationTargetFilterDialog tests', () => {
   test('should render dialog with default fields', () => {
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const gmp = {filter: {}};
     const {render} = rendererWith({capabilities: true, gmp});
     render(<WebApplicationTargetFilterDialog filter={filter} />);
@@ -36,7 +37,7 @@ describe('WebApplicationTargetFilterDialog tests', () => {
   });
 
   test('should call onFilterChanged when filter is updated', () => {
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const handleFilterChanged = testing.fn();
     const gmp = {filter: {}};
     const {render} = rendererWith({capabilities: true, gmp});
@@ -51,12 +52,12 @@ describe('WebApplicationTargetFilterDialog tests', () => {
     const saveButton = screen.getDialogSaveButton();
     fireEvent.click(saveButton);
     expect(handleFilterChanged).toHaveBeenCalledWith(
-      Filter.fromString('foo=bar'),
+      BaseFilter.fromString('foo=bar'),
     );
   });
 
   test('should call onFilterCreated when a new filter is saved', async () => {
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const newFilter = new Filter({
       id: 'new-filter-id',
       name: 'New Filter',

--- a/src/web/store/entities/utils/__tests__/actions.test.js
+++ b/src/web/store/entities/utils/__tests__/actions.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect, testing} from '@gsa/testing';
-import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import {isFunction} from 'gmp/utils/identity';
 import {
   types,
@@ -40,7 +40,7 @@ describe('entities loading actions tests', () => {
     });
 
     test('should create a load request action with filter', () => {
-      const filter = Filter.fromString('type=abc');
+      const filter = BaseFilter.fromString('type=abc');
       const actions = createEntitiesLoadingActions('foo');
       const action = actions.request(filter);
 
@@ -63,7 +63,7 @@ describe('entities loading actions tests', () => {
     });
 
     test('should create a load success action with filter', () => {
-      const filter = Filter.fromString('type=abc');
+      const filter = BaseFilter.fromString('type=abc');
       const actions = createEntitiesLoadingActions('foo');
       const action = actions.success(['foo', 'bar'], filter);
 
@@ -76,8 +76,8 @@ describe('entities loading actions tests', () => {
     });
 
     test('should create a load success action with meta info', () => {
-      const filter = Filter.fromString('type=abc');
-      const loadedFilter = Filter.fromString('type=abc rows=100');
+      const filter = BaseFilter.fromString('type=abc');
+      const loadedFilter = BaseFilter.fromString('type=abc rows=100');
       const actions = createEntitiesLoadingActions('foo');
       const counts = {first: 1};
       const action = actions.success(
@@ -109,7 +109,7 @@ describe('entities loading actions tests', () => {
     });
 
     test('should create a load error action with filter', () => {
-      const filter = Filter.fromString('type=abc');
+      const filter = BaseFilter.fromString('type=abc');
       const actions = createEntitiesLoadingActions('foo');
       const action = actions.error('An error', filter);
 
@@ -216,7 +216,7 @@ describe('entities loading actions tests', () => {
 
       const getState = testing.fn().mockReturnValue({foo: 'bar'});
 
-      const loadedFilter = Filter.fromString('name=abc');
+      const loadedFilter = BaseFilter.fromString('name=abc');
       const counts = {first: 1};
       const dispatch = testing.fn();
       const get = testing.fn().mockReturnValue(
@@ -245,12 +245,9 @@ describe('entities loading actions tests', () => {
         entityType: 'foo',
       });
 
-      const filter = Filter.fromString('type=teip');
+      const filter = BaseFilter.fromString('type=teip');
 
-      const myFilterAll = new Filter({
-        entityType: 'filter',
-        filter_type: undefined,
-        id: undefined,
+      const myFilterAll = new BaseFilter({
         terms: [
           {
             keyword: 'type',
@@ -319,11 +316,9 @@ describe('entities loading actions tests', () => {
         entityType: 'foo',
       });
 
-      const filter = Filter.fromString('type=teip');
+      const filter = BaseFilter.fromString('type=teip');
 
-      const myFilterAll = new Filter({
-        filter_type: undefined,
-        id: undefined,
+      const myFilterAll = new BaseFilter({
         terms: [
           {
             keyword: 'type',
@@ -407,7 +402,7 @@ describe('entities loading actions tests', () => {
 
       const getState = testing.fn().mockReturnValue({foo: 'bar'});
 
-      const loadedFilter = Filter.fromString('name=abc');
+      const loadedFilter = BaseFilter.fromString('name=abc');
       const counts = {first: 1};
       const dispatch = testing.fn();
       const get = testing.fn().mockReturnValue(

--- a/src/web/store/entities/utils/__tests__/selectors.test.js
+++ b/src/web/store/entities/utils/__tests__/selectors.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import {createSelector} from 'web/store/entities/utils/selectors';
 import {createRootState, createState} from 'web/store/entities/utils/testing';
 import {filterIdentifier} from 'web/store/utils';
@@ -21,7 +21,7 @@ describe('EntitiesSelector isLoadingEntities tests', () => {
   test('should be false for undefined state with filter', () => {
     const selector = createSelector('foo');
     const rootState = createRootState({});
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
     const fooSelector = selector(rootState);
 
     expect(fooSelector.isLoadingEntities(filter)).toEqual(false);
@@ -39,7 +39,7 @@ describe('EntitiesSelector isLoadingEntities tests', () => {
     const selector = createSelector('foo');
     const rootState = createState('foo', {});
     const fooSelector = selector(rootState);
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
 
     expect(fooSelector.isLoadingEntities(filter)).toEqual(false);
   });
@@ -58,7 +58,7 @@ describe('EntitiesSelector isLoadingEntities tests', () => {
   });
 
   test('should be true for filter', () => {
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       isLoading: {
@@ -80,7 +80,7 @@ describe('EntitiesSelector isLoadingEntities tests', () => {
       },
     });
     const fooSelector = selector(rootState);
-    const filter = Filter.fromString('name=bar');
+    const filter = BaseFilter.fromString('name=bar');
 
     expect(fooSelector.isLoadingEntities(filter)).toEqual(false);
   });
@@ -169,7 +169,7 @@ describe('EntitiesSelector getEntities tests', () => {
     const selector = createSelector('foo');
     const rootState = createRootState({});
     const fooSelector = selector(rootState);
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
 
     expect(fooSelector.getEntities(filter)).toBeUndefined();
   });
@@ -186,7 +186,7 @@ describe('EntitiesSelector getEntities tests', () => {
     const selector = createSelector('foo');
     const rootState = createState('foo', {});
     const fooSelector = selector(rootState);
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
 
     expect(fooSelector.getEntities(filter)).toBeUndefined();
   });
@@ -231,7 +231,7 @@ describe('EntitiesSelector getEntities tests', () => {
   });
 
   test('getEntities should return entities with filter', () => {
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       byId: {
@@ -280,7 +280,7 @@ describe('EntitiesSelector getEntities tests', () => {
       'name=foo': ['lorem', 'ipsum'],
     });
     const fooSelector = selector(rootState);
-    const filter = Filter.fromString('name=bar');
+    const filter = BaseFilter.fromString('name=bar');
 
     expect(fooSelector.getEntities(filter)).toBeUndefined();
   });
@@ -288,7 +288,7 @@ describe('EntitiesSelector getEntities tests', () => {
 
 describe('EntitiesSelector getAllEntities tests', () => {
   test('getAllEntities should return entities with all-filter', () => {
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       byId: {
@@ -323,7 +323,7 @@ describe('EntitiesSelector getAllEntities tests', () => {
   });
 
   test('getAllEntities should return entities with all-filter if filter is undefined', () => {
-    const filter = new Filter();
+    const filter = new BaseFilter();
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       byId: {
@@ -371,7 +371,7 @@ describe('EntitiesSelector getEntitiesError tests', () => {
     const selector = createSelector('foo');
     const rootState = createRootState({});
     const fooSelector = selector(rootState);
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
 
     expect(fooSelector.getEntitiesError(filter)).toBeUndefined();
   });
@@ -388,13 +388,13 @@ describe('EntitiesSelector getEntitiesError tests', () => {
     const selector = createSelector('foo');
     const rootState = createState('foo', {});
     const fooSelector = selector(rootState);
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
 
     expect(fooSelector.getEntitiesError(filter)).toBeUndefined();
   });
 
   test('should return error with default filter', () => {
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       errors: {
@@ -408,7 +408,7 @@ describe('EntitiesSelector getEntitiesError tests', () => {
   });
 
   test('should return error with filter', () => {
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       errors: {
@@ -432,7 +432,7 @@ describe('EntitiesSelector getEntitiesError tests', () => {
   });
 
   test('should return undefined for unknown filter', () => {
-    const otherFilter = Filter.fromString('name=foo');
+    const otherFilter = BaseFilter.fromString('name=foo');
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       errors: {
@@ -440,7 +440,7 @@ describe('EntitiesSelector getEntitiesError tests', () => {
         [filterIdentifier(otherFilter)]: 'Another error',
       },
     });
-    const filter = Filter.fromString('name=bar');
+    const filter = BaseFilter.fromString('name=bar');
     const fooSelector = selector(rootState);
 
     expect(fooSelector.getEntitiesError(filter)).toBeUndefined();
@@ -460,7 +460,7 @@ describe('EntitiesSelector getEntitiesCounts tests', () => {
     const selector = createSelector('foo');
     const rootState = createRootState({});
     const fooSelector = selector(rootState);
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
 
     expect(fooSelector.getEntitiesCounts(filter)).toBeUndefined();
   });
@@ -477,7 +477,7 @@ describe('EntitiesSelector getEntitiesCounts tests', () => {
     const selector = createSelector('foo');
     const rootState = createState('foo', {});
     const fooSelector = selector(rootState);
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
 
     expect(fooSelector.getEntitiesCounts(filter)).toBeUndefined();
   });
@@ -502,7 +502,7 @@ describe('EntitiesSelector getEntitiesCounts tests', () => {
     const counts = {
       first: 1,
     };
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
     const filterId = filterIdentifier(filter);
     const rootState = createState('foo', {
       [filterId]: {
@@ -528,7 +528,7 @@ describe('EntitiesSelector getLoadedFilter tests', () => {
     const selector = createSelector('foo');
     const rootState = createRootState({});
     const fooSelector = selector(rootState);
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
 
     expect(fooSelector.getLoadedFilter(filter)).toBeUndefined();
   });
@@ -545,14 +545,14 @@ describe('EntitiesSelector getLoadedFilter tests', () => {
     const selector = createSelector('foo');
     const rootState = createState('foo', {});
     const fooSelector = selector(rootState);
-    const filter = Filter.fromString('name=foo');
+    const filter = BaseFilter.fromString('name=foo');
 
     expect(fooSelector.getLoadedFilter(filter)).toBeUndefined();
   });
 
   test('should return loaded filter', () => {
     const selector = createSelector('foo');
-    const loadedFilter = Filter.fromString('foo=bar');
+    const loadedFilter = BaseFilter.fromString('foo=bar');
     const rootState = createState('foo', {
       default: {
         loadedFilter,
@@ -565,8 +565,8 @@ describe('EntitiesSelector getLoadedFilter tests', () => {
 
   test('should return loadedFilter with filter', () => {
     const selector = createSelector('foo');
-    const loadedFilter = Filter.fromString('foo=bar');
-    const filter = Filter.fromString('name=foo');
+    const loadedFilter = BaseFilter.fromString('foo=bar');
+    const filter = BaseFilter.fromString('name=foo');
     const filterId = filterIdentifier(filter);
     const rootState = createState('foo', {
       [filterId]: {


### PR DESCRIPTION
## What

Strip Filter model class into a model class and remove the additional parsing into another class.

## Why

All model classes should require an ID in future. In reality the ID is always present if a model is created from an XML element.

Currently, this is being prevented by the extra parsing stuff `fromString`, `fromTerm` and `fromResponeElement` which don't provide an ID. Therefore these methods were moved into the new `BaseFilter` class and the `Filter` model class only forwards the calls to this new class for backwards compatibility. In future these methods should be removed from `Filter` completely.

## References

https://jira.greenbone.net/browse/GEA-1933

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


