### PR TITLE
Remove Filter.fromResponseElement method

### DIFF
--- a/src/gmp/commands/__tests__/entities.test.ts
+++ b/src/gmp/commands/__tests__/entities.test.ts
@@ -8,6 +8,7 @@ import EntitiesCommand from 'gmp/commands/entities';
 import {createEntitiesResponse, createHttp} from 'gmp/commands/testing';
 import type Http from 'gmp/http/http';
 import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import Model, {type Element} from 'gmp/models/model';
 
 class Foo extends Model {}
@@ -63,7 +64,7 @@ describe('EntitiesCommand tests', () => {
   });
 
   test('should prefer filter_id over filter parameter', async () => {
-    const filter = Filter.fromResponseElement({
+    const filter = BaseFilter.fromResponseElement({
       _id: 'bar',
       keywords: {
         keyword: {relation: '=', value: 'bar', column: 'foo'},

--- a/src/gmp/commands/__tests__/entity.test.ts
+++ b/src/gmp/commands/__tests__/entity.test.ts
@@ -20,6 +20,7 @@ import {
   type EntityModelProperties,
 } from 'gmp/models/entity-model';
 import Filter from 'gmp/models/filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import Model from 'gmp/models/model';
 
 type FooElement = EntityModelElement;
@@ -112,7 +113,7 @@ describe('EntityCommand tests', () => {
   });
 
   test('should get entity and prefer filter_id over filter parameter', async () => {
-    const filter = Filter.fromResponseElement({
+    const filter = BaseFilter.fromResponseElement({
       _id: 'bar',
       keywords: {
         keyword: {relation: '=', value: 'bar', column: 'foo'},

--- a/src/gmp/models/__tests__/filter.test.ts
+++ b/src/gmp/models/__tests__/filter.test.ts
@@ -1220,49 +1220,17 @@ describe('Filter tests', () => {
       );
     });
 
-    test('should do the same for filters from arrays', () => {
-      const element = {
-        keywords: {
-          keyword: [
-            {
-              column: '',
-              relation: '~',
-              value: 'abc',
-            },
-            {
-              column: '',
-              relation: '~',
-              value: 'and',
-            },
-            {
-              column: '',
-              relation: '~',
-              value: 'not',
-            },
-            {
-              column: '',
-              relation: '~',
-              value: 'def',
-            },
-            {
-              column: 'ROWS',
-              relation: '=',
-              value: '10',
-            },
-            {
-              column: 'fiRsT',
-              relation: '=',
-              value: '1',
-            },
-            {
-              column: 'sORt',
-              relation: '=',
-              value: 'name',
-            },
-          ],
-        },
-      };
-      const filter = Filter.fromResponseElement(element);
+    test('should lower the case of keywords for filters from terms', () => {
+      const terms = [
+        new FilterTerm({value: 'abc', relation: '~'}),
+        new FilterTerm({value: 'and', relation: ''}),
+        new FilterTerm({value: 'not', relation: ''}),
+        new FilterTerm({value: 'def', relation: '~'}),
+        new FilterTerm({keyword: 'ROWS', relation: '=', value: '10'}),
+        new FilterTerm({keyword: 'fiRsT', relation: '=', value: '1'}),
+        new FilterTerm({keyword: 'sORt', relation: '=', value: 'name'}),
+      ];
+      const filter = new Filter({id: 'foo', terms});
       expect(filter.toFilterString()).toEqual(
         '~abc and not ~def rows=10 first=1 sort=name',
       );

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -4,9 +4,7 @@
  */
 
 import EntityModel, {parseEntityModelProperties} from 'gmp/models/entity-model';
-import BaseFilter, {
-  type FilterResponseElement,
-} from 'gmp/models/filter/base-filter';
+import BaseFilter from 'gmp/models/filter/base-filter';
 import {
   type default as FilterTerm,
   parseFilterTermsFromString,
@@ -153,19 +151,6 @@ class Filter extends EntityModel implements FilterType {
     }
 
     return new Filter(ret);
-  }
-
-  /**
-   * Create a new Filter from the passed response element.
-   *
-   * @deprecated Use `BaseFilter.fromResponseElement` instead.
-   *
-   * @param element Response element to parse properties from.
-   *
-   * @returns A new Filter model instance.
-   */
-  static fromResponseElement(element: FilterResponseElement = {}) {
-    return BaseFilter.fromResponseElement(element);
   }
 
   /**


### PR DESCRIPTION


## What

Remove Filter.fromResponseElement method

## Why

The method got replaced by BaseFilter.fromResponseElement.

## References

https://jira.greenbone.net/browse/GEA-1933


