### PR TITLE
fix: Operating system show unknown when there are no details instead of empty cell

### DIFF
--- a/src/web/pages/reports/details/__tests__/OperatingSystemsTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/OperatingSystemsTab.test.tsx
@@ -45,6 +45,65 @@ const createOperatingSystemsData = apiEntities => ({
 });
 
 describe('Report Operating Systems Tab tests', () => {
+  const cases = [
+    {
+      name: 'normal os',
+      entities: [
+        ReportOperatingSystem.fromElement({
+          best_os_cpe: 'cpe:/foo/bar',
+          best_os_txt: 'Foo OS',
+          hosts_count: 2,
+        }),
+      ],
+      expected: {
+        displayName: 'Foo OS',
+        cpe: 'cpe:/foo/bar',
+        img: '/img/os_not_available.svg',
+      },
+    },
+    {
+      name: 'unknown os',
+      entities: [
+        ReportOperatingSystem.fromElement({
+          best_os_cpe: '',
+          best_os_txt: '',
+          hosts_count: 1,
+        }),
+      ],
+      expected: {
+        displayName: 'Unknown',
+        cpe: 'Unknown',
+        img: '/img/os_unknown.svg',
+      },
+    },
+  ];
+
+  test.each(cases)('renders $name correctly', async ({entities, expected}) => {
+    const operatingSystemsData = createOperatingSystemsData(entities);
+    const {render} = rendererWith({gmp: {}});
+
+    render(
+      <OperatingSystemsTab
+        filter={filter}
+        operatingSystemsData={operatingSystemsData}
+        reportId="test-report"
+      />,
+    );
+
+    // Wait for table to render and then inspect cells
+    const table = await screen.findByRole('table');
+    const rows = within(table).getAllByRole('row');
+
+    const rowImage = within(rows[1]).getByAltText('');
+    expect(rowImage).toHaveAttribute('src', expected.img);
+
+    const cells = within(rows[1]).getAllByRole('cell');
+    // name cell
+    expect(cells[0]).toHaveTextContent(expected.displayName);
+    // cpe cell
+    expect(cells[1]).toHaveTextContent(expected.cpe);
+  });
+
   test('should render Report Operating Systems Tab', async () => {
     const apiEntities = buildApiEntities();
     const operatingSystemsData = createOperatingSystemsData(apiEntities);
@@ -141,6 +200,9 @@ describe('Report Operating Systems Tab tests', () => {
 
     const row1Image = within(rows[1]).getByAltText('');
     expect(row1Image).toHaveAttribute('src', '/img/os_unknown.svg');
+    // verify the CPE column shows 'Unknown'
+    const cells = within(rows[1]).getAllByRole('cell');
+    expect(cells[1]).toHaveTextContent('Unknown');
   });
 });
 

--- a/src/web/pages/reports/details/operating-system/OperatingSystemsTable.tsx
+++ b/src/web/pages/reports/details/operating-system/OperatingSystemsTable.tsx
@@ -29,20 +29,23 @@ const getColumns = (audit = false) => [
     key: 'name',
     title: _('Operating System'),
     sortBy: 'name',
-    render: (entity: ReportOperatingSystem) => (
-      <span>
-        <Link
-          filter={`name=${entity.cpe}`}
-          textOnly={!entity.cpe}
-          to="operatingsystems"
-        >
-          <IconDivider>
-            <OsIcon osCpe={entity.cpe} osTxt={entity.name} />
-            <span>{entity.name}</span>
-          </IconDivider>
-        </Link>
-      </span>
-    ),
+    render: (entity: ReportOperatingSystem) => {
+      const displayName = entity.name || entity.cpe || _('Unknown');
+      return (
+        <span>
+          <Link
+            filter={`name=${entity.cpe}`}
+            textOnly={!entity.cpe}
+            to="operatingsystems"
+          >
+            <IconDivider>
+              <OsIcon osCpe={entity.cpe} osTxt={entity.name} />
+              <span>{displayName}</span>
+            </IconDivider>
+          </Link>
+        </span>
+      );
+    },
     align: 'center',
   },
   {
@@ -51,13 +54,17 @@ const getColumns = (audit = false) => [
     sortBy: 'cpe',
     render: (entity: ReportOperatingSystem) => (
       <span>
-        <Link
-          filter={`name=${entity.cpe}`}
-          textOnly={!entity.cpe}
-          to="operatingsystems"
-        >
-          {entity.cpe}
-        </Link>
+        {entity.cpe ? (
+          <Link
+            filter={`name=${entity.cpe}`}
+            textOnly={!entity.cpe}
+            to="operatingsystems"
+          >
+            {entity.cpe}
+          </Link>
+        ) : (
+          <i aria-hidden="true">{_('Unknown')}</i>
+        )}
       </span>
     ),
     align: 'center',


### PR DESCRIPTION
## What

- In the report> details>  operating system tab, when no data is received, we display `unknown`, instead of empty cell.

## Why



## References

GEA-1880

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


