### PR TITLE
Require Model ID

### DIFF
--- a/src/gmp/commands/__tests__/entity.test.ts
+++ b/src/gmp/commands/__tests__/entity.test.ts
@@ -15,20 +15,17 @@ import {
 import type Http from 'gmp/http/http';
 import Response from 'gmp/http/response';
 import {type XmlResponseData} from 'gmp/http/transform/fast-xml';
-import {
-  type EntityModelElement,
-  type EntityModelProperties,
-} from 'gmp/models/entity-model';
+import {type EntityModelElement} from 'gmp/models/entity-model';
 import Filter from 'gmp/models/filter';
 import BaseFilter from 'gmp/models/filter/base-filter';
 import Model from 'gmp/models/model';
 
 type FooElement = EntityModelElement;
-type FooProperties = EntityModelProperties;
 
 class Foo extends Model {
   static fromElement(element: FooElement): Foo {
-    return new Foo(element as FooProperties);
+    const ret = super.fromElement(element);
+    return new Foo(ret);
   }
 }
 

--- a/src/gmp/commands/alert.ts
+++ b/src/gmp/commands/alert.ts
@@ -305,6 +305,7 @@ class AlertCommand extends EntityCommand<Alert> {
     })) as Response<EditAlertElement>;
     const {edit_alert} = response.data;
     const editAlert: EditAlertSettings = {
+      // @ts-expect-error
       alert: Alert.fromElement(edit_alert?.get_alerts_response?.alert),
       report_formats: map(
         edit_alert?.get_report_formats_response?.report_format,

--- a/src/gmp/models/__tests__/agent-group.test.ts
+++ b/src/gmp/models/__tests__/agent-group.test.ts
@@ -7,13 +7,13 @@ import {describe, test, expect} from '@gsa/testing';
 import AgentGroup from 'gmp/models/agent-group';
 import {testModel} from 'gmp/models/testing';
 
-testModel(AgentGroup, 'agentgroup');
-
 describe('AgentGroup model tests', () => {
-  test('should use defaults', () => {
-    const agentGroup = new AgentGroup();
+  testModel(AgentGroup, 'agentgroup');
 
-    expect(agentGroup.id).toBeUndefined();
+  test('should use defaults', () => {
+    const agentGroup = new AgentGroup({id: '123'});
+
+    expect(agentGroup.id).toEqual('123');
     expect(agentGroup.name).toBeUndefined();
     expect(agentGroup.comment).toBeUndefined();
     expect(agentGroup.scanner).toBeUndefined();
@@ -22,6 +22,7 @@ describe('AgentGroup model tests', () => {
 
   test('should parse agents', () => {
     const agentGroup = AgentGroup.fromElement({
+      _id: '123',
       agents: {
         agent: [
           {
@@ -50,6 +51,7 @@ describe('AgentGroup model tests', () => {
 
   test('should parse single agent', () => {
     const agentGroup = AgentGroup.fromElement({
+      _id: '123',
       agents: {
         agent: {
           _id: '6b9ac61f-ffff-0000-1111-223344556677',
@@ -68,6 +70,7 @@ describe('AgentGroup model tests', () => {
 
   test('should handle empty agents element', () => {
     const agentGroup = AgentGroup.fromElement({
+      _id: '123',
       agents: {},
     });
 
@@ -75,13 +78,14 @@ describe('AgentGroup model tests', () => {
   });
 
   test('should handle missing agents element', () => {
-    const agentGroup = AgentGroup.fromElement();
+    const agentGroup = AgentGroup.fromElement({_id: '123'});
 
     expect(agentGroup.agents).toEqual([]);
   });
 
   test('should parse scanner', () => {
     const agentGroup = AgentGroup.fromElement({
+      _id: '123',
       scanner: {
         _id: '3b4be213-281f-49ee-b457-5a5f34f71510',
         name: 'Agent Controller',
@@ -97,6 +101,7 @@ describe('AgentGroup model tests', () => {
 
   test('should parse scheduler cron time', () => {
     const agentGroup = AgentGroup.fromElement({
+      _id: '123',
       scheduler_cron_time: '0 0 * * *',
     });
 

--- a/src/gmp/models/__tests__/agent-installer.test.ts
+++ b/src/gmp/models/__tests__/agent-installer.test.ts
@@ -11,9 +11,9 @@ describe('AgentInstaller model tests', () => {
   testModel(AgentInstaller, 'agentinstaller');
 
   test('should use defaults', () => {
-    const agentInstaller = new AgentInstaller();
+    const agentInstaller = new AgentInstaller({id: '123'});
 
-    expect(agentInstaller.id).toBeUndefined();
+    expect(agentInstaller.id).toEqual('123');
     expect(agentInstaller.name).toBeUndefined();
     expect(agentInstaller.comment).toBeUndefined();
     expect(agentInstaller.description).toBeUndefined();
@@ -26,6 +26,7 @@ describe('AgentInstaller model tests', () => {
 
   test('should parse contentType', () => {
     const agentInstaller = AgentInstaller.fromElement({
+      _id: '123',
       content_type: 'application/octet-stream',
     });
 
@@ -34,6 +35,7 @@ describe('AgentInstaller model tests', () => {
 
   test('should parse description', () => {
     const agentInstaller = AgentInstaller.fromElement({
+      _id: '123',
       description: 'This is a test agent installer.',
     });
 
@@ -42,6 +44,7 @@ describe('AgentInstaller model tests', () => {
 
   test('should parse fileExtension', () => {
     const agentInstaller = AgentInstaller.fromElement({
+      _id: '123',
       file_extension: '.exe',
     });
 
@@ -50,6 +53,7 @@ describe('AgentInstaller model tests', () => {
 
   test('should parse version', () => {
     const agentInstaller = AgentInstaller.fromElement({
+      _id: '123',
       version: '1.0.0',
     });
 
@@ -58,6 +62,7 @@ describe('AgentInstaller model tests', () => {
 
   test('should parse checksum', () => {
     const agentInstaller = AgentInstaller.fromElement({
+      _id: '123',
       checksum: 'abc123',
     });
 

--- a/src/gmp/models/__tests__/agent.test.ts
+++ b/src/gmp/models/__tests__/agent.test.ts
@@ -13,9 +13,8 @@ describe('Agent model tests', () => {
   testModel(Agent, 'agent');
 
   test('should use defaults', () => {
-    const agent = new Agent();
-
-    expect(agent.id).toBeUndefined();
+    const agent = new Agent({id: 'test-id'});
+    expect(agent.id).toEqual('test-id');
     expect(agent.name).toBeUndefined();
     expect(agent.comment).toBeUndefined();
     expect(agent.hostname).toBeUndefined();
@@ -40,9 +39,8 @@ describe('Agent model tests', () => {
   });
 
   test('should parse defaults', () => {
-    const agent = Agent.fromElement({});
-
-    expect(agent.id).toBeUndefined();
+    const agent = Agent.fromElement({_id: 'test-id'});
+    expect(agent.id).toEqual('test-id');
     expect(agent.name).toBeUndefined();
     expect(agent.comment).toBeUndefined();
     expect(agent.hostname).toBeUndefined();
@@ -67,61 +65,92 @@ describe('Agent model tests', () => {
   });
 
   test('should parse hostname', () => {
-    const agent = Agent.fromElement({hostname: 'agent-hostname'});
+    const agent = Agent.fromElement({
+      _id: 'test-id',
+      hostname: 'agent-hostname',
+    });
     expect(agent.hostname).toEqual('agent-hostname');
   });
 
   test('should parse ipAddresses', () => {
-    const agent = Agent.fromElement({ip: ['192.168.1.1', '192.168.1.2']});
+    const agent = Agent.fromElement({
+      _id: 'test-id',
+      ip: ['192.168.1.1', '192.168.1.2'],
+    });
     expect(agent.ipAddresses).toEqual(['192.168.1.1', '192.168.1.2']);
   });
 
   test('should parse single ipAddress', () => {
-    const agent = Agent.fromElement({ip: '192.168.1.1'});
+    const agent = Agent.fromElement({_id: 'test-id', ip: '192.168.1.1'});
     expect(agent.ipAddresses).toEqual(['192.168.1.1']);
   });
 
   test('should parse agentId', () => {
-    const agent = Agent.fromElement({agent_id: 'agent-1234'});
+    const agent = Agent.fromElement({_id: 'test-id', agent_id: 'agent-1234'});
     expect(agent.agentId).toEqual('agent-1234');
   });
 
   test('should parse authorized', () => {
-    const agentTrue = Agent.fromElement({authorized: YES_VALUE});
+    const agentTrue = Agent.fromElement({
+      _id: 'test-id',
+      authorized: YES_VALUE,
+    });
     expect(agentTrue.authorized).toEqual(true);
 
-    const agentFalse = Agent.fromElement({authorized: NO_VALUE});
+    const agentFalse = Agent.fromElement({
+      _id: 'test-id',
+      authorized: NO_VALUE,
+    });
     expect(agentFalse.authorized).toEqual(false);
   });
 
   test('should parse agent_update_available', () => {
-    const agentTrue = Agent.fromElement({agent_update_available: YES_VALUE});
+    const agentTrue = Agent.fromElement({
+      _id: 'test-id',
+      agent_update_available: YES_VALUE,
+    });
     expect(agentTrue.agentUpdateAvailable).toEqual(true);
 
-    const agentFalse = Agent.fromElement({agent_update_available: NO_VALUE});
+    const agentFalse = Agent.fromElement({
+      _id: 'test-id',
+      agent_update_available: NO_VALUE,
+    });
     expect(agentFalse.agentUpdateAvailable).toEqual(false);
   });
 
   test('should parse updater_update_available', () => {
-    const agentTrue = Agent.fromElement({updater_update_available: YES_VALUE});
+    const agentTrue = Agent.fromElement({
+      _id: 'test-id',
+      updater_update_available: YES_VALUE,
+    });
     expect(agentTrue.updaterUpdateAvailable).toEqual(true);
 
-    const agentFalse = Agent.fromElement({updater_update_available: NO_VALUE});
+    const agentFalse = Agent.fromElement({
+      _id: 'test-id',
+      updater_update_available: NO_VALUE,
+    });
     expect(agentFalse.updaterUpdateAvailable).toEqual(false);
   });
 
   test('should parse connectionStatus', () => {
-    const agent = Agent.fromElement({connection_status: 'connected'});
+    const agent = Agent.fromElement({
+      _id: 'test-id',
+      connection_status: 'connected',
+    });
     expect(agent.connectionStatus).toEqual('connected');
   });
 
   test('should parse lastUpdate', () => {
-    const agent = Agent.fromElement({last_update: '2024-01-01T12:00:00Z'});
+    const agent = Agent.fromElement({
+      _id: 'test-id',
+      last_update: '2024-01-01T12:00:00Z',
+    });
     expect(agent.lastUpdate).toEqual(date('2024-01-01T12:00:00.000Z'));
   });
 
   test('should parse lastUpdaterHeartbeat', () => {
     const agent = Agent.fromElement({
+      _id: 'test-id',
       last_updater_heartbeat: '2024-01-02T15:30:00Z',
     });
     expect(agent.lastUpdaterHeartbeat).toEqual(
@@ -130,40 +159,50 @@ describe('Agent model tests', () => {
   });
 
   test('should parse updaterVersion', () => {
-    const agent = Agent.fromElement({updater_version: '1.2.3'});
+    const agent = Agent.fromElement({_id: 'test-id', updater_version: '1.2.3'});
     expect(agent.updaterVersion).toEqual('1.2.3');
   });
 
   test('should parse agentVersion', () => {
-    const agent = Agent.fromElement({agent_version: '4.5.6'});
+    const agent = Agent.fromElement({_id: 'test-id', agent_version: '4.5.6'});
     expect(agent.agentVersion).toEqual('4.5.6');
   });
 
   test('should parse operatingSystem', () => {
-    const agent = Agent.fromElement({operating_system: 'Linux'});
+    const agent = Agent.fromElement({
+      _id: 'test-id',
+      operating_system: 'Linux',
+    });
     expect(agent.operatingSystem).toEqual('Linux');
   });
 
   test('should parse architecture', () => {
-    const agent = Agent.fromElement({architecture: 'x86_64'});
+    const agent = Agent.fromElement({_id: 'test-id', architecture: 'x86_64'});
     expect(agent.architecture).toEqual('x86_64');
   });
 
   test('should parse updateToLatest boolean', () => {
-    const agentTrue = Agent.fromElement({update_to_latest: YES_VALUE});
+    const agentTrue = Agent.fromElement({
+      _id: 'test-id',
+      update_to_latest: YES_VALUE,
+    });
     expect(agentTrue.updateToLatest).toEqual(true);
 
-    const agentFalse = Agent.fromElement({update_to_latest: NO_VALUE});
+    const agentFalse = Agent.fromElement({
+      _id: 'test-id',
+      update_to_latest: NO_VALUE,
+    });
     expect(agentFalse.updateToLatest).toEqual(false);
   });
 
   test('should parse schedule', () => {
-    const agent = Agent.fromElement({schedule: 'daily at 2am'});
+    const agent = Agent.fromElement({_id: 'test-id', schedule: 'daily at 2am'});
     expect(agent.schedule).toEqual('daily at 2am');
   });
 
   test('should parse scanner', () => {
     const agent = Agent.fromElement({
+      _id: 'test-id',
       scanner: {
         _id: '3b4be213-281f-49ee-b457-5a5f34f71510',
         name: 'Agent1',
@@ -175,17 +214,24 @@ describe('Agent model tests', () => {
   });
 
   test('should parse latest_agent_version', () => {
-    const agent = Agent.fromElement({latest_agent_version: 'v1'});
+    const agent = Agent.fromElement({
+      _id: 'test-id',
+      latest_agent_version: 'v1',
+    });
     expect(agent.latestAgentVersion).toEqual('v1');
   });
 
   test('should parse latest_updater_version', () => {
-    const agent = Agent.fromElement({latest_updater_version: 'v1'});
+    const agent = Agent.fromElement({
+      _id: 'test-id',
+      latest_updater_version: 'v1',
+    });
     expect(agent.latestUpdaterVersion).toEqual('v1');
   });
 
   test('should parse config', () => {
     const agent = Agent.fromElement({
+      _id: 'test-id',
       config: {
         heartbeat: {
           interval_in_seconds: 300,
@@ -226,29 +272,32 @@ describe('Agent model tests', () => {
   });
 
   test('should check if agent is authorized', () => {
-    const authorizedAgent = new Agent({authorized: true});
+    const authorizedAgent = new Agent({id: '123', authorized: true});
     expect(authorizedAgent.isAuthorized()).toEqual(true);
 
-    const unauthorizedAgent = new Agent({authorized: false});
+    const unauthorizedAgent = new Agent({id: '123', authorized: false});
     expect(unauthorizedAgent.isAuthorized()).toEqual(false);
 
-    const undefinedAgent = new Agent();
+    const undefinedAgent = new Agent({id: 'test-id'});
     expect(undefinedAgent.isAuthorized()).toEqual(false);
   });
 
   test('should check if agent should update to latest', () => {
-    const updateAgent = new Agent({updateToLatest: true});
+    const updateAgent = new Agent({id: '123', updateToLatest: true});
     expect(updateAgent.isUpdateToLatest()).toEqual(true);
 
-    const noUpdateAgent = new Agent({updateToLatest: false});
+    const noUpdateAgent = new Agent({id: '123', updateToLatest: false});
     expect(noUpdateAgent.isUpdateToLatest()).toEqual(false);
   });
 
   test('should get connection status', () => {
-    const connectedAgent = new Agent({connectionStatus: 'connected'});
+    const connectedAgent = new Agent({
+      id: '123',
+      connectionStatus: 'connected',
+    });
     expect(connectedAgent.getConnectionStatus()).toEqual('connected');
 
-    const undefinedStatusAgent = new Agent();
+    const undefinedStatusAgent = new Agent({id: 'test-id'});
     expect(undefinedStatusAgent.getConnectionStatus()).toEqual('unknown');
   });
 });

--- a/src/gmp/models/__tests__/alert.test.ts
+++ b/src/gmp/models/__tests__/alert.test.ts
@@ -21,7 +21,7 @@ describe('Alert Model tests', () => {
   testModel(Alert, 'alert', {testIsActive: false});
 
   test('should use defaults', () => {
-    const alert = new Alert();
+    const alert = new Alert({id: 'test-id'});
     expect(alert.active).toBeUndefined();
     expect(alert.condition).toBeUndefined();
     expect(alert.event).toBeUndefined();
@@ -31,7 +31,7 @@ describe('Alert Model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const alert = Alert.fromElement();
+    const alert = Alert.fromElement({_id: 'test-id'});
     expect(alert.active).toBeUndefined();
     expect(alert.condition).toBeUndefined();
     expect(alert.event).toBeUndefined();
@@ -42,6 +42,7 @@ describe('Alert Model tests', () => {
 
   test('should parse condition, event, and method', () => {
     const elem = {
+      _id: 'test-id',
       condition: {
         __text: 'text',
       },
@@ -82,6 +83,7 @@ describe('Alert Model tests', () => {
 
   test('should parse method data', () => {
     const elem = {
+      _id: 'test-id',
       method: {
         __text: 'foo',
         data: {
@@ -112,6 +114,7 @@ describe('Alert Model tests', () => {
 
   test('should parse method data with report formats', () => {
     const elem = {
+      _id: 'test-id',
       method: {
         __text: 'foo',
         data: [
@@ -149,6 +152,7 @@ describe('Alert Model tests', () => {
 
   test('should parse method data with notice', () => {
     const elem = {
+      _id: 'test-id',
       method: {
         __text: 'foo',
         data: [
@@ -187,21 +191,22 @@ describe('Alert Model tests', () => {
   });
 
   test('should parse filter', () => {
-    const elem = {filter: {_id: '1', term: 'rows=1337'}};
+    const elem = {_id: 'test-id', filter: {_id: '1', term: 'rows=1337'}};
     const alert = Alert.fromElement(elem);
     expect(alert.filter?.entityType).toEqual('filter');
     expect(alert.filter?.id).toEqual('1');
   });
 
   test('should parse active', () => {
-    const alert = Alert.fromElement({active: 1});
+    const alert = Alert.fromElement({_id: 'test-id', active: 1});
     expect(alert.active).toEqual(1);
-    const alert2 = Alert.fromElement({active: 0});
+    const alert2 = Alert.fromElement({_id: 'test-id', active: 0});
     expect(alert2.active).toEqual(0);
   });
 
   test('should parse report formats', () => {
     const elem = {
+      _id: 'test-id',
       method: {
         data: {
           __text: '123, 456, 789',
@@ -216,6 +221,7 @@ describe('Alert Model tests', () => {
 
   test('should parse notice', () => {
     const elem = {
+      _id: 'test-id',
       method: {
         data: {
           __text: 1,
@@ -231,8 +237,8 @@ describe('Alert Model tests', () => {
 
 describe('Alert model method tests', () => {
   test('isActive() should return correct true/false', () => {
-    const alert1 = new Alert({active: 0});
-    const alert2 = new Alert({active: 1});
+    const alert1 = new Alert({id: '123', active: 0});
+    const alert2 = new Alert({id: '123', active: 1});
 
     expect(alert1.isActive()).toBe(false);
     expect(alert2.isActive()).toBe(true);

--- a/src/gmp/models/__tests__/audit-report.test.ts
+++ b/src/gmp/models/__tests__/audit-report.test.ts
@@ -11,7 +11,7 @@ describe('AuditReport tests', () => {
   testModel(AuditReport, 'auditreport');
 
   test('should use defaults', () => {
-    const report = new AuditReport();
+    const report = new AuditReport({id: 'test-id'});
     expect(report.contentType).toBeUndefined();
     expect(report.report).toBeUndefined();
     expect(report.reportFormat).toBeUndefined();
@@ -20,7 +20,7 @@ describe('AuditReport tests', () => {
   });
 
   test('should parse empty element', () => {
-    const report = AuditReport.fromElement();
+    const report = AuditReport.fromElement({_id: 'test-id'});
     expect(report.contentType).toBeUndefined();
     expect(report.report).toBeUndefined();
     expect(report.reportFormat).toBeUndefined();
@@ -30,6 +30,7 @@ describe('AuditReport tests', () => {
 
   test('should parse report', () => {
     const report = AuditReport.fromElement({
+      _id: 'test-id',
       report: {
         _type: 'delta',
         _id: '123',
@@ -43,14 +44,13 @@ describe('AuditReport tests', () => {
   });
 
   test('should parse report type', () => {
-    const report = AuditReport.fromElement({
-      _type: 'delta',
-    });
+    const report = AuditReport.fromElement({_id: 'test-id', _type: 'delta'});
     expect(report.reportType).toEqual('delta');
   });
 
   test('should parse report format', () => {
     const report = AuditReport.fromElement({
+      _id: 'test-id',
       report_format: {
         _id: 'format123',
         name: 'Test Format',
@@ -63,6 +63,7 @@ describe('AuditReport tests', () => {
 
   test('should parse task', () => {
     const report = AuditReport.fromElement({
+      _id: 'test-id',
       task: {
         _id: 'task123',
         name: 'Test Task',
@@ -75,6 +76,7 @@ describe('AuditReport tests', () => {
 
   test('should parse content type', () => {
     const report = AuditReport.fromElement({
+      _id: 'test-id',
       _content_type: 'application/xml',
     });
     expect(report.contentType).toEqual('application/xml');

--- a/src/gmp/models/__tests__/audit.test.ts
+++ b/src/gmp/models/__tests__/audit.test.ts
@@ -16,7 +16,7 @@ describe('Audit model tests', () => {
   testModel(Audit, 'audit', {testIsActive: false});
 
   test('should use defaults', () => {
-    const audit = new Audit();
+    const audit = new Audit({id: 'test-id'});
     expect(audit.alerts).toEqual([]);
     expect(audit.alterable).toBeUndefined();
     expect(audit.apply_overrides).toBeUndefined();
@@ -48,7 +48,7 @@ describe('Audit model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const audit = Audit.fromElement();
+    const audit = Audit.fromElement({_id: 'test-id'});
     expect(audit.alerts).toEqual([]);
     expect(audit.alterable).toBeUndefined();
     expect(audit.apply_overrides).toBeUndefined();
@@ -341,12 +341,11 @@ describe('Audit model tests', () => {
   });
 
   test('should parse observers', () => {
-    const audit = Audit.fromElement({
-      observers: 'foo bar',
-    });
+    const audit = Audit.fromElement({_id: 'test-id', observers: 'foo bar'});
     expect(audit.observers?.user).toEqual(['foo', 'bar']);
 
     const audit2 = Audit.fromElement({
+      _id: 'test-id',
       observers: {
         __text: 'anon nymous',
         role: [{name: 'lorem'}],
@@ -358,14 +357,13 @@ describe('Audit model tests', () => {
     expect(audit2.observers?.role).toEqual(['lorem']);
     expect(audit2.observers?.group).toEqual(['ipsum', 'dolor']);
 
-    const audit3 = Audit.fromElement({
-      observers: '',
-    });
+    const audit3 = Audit.fromElement({_id: 'test-id', observers: ''});
     expect(audit3.observers?.user).toBeUndefined();
     expect(audit3.observers?.role).toBeUndefined();
     expect(audit3.observers?.group).toBeUndefined();
 
     const audit4 = Audit.fromElement({
+      _id: 'test-id',
       observers: {
         __text: '',
       },
@@ -454,7 +452,10 @@ describe(`Audit Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const audit = Audit.fromElement({status: status as AuditStatus});
+      const audit = Audit.fromElement({
+        _id: 'test-id',
+        status: status as AuditStatus,
+      });
       expect(audit.isActive()).toEqual(exp);
     }
   });
@@ -477,7 +478,10 @@ describe(`Audit Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const audit = Audit.fromElement({status: status as AuditStatus});
+      const audit = Audit.fromElement({
+        _id: 'test-id',
+        status: status as AuditStatus,
+      });
       expect(audit.isRunning()).toEqual(exp);
     }
   });
@@ -500,7 +504,10 @@ describe(`Audit Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const audit = Audit.fromElement({status: status as AuditStatus});
+      const audit = Audit.fromElement({
+        _id: 'test-id',
+        status: status as AuditStatus,
+      });
       expect(audit.isStopped()).toEqual(exp);
     }
   });
@@ -523,7 +530,10 @@ describe(`Audit Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const audit = Audit.fromElement({status: status as AuditStatus});
+      const audit = Audit.fromElement({
+        _id: 'test-id',
+        status: status as AuditStatus,
+      });
       expect(audit.isInterrupted()).toEqual(exp);
     }
   });
@@ -546,16 +556,27 @@ describe(`Audit Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const audit = Audit.fromElement({status: status as AuditStatus});
+      const audit = Audit.fromElement({
+        _id: 'test-id',
+        status: status as AuditStatus,
+      });
       expect(audit.isNew()).toEqual(exp);
     }
   });
 
   test('should be changeable if alterable or new', () => {
-    let audit = Audit.fromElement({status: AUDIT_STATUS.new, alterable: 0});
+    let audit = Audit.fromElement({
+      _id: 'test-id',
+      status: AUDIT_STATUS.new,
+      alterable: 0,
+    });
     expect(audit.isChangeable()).toEqual(true);
 
-    audit = Audit.fromElement({status: AUDIT_STATUS.done, alterable: 1});
+    audit = Audit.fromElement({
+      _id: 'test-id',
+      status: AUDIT_STATUS.done,
+      alterable: 1,
+    });
     expect(audit.isChangeable()).toEqual(true);
   });
 });

--- a/src/gmp/models/__tests__/base-model.test.ts
+++ b/src/gmp/models/__tests__/base-model.test.ts
@@ -10,7 +10,6 @@ import date from 'gmp/models/date';
 describe('BaseModel tests', () => {
   test('should create an instance of BaseModel', () => {
     const model = new BaseModel();
-    expect(model.id).toBeUndefined();
     expect(model.creationTime).toBeUndefined();
     expect(model.modificationTime).toBeUndefined();
     expect(model._type).toBeUndefined();
@@ -19,7 +18,6 @@ describe('BaseModel tests', () => {
   test('should create empty BaseModel from element', () => {
     const element = {};
     const model = BaseModel.fromElement(element);
-    expect(model.id).toBeUndefined();
     expect(model.creationTime).toBeUndefined();
     expect(model.modificationTime).toBeUndefined();
     expect(model._type).toBeUndefined();
@@ -27,14 +25,12 @@ describe('BaseModel tests', () => {
 
   test('should parse properties from element', () => {
     const element = {
-      _id: '1',
       creation_time: '2024-01-01T00:00:00Z',
       modification_time: '2024-01-02T00:00:00Z',
       type: 'test',
     };
     const model = BaseModel.fromElement(element);
 
-    expect(model.id).toEqual('1');
     expect(model.creationTime).toEqual(date('2024-01-01T00:00:00.000Z'));
     expect(model.modificationTime).toEqual(date('2024-01-02T00:00:00.000Z'));
     expect(model._type).toEqual('test');
@@ -49,14 +45,12 @@ describe('parseBaseModelProperties tests', () => {
 
   test('should parse properties from BaseModelElement', () => {
     const element = {
-      _id: '1',
       creation_time: '2024-01-01T00:00:00Z',
       modification_time: '2024-01-02T00:00:00Z',
       type: 'test',
     };
     const properties = parseBaseModelProperties(element);
 
-    expect(properties.id).toEqual('1');
     expect(properties.creationTime).toEqual(date('2024-01-01T00:00:00.000Z'));
     expect(properties.modificationTime).toEqual(
       date('2024-01-02T00:00:00.000Z'),

--- a/src/gmp/models/__tests__/cert-bund.test.ts
+++ b/src/gmp/models/__tests__/cert-bund.test.ts
@@ -12,7 +12,7 @@ testModel(CertBundAdv, 'certbund');
 
 describe('CertBundAdv model tests', () => {
   test('should set defaults', () => {
-    const certBundAdv = new CertBundAdv();
+    const certBundAdv = new CertBundAdv({id: 'test-id'});
 
     expect(certBundAdv.additionalInformation).toEqual([]);
     expect(certBundAdv.categories).toEqual([]);
@@ -34,20 +34,21 @@ describe('CertBundAdv model tests', () => {
   });
 
   test('should parse severity', () => {
-    const elem = {cert_bund_adv: {severity: 8.5}};
+    const elem = {_id: 'test-id', cert_bund_adv: {severity: 8.5}};
     const certBundAdv = CertBundAdv.fromElement(elem);
 
     expect(certBundAdv.severity).toEqual(8.5);
   });
 
   test('should parse summary', () => {
-    const elem = {cert_bund_adv: {summary: 'foo'}};
+    const elem = {_id: 'test-id', cert_bund_adv: {summary: 'foo'}};
     const certBundAdv = CertBundAdv.fromElement(elem);
     expect(certBundAdv.summary).toEqual('foo');
   });
 
   test('should parse title', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         title: 'foo',
       },
@@ -58,6 +59,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse categories', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -72,6 +74,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse single category', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -86,6 +89,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse descriptions', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -102,6 +106,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse single description', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -120,6 +125,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse additional information', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -161,6 +167,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse single additional information', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -192,6 +199,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse version', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -208,6 +216,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse revision history', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -247,6 +256,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse CVEs', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -264,6 +274,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse single CVE', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -281,6 +292,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse platform', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -295,6 +307,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse effect', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -309,6 +322,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse reference source', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -323,6 +337,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse reference URL', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -337,6 +352,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse remote attack', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -351,6 +367,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse risk', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {
@@ -365,6 +382,7 @@ describe('CertBundAdv model tests', () => {
 
   test('should parse software', () => {
     const elem = {
+      _id: 'test-id',
       cert_bund_adv: {
         raw_data: {
           Advisory: {

--- a/src/gmp/models/__tests__/cpe.test.ts
+++ b/src/gmp/models/__tests__/cpe.test.ts
@@ -8,11 +8,11 @@ import Cpe from 'gmp/models/cpe';
 import {isDate} from 'gmp/models/date';
 import {testModel} from 'gmp/models/testing';
 
-testModel(Cpe, 'cpe');
-
 describe('CPE model tests', () => {
+  testModel(Cpe, 'cpe');
+
   test('should use defaults', () => {
-    const cpe = new Cpe();
+    const cpe = new Cpe({id: 'test-id'});
     expect(cpe.cpeNameId).toBeUndefined();
     expect(cpe.cveRefs).toEqual(0);
     expect(cpe.cves).toEqual([]);
@@ -24,7 +24,7 @@ describe('CPE model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const cpe = Cpe.fromElement({});
+    const cpe = Cpe.fromElement({_id: 'test-id'});
     expect(cpe.cpeNameId).toBeUndefined();
     expect(cpe.cveRefs).toEqual(0);
     expect(cpe.cves).toEqual([]);
@@ -36,8 +36,8 @@ describe('CPE model tests', () => {
   });
 
   test('should parse severity', () => {
-    const cpe = Cpe.fromElement({cpe: {severity: 5.0}});
-    const cpe2 = Cpe.fromElement({cpe: {severity: 10.0}});
+    const cpe = Cpe.fromElement({_id: 'test-id', cpe: {severity: 5.0}});
+    const cpe2 = Cpe.fromElement({_id: 'test-id', cpe: {severity: 10.0}});
 
     expect(cpe.severity).toEqual(5.0);
     expect(cpe2.severity).toEqual(10);
@@ -45,6 +45,7 @@ describe('CPE model tests', () => {
 
   test('should parse id and severity of cves', () => {
     const elem = {
+      _id: 'test-id',
       cpe: {
         cves: {
           cve: [
@@ -87,13 +88,16 @@ describe('CPE model tests', () => {
   });
 
   test('should return empty array if no cves are defined', () => {
-    const cpe = Cpe.fromElement({});
+    const cpe = Cpe.fromElement({_id: 'test-id'});
 
     expect(cpe.cves).toEqual([]);
   });
 
   test('should parse update time', () => {
-    const cpe = Cpe.fromElement({update_time: '2018-10-10T11:41:23.022Z'});
+    const cpe = Cpe.fromElement({
+      _id: 'test-id',
+      update_time: '2018-10-10T11:41:23.022Z',
+    });
 
     expect(cpe.updateTime).toBeDefined();
     expect(isDate(cpe.updateTime)).toBe(true);
@@ -101,6 +105,7 @@ describe('CPE model tests', () => {
 
   test('should parse deprecated', () => {
     const cpe = Cpe.fromElement({
+      _id: 'test-id',
       cpe: {
         deprecated: 1,
       },
@@ -108,18 +113,20 @@ describe('CPE model tests', () => {
     expect(cpe.deprecated).toBe(true);
 
     const cpe2 = Cpe.fromElement({
+      _id: 'test-id',
       cpe: {
         deprecated: 0,
       },
     });
     expect(cpe2.deprecated).toBe(false);
 
-    const cpe3 = Cpe.fromElement({});
+    const cpe3 = Cpe.fromElement({_id: 'test-id'});
     expect(cpe3.deprecated).toBe(false);
   });
 
   test('should parse deprecatedBy', () => {
     const cpe = Cpe.fromElement({
+      _id: 'test-id',
       cpe: {
         deprecated: 1,
         deprecated_by: {_cpe_id: 'foo:/bar'},
@@ -128,6 +135,7 @@ describe('CPE model tests', () => {
     expect(cpe.deprecatedBy).toEqual('foo:/bar');
 
     const cpe2 = Cpe.fromElement({
+      _id: 'test-id',
       cpe: {
         deprecated: 1,
         deprecated_by: {_cpe_id: 'foo:/bar'},
@@ -138,6 +146,7 @@ describe('CPE model tests', () => {
     expect(cpe2.deprecatedBy).toEqual('foo:/bar');
 
     const cpe3 = Cpe.fromElement({
+      _id: 'test-id',
       cpe: {
         raw_data: {'cpe-item': {_deprecated_by: 'foo:/bar'}},
       },
@@ -145,6 +154,7 @@ describe('CPE model tests', () => {
     expect(cpe3.deprecatedBy).toEqual('foo:/bar');
 
     const cpe4 = Cpe.fromElement({
+      _id: 'test-id',
       cpe: {
         deprecated: 0,
         deprecated_by: {_cpe_id: 'foo:/bar'},
@@ -155,32 +165,38 @@ describe('CPE model tests', () => {
   });
 
   test('should not parse deprecatedBy', () => {
-    const cpe = Cpe.fromElement({cpe: {raw_data: {'cpe-item': {}}}});
+    const cpe = Cpe.fromElement({
+      _id: 'test-id',
+      cpe: {raw_data: {'cpe-item': {}}},
+    });
 
     expect(cpe.deprecatedBy).toBeUndefined();
   });
 
   test('should parse old nvd_id', () => {
-    const cpe = Cpe.fromElement({cpe: {nvd_id: 'ABC'}});
+    const cpe = Cpe.fromElement({_id: 'test-id', cpe: {nvd_id: 'ABC'}});
 
     expect(cpe.cpeNameId).toEqual('ABC');
   });
 
   test('should parse cpeNameId', () => {
-    const cpe = Cpe.fromElement({cpe: {cpe_name_id: 'ABC'}});
-    const cpe2 = Cpe.fromElement({cpe: {cpe_name_id: 'ABC', nvd_id: 'DEF'}});
+    const cpe = Cpe.fromElement({_id: 'test-id', cpe: {cpe_name_id: 'ABC'}});
+    const cpe2 = Cpe.fromElement({
+      _id: 'test-id',
+      cpe: {cpe_name_id: 'ABC', nvd_id: 'DEF'},
+    });
 
     expect(cpe.cpeNameId).toEqual('ABC');
     expect(cpe2.cpeNameId).toEqual('ABC');
   });
 
   test('should parse title', () => {
-    const cpe = Cpe.fromElement({cpe: {title: 'Test Title'}});
+    const cpe = Cpe.fromElement({_id: 'test-id', cpe: {title: 'Test Title'}});
     expect(cpe.title).toEqual('Test Title');
   });
 
   test('should parse cveRefs', () => {
-    const cpe = Cpe.fromElement({cpe: {cve_refs: 5}});
+    const cpe = Cpe.fromElement({_id: 'test-id', cpe: {cve_refs: 5}});
     expect(cpe.cveRefs).toEqual(5);
   });
 });

--- a/src/gmp/models/__tests__/credential-store.test.ts
+++ b/src/gmp/models/__tests__/credential-store.test.ts
@@ -16,9 +16,9 @@ describe('CredentialStore model tests', () => {
   testModel(CredentialStore, 'credential');
 
   test('should use defaults', () => {
-    const credentialStore = new CredentialStore();
+    const credentialStore = new CredentialStore({id: 'test-id'});
 
-    expect(credentialStore.id).toBeUndefined();
+    expect(credentialStore.id).toEqual('test-id');
     expect(credentialStore.name).toBeUndefined();
     expect(credentialStore.comment).toBeUndefined();
     expect(credentialStore.entityType).toEqual('credential');
@@ -31,27 +31,40 @@ describe('CredentialStore model tests', () => {
   });
 
   test('should parse version', () => {
-    const credentialStore = CredentialStore.fromElement({version: '1.2.3'});
+    const credentialStore = CredentialStore.fromElement({
+      _id: 'test-id',
+      version: '1.2.3',
+    });
     expect(credentialStore.version).toEqual('1.2.3');
   });
 
   test('should parse host', () => {
-    const credentialStore = CredentialStore.fromElement({host: 'example.com'});
+    const credentialStore = CredentialStore.fromElement({
+      _id: 'test-id',
+      host: 'example.com',
+    });
     expect(credentialStore.host).toEqual('example.com');
   });
 
   test('should parse path', () => {
-    const credentialStore = CredentialStore.fromElement({path: '/some/path'});
+    const credentialStore = CredentialStore.fromElement({
+      _id: 'test-id',
+      path: '/some/path',
+    });
     expect(credentialStore.path).toEqual('/some/path');
   });
 
   test('should parse port', () => {
-    const credentialStore = CredentialStore.fromElement({port: '8080'});
+    const credentialStore = CredentialStore.fromElement({
+      _id: 'test-id',
+      port: '8080',
+    });
     expect(credentialStore.port).toEqual('8080');
   });
 
   test('should parse preferences', () => {
     const credentialStore = CredentialStore.fromElement({
+      _id: 'test-id',
       preferences: {
         preference: [
           {name: 'pref1', type: 'string', value: 'value1'},
@@ -82,6 +95,7 @@ describe('CredentialStore model tests', () => {
 
   test('should parse selectors', () => {
     const credentialStore = CredentialStore.fromElement({
+      _id: 'test-id',
       selectors: {
         selector: [
           {
@@ -114,6 +128,7 @@ describe('CredentialStore model tests', () => {
 
   test('should parse selector with single credential_type and default_value', () => {
     const credentialStore = CredentialStore.fromElement({
+      _id: 'test-id',
       selectors: {
         selector: {
           name: 'selector-single',
@@ -136,6 +151,7 @@ describe('CredentialStore model tests', () => {
 
   test('should parse selector with credential_types but no credential_type property', () => {
     const credentialStore = CredentialStore.fromElement({
+      _id: 'test-id',
       selectors: {
         selector: {
           name: 'selector-empty',

--- a/src/gmp/models/__tests__/credential.test.ts
+++ b/src/gmp/models/__tests__/credential.test.ts
@@ -25,15 +25,29 @@ import {testModel} from 'gmp/models/testing';
 import {parseDate} from 'gmp/parser';
 
 const USERNAME_PASSWORD_CREDENTIAL = Credential.fromElement({
+  _id: 'test-id',
   type: USERNAME_PASSWORD_CREDENTIAL_TYPE,
 });
 const USERNAME_SSH_KEY_CREDENTIAL = Credential.fromElement({
+  _id: 'test-id',
   type: USERNAME_SSH_KEY_CREDENTIAL_TYPE,
 });
-const SNMP_CREDENTIAL = Credential.fromElement({type: SNMP_CREDENTIAL_TYPE});
-const PGP_CREDENTIAL = Credential.fromElement({type: PGP_CREDENTIAL_TYPE});
-const SMIME_CREDENTIAL = Credential.fromElement({type: SMIME_CREDENTIAL_TYPE});
-const KRB5_CREDENTIAL = Credential.fromElement({type: KRB5_CREDENTIAL_TYPE});
+const SNMP_CREDENTIAL = Credential.fromElement({
+  _id: 'test-id',
+  type: SNMP_CREDENTIAL_TYPE,
+});
+const PGP_CREDENTIAL = Credential.fromElement({
+  _id: 'test-id',
+  type: PGP_CREDENTIAL_TYPE,
+});
+const SMIME_CREDENTIAL = Credential.fromElement({
+  _id: 'test-id',
+  type: SMIME_CREDENTIAL_TYPE,
+});
+const KRB5_CREDENTIAL = Credential.fromElement({
+  _id: 'test-id',
+  type: KRB5_CREDENTIAL_TYPE,
+});
 
 const createAllCredentials = () => [
   USERNAME_PASSWORD_CREDENTIAL,
@@ -48,7 +62,8 @@ describe('Credential Model tests', () => {
   testModel(Credential, 'credential');
 
   test('should use defaults', () => {
-    const credential = new Credential();
+    const credential = new Credential({id: 'test-id'});
+    expect(credential.id).toEqual('test-id');
     expect(credential.authAlgorithm).toBeUndefined();
     expect(credential.certificateInfo).toBeUndefined();
     expect(credential.credentialType).toBeUndefined();
@@ -63,7 +78,7 @@ describe('Credential Model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const credential = Credential.fromElement({});
+    const credential = Credential.fromElement({_id: 'test-id'});
     expect(credential.authAlgorithm).toBeUndefined();
     expect(credential.certificateInfo).toBeUndefined();
     expect(credential.credentialType).toBeUndefined();
@@ -79,6 +94,7 @@ describe('Credential Model tests', () => {
 
   test('should parse auth_algorithm', () => {
     const credential = Credential.fromElement({
+      _id: 'test-id',
       auth_algorithm: 'md5',
     });
     expect(credential.authAlgorithm).toEqual('md5');
@@ -86,6 +102,7 @@ describe('Credential Model tests', () => {
 
   test('should parse certificate_info', () => {
     const credential = Credential.fromElement({
+      _id: 'test-id',
       certificate_info: {
         activation_time: '2018-10-10T11:41:23.022Z',
         expiration_time: '2019-10-10T11:41:23.022Z',
@@ -118,6 +135,7 @@ describe('Credential Model tests', () => {
 
   test('should parse private key info', () => {
     const credential = Credential.fromElement({
+      _id: 'test-id',
       private_key_info: {
         sha256_hash: 'sha256-hash-value',
         type: 'ssh-rsa',
@@ -128,6 +146,7 @@ describe('Credential Model tests', () => {
     expect(credential.privateKeyInfo?.keyType).toEqual('rsa');
 
     const credential2 = Credential.fromElement({
+      _id: 'test-id',
       private_key_info: {
         sha256_hash: 'sha256-hash-value',
         type: 'rsa-ssh',
@@ -138,6 +157,7 @@ describe('Credential Model tests', () => {
     expect(credential2.privateKeyInfo?.keyType).toEqual('rsa-ssh');
 
     const credential3 = Credential.fromElement({
+      _id: 'test-id',
       // @ts-expect-error
       private_key_info: '',
     });
@@ -147,6 +167,7 @@ describe('Credential Model tests', () => {
 
   test('should parse public key info', () => {
     const credential = Credential.fromElement({
+      _id: 'test-id',
       public_key_info: {
         fingerprint: 'public-key-fingerprint',
       },
@@ -157,6 +178,7 @@ describe('Credential Model tests', () => {
     );
 
     const credential2 = Credential.fromElement({
+      _id: 'test-id',
       // @ts-expect-error
       public_key_info: '',
     });
@@ -164,13 +186,14 @@ describe('Credential Model tests', () => {
   });
 
   test('should parse type', () => {
-    const credential = Credential.fromElement({type: 'foo'});
+    const credential = Credential.fromElement({_id: 'test-id', type: 'foo'});
 
     expect(credential.credentialType).toEqual('foo');
   });
 
   test('should parse targets', () => {
     const credential = Credential.fromElement({
+      _id: 'test-id',
       targets: {
         target: {_id: 't1'},
       },
@@ -182,6 +205,7 @@ describe('Credential Model tests', () => {
     expect(target.entityType).toEqual('target');
 
     const credential2 = Credential.fromElement({
+      _id: 'test-id',
       // @ts-expect-error
       targets: '',
     });
@@ -190,6 +214,7 @@ describe('Credential Model tests', () => {
 
   test('should parse scanners', () => {
     const credential = Credential.fromElement({
+      _id: 'test-id',
       scanners: {
         scanner: {_id: 's1'},
       },
@@ -201,6 +226,7 @@ describe('Credential Model tests', () => {
     expect(scanner.entityType).toEqual('scanner');
 
     const credential2 = Credential.fromElement({
+      _id: 'test-id',
       // @ts-expect-error
       scanners: '',
     });
@@ -284,6 +310,7 @@ describe('Credential model function tests', () => {
 
   test('should parse kdcs', () => {
     const credential = Credential.fromElement({
+      _id: 'test-id',
       kdcs: {kdc: ['kdc1.example.com', 'kdc2.example.com']},
     });
     expect(credential.kdcs).toEqual(['kdc1.example.com', 'kdc2.example.com']);
@@ -291,6 +318,7 @@ describe('Credential model function tests', () => {
 
   test('should parse login', () => {
     const credential = Credential.fromElement({
+      _id: 'test-id',
       login: 'test-user',
     });
     expect(credential.login).toEqual('test-user');
@@ -298,6 +326,7 @@ describe('Credential model function tests', () => {
 
   test('should parse privacy_algorithm', () => {
     const credential = Credential.fromElement({
+      _id: 'test-id',
       privacy: {algorithm: 'aes'},
     });
     expect(credential.privacyAlgorithm).toEqual('aes');
@@ -305,6 +334,7 @@ describe('Credential model function tests', () => {
 
   test('should parse realm', () => {
     const credential = Credential.fromElement({
+      _id: 'test-id',
       realm: 'test-realm',
     });
     expect(credential.realm).toEqual('test-realm');
@@ -312,6 +342,7 @@ describe('Credential model function tests', () => {
 
   test('should parse credential store with privacy host identifier', () => {
     const credential = Credential.fromElement({
+      _id: 'test-id',
       credential_store: {
         vault_id: 'test-vault',
         host_identifier: 'host-123',
@@ -326,6 +357,7 @@ describe('Credential model function tests', () => {
 
   test('should parse credential store without privacy host identifier', () => {
     const credential = Credential.fromElement({
+      _id: 'test-id',
       credential_store: {
         vault_id: 'test-vault',
         host_identifier: 'host-123',

--- a/src/gmp/models/__tests__/cve.test.ts
+++ b/src/gmp/models/__tests__/cve.test.ts
@@ -9,11 +9,11 @@ import {isDate} from 'gmp/models/date';
 import {testModel} from 'gmp/models/testing';
 import {parseDate} from 'gmp/parser';
 
-testModel(Cve, 'cve');
-
 describe('CVE model tests', () => {
+  testModel(Cve, 'cve');
+
   test('should use defaults', () => {
-    const cve = new Cve();
+    const cve = new Cve({id: 'test-id'});
     expect(cve.certs).toEqual([]);
     expect(cve.cvssAccessComplexity).toBeUndefined();
     expect(cve.cvssAccessVector).toBeUndefined();
@@ -37,7 +37,7 @@ describe('CVE model tests', () => {
     expect(cve.cvssUserInteraction).toBeUndefined();
     expect(cve.description).toBeUndefined();
     expect(cve.epss).toBeUndefined();
-    expect(cve.id).toBeUndefined();
+    expect(cve.id).toEqual('test-id');
     expect(cve.lastModifiedTime).toBeUndefined();
     expect(cve.nvts).toEqual([]);
     expect(cve.products).toEqual([]);
@@ -48,7 +48,7 @@ describe('CVE model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const cve = Cve.fromElement();
+    const cve = Cve.fromElement({_id: 'test-id'});
     expect(cve.certs).toEqual([]);
     expect(cve.cvssAccessComplexity).toBeUndefined();
     expect(cve.cvssAccessVector).toBeUndefined();
@@ -72,7 +72,7 @@ describe('CVE model tests', () => {
     expect(cve.cvssUserInteraction).toBeUndefined();
     expect(cve.description).toBeUndefined();
     expect(cve.epss).toBeUndefined();
-    expect(cve.id).toBeUndefined();
+    expect(cve.id).toEqual('test-id');
     expect(cve.lastModifiedTime).toBeUndefined();
     expect(cve.nvts).toEqual([]);
     expect(cve.products).toEqual([]);
@@ -83,15 +83,13 @@ describe('CVE model tests', () => {
   });
 
   test('should parse update time', () => {
-    const elem = {
-      update_time: '2018-10-10T23:00:00.000+0000',
-    };
+    const elem = {_id: 'test-id', update_time: '2018-10-10T23:00:00.000+0000'};
     const cve = Cve.fromElement(elem);
     expect(cve.updateTime).toEqual(parseDate('2018-10-10T23:00:00.000+0000'));
   });
 
   test('should parse severity', () => {
-    const elem = {cve: {severity: 8.5}};
+    const elem = {_id: 'test-id', cve: {severity: 8.5}};
     const cve = Cve.fromElement(elem);
 
     expect(cve.severity).toEqual(8.5);
@@ -99,6 +97,7 @@ describe('CVE model tests', () => {
 
   test('should parse NVTs', () => {
     const elem = {
+      _id: 'test-id',
       cve: {
         nvts: {
           nvt: [
@@ -133,6 +132,7 @@ describe('CVE model tests', () => {
 
   test('should parse CERT-Bund Advs', () => {
     const elem = {
+      _id: 'test-id',
       cve: {
         cert: {
           cert_ref: [
@@ -169,6 +169,7 @@ describe('CVE model tests', () => {
 
   test('should parse CVSS metrics', () => {
     const elem = {
+      _id: 'test-id',
       cve: {
         severity: 10.0,
         cvss_vector: 'AV:N/AC:L/Au:N/C:C/I:C/A:C',
@@ -187,6 +188,7 @@ describe('CVE model tests', () => {
 
   test('should parse products', () => {
     const elem = {
+      _id: 'test-id',
       cve: {
         products: 'foo:bar/dolor ipsum:lorem',
       },
@@ -194,10 +196,11 @@ describe('CVE model tests', () => {
     const cve = Cve.fromElement(elem);
     expect(cve.products).toEqual(['foo:bar/dolor', 'ipsum:lorem']);
 
-    const cve2 = Cve.fromElement({cve: {products: ''}});
+    const cve2 = Cve.fromElement({_id: 'test-id', cve: {products: ''}});
     expect(cve2.products).toEqual([]);
 
     const cve3 = Cve.fromElement({
+      _id: 'test-id',
       cve: {
         configuration_nodes: {
           node: [
@@ -216,6 +219,7 @@ describe('CVE model tests', () => {
     expect(cve3.products).toEqual(['cpe:/a:foo:bar', 'cpe:/a:foo:baz']);
 
     const cve4 = Cve.fromElement({
+      _id: 'test-id',
       cve: {
         products: 'foo:bar/dolor ipsum:lorem',
         configuration_nodes: {
@@ -235,6 +239,7 @@ describe('CVE model tests', () => {
     expect(cve4.products).toEqual(['foo:bar/dolor', 'ipsum:lorem']);
 
     const cve5 = Cve.fromElement({
+      _id: 'test-id',
       cve: {
         raw_data: {
           entry: {
@@ -252,6 +257,7 @@ describe('CVE model tests', () => {
 
   test('should parse published and modified date', () => {
     const elem = {
+      _id: 'test-id',
       cve: {
         raw_data: {
           entry: {
@@ -269,6 +275,7 @@ describe('CVE model tests', () => {
 
   test('should parse references', () => {
     const cve = Cve.fromElement({
+      _id: 'test-id',
       cve: {
         raw_data: {
           entry: {
@@ -296,6 +303,7 @@ describe('CVE model tests', () => {
     ]);
 
     const cve2 = Cve.fromElement({
+      _id: 'test-id',
       cve: {
         references: {
           reference: [
@@ -331,6 +339,7 @@ describe('CVE model tests', () => {
 
   test('should parse CVSS4 metrics', () => {
     const elem = {
+      _id: 'test-id',
       cve: {
         cvss_vector:
           'CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:A/VC:H/VI:L/VA:N/SC:L/SI:H/SA:N',

--- a/src/gmp/models/__tests__/dfn-cert.test.ts
+++ b/src/gmp/models/__tests__/dfn-cert.test.ts
@@ -7,11 +7,11 @@ import {describe, test, expect} from '@gsa/testing';
 import DfnCertAdv from 'gmp/models/dfn-cert';
 import {testModel} from 'gmp/models/testing';
 
-testModel(DfnCertAdv, 'dfncert');
-
 describe('DfnCertAdv model tests', () => {
+  testModel(DfnCertAdv, 'dfncert');
+
   test('should set defaults', () => {
-    const dfnCertAdv = new DfnCertAdv();
+    const dfnCertAdv = new DfnCertAdv({id: 'test-id'});
 
     expect(dfnCertAdv.severity).toBeUndefined();
     expect(dfnCertAdv.additionalLinks).toEqual([]);
@@ -22,7 +22,7 @@ describe('DfnCertAdv model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const dfnCertAdv = DfnCertAdv.fromElement();
+    const dfnCertAdv = DfnCertAdv.fromElement({_id: 'test-id'});
 
     expect(dfnCertAdv.severity).toBeUndefined();
     expect(dfnCertAdv.additionalLinks).toEqual([]);
@@ -33,8 +33,12 @@ describe('DfnCertAdv model tests', () => {
   });
 
   test('should parse severity correctly', () => {
-    const dfnCertAdv = DfnCertAdv.fromElement({dfn_cert_adv: {severity: 5.0}});
+    const dfnCertAdv = DfnCertAdv.fromElement({
+      _id: 'test-id',
+      dfn_cert_adv: {severity: 5.0},
+    });
     const dfnCertAdv2 = DfnCertAdv.fromElement({
+      _id: 'test-id',
       dfn_cert_adv: {severity: 10.0},
     });
 
@@ -44,6 +48,7 @@ describe('DfnCertAdv model tests', () => {
 
   test('should parse advisory links', () => {
     const elem = {
+      _id: 'test-id',
       dfn_cert_adv: {
         raw_data: {
           entry: {
@@ -71,6 +76,7 @@ describe('DfnCertAdv model tests', () => {
 
   test('should parse summary', () => {
     const elem = {
+      _id: 'test-id',
       dfn_cert_adv: {
         raw_data: {
           entry: {
@@ -88,6 +94,7 @@ describe('DfnCertAdv model tests', () => {
 
   test('should parse CVEs', () => {
     const elem = {
+      _id: 'test-id',
       dfn_cert_adv: {
         raw_data: {
           entry: {
@@ -103,6 +110,7 @@ describe('DfnCertAdv model tests', () => {
 
   test('should parse title', () => {
     const elem = {
+      _id: 'test-id',
       dfn_cert_adv: {
         title: 'Test Title',
       },

--- a/src/gmp/models/__tests__/entity-model.test.ts
+++ b/src/gmp/models/__tests__/entity-model.test.ts
@@ -12,14 +12,14 @@ import {NO_VALUE, YES_VALUE, type YesNo} from 'gmp/parser';
 
 describe('EntityModel tests', () => {
   test('should use defaults', () => {
-    const model = new EntityModel();
+    const model = new EntityModel({id: 'test-id'});
     expect(model._type).toBeUndefined();
     expect(model.active).toBeUndefined();
     expect(model.comment).toBeUndefined();
     expect(model.creationTime).toBeUndefined();
     expect(model.endTime).toBeUndefined();
     expect(model.entityType).toBeUndefined();
-    expect(model.id).toBeUndefined();
+    expect(model.id).toEqual('test-id');
     expect(model.inUse).toBeUndefined();
     expect(model.modificationTime).toBeUndefined();
     expect(model.name).toBeUndefined();
@@ -143,6 +143,7 @@ describe('EntityModel tests', () => {
 
   test('should return correct status methods', () => {
     const model = new EntityModel({
+      id: 'test-id',
       active: YES_VALUE as YesNo,
       inUse: true,
       orphan: YES_VALUE as YesNo,
@@ -159,8 +160,8 @@ describe('EntityModel tests', () => {
 
 describe('parseEntityModelFromElement tests', () => {
   test('should parse empty properties from element', () => {
-    const props = parseEntityModelProperties();
-    expect(props.id).toBeUndefined();
+    const props = parseEntityModelProperties({_id: '123'});
+    expect(props.id).toEqual('123');
     expect(props._type).toBeUndefined();
     expect(props.active).toBeUndefined();
     expect(props.comment).toBeUndefined();

--- a/src/gmp/models/__tests__/filter.test.ts
+++ b/src/gmp/models/__tests__/filter.test.ts
@@ -412,9 +412,7 @@ describe('Filter tests', () => {
     });
 
     test('Should not parse term as public property', () => {
-      const filter1 = Filter.fromElement({
-        term: 'abc=1',
-      });
+      const filter1 = Filter.fromElement({_id: 'test-id', term: 'abc=1'});
 
       // @ts-expect-error
       expect(filter1.term).toBeUndefined();
@@ -422,6 +420,7 @@ describe('Filter tests', () => {
 
     test('should parse alerts', () => {
       const filter1 = Filter.fromElement({
+        _id: 'test-id',
         term: 'abc=1',
         alerts: {
           alert: [

--- a/src/gmp/models/__tests__/group.test.ts
+++ b/src/gmp/models/__tests__/group.test.ts
@@ -11,30 +11,28 @@ testModel(Group, 'group');
 
 describe('Group model tests', () => {
   test('should parse multiple users', () => {
-    const elem = {
-      users: 'foo, bar',
-    };
+    const elem = {_id: 'test-id', users: 'foo, bar'};
     const group = Group.fromElement(elem);
 
     expect(group.users).toEqual(['foo', 'bar']);
   });
 
   test('should parse single user', () => {
-    const elem = {users: 'foo'};
+    const elem = {_id: 'test-id', users: 'foo'};
     const group = Group.fromElement(elem);
 
     expect(group.users).toEqual(['foo']);
   });
 
   test('should parse empty users string to empty array', () => {
-    const elem = {users: ''};
+    const elem = {_id: 'test-id', users: ''};
     const group = Group.fromElement(elem);
 
     expect(group.users).toEqual([]);
   });
 
   test('should parse empty object to have empty users array', () => {
-    const group = Group.fromElement({});
+    const group = Group.fromElement({_id: 'test-id'});
 
     expect(group.users).toEqual([]);
   });

--- a/src/gmp/models/__tests__/host.test.ts
+++ b/src/gmp/models/__tests__/host.test.ts
@@ -8,11 +8,12 @@ import Host from 'gmp/models/host';
 import {testModel} from 'gmp/models/testing';
 import {parseDate} from 'gmp/parser';
 
-testModel(Host, 'host');
-
 describe('Host model tests', () => {
+  testModel(Host, 'host');
+
   test('should use defaults', () => {
-    const host = new Host();
+    const host = new Host({id: 'test-id'});
+    expect(host.id).toEqual('test-id');
     expect(host.details).toBeUndefined();
     expect(host.hostname).toBeUndefined();
     expect(host.identifiers).toEqual([]);
@@ -23,7 +24,8 @@ describe('Host model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const host = Host.fromElement();
+    const host = Host.fromElement({_id: 'test-id'});
+    expect(host.id).toEqual('test-id');
     expect(host.details).toBeUndefined();
     expect(host.hostname).toBeUndefined();
     expect(host.identifiers).toEqual([]);
@@ -35,6 +37,7 @@ describe('Host model tests', () => {
 
   test('should parse severity', () => {
     const elem = {
+      _id: 'test-id',
       host: {
         severity: {
           value: '8.5',
@@ -42,6 +45,7 @@ describe('Host model tests', () => {
       },
     };
     const elem2 = {
+      _id: 'test-id',
       host: {
         severity: {
           value: '10',
@@ -57,10 +61,10 @@ describe('Host model tests', () => {
 
   test('should parse identifiers', () => {
     const host = Host.fromElement({
+      _id: 'test-id',
       identifiers: {
         identifier: [
           {
-            _id: '123abc',
             name: 'foo',
             value: 'bar:/3',
             creation_time: '2018-10-10T13:31:00+01:00',
@@ -76,7 +80,6 @@ describe('Host model tests', () => {
             },
           },
           {
-            _id: '321abc',
             name: 'bar',
             value: 'foo:/3',
             creation_time: '2018-10-10T13:31:00+01:00',
@@ -97,7 +100,6 @@ describe('Host model tests', () => {
     expect(host.identifiers).toEqual([
       {
         creationTime: parseDate('2018-10-10T13:31:00+01:00'),
-        id: '123abc',
         modificationTime: parseDate('2018-10-10T13:32:00+01:00'),
         name: 'foo',
         os: {id: 'teitl'},
@@ -111,7 +113,6 @@ describe('Host model tests', () => {
       },
       {
         creationTime: parseDate('2018-10-10T13:31:00+01:00'),
-        id: '321abc',
         modificationTime: parseDate('2018-10-10T13:32:00+01:00'),
         name: 'bar',
         os: {id: 'teitl'},
@@ -128,6 +129,7 @@ describe('Host model tests', () => {
 
   test('should parse hostname', () => {
     const host = Host.fromElement({
+      _id: 'test-id',
       identifiers: {
         identifier: [
           {
@@ -138,6 +140,7 @@ describe('Host model tests', () => {
       },
     });
     const host2 = Host.fromElement({
+      _id: 'test-id',
       identifiers: {
         identifier: [
           {
@@ -154,6 +157,7 @@ describe('Host model tests', () => {
 
   test('should parse os', () => {
     const host1 = Host.fromElement({
+      _id: 'test-id',
       host: {
         detail: [
           {
@@ -164,6 +168,7 @@ describe('Host model tests', () => {
       },
     });
     const host2 = Host.fromElement({
+      _id: 'test-id',
       identifiers: {
         identifier: [
           {
@@ -180,6 +185,7 @@ describe('Host model tests', () => {
 
   test('should parse ip', () => {
     const host = Host.fromElement({
+      _id: 'test-id',
       identifiers: {
         identifier: [
           {
@@ -195,6 +201,7 @@ describe('Host model tests', () => {
 
   test('should parse details', () => {
     const host = Host.fromElement({
+      _id: 'test-id',
       host: {
         detail: [
           {
@@ -233,6 +240,7 @@ describe('Host model tests', () => {
 
   test('should parse routes', () => {
     const host = Host.fromElement({
+      _id: 'test-id',
       host: {
         routes: {
           route: [

--- a/src/gmp/models/__tests__/note.test.ts
+++ b/src/gmp/models/__tests__/note.test.ts
@@ -14,7 +14,7 @@ describe('Note model tests', () => {
   testModel(Note, 'note', {testIsActive: false});
 
   test('should use defaults', () => {
-    const note = new Note();
+    const note = new Note({id: 'test-id'});
     expect(note.hosts).toEqual([]);
     expect(note.nvt).toBeUndefined();
     expect(note.port).toBeUndefined();
@@ -26,7 +26,7 @@ describe('Note model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const note = Note.fromElement();
+    const note = Note.fromElement({_id: 'test-id'});
     expect(note.hosts).toEqual([]);
     expect(note.nvt).toBeUndefined();
     expect(note.port).toBeUndefined();
@@ -38,24 +38,24 @@ describe('Note model tests', () => {
   });
 
   test('should parse severity', () => {
-    const note = Note.fromElement({severity: 8.5});
-    const note2 = Note.fromElement({severity: 10});
+    const note = Note.fromElement({_id: 'test-id', severity: 8.5});
+    const note2 = Note.fromElement({_id: 'test-id', severity: 10});
 
     expect(note.severity).toEqual(8.5);
     expect(note2.severity).toEqual(10);
   });
 
   test('should parse active', () => {
-    const note1 = Note.fromElement({active: 0});
-    const note2 = Note.fromElement({active: 1});
+    const note1 = Note.fromElement({_id: 'test-id', active: 0});
+    const note2 = Note.fromElement({_id: 'test-id', active: 1});
 
     expect(note1.active).toEqual(NO_VALUE);
     expect(note2.active).toEqual(YES_VALUE);
   });
 
   test('should parse text excerpt', () => {
-    const note1 = Note.fromElement({text_excerpt: '0'});
-    const note2 = Note.fromElement({text_excerpt: '1'});
+    const note1 = Note.fromElement({_id: 'test-id', text_excerpt: '0'});
+    const note2 = Note.fromElement({_id: 'test-id', text_excerpt: '1'});
 
     expect(note1.textExcerpt).toEqual(NO_VALUE);
     expect(note2.textExcerpt).toEqual(YES_VALUE);
@@ -63,17 +63,18 @@ describe('Note model tests', () => {
 
   test('should parse hosts', () => {
     const note1 = Note.fromElement({
+      _id: 'test-id',
       hosts: '123.456.789.42, 987.654.321.1',
     });
-    const note2 = Note.fromElement({hosts: ''});
+    const note2 = Note.fromElement({_id: 'test-id', hosts: ''});
 
     expect(note1.hosts).toEqual(['123.456.789.42', '987.654.321.1']);
     expect(note2.hosts).toEqual([]);
   });
 
   test('should parse port', () => {
-    const note1 = Note.fromElement({port: 'general/tcp'});
-    const note2 = Note.fromElement({port: ''});
+    const note1 = Note.fromElement({_id: 'test-id', port: 'general/tcp'});
+    const note2 = Note.fromElement({_id: 'test-id', port: ''});
 
     expect(note1.port).toEqual('general/tcp');
     expect(note2.port).toBeUndefined();
@@ -81,16 +82,18 @@ describe('Note model tests', () => {
 
   test('should parse task', () => {
     const note1 = Note.fromElement({
+      _id: 'test-id',
       task: {
         _id: '123abc',
       },
     });
     const note2 = Note.fromElement({
+      _id: 'test-id',
       task: {
         _id: '',
       },
     });
-    const note3 = Note.fromElement({});
+    const note3 = Note.fromElement({_id: 'test-id'});
 
     expect(note1.task?.id).toEqual('123abc');
     expect(note1.task?.entityType).toEqual('task');
@@ -100,11 +103,13 @@ describe('Note model tests', () => {
 
   test('should parse result', () => {
     const note1 = Note.fromElement({
+      _id: 'test-id',
       result: {
         _id: '123abc',
       },
     });
     const note2 = Note.fromElement({
+      _id: 'test-id',
       result: {
         _id: '',
       },
@@ -118,6 +123,7 @@ describe('Note model tests', () => {
 
   test('should parse NVT', () => {
     const note = Note.fromElement({
+      _id: 'test-id',
       nvt: {
         _oid: '1.2.3',
         name: 'foo',
@@ -132,8 +138,8 @@ describe('Note model tests', () => {
 
 describe('Note model methods tests', () => {
   test('isExcerpt() should return correct true/false', () => {
-    const note1 = Note.fromElement({text_excerpt: '1'});
-    const note2 = Note.fromElement({text_excerpt: '0'});
+    const note1 = Note.fromElement({_id: 'test-id', text_excerpt: '1'});
+    const note2 = Note.fromElement({_id: 'test-id', text_excerpt: '0'});
 
     expect(note1.isExcerpt()).toEqual(true);
     expect(note2.isExcerpt()).toEqual(false);

--- a/src/gmp/models/__tests__/nvt.test.ts
+++ b/src/gmp/models/__tests__/nvt.test.ts
@@ -5,23 +5,33 @@
 
 import {describe, test, expect} from '@gsa/testing';
 import date from 'gmp/models/date';
-import Nvt, {getRefs, hasRefType, getFilteredRefIds} from 'gmp/models/nvt';
+import Nvt, {
+  getRefs,
+  hasRefType,
+  getFilteredRefIds,
+  type NvtElement,
+  type NvtProperties,
+} from 'gmp/models/nvt';
 import {testModelFromElement, testModelMethods} from 'gmp/models/testing';
 
 describe('Nvt model tests', () => {
-  testModelFromElement(Nvt, 'nvt');
-  testModelMethods(Nvt);
+  testModelFromElement<Nvt, NvtElement, NvtProperties>(Nvt, 'nvt', {
+    initElementData: {_id: '123', nvt: {_oid: '1.2.3'}},
+  });
+  testModelMethods<Nvt, NvtElement, NvtProperties>(Nvt, {
+    initElementData: {_id: '123', nvt: {_oid: '1.2.3'}},
+  });
 
   test('should use defaults for Nvt', () => {
-    const nvt = new Nvt();
+    const nvt = new Nvt({id: 'test-id', oid: '1.2.3'});
 
     expect(nvt.certs).toEqual([]);
     expect(nvt.cves).toEqual([]);
     expect(nvt.defaultTimeout).toBeUndefined();
     expect(nvt.epss).toBeUndefined();
     expect(nvt.family).toBeUndefined();
-    expect(nvt.id).toBeUndefined();
-    expect(nvt.oid).toBeUndefined();
+    expect(nvt.id).toEqual('test-id');
+    expect(nvt.oid).toEqual('1.2.3');
     expect(nvt.preferences).toEqual([]);
     expect(nvt.qod).toBeUndefined();
     expect(nvt.severity).toBeUndefined();
@@ -34,15 +44,15 @@ describe('Nvt model tests', () => {
   });
 
   test('should parse NVT from element', () => {
-    const nvt = Nvt.fromElement({});
+    const nvt = Nvt.fromElement({_id: 'test-id', nvt: {_oid: '1.2.3'}});
 
     expect(nvt.certs).toEqual([]);
     expect(nvt.cves).toEqual([]);
     expect(nvt.defaultTimeout).toBeUndefined();
     expect(nvt.epss).toBeUndefined();
     expect(nvt.family).toBeUndefined();
-    expect(nvt.id).toBeUndefined();
-    expect(nvt.oid).toBeUndefined();
+    expect(nvt.id).toEqual('1.2.3');
+    expect(nvt.oid).toEqual('1.2.3');
     expect(nvt.preferences).toEqual([]);
     expect(nvt.qod).toBeUndefined();
     expect(nvt.severity).toBeUndefined();
@@ -54,19 +64,15 @@ describe('Nvt model tests', () => {
     expect(nvt.xrefs).toEqual([]);
   });
 
-  test('should parse NVT oid as id', () => {
-    const nvt1 = Nvt.fromElement({});
-    const nvt2 = Nvt.fromElement({nvt: {_oid: '1.2.3'}});
-
-    expect(nvt1.id).toBeUndefined();
-    expect(nvt1.oid).toBeUndefined();
-    expect(nvt2.oid).toEqual('1.2.3');
-    expect(nvt2.id).toEqual('1.2.3');
-  });
-
   test('should parse tags', () => {
-    const nvt1 = Nvt.fromElement({nvt: {tags: 'bv=/A:P|st=vf'}});
-    const nvt2 = Nvt.fromElement({nvt: {tags: 'bv='}});
+    const nvt1 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {_oid: '1.2.3', tags: 'bv=/A:P|st=vf'},
+    });
+    const nvt2 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {_oid: '1.2.3', tags: 'bv='},
+    });
     const res = {
       bv: '/A:P',
       st: 'vf',
@@ -78,7 +84,9 @@ describe('Nvt model tests', () => {
 
   test('should parse refs', () => {
     const elem = {
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         refs: {
           ref: [
             {
@@ -120,14 +128,19 @@ describe('Nvt model tests', () => {
   });
 
   test('should parse severity from cvss_base', () => {
-    const nvt1 = Nvt.fromElement({nvt: {cvss_base: 9.5}});
+    const nvt1 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {_oid: '1.2.3', cvss_base: 9.5},
+    });
 
     expect(nvt1.severity).toEqual(9.5);
   });
 
   test('should parse severity, severity date and severity origin from severities', () => {
     const nvt1 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         severities: {
           severity: {
             score: 9.4,
@@ -139,7 +152,9 @@ describe('Nvt model tests', () => {
       },
     });
     const nvt2 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         severities: {
           severity: {
             score: 7.4,
@@ -150,7 +165,9 @@ describe('Nvt model tests', () => {
       },
     });
     const nvt3 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         severities: {
           severity: {
             score: 1.0,
@@ -173,7 +190,9 @@ describe('Nvt model tests', () => {
 
   test('should fall back to cvss_base when severity is missing', () => {
     const nvt = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         cvss_base: 10.0,
         severities: {},
       },
@@ -185,8 +204,17 @@ describe('Nvt model tests', () => {
   });
 
   test('should parse preferences', () => {
-    const elem = {
+    const res = [
+      {
+        id: 1,
+        name: 'foo',
+        value: 'bar',
+      },
+    ];
+    const nvt = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         preferences: {
           preference: [
             {
@@ -200,47 +228,65 @@ describe('Nvt model tests', () => {
           ],
         },
       },
-    };
-    const res = [
-      {
-        id: 1,
-        name: 'foo',
-        value: 'bar',
-      },
-    ];
-    const nvt = Nvt.fromElement(elem);
+    });
 
     expect(nvt.preferences).toEqual(res);
   });
 
   test('should parse xrefs with correct protocol', () => {
-    const nvt1 = Nvt.fromElement({nvt: {refs: {ref: [{_id: '42'}]}}});
+    const nvt1 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {
+        _oid: '1.2.3',
+        refs: {ref: [{_id: '42'}]},
+      },
+    });
     const nvt2 = Nvt.fromElement({
-      nvt: {refs: {ref: [{_type: 'URL', _id: '42'}]}},
+      _id: 'test-id',
+      nvt: {
+        _oid: '1.2.3',
+        refs: {ref: [{_type: 'URL', _id: '42'}]},
+      },
     });
     const nvt3 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         refs: {ref: [{_type: 'URL', _id: 'http://42'}]},
       },
     });
     const nvt4 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         refs: {ref: [{_type: 'URL', _id: 'https://42'}]},
       },
     });
     const nvt5 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         refs: {ref: [{_type: 'URL', _id: 'ftp://42'}]},
       },
     });
     const nvt6 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
         refs: {ref: [{_type: 'URL', _id: 'ftps://42'}]},
+        _oid: '1.2.3',
       },
     });
-    const nvt7 = Nvt.fromElement({nvt: {refs: {ref: [{_id: 'ftps://42'}]}}});
-    const nvt8 = Nvt.fromElement({
+    const nvt7 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
+        refs: {ref: [{_id: 'ftps://42'}]},
+      },
+    });
+    const nvt8 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {
+        _oid: '1.2.3',
         refs: {ref: [{_type: 'URL', _id: 'https://42'}]},
       },
     });
@@ -256,11 +302,41 @@ describe('Nvt model tests', () => {
   });
 
   test('should parse qod', () => {
-    const nvt1 = Nvt.fromElement({nvt: {qod: {value: ''}}});
-    const nvt2 = Nvt.fromElement({nvt: {qod: {value: '75.5'}}});
-    const nvt3 = Nvt.fromElement({nvt: {qod: {type: ''}}});
-    const nvt4 = Nvt.fromElement({nvt: {qod: {type: 'foo'}}});
-    const nvt5 = Nvt.fromElement({nvt: {qod: {value: '75.5', type: 'foo'}}});
+    const nvt1 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {
+        _oid: '1.2.3',
+        qod: {value: ''},
+      },
+    });
+    const nvt2 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {
+        _oid: '1.2.3',
+        qod: {value: '75.5'},
+      },
+    });
+    const nvt3 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {
+        _oid: '1.2.3',
+        qod: {type: ''},
+      },
+    });
+    const nvt4 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {
+        _oid: '1.2.3',
+        qod: {type: 'foo'},
+      },
+    });
+    const nvt5 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {
+        _oid: '1.2.3',
+        qod: {value: '75.5', type: 'foo'},
+      },
+    });
 
     expect(nvt1.qod?.value).toBeUndefined();
     expect(nvt2.qod?.value).toEqual(75.5);
@@ -270,16 +346,40 @@ describe('Nvt model tests', () => {
   });
 
   test('should parse default timeout', () => {
-    const nvt1 = Nvt.fromElement({nvt: {default_timeout: ''}});
-    const nvt2 = Nvt.fromElement({nvt: {default_timeout: '123'}});
+    const nvt1 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {
+        _oid: '1.2.3',
+        default_timeout: '',
+      },
+    });
+    const nvt2 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {
+        _oid: '1.2.3',
+        default_timeout: '123',
+      },
+    });
 
     expect(nvt1.defaultTimeout).toBeUndefined();
     expect(nvt2.defaultTimeout).toEqual(123);
   });
 
   test('should parse timeout', () => {
-    const nvt1 = Nvt.fromElement({nvt: {timeout: ''}});
-    const nvt2 = Nvt.fromElement({nvt: {timeout: '123'}});
+    const nvt1 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {
+        _oid: '1.2.3',
+        timeout: '',
+      },
+    });
+    const nvt2 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {
+        _oid: '1.2.3',
+        timeout: '123',
+      },
+    });
 
     expect(nvt1.timeout).toBeUndefined();
     expect(nvt2.timeout).toEqual(123);
@@ -287,7 +387,9 @@ describe('Nvt model tests', () => {
 
   test('should parse unified solution type', () => {
     const nvt = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         solution: {
           _type: 'foo',
           _method: 'bar',
@@ -303,7 +405,9 @@ describe('Nvt model tests', () => {
 
   test('should set correct solution information for log NVTs', () => {
     const nvt1 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         solution: {
           _type: 'foo',
         },
@@ -320,7 +424,9 @@ describe('Nvt model tests', () => {
       method: undefined,
     };
     const nvt2 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         solution: {
           __text: 'bar',
         },
@@ -337,7 +443,9 @@ describe('Nvt model tests', () => {
       method: undefined,
     };
     const nvt3 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         solution: {
           _method: 'baz',
         },
@@ -354,7 +462,9 @@ describe('Nvt model tests', () => {
       method: 'baz',
     };
     const nvt4 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         solution: {
           _type: '',
           __text: 'foo',
@@ -379,8 +489,20 @@ describe('Nvt model tests', () => {
   });
 
   test('should parse family', () => {
-    const nvt1 = Nvt.fromElement({nvt: {family: 'foo'}});
-    const nvt2 = Nvt.fromElement({nvt: {family: ''}});
+    const nvt1 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {
+        _oid: '1.2.3',
+        family: 'foo',
+      },
+    });
+    const nvt2 = Nvt.fromElement({
+      _id: 'test-id',
+      nvt: {
+        _oid: '1.2.3',
+        family: '',
+      },
+    });
 
     expect(nvt1.family).toEqual('foo');
     expect(nvt2.family).toBeUndefined();
@@ -388,7 +510,9 @@ describe('Nvt model tests', () => {
 
   test('should parse epss', () => {
     const nvt1 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         epss: {
           max_epss: {
             percentile: 0.5,
@@ -410,7 +534,9 @@ describe('Nvt model tests', () => {
       },
     });
     const nvt2 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         epss: {
           max_epss: {
             percentile: 0.5,
@@ -424,7 +550,9 @@ describe('Nvt model tests', () => {
       },
     });
     const nvt3 = Nvt.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         epss: {
           max_severity: {
             percentile: 0.8,
@@ -619,17 +747,23 @@ describe('getFilteredRefIds tests', () => {
 describe('Nvt model method tests', () => {
   test('isDeprecated() returns correct true/false', () => {
     const nvt1 = new Nvt({
+      id: 'test-id',
+      oid: '1.2.3',
       tags: {
         summary: 'foo',
         deprecated: '1',
       },
     });
     const nvt2 = new Nvt({
+      id: 'test-id',
+      oid: '1.2.3',
       tags: {
         summary: 'bar',
       },
     });
     const nvt3 = new Nvt({
+      id: 'test-id',
+      oid: '1.2.3',
       tags: {
         summary: 'lorem',
         deprecated: '0',

--- a/src/gmp/models/__tests__/oci-image-target.test.ts
+++ b/src/gmp/models/__tests__/oci-image-target.test.ts
@@ -12,8 +12,8 @@ describe('OciImageTarget model tests', () => {
   testModel(OciImageTarget, 'ociimagetarget');
 
   test('should use defaults', () => {
-    const target = new OciImageTarget();
-    expect(target.id).toBeUndefined();
+    const target = new OciImageTarget({id: 'test-id'});
+    expect(target.id).toEqual('test-id');
     expect(target.name).toBeUndefined();
     expect(target.comment).toBeUndefined();
     expect(target.imageReferences).toEqual([]);
@@ -24,8 +24,8 @@ describe('OciImageTarget model tests', () => {
   });
 
   test('should parse defaults', () => {
-    const target = OciImageTarget.fromElement({});
-    expect(target.id).toBeUndefined();
+    const target = OciImageTarget.fromElement({_id: 'test-id'});
+    expect(target.id).toEqual('test-id');
     expect(target.name).toBeUndefined();
     expect(target.comment).toBeUndefined();
     expect(target.imageReferences).toEqual([]);
@@ -36,34 +36,45 @@ describe('OciImageTarget model tests', () => {
   });
 
   test('should parse imageReferences', () => {
-    const target = OciImageTarget.fromElement({image_references: 'img1,img2'});
+    const target = OciImageTarget.fromElement({
+      _id: 'test-id',
+      image_references: 'img1,img2',
+    });
     expect(target.imageReferences).toEqual(['img1', 'img2']);
   });
 
   test('should parse credential', () => {
     const credential = {_id: 'cred-1', name: 'Credential1'};
-    const target = OciImageTarget.fromElement({credential});
+    const target = OciImageTarget.fromElement({_id: 'test-id', credential});
     expect(target.credential).toBeDefined();
     expect(target.credential?.id).toEqual('cred-1');
     expect(target.credential?.name).toEqual('Credential1');
   });
 
   test('should parse excludeImages', () => {
-    const target = OciImageTarget.fromElement({exclude_images: 'excl1,excl2'});
+    const target = OciImageTarget.fromElement({
+      _id: 'test-id',
+      exclude_images: 'excl1,excl2',
+    });
     expect(target.excludeImages).toEqual(['excl1', 'excl2']);
   });
 
   test('should ignore empty credential', () => {
-    const target = OciImageTarget.fromElement({credential: {_id: ''}});
+    const target = OciImageTarget.fromElement({
+      _id: 'test-id',
+      credential: {_id: ''},
+    });
     expect(target.credential).toBeUndefined();
   });
 
   test('should parse reverseLookupOnly', () => {
     const targetTrue = OciImageTarget.fromElement({
+      _id: 'test-id',
       reverse_lookup_only: YES_VALUE,
     });
     expect(targetTrue.reverseLookupOnly).toEqual(true);
     const targetFalse = OciImageTarget.fromElement({
+      _id: 'test-id',
       reverse_lookup_only: NO_VALUE,
     });
     expect(targetFalse.reverseLookupOnly).toEqual(false);
@@ -71,10 +82,12 @@ describe('OciImageTarget model tests', () => {
 
   test('should parse reverseLookupUnify', () => {
     const targetTrue = OciImageTarget.fromElement({
+      _id: 'test-id',
       reverse_lookup_unify: YES_VALUE,
     });
     expect(targetTrue.reverseLookupUnify).toEqual(true);
     const targetFalse = OciImageTarget.fromElement({
+      _id: 'test-id',
       reverse_lookup_unify: NO_VALUE,
     });
     expect(targetFalse.reverseLookupUnify).toEqual(false);
@@ -82,6 +95,7 @@ describe('OciImageTarget model tests', () => {
 
   test('should parse all fields together', () => {
     const target = OciImageTarget.fromElement({
+      _id: 'test-id',
       image_references: 'imgA,imgB',
       exclude_images: 'exclA,exclB',
       credential: {_id: 'cred-2', name: 'Cred2'},

--- a/src/gmp/models/__tests__/os.test.ts
+++ b/src/gmp/models/__tests__/os.test.ts
@@ -11,7 +11,8 @@ testModel(OperatingSystem, 'operatingsystem');
 
 describe('OperatingSystem model tests', () => {
   test('should use defaults', () => {
-    const os = new OperatingSystem();
+    const os = new OperatingSystem({id: 'test-id'});
+    expect(os.id).toEqual('test-id');
     expect(os.averageSeverity).toBeUndefined();
     expect(os.highestSeverity).toBeUndefined();
     expect(os.latestSeverity).toBeUndefined();
@@ -21,7 +22,8 @@ describe('OperatingSystem model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const os = OperatingSystem.fromElement();
+    const os = OperatingSystem.fromElement({_id: 'test-id'});
+    expect(os.id).toEqual('test-id');
     expect(os.averageSeverity).toBeUndefined();
     expect(os.highestSeverity).toBeUndefined();
     expect(os.latestSeverity).toBeUndefined();
@@ -32,6 +34,7 @@ describe('OperatingSystem model tests', () => {
 
   test('should parse os severities', () => {
     const os1 = OperatingSystem.fromElement({
+      _id: 'test-id',
       os: {
         average_severity: {
           value: 7,
@@ -52,6 +55,7 @@ describe('OperatingSystem model tests', () => {
 
   test('should parse title', () => {
     const os = OperatingSystem.fromElement({
+      _id: 'test-id',
       os: {
         title: 'foo',
       },
@@ -62,6 +66,7 @@ describe('OperatingSystem model tests', () => {
 
   test('should parse hosts', () => {
     const os = OperatingSystem.fromElement({
+      _id: 'test-id',
       os: {
         installs: 42,
       },
@@ -71,6 +76,7 @@ describe('OperatingSystem model tests', () => {
 
   test('should parse allHosts', () => {
     const os = OperatingSystem.fromElement({
+      _id: 'test-id',
       os: {
         all_installs: 100,
       },

--- a/src/gmp/models/__tests__/override.test.ts
+++ b/src/gmp/models/__tests__/override.test.ts
@@ -13,7 +13,8 @@ describe('Override model tests', () => {
   testModel(Override, 'override', {testIsActive: false});
 
   test('should use defaults', () => {
-    const override = new Override();
+    const override = new Override({id: 'test-id'});
+    expect(override.id).toEqual('test-id');
     expect(override.hosts).toEqual([]);
     expect(override.newSeverity).toBeUndefined();
     expect(override.nvt).toBeUndefined();
@@ -26,7 +27,8 @@ describe('Override model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const override = Override.fromElement();
+    const override = Override.fromElement({_id: 'test-id'});
+    expect(override.id).toEqual('test-id');
     expect(override.hosts).toEqual([]);
     expect(override.newSeverity).toBeUndefined();
     expect(override.nvt).toBeUndefined();
@@ -39,56 +41,59 @@ describe('Override model tests', () => {
   });
 
   test('should parse severity', () => {
-    const override1 = Override.fromElement({severity: 8.5});
-    const override2 = Override.fromElement({severity: 10});
+    const override1 = Override.fromElement({_id: 'test-id', severity: 8.5});
+    const override2 = Override.fromElement({_id: 'test-id', severity: 10});
     expect(override1.severity).toEqual(8.5);
     expect(override2.severity).toEqual(10);
   });
 
   test('should parse new severity', () => {
-    const override1 = Override.fromElement({new_severity: 8.5});
-    const override2 = Override.fromElement({new_severity: 10});
+    const override1 = Override.fromElement({_id: 'test-id', new_severity: 8.5});
+    const override2 = Override.fromElement({_id: 'test-id', new_severity: 10});
     expect(override1.newSeverity).toEqual(8.5);
     expect(override2.newSeverity).toEqual(10);
   });
 
   test('should parse text', () => {
-    const override1 = Override.fromElement({text: 'foo bar'});
-    const override2 = Override.fromElement({text: ''});
+    const override1 = Override.fromElement({_id: 'test-id', text: 'foo bar'});
+    const override2 = Override.fromElement({_id: 'test-id', text: ''});
     expect(override1.text).toEqual('foo bar');
     expect(override2.text).toBeUndefined();
   });
 
   test('should parse text excerpt', () => {
-    const override1 = Override.fromElement({text_excerpt: 0});
-    const override2 = Override.fromElement({text_excerpt: 1});
+    const override1 = Override.fromElement({_id: 'test-id', text_excerpt: 0});
+    const override2 = Override.fromElement({_id: 'test-id', text_excerpt: 1});
     expect(override1.textExcerpt).toEqual(NO_VALUE);
     expect(override2.textExcerpt).toEqual(YES_VALUE);
   });
 
   test('should parse hosts', () => {
     const override1 = Override.fromElement({
+      _id: 'test-id',
       hosts: '123.456.789.42, 987.654.321.1',
     });
-    const override2 = Override.fromElement({hosts: ''});
+    const override2 = Override.fromElement({_id: 'test-id', hosts: ''});
     expect(override1.hosts).toEqual(['123.456.789.42', '987.654.321.1']);
     expect(override2.hosts).toEqual([]);
   });
 
   test('should parse port', () => {
-    const override1 = Override.fromElement({port: '1234'});
-    const override2 = Override.fromElement({port: ''});
+    const override1 = Override.fromElement({_id: 'test-id', port: '1234'});
+    const override2 = Override.fromElement({_id: 'test-id', port: ''});
     expect(override1.port).toEqual('1234');
     expect(override2.port).toBeUndefined();
   });
 
   test('should parse task', () => {
     const override1 = Override.fromElement({
+      _id: 'test-id',
       task: {
         _id: '123abc',
       },
     });
     const override2 = Override.fromElement({
+      _id: 'test-id',
       task: {
         _id: '',
       },
@@ -100,11 +105,13 @@ describe('Override model tests', () => {
 
   test('should parse result', () => {
     const override1 = Override.fromElement({
+      _id: 'test-id',
       result: {
         _id: '123abc',
       },
     });
     const override2 = Override.fromElement({
+      _id: 'test-id',
       result: {
         _id: '',
       },
@@ -117,6 +124,7 @@ describe('Override model tests', () => {
 
   test('should parse NVT', () => {
     const override = Override.fromElement({
+      _id: 'test-id',
       nvt: {
         _oid: '1.2.3',
         name: 'foo',
@@ -128,8 +136,8 @@ describe('Override model tests', () => {
   });
 
   test('should provide isExcerpt()', () => {
-    const override1 = new Override({textExcerpt: 1});
-    const override2 = new Override({textExcerpt: 0});
+    const override1 = new Override({id: 'test-id', textExcerpt: 1});
+    const override2 = new Override({id: 'test-id', textExcerpt: 0});
     expect(override1.isExcerpt()).toEqual(true);
     expect(override2.isExcerpt()).toEqual(false);
   });

--- a/src/gmp/models/__tests__/permission.test.ts
+++ b/src/gmp/models/__tests__/permission.test.ts
@@ -8,23 +8,26 @@ import Model from 'gmp/models/model';
 import Permission from 'gmp/models/permission';
 import {testModel} from 'gmp/models/testing';
 
-testModel(Permission, 'permission');
-
 describe('Permission model tests', () => {
+  testModel(Permission, 'permission');
+
   test('should use defaults', () => {
-    const permission = new Permission();
+    const permission = new Permission({id: 'test-id'});
+    expect(permission.id).toEqual('test-id');
     expect(permission.resource).toBeUndefined();
     expect(permission.subject).toBeUndefined();
   });
 
   test('should parse empty element', () => {
-    const permission = Permission.fromElement();
+    const permission = Permission.fromElement({_id: 'test-id'});
+    expect(permission.id).toEqual('test-id');
     expect(permission.resource).toBeUndefined();
     expect(permission.subject).toBeUndefined();
   });
 
   test('should parse resource', () => {
     const permission = Permission.fromElement({
+      _id: 'test-id',
       resource: {
         _id: '123',
         type: 'alert',
@@ -35,6 +38,7 @@ describe('Permission model tests', () => {
     expect(permission.resource?.id).toEqual('123');
 
     const permission2 = Permission.fromElement({
+      _id: 'test-id',
       resource: {
         type: 'alert',
       },
@@ -44,6 +48,7 @@ describe('Permission model tests', () => {
 
   test('should parse subject as model of their type', () => {
     const permission = Permission.fromElement({
+      _id: 'test-id',
       subject: {
         _id: '123',
         type: 'group',
@@ -54,6 +59,7 @@ describe('Permission model tests', () => {
     expect(permission.subject?.entityType).toEqual('group');
 
     const permission2 = Permission.fromElement({
+      _id: 'test-id',
       subject: {
         type: 'user',
       },

--- a/src/gmp/models/__tests__/policy.test.ts
+++ b/src/gmp/models/__tests__/policy.test.ts
@@ -12,7 +12,8 @@ describe('Policy model tests', () => {
   testModel(Policy, 'policy');
 
   test('should use defaults', () => {
-    const policy = new Policy();
+    const policy = new Policy({id: 'test-id'});
+    expect(policy.id).toEqual('test-id');
     expect(policy.families).toBeUndefined();
     expect(policy.family_list).toEqual([]);
     expect(policy.nvts).toBeUndefined();
@@ -26,7 +27,8 @@ describe('Policy model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const policy = Policy.fromElement();
+    const policy = Policy.fromElement({_id: 'test-id'});
+    expect(policy.id).toEqual('test-id');
     expect(policy.families).toEqual({count: 0});
     expect(policy.family_list).toEqual([]);
     expect(policy.nvts).toBeUndefined();
@@ -41,6 +43,7 @@ describe('Policy model tests', () => {
 
   test('should parse families', () => {
     const policy = Policy.fromElement({
+      _id: 'test-id',
       families: {
         family: [
           {
@@ -76,6 +79,7 @@ describe('Policy model tests', () => {
     });
 
     const policy2 = Policy.fromElement({
+      _id: 'test-id',
       families: {
         family: [
           {
@@ -93,6 +97,7 @@ describe('Policy model tests', () => {
 
   test('should parse family_count', () => {
     const policy = Policy.fromElement({
+      _id: 'test-id',
       family_count: {
         __text: '42',
         growing: 1,
@@ -104,6 +109,7 @@ describe('Policy model tests', () => {
 
   test('should parse nvt', () => {
     const policy = Policy.fromElement({
+      _id: 'test-id',
       nvt_count: {
         __text: '42',
         growing: 1,
@@ -139,6 +145,7 @@ describe('Policy model tests', () => {
     ];
 
     const policy = Policy.fromElement({
+      _id: 'test-id',
       preferences: {
         preference: [
           {
@@ -166,6 +173,7 @@ describe('Policy model tests', () => {
 
   test('should parse scanner', () => {
     const policy = Policy.fromElement({
+      _id: 'test-id',
       scanner: {
         __text: 'foo',
         _id: '123abc',
@@ -177,6 +185,7 @@ describe('Policy model tests', () => {
 
   test('should parse audits', () => {
     const policy = Policy.fromElement({
+      _id: 'test-id',
       tasks: {
         task: [
           {
@@ -191,10 +200,10 @@ describe('Policy model tests', () => {
   });
 
   test('should parse predefined as boolean correctly', () => {
-    const policy = Policy.fromElement({predefined: 0});
+    const policy = Policy.fromElement({_id: 'test-id', predefined: 0});
     expect(policy.predefined).toEqual(false);
 
-    const policy2 = Policy.fromElement({predefined: 1});
+    const policy2 = Policy.fromElement({_id: 'test-id', predefined: 1});
     expect(policy2.predefined).toEqual(true);
   });
 });

--- a/src/gmp/models/__tests__/port-list.test.ts
+++ b/src/gmp/models/__tests__/port-list.test.ts
@@ -53,6 +53,7 @@ describe('PortList model tests', () => {
 
   test('should parse port_count correctly and as integer', () => {
     const elem = {
+      _id: 'test-id',
       port_count: {
         all: '42',
         tcp: '20',
@@ -67,7 +68,7 @@ describe('PortList model tests', () => {
   });
 
   test('should return counts of zero, if port_count is not defined', () => {
-    const portList = PortList.fromElement({});
+    const portList = PortList.fromElement({_id: 'test-id'});
 
     expect(portList.portCount.all).toEqual(0);
     expect(portList.portCount.tcp).toEqual(0);
@@ -92,22 +93,22 @@ describe('PortList model tests', () => {
   });
 
   test('should return empty array if no targets are given', () => {
-    const portList = PortList.fromElement({});
+    const portList = PortList.fromElement({_id: 'test-id'});
 
     expect(portList.targets).toEqual([]);
   });
 
   test('should parse predefined as boolean correctly', () => {
-    const portList = PortList.fromElement({predefined: 0});
-    const portList2 = PortList.fromElement({predefined: 1});
+    const portList = PortList.fromElement({_id: 'test-id', predefined: 0});
+    const portList2 = PortList.fromElement({_id: 'test-id', predefined: 1});
 
     expect(portList.predefined).toEqual(false);
     expect(portList2.predefined).toEqual(true);
   });
 
   test('should parse deprecated as boolean correctly', () => {
-    const portList = PortList.fromElement({deprecated: 0});
-    const portList2 = PortList.fromElement({deprecated: 1});
+    const portList = PortList.fromElement({_id: 'test-id', deprecated: 0});
+    const portList2 = PortList.fromElement({_id: 'test-id', deprecated: 1});
 
     expect(portList.deprecated).toEqual(false);
     expect(portList2.deprecated).toEqual(true);

--- a/src/gmp/models/__tests__/report-config.test.ts
+++ b/src/gmp/models/__tests__/report-config.test.ts
@@ -11,14 +11,16 @@ describe('Report Config model tests', () => {
   testModel(ReportConfig, 'reportconfig', {testIsActive: false});
 
   test('should use defaults', () => {
-    const reportConfig = new ReportConfig();
+    const reportConfig = new ReportConfig({id: 'test-id'});
+    expect(reportConfig.id).toEqual('test-id');
     expect(reportConfig.alerts).toEqual([]);
     expect(reportConfig.params).toEqual([]);
     expect(reportConfig.reportFormat).toBeUndefined();
   });
 
   test('should parse empty element', () => {
-    const reportConfig = ReportConfig.fromElement();
+    const reportConfig = ReportConfig.fromElement({_id: 'test-id'});
+    expect(reportConfig.id).toEqual('test-id');
     expect(reportConfig.alerts).toEqual([]);
     expect(reportConfig.params).toEqual([]);
     expect(reportConfig.reportFormat).toBeUndefined();
@@ -26,6 +28,7 @@ describe('Report Config model tests', () => {
 
   test('should parse report format', () => {
     const reportConfig = ReportConfig.fromElement({
+      _id: 'test-id',
       report_format: {
         _id: 'foo',
         name: 'bar',
@@ -37,6 +40,7 @@ describe('Report Config model tests', () => {
 
   test('should parse alerts', () => {
     const reportConfig = ReportConfig.fromElement({
+      _id: 'test-id',
       alerts: {
         alert: {
           _id: 'foo',
@@ -48,6 +52,7 @@ describe('Report Config model tests', () => {
     expect(reportConfig.alerts[0].name).toEqual('bar');
 
     const reportConfig2 = ReportConfig.fromElement({
+      _id: 'test-id',
       alerts: {
         alert: [
           {
@@ -70,6 +75,7 @@ describe('Report Config model tests', () => {
   describe('params tests', () => {
     test('should parse params with attributes given as objects where applicable', () => {
       const reportConfig = ReportConfig.fromElement({
+        _id: 'test-id',
         param: [
           {
             value: {
@@ -97,6 +103,7 @@ describe('Report Config model tests', () => {
 
     test('should parse params with attributes not given as objects', () => {
       const reportConfig = ReportConfig.fromElement({
+        _id: 'test-id',
         param: [
           {
             value: 'lorem',
@@ -116,6 +123,7 @@ describe('Report Config model tests', () => {
 
     test('should parse options in params', () => {
       const reportConfig = ReportConfig.fromElement({
+        _id: 'test-id',
         param: [
           {
             options: {
@@ -136,6 +144,7 @@ describe('Report Config model tests', () => {
 
     test('should return empty array if no options are given', () => {
       const reportConfig = ReportConfig.fromElement({
+        _id: 'test-id',
         param: [
           {
             type: {
@@ -150,6 +159,7 @@ describe('Report Config model tests', () => {
 
     test('should parse param if it is not in an array', () => {
       const reportConfig = ReportConfig.fromElement({
+        _id: 'test-id',
         param: {
           name: 'foo',
           type: {
@@ -163,6 +173,7 @@ describe('Report Config model tests', () => {
 
     test('should parse param valueUsingDefault', () => {
       const reportConfig = ReportConfig.fromElement({
+        _id: 'test-id',
         param: [
           {
             name: 'foo',
@@ -194,6 +205,7 @@ describe('Report Config model tests', () => {
 
     test('should parse value, default and type in string params', () => {
       const reportConfig = ReportConfig.fromElement({
+        _id: 'test-id',
         param: [
           {
             value: {
@@ -232,6 +244,7 @@ describe('Report Config model tests', () => {
 
     test('should parse value, default and type in text params', () => {
       const reportConfig = ReportConfig.fromElement({
+        _id: 'test-id',
         param: [
           {
             value: {
@@ -270,6 +283,7 @@ describe('Report Config model tests', () => {
 
     test('should parse value, default and type in integer params', () => {
       const reportConfig = ReportConfig.fromElement({
+        _id: 'test-id',
         param: [
           {
             value: {
@@ -308,6 +322,7 @@ describe('Report Config model tests', () => {
 
     test('should parse value, default and type in boolean params', () => {
       const reportConfig = ReportConfig.fromElement({
+        _id: 'test-id',
         param: [
           {
             value: {
@@ -346,6 +361,7 @@ describe('Report Config model tests', () => {
 
     test('should parse options, value, default and type in selection params', () => {
       const reportConfig = ReportConfig.fromElement({
+        _id: 'test-id',
         param: [
           {
             value: {
@@ -408,6 +424,7 @@ describe('Report Config model tests', () => {
 
     test('should parse value, default and type in report_format_list params', () => {
       const reportConfig = ReportConfig.fromElement({
+        _id: 'test-id',
         param: [
           {
             type: {

--- a/src/gmp/models/__tests__/report-format.test.ts
+++ b/src/gmp/models/__tests__/report-format.test.ts
@@ -13,7 +13,8 @@ describe('ReportFormat model tests', () => {
   testModel(ReportFormat, 'reportformat', {testIsActive: false});
 
   test('should use defaults', () => {
-    const reportFormat = new ReportFormat();
+    const reportFormat = new ReportFormat({id: 'test-id'});
+    expect(reportFormat.id).toEqual('test-id');
     expect(reportFormat.alerts).toEqual([]);
     expect(reportFormat.configurable).toBeUndefined();
     expect(reportFormat.content_type).toBeUndefined();
@@ -28,7 +29,8 @@ describe('ReportFormat model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const reportFormat = ReportFormat.fromElement();
+    const reportFormat = ReportFormat.fromElement({_id: 'test-id'});
+    expect(reportFormat.id).toEqual('test-id');
     expect(reportFormat.alerts).toEqual([]);
     expect(reportFormat.configurable).toBeUndefined();
     expect(reportFormat.content_type).toBeUndefined();
@@ -44,12 +46,14 @@ describe('ReportFormat model tests', () => {
 
   test('should parse trust', () => {
     const reportFormat = ReportFormat.fromElement({
+      _id: 'test-id',
       trust: {
         __text: 'foo',
         time: '2018-10-10T13:30:00+01:00',
       },
     });
     const reportFormat2 = ReportFormat.fromElement({
+      _id: 'test-id',
       trust: {
         __text: 'bar',
       },
@@ -62,24 +66,36 @@ describe('ReportFormat model tests', () => {
   });
 
   test('should parse active', () => {
-    const reportFormat = ReportFormat.fromElement({active: 0});
-    const reportFormat2 = ReportFormat.fromElement({active: 1});
+    const reportFormat = ReportFormat.fromElement({_id: 'test-id', active: 0});
+    const reportFormat2 = ReportFormat.fromElement({_id: 'test-id', active: 1});
 
     expect(reportFormat.active).toEqual(NO_VALUE);
     expect(reportFormat2.active).toEqual(YES_VALUE);
   });
 
   test('should parse configurable', () => {
-    const reportFormat = ReportFormat.fromElement({configurable: 0});
-    const reportFormat2 = ReportFormat.fromElement({configurable: 1});
+    const reportFormat = ReportFormat.fromElement({
+      _id: 'test-id',
+      configurable: 0,
+    });
+    const reportFormat2 = ReportFormat.fromElement({
+      _id: 'test-id',
+      configurable: 1,
+    });
 
     expect(reportFormat.configurable).toEqual(false);
     expect(reportFormat2.configurable).toEqual(true);
   });
 
   test('should parse predefined', () => {
-    const reportFormat = ReportFormat.fromElement({predefined: 0});
-    const reportFormat2 = ReportFormat.fromElement({predefined: 1});
+    const reportFormat = ReportFormat.fromElement({
+      _id: 'test-id',
+      predefined: 0,
+    });
+    const reportFormat2 = ReportFormat.fromElement({
+      _id: 'test-id',
+      predefined: 1,
+    });
 
     expect(reportFormat.predefined).toEqual(false);
     expect(reportFormat2.predefined).toEqual(true);
@@ -87,6 +103,7 @@ describe('ReportFormat model tests', () => {
 
   test('should parse alerts', () => {
     const reportFormat = ReportFormat.fromElement({
+      _id: 'test-id',
       alerts: {
         alert: [{_id: '12'}],
       },
@@ -98,6 +115,7 @@ describe('ReportFormat model tests', () => {
 
   test('should parse content type', () => {
     const reportFormat = ReportFormat.fromElement({
+      _id: 'test-id',
       content_type: 'application/pdf',
     });
     expect(reportFormat.content_type).toEqual('application/pdf');
@@ -105,6 +123,7 @@ describe('ReportFormat model tests', () => {
 
   test('should parse extension', () => {
     const reportFormat = ReportFormat.fromElement({
+      _id: 'test-id',
       extension: 'pdf',
     });
     expect(reportFormat.extension).toEqual('pdf');
@@ -112,6 +131,7 @@ describe('ReportFormat model tests', () => {
 
   test('should parse report type', () => {
     const reportFormat = ReportFormat.fromElement({
+      _id: 'test-id',
       report_type: 'scan',
     });
     expect(reportFormat.report_type).toEqual('scan');
@@ -119,6 +139,7 @@ describe('ReportFormat model tests', () => {
 
   test('should parse invisible alerts count', () => {
     const reportFormat = ReportFormat.fromElement({
+      _id: 'test-id',
       invisible_alerts: 3,
     });
 
@@ -127,6 +148,7 @@ describe('ReportFormat model tests', () => {
 
   test('should parse invisible report configs count', () => {
     const reportFormat = ReportFormat.fromElement({
+      _id: 'test-id',
       invisible_report_configs: 5,
     });
 
@@ -135,6 +157,7 @@ describe('ReportFormat model tests', () => {
 
   test('should parse params', () => {
     const reportFormat = ReportFormat.fromElement({
+      _id: 'test-id',
       param: [
         {
           default: 'ipsum',
@@ -160,6 +183,7 @@ describe('ReportFormat model tests', () => {
     expect(reportFormat.params[0].valueUsingDefault).toBeUndefined();
 
     const reportFormat2 = ReportFormat.fromElement({
+      _id: 'test-id',
       param: [
         {
           default: 'ipsum',
@@ -184,6 +208,7 @@ describe('ReportFormat model tests', () => {
     expect(reportFormat2.params[0].valueUsingDefault).toBeUndefined();
 
     const reportFormat3 = ReportFormat.fromElement({
+      _id: 'test-id',
       param: [
         {
           default: {
@@ -210,6 +235,7 @@ describe('ReportFormat model tests', () => {
     expect(reportFormat3.params[0].valueUsingDefault).toBeUndefined();
 
     const reportFormat4 = ReportFormat.fromElement({
+      _id: 'test-id',
       param: [
         {
           options: {
@@ -238,6 +264,7 @@ describe('ReportFormat model tests', () => {
     expect(reportFormat4.params[0].valueUsingDefault).toBeUndefined();
 
     const reportFormat5 = ReportFormat.fromElement({
+      _id: 'test-id',
       param: [
         {
           value: {
@@ -262,6 +289,7 @@ describe('ReportFormat model tests', () => {
     expect(reportFormat5.params[0].valueUsingDefault).toBeUndefined();
 
     const reportFormat6 = ReportFormat.fromElement({
+      _id: 'test-id',
       param: [
         {
           value: 'bar',
@@ -284,6 +312,7 @@ describe('ReportFormat model tests', () => {
     expect(reportFormat6.params[0].valueUsingDefault).toBeUndefined();
 
     const reportFormat7 = ReportFormat.fromElement({
+      _id: 'test-id',
       param: [
         {
           type: {
@@ -318,6 +347,7 @@ describe('ReportFormat model tests', () => {
     expect(reportFormat7.params[0].valueUsingDefault).toBeUndefined();
 
     const reportFormat8 = ReportFormat.fromElement({
+      _id: 'test-id',
       param: [
         {
           type: {
@@ -346,6 +376,7 @@ describe('ReportFormat model tests', () => {
     expect(reportFormat8.params[0].valueUsingDefault).toBeUndefined();
 
     const reportFormat9 = ReportFormat.fromElement({
+      _id: 'test-id',
       param: [
         {
           type: {
@@ -380,6 +411,7 @@ describe('ReportFormat model tests', () => {
     expect(reportFormat9.params[0].valueUsingDefault).toBeUndefined();
 
     const reportFormat10 = ReportFormat.fromElement({
+      _id: 'test-id',
       param: [
         {
           value: {
@@ -407,8 +439,8 @@ describe('ReportFormat model tests', () => {
 
   describe('ReportFormat model method tests', () => {
     test('isActive() returns correct true/false', () => {
-      const reportFormat = new ReportFormat({active: 0});
-      const reportFormat2 = new ReportFormat({active: 1});
+      const reportFormat = new ReportFormat({id: 'test-id', active: 0});
+      const reportFormat2 = new ReportFormat({id: 'test-id', active: 1});
 
       expect(reportFormat.isActive()).toBe(false);
       expect(reportFormat2.isActive()).toBe(true);
@@ -416,11 +448,13 @@ describe('ReportFormat model tests', () => {
 
     test('isTrusted() returns correct true/false', () => {
       const reportFormat = new ReportFormat({
+        id: 'test-id',
         trust: {
           value: 'no',
         },
       });
       const reportFormat2 = new ReportFormat({
+        id: 'test-id',
         trust: {
           value: 'yes',
         },

--- a/src/gmp/models/__tests__/report.test.ts
+++ b/src/gmp/models/__tests__/report.test.ts
@@ -11,7 +11,8 @@ describe('Report tests', () => {
   testModel(Report, 'report');
 
   test('should use defaults', () => {
-    const report = new Report();
+    const report = new Report({id: 'test-id'});
+    expect(report.id).toEqual('test-id');
     expect(report.content_type).toBeUndefined();
     expect(report.report).toBeUndefined();
     expect(report.report_config).toBeUndefined();
@@ -21,7 +22,7 @@ describe('Report tests', () => {
   });
 
   test('should parse empty element', () => {
-    const report = Report.fromElement();
+    const report = Report.fromElement({_id: 'test-id'});
     expect(report.content_type).toBeUndefined();
     expect(report.report).toBeUndefined();
     expect(report.report_config).toBeUndefined();
@@ -32,6 +33,7 @@ describe('Report tests', () => {
 
   test('should parse report', () => {
     const report = Report.fromElement({
+      _id: 'test-id',
       report: {
         _type: 'delta',
         _id: '123',
@@ -45,14 +47,13 @@ describe('Report tests', () => {
   });
 
   test('should parse report type', () => {
-    const report = Report.fromElement({
-      _type: 'delta',
-    });
+    const report = Report.fromElement({_id: 'test-id', _type: 'delta'});
     expect(report.report_type).toEqual('delta');
   });
 
   test('should parse report config', () => {
     const report = Report.fromElement({
+      _id: 'test-id',
       report_config: {
         _id: 'config123',
         name: 'Test Config',
@@ -65,6 +66,7 @@ describe('Report tests', () => {
 
   test('should parse report format', () => {
     const report = Report.fromElement({
+      _id: 'test-id',
       report_format: {
         _id: 'format123',
         name: 'Test Format',
@@ -77,6 +79,7 @@ describe('Report tests', () => {
 
   test('should parse task', () => {
     const report = Report.fromElement({
+      _id: 'test-id',
       task: {
         _id: 'task123',
         name: 'Test Task',
@@ -89,6 +92,7 @@ describe('Report tests', () => {
 
   test('should parse content type', () => {
     const report = Report.fromElement({
+      _id: 'test-id',
       _content_type: 'application/xml',
     });
     expect(report.content_type).toEqual('application/xml');

--- a/src/gmp/models/__tests__/result.test.ts
+++ b/src/gmp/models/__tests__/result.test.ts
@@ -12,7 +12,8 @@ describe('Result model tests', () => {
   testModel(Result, 'result');
 
   test('should use defaults', () => {
-    const result = new Result();
+    const result = new Result({id: 'test-id'});
+    expect(result.id).toEqual('test-id');
     expect(result.compliance).toBeUndefined();
     expect(result.delta).toBeUndefined();
     expect(result.detection).toBeUndefined();
@@ -33,7 +34,8 @@ describe('Result model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const result = Result.fromElement();
+    const result = Result.fromElement({_id: 'test-id'});
+    expect(result.id).toEqual('test-id');
     expect(result.compliance).toBeUndefined();
     expect(result.delta).toBeUndefined();
     expect(result.detection).toBeUndefined();
@@ -55,6 +57,7 @@ describe('Result model tests', () => {
 
   test('should parse host', () => {
     const result = Result.fromElement({
+      _id: 'test-id',
       host: {
         __text: 'foo',
         asset: {
@@ -70,6 +73,7 @@ describe('Result model tests', () => {
     });
 
     const result2 = Result.fromElement({
+      _id: 'test-id',
       host: {
         __text: 'foo',
       },
@@ -79,6 +83,7 @@ describe('Result model tests', () => {
     });
 
     const result3 = Result.fromElement({
+      _id: 'test-id',
       host: {
         asset: {_asset_id: ''},
         __text: 'foo',
@@ -93,6 +98,7 @@ describe('Result model tests', () => {
 
   test('should parse host with container image fields', () => {
     const result = Result.fromElement({
+      _id: 'test-id',
       host: {
         __text: 'sha256:abc123',
         asset: {
@@ -124,6 +130,7 @@ describe('Result model tests', () => {
 
   test('should parse NVT', () => {
     const result = Result.fromElement({
+      _id: 'test-id',
       nvt: {
         _oid: 'bar',
         type: 'nvt',
@@ -135,6 +142,7 @@ describe('Result model tests', () => {
 
   test('should parse CVE', () => {
     const result = Result.fromElement({
+      _id: 'test-id',
       nvt: {
         name: 'CVE-1234',
         type: 'cve',
@@ -148,6 +156,7 @@ describe('Result model tests', () => {
 
   test('should parse EPSS cve', () => {
     const result = Result.fromElement({
+      _id: 'test-id',
       nvt: {
         name: 'CVE-1234',
         type: 'cve',
@@ -179,6 +188,7 @@ describe('Result model tests', () => {
 
   test('should parse EPSS nvt', () => {
     const result = Result.fromElement({
+      _id: 'test-id',
       nvt: {
         name: 'CVE-1234',
         type: 'nvt',
@@ -209,15 +219,16 @@ describe('Result model tests', () => {
   });
 
   test('should parse severity', () => {
-    const result = Result.fromElement({severity: 4.2});
+    const result = Result.fromElement({_id: 'test-id', severity: 4.2});
     expect(result.severity).toEqual(4.2);
   });
 
   test('should parse vulnerability', () => {
-    const result = Result.fromElement({name: 'foo'});
+    const result = Result.fromElement({_id: 'test-id', name: 'foo'});
     expect(result.vulnerability).toEqual('foo');
 
     const result2 = Result.fromElement({
+      _id: 'test-id',
       nvt: {
         _oid: '42',
       },
@@ -226,19 +237,20 @@ describe('Result model tests', () => {
   });
 
   test('should parse report', () => {
-    const result = Result.fromElement({report: {_id: 'foo'}});
+    const result = Result.fromElement({_id: 'test-id', report: {_id: 'foo'}});
     expect(result.report?.id).toEqual('foo');
     expect(result.report?.entityType).toEqual('report');
   });
 
   test('should parse task', () => {
-    const result = Result.fromElement({task: {_id: 'foo'}});
+    const result = Result.fromElement({_id: 'test-id', task: {_id: 'foo'}});
     expect(result.task?.id).toEqual('foo');
     expect(result.task?.entityType).toEqual('task');
   });
 
   test('should parse detection', () => {
     const result = Result.fromElement({
+      _id: 'test-id',
       detection: {
         result: {
           _id: '1337',
@@ -269,11 +281,12 @@ describe('Result model tests', () => {
   });
 
   test('should parse delta', () => {
-    const result = Result.fromElement({delta: 'foo'});
+    const result = Result.fromElement({_id: 'test-id', delta: 'foo'});
     expect(result.delta).toBeInstanceOf(Delta);
     expect(result.delta?.delta_type).toEqual('foo');
 
     const result2 = Result.fromElement({
+      _id: 'test-id',
       delta: {
         __text: 'foo',
       },
@@ -282,6 +295,7 @@ describe('Result model tests', () => {
     expect(result2.delta?.delta_type).toEqual('foo');
 
     const result3 = Result.fromElement({
+      _id: 'test-id',
       delta: {
         __text: Delta.TYPE_CHANGED,
         diff: 'some foobar diff',
@@ -300,12 +314,13 @@ describe('Result model tests', () => {
   });
 
   test('should parse original severity', () => {
-    const result = Result.fromElement({original_severity: 4.2});
+    const result = Result.fromElement({_id: 'test-id', original_severity: 4.2});
     expect(result.original_severity).toEqual(4.2);
   });
 
   test('should parse QoD', () => {
     const result = Result.fromElement({
+      _id: 'test-id',
       qod: {
         type: 'foo',
         value: '42.5',
@@ -317,6 +332,7 @@ describe('Result model tests', () => {
 
   test('should parse notes', () => {
     const result = Result.fromElement({
+      _id: 'test-id',
       notes: {
         note: [
           {
@@ -336,6 +352,7 @@ describe('Result model tests', () => {
     expect(result.notes?.[1].id).toEqual('bar');
 
     const result2 = Result.fromElement({
+      _id: 'test-id',
       notes: {
         note: {
           _id: 'baz',
@@ -348,6 +365,7 @@ describe('Result model tests', () => {
 
   test('should parse overrides', () => {
     const result = Result.fromElement({
+      _id: 'test-id',
       overrides: {
         override: [{_id: 'foo'}, {_id: 'bar'}],
       },
@@ -358,6 +376,7 @@ describe('Result model tests', () => {
     expect(result.overrides[1].id).toEqual('bar');
 
     const result2 = Result.fromElement({
+      _id: 'test-id',
       overrides: {
         override: {_id: 'baz'},
       },
@@ -368,6 +387,7 @@ describe('Result model tests', () => {
 
   test('should parse compliance', () => {
     const result = Result.fromElement({
+      _id: 'test-id',
       compliance: 'undefined',
     });
     expect(result.compliance).toEqual('undefined');
@@ -375,6 +395,7 @@ describe('Result model tests', () => {
 
   test('should parse description', () => {
     const result = Result.fromElement({
+      _id: 'test-id',
       description: 'This is a test description',
     });
     expect(result.description).toEqual('This is a test description');
@@ -382,6 +403,7 @@ describe('Result model tests', () => {
 
   test('should parse tickets', () => {
     const result = Result.fromElement({
+      _id: 'test-id',
       tickets: {
         ticket: [{_id: 'foo'}, {_id: 'bar'}],
       },
@@ -392,6 +414,7 @@ describe('Result model tests', () => {
     expect(result.tickets[1].id).toEqual('bar');
 
     const result2 = Result.fromElement({
+      _id: 'test-id',
       tickets: {
         ticket: {_id: 'baz'},
       },
@@ -401,18 +424,21 @@ describe('Result model tests', () => {
   });
 
   test('should parse port', () => {
-    const result = Result.fromElement({port: '1234/tcp'});
+    const result = Result.fromElement({_id: 'test-id', port: '1234/tcp'});
     expect(result.port).toEqual('1234/tcp');
   });
 
   test('should parse scan_nvt_version', () => {
-    const result = Result.fromElement({scan_nvt_version: '1.2.3'});
+    const result = Result.fromElement({
+      _id: 'test-id',
+      scan_nvt_version: '1.2.3',
+    });
     expect(result.scan_nvt_version).toEqual('1.2.3');
   });
 
   test('hasDelta() should return correct true/false', () => {
-    const result = Result.fromElement({delta: 'defined'});
-    const result2 = Result.fromElement();
+    const result = Result.fromElement({_id: 'test-id', delta: 'defined'});
+    const result2 = Result.fromElement({_id: 'test-id'});
 
     expect(result.hasDelta()).toEqual(true);
     expect(result2.hasDelta()).toEqual(false);

--- a/src/gmp/models/__tests__/role.test.ts
+++ b/src/gmp/models/__tests__/role.test.ts
@@ -16,18 +16,18 @@ describe('Role model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const role = Role.fromElement({});
+    const role = Role.fromElement({_id: 'test-id'});
     expect(role.users).toEqual([]);
   });
 
   test('should parse users', () => {
-    const role = Role.fromElement({users: 'foo, bar'});
+    const role = Role.fromElement({_id: 'test-id', users: 'foo, bar'});
     expect(role.users).toEqual(['foo', 'bar']);
 
-    const role2 = Role.fromElement({users: 'foo'});
+    const role2 = Role.fromElement({_id: 'test-id', users: 'foo'});
     expect(role2.users).toEqual(['foo']);
 
-    const role3 = Role.fromElement({users: ''});
+    const role3 = Role.fromElement({_id: 'test-id', users: ''});
     expect(role3.users).toEqual([]);
   });
 });

--- a/src/gmp/models/__tests__/scan-config.test.ts
+++ b/src/gmp/models/__tests__/scan-config.test.ts
@@ -15,7 +15,8 @@ describe('ScanConfig model tests', () => {
   testModel(ScanConfig, 'scanconfig');
 
   test('should use defaults', () => {
-    const scanConfig = new ScanConfig();
+    const scanConfig = new ScanConfig({id: 'test-id'});
+    expect(scanConfig.id).toEqual('test-id');
     expect(scanConfig.family_list).toEqual([]);
     expect(scanConfig.families).toBeUndefined();
     expect(scanConfig.nvts).toBeUndefined();
@@ -29,7 +30,7 @@ describe('ScanConfig model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const scanConfig = ScanConfig.fromElement();
+    const scanConfig = ScanConfig.fromElement({_id: 'test-id'});
     expect(scanConfig.family_list).toEqual([]);
     expect(scanConfig.families).toEqual({count: 0});
     expect(scanConfig.nvts).toBeUndefined();
@@ -44,6 +45,7 @@ describe('ScanConfig model tests', () => {
 
   test('should parse families', () => {
     const scanConfig = ScanConfig.fromElement({
+      _id: 'test-id',
       families: {
         family: [
           {
@@ -78,6 +80,7 @@ describe('ScanConfig model tests', () => {
     });
 
     const scanConfig2 = ScanConfig.fromElement({
+      _id: 'test-id',
       families: {
         family: [
           {
@@ -95,6 +98,7 @@ describe('ScanConfig model tests', () => {
 
   test('should parse family count', () => {
     const scanConfig = ScanConfig.fromElement({
+      _id: 'test-id',
       family_count: {
         __text: '42',
         growing: 1,
@@ -106,6 +110,7 @@ describe('ScanConfig model tests', () => {
 
   test('should parse nvts', () => {
     const scanConfig = ScanConfig.fromElement({
+      _id: 'test-id',
       nvt_count: {
         __text: '42',
         growing: 1,
@@ -141,6 +146,7 @@ describe('ScanConfig model tests', () => {
     ];
 
     const scanConfig = ScanConfig.fromElement({
+      _id: 'test-id',
       preferences: {
         preference: [
           {
@@ -168,6 +174,7 @@ describe('ScanConfig model tests', () => {
 
   test('should parse scanner', () => {
     const scanConfig = ScanConfig.fromElement({
+      _id: 'test-id',
       scanner: {
         __text: 'foo',
         _id: '123abc',
@@ -180,6 +187,7 @@ describe('ScanConfig model tests', () => {
 
   test('should parse tasks', () => {
     const scanConfig = ScanConfig.fromElement({
+      _id: 'test-id',
       tasks: {
         task: [
           {
@@ -195,16 +203,16 @@ describe('ScanConfig model tests', () => {
   });
 
   test('should parse predefined', () => {
-    const scanConfig = ScanConfig.fromElement({predefined: 0});
-    const scanConfig2 = ScanConfig.fromElement({predefined: 1});
+    const scanConfig = ScanConfig.fromElement({_id: 'test-id', predefined: 0});
+    const scanConfig2 = ScanConfig.fromElement({_id: 'test-id', predefined: 1});
 
     expect(scanConfig.predefined).toEqual(false);
     expect(scanConfig2.predefined).toEqual(true);
   });
 
   test('should parse deprecated', () => {
-    const scanConfig = ScanConfig.fromElement({deprecated: 0});
-    const scanConfig2 = ScanConfig.fromElement({deprecated: 1});
+    const scanConfig = ScanConfig.fromElement({_id: 'test-id', deprecated: 0});
+    const scanConfig2 = ScanConfig.fromElement({_id: 'test-id', deprecated: 1});
 
     expect(scanConfig.deprecated).toEqual(false);
     expect(scanConfig2.deprecated).toEqual(true);

--- a/src/gmp/models/__tests__/scanner.test.ts
+++ b/src/gmp/models/__tests__/scanner.test.ts
@@ -28,7 +28,8 @@ describe('Scanner model tests', () => {
   });
 
   test('should use defaults', () => {
-    const scanner = new Scanner();
+    const scanner = new Scanner({id: 'test-id'});
+    expect(scanner.id).toEqual('test-id');
     expect(scanner.caPub).toBeUndefined();
     expect(scanner.configs).toEqual([]);
     expect(scanner.credential).toBeUndefined();
@@ -41,7 +42,7 @@ describe('Scanner model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const scanner = Scanner.fromElement({});
+    const scanner = Scanner.fromElement({_id: 'test-id'});
     expect(scanner.caPub).toBeUndefined();
     expect(scanner.configs).toEqual([]);
     expect(scanner.credential).toBeUndefined();
@@ -54,18 +55,20 @@ describe('Scanner model tests', () => {
   });
 
   test('should parse type', () => {
-    const scanner = Scanner.fromElement({type: '42'});
+    const scanner = Scanner.fromElement({_id: 'test-id', type: '42'});
 
     expect(scanner.scannerType).toEqual('42');
   });
 
   test('should parse credential', () => {
     const scanner = Scanner.fromElement({
+      _id: 'test-id',
       credential: {
         _id: '123abc',
       },
     });
     const scanner2 = Scanner.fromElement({
+      _id: 'test-id',
       credential: {
         _id: '',
       },
@@ -78,18 +81,15 @@ describe('Scanner model tests', () => {
   });
 
   test('should parse ca pub', () => {
-    const scanner = Scanner.fromElement({
-      ca_pub: '',
-    });
+    const scanner = Scanner.fromElement({_id: 'test-id', ca_pub: ''});
     expect(scanner.caPub).toBeUndefined();
-    const scanner2 = Scanner.fromElement({
-      ca_pub: 'foobar',
-    });
+    const scanner2 = Scanner.fromElement({_id: 'test-id', ca_pub: 'foobar'});
     expect(scanner2.caPub).toEqual({certificate: 'foobar'});
   });
 
   test('should parse ca pub info', () => {
     const elem = {
+      _id: 'test-id',
       ca_pub: 'foo',
       ca_pub_info: {
         activation_time: '2018-10-10T23:00:00.000+0000',
@@ -104,6 +104,7 @@ describe('Scanner model tests', () => {
 
   test('should parse tasks', () => {
     const scanner = Scanner.fromElement({
+      _id: 'test-id',
       tasks: {
         task: [
           {_id: '123', usage_type: 'scan'},
@@ -123,6 +124,7 @@ describe('Scanner model tests', () => {
 
   test('should parse scan configs', () => {
     const scanner = Scanner.fromElement({
+      _id: 'test-id',
       configs: {
         config: [{_id: '123'}],
       },
@@ -134,6 +136,7 @@ describe('Scanner model tests', () => {
 
   test('should parse scanner info', () => {
     const scanner = Scanner.fromElement({
+      _id: 'test-id',
       info: {
         scanner: {
           name: 'foo',
@@ -160,6 +163,7 @@ describe('Scanner model tests', () => {
       },
     });
     const scanner2 = Scanner.fromElement({
+      _id: 'test-id',
       info: {
         description: '',
         params: {},
@@ -186,18 +190,21 @@ describe('Scanner model tests', () => {
 
   test('should parse port', () => {
     const scanner = Scanner.fromElement({
+      _id: 'test-id',
       // @ts-expect-error
       port: '9392',
     });
     const scanner2 = Scanner.fromElement({
+      _id: 'test-id',
       // @ts-expect-error
       port: 'not-a-number',
     });
     const scanner3 = Scanner.fromElement({
+      _id: 'test-id',
       // @ts-expect-error
       port: '',
     });
-    const scanner4 = Scanner.fromElement({port: 1234});
+    const scanner4 = Scanner.fromElement({_id: 'test-id', port: 1234});
 
     expect(scanner.port).toEqual(9392);
     expect(scanner2.port).toBeUndefined();
@@ -206,8 +213,8 @@ describe('Scanner model tests', () => {
   });
 
   test('should parse disabled', () => {
-    const scanner = Scanner.fromElement({disabled: 0});
-    const scanner2 = Scanner.fromElement({disabled: 1});
+    const scanner = Scanner.fromElement({_id: 'test-id', disabled: 0});
+    const scanner2 = Scanner.fromElement({_id: 'test-id', disabled: 1});
 
     expect(scanner.disabled).toEqual(false);
     expect(scanner2.disabled).toEqual(true);
@@ -216,9 +223,18 @@ describe('Scanner model tests', () => {
 
 describe('Scanner model method tests', () => {
   test('isCloneable() should return correct true/false', () => {
-    const scanner1 = new Scanner({scannerType: CVE_SCANNER_TYPE});
-    const scanner2 = new Scanner({scannerType: OPENVAS_SCANNER_TYPE});
-    const scanner3 = new Scanner({scannerType: GREENBONE_SENSOR_SCANNER_TYPE});
+    const scanner1 = new Scanner({
+      id: 'test-id',
+      scannerType: CVE_SCANNER_TYPE,
+    });
+    const scanner2 = new Scanner({
+      id: 'test-id',
+      scannerType: OPENVAS_SCANNER_TYPE,
+    });
+    const scanner3 = new Scanner({
+      id: 'test-id',
+      scannerType: GREENBONE_SENSOR_SCANNER_TYPE,
+    });
 
     expect(scanner1.isCloneable()).toEqual(false);
     expect(scanner2.isCloneable()).toEqual(true);
@@ -226,9 +242,18 @@ describe('Scanner model method tests', () => {
   });
 
   test('isWritable() should return correct true/false', () => {
-    const scanner1 = new Scanner({scannerType: CVE_SCANNER_TYPE});
-    const scanner2 = new Scanner({scannerType: OPENVAS_SCANNER_TYPE});
-    const scanner3 = new Scanner({scannerType: GREENBONE_SENSOR_SCANNER_TYPE});
+    const scanner1 = new Scanner({
+      id: 'test-id',
+      scannerType: CVE_SCANNER_TYPE,
+    });
+    const scanner2 = new Scanner({
+      id: 'test-id',
+      scannerType: OPENVAS_SCANNER_TYPE,
+    });
+    const scanner3 = new Scanner({
+      id: 'test-id',
+      scannerType: GREENBONE_SENSOR_SCANNER_TYPE,
+    });
 
     expect(scanner1.isWritable()).toEqual(false);
     expect(scanner2.isWritable()).toEqual(true);
@@ -236,9 +261,9 @@ describe('Scanner model method tests', () => {
   });
 
   test('hasUnixSocket() should return correct true/false', () => {
-    const scanner1 = new Scanner({host: '/foo'});
-    const scanner2 = new Scanner({host: 'bar'});
-    const scanner3 = new Scanner({host: ''});
+    const scanner1 = new Scanner({id: 'test-id', host: '/foo'});
+    const scanner2 = new Scanner({id: 'test-id', host: 'bar'});
+    const scanner3 = new Scanner({id: 'test-id', host: ''});
 
     expect(scanner1.hasUnixSocket()).toEqual(true);
     expect(scanner2.hasUnixSocket()).toEqual(false);
@@ -294,6 +319,7 @@ describe('Scanner model function tests', () => {
 
   test('should parse agent_control_config_defaults with all fields', () => {
     const scanner = Scanner.fromElement({
+      _id: 'test-id',
       agent_control_config_defaults: {
         agent_defaults: {
           agent_control: {
@@ -363,6 +389,7 @@ describe('Scanner model function tests', () => {
 
   test('should parse agent_control_config_defaults with single scheduler_cron_time', () => {
     const scanner = Scanner.fromElement({
+      _id: 'test-id',
       agent_control_config_defaults: {
         agent_defaults: {
           agent_script_executor: {
@@ -383,6 +410,7 @@ describe('Scanner model function tests', () => {
 
   test('should handle missing agent_control_config_defaults', () => {
     const scanner = Scanner.fromElement({
+      _id: 'test-id',
       type: AGENT_CONTROLLER_SCANNER_TYPE,
     });
 
@@ -391,6 +419,7 @@ describe('Scanner model function tests', () => {
 
   test('should handle empty agent_control_config_defaults', () => {
     const scanner = Scanner.fromElement({
+      _id: 'test-id',
       agent_control_config_defaults: {},
     });
 
@@ -399,6 +428,7 @@ describe('Scanner model function tests', () => {
 
   test('should use defaults for missing fields in agent_control_config_defaults', () => {
     const scanner = Scanner.fromElement({
+      _id: 'test-id',
       agent_control_config_defaults: {
         agent_defaults: {
           agent_control: {

--- a/src/gmp/models/__tests__/schedule.test.ts
+++ b/src/gmp/models/__tests__/schedule.test.ts
@@ -12,7 +12,8 @@ describe('Schedule model tests', () => {
   testModel(Schedule, 'schedule');
 
   test('should use defaults', () => {
-    const schedule = new Schedule();
+    const schedule = new Schedule({id: 'test-id'});
+    expect(schedule.id).toEqual('test-id');
     expect(schedule.event).toBeUndefined();
     expect(schedule.tasks).toEqual([]);
     expect(schedule.timezone).toBeUndefined();
@@ -20,7 +21,8 @@ describe('Schedule model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const schedule = Schedule.fromElement();
+    const schedule = Schedule.fromElement({_id: 'test-id'});
+    expect(schedule.id).toEqual('test-id');
     expect(schedule.event).toBeUndefined();
     expect(schedule.tasks).toEqual([]);
     expect(schedule.timezone).toBeUndefined();
@@ -29,6 +31,7 @@ describe('Schedule model tests', () => {
 
   test('should parse tasks', () => {
     const schedule = Schedule.fromElement({
+      _id: 'test-id',
       tasks: {
         task: [{_id: '123'}],
       },
@@ -39,6 +42,7 @@ describe('Schedule model tests', () => {
 
   test('should parse tasks with usage_type', () => {
     const schedule = Schedule.fromElement({
+      _id: 'test-id',
       tasks: {
         task: [
           {
@@ -90,6 +94,7 @@ describe('Schedule model tests', () => {
 
   test('should parse timezone and timezone_abbrev', () => {
     const schedule = Schedule.fromElement({
+      _id: 'test-id',
       timezone: 'Europe/Berlin',
       timezone_abbrev: 'CET',
     });
@@ -109,6 +114,7 @@ END:VEVENT
 END:VCALENDAR
 `;
     const schedule = Schedule.fromElement({
+      _id: 'test-id',
       icalendar,
       timezone: 'Europe/Berlin',
     });

--- a/src/gmp/models/__tests__/tag.test.ts
+++ b/src/gmp/models/__tests__/tag.test.ts
@@ -12,14 +12,16 @@ describe('Tag model tests', () => {
   testModel(Tag, 'tag');
 
   test('should use defaults', () => {
-    const tag = new Tag();
+    const tag = new Tag({id: 'test-id'});
+    expect(tag.id).toEqual('test-id');
     expect(tag.resourceType).toBeUndefined();
     expect(tag.resourceCount).toEqual(0);
     expect(tag.value).toBeUndefined();
   });
 
   test('should parse empty element', () => {
-    const tag = Tag.fromElement();
+    const tag = Tag.fromElement({_id: 'test-id'});
+    expect(tag.id).toEqual('test-id');
     expect(tag.resourceType).toBeUndefined();
     expect(tag.resourceCount).toEqual(0);
     expect(tag.value).toBeUndefined();
@@ -34,6 +36,7 @@ describe('Tag model tests', () => {
     'should parse resource type $resourceType',
     ({resourceType, entityType}) => {
       const tag = Tag.fromElement({
+        _id: 'test-id',
         resources: {
           type: resourceType as ApiType,
           count: {
@@ -48,10 +51,10 @@ describe('Tag model tests', () => {
   );
 
   test('should parse value', () => {
-    const tag = Tag.fromElement({value: 'foo'});
+    const tag = Tag.fromElement({_id: 'test-id', value: 'foo'});
     expect(tag.value).toEqual('foo');
 
-    const tag2 = Tag.fromElement({value: 42});
+    const tag2 = Tag.fromElement({_id: 'test-id', value: 42});
     expect(tag2.value).toEqual('42');
   });
 });

--- a/src/gmp/models/__tests__/target.test.ts
+++ b/src/gmp/models/__tests__/target.test.ts
@@ -17,8 +17,8 @@ describe('Target model tests', () => {
   testModel(Target, 'target');
 
   test('should use defaults', () => {
-    const target = new Target();
-
+    const target = new Target({id: 'test-id'});
+    expect(target.id).toEqual('test-id');
     expect(target.aliveTests).toEqual([]);
     expect(target.allowSimultaneousIPs).toEqual(false);
     expect(target.esxiCredential).toBeUndefined();
@@ -37,8 +37,8 @@ describe('Target model tests', () => {
   });
 
   test('should parse defaults', () => {
-    const target = Target.fromElement({});
-
+    const target = Target.fromElement({_id: 'test-id'});
+    expect(target.id).toEqual('test-id');
     expect(target.aliveTests).toEqual([]);
     expect(target.allowSimultaneousIPs).toEqual(false);
     expect(target.esxiCredential).toBeUndefined();
@@ -58,18 +58,20 @@ describe('Target model tests', () => {
 
   test('should parse port list', () => {
     const elem1 = {
+      _id: 'test-id',
       port_list: {
         _id: '123',
       },
     };
     const elem2 = {
+      _id: 'test-id',
       port_list: {
         _id: '',
       },
     };
     const target1 = Target.fromElement(elem1);
     const target2 = Target.fromElement(elem2);
-    const target3 = Target.fromElement({});
+    const target3 = Target.fromElement({_id: 'test-id'});
 
     expect(target1.portList).toBeInstanceOf(PortList);
     expect(target1.portList?.entityType).toEqual('portlist');
@@ -79,9 +81,15 @@ describe('Target model tests', () => {
   });
 
   test('should parse smb credentials', () => {
-    const target1 = Target.fromElement({smb_credential: {_id: '123'}});
-    const target2 = Target.fromElement({smb_credential: {_id: ''}});
-    const target3 = Target.fromElement({});
+    const target1 = Target.fromElement({
+      _id: 'test-id',
+      smb_credential: {_id: '123'},
+    });
+    const target2 = Target.fromElement({
+      _id: 'test-id',
+      smb_credential: {_id: ''},
+    });
+    const target3 = Target.fromElement({_id: 'test-id'});
 
     expect(target1.smbCredential).toBeInstanceOf(Model);
     expect(target1.smbCredential?.entityType).toEqual('credential');
@@ -91,9 +99,15 @@ describe('Target model tests', () => {
   });
 
   test('should parse snmp credentials', () => {
-    const target1 = Target.fromElement({snmp_credential: {_id: '123'}});
-    const target2 = Target.fromElement({snmp_credential: {_id: ''}});
-    const target3 = Target.fromElement({});
+    const target1 = Target.fromElement({
+      _id: 'test-id',
+      snmp_credential: {_id: '123'},
+    });
+    const target2 = Target.fromElement({
+      _id: 'test-id',
+      snmp_credential: {_id: ''},
+    });
+    const target3 = Target.fromElement({_id: 'test-id'});
 
     expect(target1.snmpCredential).toBeInstanceOf(Model);
     expect(target1.snmpCredential?.entityType).toEqual('credential');
@@ -103,10 +117,17 @@ describe('Target model tests', () => {
   });
 
   test('should parse ssh credentials', () => {
-    const target1 = Target.fromElement({ssh_credential: {_id: '123'}});
-    const target2 = Target.fromElement({ssh_credential: {_id: ''}});
-    const target3 = Target.fromElement({});
+    const target1 = Target.fromElement({
+      _id: 'test-id',
+      ssh_credential: {_id: '123'},
+    });
+    const target2 = Target.fromElement({
+      _id: 'test-id',
+      ssh_credential: {_id: ''},
+    });
+    const target3 = Target.fromElement({_id: 'test-id'});
     const target4 = Target.fromElement({
+      _id: 'test-id',
       ssh_credential: {_id: '456', port: 2222},
     });
 
@@ -122,9 +143,15 @@ describe('Target model tests', () => {
   });
 
   test('should parse ssh elevate credentials', () => {
-    const target1 = Target.fromElement({ssh_elevate_credential: {_id: '123'}});
-    const target2 = Target.fromElement({ssh_elevate_credential: {_id: ''}});
-    const target3 = Target.fromElement({});
+    const target1 = Target.fromElement({
+      _id: 'test-id',
+      ssh_elevate_credential: {_id: '123'},
+    });
+    const target2 = Target.fromElement({
+      _id: 'test-id',
+      ssh_elevate_credential: {_id: ''},
+    });
+    const target3 = Target.fromElement({_id: 'test-id'});
 
     expect(target1.sshElevateCredential).toBeInstanceOf(Model);
     expect(target1.sshElevateCredential?.entityType).toEqual('credential');
@@ -134,9 +161,15 @@ describe('Target model tests', () => {
   });
 
   test('should parse esxi credentials', () => {
-    const target1 = Target.fromElement({esxi_credential: {_id: '123'}});
-    const target2 = Target.fromElement({esxi_credential: {_id: ''}});
-    const target3 = Target.fromElement({});
+    const target1 = Target.fromElement({
+      _id: 'test-id',
+      esxi_credential: {_id: '123'},
+    });
+    const target2 = Target.fromElement({
+      _id: 'test-id',
+      esxi_credential: {_id: ''},
+    });
+    const target3 = Target.fromElement({_id: 'test-id'});
 
     expect(target1.esxiCredential).toBeInstanceOf(Model);
     expect(target1.esxiCredential?.entityType).toEqual('credential');
@@ -146,9 +179,15 @@ describe('Target model tests', () => {
   });
 
   test('should parse krb5 credentials', () => {
-    const target1 = Target.fromElement({krb5_credential: {_id: '123'}});
-    const target2 = Target.fromElement({krb5_credential: {_id: ''}});
-    const target3 = Target.fromElement({});
+    const target1 = Target.fromElement({
+      _id: 'test-id',
+      krb5_credential: {_id: '123'},
+    });
+    const target2 = Target.fromElement({
+      _id: 'test-id',
+      krb5_credential: {_id: ''},
+    });
+    const target3 = Target.fromElement({_id: 'test-id'});
 
     expect(target1.krb5Credential).toBeInstanceOf(Model);
     expect(target1.krb5Credential?.entityType).toEqual('credential');
@@ -158,11 +197,9 @@ describe('Target model tests', () => {
   });
 
   test('should parse hosts or return empty array', () => {
-    const elem = {
-      hosts: '123.456.789.42, 987.654.321.1',
-    };
+    const elem = {_id: 'test-id', hosts: '123.456.789.42, 987.654.321.1'};
     const target1 = Target.fromElement(elem);
-    const target2 = Target.fromElement({hosts: ''});
+    const target2 = Target.fromElement({_id: 'test-id', hosts: ''});
 
     expect(target1.hosts).toEqual(['123.456.789.42', '987.654.321.1']);
     expect(target2.hosts).toEqual([]);
@@ -170,26 +207,36 @@ describe('Target model tests', () => {
 
   test('should parse exclude_hosts or return empty array', () => {
     const elem = {
+      _id: 'test-id',
       exclude_hosts: '123.456.789.42, 987.654.321.1',
     };
     const target1 = Target.fromElement(elem);
-    const target2 = Target.fromElement({exclude_hosts: ''});
+    const target2 = Target.fromElement({_id: 'test-id', exclude_hosts: ''});
 
     expect(target1.excludeHosts).toEqual(['123.456.789.42', '987.654.321.1']);
     expect(target2.excludeHosts).toEqual([]);
   });
 
   test('should parse max_hosts', () => {
-    const target = Target.fromElement({max_hosts: 42});
+    const target = Target.fromElement({_id: 'test-id', max_hosts: 42});
 
     expect(target.maxHosts).toEqual(42);
   });
 
   test('should parse allowSimultaneousIps', () => {
-    const target1 = Target.fromElement({allow_simultaneous_ips: 1});
-    const target2 = Target.fromElement({allow_simultaneous_ips: 0});
-    // @ts-expect-error
-    const target3 = Target.fromElement({allow_simultaneous_ips: 'foo'});
+    const target1 = Target.fromElement({
+      _id: 'test-id',
+      allow_simultaneous_ips: 1,
+    });
+    const target2 = Target.fromElement({
+      _id: 'test-id',
+      allow_simultaneous_ips: 0,
+    });
+    const target3 = Target.fromElement({
+      _id: 'test-id',
+      // @ts-expect-error
+      allow_simultaneous_ips: 'foo',
+    });
 
     expect(target1.allowSimultaneousIPs).toEqual(true);
     expect(target2.allowSimultaneousIPs).toEqual(false);
@@ -197,10 +244,19 @@ describe('Target model tests', () => {
   });
 
   test('should parse reverse_lookup_only', () => {
-    const target1 = Target.fromElement({reverse_lookup_only: 0});
-    const target2 = Target.fromElement({reverse_lookup_only: 1});
-    // @ts-expect-error
-    const target3 = Target.fromElement({reverse_lookup_only: 'foo'});
+    const target1 = Target.fromElement({
+      _id: 'test-id',
+      reverse_lookup_only: 0,
+    });
+    const target2 = Target.fromElement({
+      _id: 'test-id',
+      reverse_lookup_only: 1,
+    });
+    const target3 = Target.fromElement({
+      _id: 'test-id',
+      // @ts-expect-error
+      reverse_lookup_only: 'foo',
+    });
 
     expect(target1.reverseLookupOnly).toEqual(false);
     expect(target2.reverseLookupOnly).toEqual(true);
@@ -208,10 +264,19 @@ describe('Target model tests', () => {
   });
 
   test('should parse reverse_lookup_unify', () => {
-    const target1 = Target.fromElement({reverse_lookup_unify: 0});
-    const target2 = Target.fromElement({reverse_lookup_unify: 1});
-    // @ts-expect-error
-    const target3 = Target.fromElement({reverse_lookup_unify: 'foo'});
+    const target1 = Target.fromElement({
+      _id: 'test-id',
+      reverse_lookup_unify: 0,
+    });
+    const target2 = Target.fromElement({
+      _id: 'test-id',
+      reverse_lookup_unify: 1,
+    });
+    const target3 = Target.fromElement({
+      _id: 'test-id',
+      // @ts-expect-error
+      reverse_lookup_unify: 'foo',
+    });
 
     expect(target1.reverseLookupUnify).toEqual(false);
     expect(target2.reverseLookupUnify).toEqual(true);
@@ -220,6 +285,7 @@ describe('Target model tests', () => {
 
   test('should parse tasks', () => {
     const target1 = Target.fromElement({
+      _id: 'test-id',
       tasks: {
         task: [
           {
@@ -229,6 +295,7 @@ describe('Target model tests', () => {
       },
     });
     const target2 = Target.fromElement({
+      _id: 'test-id',
       tasks: {
         task: {_id: '123'},
       },
@@ -249,6 +316,7 @@ describe('Target model tests', () => {
 
   test('should parse tasks with usage_type', () => {
     const target = Target.fromElement({
+      _id: 'test-id',
       tasks: {
         task: [
           {
@@ -283,21 +351,29 @@ describe('Target model tests', () => {
   });
 
   test('should parse alive_tests', () => {
-    const target = Target.fromElement({alive_tests: {alive_test: ICMP_PING}});
+    const target = Target.fromElement({
+      _id: 'test-id',
+      alive_tests: {alive_test: ICMP_PING},
+    });
     expect(target.aliveTests).toEqual([ICMP_PING]);
 
     const target1 = Target.fromElement({
+      _id: 'test-id',
       alive_tests: {alive_test: [ICMP_PING, ARP_PING]},
     });
     expect(target1.aliveTests).toEqual([ICMP_PING, ARP_PING]);
 
-    const target2 = Target.fromElement({alive_tests: {}});
+    const target2 = Target.fromElement({_id: 'test-id', alive_tests: {}});
     expect(target2.aliveTests).toEqual([]);
 
-    const target3 = Target.fromElement({alive_tests: {alive_test: []}});
+    const target3 = Target.fromElement({
+      _id: 'test-id',
+      alive_tests: {alive_test: []},
+    });
     expect(target3.aliveTests).toEqual([]);
 
     const target4 = Target.fromElement({
+      _id: 'test-id',
       alive_tests: {alive_test: HOST_DISCOVERY_IPV6},
     });
     expect(target4.aliveTests).toEqual([HOST_DISCOVERY_IPV6]);

--- a/src/gmp/models/__tests__/task.test.ts
+++ b/src/gmp/models/__tests__/task.test.ts
@@ -12,7 +12,8 @@ describe('Task Model parse tests', () => {
   testModel(Task, 'task', {testIsActive: false});
 
   test('should use defaults', () => {
-    const task = new Task();
+    const task = new Task({id: 'test-id'});
+    expect(task.id).toEqual('test-id');
     expect(task.alerts).toEqual([]);
     expect(task.alterable).toBeUndefined();
     expect(task.apply_overrides).toBeUndefined();
@@ -46,7 +47,8 @@ describe('Task Model parse tests', () => {
   });
 
   test('should parse empty element', () => {
-    const task = Task.fromElement();
+    const task = Task.fromElement({_id: 'test-id'});
+    expect(task.id).toEqual('test-id');
     expect(task.alerts).toEqual([]);
     expect(task.alterable).toBeUndefined();
     expect(task.apply_overrides).toBeUndefined();
@@ -429,12 +431,11 @@ describe('Task Model parse tests', () => {
   });
 
   test('should parse observers', () => {
-    const task = Task.fromElement({
-      observers: 'foo bar',
-    });
+    const task = Task.fromElement({_id: 'test-id', observers: 'foo bar'});
     expect(task.observers?.user).toEqual(['foo', 'bar']);
 
     const task2 = Task.fromElement({
+      _id: 'test-id',
       observers: {
         __text: 'anon nymous',
         role: [{name: 'lorem'}],
@@ -446,14 +447,13 @@ describe('Task Model parse tests', () => {
     expect(task2.observers?.role).toEqual(['lorem']);
     expect(task2.observers?.group).toEqual(['ipsum', 'dolor']);
 
-    const task3 = Task.fromElement({
-      observers: '',
-    });
+    const task3 = Task.fromElement({_id: 'test-id', observers: ''});
     expect(task3.observers?.user).toBeUndefined();
     expect(task3.observers?.role).toBeUndefined();
     expect(task3.observers?.group).toBeUndefined();
 
     const task4 = Task.fromElement({
+      _id: 'test-id',
       observers: {
         __text: '',
       },
@@ -561,14 +561,16 @@ describe('Task Model parse tests', () => {
 
 describe(`Task Model methods tests`, () => {
   test('should be a container only if neither target nor agentGroup nor ociImageTarget is set', () => {
-    const t1 = Task.fromElement({});
-    const t2 = Task.fromElement({target: {_id: 'foo'}});
-    const t3 = Task.fromElement({agent_group: {_id: 'ag1'}});
+    const t1 = Task.fromElement({_id: 'test-id'});
+    const t2 = Task.fromElement({_id: 'test-id', target: {_id: 'foo'}});
+    const t3 = Task.fromElement({_id: 'test-id', agent_group: {_id: 'ag1'}});
     const t4 = Task.fromElement({
+      _id: 'test-id',
       target: {_id: 'foo'},
       agent_group: {_id: 'ag1'},
     });
     const t5 = Task.fromElement({
+      _id: 'test-id',
       oci_image_target: {_id: 'oci1'},
     });
 
@@ -580,13 +582,15 @@ describe(`Task Model methods tests`, () => {
   });
 
   test('should be a container image if ociImageTarget is set', () => {
-    const t1 = Task.fromElement({});
-    const t2 = Task.fromElement({target: {_id: 'foo'}});
-    const t3 = Task.fromElement({agent_group: {_id: 'ag1'}});
+    const t1 = Task.fromElement({_id: 'test-id'});
+    const t2 = Task.fromElement({_id: 'test-id', target: {_id: 'foo'}});
+    const t3 = Task.fromElement({_id: 'test-id', agent_group: {_id: 'ag1'}});
     const t4 = Task.fromElement({
+      _id: 'test-id',
       oci_image_target: {_id: 'oci1'},
     });
     const t5 = Task.fromElement({
+      _id: 'test-id',
       target: {_id: 'foo'},
       oci_image_target: {_id: 'oci1'},
     });
@@ -616,7 +620,7 @@ describe(`Task Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const task = new Task({status: status as TaskStatus});
+      const task = new Task({id: 'test-id', status: status as TaskStatus});
       expect(task.isActive()).toEqual(exp);
     }
   });
@@ -639,7 +643,7 @@ describe(`Task Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const task = new Task({status: status as TaskStatus});
+      const task = new Task({id: 'test-id', status: status as TaskStatus});
       expect(task.isRunning()).toEqual(exp);
     }
   });
@@ -662,7 +666,7 @@ describe(`Task Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const task = new Task({status: status as TaskStatus});
+      const task = new Task({id: 'test-id', status: status as TaskStatus});
       expect(task.isStopped()).toEqual(exp);
     }
   });
@@ -685,7 +689,7 @@ describe(`Task Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const task = new Task({status: status as TaskStatus});
+      const task = new Task({id: 'test-id', status: status as TaskStatus});
       expect(task.isInterrupted()).toEqual(exp);
     }
   });
@@ -708,16 +712,16 @@ describe(`Task Model methods tests`, () => {
     };
 
     for (const [status, exp] of Object.entries(statusList)) {
-      const task = new Task({status: status as TaskStatus});
+      const task = new Task({id: 'test-id', status: status as TaskStatus});
       expect(task.isNew()).toEqual(exp);
     }
   });
 
   test('should be changeable if alterable or new', () => {
-    let task = new Task({status: TASK_STATUS.new, alterable: 0});
+    let task = new Task({id: 'test-id', status: TASK_STATUS.new, alterable: 0});
     expect(task.isChangeable()).toEqual(true);
 
-    task = new Task({status: TASK_STATUS.done, alterable: 1});
+    task = new Task({id: 'test-id', status: TASK_STATUS.done, alterable: 1});
     expect(task.isChangeable()).toEqual(true);
   });
 
@@ -734,22 +738,23 @@ describe(`Task Model methods tests`, () => {
   });
 
   test('container vs agent vs target vs container image parsing check', () => {
-    const t1 = Task.fromElement({});
+    const t1 = Task.fromElement({_id: 'test-id'});
     expect(t1.isImport()).toBe(true);
     expect(t1.isAgent()).toBe(false);
     expect(t1.isContainerImage()).toBe(false);
 
-    const t2 = Task.fromElement({target: {_id: 'tgt1'}});
+    const t2 = Task.fromElement({_id: 'test-id', target: {_id: 'tgt1'}});
     expect(t2.isImport()).toBe(false);
     expect(t2.isAgent()).toBe(false);
     expect(t2.isContainerImage()).toBe(false);
 
-    const t3 = Task.fromElement({agent_group: {_id: 'ag1'}});
+    const t3 = Task.fromElement({_id: 'test-id', agent_group: {_id: 'ag1'}});
     expect(t3.isImport()).toBe(false);
     expect(t3.isAgent()).toBe(true);
     expect(t3.isContainerImage()).toBe(false);
 
     const t4 = Task.fromElement({
+      _id: 'test-id',
       target: {_id: 'tgt1'},
       agent_group: {_id: 'ag1'},
     });
@@ -758,6 +763,7 @@ describe(`Task Model methods tests`, () => {
     expect(t4.isContainerImage()).toBe(false);
 
     const t5 = Task.fromElement({
+      _id: 'test-id',
       oci_image_target: {_id: 'oci1'},
     });
     expect(t5.isImport()).toBe(false);
@@ -766,10 +772,11 @@ describe(`Task Model methods tests`, () => {
   });
 
   test('should be agent if agentGroup is set', () => {
-    const t1 = Task.fromElement({});
-    const t2 = Task.fromElement({agent_group: {_id: 'ag1'}});
-    const t3 = Task.fromElement({target: {_id: 'tgt1'}});
+    const t1 = Task.fromElement({_id: 'test-id'});
+    const t2 = Task.fromElement({_id: 'test-id', agent_group: {_id: 'ag1'}});
+    const t3 = Task.fromElement({_id: 'test-id', target: {_id: 'tgt1'}});
     const t4 = Task.fromElement({
+      _id: 'test-id',
       target: {_id: 'tgt1'},
       agent_group: {_id: 'ag1'},
     });

--- a/src/gmp/models/__tests__/ticket.test.ts
+++ b/src/gmp/models/__tests__/ticket.test.ts
@@ -8,11 +8,12 @@ import {testModel} from 'gmp/models/testing';
 import Ticket from 'gmp/models/ticket';
 import {parseDate} from 'gmp/parser';
 
-testModel(Ticket, 'ticket');
-
 describe('Ticket Model tests', () => {
+  testModel(Ticket, 'ticket');
+
   test('should use defaults', () => {
-    const ticket = new Ticket();
+    const ticket = new Ticket({id: 'test-id'});
+    expect(ticket.id).toEqual('test-id');
     expect(ticket.assignedTo).toBeUndefined();
     expect(ticket.closedNote).toBeUndefined();
     expect(ticket.closedTime).toBeUndefined();
@@ -34,7 +35,8 @@ describe('Ticket Model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const ticket = Ticket.fromElement();
+    const ticket = Ticket.fromElement({_id: 'test-id'});
+    expect(ticket.id).toEqual('test-id');
     expect(ticket.assignedTo).toBeUndefined();
     expect(ticket.closedNote).toBeUndefined();
     expect(ticket.closedTime).toBeUndefined();
@@ -56,113 +58,129 @@ describe('Ticket Model tests', () => {
   });
 
   test('should parse assignedTo', () => {
-    const ticket = Ticket.fromElement({assigned_to: {user: {_id: 'foo'}}});
+    const ticket = Ticket.fromElement({
+      _id: 'test-id',
+      assigned_to: {user: {_id: 'foo'}},
+    });
     expect(ticket.assignedTo?.id).toEqual('foo');
   });
 
   test('should parse result', () => {
-    const ticket = Ticket.fromElement({result: {_id: 'foo'}});
+    const ticket = Ticket.fromElement({_id: 'test-id', result: {_id: 'foo'}});
     expect(ticket.result?.id).toEqual('foo');
   });
 
   test('should parse report', () => {
-    const ticket = Ticket.fromElement({report: {_id: 'foo'}});
+    const ticket = Ticket.fromElement({_id: 'test-id', report: {_id: 'foo'}});
     expect(ticket.report?.id).toEqual('foo');
   });
 
   test('should parse task', () => {
-    const ticket = Ticket.fromElement({task: {_id: 'foo'}});
+    const ticket = Ticket.fromElement({_id: 'test-id', task: {_id: 'foo'}});
     expect(ticket.task?.id).toEqual('foo');
   });
 
   test('should parse fixVerifiedReport', () => {
-    const ticket = Ticket.fromElement({fix_verified_report: {_id: 'foo'}});
+    const ticket = Ticket.fromElement({
+      _id: 'test-id',
+      fix_verified_report: {_id: 'foo'},
+    });
     expect(ticket.fixVerifiedReport).toBeDefined();
     expect(ticket.fixVerifiedReport?.id).toEqual('foo');
   });
 
   test('should parse severity', () => {
-    const ticket = Ticket.fromElement({severity: 10.0});
+    const ticket = Ticket.fromElement({_id: 'test-id', severity: 10.0});
     expect(ticket.severity).toBe(10);
   });
 
   test('should parse nvt', () => {
-    const ticket = Ticket.fromElement({nvt: {_oid: 'foo'}});
+    const ticket = Ticket.fromElement({_id: 'test-id', nvt: {_oid: 'foo'}});
     expect(ticket.nvt?.oid).toEqual('foo');
   });
 
   test('should parse openTime', () => {
-    const ticket = Ticket.fromElement({open_time: '2019-01-01T12:00:00Z'});
+    const ticket = Ticket.fromElement({
+      _id: 'test-id',
+      open_time: '2019-01-01T12:00:00Z',
+    });
     expect(ticket.openTime).toEqual(parseDate('2019-01-01T12:00:00Z'));
   });
 
   test('should parse fixVerifiedTime', () => {
     const ticket = Ticket.fromElement({
+      _id: 'test-id',
       fix_verified_time: '2019-01-01T12:00:00Z',
     });
     expect(ticket.fixVerifiedTime).toEqual(parseDate('2019-01-01T12:00:00Z'));
   });
 
   test('should parse fixedTime', () => {
-    const ticket = Ticket.fromElement({fixed_time: '2019-01-01T12:00:00Z'});
+    const ticket = Ticket.fromElement({
+      _id: 'test-id',
+      fixed_time: '2019-01-01T12:00:00Z',
+    });
     expect(ticket.fixedTime).toEqual(parseDate('2019-01-01T12:00:00Z'));
   });
 
   test('should parse closedTime', () => {
-    const ticket = Ticket.fromElement({closed_time: '2019-01-01T12:00:00Z'});
+    const ticket = Ticket.fromElement({
+      _id: 'test-id',
+      closed_time: '2019-01-01T12:00:00Z',
+    });
     expect(ticket.closedTime).toEqual(parseDate('2019-01-01T12:00:00Z'));
   });
 
   test('should parse host', () => {
-    const ticket = Ticket.fromElement({host: 'foo'});
+    const ticket = Ticket.fromElement({_id: 'test-id', host: 'foo'});
     expect(ticket.host).toEqual('foo');
   });
 
   test('should parse location', () => {
-    const ticket = Ticket.fromElement({location: 'foo'});
+    const ticket = Ticket.fromElement({_id: 'test-id', location: 'foo'});
     expect(ticket.location).toEqual('foo');
   });
 
   test('should parse solutionType', () => {
-    const ticket = Ticket.fromElement({solution_type: 'foo'});
+    const ticket = Ticket.fromElement({_id: 'test-id', solution_type: 'foo'});
     expect(ticket.solutionType).toEqual('foo');
   });
 
   test('should parse openNote', () => {
-    let ticket = Ticket.fromElement({open_note: ''});
+    let ticket = Ticket.fromElement({_id: 'test-id', open_note: ''});
     expect(ticket.openNote).toBeUndefined();
 
-    ticket = Ticket.fromElement({open_note: 'foo'});
+    ticket = Ticket.fromElement({_id: 'test-id', open_note: 'foo'});
     expect(ticket.openNote).toEqual('foo');
   });
 
   test('should parse fixedNote', () => {
-    let ticket = Ticket.fromElement({fixed_note: ''});
+    let ticket = Ticket.fromElement({_id: 'test-id', fixed_note: ''});
     expect(ticket.fixedNote).toBeUndefined();
 
-    ticket = Ticket.fromElement({fixed_note: 'foo'});
+    ticket = Ticket.fromElement({_id: 'test-id', fixed_note: 'foo'});
     expect(ticket.fixedNote).toEqual('foo');
   });
 
   test('should parse closedNote', () => {
-    let ticket = Ticket.fromElement({closed_note: ''});
+    let ticket = Ticket.fromElement({_id: 'test-id', closed_note: ''});
     expect(ticket.closedNote).toBeUndefined();
 
-    ticket = Ticket.fromElement({closed_note: 'foo'});
+    ticket = Ticket.fromElement({_id: 'test-id', closed_note: 'foo'});
     expect(ticket.closedNote).toEqual('foo');
   });
 
   test('should parse status', () => {
-    const ticket = Ticket.fromElement({status: 'open'});
+    const ticket = Ticket.fromElement({_id: 'test-id', status: 'open'});
     expect(ticket.status).toEqual('open');
 
-    const ticket2 = Ticket.fromElement({status: 'closed'});
+    const ticket2 = Ticket.fromElement({_id: 'test-id', status: 'closed'});
     expect(ticket2.status).toEqual('closed');
 
-    const ticket3 = Ticket.fromElement({status: 'fixed'});
+    const ticket3 = Ticket.fromElement({_id: 'test-id', status: 'fixed'});
     expect(ticket3.status).toEqual('fixed');
 
-    const ticket4 = Ticket.fromElement({status: 'verified'});
+    const ticket4 = Ticket.fromElement({_id: 'test-id', status: 'verified'});
     expect(ticket4.status).toEqual('verified');
   });
 });

--- a/src/gmp/models/__tests__/tls-certificate.test.ts
+++ b/src/gmp/models/__tests__/tls-certificate.test.ts
@@ -12,7 +12,8 @@ describe('TlsCertificate Model tests', () => {
   testModel(TlsCertificate, 'tlscertificate', {testName: false});
 
   test('should use defaults', () => {
-    const tlsCertificate = new TlsCertificate();
+    const tlsCertificate = new TlsCertificate({id: 'test-id'});
+    expect(tlsCertificate.id).toEqual('test-id');
     expect(tlsCertificate.activationTime).toBeUndefined();
     expect(tlsCertificate.certificate).toBeUndefined();
     expect(tlsCertificate.expirationTime).toBeUndefined();
@@ -31,7 +32,8 @@ describe('TlsCertificate Model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const tlsCertificate = TlsCertificate.fromElement();
+    const tlsCertificate = TlsCertificate.fromElement({_id: 'test-id'});
+    expect(tlsCertificate.id).toEqual('test-id');
     expect(tlsCertificate.activationTime).toBeUndefined();
     expect(tlsCertificate.certificate).toBeUndefined();
     expect(tlsCertificate.expirationTime).toBeUndefined();
@@ -51,6 +53,7 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse certificate', () => {
     const tlsCertificate1 = TlsCertificate.fromElement({
+      _id: 'test-id',
       certificate: {
         __text: 'CERT123',
       },
@@ -60,6 +63,7 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse issuer dn', () => {
     const tlsCertificate = TlsCertificate.fromElement({
+      _id: 'test-id',
       issuer_dn: 'CN=issuer',
     });
     expect(tlsCertificate.issuerDn).toEqual('CN=issuer');
@@ -67,6 +71,7 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse subject dn', () => {
     const tlsCertificate = TlsCertificate.fromElement({
+      _id: 'test-id',
       subject_dn: 'CN=subject',
     });
     expect(tlsCertificate.subjectDn).toEqual('CN=subject');
@@ -74,12 +79,15 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse activation_time', () => {
     const tlsCertificate1 = TlsCertificate.fromElement({
+      _id: 'test-id',
       activation_time: '2019-10-10T11:09:23.022Z',
     });
     const tlsCertificate2 = TlsCertificate.fromElement({
+      _id: 'test-id',
       activation_time: 'undefined',
     });
     const tlsCertificate3 = TlsCertificate.fromElement({
+      _id: 'test-id',
       activation_time: 'unlimited',
     });
 
@@ -92,12 +100,15 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse expiration time', () => {
     const tlsCertificate1 = TlsCertificate.fromElement({
+      _id: 'test-id',
       expiration_time: '2019-10-10T11:09:23.022Z',
     });
     const tlsCertificate2 = TlsCertificate.fromElement({
+      _id: 'test-id',
       expiration_time: 'undefined',
     });
     const tlsCertificate3 = TlsCertificate.fromElement({
+      _id: 'test-id',
       expiration_time: 'unlimited',
     });
 
@@ -110,12 +121,15 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse last seen', () => {
     const tlsCertificate1 = TlsCertificate.fromElement({
+      _id: 'test-id',
       last_seen: '2019-10-10T11:09:23.022Z',
     });
     const tlsCertificate2 = TlsCertificate.fromElement({
+      _id: 'test-id',
       last_seen: 'undefined',
     });
     const tlsCertificate3 = TlsCertificate.fromElement({
+      _id: 'test-id',
       last_seen: 'unlimited',
     });
 
@@ -128,15 +142,19 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse time status', () => {
     const tlsCertificate1 = TlsCertificate.fromElement({
+      _id: 'test-id',
       time_status: TIME_STATUS.inactive,
     });
     const tlsCertificate2 = TlsCertificate.fromElement({
+      _id: 'test-id',
       time_status: TIME_STATUS.valid,
     });
     const tlsCertificate3 = TlsCertificate.fromElement({
+      _id: 'test-id',
       time_status: TIME_STATUS.expired,
     });
     const tlsCertificate4 = TlsCertificate.fromElement({
+      _id: 'test-id',
       time_status: TIME_STATUS.unknown,
     });
 
@@ -148,9 +166,11 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse valid', () => {
     const tlsCertificate1 = TlsCertificate.fromElement({
+      _id: 'test-id',
       valid: 1,
     });
     const tlsCertificate2 = TlsCertificate.fromElement({
+      _id: 'test-id',
       valid: 0,
     });
 
@@ -160,9 +180,11 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse trust', () => {
     const tlsCertificate1 = TlsCertificate.fromElement({
+      _id: 'test-id',
       trust: 1,
     });
     const tlsCertificate2 = TlsCertificate.fromElement({
+      _id: 'test-id',
       trust: 0,
     });
 
@@ -172,6 +194,7 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse sha256 fingerprint', () => {
     const tlsCertificate1 = TlsCertificate.fromElement({
+      _id: 'test-id',
       sha256_fingerprint: 'SHA256',
     });
     expect(tlsCertificate1.sha256Fingerprint).toEqual('SHA256');
@@ -179,6 +202,7 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse md5 fingerprint', () => {
     const tlsCertificate1 = TlsCertificate.fromElement({
+      _id: 'test-id',
       md5_fingerprint: 'MD5',
     });
     expect(tlsCertificate1.md5Fingerprint).toEqual('MD5');
@@ -186,6 +210,7 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse source reports', () => {
     const tlsCertificate = TlsCertificate.fromElement({
+      _id: 'test-id',
       sources: {
         source: [
           {
@@ -230,6 +255,7 @@ describe('TlsCertificate Model tests', () => {
     ]);
 
     const tlsCertificate2 = TlsCertificate.fromElement({
+      _id: 'test-id',
       sources: {
         source: [
           {
@@ -263,6 +289,7 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse source hosts', () => {
     const tlsCertificate = TlsCertificate.fromElement({
+      _id: 'test-id',
       sources: {
         source: [
           {
@@ -300,6 +327,7 @@ describe('TlsCertificate Model tests', () => {
     ]);
 
     const tlsCertificate2 = TlsCertificate.fromElement({
+      _id: 'test-id',
       certificate: {
         __text: 'CERT123',
       },
@@ -338,6 +366,7 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse source ports', () => {
     const tlsCertificate = TlsCertificate.fromElement({
+      _id: 'test-id',
       sources: {
         source: [
           {
@@ -356,6 +385,7 @@ describe('TlsCertificate Model tests', () => {
     expect(tlsCertificate.sourcePorts).toEqual(['1234', '5678']);
 
     const tlsCertificate2 = TlsCertificate.fromElement({
+      _id: 'test-id',
       sources: {
         source: [
           {
@@ -376,6 +406,7 @@ describe('TlsCertificate Model tests', () => {
 
   test('should parse serial', () => {
     const tlsCertificate = TlsCertificate.fromElement({
+      _id: 'test-id',
       serial: '1234567890',
     });
     expect(tlsCertificate.serial).toEqual('1234567890');

--- a/src/gmp/models/__tests__/user.test.ts
+++ b/src/gmp/models/__tests__/user.test.ts
@@ -44,7 +44,7 @@ describe('User model tests', () => {
       },
     };
     const user = User.fromElement(elem);
-    const user2 = User.fromElement();
+    const user2 = User.fromElement({_id: 'test-id'});
 
     expect(user.groups[0]).toBeInstanceOf(Model);
     expect(user.groups[0].entityType).toEqual('group');
@@ -67,7 +67,7 @@ describe('User model tests', () => {
       addresses: [],
     };
     const user = User.fromElement(elem);
-    const user2 = User.fromElement({});
+    const user2 = User.fromElement({_id: 'test-id'});
 
     expect(user.hosts).toEqual(res);
     expect(user2.hosts).toEqual(res2);
@@ -88,7 +88,7 @@ describe('User model tests', () => {
     };
     const user1 = User.fromElement(elem1);
     const user2 = User.fromElement(elem2);
-    const user3 = User.fromElement();
+    const user3 = User.fromElement({_id: 'test-id'});
 
     expect(user1.authMethod).toEqual(AUTH_METHOD_LDAP);
     expect(user2.authMethod).toEqual(AUTH_METHOD_RADIUS);

--- a/src/gmp/models/__tests__/vulnerability.test.ts
+++ b/src/gmp/models/__tests__/vulnerability.test.ts
@@ -8,11 +8,12 @@ import {testModel} from 'gmp/models/testing';
 import Vulnerability from 'gmp/models/vulnerability';
 import {parseDate} from 'gmp/parser';
 
-testModel(Vulnerability, 'vulnerability');
-
 describe('Vulnerability model tests', () => {
+  testModel(Vulnerability, 'vulnerability');
+
   test('should use defaults', () => {
-    const model = new Vulnerability();
+    const model = new Vulnerability({id: 'test-id'});
+    expect(model.id).toEqual('test-id');
     expect(model.hosts).toBeUndefined();
     expect(model.results).toBeUndefined();
     expect(model.qod).toBeUndefined();
@@ -20,7 +21,8 @@ describe('Vulnerability model tests', () => {
   });
 
   test('should parse empty element', () => {
-    const vulnerability = Vulnerability.fromElement();
+    const vulnerability = Vulnerability.fromElement({_id: 'test-id'});
+    expect(vulnerability.id).toEqual('test-id');
     expect(vulnerability.hosts).toBeUndefined();
     expect(vulnerability.results).toBeUndefined();
     expect(vulnerability.qod).toBeUndefined();
@@ -29,6 +31,7 @@ describe('Vulnerability model tests', () => {
 
   test('should parse hosts', () => {
     const vulnerability = Vulnerability.fromElement({
+      _id: 'test-id',
       hosts: {
         count: 5,
       },
@@ -38,6 +41,7 @@ describe('Vulnerability model tests', () => {
 
   test('should parse results', () => {
     const vulnerability = Vulnerability.fromElement({
+      _id: 'test-id',
       results: {
         count: 10,
         newest: '2024-01-01T00:00:00Z',
@@ -52,14 +56,13 @@ describe('Vulnerability model tests', () => {
   });
 
   test('should parse qod', () => {
-    const vulnerability = Vulnerability.fromElement({
-      qod: 75,
-    });
+    const vulnerability = Vulnerability.fromElement({_id: 'test-id', qod: 75});
     expect(vulnerability.qod).toBe(75);
   });
 
   test('should parse severity', () => {
     const vulnerability = Vulnerability.fromElement({
+      _id: 'test-id',
       severity: 3,
     });
     expect(vulnerability.severity).toBe(3);

--- a/src/gmp/models/__tests__/web-application-target.test.ts
+++ b/src/gmp/models/__tests__/web-application-target.test.ts
@@ -12,8 +12,8 @@ describe('WebApplicationTarget model tests', () => {
   testModel(WebApplicationTarget, 'webapplicationtarget');
 
   test('should use defaults', () => {
-    const target = new WebApplicationTarget();
-    expect(target.id).toBeUndefined();
+    const target = new WebApplicationTarget({id: 'test-id'});
+    expect(target.id).toEqual('test-id');
     expect(target.name).toBeUndefined();
     expect(target.comment).toBeUndefined();
     expect(target.urls).toEqual([]);
@@ -24,8 +24,8 @@ describe('WebApplicationTarget model tests', () => {
   });
 
   test('should parse defaults', () => {
-    const target = WebApplicationTarget.fromElement({});
-    expect(target.id).toBeUndefined();
+    const target = WebApplicationTarget.fromElement({_id: 'test-id'});
+    expect(target.id).toEqual('test-id');
     expect(target.name).toBeUndefined();
     expect(target.comment).toBeUndefined();
     expect(target.urls).toEqual([]);
@@ -37,6 +37,7 @@ describe('WebApplicationTarget model tests', () => {
 
   test('should parse target_url as array of urls', () => {
     const target = WebApplicationTarget.fromElement({
+      _id: 'test-id',
       urls: 'https://example.com,https://test.com',
     });
     expect(target.urls).toEqual(['https://example.com', 'https://test.com']);
@@ -44,6 +45,7 @@ describe('WebApplicationTarget model tests', () => {
 
   test('should parse single target_url', () => {
     const target = WebApplicationTarget.fromElement({
+      _id: 'test-id',
       urls: 'https://example.com',
     });
     expect(target.urls).toEqual(['https://example.com']);
@@ -51,18 +53,20 @@ describe('WebApplicationTarget model tests', () => {
 
   test('should expose backward-compatible url getter', () => {
     const target = WebApplicationTarget.fromElement({
+      _id: 'test-id',
       urls: 'https://example.com,https://test.com',
     });
     expect(target.url).toEqual('https://example.com');
   });
 
   test('should return empty string from url getter when urls is empty', () => {
-    const target = WebApplicationTarget.fromElement({});
+    const target = WebApplicationTarget.fromElement({_id: 'test-id'});
     expect(target.url).toEqual('');
   });
 
   test('should parse exclude_url as array', () => {
     const target = WebApplicationTarget.fromElement({
+      _id: 'test-id',
       exclude_urls: 'https://exclude1.com,https://exclude2.com',
     });
     expect(target.excludeUrls).toEqual([
@@ -73,7 +77,10 @@ describe('WebApplicationTarget model tests', () => {
 
   test('should parse credential', () => {
     const credential = {_id: 'cred-1', name: 'Credential1'};
-    const target = WebApplicationTarget.fromElement({credential});
+    const target = WebApplicationTarget.fromElement({
+      _id: 'test-id',
+      credential,
+    });
     expect(target.credential).toBeDefined();
     expect(target.credential?.id).toEqual('cred-1');
     expect(target.credential?.name).toEqual('Credential1');
@@ -81,6 +88,7 @@ describe('WebApplicationTarget model tests', () => {
 
   test('should ignore empty credential', () => {
     const target = WebApplicationTarget.fromElement({
+      _id: 'test-id',
       credential: {_id: ''},
     });
     expect(target.credential).toBeUndefined();
@@ -88,10 +96,12 @@ describe('WebApplicationTarget model tests', () => {
 
   test('should parse reverseLookupOnly', () => {
     const targetTrue = WebApplicationTarget.fromElement({
+      _id: 'test-id',
       reverse_lookup_only: YES_VALUE,
     });
     expect(targetTrue.reverseLookupOnly).toEqual(true);
     const targetFalse = WebApplicationTarget.fromElement({
+      _id: 'test-id',
       reverse_lookup_only: NO_VALUE,
     });
     expect(targetFalse.reverseLookupOnly).toEqual(false);
@@ -99,10 +109,12 @@ describe('WebApplicationTarget model tests', () => {
 
   test('should parse reverseLookupUnify', () => {
     const targetTrue = WebApplicationTarget.fromElement({
+      _id: 'test-id',
       reverse_lookup_unify: YES_VALUE,
     });
     expect(targetTrue.reverseLookupUnify).toEqual(true);
     const targetFalse = WebApplicationTarget.fromElement({
+      _id: 'test-id',
       reverse_lookup_unify: NO_VALUE,
     });
     expect(targetFalse.reverseLookupUnify).toEqual(false);
@@ -110,6 +122,7 @@ describe('WebApplicationTarget model tests', () => {
 
   test('should parse all fields together', () => {
     const target = WebApplicationTarget.fromElement({
+      _id: 'test-id',
       urls: 'https://a.com,https://b.com',
       exclude_urls: 'https://ex.com',
       credential: {_id: 'cred-2', name: 'Cred2'},

--- a/src/gmp/models/agent-group.ts
+++ b/src/gmp/models/agent-group.ts
@@ -54,7 +54,7 @@ class AgentGroup extends Model {
     agents = [],
     schedulerCronTime,
     ...properties
-  }: AgentGroupProperties = {}) {
+  }: AgentGroupProperties) {
     super(properties);
 
     this.scanner = scanner;
@@ -62,11 +62,11 @@ class AgentGroup extends Model {
     this.schedulerCronTime = schedulerCronTime;
   }
 
-  static fromElement(element: AgentGroupElement = {}): AgentGroup {
+  static fromElement(element: AgentGroupElement): AgentGroup {
     return new AgentGroup(this.parseElement(element));
   }
 
-  static parseElement(element: AgentGroupElement = {}): AgentGroupProperties {
+  static parseElement(element: AgentGroupElement): AgentGroupProperties {
     const copy = super.parseElement(element) as AgentGroupProperties;
 
     const {scanner, agents} = element;

--- a/src/gmp/models/agent-installer.ts
+++ b/src/gmp/models/agent-installer.ts
@@ -39,7 +39,7 @@ class AgentInstaller extends Model {
     version,
     checksum,
     ...properties
-  }: AgentInstallerProperties = {}) {
+  }: AgentInstallerProperties) {
     super(properties);
 
     this.contentType = contentType;
@@ -49,13 +49,13 @@ class AgentInstaller extends Model {
     this.checksum = checksum;
   }
 
-  static fromElement(element: AgentInstallerElement = {}): AgentInstaller {
+  static fromElement(element: AgentInstallerElement): AgentInstaller {
     const props = this.parseElement(element);
     return new AgentInstaller(props);
   }
 
   static parseElement(
-    element: AgentInstallerElement = {},
+    element: AgentInstallerElement,
   ): AgentInstallerProperties {
     const copy = super.parseElement(element) as AgentInstallerProperties;
 

--- a/src/gmp/models/agent.ts
+++ b/src/gmp/models/agent.ts
@@ -186,7 +186,7 @@ class Agent extends Model {
     latestUpdaterVersion,
     config,
     ...properties
-  }: AgentProperties = {}) {
+  }: AgentProperties) {
     super(properties);
 
     this.hostname = hostname;
@@ -210,12 +210,12 @@ class Agent extends Model {
     this.config = config;
   }
 
-  static fromElement(element: AgentElement = {}): Agent {
+  static fromElement(element: AgentElement): Agent {
     const props = this.parseElement(element);
     return new Agent(props);
   }
 
-  static parseElement(element: AgentElement = {}): AgentProperties {
+  static parseElement(element: AgentElement): AgentProperties {
     const copy = super.parseElement(element) as AgentProperties;
 
     const {scanner, config} = element;

--- a/src/gmp/models/alert.ts
+++ b/src/gmp/models/alert.ts
@@ -216,7 +216,7 @@ class Alert extends Model {
     method,
     tasks = [],
     ...properties
-  }: AlertProperties = {}) {
+  }: AlertProperties) {
     super(properties);
 
     this.active = active;
@@ -227,18 +227,18 @@ class Alert extends Model {
     this.tasks = tasks;
   }
 
-  static fromElement(element?: AlertElement): Alert {
+  static fromElement(element: AlertElement): Alert {
     return new Alert(this.parseElement(element));
   }
 
-  static parseElement(element: AlertElement = {}): AlertProperties {
+  static parseElement(element: AlertElement): AlertProperties {
     const ret = super.parseElement(element) as AlertProperties;
 
     ret.condition = parseAlertData(element.condition);
     ret.event = parseAlertData(element.event);
     ret.method = parseAlertData(element.method) as MethodData;
 
-    if (isDefined(ret.filter)) {
+    if (isDefined(element.filter)) {
       ret.filter = Model.fromElement(element.filter, 'filter');
     }
 

--- a/src/gmp/models/audit-report.ts
+++ b/src/gmp/models/audit-report.ts
@@ -34,7 +34,7 @@ class AuditReport extends Model {
     reportType,
     task,
     ...properties
-  }: AuditReportProperties = {}) {
+  }: AuditReportProperties) {
     super(properties);
 
     this.contentType = contentType;
@@ -44,11 +44,11 @@ class AuditReport extends Model {
     this.task = task;
   }
 
-  static fromElement(element?: AuditReportElement): AuditReport {
+  static fromElement(element: AuditReportElement): AuditReport {
     return new AuditReport(this.parseElement(element));
   }
 
-  static parseElement(element: AuditReportElement = {}): AuditReportProperties {
+  static parseElement(element: AuditReportElement): AuditReportProperties {
     const copy = super.parseElement(element) as AuditReportProperties;
 
     const {

--- a/src/gmp/models/audit.ts
+++ b/src/gmp/models/audit.ts
@@ -127,7 +127,7 @@ class Audit extends Model {
     target,
     trend,
     ...properties
-  }: AuditProperties = {}) {
+  }: AuditProperties) {
     super(properties);
 
     this.alerts = alerts;
@@ -157,7 +157,7 @@ class Audit extends Model {
     this.trend = trend;
   }
 
-  static fromElement(element: AuditElement = {}): Audit {
+  static fromElement(element: AuditElement): Audit {
     if (
       isDefined(element?.usage_type) &&
       element.usage_type !== USAGE_TYPE.audit
@@ -167,7 +167,7 @@ class Audit extends Model {
     return new Audit(this.parseElement(element));
   }
 
-  static parseElement(element: AuditElement = {}): AuditProperties {
+  static parseElement(element: AuditElement): AuditProperties {
     return Task.parseElement(element) as AuditProperties;
   }
 

--- a/src/gmp/models/base-model.ts
+++ b/src/gmp/models/base-model.ts
@@ -5,13 +5,12 @@
 
 import {type Date as GmpDate} from 'gmp/models/date';
 import {parseDate} from 'gmp/parser';
-import {isDefined, isString} from 'gmp/utils/identity';
+import {isDefined} from 'gmp/utils/identity';
 
 /**
  * Represents the data returned by the backend
  */
 export interface BaseModelElement {
-  _id?: string;
   creation_time?: string;
   modification_time?: string;
   type?: string | number;
@@ -23,7 +22,6 @@ export interface BaseModelElement {
 export interface BaseModelProperties {
   _type?: string;
   creationTime?: GmpDate;
-  id?: string;
   modificationTime?: GmpDate;
 }
 
@@ -35,11 +33,6 @@ export const parseBaseModelProperties = (
   // for now we need to return the whole object
   // to not break existing code
   const copy = {...element} as BaseModelProperties; // create shallow copy
-
-  if (isString(element._id) && element._id.length > 0) {
-    // only set id if it id defined
-    copy.id = element._id;
-  }
 
   if (isDefined(element.creation_time)) {
     copy.creationTime = parseDate(element.creation_time);
@@ -65,16 +58,13 @@ export const parseBaseModelProperties = (
 class BaseModel {
   readonly _type?: string;
   readonly creationTime?: GmpDate;
-  readonly id?: string;
   readonly modificationTime?: GmpDate;
 
   constructor({
-    id,
     creationTime,
     modificationTime,
     _type,
   }: BaseModelProperties = {}) {
-    this.id = id;
     this.creationTime = creationTime;
     this.modificationTime = modificationTime;
     this._type = _type;

--- a/src/gmp/models/cert-bund.ts
+++ b/src/gmp/models/cert-bund.ts
@@ -143,7 +143,7 @@ class CertBundAdv extends Model {
     title,
     version,
     ...properties
-  }: CertBundAdvProperties = {}) {
+  }: CertBundAdvProperties) {
     super(properties);
 
     this.additionalInformation = additionalInformation;
@@ -164,11 +164,11 @@ class CertBundAdv extends Model {
     this.version = version;
   }
 
-  static fromElement(element?: CertBundAdvElement): CertBundAdv {
+  static fromElement(element: CertBundAdvElement): CertBundAdv {
     return new CertBundAdv(this.parseElement(element));
   }
 
-  static parseElement(element: CertBundAdvElement = {}): CertBundAdvProperties {
+  static parseElement(element: CertBundAdvElement): CertBundAdvProperties {
     const {cert_bund_adv: certBundAdv} = element;
     const ret = super.parseElement(element) as CertBundAdvProperties;
 

--- a/src/gmp/models/cpe.ts
+++ b/src/gmp/models/cpe.ts
@@ -85,7 +85,7 @@ class Cpe extends Model {
     severity,
     updateTime,
     ...properties
-  }: CpeProperties = {}) {
+  }: CpeProperties) {
     super(properties);
 
     this.cpeNameId = cpeNameId;
@@ -98,7 +98,7 @@ class Cpe extends Model {
     this.updateTime = updateTime;
   }
 
-  static fromElement(element: CpeElement = {}): Cpe {
+  static fromElement(element: CpeElement): Cpe {
     return new Cpe(this.parseElement(element));
   }
 

--- a/src/gmp/models/credential-store.ts
+++ b/src/gmp/models/credential-store.ts
@@ -88,7 +88,7 @@ class CredentialStore extends Model {
     preferences = [],
     selectors = [],
     ...properties
-  }: CredentialStoreProperties = {}) {
+  }: CredentialStoreProperties) {
     super(properties);
 
     this.version = version;
@@ -99,13 +99,13 @@ class CredentialStore extends Model {
     this.selectors = selectors;
   }
 
-  static fromElement(element: CredentialStoreElement = {}): CredentialStore {
+  static fromElement(element: CredentialStoreElement): CredentialStore {
     const props = this.parseElement(element);
     return new CredentialStore(props);
   }
 
   static parseElement(
-    element: CredentialStoreElement = {},
+    element: CredentialStoreElement,
   ): CredentialStoreProperties {
     const copy = super.parseElement(element) as CredentialStoreProperties;
 

--- a/src/gmp/models/credential.ts
+++ b/src/gmp/models/credential.ts
@@ -329,7 +329,7 @@ class Credential extends Model {
     privateKeyInfo,
     publicKeyInfo,
     ...properties
-  }: CredentialProperties = {}) {
+  }: CredentialProperties) {
     super(properties);
 
     this.authAlgorithm = authAlgorithm;
@@ -347,11 +347,11 @@ class Credential extends Model {
     this.publicKeyInfo = publicKeyInfo;
   }
 
-  static fromElement(element: CredentialElement = {}): Credential {
+  static fromElement(element: CredentialElement): Credential {
     return new Credential(this.parseElement(element));
   }
 
-  static parseElement(element: CredentialElement = {}): CredentialProperties {
+  static parseElement(element: CredentialElement): CredentialProperties {
     const ret = super.parseElement(element) as CredentialProperties;
 
     ret.authAlgorithm = element.auth_algorithm;

--- a/src/gmp/models/cve.ts
+++ b/src/gmp/models/cve.ts
@@ -248,7 +248,7 @@ class Cve extends Model {
     severity,
     updateTime,
     ...properties
-  }: CveProperties = {}) {
+  }: CveProperties) {
     super(properties);
 
     this.certs = certs;
@@ -282,11 +282,11 @@ class Cve extends Model {
     this.updateTime = updateTime;
   }
 
-  static fromElement(element: CveElement = {}): Cve {
+  static fromElement(element: CveElement): Cve {
     return new Cve(this.parseElement(element));
   }
 
-  static parseElement(element: CveElement = {}): CveProperties {
+  static parseElement(element: CveElement): CveProperties {
     const cveElement = element.cve;
     const ret = super.parseElement(element) as CveProperties;
 

--- a/src/gmp/models/dfn-cert.ts
+++ b/src/gmp/models/dfn-cert.ts
@@ -69,7 +69,7 @@ class DfnCertAdv extends Model {
     summary,
     title,
     ...properties
-  }: DfnCertAdvProperties = {}) {
+  }: DfnCertAdvProperties) {
     super(properties);
 
     this.additionalLinks = additionalLinks;
@@ -80,11 +80,11 @@ class DfnCertAdv extends Model {
     this.title = title;
   }
 
-  static fromElement(element?: DfnCertAdvElement): DfnCertAdv {
+  static fromElement(element: DfnCertAdvElement): DfnCertAdv {
     return new DfnCertAdv(this.parseElement(element));
   }
 
-  static parseElement(element: DfnCertAdvElement = {}): DfnCertAdvProperties {
+  static parseElement(element: DfnCertAdvElement): DfnCertAdvProperties {
     const dfnCertAdvElement = element.dfn_cert_adv;
     const ret = super.parseElement(element) as DfnCertAdvProperties;
     ret.severity = parseSeverity(dfnCertAdvElement?.severity);

--- a/src/gmp/models/entity-model.ts
+++ b/src/gmp/models/entity-model.ts
@@ -35,6 +35,7 @@ export interface EntityModelPermissionElement {
 }
 
 export interface EntityModelElement extends BaseModelElement {
+  _id: string;
   name?: string;
   end_time?: string;
   timestamp?: string;
@@ -58,6 +59,7 @@ export interface EntityModelProperties extends BaseModelProperties {
   active?: YesNo;
   comment?: string;
   endTime?: GmpDate;
+  id: string;
   inUse?: boolean;
   name?: string;
   orphan?: YesNo;
@@ -80,6 +82,7 @@ class EntityModel extends BaseModel {
   readonly comment?: string;
   readonly endTime?: GmpDate;
   readonly entityType: EntityType;
+  readonly id: string;
   readonly inUse?: boolean;
   readonly name?: string;
   readonly orphan?: YesNo;
@@ -110,10 +113,10 @@ class EntityModel extends BaseModel {
       userCapabilities,
       userTags = [],
       writable,
-    }: EntityModelProperties = {},
+    }: EntityModelProperties,
     entityType?: EntityType,
   ) {
-    super({id, creationTime, modificationTime, _type});
+    super({creationTime, modificationTime, _type});
 
     const defaultEntityType = (this.constructor as typeof EntityModel)
       .entityType;
@@ -122,6 +125,7 @@ class EntityModel extends BaseModel {
     this.active = active;
     this.comment = comment;
     this.endTime = endTime;
+    this.id = id;
     this.inUse = inUse;
     this.name = name;
     this.orphan = orphan;
@@ -155,7 +159,7 @@ class EntityModel extends BaseModel {
   }
 
   static fromElement(
-    element: EntityModelElement = {},
+    element: EntityModelElement,
     entityType?: EntityType,
   ): EntityModel {
     return new this(parseEntityModelProperties(element), entityType);
@@ -163,12 +167,17 @@ class EntityModel extends BaseModel {
 }
 
 export const parseEntityModelProperties = (
-  element: EntityModelElement = {},
+  element: EntityModelElement,
 ): EntityModelProperties => {
   // in future parseDefaultProperties should only return known properties
   // and not the whole object
   // for now we need to delete the properties we don't want
   const copy = parseBaseModelProperties(element) as EntityModelProperties;
+
+  if (!isEmpty(element._id)) {
+    // only set id if it id defined
+    copy.id = element._id;
+  }
 
   if (isDefined(element.name)) {
     copy.name = parseToString(element.name);

--- a/src/gmp/models/group.ts
+++ b/src/gmp/models/group.ts
@@ -19,17 +19,17 @@ class Group extends Model {
 
   readonly users: string[];
 
-  constructor({users = [], ...properties}: GroupProperties = {}) {
+  constructor({users = [], ...properties}: GroupProperties = {id: 'test-id'}) {
     super(properties);
 
     this.users = users;
   }
 
-  static fromElement(element: GroupElement = {}): Group {
+  static fromElement(element: GroupElement): Group {
     return new Group(this.parseElement(element));
   }
 
-  static parseElement(element: GroupElement = {}): GroupProperties {
+  static parseElement(element: GroupElement): GroupProperties {
     const ret = super.parseElement(element) as GroupProperties;
 
     ret.users = parseCsv(element.users);

--- a/src/gmp/models/host.ts
+++ b/src/gmp/models/host.ts
@@ -4,6 +4,7 @@
  */
 
 import BaseModel, {
+  type BaseModelElement,
   type BaseModelProperties,
   parseBaseModelProperties,
 } from 'gmp/models/base-model';
@@ -35,7 +36,8 @@ interface IdentifierProperties extends BaseModelProperties {
   value?: string;
 }
 
-interface IdentifierElement extends ModelElement {
+interface IdentifierElement extends BaseModelElement {
+  name?: string;
   os?: {
     id?: string;
   };
@@ -181,7 +183,7 @@ class Host extends Model {
     routes = [],
     severity,
     ...properties
-  }: HostProperties = {}) {
+  }: HostProperties) {
     super(properties);
 
     this.details = details;
@@ -193,11 +195,11 @@ class Host extends Model {
     this.severity = severity;
   }
 
-  static fromElement(element?: HostElement): Host {
+  static fromElement(element: HostElement): Host {
     return new Host(this.parseElement(element));
   }
 
-  static parseElement(element: HostElement = {}): HostProperties {
+  static parseElement(element: HostElement): HostProperties {
     const ret = super.parseElement(element) as HostProperties;
 
     if (isDefined(element.host?.severity)) {

--- a/src/gmp/models/model.ts
+++ b/src/gmp/models/model.ts
@@ -20,14 +20,11 @@ export type ModelProperties = EntityModelProperties;
  * A model representing an entity with a required ID
  */
 class Model extends EntityModel {
-  constructor(properties: ModelProperties = {}, entityType?: EntityType) {
+  constructor(properties: ModelProperties, entityType?: EntityType) {
     super(properties, entityType);
   }
 
-  static fromElement(
-    element: ModelElement = {},
-    entityType?: EntityType,
-  ): Model {
+  static fromElement(element: ModelElement, entityType?: EntityType): Model {
     const {
       id,
       creationTime,
@@ -77,7 +74,7 @@ class Model extends EntityModel {
     return f;
   }
 
-  static parseElement(element: ModelElement = {}): ModelProperties {
+  static parseElement(element: ModelElement): ModelProperties {
     return parseEntityModelProperties(element);
   }
 }
@@ -86,7 +83,7 @@ export const parseModelFromElement = (
   element: ModelElement,
   entityType: EntityType,
 ) => {
-  return Model.fromElement(element as Element, entityType);
+  return Model.fromElement(element, entityType);
 };
 
 export default Model;

--- a/src/gmp/models/note.ts
+++ b/src/gmp/models/note.ts
@@ -64,7 +64,7 @@ class Note extends Model {
     text,
     textExcerpt,
     ...properties
-  }: NoteProperties = {}) {
+  }: NoteProperties) {
     super(properties);
 
     this.hosts = hosts;
@@ -77,15 +77,15 @@ class Note extends Model {
     this.textExcerpt = textExcerpt;
   }
 
-  static fromElement(element?: NoteElement): Note {
+  static fromElement(element: NoteElement): Note {
     return new Note(this.parseElement(element));
   }
 
-  static parseElement(element: NoteElement = {}): NoteProperties {
+  static parseElement(element: NoteElement): NoteProperties {
     let ret = super.parseElement(element) as NoteProperties;
 
     if (element.nvt) {
-      ret.nvt = Nvt.fromElement({nvt: element.nvt});
+      ret.nvt = Nvt.fromElement({_id: 'test-id', nvt: element.nvt});
       ret.name = ret.nvt.name;
     }
 

--- a/src/gmp/models/nvt.ts
+++ b/src/gmp/models/nvt.ts
@@ -70,7 +70,7 @@ export interface NvtSeveritiesElement {
 }
 
 export interface NvtNvtElement {
-  _oid?: string;
+  _oid: string;
   category?: number;
   creation_time?: string;
   cvss_base?: number;
@@ -101,7 +101,7 @@ export interface NvtNvtElement {
 
 export interface NvtElement extends ModelElement {
   update_time?: string;
-  nvt?: NvtNvtElement;
+  nvt: NvtNvtElement;
 }
 
 export type NvtPreferenceValue = string | number | undefined;
@@ -148,13 +148,13 @@ interface Epss {
   maxSeverity?: EpssValue;
 }
 
-interface NvtProperties extends ModelProperties {
+export interface NvtProperties extends ModelProperties {
   certs?: Cert[];
   cves?: string[];
   defaultTimeout?: number;
   epss?: Epss;
   family?: string;
-  oid?: string;
+  oid: string;
   preferences?: NvtPreference[];
   qod?: QoD;
   severity?: number;
@@ -277,7 +277,7 @@ class Nvt extends Model {
     timeout,
     xrefs = [],
     ...other
-  }: NvtProperties = {}) {
+  }: NvtProperties) {
     super(other);
 
     this.certs = certs;
@@ -297,16 +297,16 @@ class Nvt extends Model {
     this.xrefs = xrefs;
   }
 
-  static fromElement(element: NvtElement = {}): Nvt {
+  static fromElement(element: NvtElement): Nvt {
     return new Nvt(this.parseElement(element));
   }
 
-  static parseElement(element: NvtElement = {}): NvtProperties {
+  static parseElement(element: NvtElement): NvtProperties {
     const {nvt: nvtElement} = element;
     const ret = super.parseElement(element) as NvtProperties;
 
     ret.name = parseToString(nvtElement?.name) ?? ret.name;
-    ret.oid = isEmpty(nvtElement?._oid) ? undefined : nvtElement?._oid;
+    ret.oid = nvtElement._oid;
     ret.id = ret.oid;
     ret.tags = parseTags(nvtElement?.tags);
     ret.family = isEmpty(nvtElement?.family)

--- a/src/gmp/models/oci-image-target.ts
+++ b/src/gmp/models/oci-image-target.ts
@@ -40,7 +40,7 @@ class OciImageTarget extends Model {
     reverseLookupOnly = false,
     reverseLookupUnify = false,
     ...properties
-  }: OciImageTargetProperties = {}) {
+  }: OciImageTargetProperties) {
     super(properties);
 
     this.imageReferences = imageReferences;
@@ -50,7 +50,7 @@ class OciImageTarget extends Model {
     this.reverseLookupUnify = reverseLookupUnify;
   }
 
-  static fromElement(element: OciImageTargetElement = {}): OciImageTarget {
+  static fromElement(element: OciImageTargetElement): OciImageTarget {
     return new OciImageTarget(this.parseElement(element));
   }
 

--- a/src/gmp/models/os.ts
+++ b/src/gmp/models/os.ts
@@ -60,7 +60,7 @@ class OperatingSystem extends Model {
     hosts,
     allHosts,
     ...properties
-  }: OperatingSystemProperties = {}) {
+  }: OperatingSystemProperties) {
     super(properties);
 
     this.averageSeverity = averageSeverity;
@@ -71,12 +71,12 @@ class OperatingSystem extends Model {
     this.allHosts = allHosts;
   }
 
-  static fromElement(element?: OperatingSystemElement): OperatingSystem {
+  static fromElement(element: OperatingSystemElement): OperatingSystem {
     return new OperatingSystem(this.parseElement(element));
   }
 
   static parseElement(
-    element: OperatingSystemElement = {},
+    element: OperatingSystemElement,
   ): OperatingSystemProperties {
     const ret = super.parseElement(element) as OperatingSystemProperties;
 

--- a/src/gmp/models/override.ts
+++ b/src/gmp/models/override.ts
@@ -94,7 +94,7 @@ class Override extends Model {
     text,
     textExcerpt,
     ...properties
-  }: OverrideProperties = {}) {
+  }: OverrideProperties) {
     super(properties);
 
     this.hosts = hosts;
@@ -108,15 +108,15 @@ class Override extends Model {
     this.textExcerpt = textExcerpt;
   }
 
-  static fromElement(element: OverrideElement = {}): Override {
+  static fromElement(element: OverrideElement): Override {
     return new Override(this.parseElement(element));
   }
 
-  static parseElement(element: OverrideElement = {}): OverrideProperties {
+  static parseElement(element: OverrideElement): OverrideProperties {
     const ret = super.parseElement(element) as OverrideProperties;
 
     if (element.nvt) {
-      ret.nvt = Nvt.fromElement({nvt: element.nvt});
+      ret.nvt = Nvt.fromElement({_id: 'test-id', nvt: element.nvt});
       ret.name = ret.nvt.name;
     }
 

--- a/src/gmp/models/permission.ts
+++ b/src/gmp/models/permission.ts
@@ -32,23 +32,23 @@ class Permission extends Model {
   readonly resource?: Model;
   readonly subject?: Model;
 
-  constructor({resource, subject, ...properties}: PermissionProperties = {}) {
+  constructor({resource, subject, ...properties}: PermissionProperties) {
     super(properties);
 
     this.resource = resource;
     this.subject = subject;
   }
 
-  static fromElement(element: PermissionElement = {}): Permission {
+  static fromElement(element: PermissionElement): Permission {
     return new Permission(this.parseElement(element));
   }
 
-  static parseElement(element: PermissionElement = {}): PermissionProperties {
+  static parseElement(element: PermissionElement): PermissionProperties {
     const ret = super.parseElement(element) as PermissionProperties;
 
     if (isDefined(element.resource) && !isEmpty(element.resource._id)) {
       ret.resource = Model.fromElement(
-        element.resource,
+        element.resource as ModelElement,
         normalizeType(element.resource.type),
       );
     } else {
@@ -56,7 +56,10 @@ class Permission extends Model {
     }
 
     if (isDefined(element.subject) && !isEmpty(element.subject._id)) {
-      ret.subject = Model.fromElement(element.subject, element.subject.type);
+      ret.subject = Model.fromElement(
+        element.subject as ModelElement,
+        element.subject.type,
+      );
     } else {
       delete ret.subject;
     }

--- a/src/gmp/models/policy.ts
+++ b/src/gmp/models/policy.ts
@@ -87,7 +87,7 @@ class Policy extends Model {
     scanner,
     audits = [],
     ...properties
-  }: PolicyProperties = {}) {
+  }: PolicyProperties) {
     super(properties);
 
     this.families = families;
@@ -99,11 +99,11 @@ class Policy extends Model {
     this.audits = audits;
   }
 
-  static fromElement(element: PolicyElement = {}): Policy {
+  static fromElement(element: PolicyElement): Policy {
     return new Policy(this.parseElement(element));
   }
 
-  static parseElement(element: PolicyElement = {}): PolicyProperties {
+  static parseElement(element: PolicyElement): PolicyProperties {
     const ret = super.parseElement(element) as PolicyProperties;
 
     // for displaying the selected nvts (1 of 33) an object for accessing the

--- a/src/gmp/models/port-list.ts
+++ b/src/gmp/models/port-list.ts
@@ -101,7 +101,7 @@ class PortList extends Model {
     predefined = false,
     targets = [],
     ...properties
-  }: PortListProperties = {}) {
+  }: PortListProperties) {
     super(properties);
 
     this.deprecated = deprecated;
@@ -111,7 +111,7 @@ class PortList extends Model {
     this.targets = targets;
   }
 
-  static fromElement(element: PortListElement = {}): PortList {
+  static fromElement(element: PortListElement): PortList {
     return new PortList(this.parseElement(element));
   }
 

--- a/src/gmp/models/report-config.ts
+++ b/src/gmp/models/report-config.ts
@@ -42,7 +42,7 @@ class ReportConfig extends Model {
     params = [],
     reportFormat,
     ...properties
-  }: ReportConfigProperties = {}) {
+  }: ReportConfigProperties) {
     super(properties, ReportConfig.entityType);
 
     this.alerts = alerts;
@@ -50,13 +50,11 @@ class ReportConfig extends Model {
     this.reportFormat = reportFormat;
   }
 
-  static fromElement(element?: ReportConfigElement): ReportConfig {
+  static fromElement(element: ReportConfigElement): ReportConfig {
     return new ReportConfig(this.parseElement(element));
   }
 
-  static parseElement(
-    element: ReportConfigElement = {},
-  ): ReportConfigProperties {
+  static parseElement(element: ReportConfigElement): ReportConfigProperties {
     const ret = super.parseElement(element) as ReportConfigProperties;
 
     if (isDefined(element.report_format)) {

--- a/src/gmp/models/report-format.ts
+++ b/src/gmp/models/report-format.ts
@@ -225,7 +225,7 @@ class ReportFormat extends Model {
     report_type,
     trust,
     ...properties
-  }: ReportFormatProperties = {}) {
+  }: ReportFormatProperties) {
     super(properties);
 
     this.alerts = alerts;
@@ -241,13 +241,11 @@ class ReportFormat extends Model {
     this.trust = trust;
   }
 
-  static fromElement(element: ReportFormatElement = {}): ReportFormat {
+  static fromElement(element: ReportFormatElement): ReportFormat {
     return new ReportFormat(this.parseElement(element));
   }
 
-  static parseElement(
-    element: ReportFormatElement = {},
-  ): ReportFormatProperties {
+  static parseElement(element: ReportFormatElement): ReportFormatProperties {
     const ret = super.parseElement(element) as ReportFormatProperties;
 
     if (isDefined(element.trust)) {

--- a/src/gmp/models/report.ts
+++ b/src/gmp/models/report.ts
@@ -18,16 +18,16 @@ export interface ReportElement extends ModelElement {
   _type?: ReportType;
   report?: ReportReportElement;
   report_config?: {
-    _id?: string;
+    _id: string;
     name?: string;
   };
   report_format?: {
-    _id?: string;
+    _id: string;
     name?: string;
   };
   task?: {
     name?: string;
-    _id?: string;
+    _id: string;
   };
 }
 
@@ -62,7 +62,7 @@ class Report extends Model {
     report_type,
     task,
     ...properties
-  }: ReportProperties = {}) {
+  }: ReportProperties) {
     super(properties);
 
     this.content_type = content_type;
@@ -73,11 +73,11 @@ class Report extends Model {
     this.task = task;
   }
 
-  static fromElement(element: ReportElement = {}): Report {
+  static fromElement(element: ReportElement): Report {
     return new Report(this.parseElement(element));
   }
 
-  static parseElement(element: ReportElement = {}): ReportProperties {
+  static parseElement(element: ReportElement): ReportProperties {
     const copy = super.parseElement(element) as ReportProperties;
 
     const {

--- a/src/gmp/models/report/__tests__/app.test.ts
+++ b/src/gmp/models/report/__tests__/app.test.ts
@@ -19,7 +19,7 @@ describe('App tests', () => {
   });
 
   test('should parse empty element', () => {
-    const app = ReportApp.fromElement();
+    const app = ReportApp.fromElement({});
     expect(app.id).toBeUndefined();
     expect(app.name).toBeUndefined();
     expect(app.severity).toBeUndefined();

--- a/src/gmp/models/report/__tests__/audit-report.test.ts
+++ b/src/gmp/models/report/__tests__/audit-report.test.ts
@@ -10,7 +10,8 @@ import {parseDate} from 'gmp/parser';
 
 describe('AuditReportReport tests', () => {
   test('should use defaults', () => {
-    const report = new AuditReportReport();
+    const report = new AuditReportReport({id: 'test-id'});
+    expect(report.id).toEqual('test-id');
     expect(report.compliance).toBeUndefined();
     expect(report.complianceCounts).toBeUndefined();
     expect(report.delta_report).toBeUndefined();
@@ -25,7 +26,8 @@ describe('AuditReportReport tests', () => {
   });
 
   test('should parse empty element', () => {
-    const report = AuditReportReport.fromElement();
+    const report = AuditReportReport.fromElement({_id: 'test-id'});
+    expect(report.id).toEqual('test-id');
     expect(report.compliance).toBeUndefined();
     expect(report.complianceCounts).toBeUndefined();
     expect(report.delta_report).toBeUndefined();
@@ -34,13 +36,14 @@ describe('AuditReportReport tests', () => {
     expect(report.scan_end).toBeUndefined();
     expect(report.scan_run_status).toBeUndefined();
     expect(report.scan_start).toBeUndefined();
-    expect(report.task).toBeDefined();
+    expect(report.task).toBeUndefined();
     expect(report.timezone).toBeUndefined();
     expect(report.timezone_abbrev).toBeUndefined();
   });
 
   test('should parse filter', () => {
     const report = AuditReportReport.fromElement({
+      _id: 'test-id',
       filters: {
         _id: 'filter1',
         term: 'foo=bar',
@@ -53,6 +56,7 @@ describe('AuditReportReport tests', () => {
 
   test('should parse report type', () => {
     const report = AuditReportReport.fromElement({
+      _id: 'test-id',
       _type: 'delta',
     });
     expect(report.reportType).toEqual('delta');
@@ -60,6 +64,7 @@ describe('AuditReportReport tests', () => {
 
   test('should parse scan start', () => {
     const report = AuditReportReport.fromElement({
+      _id: 'test-id',
       scan_start: '2024-01-01T00:00:00Z',
     });
     expect(report.scan_start).toEqual(parseDate('2024-01-01T00:00:00Z'));
@@ -67,6 +72,7 @@ describe('AuditReportReport tests', () => {
 
   test('should parse scan end', () => {
     const report = AuditReportReport.fromElement({
+      _id: 'test-id',
       scan_end: '2024-01-02T00:00:00Z',
     });
     expect(report.scan_end).toEqual(parseDate('2024-01-02T00:00:00Z'));
@@ -74,6 +80,7 @@ describe('AuditReportReport tests', () => {
 
   test('should parse task', () => {
     const report = AuditReportReport.fromElement({
+      _id: 'test-id',
       task: {
         _id: 'task1',
         name: 'Test Task',
@@ -86,6 +93,7 @@ describe('AuditReportReport tests', () => {
 
   test('should parse delta report', () => {
     const report = AuditReportReport.fromElement({
+      _id: 'test-id',
       delta: {
         report: {
           _id: 'delta1',
@@ -108,6 +116,7 @@ describe('AuditReportReport tests', () => {
 
   test('should parse scan run status', () => {
     const report = AuditReportReport.fromElement({
+      _id: 'test-id',
       scan_run_status: 'completed',
     });
     expect(report.scan_run_status).toEqual('completed');
@@ -115,6 +124,7 @@ describe('AuditReportReport tests', () => {
 
   test('should parse results', () => {
     const report = AuditReportReport.fromElement({
+      _id: 'test-id',
       results: {
         _start: '1',
         _max: '8',
@@ -139,6 +149,7 @@ describe('AuditReportReport tests', () => {
 
   test('should parse compliance count', () => {
     const report = AuditReportReport.fromElement({
+      _id: 'test-id',
       compliance_count: {
         full: 20,
         filtered: 5,
@@ -175,6 +186,7 @@ describe('AuditReportReport tests', () => {
 
   test('should parse compliance', () => {
     const report = AuditReportReport.fromElement({
+      _id: 'test-id',
       compliance: {
         full: COMPLIANCE.INCOMPLETE,
         filtered: COMPLIANCE.YES,
@@ -187,6 +199,7 @@ describe('AuditReportReport tests', () => {
 
   test('should parse timezone', () => {
     const report = AuditReportReport.fromElement({
+      _id: 'test-id',
       timezone: 'Europe/Berlin',
     });
     expect(report.timezone).toEqual('Europe/Berlin');
@@ -194,6 +207,7 @@ describe('AuditReportReport tests', () => {
 
   test('should parse timezone abbreviation', () => {
     const report = AuditReportReport.fromElement({
+      _id: 'test-id',
       timezone_abbrev: 'CET',
     });
     expect(report.timezone_abbrev).toEqual('CET');

--- a/src/gmp/models/report/__tests__/cve.test.ts
+++ b/src/gmp/models/report/__tests__/cve.test.ts
@@ -20,9 +20,12 @@ describe('ReportCve tests', () => {
   });
 
   test('should parse empty element', () => {
-    const cve = ReportCve.fromElement();
+    const cve = ReportCve.fromElement({
+      _id: 'test-id',
+      nvt: {_oid: '1.2.3'},
+    });
     expect(cve.cves).toEqual([]);
-    expect(cve.id).toBeUndefined();
+    expect(cve.id).toEqual('1.2.3');
     expect(cve.nvtName).toBeUndefined();
     expect(cve.severity).toBeUndefined();
     expect(cve.hosts).toBeDefined();
@@ -33,7 +36,9 @@ describe('ReportCve tests', () => {
 
   test('should parse cves', () => {
     const cve = ReportCve.fromElement({
+      _id: 'test-id',
       nvt: {
+        _oid: '1.2.3',
         refs: {
           ref: [
             {
@@ -55,6 +60,7 @@ describe('ReportCve tests', () => {
 
   test('should parse oid/id', () => {
     const cve = ReportCve.fromElement({
+      _id: 'test-id',
       nvt: {
         _oid: 'c1',
       },
@@ -64,13 +70,14 @@ describe('ReportCve tests', () => {
 
   test('should parse nvtName', () => {
     const cve = ReportCve.fromElement({
+      _id: 'test-id',
       nvt: {_oid: '1.2.3', name: 'Foo'},
     });
     expect(cve.nvtName).toEqual('Foo');
   });
 
   test('should add hosts', () => {
-    const cve = ReportCve.fromElement();
+    const cve = ReportCve.fromElement({_id: 'test-id', nvt: {_oid: '1.2.3'}});
     expect(cve.hosts).toBeDefined();
     expect(cve.hosts.hostsByIp).toEqual({});
     expect(cve.hosts.count).toEqual(0);
@@ -94,7 +101,7 @@ describe('ReportCve tests', () => {
   });
 
   test('should add result', () => {
-    const cve = ReportCve.fromElement();
+    const cve = ReportCve.fromElement({_id: 'test-id', nvt: {_oid: '1.2.3'}});
     expect(cve.occurrences).toEqual(0);
     expect(cve.severity).toBeUndefined();
 

--- a/src/gmp/models/report/__tests__/host.test.ts
+++ b/src/gmp/models/report/__tests__/host.test.ts
@@ -39,7 +39,7 @@ describe('ReportHost tests', () => {
   });
 
   test('should parse empty element', () => {
-    const host = ReportHost.fromElement();
+    const host = ReportHost.fromElement({});
     expect(host.asset).toBeUndefined();
     expect(host.authSuccess).toEqual({});
     expect(host.complianceCounts).toEqual({
@@ -78,9 +78,7 @@ describe('ReportHost tests', () => {
   });
 
   test('should parse port count', () => {
-    const host1 = ReportHost.fromElement({
-      port_count: {},
-    });
+    const host1 = ReportHost.fromElement({port_count: {}});
     expect(host1.portsCount).toEqual(0);
 
     const host2 = ReportHost.fromElement({
@@ -168,16 +166,12 @@ describe('ReportHost tests', () => {
   });
 
   test('should parse start', () => {
-    const host = ReportHost.fromElement({
-      start: '2019-10-02T12:17:10+02:00',
-    });
+    const host = ReportHost.fromElement({start: '2019-10-02T12:17:10+02:00'});
     expect(host.start).toEqual(parseDate('2019-10-02T12:17:10+02:00'));
   });
 
   test('should parse end', () => {
-    const host = ReportHost.fromElement({
-      end: '2019-10-02T12:29:22+02:00',
-    });
+    const host = ReportHost.fromElement({end: '2019-10-02T12:29:22+02:00'});
     expect(host.end).toEqual(parseDate('2019-10-02T12:29:22+02:00'));
   });
 
@@ -256,17 +250,13 @@ describe('ReportHost tests', () => {
   });
 
   test('should parse ip as id', () => {
-    const host = ReportHost.fromElement({
-      ip: '1.2.3.4',
-    });
+    const host = ReportHost.fromElement({ip: '1.2.3.4'});
     expect(host.ip).toEqual('1.2.3.4');
     expect(host.id).toEqual('1.2.3.4');
   });
 
   test('should parse severity', () => {
-    const host = ReportHost.fromElement({
-      severity: 5.5,
-    });
+    const host = ReportHost.fromElement({severity: 5.5});
     expect(host.severity).toEqual(5.5);
   });
 });

--- a/src/gmp/models/report/__tests__/port.test.ts
+++ b/src/gmp/models/report/__tests__/port.test.ts
@@ -20,7 +20,7 @@ describe('ReportPort tests', () => {
   });
 
   test('should parse empty element', () => {
-    const port = ReportPort.fromElement();
+    const port = ReportPort.fromElement({});
     expect(port.id).toBeUndefined();
     expect(port.threat).toBeUndefined();
     expect(port.number).toEqual(0);
@@ -32,7 +32,7 @@ describe('ReportPort tests', () => {
   });
 
   test('should add hosts', () => {
-    const port = ReportPort.fromElement();
+    const port = ReportPort.fromElement({});
     expect(port.hosts).toBeDefined();
     expect(port.hosts.hostsByIp).toEqual({});
     expect(port.hosts.count).toEqual(0);
@@ -44,7 +44,7 @@ describe('ReportPort tests', () => {
   });
 
   test('should allow to set severity', () => {
-    const port = ReportPort.fromElement();
+    const port = ReportPort.fromElement({});
     expect(port.severity).toBeUndefined();
 
     port.setSeverity(5.5);
@@ -62,16 +62,12 @@ describe('ReportPort tests', () => {
   });
 
   test('should parse port information', () => {
-    const port1 = ReportPort.fromElement({
-      __text: '123/tcp',
-    });
+    const port1 = ReportPort.fromElement({__text: '123/tcp'});
     expect(port1.id).toEqual('123/tcp');
     expect(port1.number).toEqual(123);
     expect(port1.protocol).toEqual('tcp');
 
-    const port2 = ReportPort.fromElement({
-      __text: 'general/tcp',
-    });
+    const port2 = ReportPort.fromElement({__text: 'general/tcp'});
     expect(port2.id).toEqual('general/tcp');
     expect(port2.number).toEqual(0);
     expect(port2.protocol).toEqual('tcp');

--- a/src/gmp/models/report/__tests__/report.test.ts
+++ b/src/gmp/models/report/__tests__/report.test.ts
@@ -9,7 +9,8 @@ import {parseDate} from 'gmp/parser';
 
 describe('ReportReport tests', () => {
   test('should use defaults', () => {
-    const report = new ReportReport();
+    const report = new ReportReport({id: 'test-id'});
+    expect(report.id).toEqual('test-id');
     expect(report.delta_report).toBeUndefined();
     expect(report.filter).toBeUndefined();
     expect(report.report_type).toBeUndefined();
@@ -22,7 +23,8 @@ describe('ReportReport tests', () => {
   });
 
   test('should parse empty element', () => {
-    const report = ReportReport.fromElement();
+    const report = ReportReport.fromElement({_id: 'test-id'});
+    expect(report.id).toEqual('test-id');
     expect(report.delta_report).toBeUndefined();
     expect(report.filter).toBeDefined();
     expect(report.report_type).toBeUndefined();
@@ -31,11 +33,12 @@ describe('ReportReport tests', () => {
     expect(report.scan_run_status).toBeUndefined();
     expect(report.scan_start).toBeUndefined();
     expect(report.severity).toBeUndefined();
-    expect(report.task).toBeDefined();
+    expect(report.task).toBeUndefined();
   });
 
   test('should parse filter', () => {
     const report = ReportReport.fromElement({
+      _id: 'test-id',
       filters: {
         _id: 'filter1',
         term: 'foo=bar',
@@ -47,14 +50,13 @@ describe('ReportReport tests', () => {
   });
 
   test('should parse report type', () => {
-    const report = ReportReport.fromElement({
-      _type: 'delta',
-    });
+    const report = ReportReport.fromElement({_id: 'test-id', _type: 'delta'});
     expect(report.report_type).toEqual('delta');
   });
 
   test('should parse severity', () => {
     const report = ReportReport.fromElement({
+      _id: 'test-id',
       severity: {
         filtered: 5,
         full: 7,
@@ -67,6 +69,7 @@ describe('ReportReport tests', () => {
 
   test('should parse scan start', () => {
     const report = ReportReport.fromElement({
+      _id: 'test-id',
       scan_start: '2024-01-01T00:00:00Z',
     });
     expect(report.scan_start).toEqual(parseDate('2024-01-01T00:00:00Z'));
@@ -74,6 +77,7 @@ describe('ReportReport tests', () => {
 
   test('should parse scan end', () => {
     const report = ReportReport.fromElement({
+      _id: 'test-id',
       scan_end: '2024-01-02T00:00:00Z',
     });
     expect(report.scan_end).toEqual(parseDate('2024-01-02T00:00:00Z'));
@@ -81,6 +85,7 @@ describe('ReportReport tests', () => {
 
   test('should parse task', () => {
     const report = ReportReport.fromElement({
+      _id: 'test-id',
       task: {
         _id: 'task1',
         name: 'Test Task',
@@ -93,6 +98,7 @@ describe('ReportReport tests', () => {
 
   test('should parse delta report', () => {
     const report = ReportReport.fromElement({
+      _id: 'test-id',
       delta: {
         report: {
           _id: 'delta1',
@@ -115,6 +121,7 @@ describe('ReportReport tests', () => {
 
   test('should parse scan run status', () => {
     const report = ReportReport.fromElement({
+      _id: 'test-id',
       scan_run_status: 'completed',
     });
     expect(report.scan_run_status).toEqual('completed');
@@ -122,6 +129,7 @@ describe('ReportReport tests', () => {
 
   test('should parse results', () => {
     const report = ReportReport.fromElement({
+      _id: 'test-id',
       results: {
         _start: '1',
         _max: '8',
@@ -146,6 +154,7 @@ describe('ReportReport tests', () => {
 
   test('should parse result_count', () => {
     const report = ReportReport.fromElement({
+      _id: 'test-id',
       result_count: {
         full: 10,
         filtered: 5,
@@ -194,6 +203,7 @@ describe('ReportReport tests', () => {
 
   test('should parse timezone', () => {
     const report = ReportReport.fromElement({
+      _id: 'test-id',
       timezone: 'Europe/Berlin',
     });
     expect(report.timezone).toEqual('Europe/Berlin');
@@ -201,6 +211,7 @@ describe('ReportReport tests', () => {
 
   test('should parse timezone abbreviation', () => {
     const report = ReportReport.fromElement({
+      _id: 'test-id',
       timezone_abbrev: 'CET',
     });
     expect(report.timezone_abbrev).toEqual('CET');

--- a/src/gmp/models/report/__tests__/task.test.ts
+++ b/src/gmp/models/report/__tests__/task.test.ts
@@ -8,14 +8,16 @@ import ReportTask from 'gmp/models/report/task';
 
 describe('ReportTask tests', () => {
   test('should use defaults', () => {
-    const task = new ReportTask();
+    const task = new ReportTask({id: 'test-id'});
+    expect(task.id).toEqual('test-id');
     expect(task.target).toBeUndefined();
     expect(task.progress).toBeUndefined();
     expect(task.agentGroup).toBeUndefined();
   });
 
   test('should parse empty element', () => {
-    const task = ReportTask.fromElement();
+    const task = ReportTask.fromElement({_id: 'test-id'});
+    expect(task.id).toEqual('test-id');
     expect(task.target).toBeUndefined();
     expect(task.progress).toBeUndefined();
     expect(task.agentGroup).toBeUndefined();
@@ -28,16 +30,20 @@ describe('ReportTask tests', () => {
   });
 
   test('container vs target vs agentGroup precedence', () => {
-    const t1 = ReportTask.fromElement({});
+    const t1 = ReportTask.fromElement({_id: 'test-id'});
     expect(t1.isImport()).toBe(true);
 
-    const t2 = ReportTask.fromElement({target: {_id: 'tgt1'}});
+    const t2 = ReportTask.fromElement({_id: 'test-id', target: {_id: 'tgt1'}});
     expect(t2.isImport()).toBe(false);
 
-    const t3 = ReportTask.fromElement({agent_group: {_id: 'ag1'}});
+    const t3 = ReportTask.fromElement({
+      _id: 'test-id',
+      agent_group: {_id: 'ag1'},
+    });
     expect(t3.isImport()).toBe(false);
 
     const t4 = ReportTask.fromElement({
+      _id: 'test-id',
       target: {_id: 'tgt1'},
       agent_group: {_id: 'ag1'},
     });
@@ -46,6 +52,7 @@ describe('ReportTask tests', () => {
 
   test('should parse target', () => {
     const task = ReportTask.fromElement({
+      _id: 'test-id',
       target: {
         _id: 't1',
       },
@@ -57,16 +64,19 @@ describe('ReportTask tests', () => {
   });
 
   test('should parse progress', () => {
-    const task1 = ReportTask.fromElement({progress: {}});
+    const task1 = ReportTask.fromElement({_id: 'test-id', progress: {}});
     expect(task1.progress).toEqual(0);
 
-    const task2 = ReportTask.fromElement({progress: {__text: '99'}});
+    const task2 = ReportTask.fromElement({
+      _id: 'test-id',
+      progress: {__text: '99'},
+    });
     expect(task2.progress).toEqual(99);
 
-    const task3 = ReportTask.fromElement({progress: '100'});
+    const task3 = ReportTask.fromElement({_id: 'test-id', progress: '100'});
     expect(task3.progress).toEqual(100);
 
-    const task4 = ReportTask.fromElement({progress: 25});
+    const task4 = ReportTask.fromElement({_id: 'test-id', progress: 25});
     expect(task4.progress).toEqual(25);
   });
 
@@ -85,6 +95,7 @@ describe('ReportTask tests', () => {
 
   test('should still parse progress with agentGroup present', () => {
     const t = ReportTask.fromElement({
+      _id: 'test-id',
       progress: {__text: '42'},
       agent_group: {_id: 'ag1'},
     });

--- a/src/gmp/models/report/app.ts
+++ b/src/gmp/models/report/app.ts
@@ -50,11 +50,11 @@ class ReportApp {
     };
   }
 
-  static fromElement(element: AppElement = {}): ReportApp {
+  static fromElement(element: AppElement): ReportApp {
     return new ReportApp(this.parseElement(element));
   }
 
-  static parseElement(element: AppElement = {}): AppProperties {
+  static parseElement(element: AppElement): AppProperties {
     const copy: AppProperties = {};
 
     const {name: cpe} = element;

--- a/src/gmp/models/report/audit-report.ts
+++ b/src/gmp/models/report/audit-report.ts
@@ -109,7 +109,7 @@ class AuditReportReport extends Model {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     timezone_abbrev,
     ...properties
-  }: AuditReportReportProperties = {}) {
+  }: AuditReportReportProperties) {
     super(properties);
 
     this.compliance = compliance;
@@ -126,12 +126,12 @@ class AuditReportReport extends Model {
     this.timezone_abbrev = timezone_abbrev;
   }
 
-  static fromElement(element?: AuditReportReportElement): AuditReportReport {
+  static fromElement(element: AuditReportReportElement): AuditReportReport {
     return new AuditReportReport(this.parseElement(element));
   }
 
   static parseElement(
-    element: AuditReportReportElement = {},
+    element: AuditReportReportElement,
   ): AuditReportReportProperties {
     const copy = super.parseElement(element) as AuditReportReportProperties;
 
@@ -172,7 +172,7 @@ class AuditReportReport extends Model {
       };
     }
 
-    copy.task = ReportTask.fromElement(task);
+    copy.task = isDefined(task) ? ReportTask.fromElement(task) : undefined;
 
     copy.results = parseResults(element);
 

--- a/src/gmp/models/report/cve.ts
+++ b/src/gmp/models/report/cve.ts
@@ -43,11 +43,11 @@ class ReportCve {
     };
   }
 
-  static fromElement(element: ReportCveElement = {}): ReportCve {
+  static fromElement(element: ReportCveElement): ReportCve {
     return new ReportCve(this.parseElement(element));
   }
 
-  static parseElement(element: ReportCveElement = {}): ReportCveProperties {
+  static parseElement(element: ReportCveElement): ReportCveProperties {
     const copy: ReportCveProperties = {};
 
     const nvt = Nvt.fromElement(element);

--- a/src/gmp/models/report/host.ts
+++ b/src/gmp/models/report/host.ts
@@ -184,11 +184,11 @@ class ReportHost {
     this.start = start;
   }
 
-  static fromElement(element: HostElementWithSeverity = {}): ReportHost {
+  static fromElement(element: HostElementWithSeverity): ReportHost {
     return new ReportHost(this.parseElement(element));
   }
 
-  static parseElement(element: HostElementWithSeverity = {}): HostProperties {
+  static parseElement(element: HostElementWithSeverity): HostProperties {
     const copy = {} as HostProperties;
 
     const {

--- a/src/gmp/models/report/port.ts
+++ b/src/gmp/models/report/port.ts
@@ -75,11 +75,11 @@ class ReportPort {
     }
   }
 
-  static fromElement(element: ReportPortElement = {}): ReportPort {
+  static fromElement(element: ReportPortElement): ReportPort {
     return new ReportPort(this.parseElement(element));
   }
 
-  static parseElement(element: ReportPortElement = {}): ReportPortProperties {
+  static parseElement(element: ReportPortElement): ReportPortProperties {
     const copy: ReportPortProperties = {};
     const {__text: name} = element;
 

--- a/src/gmp/models/report/report.ts
+++ b/src/gmp/models/report/report.ts
@@ -41,21 +41,21 @@ interface ReportDeltaElement {
 }
 
 export interface ReportReportTaskElement {
-  _id?: string;
+  _id: string;
   comment?: string;
   name?: string;
   progress?: number;
   target?: {
-    _id?: string;
+    _id: string;
     comment?: string;
     name?: string;
     trash?: YesNo;
   };
   agent_group?: {
-    _id?: string;
+    _id: string;
   };
   oci_image_target?: {
-    _id?: string;
+    _id: string;
   };
 }
 
@@ -185,7 +185,7 @@ class ReportReport extends Model {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     timezone_abbrev,
     ...properties
-  }: ReportReportProperties = {}) {
+  }: ReportReportProperties) {
     super(properties);
 
     this.delta_report = delta_report;
@@ -202,13 +202,11 @@ class ReportReport extends Model {
     this.timezone_abbrev = timezone_abbrev;
   }
 
-  static fromElement(element?: ReportReportElement): ReportReport {
+  static fromElement(element: ReportReportElement): ReportReport {
     return new ReportReport(this.parseElement(element));
   }
 
-  static parseElement(
-    element: ReportReportElement = {},
-  ): ReportReportProperties {
+  static parseElement(element: ReportReportElement): ReportReportProperties {
     const copy = super.parseElement(element) as ReportReportProperties;
 
     const {delta, severity, scan_start, scan_end, task} = element;
@@ -224,7 +222,7 @@ class ReportReport extends Model {
         }
       : undefined;
 
-    copy.task = ReportTask.fromElement(task);
+    copy.task = isDefined(task) ? ReportTask.fromElement(task) : undefined;
 
     copy.results = parseResults(element);
 

--- a/src/gmp/models/report/task.ts
+++ b/src/gmp/models/report/task.ts
@@ -44,7 +44,7 @@ class ReportTask extends Model {
     ociImageTarget,
     webApplicationTarget,
     ...properties
-  }: ReportTaskProperties = {}) {
+  }: ReportTaskProperties) {
     super(properties);
 
     this.progress = progress;
@@ -54,26 +54,29 @@ class ReportTask extends Model {
     this.webApplicationTarget = webApplicationTarget;
   }
 
-  static fromElement(element: ReportTaskElement = {}): ReportTask {
+  static fromElement(element: ReportTaskElement): ReportTask {
     return new ReportTask(this.parseElement(element));
   }
 
-  static parseElement(element: ReportTaskElement = {}): ReportTaskProperties {
+  static parseElement(element: ReportTaskElement): ReportTaskProperties {
     const copy = super.parseElement(element) as ReportTaskProperties;
 
     copy.target = isEmpty(element.target?._id)
       ? undefined
-      : Model.fromElement(element.target, 'target');
+      : Model.fromElement(element.target as {_id: string}, 'target');
     copy.agentGroup = isEmpty(element.agent_group?._id)
       ? undefined
-      : Model.fromElement(element.agent_group, 'agentgroup');
+      : Model.fromElement(element.agent_group as {_id: string}, 'agentgroup');
     copy.ociImageTarget = isEmpty(element.oci_image_target?._id)
       ? undefined
-      : Model.fromElement(element.oci_image_target, 'ociimagetarget');
+      : Model.fromElement(
+          element.oci_image_target as {_id: string},
+          'ociimagetarget',
+        );
     copy.webApplicationTarget = isEmpty(element.web_application_target?._id)
       ? undefined
       : Model.fromElement(
-          element.web_application_target,
+          element.web_application_target as {_id: string},
           'webapplicationtarget',
         );
     copy.progress = isDefined(element.progress)

--- a/src/gmp/models/result.ts
+++ b/src/gmp/models/result.ts
@@ -74,7 +74,7 @@ interface DeltaResult {
 }
 
 interface TicketElement {
-  _id?: string;
+  _id: string;
 }
 
 interface ResultDetectionDetailElement {
@@ -111,7 +111,7 @@ interface ResultElement extends ModelElement {
   description?: string;
   detection?: {
     result?: {
-      _id?: string;
+      _id: string;
       details?: {
         detail?: ResultDetectionDetailElement | ResultDetectionDetailElement[];
       };
@@ -142,12 +142,12 @@ interface ResultElement extends ModelElement {
   };
   port?: string;
   report?: {
-    _id?: string;
+    _id: string;
   };
   scan_nvt_version?: string;
   severity?: number;
   task?: {
-    _id?: string;
+    _id: string;
     name?: string;
   };
   threat?: string;
@@ -312,7 +312,7 @@ class Result extends Model {
     tickets = [],
     vulnerability,
     ...properties
-  }: ResultProperties = {}) {
+  }: ResultProperties) {
     super(properties);
 
     this.compliance = compliance;
@@ -335,11 +335,11 @@ class Result extends Model {
     this.vulnerability = vulnerability;
   }
 
-  static fromElement(element: ResultElement = {}): Result {
+  static fromElement(element: ResultElement): Result {
     return new Result(this.parseElement(element));
   }
 
-  static parseElement(element: ResultElement = {}): ResultProperties {
+  static parseElement(element: ResultElement): ResultProperties {
     const copy = super.parseElement(element) as ResultProperties;
 
     const {
@@ -381,6 +381,7 @@ class Result extends Model {
 
     if (isDefined(information)) {
       if (information.type === 'nvt') {
+        // @ts-expect-error
         copy.information = Nvt.fromElement({
           nvt: information,
         } as ResultNvtElement);

--- a/src/gmp/models/role.ts
+++ b/src/gmp/models/role.ts
@@ -19,17 +19,17 @@ class Role extends Model {
 
   readonly users: string[];
 
-  constructor({users = [], ...properties}: RoleProperties = {}) {
+  constructor({users = [], ...properties}: RoleProperties = {id: 'test-id'}) {
     super(properties);
 
     this.users = users;
   }
 
-  static fromElement(element?: RoleElement): Role {
+  static fromElement(element: RoleElement): Role {
     return new Role(this.parseElement(element));
   }
 
-  static parseElement(element: RoleElement = {}): RoleProperties {
+  static parseElement(element: RoleElement): RoleProperties {
     const ret = super.parseElement(element) as RoleProperties;
 
     ret.users = parseCsv(element.users);

--- a/src/gmp/models/scan-config.ts
+++ b/src/gmp/models/scan-config.ts
@@ -173,7 +173,7 @@ class ScanConfig extends Model {
     tasks = [],
     usageType = 'scan',
     ...properties
-  }: ScanConfigProperties = {}) {
+  }: ScanConfigProperties) {
     super(properties);
 
     this.deprecated = deprecated;
@@ -187,11 +187,11 @@ class ScanConfig extends Model {
     this.usageType = usageType;
   }
 
-  static fromElement(element?: ScanConfigElement): ScanConfig {
+  static fromElement(element: ScanConfigElement): ScanConfig {
     return new ScanConfig(this.parseElement(element));
   }
 
-  static parseElement(element: ScanConfigElement = {}): ScanConfigProperties {
+  static parseElement(element: ScanConfigElement): ScanConfigProperties {
     const ret = super.parseElement(element) as ScanConfigProperties;
 
     // for displaying the selected nvts (1 of 33) an object for accessing the

--- a/src/gmp/models/scanner.ts
+++ b/src/gmp/models/scanner.ts
@@ -301,7 +301,7 @@ class Scanner extends Model {
     agentControlConfig,
     disabled,
     ...properties
-  }: ScannerProperties = {}) {
+  }: ScannerProperties) {
     super(properties);
 
     this.caPub = caPub;
@@ -316,11 +316,11 @@ class Scanner extends Model {
     this.disabled = disabled;
   }
 
-  static fromElement(element?: ScannerElement): Scanner {
+  static fromElement(element: ScannerElement): Scanner {
     return new Scanner(this.parseElement(element));
   }
 
-  static parseElement(element: ScannerElement = {}): ScannerProperties {
+  static parseElement(element: ScannerElement): ScannerProperties {
     const ret = super.parseElement(element) as ScannerProperties;
 
     ret.scannerType = isDefined(element.type)

--- a/src/gmp/models/schedule.ts
+++ b/src/gmp/models/schedule.ts
@@ -46,7 +46,7 @@ class Schedule extends Model {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     timezone_abbrev,
     ...properties
-  }: ScheduleProperties = {}) {
+  }: ScheduleProperties) {
     super(properties);
 
     this.event = event;
@@ -55,11 +55,11 @@ class Schedule extends Model {
     this.timezone_abbrev = timezone_abbrev;
   }
 
-  static fromElement(element?: ScheduleElement): Schedule {
+  static fromElement(element: ScheduleElement): Schedule {
     return new Schedule(this.parseElement(element));
   }
 
-  static parseElement(element: ScheduleElement = {}): ScheduleProperties {
+  static parseElement(element: ScheduleElement): ScheduleProperties {
     const ret = super.parseElement(element) as ScheduleProperties;
 
     const {timezone, icalendar, timezone_abbrev} = element;

--- a/src/gmp/models/tag.ts
+++ b/src/gmp/models/tag.ts
@@ -41,7 +41,7 @@ class Tag extends Model {
     resourceType,
     value,
     ...properties
-  }: TagProperties = {}) {
+  }: TagProperties) {
     super(properties);
 
     this.resourceCount = resourceCount;
@@ -49,7 +49,7 @@ class Tag extends Model {
     this.value = value;
   }
 
-  static fromElement(element: TagElement = {}): Tag {
+  static fromElement(element: TagElement): Tag {
     return new Tag(this.parseElement(element));
   }
 

--- a/src/gmp/models/target.ts
+++ b/src/gmp/models/target.ts
@@ -86,12 +86,14 @@ class SSHCredential extends Model {
 
   readonly port?: number;
 
-  constructor({port, ...properties}: SSHCredentialProperties = {}) {
+  constructor(
+    {port, ...properties}: SSHCredentialProperties = {id: 'test-id'},
+  ) {
     super(properties);
     this.port = port;
   }
 
-  static fromElement(element: SSHCredentialElement = {}): SSHCredential {
+  static fromElement(element: SSHCredentialElement): SSHCredential {
     return new SSHCredential(this.parseElement(element));
   }
 
@@ -138,7 +140,7 @@ class Target extends Model {
     sshElevateCredential,
     tasks = [],
     ...properties
-  }: TargetProperties = {}) {
+  }: TargetProperties) {
     super(properties);
 
     this.aliveTests = aliveTests;
@@ -158,7 +160,7 @@ class Target extends Model {
     this.tasks = tasks;
   }
 
-  static fromElement(element: TargetElement = {}): Target {
+  static fromElement(element: TargetElement): Target {
     return new Target(this.parseElement(element));
   }
 

--- a/src/gmp/models/task.ts
+++ b/src/gmp/models/task.ts
@@ -52,14 +52,14 @@ export interface TaskElement extends ModelElement {
   alterable?: YesNo;
   average_duration?: number;
   config?: {
-    _id?: string;
+    _id: string;
     name?: string;
     trash?: YesNo;
   };
   current_report?: {
     // only available for a running task
     report?: {
-      _id?: string;
+      _id: string;
       timestamp?: string;
       scan_start?: string;
       scan_end?: string;
@@ -69,7 +69,7 @@ export interface TaskElement extends ModelElement {
   last_report?: {
     // Only available for tasks with finished scans
     report?: {
-      _id?: string;
+      _id: string;
       compliance_count?: {
         // only available for audits
         incomplete?: number;
@@ -121,13 +121,13 @@ export interface TaskElement extends ModelElement {
   };
   result_count?: number;
   scanner?: {
-    _id?: string;
+    _id: string;
     name?: string;
     trash?: YesNo;
     type?: ScannerType;
   };
   schedule?: {
-    _id?: string;
+    _id: string;
     icalendar?: string;
     name?: string;
     timezone?: string;
@@ -138,26 +138,26 @@ export interface TaskElement extends ModelElement {
   };
   schedule_periods?: number;
   slave?: {
-    _id?: string;
+    _id: string;
   };
   status?: TaskStatus;
   target?: {
-    _id?: string;
+    _id: string;
     name?: string;
     trash?: YesNo;
   };
   oci_image_target?: {
-    _id?: string;
+    _id: string;
     name?: string;
     trash?: YesNo;
   };
   web_application_target?: {
-    _id?: string;
+    _id: string;
     name?: string;
     trash?: YesNo;
   };
   agent_group?: {
-    _id?: string;
+    _id: string;
     name?: string;
     trash?: YesNo;
   };
@@ -411,7 +411,7 @@ class Task extends Model {
     trend,
     usageType = USAGE_TYPE.scan,
     ...properties
-  }: TaskProperties = {}) {
+  }: TaskProperties) {
     super(properties);
 
     this.alerts = alerts;
@@ -450,11 +450,11 @@ class Task extends Model {
     this.scanMode = scanMode;
   }
 
-  static fromElement(element?: TaskElement): Task {
+  static fromElement(element: TaskElement): Task {
     return new Task(this.parseElement(element));
   }
 
-  static parseElement(element: TaskElement = {}): TaskProperties {
+  static parseElement(element: TaskElement): TaskProperties {
     const copy = super.parseElement(element) as TaskProperties;
 
     const usageType = (element.usage_type ?? USAGE_TYPE.scan) as
@@ -551,35 +551,35 @@ class Task extends Model {
 
     copy.config = isEmpty(element.config?._id)
       ? undefined
-      : Model.fromElement(element.config, 'scanconfig');
+      : Model.fromElement(element.config as {_id: string}, 'scanconfig');
     copy.target = isEmpty(element.target?._id)
       ? undefined
-      : Model.fromElement(element.target, 'target');
+      : Model.fromElement(element.target as {_id: string}, 'target');
     copy.ociImageTarget = isEmpty(element.oci_image_target?._id)
       ? undefined
-      : Model.fromElement(element.oci_image_target, 'target');
+      : Model.fromElement(element.oci_image_target as {_id: string}, 'target');
     copy.webApplicationTarget = isEmpty(element.web_application_target?._id)
       ? undefined
       : Model.fromElement(
-          element.web_application_target,
+          element.web_application_target as {_id: string},
           'webapplicationtarget',
         );
     copy.agentGroup = isEmpty(element.agent_group?._id)
       ? undefined
-      : Model.fromElement(element.agent_group, 'agentgroup');
+      : Model.fromElement(element.agent_group as {_id: string}, 'agentgroup');
     // slave isn't really an entity type but it has an id
     copy.slave = isEmpty(element.slave?._id)
       ? undefined
       : {id: element.slave?._id};
     copy.alerts = map(element.alert, alert =>
-      Model.fromElement(alert, 'alert'),
+      Model.fromElement(alert as {_id: string}, 'alert'),
     );
     copy.scanner = isEmpty(element.scanner?._id)
       ? undefined
-      : Scanner.fromElement(element.scanner);
+      : Scanner.fromElement(element.scanner as {_id: string});
     copy.schedule = isEmpty(element.schedule?._id)
       ? undefined
-      : Schedule.fromElement(element.schedule);
+      : Schedule.fromElement(element.schedule as {_id: string});
     copy.schedule_periods = parseInt(element.schedule_periods);
 
     // it seems element.progress is just a number now, but keep the element parsing as a fallback

--- a/src/gmp/models/testing.ts
+++ b/src/gmp/models/testing.ts
@@ -8,22 +8,44 @@ import {isDate} from 'gmp/models/date';
 import type Model from 'gmp/models/model';
 import {parseDate, NO_VALUE, YES_VALUE} from 'gmp/parser';
 
-interface ModelClass<T extends Model> {
-  fromElement: (element?: Record<string, unknown>) => T;
-  new (properties?: Record<string, unknown>): T;
+interface ModelElement {
+  _id: string;
+  [key: string]: unknown;
 }
 
-interface TestOptions {
+interface ModelProperties {
+  id: string;
+  [key: string]: unknown;
+}
+
+interface ModelClass<
+  TModel extends Model,
+  TElement = ModelElement,
+  TProperties = ModelProperties,
+> {
+  fromElement: (element: TElement) => TModel;
+  new (properties: TProperties): TModel;
+}
+
+interface TestOptions<TElement = ModelElement, TProperties = ModelProperties> {
   testIsActive?: boolean;
   testName?: boolean;
   testType?: boolean;
+  initElementData?: TElement;
+  initModelData?: TProperties;
 }
 
-const testId = <T extends Model>(modelClass: ModelClass<T>) => {
+const testId = <
+  TModel extends Model,
+  TElement = ModelElement,
+  TProperties = ModelProperties,
+>(
+  modelClass: ModelClass<TModel, TElement, TProperties>,
+) => {
   test('should parse id', () => {
-    const model1 = modelClass.fromElement({_id: '1337'});
-    const model2 = modelClass.fromElement();
-    const model3 = modelClass.fromElement({_id: ''});
+    const model1 = modelClass.fromElement({_id: '1337'} as TElement);
+    const model2 = modelClass.fromElement({_id: ''} as TElement);
+    const model3 = modelClass.fromElement({} as TElement);
 
     expect(model1.id).toEqual('1337');
     expect(model2.id).toBeUndefined();
@@ -31,28 +53,40 @@ const testId = <T extends Model>(modelClass: ModelClass<T>) => {
   });
 
   test.skip('should not allow to overwrite id', () => {
-    const model = modelClass.fromElement({_id: 'foo'});
+    const model = modelClass.fromElement({_id: 'foo'} as TElement);
 
     // @ts-expect-error
     expect(() => (model.id = 'bar')).toThrow();
   });
 };
 
-export const testModelFromElement = <T extends Model>(
-  modelClass: ModelClass<T>,
+export const testModelFromElement = <
+  TModel extends Model,
+  TElement = ModelElement,
+  TProperties = ModelProperties,
+>(
+  modelClass: ModelClass<TModel, TElement, TProperties>,
   type: string | undefined,
   {
     testName = true,
     testType = true,
-  }: {testName?: boolean; testType?: boolean} = {},
+    initElementData = {_id: '123'} as TElement,
+    initModelData = {id: '123'} as TProperties,
+  }: {
+    testName?: boolean;
+    testType?: boolean;
+    initElementData?: TElement;
+    initModelData?: TProperties;
+  } = {},
 ) => {
   test('should create instance of model class in fromElement', () => {
-    const model = modelClass.fromElement();
+    const model = modelClass.fromElement(initElementData);
     expect(model).toBeInstanceOf(modelClass);
   });
 
   test('should parse end time', () => {
     const model = modelClass.fromElement({
+      ...initElementData,
       end_time: '2018-10-10T11:41:23.022Z',
     });
     expect(model.endTime).toBeDefined();
@@ -61,6 +95,7 @@ export const testModelFromElement = <T extends Model>(
 
   test('should parse permissions', () => {
     const model = modelClass.fromElement({
+      ...initElementData,
       permissions: {
         permission: [{name: 'everything'}, {name: 'get_tasks'}],
       },
@@ -71,13 +106,14 @@ export const testModelFromElement = <T extends Model>(
   });
 
   test('should return empty userCapabilities if no permissions are given to the constructor', () => {
-    const model = new modelClass();
+    const model = new modelClass(initModelData);
     expect(model.userCapabilities).toBeDefined();
     expect(model.userCapabilities.length).toEqual(0);
   });
 
   test('should parse user tags', () => {
     const model = modelClass.fromElement({
+      ...initElementData,
       user_tags: {
         tag: [{name: 'foo'}],
       },
@@ -86,15 +122,19 @@ export const testModelFromElement = <T extends Model>(
     expect(model.userTags[0].name).toEqual('foo');
     expect(model.userTags[0].entityType).toEqual('tag');
 
-    const model2 = modelClass.fromElement();
+    const model2 = modelClass.fromElement(initElementData);
     expect(model2.userTags).toEqual([]);
   });
 
   test('should parse owner', () => {
-    const model = modelClass.fromElement({owner: {name: ''}});
+    const model = modelClass.fromElement({
+      ...initElementData,
+      owner: {name: ''},
+    });
     expect(model.owner).toBeUndefined();
 
     const model2 = modelClass.fromElement({
+      ...initElementData,
       owner: {name: 'foo'},
     });
     expect(model2.owner).toBeDefined();
@@ -102,20 +142,23 @@ export const testModelFromElement = <T extends Model>(
   });
 
   test('should delete comment if comment is empty', () => {
-    const elem = {comment: ''};
-    const model = modelClass.fromElement(elem);
+    const model = modelClass.fromElement({
+      ...initElementData,
+      comment: '',
+    });
 
     expect(model.comment).toBeUndefined();
   });
 
   test('should apply entityType correctly', () => {
-    const model = modelClass.fromElement();
+    const model = modelClass.fromElement(initElementData);
 
     expect(model.entityType).toEqual(type);
   });
 
   test('should parse props as YES_VALUE/NO_VALUE', () => {
     const elem = {
+      ...initElementData,
       writable: '0',
       orphan: '1',
       active: '0',
@@ -131,6 +174,7 @@ export const testModelFromElement = <T extends Model>(
 
   test('should parse creation time', () => {
     const model = modelClass.fromElement({
+      ...initElementData,
       creation_time: '2018-10-10T08:48:46Z',
     });
     expect(model.creationTime).toEqual(parseDate('2018-10-10T08:48:46Z'));
@@ -138,6 +182,7 @@ export const testModelFromElement = <T extends Model>(
 
   test('should parse modification time', () => {
     const model = modelClass.fromElement({
+      ...initElementData,
       modification_time: '2018-10-10T08:48:46Z',
     });
     expect(model.modificationTime).toEqual(parseDate('2018-10-10T08:48:46Z'));
@@ -145,7 +190,7 @@ export const testModelFromElement = <T extends Model>(
 
   if (testType) {
     test('should privatize type from Model', () => {
-      const model = modelClass.fromElement({type: 'foo'});
+      const model = modelClass.fromElement({...initElementData, type: 'foo'});
       // @ts-expect-error
       expect(model.type).toBeUndefined();
       expect(model._type).toEqual('foo');
@@ -154,22 +199,29 @@ export const testModelFromElement = <T extends Model>(
 
   if (testName) {
     test('should parse name', () => {
-      const model = modelClass.fromElement({name: 1337});
+      const model = modelClass.fromElement({...initElementData, name: '1337'});
 
       expect(model.name).toEqual('1337');
     });
   }
 };
 
-export const testModelMethods = <T extends Model>(
-  modelClass: ModelClass<T>,
-  {testIsActive = true} = {},
+export const testModelMethods = <
+  TModel extends Model,
+  TElement = ModelElement,
+  TProperties = ModelProperties,
+>(
+  modelClass: ModelClass<TModel, TElement, TProperties>,
+  {
+    testIsActive = true,
+    initElementData = {_id: '123'} as TElement,
+  }: TestOptions<TElement, TProperties> = {},
 ) => {
   test('isInUse() should return correct true/false', () => {
-    const model1 = modelClass.fromElement({in_use: '1'});
-    const model2 = modelClass.fromElement({in_use: '0'});
-    const model3 = modelClass.fromElement({in_use: '2'});
-    const model4 = modelClass.fromElement();
+    const model1 = modelClass.fromElement({...initElementData, in_use: '1'});
+    const model2 = modelClass.fromElement({...initElementData, in_use: '0'});
+    const model3 = modelClass.fromElement({...initElementData, in_use: '2'});
+    const model4 = modelClass.fromElement({...initElementData});
 
     expect(model1.isInUse()).toBe(true);
     expect(model2.isInUse()).toBe(false);
@@ -178,10 +230,10 @@ export const testModelMethods = <T extends Model>(
   });
 
   test('isInTrash() should return correct true/false', () => {
-    const model1 = modelClass.fromElement({trash: '1'});
-    const model2 = modelClass.fromElement({trash: '0'});
-    const model3 = modelClass.fromElement({trash: '2'});
-    const model4 = modelClass.fromElement();
+    const model1 = modelClass.fromElement({...initElementData, trash: '1'});
+    const model2 = modelClass.fromElement({...initElementData, trash: '0'});
+    const model3 = modelClass.fromElement({...initElementData, trash: '2'});
+    const model4 = modelClass.fromElement({...initElementData});
 
     expect(model1.isInTrash()).toBe(true);
     expect(model2.isInTrash()).toBe(false);
@@ -190,10 +242,10 @@ export const testModelMethods = <T extends Model>(
   });
 
   test('isWritable() should return correct true/false', () => {
-    const model1 = modelClass.fromElement({writable: '1'});
-    const model2 = modelClass.fromElement({writable: '0'});
-    const model3 = modelClass.fromElement({writable: '2'});
-    const model4 = modelClass.fromElement();
+    const model1 = modelClass.fromElement({...initElementData, writable: '1'});
+    const model2 = modelClass.fromElement({...initElementData, writable: '0'});
+    const model3 = modelClass.fromElement({...initElementData, writable: '2'});
+    const model4 = modelClass.fromElement({...initElementData});
 
     expect(model1.isWritable()).toBe(true);
     expect(model2.isWritable()).toBe(false);
@@ -202,10 +254,10 @@ export const testModelMethods = <T extends Model>(
   });
 
   test('isOrphan() should return correct true/false', () => {
-    const model1 = modelClass.fromElement({orphan: '1'});
-    const model2 = modelClass.fromElement({orphan: '0'});
-    const model3 = modelClass.fromElement({orphan: '2'});
-    const model4 = modelClass.fromElement();
+    const model1 = modelClass.fromElement({...initElementData, orphan: '1'});
+    const model2 = modelClass.fromElement({...initElementData, orphan: '0'});
+    const model3 = modelClass.fromElement({...initElementData, orphan: '2'});
+    const model4 = modelClass.fromElement({...initElementData});
 
     expect(model1.isOrphan()).toBe(true);
     expect(model2.isOrphan()).toBe(false);
@@ -215,10 +267,10 @@ export const testModelMethods = <T extends Model>(
 
   if (testIsActive) {
     test('isActive() should return correct true/false', () => {
-      const model1 = modelClass.fromElement({active: '1'});
-      const model2 = modelClass.fromElement({active: '0'});
-      const model3 = modelClass.fromElement({active: '2'});
-      const model4 = modelClass.fromElement();
+      const model1 = modelClass.fromElement({...initElementData, active: '1'});
+      const model2 = modelClass.fromElement({...initElementData, active: '0'});
+      const model3 = modelClass.fromElement({...initElementData, active: '2'});
+      const model4 = modelClass.fromElement({...initElementData});
 
       expect(model1.isActive()).toBe(true);
       expect(model2.isActive()).toBe(false);
@@ -228,12 +280,20 @@ export const testModelMethods = <T extends Model>(
   }
 };
 
-export const testModel = <T extends Model>(
-  modelClass: ModelClass<T>,
+export const testModel = <
+  TModel extends Model,
+  TElement = ModelElement,
+  TProperties = ModelProperties,
+>(
+  modelClass: ModelClass<TModel, TElement, TProperties>,
   type: string | undefined,
-  options?: TestOptions,
+  options?: TestOptions<TElement, TProperties>,
 ) => {
-  testModelFromElement(modelClass, type, options);
-  testModelMethods(modelClass, options);
-  testId(modelClass);
+  testModelFromElement<TModel, TElement, TProperties>(
+    modelClass,
+    type,
+    options,
+  );
+  testModelMethods<TModel, TElement, TProperties>(modelClass, options);
+  testId<TModel, TElement, TProperties>(modelClass);
 };

--- a/src/gmp/models/ticket.ts
+++ b/src/gmp/models/ticket.ts
@@ -15,7 +15,7 @@ export type TicketStatus = keyof typeof TICKET_STATUS;
 export interface TicketElement extends ModelElement {
   assigned_to?: {
     user?: {
-      _id?: string;
+      _id: string;
       name?: string;
     };
   };
@@ -26,16 +26,16 @@ export interface TicketElement extends ModelElement {
   fix_verified_report?: ModelElement;
   fix_verified_time?: string;
   nvt?: {
-    _oid?: string;
+    _oid: string;
   };
   open_note?: string;
   open_time?: string;
   report?: {
-    _id?: string;
+    _id: string;
     timestamp?: string;
   };
   result?: {
-    _id?: string;
+    _id: string;
   };
   host?: string;
   location?: string;
@@ -43,7 +43,7 @@ export interface TicketElement extends ModelElement {
   solution_type?: string;
   status?: TicketStatus;
   task?: {
-    _id?: string;
+    _id: string;
     name?: string;
     trash?: YesNo;
   };
@@ -131,7 +131,7 @@ class Ticket extends Model {
     status,
     task,
     ...properties
-  }: TicketProperties = {}) {
+  }: TicketProperties) {
     super(properties);
 
     this.assignedTo = assignedTo;
@@ -154,14 +154,14 @@ class Ticket extends Model {
     this.task = task;
   }
 
-  static fromElement(element?: TicketElement): Ticket {
+  static fromElement(element: TicketElement): Ticket {
     return new Ticket(this.parseElement(element));
   }
 
-  static parseElement(element: TicketElement = {}): TicketProperties {
+  static parseElement(element: TicketElement): TicketProperties {
     const ret = super.parseElement(element) as TicketProperties;
 
-    if (isDefined(element.assigned_to) && isDefined(element.assigned_to.user)) {
+    if (isDefined(element.assigned_to?.user)) {
       ret.assignedTo = Model.fromElement(element.assigned_to.user, 'user');
     }
 

--- a/src/gmp/models/tls-certificate.ts
+++ b/src/gmp/models/tls-certificate.ts
@@ -144,7 +144,7 @@ class TlsCertificate extends Model {
     trust,
     valid,
     ...properties
-  }: TlsCertificateProperties = {}) {
+  }: TlsCertificateProperties) {
     super(properties);
 
     this.activationTime = activationTime;
@@ -164,12 +164,12 @@ class TlsCertificate extends Model {
     this.valid = valid;
   }
 
-  static fromElement(element: TlsCertificateElement = {}): TlsCertificate {
+  static fromElement(element: TlsCertificateElement): TlsCertificate {
     return new TlsCertificate(this.parseElement(element));
   }
 
   static parseElement(
-    element: TlsCertificateElement = {},
+    element: TlsCertificateElement,
   ): TlsCertificateProperties {
     const ret = super.parseElement(element) as TlsCertificateProperties;
 

--- a/src/gmp/models/user.ts
+++ b/src/gmp/models/user.ts
@@ -58,7 +58,7 @@ class User extends Model {
     hosts = {addresses: []},
     authMethod = AUTH_METHOD_PASSWORD,
     ...properties
-  }: UserProperties = {}) {
+  }: UserProperties) {
     super(properties);
 
     this.roles = roles;
@@ -67,7 +67,7 @@ class User extends Model {
     this.authMethod = authMethod;
   }
 
-  static fromElement(element: UserElement = {}): User {
+  static fromElement(element: UserElement): User {
     return new User(this.parseElement(element));
   }
 

--- a/src/gmp/models/vulnerability.ts
+++ b/src/gmp/models/vulnerability.ts
@@ -52,7 +52,7 @@ class Vulnerability extends Model {
     qod,
     severity,
     ...properties
-  }: VulnerabilityProperties = {}) {
+  }: VulnerabilityProperties) {
     super(properties);
 
     this.hosts = hosts;
@@ -61,13 +61,11 @@ class Vulnerability extends Model {
     this.severity = severity;
   }
 
-  static fromElement(element?: VulnerabilityElement): Vulnerability {
+  static fromElement(element: VulnerabilityElement): Vulnerability {
     return new Vulnerability(this.parseElement(element));
   }
 
-  static parseElement(
-    element: VulnerabilityElement = {},
-  ): VulnerabilityProperties {
+  static parseElement(element: VulnerabilityElement): VulnerabilityProperties {
     const ret = super.parseElement(element) as VulnerabilityProperties;
 
     if (isDefined(element.results)) {

--- a/src/gmp/models/web-application-target.ts
+++ b/src/gmp/models/web-application-target.ts
@@ -40,7 +40,7 @@ class WebApplicationTarget extends Model {
     reverseLookupOnly = false,
     reverseLookupUnify = false,
     ...properties
-  }: WebApplicationTargetProperties = {}) {
+  }: WebApplicationTargetProperties) {
     super(properties);
     this.urls = urls;
     this.excludeUrls = excludeUrls;
@@ -55,7 +55,7 @@ class WebApplicationTarget extends Model {
   }
 
   static fromElement(
-    element: WebApplicationTargetElement = {},
+    element: WebApplicationTargetElement,
   ): WebApplicationTarget {
     return new WebApplicationTarget(this.parseElement(element));
   }

--- a/src/gmp/utils/__tests__/entity-type.test.ts
+++ b/src/gmp/utils/__tests__/entity-type.test.ts
@@ -26,19 +26,19 @@ describe('getEntityType function tests', () => {
   });
 
   test('should return entity type of model', () => {
-    const model = parseModelFromElement({}, 'task');
+    const model = parseModelFromElement({_id: 'test-id'}, 'task');
 
     expect(getEntityType(model)).toEqual('task');
   });
 
   test('should return entity type for info models', () => {
-    const model = Nvt.fromElement();
+    const model = Nvt.fromElement({_id: 'test-id', nvt: {_oid: 'test-oid'}});
 
     expect(getEntityType(model)).toEqual('nvt');
   });
 
   test('should return entity type for asset models', () => {
-    const model = Host.fromElement();
+    const model = Host.fromElement({_id: 'test-id'});
 
     expect(getEntityType(model)).toEqual('host');
   });

--- a/src/web/entities/BulkTags.tsx
+++ b/src/web/entities/BulkTags.tsx
@@ -7,7 +7,7 @@ import {useCallback, useEffect, useState} from 'react';
 import type CollectionCounts from 'gmp/collection/collection-counts';
 import {type FilterType} from 'gmp/models/filter';
 import type Model from 'gmp/models/model';
-import Tag from 'gmp/models/tag';
+import type Tag from 'gmp/models/tag';
 import {apiType, type EntityType, getEntityType} from 'gmp/utils/entity-type';
 import {isDefined} from 'gmp/utils/identity';
 import TagsDialog, {type TagsDialogData} from 'web/entities/TagsDialog';
@@ -58,7 +58,7 @@ const BulkTags = <TEntity extends Model>({
 }: BulkTagsProps<TEntity>) => {
   const [_] = useTranslation();
   const gmp = useGmp();
-  const [tag, setTag] = useState<Tag>(new Tag());
+  const [tag, setTag] = useState<Tag>();
   const [tagDialogVisible, setTagDialogVisible] = useState(false);
   const [tags, setTags] = useState<Tag[]>([]);
   const [error, setError] = useState();
@@ -195,14 +195,14 @@ const BulkTags = <TEntity extends Model>({
   return (
     <>
       <TagsDialog
-        comment={tag.comment}
+        comment={tag?.comment}
         entitiesCount={multiTagEntitiesCount}
         error={error}
-        name={tag.name}
-        tagId={tag.id}
+        name={tag?.name}
+        tagId={tag?.id}
         tags={tags}
         title={title}
-        value={tag.value}
+        value={tag?.value}
         onClose={handleCloseTagsDialog}
         onErrorClose={handleErrorClose}
         onNewTagClick={openTagDialog}

--- a/src/web/entities/__tests__/EntitiesContainer.test.tsx
+++ b/src/web/entities/__tests__/EntitiesContainer.test.tsx
@@ -41,7 +41,7 @@ const setup = gmp => {
   const initialFilter = new BaseFilter();
   render(
     <EntitiesContainer
-      entities={[new PortList()]}
+      entities={[new PortList({id: '1', name: 'Port List 1'})]}
       filter={initialFilter}
       gmp={gmp}
       gmpName="portlist"

--- a/src/web/entity/__tests__/Tags.test.tsx
+++ b/src/web/entity/__tests__/Tags.test.tsx
@@ -5,9 +5,9 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {fireEvent, rendererWith, screen, wait} from 'web/testing';
-import EverythingCapabilities from 'gmp/capabilities/everything';
+import Tag from 'gmp/models/tag';
 import Task from 'gmp/models/task';
-import {YES_VALUE} from 'gmp/parser';
+import UserTag from 'gmp/models/user-tag';
 import {createSession} from 'gmp/testing';
 import EntityTags from 'web/entity/Tags';
 
@@ -16,26 +16,20 @@ const createTask = () => {
     id: 'task-1',
     name: 'Test Task',
     userTags: [
-      {
+      new UserTag({
         id: 'tag-1',
         name: 'Test Tag',
         value: 'test-value',
-        active: YES_VALUE,
         comment: 'Test comment',
-        resourceType: 'task',
-        userCapabilities: new EverythingCapabilities(),
-      },
-      {
+      }),
+      new UserTag({
         id: 'tag-2',
         name: 'Another Tag',
         value: 'another-value',
-        active: YES_VALUE,
         comment: 'Another comment',
-        resourceType: 'task',
-        userCapabilities: new EverythingCapabilities(),
-      },
+      }),
     ],
-  } as Record<string, unknown>);
+  });
 };
 
 const currentSettingsResponse = {
@@ -151,7 +145,14 @@ describe('EntityTags tests', () => {
     const entity = createTask();
     const gmp = createGmp({
       tag: {
-        get: testing.fn().mockResolvedValue({data: entity.userTags[0]}),
+        get: testing.fn().mockResolvedValue({
+          data: new Tag({
+            id: 'tag-1',
+            name: 'Test Tag',
+            value: 'test-value',
+            resourceType: 'task',
+          }),
+        }),
       },
       tasks: {
         get: testing.fn().mockResolvedValue({data: []}),

--- a/src/web/pages/audits/__tests__/AuditDetailsPageToolBarIcons.test.tsx
+++ b/src/web/pages/audits/__tests__/AuditDetailsPageToolBarIcons.test.tsx
@@ -6,22 +6,21 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen, within} from 'web/testing';
 import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
-import Policy from 'gmp/models/policy';
 import {createSession} from 'gmp/testing';
 import AuditDetailsPageToolBarIcons from 'web/pages/audits/AuditDetailsPageToolBarIcons';
 
-const policy = Policy.fromElement({
+const policyElement = {
   _id: '314',
   name: 'Policy 1',
   comment: 'bar',
-  scanner: {name: 'scanner1', type: '0'},
+  scanner: {_id: 'test-id', name: 'scanner1', type: '0'},
   tasks: {
     task: [
       {_id: '12345', name: 'foo'},
       {_id: '678910', name: 'audit2'},
     ],
   },
-});
+};
 
 const preferences = {
   preference: [
@@ -83,7 +82,7 @@ describe('AuditDetailsPageToolBarIcons tests', () => {
       target: {_id: '5678', name: 'target1'},
       alert: {_id: '91011', name: 'alert1'},
       scanner: {_id: '1516', name: 'scanner1', type: '2'},
-      config: policy,
+      config: policyElement,
       preferences: preferences,
       usage_type: 'audit',
     });
@@ -144,7 +143,7 @@ describe('AuditDetailsPageToolBarIcons tests', () => {
       target: {_id: '5678', name: 'target1'},
       alert: {_id: '91011', name: 'alert1'},
       scanner: {_id: '1516', name: 'scanner1', type: '2'},
-      config: policy,
+      config: policyElement,
       preferences: preferences,
       usage_type: 'audit',
     });
@@ -241,7 +240,7 @@ describe('AuditDetailsPageToolBarIcons tests', () => {
       target: {_id: '5678', name: 'target1'},
       alert: {_id: '91011', name: 'alert1'},
       scanner: {_id: '1516', name: 'scanner1', type: '2'},
-      config: policy,
+      config: policyElement,
       preferences: preferences,
       usage_type: 'audit',
     });
@@ -347,7 +346,7 @@ describe('AuditDetailsPageToolBarIcons tests', () => {
       target: {_id: '5678', name: 'target1'},
       alert: {_id: '91011', name: 'alert1'},
       scanner: {_id: '1516', name: 'scanner1', type: '2'},
-      config: policy,
+      config: policyElement,
       preferences: preferences,
       usage_type: 'audit',
     });
@@ -452,7 +451,7 @@ describe('AuditDetailsPageToolBarIcons tests', () => {
       target: {_id: '5678', name: 'target1'},
       alert: {_id: '91011', name: 'alert1'},
       scanner: {_id: '1516', name: 'scanner1', type: '2'},
-      config: policy,
+      config: policyElement,
       preferences: preferences,
       usage_type: 'audit',
     });
@@ -555,7 +554,7 @@ describe('AuditDetailsPageToolBarIcons tests', () => {
       target: {_id: '5678', name: 'target1'},
       alert: {_id: '91011', name: 'alert1'},
       scanner: {_id: '1516', name: 'scanner1', type: '2'},
-      config: policy,
+      config: policyElement,
       preferences: preferences,
       usage_type: 'audit',
     });
@@ -666,7 +665,7 @@ describe('AuditDetailsPageToolBarIcons tests', () => {
       target: {_id: '5678', name: 'target1'},
       alert: {_id: '91011', name: 'alert1'},
       scanner: {_id: '1516', name: 'scanner1', type: '2'},
-      config: policy,
+      config: policyElement,
       schedule: {
         _id: '121314',
         name: 'schedule1',

--- a/src/web/pages/audits/__tests__/DetailsPage.test.tsx
+++ b/src/web/pages/audits/__tests__/DetailsPage.test.tsx
@@ -16,18 +16,20 @@ import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
 import DetailsPage from 'web/pages/audits/DetailsPage';
 
-const policy = Policy.fromElement({
+const policyElement = {
   _id: '314',
   name: 'Policy 1',
   comment: 'bar',
-  scanner: {name: 'scanner1', type: '0'},
+  scanner: {_id: 'test-id', name: 'scanner1', type: '0'},
   tasks: {
     task: [
       {_id: '12345', name: 'foo'},
       {_id: '678910', name: 'audit2'},
     ],
   },
-});
+};
+
+const policy = Policy.fromElement(policyElement);
 
 const schedule = Schedule.fromElement({
   _id: '121314',
@@ -84,7 +86,7 @@ const audit = Audit.fromElement({
   target: {_id: '5678', name: 'target1'},
   alert: {_id: '91011', name: 'alert1'},
   scanner: {_id: '1516', name: 'scanner1', type: '2'},
-  config: policy,
+  config: policyElement,
   preferences: preferences,
   usage_type: 'audit',
 });
@@ -105,7 +107,7 @@ const audit2 = Audit.fromElement({
   target: {_id: '5678', name: 'target1'},
   alert: {_id: '91011', name: 'alert1'},
   scanner: {_id: '1516', name: 'scanner1', type: '2'},
-  config: policy,
+  config: policyElement,
   preferences: preferences,
   usage_type: 'audit',
 });
@@ -127,7 +129,7 @@ const audit5 = Audit.fromElement({
   target: {_id: '5678', name: 'target1'},
   alert: {_id: '91011', name: 'alert1'},
   scanner: {_id: '1516', name: 'scanner1', type: '2'},
-  config: policy,
+  config: policyElement,
   preferences: preferences,
   usage_type: 'audit',
 });
@@ -255,37 +257,27 @@ describe('Audit DetailsPage tests', () => {
       screen.getByRole('heading', {name: /^Target$/})
         .parentElement as HTMLElement,
     );
-    expect(targetDetails.getByTestId('details-link')).toHaveAttribute(
+    expect(targetDetails.getByRole('link', {name: 'target1'})).toHaveAttribute(
       'href',
       '/target/5678',
-    );
-    expect(targetDetails.getByTestId('details-link')).toHaveTextContent(
-      'target1',
     );
 
     const alertsDetails = within(
       screen.getByRole('heading', {name: /^Alerts$/})
         .parentElement as HTMLElement,
     );
-    expect(alertsDetails.getByTestId('details-link')).toHaveAttribute(
+    expect(alertsDetails.getByRole('link', {name: 'alert1'})).toHaveAttribute(
       'href',
       '/alert/91011',
-    );
-    expect(alertsDetails.getByTestId('details-link')).toHaveTextContent(
-      'alert1',
     );
 
     const scannerDetails = within(
       screen.getByRole('heading', {name: /^Scanner$/})
         .parentElement as HTMLElement,
     );
-    expect(scannerDetails.getByTestId('details-link')).toHaveAttribute(
-      'href',
-      '/scanner/1516',
-    );
-    expect(scannerDetails.getByTestId('details-link')).toHaveTextContent(
-      'scanner1',
-    );
+    expect(
+      scannerDetails.getByRole('link', {name: 'scanner1'}),
+    ).toHaveAttribute('href', '/scanner/1516');
     expect(scannerDetails.getByRole('row', {name: /^Type/})).toHaveTextContent(
       'OpenVAS Scanner',
     );

--- a/src/web/pages/credential-store/__tests__/CredentialStorePage.test.tsx
+++ b/src/web/pages/credential-store/__tests__/CredentialStorePage.test.tsx
@@ -173,6 +173,7 @@ describe('CredentialStorePage tests', () => {
 
   test('should show error when credential store has no id on test', async () => {
     const credentialStore = CredentialStore.fromElement({
+      _id: '',
       name: 'No ID Store',
       active: 1,
       host: 'h',
@@ -205,6 +206,7 @@ describe('CredentialStorePage tests', () => {
 
   test('should not call edit when saving and credential store has no id', async () => {
     const credentialStore = CredentialStore.fromElement({
+      _id: '',
       name: 'No ID Store',
       active: 1,
       host: 'h',

--- a/src/web/pages/notes/__tests__/NoteTable.test.tsx
+++ b/src/web/pages/notes/__tests__/NoteTable.test.tsx
@@ -29,7 +29,7 @@ const createNote = ({
     id,
     active: 1,
     hosts: ['127.0.0.1'],
-    nvt: new Nvt({oid: `1.3.6.1.4.1.${id}`, name: `NVT ${id}`}),
+    nvt: new Nvt({id: 'nvt-1', oid: `1.3.6.1.4.1.${id}`, name: `NVT ${id}`}),
     port: '22/tcp',
     text,
     userCapabilities,

--- a/src/web/pages/notes/__tests__/NoteTableRow.test.tsx
+++ b/src/web/pages/notes/__tests__/NoteTableRow.test.tsx
@@ -26,6 +26,7 @@ const note = new Note({
     'host-three.example.invalid',
   ],
   nvt: new Nvt({
+    id: 'nvt-1',
     oid: '1.3.6.1.4.1',
     name: 'Test NVT',
   }),

--- a/src/web/pages/overrides/__tests__/OverrideTableRow.test.tsx
+++ b/src/web/pages/overrides/__tests__/OverrideTableRow.test.tsx
@@ -41,6 +41,7 @@ const createOverride = ({
     inUse,
     newSeverity: 7,
     nvt: new Nvt({
+      id: 'nvt-1',
       oid: '1.3.6.1.4.1',
       name: 'Test NVT',
     }),

--- a/src/web/pages/permissions/PermissionDialog.tsx
+++ b/src/web/pages/permissions/PermissionDialog.tsx
@@ -229,6 +229,7 @@ const PermissionDialog = ({
 
         const resource = isDefined(state.resourceType)
           ? Model.fromElement(
+              // @ts-expect-error
               {name: resourceNameOrId},
               resourceTypeOrType as EntityType,
             )

--- a/src/web/pages/permissions/__tests__/PermissionDetails.test.tsx
+++ b/src/web/pages/permissions/__tests__/PermissionDetails.test.tsx
@@ -11,6 +11,7 @@ import PermissionDetails from 'web/pages/permissions/PermissionDetails';
 describe('PermissionDetails tests', () => {
   test('should render comment', () => {
     const permission = new Permission({
+      id: 'test-id',
       comment: 'Test permission comment',
       name: 'get_tasks',
     });
@@ -21,9 +22,7 @@ describe('PermissionDetails tests', () => {
   });
 
   test('should not render comment row when comment is undefined', () => {
-    const permission = new Permission({
-      name: 'get_tasks',
-    });
+    const permission = new Permission({id: 'test-id', name: 'get_tasks'});
     const {render} = rendererWith({capabilities: true});
     render(<PermissionDetails entity={permission} />);
     expect(screen.queryByText('Comment')).not.toBeInTheDocument();
@@ -31,6 +30,7 @@ describe('PermissionDetails tests', () => {
 
   test('should render description', () => {
     const permission = new Permission({
+      id: 'test-id',
       name: 'get_tasks',
       comment: 'Test comment',
     });
@@ -43,6 +43,7 @@ describe('PermissionDetails tests', () => {
 
   test('should render resource information', () => {
     const permission = Permission.fromElement({
+      _id: 'test-id',
       name: 'get_tasks',
       comment: 'Test comment',
       resource: {
@@ -59,6 +60,7 @@ describe('PermissionDetails tests', () => {
 
   test('should not render resource row when resource is undefined', () => {
     const permission = new Permission({
+      id: 'test-id',
       name: 'get_tasks',
       comment: 'Test comment',
     });
@@ -69,6 +71,7 @@ describe('PermissionDetails tests', () => {
 
   test('should render subject information', () => {
     const permission = Permission.fromElement({
+      _id: 'test-id',
       name: 'get_tasks',
       comment: 'Test comment',
       subject: {
@@ -85,6 +88,7 @@ describe('PermissionDetails tests', () => {
 
   test('should not render subject row when subject is undefined', () => {
     const permission = new Permission({
+      id: 'test-id',
       name: 'get_tasks',
       comment: 'Test comment',
     });
@@ -95,6 +99,7 @@ describe('PermissionDetails tests', () => {
 
   test('should render with both resource and subject', () => {
     const permission = Permission.fromElement({
+      _id: 'test-id',
       name: 'get_tasks',
       comment: 'Full permission test',
       resource: {
@@ -120,6 +125,7 @@ describe('PermissionDetails tests', () => {
 
   test('should render with empty comment', () => {
     const permission = new Permission({
+      id: 'test-id',
       name: 'get_tasks',
       comment: '',
     });
@@ -132,6 +138,7 @@ describe('PermissionDetails tests', () => {
 
   test('should render Super permission description', () => {
     const permission = new Permission({
+      id: 'test-id',
       name: 'Super',
       comment: 'Super user permission',
     });
@@ -143,6 +150,7 @@ describe('PermissionDetails tests', () => {
 
   test('should render permission with resource but without subject', () => {
     const permission = Permission.fromElement({
+      _id: 'test-id',
       name: 'modify_config',
       comment: 'Modify config permission',
       resource: {
@@ -162,6 +170,7 @@ describe('PermissionDetails tests', () => {
 
   test('should render permission with subject but without resource', () => {
     const permission = Permission.fromElement({
+      _id: 'test-id',
       name: 'authenticate',
       comment: 'Login permission',
       subject: {
@@ -180,9 +189,7 @@ describe('PermissionDetails tests', () => {
   });
 
   test('should render minimal permission without comment, resource, or subject', () => {
-    const permission = new Permission({
-      name: 'authenticate',
-    });
+    const permission = new Permission({id: 'test-id', name: 'authenticate'});
     const {render} = rendererWith({capabilities: true});
     render(<PermissionDetails entity={permission} />);
 
@@ -195,6 +202,7 @@ describe('PermissionDetails tests', () => {
 
   test('should render description with resource information when resource is provided', () => {
     const permission = Permission.fromElement({
+      _id: 'test-id',
       name: 'get_tasks',
       resource: {
         _id: 'task-456',
@@ -211,6 +219,7 @@ describe('PermissionDetails tests', () => {
 
   test('should render description with subject information when subject is provided', () => {
     const permission = Permission.fromElement({
+      _id: 'test-id',
       name: 'get_tasks',
       subject: {
         _id: 'user-789',

--- a/src/web/pages/policies/__tests__/DetailsPage.test.tsx
+++ b/src/web/pages/policies/__tests__/DetailsPage.test.tsx
@@ -101,7 +101,7 @@ const policy = Policy.fromElement({
   families: {family: families},
   preferences: preferences,
   permissions: {permission: [{name: 'everything'}]},
-  scanner: {name: 'scanner', type: '42'},
+  scanner: {_id: 'test-id', name: 'scanner', type: '42'},
   tasks: {
     task: [
       {_id: '1234', name: 'audit1'},
@@ -123,7 +123,7 @@ const policy2 = Policy.fromElement({
   families: {family: families},
   preferences: preferences,
   permissions: {permission: [{name: 'get_config'}]},
-  scanner: {name: 'scanner', type: '42'},
+  scanner: {_id: 'test-id', name: 'scanner', type: '42'},
   tasks: {
     task: [
       {_id: '1234', name: 'audit1'},
@@ -145,7 +145,7 @@ const policy3 = Policy.fromElement({
   families: {family: families},
   preferences: preferences,
   permissions: {permission: [{name: 'everything'}]},
-  scanner: {name: 'scanner', type: '42'},
+  scanner: {_id: 'test-id', name: 'scanner', type: '42'},
   tasks: {
     task: [
       {_id: '1234', name: 'audit1'},
@@ -167,7 +167,7 @@ const policy4 = Policy.fromElement({
   families: {family: families},
   preferences: preferences,
   permissions: {permission: [{name: 'everything'}]},
-  scanner: {name: 'scanner', type: '42'},
+  scanner: {_id: 'test-id', name: 'scanner', type: '42'},
   tasks: {
     task: [
       {_id: '1234', name: 'audit1'},

--- a/src/web/pages/policies/__tests__/PolicyDetailsPageToolBarIcons.test.tsx
+++ b/src/web/pages/policies/__tests__/PolicyDetailsPageToolBarIcons.test.tsx
@@ -93,7 +93,7 @@ const policy = Policy.fromElement({
   families: {family: families},
   preferences: preferences,
   permissions: {permission: [{name: 'everything'}]},
-  scanner: {name: 'scanner', type: '42'},
+  scanner: {_id: 'test-id', name: 'scanner', type: '42'},
   tasks: {
     task: [
       {_id: '1234', name: 'audit1'},
@@ -197,7 +197,7 @@ describe('PolicyDetailsPageToolBarIcons tests', () => {
       families: {family: families},
       preferences: preferences,
       permissions: {permission: [{name: 'get_config'}]},
-      scanner: {name: 'scanner', type: '42'},
+      scanner: {_id: 'test-id', name: 'scanner', type: '42'},
       tasks: {
         task: [
           {_id: '1234', name: 'audit1'},
@@ -270,7 +270,7 @@ describe('PolicyDetailsPageToolBarIcons tests', () => {
       families: {family: families},
       preferences: preferences,
       permissions: {permission: [{name: 'everything'}]},
-      scanner: {name: 'scanner', type: '42'},
+      scanner: {_id: 'test-id', name: 'scanner', type: '42'},
       tasks: {
         task: [
           {_id: '1234', name: 'audit1'},
@@ -334,7 +334,7 @@ describe('PolicyDetailsPageToolBarIcons tests', () => {
       families: {family: families},
       preferences: preferences,
       permissions: {permission: [{name: 'everything'}]},
-      scanner: {name: 'scanner', type: '42'},
+      scanner: {_id: 'test-id', name: 'scanner', type: '42'},
       tasks: {
         task: [
           {_id: '1234', name: 'audit1'},

--- a/src/web/pages/portlists/__tests__/PortListComponent.test.tsx
+++ b/src/web/pages/portlists/__tests__/PortListComponent.test.tsx
@@ -19,7 +19,7 @@ import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-set
 import PortListComponent from 'web/pages/portlists/PortListComponent';
 
 const defaultGetPortListResponse = {
-  data: PortList.fromElement({id: '123', name: 'foo'}),
+  data: PortList.fromElement({_id: '123', name: 'foo'}),
 };
 const currentSettings = testing
   .fn()
@@ -298,12 +298,12 @@ describe('PortListComponent tests', () => {
 
   test('should allow editing a port list and delete a port range', async () => {
     const portList = PortList.fromElement({
-      id: '123',
+      _id: '123',
       name: 'foo',
       port_ranges: {
         port_range: [
           {
-            id: '123',
+            _id: '123',
             start: 1,
             end: 2,
             type: 'tcp',
@@ -357,7 +357,10 @@ describe('PortListComponent tests', () => {
   });
 
   test('should call onSaveError if saving a port list fails', async () => {
-    const portList = PortList.fromElement({id: '123', name: 'foo'});
+    const portList = PortList.fromElement({
+      _id: '123',
+      name: 'foo',
+    });
     const portListResponse = {data: portList};
     const error = new Error('error');
     const gmp = createGmp({
@@ -392,7 +395,10 @@ describe('PortListComponent tests', () => {
   });
 
   test('should show error in dialog if saving a port list fails', async () => {
-    const portList = PortList.fromElement({id: '123', name: 'foo'});
+    const portList = PortList.fromElement({
+      _id: '123',
+      name: 'foo',
+    });
     const portListResponse = {data: portList};
     const error = new Error('some error');
     const gmp = createGmp({

--- a/src/web/pages/portlists/__tests__/PortListDetails.test.tsx
+++ b/src/web/pages/portlists/__tests__/PortListDetails.test.tsx
@@ -12,6 +12,7 @@ import PortListDetails from 'web/pages/portlists/PortListDetails';
 describe('PortListDetails tests', () => {
   test('should render deprecated information when entity is deprecated', () => {
     const portList = new PortList({
+      id: 'pl-1',
       comment: 'Test comment',
       portCount: {
         all: 100,
@@ -32,6 +33,7 @@ describe('PortListDetails tests', () => {
 
   test('should render comment', () => {
     const portList = new PortList({
+      id: 'pl-1',
       comment: 'Test comment',
       portCount: {
         all: 100,
@@ -51,6 +53,7 @@ describe('PortListDetails tests', () => {
 
   test('should render port counts', () => {
     const portList = new PortList({
+      id: 'pl-1',
       comment: 'Test comment',
       portCount: {
         all: 100,
@@ -74,6 +77,7 @@ describe('PortListDetails tests', () => {
 
   test('should render targets using the port list', () => {
     const portList = new PortList({
+      id: 'pl-1',
       comment: 'Test comment',
       portCount: {
         all: 100,
@@ -96,6 +100,7 @@ describe('PortListDetails tests', () => {
 
   test('should not render deprecated information when entity is not deprecated', () => {
     const portList = new PortList({
+      id: 'pl-1',
       comment: 'Test comment',
       portCount: {
         all: 100,
@@ -114,6 +119,7 @@ describe('PortListDetails tests', () => {
 
   test('should not render targets when no targets are provided', () => {
     const portList = new PortList({
+      id: 'pl-1',
       comment: 'Test comment',
       portCount: {
         all: 100,

--- a/src/web/pages/reports/__tests__/ReportTableRow.test.tsx
+++ b/src/web/pages/reports/__tests__/ReportTableRow.test.tsx
@@ -23,6 +23,7 @@ describe('ReportTableRow tests', () => {
     const report = Report.fromElement({
       _id: '1',
       report: {
+        _id: 'test-id',
         timestamp: '2024-01-01T12:00:00Z',
         scan_run_status: TASK_STATUS.running,
         severity: {filtered: 5},
@@ -70,6 +71,7 @@ describe('ReportTableRow tests', () => {
     const report = Report.fromElement({
       _id: '1',
       report: {
+        _id: 'test-id',
         timestamp: '2024-01-01T12:00:00Z',
         scan_run_status: TASK_STATUS.done,
         severity: {filtered: 5},
@@ -105,6 +107,7 @@ describe('ReportTableRow tests', () => {
     const report = Report.fromElement({
       _id: '1',
       report: {
+        _id: 'test-id',
         timestamp: '2024-01-01T12:00:00Z',
         scan_run_status: TASK_STATUS.done,
         severity: {filtered: 5},
@@ -139,6 +142,7 @@ describe('ReportTableRow tests', () => {
     const report = Report.fromElement({
       _id: '1',
       report: {
+        _id: 'test-id',
         timestamp: '2024-01-01T12:00:00Z',
         scan_run_status: TASK_STATUS.running,
         severity: {filtered: 5},
@@ -174,6 +178,7 @@ describe('ReportTableRow tests', () => {
     const report = Report.fromElement({
       _id: '1',
       report: {
+        _id: 'test-id',
         timestamp: '2024-01-01T12:00:00Z',
         scan_run_status: TASK_STATUS.done,
         severity: {filtered: 5},
@@ -212,6 +217,7 @@ describe('ReportTableRow tests', () => {
     const report = Report.fromElement({
       _id: '1',
       report: {
+        _id: 'test-id',
         timestamp: '2024-01-01T12:00:00Z',
         scan_run_status: TASK_STATUS.done,
         severity: {filtered: 5},

--- a/src/web/pages/roles/__tests__/RoleDetails.test.tsx
+++ b/src/web/pages/roles/__tests__/RoleDetails.test.tsx
@@ -11,6 +11,7 @@ import RoleDetails from 'web/pages/roles/RoleDetails';
 describe('RoleDetails tests', () => {
   test('should render comment', () => {
     const role = new Role({
+      id: 'test-id',
       comment: 'Test role comment',
       users: ['user1', 'user2'],
     });
@@ -22,6 +23,7 @@ describe('RoleDetails tests', () => {
 
   test('should render users list', () => {
     const role = new Role({
+      id: 'test-id',
       comment: 'Test role comment',
       users: ['admin', 'editor', 'viewer'],
     });
@@ -35,6 +37,7 @@ describe('RoleDetails tests', () => {
 
   test('should render empty users list when no users are provided', () => {
     const role = new Role({
+      id: 'test-id',
       comment: 'Test role comment',
       users: [],
     });
@@ -47,6 +50,7 @@ describe('RoleDetails tests', () => {
 
   test('should render with single user', () => {
     const role = new Role({
+      id: 'test-id',
       comment: 'Single user role',
       users: ['singleUser'],
     });
@@ -57,9 +61,7 @@ describe('RoleDetails tests', () => {
   });
 
   test('should render with undefined comment', () => {
-    const role = new Role({
-      users: ['testUser'],
-    });
+    const role = new Role({id: 'test-id', users: ['testUser']});
     const {render} = rendererWith({capabilities: true});
     render(<RoleDetails entity={role} />);
     expect(screen.getByText('Comment')).toBeVisible();
@@ -69,10 +71,7 @@ describe('RoleDetails tests', () => {
   });
 
   test('should render with empty comment', () => {
-    const role = new Role({
-      comment: '',
-      users: ['testUser'],
-    });
+    const role = new Role({id: 'test-id', comment: '', users: ['testUser']});
     const {render} = rendererWith({capabilities: true});
     render(<RoleDetails entity={role} />);
     expect(screen.getByText('Comment')).toBeVisible();

--- a/src/web/pages/roles/__tests__/RoleDialog.test.tsx
+++ b/src/web/pages/roles/__tests__/RoleDialog.test.tsx
@@ -243,7 +243,10 @@ describe('RoleDialog tests', () => {
   });
 
   test('should handle user selection', () => {
-    const allUsers = [{name: 'User 1'}, {name: 'User 2'}];
+    const allUsers = [
+      {id: 'test-id', name: 'User 1'},
+      {id: 'test-id', name: 'User 2'},
+    ];
 
     render(
       <RoleDialog

--- a/src/web/pages/scanconfigs/__tests__/ScanConfigComponent.test.tsx
+++ b/src/web/pages/scanconfigs/__tests__/ScanConfigComponent.test.tsx
@@ -160,7 +160,7 @@ const config = ScanConfig.fromElement({
   families: {family: families},
   preferences,
   permissions: {permission: [{name: 'everything'}]},
-  scanner: {name: 'scanner', type: '42'},
+  scanner: {_id: 'test-id', name: 'scanner', type: '42'},
   tasks: {task: []},
 });
 
@@ -177,7 +177,7 @@ const configInUse = ScanConfig.fromElement({
   families: {family: families},
   preferences,
   permissions: {permission: [{name: 'everything'}]},
-  scanner: {name: 'scanner', type: '42'},
+  scanner: {_id: 'test-id', name: 'scanner', type: '42'},
   tasks: {task: [{_id: 't1', name: 'task1'}]},
 });
 
@@ -851,7 +851,7 @@ describe('ScanConfigComponent', () => {
           },
           preferences,
           permissions: {permission: [{name: 'everything'}]},
-          scanner: {name: 'scanner', type: '42'},
+          scanner: {_id: 'test-id', name: 'scanner', type: '42'},
           tasks: {task: []},
         });
 
@@ -1026,7 +1026,7 @@ describe('ScanConfigComponent', () => {
         },
         preferences,
         permissions: {permission: [{name: 'everything'}]},
-        scanner: {name: 'scanner', type: '42'},
+        scanner: {_id: 'test-id', name: 'scanner', type: '42'},
         tasks: {task: []},
       });
 

--- a/src/web/pages/scanconfigs/__tests__/ScanConfigDetailsPageToolBarIcons.test.tsx
+++ b/src/web/pages/scanconfigs/__tests__/ScanConfigDetailsPageToolBarIcons.test.tsx
@@ -96,7 +96,7 @@ const config = ScanConfig.fromElement({
   families: {family: families},
   preferences: preferences,
   permissions: {permission: [{name: 'everything'}]},
-  scanner: {name: 'scanner', type: '42'},
+  scanner: {_id: 'test-id', name: 'scanner', type: '42'},
   tasks: {
     task: [
       {_id: '1234', name: 'task1'},
@@ -212,7 +212,7 @@ describe('ScanConfigDetailPageToolBarIcons tests', () => {
       families: {family: families},
       preferences: preferences,
       permissions: {permission: [{name: 'get_config'}]},
-      scanner: {name: 'scanner', type: '42'},
+      scanner: {_id: 'test-id', name: 'scanner', type: '42'},
       tasks: {
         task: [
           {_id: '1234', name: 'task1'},
@@ -280,7 +280,7 @@ describe('ScanConfigDetailPageToolBarIcons tests', () => {
       families: {family: families},
       preferences: preferences,
       permissions: {permission: [{name: 'everything'}]},
-      scanner: {name: 'scanner', type: '42'},
+      scanner: {_id: 'test-id', name: 'scanner', type: '42'},
       tasks: {
         task: [
           {_id: '1234', name: 'task1'},
@@ -346,7 +346,7 @@ describe('ScanConfigDetailPageToolBarIcons tests', () => {
       families: {family: families},
       preferences: preferences,
       permissions: {permission: [{name: 'everything'}]},
-      scanner: {name: 'scanner', type: '42'},
+      scanner: {_id: 'test-id', name: 'scanner', type: '42'},
       tasks: {
         task: [
           {_id: '1234', name: 'task1'},

--- a/src/web/pages/scanners/__tests__/ScannerAgentConfigSettings.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerAgentConfigSettings.test.tsx
@@ -564,6 +564,7 @@ describe('ScannerAgentConfigSettings tests', () => {
 
   test('should handle missing scanner ID when saving', async () => {
     const scanner = Scanner.fromElement({
+      _id: '',
       name: 'Scanner Without ID',
       type: AGENT_CONTROLLER_SCANNER_TYPE,
       agent_control_config_defaults: {

--- a/src/web/pages/scanners/__tests__/ScannerDetailsPageToolBarIcons.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerDetailsPageToolBarIcons.test.tsx
@@ -13,7 +13,7 @@ import ScannerDetailsPageToolBarIcons from 'web/pages/scanners/ScannerDetailsPag
 
 describe('ScannerDetailsPageToolBarIcons', () => {
   test('should renders the create icon when agents feature is enabled', () => {
-    const scanner = new Scanner({});
+    const scanner = new Scanner({id: 'test-id'});
     const gmp = {
       settings: {
         enableGreenboneSensor: false,
@@ -30,7 +30,7 @@ describe('ScannerDetailsPageToolBarIcons', () => {
   });
 
   test('should renders the create icon when sensors are enabled', () => {
-    const scanner = new Scanner({});
+    const scanner = new Scanner({id: 'test-id'});
     const gmp = {
       settings: {
         enableGreenboneSensor: true,
@@ -46,7 +46,7 @@ describe('ScannerDetailsPageToolBarIcons', () => {
   });
 
   test('should not render the create icon when agents feature is disabled', () => {
-    const scanner = new Scanner({});
+    const scanner = new Scanner({id: 'test-id'});
     const gmp = {
       settings: {
         enableGreenboneSensor: false,
@@ -62,7 +62,7 @@ describe('ScannerDetailsPageToolBarIcons', () => {
   });
 
   test('should not render the create icon when user has no create scanner permission', () => {
-    const scanner = new Scanner({});
+    const scanner = new Scanner({id: 'test-id'});
     const gmp = {
       settings: {
         enableGreenboneSensor: false,
@@ -78,7 +78,7 @@ describe('ScannerDetailsPageToolBarIcons', () => {
   });
 
   test('should call create handler', () => {
-    const scanner = new Scanner({});
+    const scanner = new Scanner({id: 'test-id'});
     const gmp = {
       settings: {
         enableGreenboneSensor: true,
@@ -101,7 +101,7 @@ describe('ScannerDetailsPageToolBarIcons', () => {
   });
 
   test('should render manual icon with correct props', () => {
-    const scanner = new Scanner({});
+    const scanner = new Scanner({id: 'test-id'});
     const gmp = {
       settings: {
         enableGreenboneSensor: false,
@@ -119,7 +119,7 @@ describe('ScannerDetailsPageToolBarIcons', () => {
   });
 
   test('should render the list icon', () => {
-    const scanner = new Scanner({});
+    const scanner = new Scanner({id: 'test-id'});
     const gmp = {
       settings: {
         enableGreenboneSensor: false,
@@ -140,6 +140,7 @@ describe('ScannerDetailsPageToolBarIcons', () => {
 
   test('should render clone icon and call clone handler', () => {
     const scanner = new Scanner({
+      id: 'test-id',
       userCapabilities: new EverythingCapabilities(),
     });
     const gmp = {
@@ -166,6 +167,7 @@ describe('ScannerDetailsPageToolBarIcons', () => {
 
   test('should render clone icon disabled when user may not clone scanner', () => {
     const scanner = new Scanner({
+      id: 'test-id',
       scannerType: OPENVASD_SCANNER_TYPE,
     });
     const gmp = {
@@ -193,6 +195,7 @@ describe('ScannerDetailsPageToolBarIcons', () => {
 
   test('should render edit icon and call edit handler', () => {
     const scanner = new Scanner({
+      id: 'test-id',
       userCapabilities: new EverythingCapabilities(),
     });
     const gmp = {
@@ -219,6 +222,7 @@ describe('ScannerDetailsPageToolBarIcons', () => {
 
   test('should render trash icon and call delete handler', () => {
     const scanner = new Scanner({
+      id: 'test-id',
       userCapabilities: new EverythingCapabilities(),
     });
     const gmp = {
@@ -245,6 +249,7 @@ describe('ScannerDetailsPageToolBarIcons', () => {
 
   test('should render export icon and call download handler', () => {
     const scanner = new Scanner({
+      id: 'test-id',
       userCapabilities: new EverythingCapabilities(),
     });
     const gmp = {
@@ -271,6 +276,7 @@ describe('ScannerDetailsPageToolBarIcons', () => {
 
   test('should render verify icon and call verify handler', () => {
     const scanner = new Scanner({
+      id: 'test-id',
       userCapabilities: new EverythingCapabilities(),
     });
     const gmp = {
@@ -297,8 +303,9 @@ describe('ScannerDetailsPageToolBarIcons', () => {
 
   test('should render download key icon and call credential download handler', () => {
     const scanner = new Scanner({
+      id: 'test-id',
       userCapabilities: new EverythingCapabilities(),
-      credential: new Credential(),
+      credential: new Credential({id: 'cred-1'}),
     });
     const gmp = {
       settings: {

--- a/src/web/pages/scanners/__tests__/ScannerFilterDialog.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerFilterDialog.test.tsx
@@ -30,6 +30,7 @@ describe('ScannerFilterDialog tests', () => {
       gmp,
     });
     const filter = new Filter({
+      id: 'test-id',
       terms: [
         new FilterTerm({keyword: 'first', value: '1', relation: '='}),
         new FilterTerm({keyword: 'rows', value: '20', relation: '='}),
@@ -138,6 +139,7 @@ describe('ScannerFilterDialog tests', () => {
       filter: {},
     };
     const filter = new Filter({
+      id: 'test-id',
       terms: [
         new FilterTerm({keyword: 'foo', value: 'bar', relation: '='}),
         new FilterTerm({

--- a/src/web/pages/targets/__tests__/TargetDialog.test.tsx
+++ b/src/web/pages/targets/__tests__/TargetDialog.test.tsx
@@ -631,7 +631,7 @@ describe('TargetDialog tests', () => {
 
   test('should allow to create a target from asset hosts', () => {
     const handleSave = testing.fn();
-    const hostsFilter = new Filter({filter_type: 'asset'});
+    const hostsFilter = new Filter({id: 'test-id', filter_type: 'asset'});
 
     const {render} = rendererWith({gmp, capabilities: true});
 

--- a/src/web/pages/tasks/TaskComponent.tsx
+++ b/src/web/pages/tasks/TaskComponent.tsx
@@ -439,17 +439,13 @@ const TaskComponent = ({
   };
 
   const handleTaskStart = (task: Task) => {
-    return actionFunction<void, Rejection>(
-      // @ts-expect-error
-      gmp.task.start(task),
-      {
-        onSuccess: onStarted,
-        onError: onStartError,
-        successMessage: _('Task {{- name}} started successfully.', {
-          name: task.name as string,
-        }),
-      },
-    );
+    return actionFunction<void, Rejection>(gmp.task.start(task), {
+      onSuccess: onStarted,
+      onError: onStartError,
+      successMessage: _('Task {{- name}} started successfully.', {
+        name: task.name as string,
+      }),
+    });
   };
 
   const handleTaskStop = (task: Task) => {
@@ -468,7 +464,6 @@ const TaskComponent = ({
 
   const handleTaskResume = (task: Task) => {
     return actionFunction<Response<Task, XmlMeta>, Rejection>(
-      // @ts-expect-error
       gmp.task.resume(task),
       {
         onSuccess: onResumed,

--- a/src/web/pages/tasks/__tests__/AgentTaskDialog.test.tsx
+++ b/src/web/pages/tasks/__tests__/AgentTaskDialog.test.tsx
@@ -95,7 +95,11 @@ describe('AgentTaskDialog component tests', () => {
   });
 
   test('hides Tag selector in edit mode (task provided)', () => {
-    const task = new Task({status: TASK_STATUS.new, alterable: YES_VALUE});
+    const task = new Task({
+      id: 'test-id',
+      status: TASK_STATUS.new,
+      alterable: YES_VALUE,
+    });
     renderDialog({task});
     expect(screen.queryByName('addTag')).toBeNull();
     expect(screen.queryByName('tagId')).toBeNull();

--- a/src/web/pages/tasks/__tests__/TaskActions.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskActions.test.tsx
@@ -19,6 +19,7 @@ const createGmp = () => ({
 describe('TaskActions tests', () => {
   test('should render', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.new,
       alterable: 0,
       permissions: {permission: [{name: 'everything'}]},
@@ -58,6 +59,7 @@ describe('TaskActions tests', () => {
 
   test('should call click handlers', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.done,
       alterable: 0,
       last_report: {report: {_id: 'id'}},
@@ -126,6 +128,7 @@ describe('TaskActions tests', () => {
 
   test('should not call click handlers without permissions', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.done,
       alterable: 0,
       last_report: {report: {_id: 'id'}},
@@ -203,6 +206,7 @@ describe('TaskActions tests', () => {
 
   test('should not call click handlers for stopped task without permissions', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.stopped,
       alterable: 0,
       last_report: {report: {_id: 'id'}},
@@ -283,6 +287,7 @@ describe('TaskActions tests', () => {
 
   test('should not call click handlers for running task without permissions', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.running,
       alterable: 0,
       last_report: {report: {_id: 'id'}},
@@ -357,6 +362,7 @@ describe('TaskActions tests', () => {
 
   test('should call click handlers for running task', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.running,
       alterable: 0,
       in_use: 1,
@@ -425,6 +431,7 @@ describe('TaskActions tests', () => {
 
   test('should call click handlers for stopped task', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.stopped,
       alterable: 0,
       last_report: {report: {_id: 'id'}},
@@ -493,6 +500,7 @@ describe('TaskActions tests', () => {
 
   test('should render schedule icon if task is scheduled', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.stopped,
       alterable: 0,
       last_report: {report: {_id: 'id'}},
@@ -574,6 +582,7 @@ describe('TaskActions tests', () => {
 
   test('should call click handlers for import task', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       permissions: {permission: [{name: 'everything'}]},
     });
 

--- a/src/web/pages/tasks/__tests__/TaskDetails.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskDetails.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect, testing} from '@gsa/testing';
-import {screen, rendererWith} from 'web/testing';
+import {screen, rendererWith, within} from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import Features from 'gmp/capabilities/features';
 import ScanConfig from 'gmp/models/scan-config';
@@ -14,18 +14,20 @@ import Details from 'web/pages/tasks/TaskDetails';
 import {entityLoadingActions as scanconfigActions} from 'web/store/entities/scanconfigs';
 import {entityLoadingActions as scheduleActions} from 'web/store/entities/schedules';
 
-const config = ScanConfig.fromElement({
+const scanConfigElement = {
   _id: '314',
   name: 'foo',
   comment: 'bar',
-  scanner: {name: 'scanner1', type: 0},
+  scanner: {_id: 'test-id', name: 'scanner1', type: 0},
   tasks: {
     task: [
       {_id: '12345', name: 'foo'},
       {_id: '678910', name: 'task2'},
     ],
   },
-});
+};
+
+const scanConfig = ScanConfig.fromElement(scanConfigElement);
 
 const lastReport = {
   report: {
@@ -71,11 +73,16 @@ const preferences = {
   ],
 };
 
-const schedule = Schedule.fromElement({_id: '121314', name: 'schedule1'});
+const scheduleElement = {
+  _id: '121314',
+  name: 'schedule1',
+};
+
+const schedule = Schedule.fromElement(scheduleElement);
 
 const getConfig = testing.fn().mockReturnValue(
   Promise.resolve({
-    data: config,
+    data: scanConfig,
   }),
 );
 
@@ -126,6 +133,7 @@ describe('TaskDetails tests', () => {
     expect(link).toBeVisible();
     expect(link.closest('a')).toHaveAttribute('href', '/ociimagetargets');
   });
+
   test('should render full task details', () => {
     const task = Task.fromElement({
       _id: '12345',
@@ -140,8 +148,8 @@ describe('TaskDetails tests', () => {
       alert: {_id: '91011', name: 'alert1'},
       scanner: {_id: '1516', name: 'scanner1', type: '2'},
       preferences: preferences,
-      schedule: schedule,
-      config: config,
+      schedule: scheduleElement,
+      config: scanConfigElement,
     });
     const caps = new Capabilities(['everything']);
     const features = new Features(['ENABLE_CREDENTIAL_STORES']);
@@ -154,34 +162,47 @@ describe('TaskDetails tests', () => {
       features,
     });
 
-    store.dispatch(scanconfigActions.success('314', config));
+    store.dispatch(scanconfigActions.success('314', scanConfig));
     store.dispatch(scheduleActions.success('121314', schedule));
 
     const {element} = render(<Details entity={task} />);
 
-    const headings = element.querySelectorAll('h2');
-    const detailsLinks = screen.getAllByTestId('details-link');
+    const targetDetails = within(
+      screen.getByRole('heading', {name: /^Target$/})
+        .parentElement as HTMLElement,
+    );
+    expect(targetDetails.getByRole('link', {name: 'target1'})).toHaveAttribute(
+      'href',
+      '/target/5678',
+    );
 
-    expect(headings[0]).toHaveTextContent('Target');
-    expect(detailsLinks[0]).toHaveAttribute('href', '/target/5678');
-    expect(element).toHaveTextContent('target1');
+    const alertsDetails = within(
+      screen.getByRole('heading', {name: /^Alerts$/})
+        .parentElement as HTMLElement,
+    );
+    expect(alertsDetails.getByRole('link', {name: 'alert1'})).toHaveAttribute(
+      'href',
+      '/alert/91011',
+    );
 
-    expect(headings[1]).toHaveTextContent('Alerts');
-    expect(detailsLinks[1]).toHaveAttribute('href', '/alert/91011');
-    expect(element).toHaveTextContent('alert1');
+    const scannerDetails = within(
+      screen.getByRole('heading', {name: /^Scanner$/})
+        .parentElement as HTMLElement,
+    );
+    expect(
+      scannerDetails.getByRole('link', {name: 'scanner1'}),
+    ).toHaveAttribute('href', '/scanner/1516');
+    expect(scannerDetails.getByRole('row', {name: /^Type/})).toHaveTextContent(
+      'OpenVAS Scanner',
+    );
 
-    expect(headings[2]).toHaveTextContent('Scanner');
-    expect(detailsLinks[2]).toHaveAttribute('href', '/scanner/1516');
-    expect(element).toHaveTextContent('scanner1');
-    expect(element).toHaveTextContent('OpenVAS Scanner');
-
-    expect(headings[3]).toHaveTextContent('Assets');
+    screen.getByRole('heading', {name: /^Assets$/});
     expect(element).toHaveTextContent(
       'Allow scan when credential store retrieval fails',
     );
     expect(element).toHaveTextContent('Yes');
 
-    expect(headings[4]).toHaveTextContent('Scan');
+    screen.getByRole('heading', {name: /^Scan$/});
     expect(element).toHaveTextContent('2 minutes');
     expect(element).toHaveTextContent('Do not automatically delete reports');
   });

--- a/src/web/pages/tasks/__tests__/TaskDetailsPage.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskDetailsPage.test.tsx
@@ -17,18 +17,20 @@ import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-set
 import TaskDetailsPage from 'web/pages/tasks/TaskDetailsPage';
 import {entityLoadingActions} from 'web/store/entities/tasks';
 
-const config = ScanConfig.fromElement({
+const scanConfigElement = {
   _id: '314',
   name: 'foo',
   comment: 'bar',
-  scanner: {name: 'scanner1', type: '0'},
+  scanner: {_id: 'test-id', name: 'scanner1', type: '0'},
   tasks: {
     task: [
       {_id: '12345', name: 'foo'},
       {_id: '678910', name: 'task2'},
     ],
   },
-});
+};
+
+const scanConfig = ScanConfig.fromElement(scanConfigElement);
 
 const schedule = Schedule.fromElement({
   _id: '121314',
@@ -104,7 +106,7 @@ const task = Task.fromElement({
   target: {_id: '5678', name: 'target1'},
   alert: {_id: '91011', name: 'alert1'},
   scanner: {_id: '1516', name: 'scanner1', type: OPENVAS_SCANNER_TYPE},
-  config: config,
+  config: scanConfigElement,
   preferences: preferences,
 });
 
@@ -124,7 +126,7 @@ const task2 = Task.fromElement({
   target: {_id: '5678', name: 'target1'},
   alert: {_id: '91011', name: 'alert1'},
   scanner: {_id: '1516', name: 'scanner1', type: OPENVAS_SCANNER_TYPE},
-  config: config,
+  config: scanConfigElement,
   preferences: preferences,
 });
 
@@ -145,7 +147,7 @@ const task5 = Task.fromElement({
   target: {_id: '5678', name: 'target1'},
   alert: {_id: '91011', name: 'alert1'},
   scanner: {_id: '1516', name: 'scanner1', type: OPENVAS_SCANNER_TYPE},
-  config: config,
+  config: scanConfigElement,
   preferences: preferences,
 });
 
@@ -165,7 +167,7 @@ const createGmp = ({
     data: task,
   }),
   getConfig = testing.fn().mockResolvedValue({
-    data: config,
+    data: scanConfig,
   }),
   getSchedule = testing.fn().mockResolvedValue({
     data: schedule,

--- a/src/web/pages/tasks/__tests__/TaskFilterDialog.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskFilterDialog.test.tsx
@@ -45,6 +45,7 @@ describe('TaskFilterDialog tests', () => {
     const handleFilterChanged = testing.fn();
     const handleFilterCreated = testing.fn();
     const filter = new Filter({
+      id: 'test-id',
       terms: [new FilterTerm({keyword: 'name', value: 'test'})],
     });
     const newFilter = new Filter({id: 'new-filter'});
@@ -117,6 +118,7 @@ describe('TaskFilterDialog tests', () => {
 
   test('should render filter string', () => {
     const filter = new Filter({
+      id: 'test-id',
       terms: [new FilterTerm({keyword: 'foo', value: 'bar', relation: '='})],
     });
     const gmp = {

--- a/src/web/pages/tasks/__tests__/TaskStatus.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskStatus.test.tsx
@@ -11,6 +11,7 @@ import Status from 'web/pages/tasks/TaskStatus';
 describe('TaskStatus tests', () => {
   test('should render', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.new,
       alterable: 0,
       permissions: {permission: [{name: 'everything'}]},
@@ -30,6 +31,7 @@ describe('TaskStatus tests', () => {
 
   test('should render with last report', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.done,
       alterable: 0,
       permissions: {permission: [{name: 'everything'}]},
@@ -51,6 +53,7 @@ describe('TaskStatus tests', () => {
 
   test('should render with current report', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.running,
       alterable: 0,
       permissions: {permission: [{name: 'everything'}]},
@@ -73,6 +76,7 @@ describe('TaskStatus tests', () => {
 
   test('should render import task', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       permissions: {permission: [{name: 'everything'}]},
       last_report: {report: {_id: '42'}},
     });
@@ -91,6 +95,7 @@ describe('TaskStatus tests', () => {
 
   test('should render import task with status interrupted', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.interrupted,
       permissions: {permission: [{name: 'everything'}]},
     });
@@ -105,6 +110,7 @@ describe('TaskStatus tests', () => {
 
   test('should render running import task as processing', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.running,
       permissions: {permission: [{name: 'everything'}]},
     });
@@ -119,6 +125,7 @@ describe('TaskStatus tests', () => {
 
   test('should render processing import task as processing', () => {
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.processing,
       permissions: {permission: [{name: 'everything'}]},
     });

--- a/src/web/pages/tasks/icons/__tests__/TaskDetailsPageToolBarIcons.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskDetailsPageToolBarIcons.test.tsx
@@ -5,24 +5,24 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen, within} from 'web/testing';
-import ScanConfig from 'gmp/models/scan-config';
 import {OPENVAS_SCANNER_TYPE} from 'gmp/models/scanner';
-import Task, {TASK_STATUS} from 'gmp/models/task';
+import Task, {TASK_STATUS, type TaskElement} from 'gmp/models/task';
+import {YES_VALUE, type YesNo} from 'gmp/parser';
 import {createSession} from 'gmp/testing';
 import TaskDetailsPageToolBarIcons from 'web/pages/tasks/icons/TaskDetailsPageToolBarIcons';
 
-const scanConfig = ScanConfig.fromElement({
+const scanConfigElement = {
   _id: '314',
   name: 'foo',
   comment: 'bar',
-  scanner: {name: 'scanner1', type: '0'},
+  scanner: {_id: 'test-id', name: 'scanner1', type: '0'},
   tasks: {
     task: [
       {_id: '12345', name: 'foo'},
       {_id: '678910', name: 'task2'},
     ],
   },
-});
+};
 
 const preferences = {
   preference: [
@@ -80,26 +80,32 @@ const createGmp = () => ({
   session: createSession(),
 });
 
+const baseTaskElement = {
+  _id: '12345',
+  owner: {name: 'admin'},
+  name: 'foo',
+  comment: 'bar',
+  creation_time: '2019-07-16T06:31:29Z',
+  modification_time: '2019-07-16T06:44:55Z',
+  alterable: YES_VALUE as YesNo,
+  report_count: {__text: 1},
+  result_count: 1,
+  permissions: {permission: [{name: 'everything'}]},
+  target: {_id: '5678', name: 'target1'},
+  alert: {_id: '91011', name: 'alert1'},
+  scanner: {_id: '1516', name: 'scanner1', type: OPENVAS_SCANNER_TYPE},
+  config: scanConfigElement,
+  preferences: preferences,
+};
+
+const createTask = (overrides: Partial<TaskElement>) =>
+  Task.fromElement({...baseTaskElement, ...overrides});
+
 describe('Task ToolBarIcons tests', () => {
   test('should render', () => {
-    const task = Task.fromElement({
-      _id: '12345',
-      owner: {name: 'admin'},
-      name: 'foo',
-      comment: 'bar',
-      creation_time: '2019-07-16T06:31:29Z',
-      modification_time: '2019-07-16T06:44:55Z',
+    const task = createTask({
       status: TASK_STATUS.done,
-      alterable: 1,
       last_report: lastReport,
-      report_count: {__text: 1},
-      result_count: 1,
-      permissions: {permission: [{name: 'everything'}]},
-      target: {_id: '5678', name: 'target1'},
-      alert: {_id: '91011', name: 'alert1'},
-      scanner: {_id: '1516', name: 'scanner1', type: OPENVAS_SCANNER_TYPE},
-      config: scanConfig,
-      preferences: preferences,
     });
     const handleReportImport = testing.fn();
     const handleTaskCreate = testing.fn();
@@ -152,23 +158,10 @@ describe('Task ToolBarIcons tests', () => {
   });
 
   test('should call click handlers for new task', async () => {
-    const task = Task.fromElement({
-      _id: '12345',
-      owner: {name: 'admin'},
-      name: 'foo',
-      comment: 'bar',
-      creation_time: '2019-07-16T06:31:29Z',
-      modification_time: '2019-07-16T06:44:55Z',
+    const task = createTask({
       status: TASK_STATUS.new,
-      alterable: 0,
       report_count: {__text: 0},
       result_count: 0,
-      permissions: {permission: [{name: 'everything'}]},
-      target: {_id: '5678', name: 'target1'},
-      alert: {_id: '91011', name: 'alert1'},
-      scanner: {_id: '1516', name: 'scanner1', type: OPENVAS_SCANNER_TYPE},
-      config: scanConfig,
-      preferences: preferences,
     });
     const handleReportImport = testing.fn();
     const handleTaskCreate = testing.fn();
@@ -274,25 +267,11 @@ describe('Task ToolBarIcons tests', () => {
   });
 
   test('should call click handlers for running task', async () => {
-    const task = Task.fromElement({
-      _id: '12345',
-      owner: {name: 'admin'},
-      name: 'foo',
-      comment: 'bar',
+    const task = createTask({
       in_use: 1,
-      creation_time: '2019-07-16T06:31:29Z',
-      modification_time: '2019-07-16T06:44:55Z',
       status: TASK_STATUS.running,
-      alterable: 0,
       current_report: currentReport,
-      report_count: {__text: 1},
       result_count: 0,
-      permissions: {permission: [{name: 'everything'}]},
-      target: {_id: '5678', name: 'target1'},
-      alert: {_id: '91011', name: 'alert1'},
-      scanner: {_id: '1516', name: 'scanner1', type: OPENVAS_SCANNER_TYPE},
-      config: scanConfig,
-      preferences: preferences,
     });
     const handleReportImport = testing.fn();
     const handleTaskCreate = testing.fn();
@@ -403,25 +382,12 @@ describe('Task ToolBarIcons tests', () => {
   });
 
   test('should call click handlers for stopped task', async () => {
-    const task = Task.fromElement({
-      _id: '12345',
-      owner: {name: 'admin'},
-      name: 'foo',
-      comment: 'bar',
-      creation_time: '2019-07-16T06:31:29Z',
-      modification_time: '2019-07-16T06:44:55Z',
+    const task = createTask({
       status: TASK_STATUS.stopped,
-      alterable: 0,
       current_report: currentReport,
       last_report: lastReport,
       report_count: {__text: 2},
       result_count: 10,
-      permissions: {permission: [{name: 'everything'}]},
-      target: {_id: '5678', name: 'target1'},
-      alert: {_id: '91011', name: 'alert1'},
-      scanner: {_id: '1516', name: 'scanner1', type: OPENVAS_SCANNER_TYPE},
-      config: scanConfig,
-      preferences: preferences,
     });
     const handleReportImport = testing.fn();
     const handleTaskCreate = testing.fn();
@@ -533,24 +499,9 @@ describe('Task ToolBarIcons tests', () => {
   });
 
   test('should call click handlers for finished task', async () => {
-    const task = Task.fromElement({
-      _id: '12345',
-      owner: {name: 'admin'},
-      name: 'foo',
-      comment: 'bar',
-      creation_time: '2019-07-16T06:31:29Z',
-      modification_time: '2019-07-16T06:44:55Z',
+    const task = createTask({
       status: TASK_STATUS.done,
-      alterable: 0,
       last_report: lastReport,
-      report_count: {__text: 1},
-      result_count: 1,
-      permissions: {permission: [{name: 'everything'}]},
-      target: {_id: '5678', name: 'target1'},
-      alert: {_id: '91011', name: 'alert1'},
-      scanner: {_id: '1516', name: 'scanner1', type: OPENVAS_SCANNER_TYPE},
-      config: scanConfig,
-      preferences: preferences,
     });
     const handleReportImport = testing.fn();
     const handleTaskCreate = testing.fn();
@@ -663,24 +614,10 @@ describe('Task ToolBarIcons tests', () => {
   });
 
   test('should not call click handlers without permission', async () => {
-    const task = Task.fromElement({
-      _id: '12345',
-      owner: {name: 'admin'},
-      name: 'foo',
-      comment: 'bar',
-      creation_time: '2019-07-16T06:31:29Z',
-      modification_time: '2019-07-16T06:44:55Z',
+    const task = createTask({
       status: TASK_STATUS.done,
-      alterable: 0,
       last_report: lastReport,
-      report_count: {__text: 1},
-      result_count: 1,
       permissions: {permission: [{name: 'get_tasks'}]},
-      target: {_id: '5678', name: 'target1'},
-      alert: {_id: '91011', name: 'alert1'},
-      scanner: {_id: '1516', name: 'scanner1', type: OPENVAS_SCANNER_TYPE},
-      config: scanConfig,
-      preferences: preferences,
     });
     const handleReportImport = testing.fn();
     const handleTaskCreate = testing.fn();
@@ -793,23 +730,9 @@ describe('Task ToolBarIcons tests', () => {
   });
 
   test('should render schedule icon if task is scheduled', () => {
-    const task = Task.fromElement({
-      _id: '12345',
-      owner: {name: 'admin'},
-      name: 'foo',
-      comment: 'bar',
-      creation_time: '2019-07-16T06:31:29Z',
-      modification_time: '2019-07-16T06:44:55Z',
+    const task = createTask({
       status: TASK_STATUS.done,
-      alterable: 0,
       last_report: lastReport,
-      report_count: {__text: 1},
-      result_count: 1,
-      permissions: {permission: [{name: 'everything'}]},
-      target: {_id: '5678', name: 'target1'},
-      alert: {_id: '91011', name: 'alert1'},
-      scanner: {_id: '1516', name: 'scanner1', type: OPENVAS_SCANNER_TYPE},
-      config: scanConfig,
       schedule: {
         _id: '121314',
         name: 'schedule1',
@@ -865,17 +788,13 @@ describe('Task ToolBarIcons tests', () => {
   });
 
   test('should call click handlers for import task', async () => {
-    const task = Task.fromElement({
-      _id: '12345',
-      owner: {name: 'admin'},
-      name: 'foo',
-      comment: 'bar',
-      creation_time: '2019-07-16T06:31:29Z',
-      modification_time: '2019-07-16T06:44:55Z',
-      report_count: {__text: 1},
-      result_count: 1,
+    const task = createTask({
       last_report: lastReport,
-      permissions: {permission: [{name: 'everything'}]},
+      target: undefined,
+      alert: undefined,
+      scanner: undefined,
+      config: undefined,
+      preferences: undefined,
     });
     const handleReportImport = testing.fn();
     const handleTaskCreate = testing.fn();

--- a/src/web/pages/tasks/icons/__tests__/TaskIconsWithSync.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskIconsWithSync.test.tsx
@@ -43,6 +43,7 @@ describe('TaskIconWithSync component tests', () => {
     ({type, taskStatus, expectedTitle, expectedFill, isSyncing = false}) => {
       const caps = new Capabilities(['everything']);
       const task = Task.fromElement({
+        _id: 'test-id',
         status: taskStatus,
         target: {_id: '123'},
         permissions: {permission: [{name: 'everything'}]},

--- a/src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx
@@ -15,6 +15,7 @@ describe('Task ResumeIcon component tests', () => {
   test('should render in active state with correct permissions', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.stopped,
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
@@ -38,6 +39,7 @@ describe('Task ResumeIcon component tests', () => {
   test('should render in inactive state if wrong command level permissions are given', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.stopped,
       target: {_id: '123'},
       permissions: {permission: [{name: 'get_task'}]},
@@ -65,6 +67,7 @@ describe('Task ResumeIcon component tests', () => {
   test('should render in inactive state if task is not stopped', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.new,
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
@@ -89,6 +92,7 @@ describe('Task ResumeIcon component tests', () => {
   test('should render in inactive state if wrong command level permissions are given for audit', () => {
     const caps = new Capabilities(['everything']);
     const audit = Audit.fromElement({
+      _id: 'test-id',
       status: AUDIT_STATUS.stopped,
       target: {_id: '123'},
       permissions: {permission: [{name: 'get_task'}]},
@@ -117,6 +121,7 @@ describe('Task ResumeIcon component tests', () => {
   test('should render in inactive state if task is scheduled', () => {
     const caps = new Capabilities(['everything']);
     const elem = {
+      _id: 'test-id',
       status: TASK_STATUS.new,
       schedule: {
         _id: 'schedule1',
@@ -144,6 +149,7 @@ describe('Task ResumeIcon component tests', () => {
 
   test('should render in inactive state if task is a import task', () => {
     const elem = {
+      _id: 'test-id',
       status: TASK_STATUS.new,
       permissions: {permission: [{name: 'everything'}]},
     };
@@ -167,6 +173,7 @@ describe('Task ResumeIcon component tests', () => {
   test('should not be rendered if task is queued', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.queued,
       permissions: {permission: [{name: 'everything'}]},
     });

--- a/src/web/pages/tasks/icons/__tests__/TaskStartIcon.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskStartIcon.test.tsx
@@ -14,6 +14,7 @@ describe('Task StartIcon component tests', () => {
   test('should render in active state with correct permissions', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.new,
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
@@ -40,6 +41,7 @@ describe('Task StartIcon component tests', () => {
   test('should render in inactive state if wrong command level permissions are given', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.new,
       target: {_id: '123'},
       permissions: {permission: [{name: 'get_task'}]},
@@ -64,6 +66,7 @@ describe('Task StartIcon component tests', () => {
   test('should render in inactive state if wrong command level permissions for audit are given', () => {
     const caps = new Capabilities(['everything']);
     const audit = Audit.fromElement({
+      _id: 'test-id',
       status: AUDIT_STATUS.new,
       target: {_id: '123'},
       permissions: {permission: [{name: 'get_task'}]},
@@ -104,6 +107,7 @@ END:VCALENDAR
 `;
 
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.new,
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
@@ -136,6 +140,7 @@ END:VCALENDAR
   test('should render in inactive state if task is already active', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.requested,
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
@@ -160,6 +165,7 @@ END:VCALENDAR
   test('should render in inactive state if task is queued', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.queued,
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
@@ -184,6 +190,7 @@ END:VCALENDAR
   test('should not be rendered if task is running', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.running,
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
@@ -201,6 +208,7 @@ END:VCALENDAR
   test('should not be rendered if task is a container', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.new,
       permissions: {permission: [{name: 'everything'}]},
     });

--- a/src/web/pages/tasks/icons/__tests__/TaskStopIcon.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskStopIcon.test.tsx
@@ -14,6 +14,7 @@ describe('Task StopIcon component tests', () => {
   test('should render in active state with correct permissions', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.running,
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
@@ -40,6 +41,7 @@ describe('Task StopIcon component tests', () => {
   test('should render in active state with correct permissions if task queued', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.queued,
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
@@ -66,6 +68,7 @@ describe('Task StopIcon component tests', () => {
   test('should render in inactive state if wrong command level permissions are given', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.running,
       target: {_id: '123'},
       permissions: {permission: [{name: 'get_task'}]},
@@ -91,6 +94,7 @@ describe('Task StopIcon component tests', () => {
   test('should render in inactive state if wrong command level permissions are given for audit', () => {
     const caps = new Capabilities(['everything']);
     const audit = Audit.fromElement({
+      _id: 'test-id',
       status: AUDIT_STATUS.running,
       target: {_id: '123'},
       permissions: {permission: [{name: 'get_task'}]},
@@ -116,6 +120,7 @@ describe('Task StopIcon component tests', () => {
   test('should not be rendered if task is not running', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.new,
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
@@ -134,6 +139,7 @@ describe('Task StopIcon component tests', () => {
   test('should not be rendered if task is a container', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({
+      _id: 'test-id',
       status: TASK_STATUS.running,
       permissions: {permission: [{name: 'everything'}]},
     });


### PR DESCRIPTION
## What

Require Model ID

## Why

With the split of the filter into two different classes it is now possible to require the id for all model classes. Filter was the only model that couldn't have an ID. The Filter model class implemented several use cases where no ID is available. These cases are now split into a different class.

## References

https://jira.greenbone.net/browse/GEA-1957

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


