### PR TITLE
Rename BaseFilter to QueryFilter

### DIFF
--- a/src/gmp/collection/parser.ts
+++ b/src/gmp/collection/parser.ts
@@ -7,10 +7,10 @@ import CollectionCounts, {
   type CollectionCountsOptions,
 } from 'gmp/collection/collection-counts';
 import logger from 'gmp/log';
-import BaseFilter, {
-  type FilterResponseElement,
-} from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter, {
+  type FilterResponseElement,
+} from 'gmp/models/filter/query-filter';
 import Model, {type Element} from 'gmp/models/model';
 import {map} from 'gmp/utils/array';
 import {hasValue, isArray, isDefined} from 'gmp/utils/identity';
@@ -154,7 +154,7 @@ export function parseInfoCounts(response: InfoWithCounts) {
 }
 
 export function parseFilter(element: FilterElement): FilterType {
-  return BaseFilter.fromResponseElement(element.filters);
+  return QueryFilter.fromResponseElement(element.filters);
 }
 
 export function parseCounts<TElement = Element>(

--- a/src/gmp/commands/__tests__/agents.test.ts
+++ b/src/gmp/commands/__tests__/agents.test.ts
@@ -13,7 +13,7 @@ import {
   createHttpMany,
 } from 'gmp/commands/testing';
 import Agent from 'gmp/models/agent';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {NO_VALUE, YES_VALUE} from 'gmp/parser';
 
 describe('AgentsCommand tests', () => {
@@ -163,7 +163,7 @@ describe('AgentsCommand tests', () => {
     const fakeHttp = createHttpMany([response1, response2]);
     const cmd = new AgentsCommand(fakeHttp);
     const result = await cmd.authorizeByFilter(
-      BaseFilter.fromString("name='AgentToAuthorize'"),
+      QueryFilter.fromString("name='AgentToAuthorize'"),
     );
     expect(fakeHttp.request).toHaveBeenNthCalledWith(1, 'get', {
       args: {
@@ -220,7 +220,7 @@ describe('AgentsCommand tests', () => {
     const fakeHttp = createHttpMany([response1, response2]);
     const cmd = new AgentsCommand(fakeHttp);
     const result = await cmd.revokeByFilter(
-      BaseFilter.fromString("name='AgentToRevoke'"),
+      QueryFilter.fromString("name='AgentToRevoke'"),
     );
     expect(fakeHttp.request).toHaveBeenNthCalledWith(1, 'get', {
       args: {
@@ -265,7 +265,7 @@ describe('AgentsCommand tests', () => {
     const cmd = new AgentsCommand(fakeHttp);
 
     const result = await cmd.enableUpdateToLatestByFilter(
-      BaseFilter.fromString("name='AgentToEnableUpdateToLatest'"),
+      QueryFilter.fromString("name='AgentToEnableUpdateToLatest'"),
     );
 
     expect(fakeHttp.request).toHaveBeenNthCalledWith(1, 'get', {
@@ -312,7 +312,7 @@ describe('AgentsCommand tests', () => {
     const cmd = new AgentsCommand(fakeHttp);
 
     const result = await cmd.disableUpdateToLatestByFilter(
-      BaseFilter.fromString("name='AgentToDisableUpdateToLatest'"),
+      QueryFilter.fromString("name='AgentToDisableUpdateToLatest'"),
     );
 
     expect(fakeHttp.request).toHaveBeenNthCalledWith(1, 'get', {

--- a/src/gmp/commands/__tests__/entities.test.ts
+++ b/src/gmp/commands/__tests__/entities.test.ts
@@ -8,7 +8,7 @@ import EntitiesCommand from 'gmp/commands/entities';
 import {createEntitiesResponse, createHttp} from 'gmp/commands/testing';
 import type Http from 'gmp/http/http';
 import Filter from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Model, {type Element} from 'gmp/models/model';
 
 class Foo extends Model {}
@@ -36,7 +36,7 @@ class FooWithAssetTypeCommand extends EntitiesCommand<Foo> {
 
 describe('EntitiesCommand tests', () => {
   test('should add filter parameter', async () => {
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const response = createEntitiesResponse('foo', []);
     const fakeHttp = createHttp(response);
     const cmd = new FooCommand(fakeHttp);
@@ -64,7 +64,7 @@ describe('EntitiesCommand tests', () => {
   });
 
   test('should prefer filter_id over filter parameter', async () => {
-    const filter = BaseFilter.fromResponseElement({
+    const filter = QueryFilter.fromResponseElement({
       _id: 'bar',
       keywords: {
         keyword: {relation: '=', value: 'bar', column: 'foo'},
@@ -107,7 +107,7 @@ describe('EntitiesCommand tests', () => {
     const response = createEntitiesResponse('foo', []);
     const fakeHttp = createHttp(response);
 
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
 
     const cmd = new FooCommand(fakeHttp);
     await cmd.exportByFilter(filter);
@@ -163,7 +163,7 @@ describe('EntitiesCommand tests', () => {
     const response = createEntitiesResponse('foo', []);
     const fakeHttp = createHttp(response);
 
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
 
     const cmd = new FooWithAssetTypeCommand(fakeHttp);
     await cmd.exportByFilter(filter);

--- a/src/gmp/commands/__tests__/entity.test.ts
+++ b/src/gmp/commands/__tests__/entity.test.ts
@@ -17,7 +17,7 @@ import Response from 'gmp/http/response';
 import {type XmlResponseData} from 'gmp/http/transform/fast-xml';
 import {type EntityModelElement} from 'gmp/models/entity-model';
 import Filter from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Model from 'gmp/models/model';
 
 type FooElement = EntityModelElement;
@@ -72,7 +72,7 @@ describe('EntityCommand tests', () => {
   });
 
   test('should get entity with filter parameter', async () => {
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const response = createEntityResponse('foo', {id: '123'});
     const fakeHttp = createHttp(response);
 
@@ -110,7 +110,7 @@ describe('EntityCommand tests', () => {
   });
 
   test('should get entity and prefer filter_id over filter parameter', async () => {
-    const filter = BaseFilter.fromResponseElement({
+    const filter = QueryFilter.fromResponseElement({
       _id: 'bar',
       keywords: {
         keyword: {relation: '=', value: 'bar', column: 'foo'},

--- a/src/gmp/commands/__tests__/scan-configs.test.ts
+++ b/src/gmp/commands/__tests__/scan-configs.test.ts
@@ -7,7 +7,7 @@ import {describe, test, expect} from '@gsa/testing';
 import ScanConfigsCommand from 'gmp/commands/scan-configs';
 import {createEntitiesResponse, createHttp} from 'gmp/commands/testing';
 import {ALL_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ScanConfig from 'gmp/models/scan-config';
 
 describe('ScanConfigsCommand tests', () => {
@@ -90,7 +90,7 @@ describe('ScanConfigsCommand tests', () => {
     const response = createEntitiesResponse('config', []);
     const fakeHttp = createHttp(response);
 
-    const filter = BaseFilter.fromString('name~foo');
+    const filter = QueryFilter.fromString('name~foo');
 
     const cmd = new ScanConfigsCommand(fakeHttp);
     await cmd.exportByFilter(filter);

--- a/src/gmp/commands/__tests__/tls-certificates.test.ts
+++ b/src/gmp/commands/__tests__/tls-certificates.test.ts
@@ -11,7 +11,7 @@ import {
 } from 'gmp/commands/testing';
 import TlsCertificatesCommand from 'gmp/commands/tls-certificates';
 import {ALL_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import TlsCertificate from 'gmp/models/tls-certificate';
 
 describe('TlsCertificatesCommand tests', () => {
@@ -147,7 +147,7 @@ describe('TlsCertificatesCommand tests', () => {
     const response = createEntitiesResponse('tls_certificate', []);
     const fakeHttp = createHttp(response);
 
-    const filter = BaseFilter.fromString("certificate='foo'");
+    const filter = QueryFilter.fromString("certificate='foo'");
 
     const cmd = new TlsCertificatesCommand(fakeHttp);
     await cmd.exportByFilter(filter);

--- a/src/gmp/commands/agents.ts
+++ b/src/gmp/commands/agents.ts
@@ -11,7 +11,7 @@ import {type XmlMeta, type XmlResponseData} from 'gmp/http/transform/fast-xml';
 import logger from 'gmp/log';
 import Agent from 'gmp/models/agent';
 import {type FilterType} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   AGENT_CONTROLLER_SCANNER_TYPE,
   AGENT_CONTROLLER_SENSOR_SCANNER_TYPE,
@@ -21,7 +21,7 @@ import {map} from 'gmp/utils/array';
 
 const log = logger.getLogger('gmp.commands.agents');
 
-const AGENT_CONTROLLER_FILTER = BaseFilter.fromString(
+const AGENT_CONTROLLER_FILTER = QueryFilter.fromString(
   `scanner_type=${AGENT_CONTROLLER_SCANNER_TYPE} or scanner_type=${AGENT_CONTROLLER_SENSOR_SCANNER_TYPE}`,
 );
 

--- a/src/gmp/commands/entities.ts
+++ b/src/gmp/commands/entities.ts
@@ -22,7 +22,7 @@ import type Http from 'gmp/http/http';
 import {type default as Response, type Meta} from 'gmp/http/response';
 import {type XmlMeta, type XmlResponseData} from 'gmp/http/transform/fast-xml';
 import {ALL_FILTER, type FilterType} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {type default as Model, type Element} from 'gmp/models/model';
 import {map, forEach} from 'gmp/utils/array';
 import {isDefined, isString} from 'gmp/utils/identity';
@@ -161,7 +161,7 @@ abstract class EntitiesCommand<
     if (!isDefined(filter)) {
       params.filter = ALL_FILTER;
     } else if (isString(filter)) {
-      params.filter = BaseFilter.fromString(filter).all();
+      params.filter = QueryFilter.fromString(filter).all();
     } else {
       params.filter = filter.all();
     }

--- a/src/gmp/commands/filters.ts
+++ b/src/gmp/commands/filters.ts
@@ -9,7 +9,7 @@ import EntitiesCommand from 'gmp/commands/entities';
 import type Http from 'gmp/http/http';
 import {type XmlResponseData} from 'gmp/http/transform/fast-xml';
 import Filter, {type FilterModelElement} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type {Element} from 'gmp/models/model';
 import {isArray, isDefined} from 'gmp/utils/identity';
 
@@ -53,8 +53,8 @@ const parseFilterFromResponse = (element: FiltersResponseElement) => {
       : undefined;
 
   return isDefined(firstFilter) && !isPaginationElement(firstFilter)
-    ? BaseFilter.fromResponseElement(firstFilter)
-    : BaseFilter.fromResponseElement();
+    ? QueryFilter.fromResponseElement(firstFilter)
+    : QueryFilter.fromResponseElement();
 };
 
 const parseCollectionCountsFromResponse = (

--- a/src/gmp/commands/resource-names.ts
+++ b/src/gmp/commands/resource-names.ts
@@ -12,7 +12,7 @@ import {type EntitiesMeta} from 'gmp/commands/entities';
 import HttpCommand from 'gmp/commands/http';
 import type Http from 'gmp/http/http';
 import {ALL_FILTER, type FilterType} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ResourceName from 'gmp/models/resource-name';
 import {resourceType, type EntityType} from 'gmp/utils/entity-type';
 import {isDefined, isString} from 'gmp/utils/identity';
@@ -78,7 +78,7 @@ class ResourceNamesCommand extends HttpCommand {
     if (!isDefined(filter)) {
       params.filter = ALL_FILTER;
     } else if (isString(filter)) {
-      params.filter = BaseFilter.fromString(filter).all();
+      params.filter = QueryFilter.fromString(filter).all();
     } else {
       params.filter = filter.all();
     }

--- a/src/gmp/models/filter.ts
+++ b/src/gmp/models/filter.ts
@@ -4,7 +4,6 @@
  */
 
 import EntityModel, {parseEntityModelProperties} from 'gmp/models/entity-model';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import {
   type default as FilterTerm,
   parseFilterTermsFromString,
@@ -14,6 +13,7 @@ import {
   type default as FilterType,
   type FilterSortOrder,
 } from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Model, {type ModelElement, type ModelProperties} from 'gmp/models/model';
 import {map} from 'gmp/utils/array';
 import {isDefined} from 'gmp/utils/identity';
@@ -113,7 +113,7 @@ class Filter extends EntityModel implements FilterType {
   private _delegate(terms: FilterTerms, keepId = false) {
     return terms === this.filterTerms
       ? this
-      : new BaseFilter({
+      : new QueryFilter({
           id: keepId ? this.id : undefined,
           name: this.name,
           terms: [...terms.getAllTerms()],
@@ -283,59 +283,59 @@ class Filter extends EntityModel implements FilterType {
   }
 }
 
-export const ALL_FILTER = new BaseFilter().all();
-export const AGENTS_FILTER_FILTER = BaseFilter.fromString('type=agent');
+export const ALL_FILTER = new QueryFilter().all();
+export const AGENTS_FILTER_FILTER = QueryFilter.fromString('type=agent');
 export const AGENT_GROUPS_FILTER_FILTER =
-  BaseFilter.fromString('type=agent_group');
-export const AGENT_INSTALLERS_FILTER_FILTER = BaseFilter.fromString(
+  QueryFilter.fromString('type=agent_group');
+export const AGENT_INSTALLERS_FILTER_FILTER = QueryFilter.fromString(
   'type=agent_installer',
 );
-export const ALERTS_FILTER_FILTER = BaseFilter.fromString('type=alert');
-export const AUDITS_FILTER_FILTER = BaseFilter.fromString('type=task');
+export const ALERTS_FILTER_FILTER = QueryFilter.fromString('type=alert');
+export const AUDITS_FILTER_FILTER = QueryFilter.fromString('type=task');
 export const AUDIT_REPORTS_FILTER_FILTER =
-  BaseFilter.fromString('type=audit_report');
-export const CERTBUND_FILTER_FILTER = BaseFilter.fromString('type=info');
-export const CPES_FILTER_FILTER = BaseFilter.fromString('type=info');
+  QueryFilter.fromString('type=audit_report');
+export const CERTBUND_FILTER_FILTER = QueryFilter.fromString('type=info');
+export const CPES_FILTER_FILTER = QueryFilter.fromString('type=info');
 export const CREDENTIALS_FILTER_FILTER =
-  BaseFilter.fromString('type=credential');
-export const CVES_FILTER_FILTER = BaseFilter.fromString('type=info');
-export const DFNCERT_FILTER_FILTER = BaseFilter.fromString('type=info');
-export const FILTERS_FILTER_FILTER = BaseFilter.fromString('type=filter');
-export const GROUPS_FILTER_FILTER = BaseFilter.fromString('type=group');
-export const HOSTS_FILTER_FILTER = BaseFilter.fromString('type=host');
-export const NOTES_FILTER_FILTER = BaseFilter.fromString('type=note');
-export const NVTS_FILTER_FILTER = BaseFilter.fromString('type=info');
-export const OS_FILTER_FILTER = BaseFilter.fromString('type=os');
-export const OVERRIDES_FILTER_FILTER = BaseFilter.fromString('type=override');
-export const PORTLISTS_FILTER_FILTER = BaseFilter.fromString('type=port_list');
-export const POLICIES_FILTER_FILTER = BaseFilter.fromString('type=config');
+  QueryFilter.fromString('type=credential');
+export const CVES_FILTER_FILTER = QueryFilter.fromString('type=info');
+export const DFNCERT_FILTER_FILTER = QueryFilter.fromString('type=info');
+export const FILTERS_FILTER_FILTER = QueryFilter.fromString('type=filter');
+export const GROUPS_FILTER_FILTER = QueryFilter.fromString('type=group');
+export const HOSTS_FILTER_FILTER = QueryFilter.fromString('type=host');
+export const NOTES_FILTER_FILTER = QueryFilter.fromString('type=note');
+export const NVTS_FILTER_FILTER = QueryFilter.fromString('type=info');
+export const OS_FILTER_FILTER = QueryFilter.fromString('type=os');
+export const OVERRIDES_FILTER_FILTER = QueryFilter.fromString('type=override');
+export const PORTLISTS_FILTER_FILTER = QueryFilter.fromString('type=port_list');
+export const POLICIES_FILTER_FILTER = QueryFilter.fromString('type=config');
 export const PERMISSIONS_FILTER_FILTER =
-  BaseFilter.fromString('type=permission');
+  QueryFilter.fromString('type=permission');
 export const REPORT_CONFIGS_FILTER_FILTER =
-  BaseFilter.fromString('type=report_config');
+  QueryFilter.fromString('type=report_config');
 export const REPORT_FORMATS_FILTER_FILTER =
-  BaseFilter.fromString('type=report_format');
-export const REPORTS_FILTER_FILTER = BaseFilter.fromString('type=report');
-export const RESULTS_FILTER_FILTER = BaseFilter.fromString('type=result');
-export const ROLES_FILTER_FILTER = BaseFilter.fromString('type=role');
-export const SCANCONFIGS_FILTER_FILTER = BaseFilter.fromString('type=config');
-export const SCANNERS_FILTER_FILTER = BaseFilter.fromString('type=scanner');
-export const SCHEDULES_FILTER_FILTER = BaseFilter.fromString('type=schedule');
-export const SECINFO_FILTER_FILTER = BaseFilter.fromString('type=info');
-export const TARGETS_FILTER_FILTER = BaseFilter.fromString('type=target');
-export const TASKS_FILTER_FILTER = BaseFilter.fromString('type=task');
-export const TAGS_FILTER_FILTER = BaseFilter.fromString('type=tag');
-export const TICKETS_FILTER_FILTER = BaseFilter.fromString('type=ticket');
-export const TLS_CERTIFICATES_FILTER_FILTER = BaseFilter.fromString(
+  QueryFilter.fromString('type=report_format');
+export const REPORTS_FILTER_FILTER = QueryFilter.fromString('type=report');
+export const RESULTS_FILTER_FILTER = QueryFilter.fromString('type=result');
+export const ROLES_FILTER_FILTER = QueryFilter.fromString('type=role');
+export const SCANCONFIGS_FILTER_FILTER = QueryFilter.fromString('type=config');
+export const SCANNERS_FILTER_FILTER = QueryFilter.fromString('type=scanner');
+export const SCHEDULES_FILTER_FILTER = QueryFilter.fromString('type=schedule');
+export const SECINFO_FILTER_FILTER = QueryFilter.fromString('type=info');
+export const TARGETS_FILTER_FILTER = QueryFilter.fromString('type=target');
+export const TASKS_FILTER_FILTER = QueryFilter.fromString('type=task');
+export const TAGS_FILTER_FILTER = QueryFilter.fromString('type=tag');
+export const TICKETS_FILTER_FILTER = QueryFilter.fromString('type=ticket');
+export const TLS_CERTIFICATES_FILTER_FILTER = QueryFilter.fromString(
   'type=tls_certificate',
 );
-export const USERS_FILTER_FILTER = BaseFilter.fromString('type=user');
-export const VULNS_FILTER_FILTER = BaseFilter.fromString('type=vuln');
+export const USERS_FILTER_FILTER = QueryFilter.fromString('type=user');
+export const VULNS_FILTER_FILTER = QueryFilter.fromString('type=vuln');
 
 export const DEFAULT_FALLBACK_FILTER =
-  BaseFilter.fromString('sort=name first=1');
+  QueryFilter.fromString('sort=name first=1');
 
-export const RESET_FILTER = BaseFilter.fromString('first=1');
+export const RESET_FILTER = QueryFilter.fromString('first=1');
 
 export const DEFAULT_ROWS_PER_PAGE = 50;
 

--- a/src/gmp/models/filter/__tests__/query-filter.test.ts
+++ b/src/gmp/models/filter/__tests__/query-filter.test.ts
@@ -4,19 +4,19 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import BaseFilter, {UNKNOWN_FILTER_ID} from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter, {UNKNOWN_FILTER_ID} from 'gmp/models/filter/query-filter';
 
-describe('BaseFilter tests', () => {
-  describe('BaseFilter constructor', () => {
+describe('QueryFilter tests', () => {
+  describe('QueryFilter constructor', () => {
     test('should create a filter with id and name', () => {
-      const filter = new BaseFilter({id: '123', name: 'Test Filter'});
+      const filter = new QueryFilter({id: '123', name: 'Test Filter'});
       expect(filter.id).toBe('123');
       expect(filter.name).toBe('Test Filter');
     });
 
     test('should create a filter with id, name and terms', () => {
-      const filter = new BaseFilter({
+      const filter = new QueryFilter({
         id: '123',
         name: 'Test Filter',
         terms: [
@@ -41,27 +41,27 @@ describe('BaseFilter tests', () => {
     });
 
     test('should create a filter with no id and name', () => {
-      const filter = new BaseFilter();
+      const filter = new QueryFilter();
       expect(filter.id).toBeUndefined();
       expect(filter.name).toBeUndefined();
     });
   });
 
-  describe('BaseFilter fromString', () => {
+  describe('QueryFilter fromString', () => {
     test('should parse empty string', () => {
-      const filter = BaseFilter.fromString('');
+      const filter = QueryFilter.fromString('');
       expect(filter.toFilterString()).toEqual('');
       expect(filter.length).toBe(0);
     });
 
     test('should parse undefined string', () => {
-      const filter = BaseFilter.fromString();
+      const filter = QueryFilter.fromString();
       expect(filter.toFilterString()).toEqual('');
       expect(filter.length).toBe(0);
     });
 
     test('should parse terms from string', () => {
-      const filter = BaseFilter.fromString('foo=bar lorem~ipsum');
+      const filter = QueryFilter.fromString('foo=bar lorem~ipsum');
       expect(filter.toFilterString()).toEqual('foo=bar lorem~ipsum');
       expect(filter.length).toBe(2);
       const terms = filter.getAllTerms();
@@ -79,7 +79,7 @@ describe('BaseFilter tests', () => {
 
     test('should parse filter strings with compound statements', () => {
       // should parse filter strings with and
-      let filter = BaseFilter.fromString('foo=bar and lorem~ipsum');
+      let filter = QueryFilter.fromString('foo=bar and lorem~ipsum');
       expect(filter.toFilterString()).toEqual('foo=bar and lorem~ipsum');
       expect(filter.length).toBe(3);
       let terms = filter.getAllTerms();
@@ -100,7 +100,7 @@ describe('BaseFilter tests', () => {
       });
 
       // should parse filter strings with or
-      filter = BaseFilter.fromString('foo=bar or lorem~ipsum');
+      filter = QueryFilter.fromString('foo=bar or lorem~ipsum');
       expect(filter.toFilterString()).toEqual('foo=bar or lorem~ipsum');
       expect(filter.length).toBe(3);
       terms = filter.getAllTerms();
@@ -121,7 +121,7 @@ describe('BaseFilter tests', () => {
       });
 
       // should parse filter strings with not
-      filter = BaseFilter.fromString('not foo=bar');
+      filter = QueryFilter.fromString('not foo=bar');
       expect(filter.toFilterString()).toEqual('not foo=bar');
       expect(filter.length).toBe(2);
       terms = filter.getAllTerms();
@@ -138,7 +138,7 @@ describe('BaseFilter tests', () => {
     });
 
     test('should parse strings with double quotes', () => {
-      const filter = BaseFilter.fromString(
+      const filter = QueryFilter.fromString(
         'name="foo bar" comment~"lorem ipsum"',
       );
       expect(filter.toFilterString()).toEqual(
@@ -160,7 +160,7 @@ describe('BaseFilter tests', () => {
     });
 
     test('should parse strings with double quotes and without columns', () => {
-      const filter = BaseFilter.fromString('="foo bar" ~"lorem ipsum"');
+      const filter = QueryFilter.fromString('="foo bar" ~"lorem ipsum"');
       expect(filter.toFilterString()).toEqual('="foo bar" ~"lorem ipsum"');
       expect(filter.length).toBe(2);
       const terms = filter.getAllTerms();
@@ -178,7 +178,7 @@ describe('BaseFilter tests', () => {
     });
 
     test('should parse strings with double quotes and special characters', () => {
-      const filter = BaseFilter.fromString(
+      const filter = QueryFilter.fromString(
         'name="foo <= bar" ~"foo & bar" and comment="hello : world ?"',
       );
       expect(filter.toFilterString()).toEqual(
@@ -209,42 +209,42 @@ describe('BaseFilter tests', () => {
     });
 
     test('should parse approx relation without column', () => {
-      const filter = BaseFilter.fromString('~abc');
+      const filter = QueryFilter.fromString('~abc');
       expect(filter.toFilterString()).toEqual('~abc');
     });
 
     test('should parse approx relation without relation and column', () => {
-      const filter = BaseFilter.fromString('abc');
+      const filter = QueryFilter.fromString('abc');
       expect(filter.toFilterString()).toEqual('abc');
     });
 
     test('should parse equal relation without column', () => {
-      const filter = BaseFilter.fromString('=abc');
+      const filter = QueryFilter.fromString('=abc');
       expect(filter.toFilterString()).toEqual('=abc');
     });
 
     test('should parse equal relation without column and with quotes', () => {
-      const filter = BaseFilter.fromString('="abc def"');
+      const filter = QueryFilter.fromString('="abc def"');
       expect(filter.toFilterString()).toEqual('="abc def"');
     });
 
     test('should parse equal relation without column and with special characters in quotes', () => {
-      const filter = BaseFilter.fromString('="abc : def"');
+      const filter = QueryFilter.fromString('="abc : def"');
       expect(filter.toFilterString()).toEqual('="abc : def"');
     });
 
     test('should parse above relation without column', () => {
-      const filter = BaseFilter.fromString('>1.0');
+      const filter = QueryFilter.fromString('>1.0');
       expect(filter.toFilterString()).toEqual('>1.0');
     });
 
     test('should parse below relation without column', () => {
-      const filter = BaseFilter.fromString('<1.0');
+      const filter = QueryFilter.fromString('<1.0');
       expect(filter.toFilterString()).toEqual('<1.0');
     });
 
     test('should parse below relation without column', () => {
-      const filter = BaseFilter.fromString(':abc');
+      const filter = QueryFilter.fromString(':abc');
       expect(filter.toFilterString()).toEqual(':abc');
     });
 
@@ -259,64 +259,64 @@ describe('BaseFilter tests', () => {
       ];
 
       fStrings.forEach(fString => {
-        expect(BaseFilter.fromString(fString).toFilterString()).toEqual(
+        expect(QueryFilter.fromString(fString).toFilterString()).toEqual(
           fString,
         );
       });
     });
 
     test('should convert first if less then 1', () => {
-      let filter = BaseFilter.fromString('first=0');
+      let filter = QueryFilter.fromString('first=0');
       expect(filter.toFilterString()).toEqual('first=1');
 
-      filter = BaseFilter.fromString('first=-1');
+      filter = QueryFilter.fromString('first=-1');
       expect(filter.toFilterString()).toEqual('first=1');
 
-      filter = BaseFilter.fromString('first=-666');
+      filter = QueryFilter.fromString('first=-666');
       expect(filter.toFilterString()).toEqual('first=1');
     });
 
     test('should always use equal relation for first keyword', () => {
-      let filter = BaseFilter.fromString('first>1');
+      let filter = QueryFilter.fromString('first>1');
       expect(filter.toFilterString()).toEqual('first=1');
 
-      filter = BaseFilter.fromString('first<1');
+      filter = QueryFilter.fromString('first<1');
       expect(filter.toFilterString()).toEqual('first=1');
 
-      filter = BaseFilter.fromString('first>1');
+      filter = QueryFilter.fromString('first>1');
       expect(filter.toFilterString()).toEqual('first=1');
     });
 
     test('should always use equal relation for rows keyword', () => {
-      let filter = BaseFilter.fromString('rows>1');
+      let filter = QueryFilter.fromString('rows>1');
       expect(filter.toFilterString()).toEqual('rows=1');
 
-      filter = BaseFilter.fromString('rows<1');
+      filter = QueryFilter.fromString('rows<1');
       expect(filter.toFilterString()).toEqual('rows=1');
 
-      filter = BaseFilter.fromString('rows>1');
+      filter = QueryFilter.fromString('rows>1');
       expect(filter.toFilterString()).toEqual('rows=1');
     });
 
     test('should ignore null as filter argument', () => {
       // @ts-expect-error
-      const filter = BaseFilter.fromString('foo=1', null);
+      const filter = QueryFilter.fromString('foo=1', null);
       expect(filter.toFilterString()).toEqual('foo=1');
     });
 
     test('should ignore filter terms starting with _', () => {
-      let filter = BaseFilter.fromString('rows=100 _foo=bar');
+      let filter = QueryFilter.fromString('rows=100 _foo=bar');
       expect(filter.toFilterString()).toEqual('rows=100');
 
-      filter = BaseFilter.fromString('_bar=foo rows=100');
+      filter = QueryFilter.fromString('_bar=foo rows=100');
       expect(filter.toFilterString()).toEqual('rows=100');
 
-      filter = BaseFilter.fromString('_foo rows=100');
+      filter = QueryFilter.fromString('_foo rows=100');
       expect(filter.toFilterString()).toEqual('rows=100');
     });
   });
 
-  describe('BaseFilter fromResponseElement', () => {
+  describe('QueryFilter fromResponseElement', () => {
     test('should parse approx relation without column', () => {
       const elem = {
         keywords: {
@@ -329,7 +329,7 @@ describe('BaseFilter tests', () => {
           ],
         },
       };
-      const filter = BaseFilter.fromResponseElement(elem);
+      const filter = QueryFilter.fromResponseElement(elem);
       expect(filter.toFilterString()).toEqual('~abc');
     });
 
@@ -360,7 +360,7 @@ describe('BaseFilter tests', () => {
           ],
         },
       };
-      let filter = BaseFilter.fromResponseElement(elem);
+      let filter = QueryFilter.fromResponseElement(elem);
       expect(filter.toFilterString()).toEqual('~abc and not ~def');
 
       elem = {
@@ -404,7 +404,7 @@ describe('BaseFilter tests', () => {
           ],
         },
       };
-      filter = BaseFilter.fromResponseElement(elem);
+      filter = QueryFilter.fromResponseElement(elem);
       expect(filter.toFilterString()).toEqual(
         '~abc and not ~def rows=10 first=1 sort=name',
       );
@@ -448,12 +448,12 @@ describe('BaseFilter tests', () => {
         },
       };
 
-      const filter = BaseFilter.fromResponseElement(elem);
+      const filter = QueryFilter.fromResponseElement(elem);
       const filterString =
         'severity>3.9 and severity<7 first=1 rows=10 sort=name';
       expect(filter.toFilterString()).toEqual(filterString);
 
-      const filter2 = BaseFilter.fromString(filterString);
+      const filter2 = QueryFilter.fromString(filterString);
       expect(filter.equals(filter2)).toEqual(true);
     });
 
@@ -469,33 +469,33 @@ describe('BaseFilter tests', () => {
           ],
         },
       };
-      const filter = BaseFilter.fromResponseElement(elem);
+      const filter = QueryFilter.fromResponseElement(elem);
       expect(filter.toFilterString()).toEqual('_foo=abc');
     });
 
     test('should parse id', () => {
-      const filter1 = BaseFilter.fromResponseElement();
+      const filter1 = QueryFilter.fromResponseElement();
       expect(filter1.id).toBeUndefined();
 
-      const filter2 = BaseFilter.fromResponseElement({_id: '123'});
+      const filter2 = QueryFilter.fromResponseElement({_id: '123'});
       expect(filter2.id).toBe('123');
 
-      const filter3 = BaseFilter.fromResponseElement({
+      const filter3 = QueryFilter.fromResponseElement({
         _id: UNKNOWN_FILTER_ID,
       });
       expect(filter3.id).toBeUndefined();
     });
 
     test('should parse name', () => {
-      const filter1 = BaseFilter.fromResponseElement();
+      const filter1 = QueryFilter.fromResponseElement();
       expect(filter1.name).toBeUndefined();
 
-      const filter2 = BaseFilter.fromResponseElement({name: 'Test Filter'});
+      const filter2 = QueryFilter.fromResponseElement({name: 'Test Filter'});
       expect(filter2.name).toBe('Test Filter');
     });
 
     test('should parse term string', () => {
-      const filter = BaseFilter.fromResponseElement({
+      const filter = QueryFilter.fromResponseElement({
         term: 'foo=bar and lorem~ipsum',
       });
       expect(filter.toFilterString()).toEqual('foo=bar and lorem~ipsum');
@@ -519,16 +519,16 @@ describe('BaseFilter tests', () => {
     });
   });
 
-  describe('BaseFilter fromTerm', () => {
+  describe('QueryFilter fromTerm', () => {
     test('should create filter from single term', () => {
-      const filter = BaseFilter.fromTerm(FilterTerm.fromString('foo=1'));
+      const filter = QueryFilter.fromTerm(FilterTerm.fromString('foo=1'));
 
       expect(filter.toFilterString()).toBe('foo=1');
       expect(filter.length).toBe(1);
     });
 
     test('should create filter from multiple terms', () => {
-      const filter = BaseFilter.fromTerm(
+      const filter = QueryFilter.fromTerm(
         FilterTerm.fromString('foo=1'),
         FilterTerm.fromString('bar=2'),
       );
@@ -538,9 +538,9 @@ describe('BaseFilter tests', () => {
     });
   });
 
-  describe('BaseFilter set', () => {
+  describe('QueryFilter set', () => {
     test('should return new filter and not mutate original', () => {
-      const filter = new BaseFilter({
+      const filter = new QueryFilter({
         id: '123',
         name: 'Test Filter',
         terms: [FilterTerm.fromString('foo=1')],
@@ -557,9 +557,9 @@ describe('BaseFilter tests', () => {
     });
   });
 
-  describe('BaseFilter copy', () => {
+  describe('QueryFilter copy', () => {
     test('should keep id and create equal filter', () => {
-      const filter = new BaseFilter({
+      const filter = new QueryFilter({
         id: '123',
         name: 'Test Filter',
         terms: [FilterTerm.fromString('foo=1')],
@@ -576,18 +576,18 @@ describe('BaseFilter tests', () => {
     });
   });
 
-  describe('BaseFilter delete', () => {
+  describe('QueryFilter delete', () => {
     test('should return same instance for unknown key', () => {
-      const filter = BaseFilter.fromString('foo=1');
+      const filter = QueryFilter.fromString('foo=1');
       const updated = filter.delete('bar');
 
       expect(updated).toBe(filter);
     });
   });
 
-  describe('BaseFilter get/has terms api', () => {
+  describe('QueryFilter get/has terms api', () => {
     test('should delegate get, has, getTerm, getTerms and hasTerm', () => {
-      const filter = BaseFilter.fromString('foo=1 foo=2 bar=3');
+      const filter = QueryFilter.fromString('foo=1 foo=2 bar=3');
 
       expect(filter.has('foo')).toBe(true);
       expect(filter.get('foo')).toBe('1');
@@ -598,9 +598,9 @@ describe('BaseFilter tests', () => {
     });
   });
 
-  describe('BaseFilter toFilterCriteriaString', () => {
+  describe('QueryFilter toFilterCriteriaString', () => {
     test('should split terms into criteria and extra strings', () => {
-      const filter = BaseFilter.fromString('foo=1 rows=10 sort=name');
+      const filter = QueryFilter.fromString('foo=1 rows=10 sort=name');
 
       expect(filter.toFilterCriteriaString()).toBe('foo=1');
       expect(filter.toFilterExtraString()).toBe('rows=10 sort=name');
@@ -608,9 +608,9 @@ describe('BaseFilter tests', () => {
     });
   });
 
-  describe('BaseFilter paging helpers', () => {
+  describe('QueryFilter paging helpers', () => {
     test('next, previous, first and all should update paging terms', () => {
-      const filter = BaseFilter.fromString('first=1 rows=10');
+      const filter = QueryFilter.fromString('first=1 rows=10');
 
       expect(filter.next().toFilterString()).toBe('first=11 rows=10');
       expect(filter.next().previous().toFilterString()).toBe('first=1 rows=10');
@@ -619,17 +619,17 @@ describe('BaseFilter tests', () => {
     });
   });
 
-  describe('BaseFilter simple', () => {
+  describe('QueryFilter simple', () => {
     test('should remove paging and sorting terms', () => {
-      const filter = BaseFilter.fromString('foo=1 first=1 rows=10 sort=name');
+      const filter = QueryFilter.fromString('foo=1 first=1 rows=10 sort=name');
 
       expect(filter.simple().toFilterString()).toBe('foo=1');
     });
   });
 
-  describe('BaseFilter sort helpers', () => {
+  describe('QueryFilter sort helpers', () => {
     test('setSortOrder and setSortBy should delegate sort updates', () => {
-      const filter = BaseFilter.fromString('sort=name');
+      const filter = QueryFilter.fromString('sort=name');
 
       const reverse = filter.setSortOrder('sort-reverse');
       expect(reverse.getSortOrder()).toBe('sort-reverse');
@@ -641,29 +641,29 @@ describe('BaseFilter tests', () => {
     });
   });
 
-  describe('BaseFilter merge/and/equals', () => {
+  describe('QueryFilter merge/and/equals', () => {
     test('should delegate merge variants and and', () => {
-      const filter = BaseFilter.fromString('foo=1 sort=name');
+      const filter = QueryFilter.fromString('foo=1 sort=name');
 
       expect(filter.merge(undefined)).toBe(filter);
       expect(
-        filter.merge(BaseFilter.fromString('bar=2')).toFilterString(),
+        filter.merge(QueryFilter.fromString('bar=2')).toFilterString(),
       ).toBe('foo=1 sort=name bar=2');
       expect(
         filter
-          .mergeKeywords(BaseFilter.fromString('foo=2 severity>3'))
+          .mergeKeywords(QueryFilter.fromString('foo=2 severity>3'))
           .toFilterString(),
       ).toBe('foo=1 sort=name severity>3');
       expect(
         filter
-          .mergeExtraKeywords(BaseFilter.fromString('bar=2 rows=50'))
+          .mergeExtraKeywords(QueryFilter.fromString('bar=2 rows=50'))
           .toFilterString(),
       ).toBe('foo=1 sort=name rows=50');
-      expect(filter.and(BaseFilter.fromString('bar=2')).toFilterString()).toBe(
+      expect(filter.and(QueryFilter.fromString('bar=2')).toFilterString()).toBe(
         'foo=1 sort=name and bar=2',
       );
       expect(filter.and(undefined)).toBe(filter);
-      expect(filter.equals(BaseFilter.fromString('sort=name foo=1'))).toBe(
+      expect(filter.equals(QueryFilter.fromString('sort=name foo=1'))).toBe(
         true,
       );
     });

--- a/src/gmp/models/filter/__tests__/utils.test.ts
+++ b/src/gmp/models/filter/__tests__/utils.test.ts
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {filterString, isFilterType} from 'gmp/models/filter/utils';
 
 describe('filterString function tests', () => {
@@ -18,17 +18,17 @@ describe('filterString function tests', () => {
   });
 
   test('should return the filter string from Filters', () => {
-    let filter = BaseFilter.fromString('foo bar');
+    let filter = QueryFilter.fromString('foo bar');
     expect(filterString(filter)).toEqual('foo bar');
 
-    filter = BaseFilter.fromString('name=foo and severity>1');
+    filter = QueryFilter.fromString('name=foo and severity>1');
     expect(filterString(filter)).toEqual('name=foo and severity>1');
   });
 });
 
 describe('isFilterType function tests', () => {
   test('should return true for Filter objects', () => {
-    const filter = BaseFilter.fromString('foo bar');
+    const filter = QueryFilter.fromString('foo bar');
     expect(isFilterType(filter)).toBe(true);
   });
 

--- a/src/gmp/models/filter/query-filter.ts
+++ b/src/gmp/models/filter/query-filter.ts
@@ -74,7 +74,7 @@ export interface FilterResponseElement {
   term?: string;
 }
 
-interface BaseFilterParams {
+interface QueryFilterParams {
   id?: string;
   name?: string;
   terms?: FilterTerm[];
@@ -82,12 +82,12 @@ interface BaseFilterParams {
 
 export const UNKNOWN_FILTER_ID = '0';
 
-class BaseFilter implements FilterType {
+class QueryFilter implements FilterType {
   public readonly id?: string;
   public readonly name?: string;
   private readonly filterTerms: FilterTerms;
 
-  constructor({id, name, terms = []}: BaseFilterParams = {}) {
+  constructor({id, name, terms = []}: QueryFilterParams = {}) {
     this.id = id;
     this.name = name;
     this.filterTerms = new FilterTerms({terms});
@@ -108,7 +108,7 @@ class BaseFilter implements FilterType {
   private _delegate(terms: FilterTerms, keepId = false) {
     return terms === this.filterTerms
       ? this
-      : new BaseFilter({
+      : new QueryFilter({
           id: keepId ? this.id : undefined,
           name: this.name,
           terms: [...terms.getAllTerms()],
@@ -141,7 +141,7 @@ class BaseFilter implements FilterType {
       terms = parseFilterTermsFromString(element.term);
     }
 
-    return new BaseFilter({id, name, terms});
+    return new QueryFilter({id, name, terms});
   }
 
   /**
@@ -158,7 +158,7 @@ class BaseFilter implements FilterType {
       terms: parseFilterTermsFromString(filterString),
     }).mergeExtraKeywords(filter) as FilterTerms;
 
-    return new BaseFilter({
+    return new QueryFilter({
       terms: [...filterTerms.getAllTerms()],
     });
   }
@@ -171,7 +171,7 @@ class BaseFilter implements FilterType {
    * @returns The new Filter
    */
   static fromTerm(...term: FilterTerm[]) {
-    return new BaseFilter({
+    return new QueryFilter({
       terms: [...term],
     });
   }
@@ -292,4 +292,4 @@ class BaseFilter implements FilterType {
   }
 }
 
-export default BaseFilter;
+export default QueryFilter;

--- a/src/gmp/models/report/__tests__/parser.test.ts
+++ b/src/gmp/models/report/__tests__/parser.test.ts
@@ -5,7 +5,7 @@
 
 import {describe, test, expect} from '@gsa/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   parseErrors,
   parseCvesFromEndpoint,
@@ -17,7 +17,7 @@ const emptyCollectionCounts = new CollectionCounts();
 
 describe('parseErrors', () => {
   test('should parse errors', () => {
-    const filter = BaseFilter.fromString('foo=bar rows=5');
+    const filter = QueryFilter.fromString('foo=bar rows=5');
     const report = {
       results: {
         result: [
@@ -123,7 +123,7 @@ describe('parseErrors', () => {
   });
 
   test('should parse empty errors', () => {
-    const filter = BaseFilter.fromString('foo=bar rows=5');
+    const filter = QueryFilter.fromString('foo=bar rows=5');
     const report = {};
     const errors = parseErrors(report, filter);
 
@@ -135,7 +135,7 @@ describe('parseErrors', () => {
 
 describe('parseCvesFromEndpoint', () => {
   test('should parse multiple cve elements', () => {
-    const filter = BaseFilter.fromString('first=1 rows=100');
+    const filter = QueryFilter.fromString('first=1 rows=100');
     const data = {
       cves: {
         cve: [
@@ -172,7 +172,7 @@ describe('parseCvesFromEndpoint', () => {
   });
 
   test('should handle a single cve element (not array)', () => {
-    const filter = BaseFilter.fromString('first=1 rows=100');
+    const filter = QueryFilter.fromString('first=1 rows=100');
     const data = {
       cves: {
         cve: {
@@ -194,7 +194,7 @@ describe('parseCvesFromEndpoint', () => {
   });
 
   test('should fall back to nvt __text when name child is absent', () => {
-    const filter = BaseFilter.fromString('first=1 rows=100');
+    const filter = QueryFilter.fromString('first=1 rows=100');
     const data = {
       cves: {
         cve: {
@@ -212,7 +212,7 @@ describe('parseCvesFromEndpoint', () => {
   });
 
   test('should return empty list when cves container is missing', () => {
-    const filter = BaseFilter.fromString('first=1 rows=100');
+    const filter = QueryFilter.fromString('first=1 rows=100');
 
     const result = parseCvesFromEndpoint({}, filter);
 
@@ -222,7 +222,7 @@ describe('parseCvesFromEndpoint', () => {
   });
 
   test('should use server count for counts.all when provided', () => {
-    const filter = BaseFilter.fromString('first=1 rows=100');
+    const filter = QueryFilter.fromString('first=1 rows=100');
     const data = {
       cves: {
         count: 999,
@@ -242,7 +242,7 @@ describe('parseCvesFromEndpoint', () => {
 
 describe('parseClosedCvesFromEndpoint', () => {
   test('should parse multiple closed_cve elements', () => {
-    const filter = BaseFilter.fromString('first=1 rows=100');
+    const filter = QueryFilter.fromString('first=1 rows=100');
     const data = {
       closed_cves: {
         closed_cve: [
@@ -279,7 +279,7 @@ describe('parseClosedCvesFromEndpoint', () => {
   });
 
   test('should handle a single closed_cve element (not array)', () => {
-    const filter = BaseFilter.fromString('first=1 rows=100');
+    const filter = QueryFilter.fromString('first=1 rows=100');
     const data = {
       closed_cves: {
         closed_cve: {
@@ -301,7 +301,7 @@ describe('parseClosedCvesFromEndpoint', () => {
   });
 
   test('should fall back to nvt __text when name child is absent', () => {
-    const filter = BaseFilter.fromString('first=1 rows=100');
+    const filter = QueryFilter.fromString('first=1 rows=100');
     const data = {
       closed_cves: {
         closed_cve: {
@@ -319,7 +319,7 @@ describe('parseClosedCvesFromEndpoint', () => {
   });
 
   test('should return empty list when closed_cves container is missing', () => {
-    const filter = BaseFilter.fromString('first=1 rows=100');
+    const filter = QueryFilter.fromString('first=1 rows=100');
 
     const result = parseClosedCvesFromEndpoint({}, filter);
 
@@ -329,7 +329,7 @@ describe('parseClosedCvesFromEndpoint', () => {
   });
 
   test('should use server count for counts.all when provided', () => {
-    const filter = BaseFilter.fromString('first=1 rows=100');
+    const filter = QueryFilter.fromString('first=1 rows=100');
     const data = {
       closed_cves: {
         count: 500,
@@ -347,7 +347,7 @@ describe('parseClosedCvesFromEndpoint', () => {
   });
 
   test('should build composite id from cve, host, and nvt oid', () => {
-    const filter = BaseFilter.fromString('first=1 rows=100');
+    const filter = QueryFilter.fromString('first=1 rows=100');
     const data = {
       closed_cves: {
         closed_cve: {

--- a/src/gmp/models/report/report.ts
+++ b/src/gmp/models/report/report.ts
@@ -6,7 +6,7 @@
 import {type CollectionList, parseFilter} from 'gmp/collection/parser';
 import {type Date} from 'gmp/models/date';
 import {type FilterType} from 'gmp/models/filter';
-import {type FilterKeyword} from 'gmp/models/filter/base-filter';
+import {type FilterKeyword} from 'gmp/models/filter/query-filter';
 import Model, {type ModelElement, type ModelProperties} from 'gmp/models/model';
 import {
   parseResults,

--- a/src/web/components/dashboard/display/created/CreatedDisplay.jsx
+++ b/src/web/components/dashboard/display/created/CreatedDisplay.jsx
@@ -4,8 +4,8 @@
  */
 
 import React from 'react';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isDefined} from 'gmp/utils/identity';
 import LineChart, {lineDataPropType} from 'web/components/chart/base/Line';
 import transformCreated from 'web/components/dashboard/display/created/CreatedTransform';
@@ -30,7 +30,7 @@ class CreatedDisplay extends React.Component {
     let {x: endDate} = end;
     const dateFormat = 'YYYY-MM-DDTHH:mm';
 
-    let newFilter = isDefined(filter) ? filter.copy() : new BaseFilter();
+    let newFilter = isDefined(filter) ? filter.copy() : new QueryFilter();
 
     if (isDefined(startDate)) {
       if (startDate.isSame(endDate)) {
@@ -43,7 +43,7 @@ class CreatedDisplay extends React.Component {
       );
 
       if (!newFilter.hasTerm(startTerm)) {
-        newFilter = newFilter.and(BaseFilter.fromTerm(startTerm));
+        newFilter = newFilter.and(QueryFilter.fromTerm(startTerm));
       }
     }
 
@@ -53,7 +53,7 @@ class CreatedDisplay extends React.Component {
       );
 
       if (!newFilter.hasTerm(endTerm)) {
-        newFilter = newFilter.and(BaseFilter.fromTerm(endTerm));
+        newFilter = newFilter.and(QueryFilter.fromTerm(endTerm));
       }
     }
 

--- a/src/web/components/dashboard/display/cvss/CvssDisplay.jsx
+++ b/src/web/components/dashboard/display/cvss/CvssDisplay.jsx
@@ -4,8 +4,8 @@
  */
 
 import React from 'react';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isDefined} from 'gmp/utils/identity';
 import BarChart from 'web/components/chart/Bar';
 import transformCvssData from 'web/components/dashboard/display/cvss/cvss-transform';
@@ -48,8 +48,8 @@ const CvssDisplay = ({
         return;
       }
 
-      statusFilter = BaseFilter.fromTerm(startTerm).and(
-        BaseFilter.fromTerm(endTerm),
+      statusFilter = QueryFilter.fromTerm(startTerm).and(
+        QueryFilter.fromTerm(endTerm),
       );
     } else {
       let statusTerm;
@@ -64,7 +64,7 @@ const CvssDisplay = ({
         return;
       }
 
-      statusFilter = BaseFilter.fromTerm(statusTerm);
+      statusFilter = QueryFilter.fromTerm(statusTerm);
     }
 
     const newFilter = isDefined(filter)

--- a/src/web/components/dashboard/display/severity/SeverityClassDisplay.tsx
+++ b/src/web/components/dashboard/display/severity/SeverityClassDisplay.tsx
@@ -4,7 +4,7 @@
  */
 
 import {type FilterType} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isDefined} from 'gmp/utils/identity';
 import DonutChart from 'web/components/chart/Donut';
 import DataDisplay, {
@@ -72,15 +72,15 @@ const SeverityClassDisplay = ({
         return;
       }
 
-      severityFilter = BaseFilter.fromTerm(startTerm).and(
-        BaseFilter.fromTerm(endTerm),
+      severityFilter = QueryFilter.fromTerm(startTerm).and(
+        QueryFilter.fromTerm(endTerm),
       );
     } else {
       if (isDefined(filter) && filter.hasTerm(startTerm)) {
         return;
       }
 
-      severityFilter = BaseFilter.fromTerm(startTerm);
+      severityFilter = QueryFilter.fromTerm(startTerm);
     }
 
     const newFilter = isDefined(filter)

--- a/src/web/components/dashboard/display/status/StatusDisplay.jsx
+++ b/src/web/components/dashboard/display/status/StatusDisplay.jsx
@@ -4,8 +4,8 @@
  */
 
 import React from 'react';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isDefined} from 'gmp/utils/identity';
 import DonutChart from 'web/components/chart/Donut';
 import DataDisplay from 'web/components/dashboard/display/DataDisplay';
@@ -32,7 +32,7 @@ class StatusDisplay extends React.Component {
         return;
       }
 
-      const statusFilter = BaseFilter.fromTerm(statusTerm);
+      const statusFilter = QueryFilter.fromTerm(statusTerm);
       const newFilter = isDefined(filter)
         ? filter.copy().and(statusFilter)
         : statusFilter;

--- a/src/web/components/link/__tests__/Link.test.tsx
+++ b/src/web/components/link/__tests__/Link.test.tsx
@@ -5,7 +5,7 @@
 
 import {describe, test, expect} from '@gsa/testing';
 import {rendererWith, fireEvent, screen} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Link from 'web/components/link/Link';
 
 describe('Link tests', () => {
@@ -40,7 +40,7 @@ describe('Link tests', () => {
   });
 
   test('should route to url with filter on click', () => {
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const {render} = rendererWith({
       router: true,
       showLocation: true,

--- a/src/web/components/powerfilter/PowerFilter.tsx
+++ b/src/web/components/powerfilter/PowerFilter.tsx
@@ -12,7 +12,7 @@ import {
   type FilterType,
   RESET_FILTER,
 } from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isFilterType} from 'gmp/models/filter/utils';
 import {KeyEvent} from 'gmp/utils/event';
 import {isDefined, isString} from 'gmp/utils/identity';
@@ -127,7 +127,7 @@ class PowerFilter extends React.Component<PowerFilterProps, PowerFilterState> {
     const {filter} = this.props;
     const {userFilterString} = this.state;
 
-    this.updateFilter(BaseFilter.fromString(userFilterString, filter));
+    this.updateFilter(QueryFilter.fromString(userFilterString, filter));
   }
 
   resetUserFilterString() {

--- a/src/web/components/powerfilter/__tests__/ApplyOverridesGroup.test.tsx
+++ b/src/web/components/powerfilter/__tests__/ApplyOverridesGroup.test.tsx
@@ -5,12 +5,12 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, render, fireEvent} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ApplyOverridesGroup from 'web/components/powerfilter/ApplyOverridesGroup';
 
 describe('ApplyOverridesGroup tests', () => {
   test('should render', () => {
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
     const handleChange = testing.fn();
     const {element} = render(
       <ApplyOverridesGroup
@@ -25,7 +25,7 @@ describe('ApplyOverridesGroup tests', () => {
   });
 
   test('should call change handler', () => {
-    const filter = BaseFilter.fromString('apply_overrides=1');
+    const filter = QueryFilter.fromString('apply_overrides=1');
     const handleChange = testing.fn();
 
     render(
@@ -43,7 +43,7 @@ describe('ApplyOverridesGroup tests', () => {
   });
 
   test('should check radio', () => {
-    const filter = BaseFilter.fromString('apply_overrides=1');
+    const filter = QueryFilter.fromString('apply_overrides=1');
     const handleChange = testing.fn();
 
     render(
@@ -60,8 +60,8 @@ describe('ApplyOverridesGroup tests', () => {
   });
 
   test('should uncheck radio of previous choice', () => {
-    const filter1 = BaseFilter.fromString('apply_overrides=1');
-    const filter2 = BaseFilter.fromString('apply_overrides=0');
+    const filter1 = QueryFilter.fromString('apply_overrides=1');
+    const filter2 = QueryFilter.fromString('apply_overrides=0');
     const handleChange = testing.fn();
 
     const {rerender} = render(
@@ -92,7 +92,7 @@ describe('ApplyOverridesGroup tests', () => {
   });
 
   test('should use filter value by default', () => {
-    const filter = BaseFilter.fromString('apply_overrides=1');
+    const filter = QueryFilter.fromString('apply_overrides=1');
     const handleChange = testing.fn();
 
     render(

--- a/src/web/components/powerfilter/__tests__/BooleanFilterGroup.test.tsx
+++ b/src/web/components/powerfilter/__tests__/BooleanFilterGroup.test.tsx
@@ -5,7 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, render, fireEvent} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {NO_VALUE, YES_VALUE} from 'gmp/parser';
 import BooleanFilterGroup from 'web/components/powerfilter/BooleanFilterGroup';
 
@@ -29,7 +29,7 @@ describe('BooleanFilterGroup tests', () => {
   });
 
   test("should check radio based on filter's value", () => {
-    const filter = BaseFilter.fromString('test=1');
+    const filter = QueryFilter.fromString('test=1');
     const {rerender} = render(
       <BooleanFilterGroup filter={filter} name="test" />,
     );

--- a/src/web/components/powerfilter/__tests__/ComplianceLevelsGroup.test.tsx
+++ b/src/web/components/powerfilter/__tests__/ComplianceLevelsGroup.test.tsx
@@ -5,12 +5,12 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {render, fireEvent, screen} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ComplianceLevelsFilterGroup from 'web/components/powerfilter/ComplianceLevelsGroup';
 
 describe('ComplianceLevelsFilterGroup audit reports tests', () => {
   test('should call change handler', () => {
-    const filter = BaseFilter.fromString('report_compliance_levels=');
+    const filter = QueryFilter.fromString('report_compliance_levels=');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     render(
@@ -46,7 +46,7 @@ describe('ComplianceLevelsFilterGroup audit reports tests', () => {
   });
 
   test('should check checkbox', () => {
-    const filter = BaseFilter.fromString('report_compliance_levels=yn');
+    const filter = QueryFilter.fromString('report_compliance_levels=yn');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     render(
@@ -77,8 +77,8 @@ describe('ComplianceLevelsFilterGroup audit reports tests', () => {
   });
 
   test('should uncheck checkbox', () => {
-    const filter1 = BaseFilter.fromString('report_compliance_levels=yni');
-    const filter2 = BaseFilter.fromString('report_compliance_levels=yn');
+    const filter1 = QueryFilter.fromString('report_compliance_levels=yni');
+    const filter2 = QueryFilter.fromString('report_compliance_levels=yn');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     const {rerender} = render(
@@ -122,7 +122,7 @@ describe('ComplianceLevelsFilterGroup audit reports tests', () => {
   });
 
   test('should be unchecked by default', () => {
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     render(
@@ -153,7 +153,7 @@ describe('ComplianceLevelsFilterGroup audit reports tests', () => {
   });
 
   test('should call remove handler', () => {
-    const filter = BaseFilter.fromString('report_compliance_levels=y');
+    const filter = QueryFilter.fromString('report_compliance_levels=y');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     render(
@@ -191,7 +191,7 @@ describe('ComplianceLevelsFilterGroup audit reports tests', () => {
 
 describe('ComplianceLevelsFilterGroup audit results tests', () => {
   test('should call change handler', () => {
-    const filter = BaseFilter.fromString('compliance_levels=');
+    const filter = QueryFilter.fromString('compliance_levels=');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     render(
@@ -226,7 +226,7 @@ describe('ComplianceLevelsFilterGroup audit results tests', () => {
   });
 
   test('should check checkbox', () => {
-    const filter = BaseFilter.fromString('compliance_levels=yn');
+    const filter = QueryFilter.fromString('compliance_levels=yn');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     render(
@@ -258,8 +258,8 @@ describe('ComplianceLevelsFilterGroup audit results tests', () => {
   });
 
   test('should uncheck checkbox', () => {
-    const filter1 = BaseFilter.fromString('compliance_levels=yni');
-    const filter2 = BaseFilter.fromString('compliance_levels=yn');
+    const filter1 = QueryFilter.fromString('compliance_levels=yni');
+    const filter2 = QueryFilter.fromString('compliance_levels=yn');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     const {rerender} = render(
@@ -305,7 +305,7 @@ describe('ComplianceLevelsFilterGroup audit results tests', () => {
   });
 
   test('should be unchecked by default', () => {
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     render(
@@ -337,7 +337,7 @@ describe('ComplianceLevelsFilterGroup audit results tests', () => {
   });
 
   test('should call remove handler', () => {
-    const filter = BaseFilter.fromString('compliance_levels=y');
+    const filter = QueryFilter.fromString('compliance_levels=y');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     render(

--- a/src/web/components/powerfilter/__tests__/DefaultFilterDialog.test.tsx
+++ b/src/web/components/powerfilter/__tests__/DefaultFilterDialog.test.tsx
@@ -12,13 +12,13 @@ import {
   openSelectElement,
 } from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import DefaultFilterDialog from 'web/components/powerfilter/DefaultFilterDialog';
 
 describe('DefaultFilterDialog tests', () => {
   test('should render with children', () => {
     const {render} = rendererWith({capabilities: true});
-    const filter = BaseFilter.fromString('first=45 rows=100 sort=name');
+    const filter = QueryFilter.fromString('first=45 rows=100 sort=name');
     render(
       <DefaultFilterDialog
         filter={filter}
@@ -39,7 +39,7 @@ describe('DefaultFilterDialog tests', () => {
 
   test("should not render save named filter if capabilities don't allow it", () => {
     const {render} = rendererWith({capabilities: new Capabilities()});
-    const filter = BaseFilter.fromString('first=45 rows=100 sort=name');
+    const filter = QueryFilter.fromString('first=45 rows=100 sort=name');
     render(
       <DefaultFilterDialog
         filter={filter}
@@ -60,7 +60,7 @@ describe('DefaultFilterDialog tests', () => {
 
   test('should allow to change filter to save', () => {
     const {render} = rendererWith({capabilities: true});
-    const filter = BaseFilter.fromString('first=45 rows=100 sort=name');
+    const filter = QueryFilter.fromString('first=45 rows=100 sort=name');
     const handleValueChange = testing.fn();
     render(
       <DefaultFilterDialog
@@ -81,7 +81,7 @@ describe('DefaultFilterDialog tests', () => {
 
   test('should allow to change filter string', () => {
     const {render} = rendererWith({capabilities: true});
-    const filter = BaseFilter.fromString('first=45 rows=100 sort=name');
+    const filter = QueryFilter.fromString('first=45 rows=100 sort=name');
     const handleFilterStringChange = testing.fn();
     render(
       <DefaultFilterDialog
@@ -104,7 +104,7 @@ describe('DefaultFilterDialog tests', () => {
 
   test('should allow to change filter value', () => {
     const {render} = rendererWith({capabilities: true});
-    const filter = BaseFilter.fromString('first=45 rows=100 sort=name');
+    const filter = QueryFilter.fromString('first=45 rows=100 sort=name');
     const handleValueChange = testing.fn();
     render(
       <DefaultFilterDialog
@@ -127,7 +127,7 @@ describe('DefaultFilterDialog tests', () => {
 
   test('should allow to change sort by field', async () => {
     const {render} = rendererWith({capabilities: true});
-    const filter = BaseFilter.fromString('first=45 rows=100 sort=name');
+    const filter = QueryFilter.fromString('first=45 rows=100 sort=name');
     const handleSortByChange = testing.fn();
     render(
       <DefaultFilterDialog

--- a/src/web/components/powerfilter/__tests__/FilterSearchGroup.test.tsx
+++ b/src/web/components/powerfilter/__tests__/FilterSearchGroup.test.tsx
@@ -5,7 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, render, changeInputValue} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import FilterSearchGroup from 'web/components/powerfilter/FilterSearchGroup';
 
 describe('FilterSearchGroup tests', () => {
@@ -15,7 +15,7 @@ describe('FilterSearchGroup tests', () => {
   });
 
   test('should display filter value', () => {
-    const filter = BaseFilter.fromString('test="value"');
+    const filter = QueryFilter.fromString('test="value"');
     render(<FilterSearchGroup filter={filter} name="test" />);
     expect(screen.getByName('test')).toHaveValue('value');
   });

--- a/src/web/components/powerfilter/__tests__/FilterStringGroup.test.tsx
+++ b/src/web/components/powerfilter/__tests__/FilterStringGroup.test.tsx
@@ -5,7 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, render, changeInputValue} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import FilterStringGroup from 'web/components/powerfilter/FilterStringGroup';
 
 describe('FilterStringGroup tests', () => {
@@ -20,7 +20,7 @@ describe('FilterStringGroup tests', () => {
   });
 
   test('should render filter', () => {
-    const filter = BaseFilter.fromString('test="value"');
+    const filter = QueryFilter.fromString('test="value"');
     render(<FilterStringGroup filter={filter} />);
     expect(screen.getByName('filter')).toHaveValue('test="value"');
   });

--- a/src/web/components/powerfilter/__tests__/FirstResultGroup.test.tsx
+++ b/src/web/components/powerfilter/__tests__/FirstResultGroup.test.tsx
@@ -5,7 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, render, changeInputValue} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import FirstResultGroup from 'web/components/powerfilter/FirstResultGroup';
 
 describe('FirstResultGroup tests', () => {
@@ -20,7 +20,7 @@ describe('FirstResultGroup tests', () => {
   });
 
   test('should render filter first value', () => {
-    const filter = BaseFilter.fromString('first=10');
+    const filter = QueryFilter.fromString('first=10');
     render(<FirstResultGroup filter={filter} />);
     expect(screen.getByName('first')).toHaveValue('10');
   });
@@ -33,7 +33,7 @@ describe('FirstResultGroup tests', () => {
     changeInputValue(screen.getByName('first'), '15');
     expect(handleChange).toHaveBeenCalledWith(15, 'first');
 
-    const filter = BaseFilter.fromString('first=20');
+    const filter = QueryFilter.fromString('first=20');
     rerender(<FirstResultGroup filter={filter} onChange={handleChange} />);
     changeInputValue(screen.getByName('first'), '25');
     expect(handleChange).toHaveBeenCalledWith(25, 'first');

--- a/src/web/components/powerfilter/__tests__/MinQodGroup.test.tsx
+++ b/src/web/components/powerfilter/__tests__/MinQodGroup.test.tsx
@@ -5,7 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, render, changeInputValue} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import MinQodGroup from 'web/components/powerfilter/MinQodGroup';
 
 describe('MinQodGroup tests', () => {
@@ -20,7 +20,7 @@ describe('MinQodGroup tests', () => {
   });
 
   test('should render filter min_qod value', () => {
-    const filter = BaseFilter.fromString('min_qod=20');
+    const filter = QueryFilter.fromString('min_qod=20');
     render(<MinQodGroup filter={filter} />);
     expect(screen.getByName('min_qod')).toHaveValue('20');
   });
@@ -31,7 +31,7 @@ describe('MinQodGroup tests', () => {
     changeInputValue(screen.getByName('min_qod'), '30');
     expect(handleChange).toHaveBeenCalledWith(30, 'min_qod');
 
-    const filter = BaseFilter.fromString('min_qod=40');
+    const filter = QueryFilter.fromString('min_qod=40');
     rerender(<MinQodGroup filter={filter} onChange={handleChange} />);
     changeInputValue(screen.getByName('min_qod'), '50');
     expect(handleChange).toHaveBeenCalledWith(50, 'min_qod');

--- a/src/web/components/powerfilter/__tests__/ResultsPerPageGroup.test.tsx
+++ b/src/web/components/powerfilter/__tests__/ResultsPerPageGroup.test.tsx
@@ -5,7 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, render, changeInputValue} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ResultsPerPageGroup from 'web/components/powerfilter/ResultsPerPageGroup';
 
 describe('ResultsPerPageGroup tests', () => {
@@ -30,7 +30,7 @@ describe('ResultsPerPageGroup tests', () => {
   });
 
   test("should use filter's rows value if provided", () => {
-    const filter = BaseFilter.fromString('rows=30');
+    const filter = QueryFilter.fromString('rows=30');
     render(<ResultsPerPageGroup filter={filter} />);
     expect(screen.getByName('rows')).toHaveValue('30');
   });

--- a/src/web/components/powerfilter/__tests__/SeverityLevelsGroup.test.tsx
+++ b/src/web/components/powerfilter/__tests__/SeverityLevelsGroup.test.tsx
@@ -5,7 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   DEFAULT_SEVERITY_RATING,
   SEVERITY_RATING_CVSS_2,
@@ -21,7 +21,7 @@ describe('SeverityLevelsFilterGroup tests', () => {
       },
     };
     const {render} = rendererWith({gmp});
-    const filter = BaseFilter.fromString('levels=h');
+    const filter = QueryFilter.fromString('levels=h');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     const {element} = render(
@@ -42,7 +42,7 @@ describe('SeverityLevelsFilterGroup tests', () => {
       },
     };
     const {render} = rendererWith({gmp});
-    const filter = BaseFilter.fromString('levels=');
+    const filter = QueryFilter.fromString('levels=');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     render(
@@ -67,7 +67,7 @@ describe('SeverityLevelsFilterGroup tests', () => {
       },
     };
     const {render} = rendererWith({gmp});
-    const filter = BaseFilter.fromString('levels=hm');
+    const filter = QueryFilter.fromString('levels=hm');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     render(
@@ -91,8 +91,8 @@ describe('SeverityLevelsFilterGroup tests', () => {
       },
     };
     const {render} = rendererWith({gmp});
-    const filter1 = BaseFilter.fromString('levels=hm');
-    const filter2 = BaseFilter.fromString('levels=m');
+    const filter1 = QueryFilter.fromString('levels=hm');
+    const filter2 = QueryFilter.fromString('levels=m');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     const {rerender} = render(
@@ -125,7 +125,7 @@ describe('SeverityLevelsFilterGroup tests', () => {
       },
     };
     const {render} = rendererWith({gmp});
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     render(
@@ -149,7 +149,7 @@ describe('SeverityLevelsFilterGroup tests', () => {
       },
     };
     const {render} = rendererWith({gmp});
-    const filter = BaseFilter.fromString('levels=h');
+    const filter = QueryFilter.fromString('levels=h');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     render(
@@ -175,7 +175,7 @@ describe('SeverityLevelsFilterGroup tests', () => {
       },
     };
     const {render} = rendererWith({gmp});
-    const filter = BaseFilter.fromString('levels=c');
+    const filter = QueryFilter.fromString('levels=c');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     render(
@@ -198,7 +198,7 @@ describe('SeverityLevelsFilterGroup tests', () => {
       },
     };
     const {render} = rendererWith({gmp});
-    const filter = BaseFilter.fromString('levels=c');
+    const filter = QueryFilter.fromString('levels=c');
     const handleChange = testing.fn();
     const handleRemove = testing.fn();
     render(

--- a/src/web/components/powerfilter/__tests__/SeverityValuesGroup.test.tsx
+++ b/src/web/components/powerfilter/__tests__/SeverityValuesGroup.test.tsx
@@ -11,12 +11,12 @@ import {
   fireEvent,
   changeInputValue,
 } from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import SeverityValuesGroup from 'web/components/powerfilter/SeverityValuesGroup';
 
 describe('Severity Values Group Tests', () => {
   test('should render', () => {
-    const filter = BaseFilter.fromString('severity>3');
+    const filter = QueryFilter.fromString('severity>3');
     const name = 'severity';
     const onChange = testing.fn();
 
@@ -35,7 +35,7 @@ describe('Severity Values Group Tests', () => {
 
   test('should initialize value with 0 in case no filter value is given', () => {
     const onChange = testing.fn();
-    const filter = BaseFilter.fromString('rows=10');
+    const filter = QueryFilter.fromString('rows=10');
     const name = 'severity';
 
     render(
@@ -53,7 +53,7 @@ describe('Severity Values Group Tests', () => {
 
   test('should change value', () => {
     const onChange = testing.fn();
-    const filter = BaseFilter.fromString('severity=3');
+    const filter = QueryFilter.fromString('severity=3');
 
     render(
       <SeverityValuesGroup
@@ -70,7 +70,7 @@ describe('Severity Values Group Tests', () => {
 
   test('should change relationship', async () => {
     const onChange = testing.fn();
-    const filter = BaseFilter.fromString('severity=3');
+    const filter = QueryFilter.fromString('severity=3');
     const name = 'severity';
 
     render(
@@ -93,7 +93,7 @@ describe('Severity Values Group Tests', () => {
 
   test('should render title', () => {
     const title = 'Severity';
-    const filter = BaseFilter.fromString('severity=3');
+    const filter = QueryFilter.fromString('severity=3');
     render(
       <SeverityValuesGroup filter={filter} name="severity" title={title} />,
     );

--- a/src/web/components/powerfilter/__tests__/SolutionTypeGroup.test.tsx
+++ b/src/web/components/powerfilter/__tests__/SolutionTypeGroup.test.tsx
@@ -5,12 +5,12 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, render, fireEvent} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import SolutionTypesFilterGroup from 'web/components/powerfilter/SolutionTypeGroup';
 
 describe('SolutionTypesFilterGroup tests', () => {
   test('should render', () => {
-    const filter = BaseFilter.fromString('solution_type=All');
+    const filter = QueryFilter.fromString('solution_type=All');
     const handleChange = testing.fn();
     const {element} = render(
       <SolutionTypesFilterGroup filter={filter} onChange={handleChange} />,
@@ -20,7 +20,7 @@ describe('SolutionTypesFilterGroup tests', () => {
   });
 
   test('should call change handler', () => {
-    const filter = BaseFilter.fromString('solution_type=Mitigation');
+    const filter = QueryFilter.fromString('solution_type=Mitigation');
     const handleChange = testing.fn();
 
     render(
@@ -36,7 +36,7 @@ describe('SolutionTypesFilterGroup tests', () => {
   });
 
   test('should check radio', () => {
-    const filter = BaseFilter.fromString('solution_type=Workaround');
+    const filter = QueryFilter.fromString('solution_type=Workaround');
     const handleChange = testing.fn();
 
     render(
@@ -47,8 +47,8 @@ describe('SolutionTypesFilterGroup tests', () => {
   });
 
   test('should uncheck radio of previous choice', () => {
-    const filter1 = BaseFilter.fromString('solution_type=Workaround');
-    const filter2 = BaseFilter.fromString('solution_type=Mitigation');
+    const filter1 = QueryFilter.fromString('solution_type=Workaround');
+    const filter2 = QueryFilter.fromString('solution_type=Mitigation');
     const handleChange = testing.fn();
 
     const {rerender} = render(
@@ -67,7 +67,7 @@ describe('SolutionTypesFilterGroup tests', () => {
   });
 
   test('should check "All" by default', () => {
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
     const handleChange = testing.fn();
 
     render(

--- a/src/web/components/powerfilter/__tests__/SortByGroup.test.tsx
+++ b/src/web/components/powerfilter/__tests__/SortByGroup.test.tsx
@@ -5,12 +5,12 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {openSelectElement, screen, render, fireEvent} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import SortByGroup from 'web/components/powerfilter/SortByGroup';
 
 describe('SortByGroup tests', () => {
   test('should render', () => {
-    const filter = BaseFilter.fromString('sort');
+    const filter = QueryFilter.fromString('sort');
     const handleSortByChange = testing.fn();
     const handleSortOrderChange = testing.fn();
     const {element} = render(
@@ -28,7 +28,7 @@ describe('SortByGroup tests', () => {
   });
 
   test('should render fields', async () => {
-    const filter1 = BaseFilter.fromString('sort=severity');
+    const filter1 = QueryFilter.fromString('sort=severity');
     const handleSortByChange = testing.fn();
     const handleSortOrderChange = testing.fn();
 
@@ -56,8 +56,8 @@ describe('SortByGroup tests', () => {
   });
 
   test('should use filter by default', () => {
-    const filter1 = BaseFilter.fromString('sort=severity');
-    const filter2 = BaseFilter.fromString('sort-reverse=severity');
+    const filter1 = QueryFilter.fromString('sort=severity');
+    const filter2 = QueryFilter.fromString('sort-reverse=severity');
     const handleSortByChange = testing.fn();
     const handleSortOrderChange = testing.fn();
 
@@ -123,7 +123,7 @@ describe('SortByGroup tests', () => {
   });
 
   test('should call change handler of select', async () => {
-    const filter = BaseFilter.fromString('sort');
+    const filter = QueryFilter.fromString('sort');
     const handleSortByChange = testing.fn();
     const handleSortOrderChange = testing.fn();
 
@@ -152,7 +152,7 @@ describe('SortByGroup tests', () => {
   });
 
   test('should call change handler of radio button', () => {
-    const filter = BaseFilter.fromString('sort');
+    const filter = QueryFilter.fromString('sort');
     const handleSortByChange = testing.fn();
     const handleSortOrderChange = testing.fn();
 

--- a/src/web/components/powerfilter/__tests__/TaskTrendGroup.test.tsx
+++ b/src/web/components/powerfilter/__tests__/TaskTrendGroup.test.tsx
@@ -5,13 +5,13 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {openSelectElement, screen, fireEvent, render} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import TaskTrendGroup from 'web/components/powerfilter/TaskTrendGroup';
 
 describe('Task Trend Selector Tests', () => {
   test('should render', () => {
     const onChange = testing.fn();
-    const filter = BaseFilter.fromString('trend=down');
+    const filter = QueryFilter.fromString('trend=down');
     const {element} = render(
       <TaskTrendGroup filter={filter} onChange={onChange} />,
     );
@@ -20,7 +20,7 @@ describe('Task Trend Selector Tests', () => {
 
   test('should return items', async () => {
     const onChange = testing.fn();
-    const filter = BaseFilter.fromString('trend=down');
+    const filter = QueryFilter.fromString('trend=down');
 
     render(<TaskTrendGroup filter={filter} onChange={onChange} />);
 
@@ -37,7 +37,7 @@ describe('Task Trend Selector Tests', () => {
 
   test('should parse filter', () => {
     const onChange = testing.fn();
-    const filter = BaseFilter.fromString('trend=same');
+    const filter = QueryFilter.fromString('trend=same');
 
     render(<TaskTrendGroup filter={filter} onChange={onChange} />);
 
@@ -47,7 +47,7 @@ describe('Task Trend Selector Tests', () => {
 
   test('should call onChange handler', async () => {
     const onChange = testing.fn();
-    const filter = BaseFilter.fromString('trend=down');
+    const filter = QueryFilter.fromString('trend=down');
 
     render(<TaskTrendGroup filter={filter} onChange={onChange} />);
 
@@ -62,7 +62,7 @@ describe('Task Trend Selector Tests', () => {
 
   test('should change value', async () => {
     const onChange = testing.fn();
-    const filter = BaseFilter.fromString('trend=down');
+    const filter = QueryFilter.fromString('trend=down');
 
     render(<TaskTrendGroup filter={filter} trend="up" onChange={onChange} />);
 

--- a/src/web/components/powerfilter/__tests__/TicketStatusGroup.test.tsx
+++ b/src/web/components/powerfilter/__tests__/TicketStatusGroup.test.tsx
@@ -5,12 +5,12 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {openSelectElement, screen, fireEvent, render} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import TicketStatusGroup from 'web/components/powerfilter/TicketStatusGroup';
 
 describe('TicketStatusGroup tests', () => {
   test('should render', () => {
-    const filter = BaseFilter.fromString('status=Closed');
+    const filter = QueryFilter.fromString('status=Closed');
     const handleChange = testing.fn();
 
     const {element} = render(
@@ -24,7 +24,7 @@ describe('TicketStatusGroup tests', () => {
   });
 
   test('should allow to change value', async () => {
-    const filter = BaseFilter.fromString('status=Closed');
+    const filter = QueryFilter.fromString('status=Closed');
     const handleChange = testing.fn();
 
     render(
@@ -47,7 +47,7 @@ describe('TicketStatusGroup tests', () => {
   });
 
   test('should render title', () => {
-    const filter = BaseFilter.fromString('status=Open');
+    const filter = QueryFilter.fromString('status=Open');
     const handleChange = testing.fn();
 
     render(

--- a/src/web/components/powerfilter/__tests__/useFilterDialogSave.test.tsx
+++ b/src/web/components/powerfilter/__tests__/useFilterDialogSave.test.tsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith} from 'web/testing';
 import Filter from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import useFilterDialogSave from 'web/components/powerfilter/useFilterDialogSave';
 
 describe('useFilterDialogSave', () => {
@@ -33,9 +33,9 @@ describe('useFilterDialogSave', () => {
         {
           filterName: '  My Filter  ',
           saveNamedFilter: true,
-          filter: BaseFilter.fromString('foo=bar'),
+          filter: QueryFilter.fromString('foo=bar'),
           filterString: 'rows=10',
-          originalFilter: BaseFilter.fromString('foo=bar'),
+          originalFilter: QueryFilter.fromString('foo=bar'),
         },
       ),
     );
@@ -71,9 +71,9 @@ describe('useFilterDialogSave', () => {
         {
           filterName: '   ',
           saveNamedFilter: true,
-          filter: BaseFilter.fromString('foo=bar'),
+          filter: QueryFilter.fromString('foo=bar'),
           filterString: 'rows=10',
-          originalFilter: BaseFilter.fromString('foo=bar'),
+          originalFilter: QueryFilter.fromString('foo=bar'),
         },
       ),
     );

--- a/src/web/components/powerfilter/useFilterDialog.tsx
+++ b/src/web/components/powerfilter/useFilterDialog.tsx
@@ -4,11 +4,11 @@
  */
 
 import {useCallback, useState} from 'react';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import {
   type default as FilterType,
   type FilterSortOrder,
 } from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isDefined} from 'gmp/utils/identity';
 
 export interface FilterDialogState {
@@ -28,7 +28,7 @@ const useFilterDialog = <TFilterDialogState extends FilterDialogState>(
 ) => {
   const [originalFilter] = useState(initialFilter);
   const [filter, setFilter] = useState<FilterType>(() =>
-    isDefined(initialFilter) ? initialFilter : new BaseFilter(),
+    isDefined(initialFilter) ? initialFilter : new QueryFilter(),
   );
   const [filterDialogState, setFilterDialogState] =
     useState<TFilterDialogState>({} as TFilterDialogState);

--- a/src/web/components/powerfilter/useFilterDialogSave.tsx
+++ b/src/web/components/powerfilter/useFilterDialogSave.tsx
@@ -5,7 +5,7 @@
 
 import {useCallback} from 'react';
 import {type default as Filter, type FilterType} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {type EntityType} from 'gmp/utils/entity-type';
 import {isDefined} from 'gmp/utils/identity';
 import useGmp from 'web/hooks/useGmp';
@@ -73,7 +73,9 @@ const useFilterDialogSave = (
   );
 
   const handleSave: () => Promise<void> = useCallback(() => {
-    const newFilter = filter.mergeKeywords(BaseFilter.fromString(filterString));
+    const newFilter = filter.mergeKeywords(
+      QueryFilter.fromString(filterString),
+    );
 
     if (saveNamedFilter) {
       if (isDefined(filterName) && filterName.trim().length > 0) {

--- a/src/web/entities/__tests__/BulkTags.test.tsx
+++ b/src/web/entities/__tests__/BulkTags.test.tsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, within, rendererWith, fireEvent, wait} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Tag from 'gmp/models/tag';
 import Task from 'gmp/models/task';
 import BulkTags from 'web/entities/BulkTags';
@@ -16,7 +16,7 @@ describe('BulkTags tests', () => {
   test('should render the BulkTags component', () => {
     const entities = [new Task({id: '1'}), new Task({id: '2'})];
     const entitiesCounts = new CollectionCounts({filtered: 2, all: 2});
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
     const selectedEntities = [];
     const onClose = testing.fn();
     const getAllTags = testing
@@ -43,7 +43,7 @@ describe('BulkTags tests', () => {
   test('should allow to tag all filtered entities', () => {
     const entities = [new Task({id: '1'}), new Task({id: '2'})];
     const entitiesCounts = new CollectionCounts({filtered: 2, all: 2});
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
     const selectedEntities = [];
     const onClose = testing.fn();
     const getAllTags = testing
@@ -70,7 +70,7 @@ describe('BulkTags tests', () => {
   test('should allow to tag tasks with a new tag', async () => {
     const entities = [new Task({id: '1'}), new Task({id: '2'})];
     const entitiesCounts = new CollectionCounts({filtered: 2, all: 2});
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
     const selectedEntities = [];
     const onClose = testing.fn();
     const createTag = testing.fn().mockResolvedValue({data: {id: '2'}});

--- a/src/web/entities/__tests__/EntitiesContainer.test.tsx
+++ b/src/web/entities/__tests__/EntitiesContainer.test.tsx
@@ -12,7 +12,7 @@ import {
   fireEvent,
   wait,
 } from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import PortList from 'gmp/models/port-list';
 import {createSession} from 'gmp/testing';
 import EntitiesContainer from 'web/entities/EntitiesContainer';
@@ -38,7 +38,7 @@ const onDownload = testing.fn();
 
 const setup = gmp => {
   const {render} = rendererWith({gmp, store: true, router: true});
-  const initialFilter = new BaseFilter();
+  const initialFilter = new QueryFilter();
   render(
     <EntitiesContainer
       entities={[new PortList({id: '1', name: 'Port List 1'})]}

--- a/src/web/entities/__tests__/FilterProvider.test.tsx
+++ b/src/web/entities/__tests__/FilterProvider.test.tsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, screen} from 'web/testing';
 import {DEFAULT_FALLBACK_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import FilterProvider from 'web/entities/FilterProvider';
 import {pageFilter} from 'web/store/pages/actions';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
@@ -14,8 +14,8 @@ import {loadingActions} from 'web/store/usersettings/defaults/actions';
 
 describe('FilterProvider component tests', () => {
   test('should prefer search params filter over defaultSettingFilter', async () => {
-    const resultingFilter = BaseFilter.fromString('location=query rows=42');
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const resultingFilter = QueryFilter.fromString('location=query rows=42');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
 
     const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
@@ -48,13 +48,13 @@ describe('FilterProvider component tests', () => {
   });
 
   test('should prefer pageFilter over defaultSettingFilter', async () => {
-    const resultingFilter = BaseFilter.fromString('page=filter rows=42');
+    const resultingFilter = QueryFilter.fromString('page=filter rows=42');
 
-    const pFilter = BaseFilter.fromString('page=filter');
+    const pFilter = QueryFilter.fromString('page=filter');
 
-    const emptyFilter = BaseFilter.fromString('rows=42');
+    const emptyFilter = QueryFilter.fromString('rows=42');
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
 
     const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
@@ -90,13 +90,13 @@ describe('FilterProvider component tests', () => {
   test('should allow to set a pageName for loading the pageFilter', async () => {
     const gmpName = 'task';
     const pageName = 'foo-bar-baz';
-    const resultingFilter = BaseFilter.fromString('page=filter rows=42');
+    const resultingFilter = QueryFilter.fromString('page=filter rows=42');
 
-    const pFilter = BaseFilter.fromString('page=filter');
+    const pFilter = QueryFilter.fromString('page=filter');
 
-    const emptyFilter = BaseFilter.fromString('rows=42');
+    const emptyFilter = QueryFilter.fromString('rows=42');
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
 
     const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
@@ -134,11 +134,11 @@ describe('FilterProvider component tests', () => {
   });
 
   test('should use defaultSettingFilter', async () => {
-    const resultingFilter = BaseFilter.fromString('foo=bar rows=42');
+    const resultingFilter = QueryFilter.fromString('foo=bar rows=42');
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
 
-    const emptyFilter = BaseFilter.fromString('rows=42');
+    const emptyFilter = QueryFilter.fromString('rows=42');
 
     const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
@@ -171,11 +171,11 @@ describe('FilterProvider component tests', () => {
   });
 
   test('should use fallbackFilter if defaultSettingFilter could not be loaded', async () => {
-    const resultingFilter = BaseFilter.fromString('fall=back rows=42');
+    const resultingFilter = QueryFilter.fromString('fall=back rows=42');
 
-    const fallbackFilter = BaseFilter.fromString('fall=back');
+    const fallbackFilter = QueryFilter.fromString('fall=back');
 
-    const emptyFilter = BaseFilter.fromString('rows=42');
+    const emptyFilter = QueryFilter.fromString('rows=42');
 
     const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
@@ -213,9 +213,9 @@ describe('FilterProvider component tests', () => {
 
   test('should use fallbackFilter if given', async () => {
     // if no usersettings defaultFilter exists use the given fallbackFilter
-    const resultingFilter = BaseFilter.fromString('fall=back rows=42');
+    const resultingFilter = QueryFilter.fromString('fall=back rows=42');
 
-    const fallbackFilter = BaseFilter.fromString('fall=back');
+    const fallbackFilter = QueryFilter.fromString('fall=back');
 
     const getSetting = testing.fn().mockResolvedValue({});
     const subscribe = testing.fn();
@@ -285,9 +285,9 @@ describe('FilterProvider component tests', () => {
   test('should not overwrite rows keyword', async () => {
     // if rows= is set already, don't overwrite it. FilterProvider makes sure
     // that rows is always set to the usersettings rowsperpage.value
-    const resultingFilter = BaseFilter.fromString('fall=back rows=21');
+    const resultingFilter = QueryFilter.fromString('fall=back rows=21');
     // use fallbackFilter as sample
-    const fallbackFilter = BaseFilter.fromString('fall=back rows=21');
+    const fallbackFilter = QueryFilter.fromString('fall=back rows=21');
 
     const getSetting = testing.fn().mockResolvedValue({});
     const subscribe = testing.fn();
@@ -323,8 +323,8 @@ describe('FilterProvider component tests', () => {
   });
 
   test('should use default rows per page if rows per page setting could not be loaded', async () => {
-    const resultingFilter = BaseFilter.fromString('fall=back rows=50');
-    const fallbackFilter = BaseFilter.fromString('fall=back');
+    const resultingFilter = QueryFilter.fromString('fall=back rows=50');
+    const fallbackFilter = QueryFilter.fromString('fall=back');
 
     const getSetting = testing.fn().mockRejectedValue(new Error('an error'));
     const gmp = {

--- a/src/web/entities/__tests__/withEntitiesFooter.test.tsx
+++ b/src/web/entities/__tests__/withEntitiesFooter.test.tsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {render, screen} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Task from 'gmp/models/task';
 import withEntitiesFooter, {
   type WithEntitiesFooterComponentProps,
@@ -29,7 +29,7 @@ describe('withEntitiesFooter tests', () => {
     const mockProps = {
       entities: [new Task({id: '1'}), new Task({id: '2'})],
       entitiesCounts: new CollectionCounts({all: 2, filtered: 2, length: 2}),
-      filter: new BaseFilter(),
+      filter: new QueryFilter(),
       onDeleteBulk: testing.fn(),
       onDownloadBulk: testing.fn(),
       onTagsBulk: testing.fn(),

--- a/src/web/entity/withEntityContainer.jsx
+++ b/src/web/entity/withEntityContainer.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import {connect} from 'react-redux';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isDefined} from 'gmp/utils/identity';
 import withDownload from 'web/components/form/withDownload';
 import Reload, {
@@ -25,10 +25,10 @@ const defaultEntityReloadIntervalFunc = ({entity}) =>
 
 // get permissions assigned to the entity as resource
 export const permissionsResourceFilter = id =>
-  BaseFilter.fromString('resource_uuid=' + id).all();
+  QueryFilter.fromString('resource_uuid=' + id).all();
 
 export const permissionsSubjectFilter = id =>
-  BaseFilter.fromString(
+  QueryFilter.fromString(
     'subject_uuid=' +
       id +
       ' and not resource_uuid=""' +

--- a/src/web/hooks/__tests__/useFilterSortBy.test.tsx
+++ b/src/web/hooks/__tests__/useFilterSortBy.test.tsx
@@ -7,7 +7,7 @@ import {useState} from 'react';
 import {describe, test, expect, testing} from '@gsa/testing';
 import {fireEvent, render, screen} from 'web/testing';
 import {type FilterType} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import useFilterSortBy from 'web/hooks/useFilterSortBy';
 
 const TestComponent = ({filter: initialFilter, changeFilter}) => {
@@ -36,7 +36,7 @@ const TestComponent = ({filter: initialFilter, changeFilter}) => {
 describe('useFilterSortBy', () => {
   test('should return the sort by field and direction', () => {
     const changeFilter = testing.fn();
-    const filter = BaseFilter.fromString('sort=field');
+    const filter = QueryFilter.fromString('sort=field');
 
     render(<TestComponent changeFilter={changeFilter} filter={filter} />);
 
@@ -45,7 +45,7 @@ describe('useFilterSortBy', () => {
   });
 
   test('should change the sort direction', () => {
-    const filter = BaseFilter.fromString('sort=field');
+    const filter = QueryFilter.fromString('sort=field');
     let currentFilter = filter;
     const changeFilter = testing.fn().mockImplementation(filter => {
       currentFilter = filter;
@@ -58,7 +58,7 @@ describe('useFilterSortBy', () => {
     fireEvent.click(screen.getByTestId('sortDirChange'));
 
     expect(changeFilter).toHaveBeenCalledWith(
-      BaseFilter.fromString('first=1 sort-reverse=field'),
+      QueryFilter.fromString('first=1 sort-reverse=field'),
     );
 
     // the filter is not in the state. so a rerender with the new filter is needed
@@ -72,7 +72,7 @@ describe('useFilterSortBy', () => {
 
   test('should handle undefined sort field', async () => {
     const changeFilter = testing.fn();
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
 
     render(<TestComponent changeFilter={changeFilter} filter={filter} />);
 
@@ -82,7 +82,7 @@ describe('useFilterSortBy', () => {
     fireEvent.click(screen.getByTestId('sortFieldChange'));
 
     expect(changeFilter).toHaveBeenCalledWith(
-      BaseFilter.fromString('first=1 sort=other-field'),
+      QueryFilter.fromString('first=1 sort=other-field'),
     );
     expect(screen.getByTestId('sortBy')).toHaveTextContent('other-field');
   });

--- a/src/web/hooks/__tests__/usePageFilter.test.tsx
+++ b/src/web/hooks/__tests__/usePageFilter.test.tsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, wait, waitFor} from 'web/testing';
 import {DEFAULT_FALLBACK_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import usePageFilter from 'web/hooks/usePageFilter';
 import {pageFilter} from 'web/store/pages/actions';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
@@ -14,7 +14,7 @@ import {loadingActions} from 'web/store/usersettings/defaults/actions';
 
 describe('usePageFilter tests', () => {
   test('should prefer search params filter over defaultSettingFilter', async () => {
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
       user: {
@@ -37,13 +37,13 @@ describe('usePageFilter tests', () => {
     const {result} = renderHook(() => usePageFilter('somePage', 'gmpName'));
     const [filter] = result.current;
     expect(
-      filter.equals(BaseFilter.fromString('location=query rows=42')),
+      filter.equals(QueryFilter.fromString('location=query rows=42')),
     ).toEqual(true);
   });
 
   test('should prefer pageFilter over defaultSettingFilter', async () => {
-    const pFilter = BaseFilter.fromString('page=filter');
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const pFilter = QueryFilter.fromString('page=filter');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
 
     const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
@@ -70,7 +70,7 @@ describe('usePageFilter tests', () => {
   });
 
   test('should use defaultSettingFilter', async () => {
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
 
     const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
@@ -94,13 +94,13 @@ describe('usePageFilter tests', () => {
 
     await waitFor(() => {
       expect(result.current[0].toString()).toEqual(
-        BaseFilter.fromString('foo=bar rows=42').toString(),
+        QueryFilter.fromString('foo=bar rows=42').toString(),
       );
     });
   });
 
   test('should use fallbackFilter if no defaultSettingsFilter is available', async () => {
-    const fallbackFilter = BaseFilter.fromString('fall=back');
+    const fallbackFilter = QueryFilter.fromString('fall=back');
 
     const getSetting = testing.fn().mockResolvedValue({});
     const subscribe = testing.fn();
@@ -124,12 +124,12 @@ describe('usePageFilter tests', () => {
       usePageFilter('somePage2', 'somePage', {fallbackFilter}),
     );
     const [filter] = result.current;
-    const expectedFilter = BaseFilter.fromString('fall=back rows=42');
+    const expectedFilter = QueryFilter.fromString('fall=back rows=42');
     expect(filter.equals(expectedFilter)).toEqual(true);
   });
 
   test('should use fallbackFilter if defaultSettingFilter could not be loaded', async () => {
-    const fallbackFilter = BaseFilter.fromString('fall=back');
+    const fallbackFilter = QueryFilter.fromString('fall=back');
 
     const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
@@ -153,7 +153,7 @@ describe('usePageFilter tests', () => {
       usePageFilter('somePage2', 'somePage', {fallbackFilter}),
     );
 
-    const expectedFilter = BaseFilter.fromString('fall=back rows=42');
+    const expectedFilter = QueryFilter.fromString('fall=back rows=42');
 
     await waitFor(() => {
       expect(result.current[0].toString()).toEqual(expectedFilter.toString());
@@ -191,7 +191,7 @@ describe('usePageFilter tests', () => {
   });
 
   test('should use default rows per page if rows per page setting could not be loaded', async () => {
-    const fallbackFilter = BaseFilter.fromString('fall=back');
+    const fallbackFilter = QueryFilter.fromString('fall=back');
 
     const getSetting = testing.fn().mockRejectedValue(new Error('an error'));
     const gmp = {
@@ -212,14 +212,14 @@ describe('usePageFilter tests', () => {
       usePageFilter('somePage2', 'somePage', {fallbackFilter}),
     );
 
-    const expectedFilter = BaseFilter.fromString('fall=back rows=50');
+    const expectedFilter = QueryFilter.fromString('fall=back rows=50');
     const [filter] = result.current;
     expect(filter.equals(expectedFilter)).toEqual(true);
   });
 
   test('should prefer pageFilter rows over defaultSettingFilter and default rows', async () => {
-    const pFilter = BaseFilter.fromString('page=filter rows=42');
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const pFilter = QueryFilter.fromString('page=filter rows=42');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
 
     const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
@@ -242,7 +242,7 @@ describe('usePageFilter tests', () => {
 
     const {result} = renderHook(() => usePageFilter('somePage2', 'somePage'));
 
-    const expectedFilter = BaseFilter.fromString('page=filter rows=42');
+    const expectedFilter = QueryFilter.fromString('page=filter rows=42');
 
     await waitFor(() => {
       expect(result.current[0].toString()).toEqual(expectedFilter.toString());
@@ -250,8 +250,8 @@ describe('usePageFilter tests', () => {
   });
 
   test('should handle missing pageName argument', async () => {
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
-    const fallbackFilter = BaseFilter.fromString('fall=back');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
+    const fallbackFilter = QueryFilter.fromString('fall=back');
 
     const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
@@ -283,7 +283,7 @@ describe('usePageFilter tests', () => {
   test('should allow to reset filter to the default settings filter', async () => {
     const pageName = 'somePage';
     const gmpName = 'foo';
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
       user: {
@@ -305,7 +305,7 @@ describe('usePageFilter tests', () => {
     const {result} = renderHook(() => usePageFilter(pageName, gmpName));
     const [filter, , {resetFilter}] = result.current;
     expect(
-      filter.equals(BaseFilter.fromString('location=query rows=42')),
+      filter.equals(QueryFilter.fromString('location=query rows=42')),
     ).toEqual(true);
     resetFilter();
 
@@ -319,7 +319,7 @@ describe('usePageFilter tests', () => {
   test('should allow to remove filter', async () => {
     const pageName = 'somePage';
     const gmpName = 'foo';
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
       user: {
@@ -341,21 +341,21 @@ describe('usePageFilter tests', () => {
     const {result} = renderHook(() => usePageFilter(pageName, gmpName));
     const [filter, , {removeFilter}] = result.current;
     expect(
-      filter.equals(BaseFilter.fromString('location=query rows=42')),
+      filter.equals(QueryFilter.fromString('location=query rows=42')),
     ).toEqual(true);
     removeFilter();
 
     await wait();
 
     const [resetFilterResult] = result.current;
-    const expectedFilter = BaseFilter.fromString('first=1 rows=42');
+    const expectedFilter = QueryFilter.fromString('first=1 rows=42');
     expect(resetFilterResult.equals(expectedFilter)).toEqual(true);
   });
 
   test('should allow to change filter', async () => {
     const pageName = 'somePage';
     const gmpName = 'foo';
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     const getSetting = testing.fn().mockResolvedValue({});
     const gmp = {
       user: {
@@ -377,9 +377,9 @@ describe('usePageFilter tests', () => {
     const {result} = renderHook(() => usePageFilter(pageName, gmpName));
     const [filter, , {changeFilter}] = result.current;
     expect(
-      filter.equals(BaseFilter.fromString('location=query rows=42')),
+      filter.equals(QueryFilter.fromString('location=query rows=42')),
     ).toEqual(true);
-    const newFilter = BaseFilter.fromString('new=filter first=32 rows=123');
+    const newFilter = QueryFilter.fromString('new=filter first=32 rows=123');
     changeFilter(newFilter);
 
     await wait();

--- a/src/web/hooks/__tests__/usePagination.test.tsx
+++ b/src/web/hooks/__tests__/usePagination.test.tsx
@@ -5,7 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {fireEvent, render, screen} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import usePagination from 'web/hooks/usePagination';
 
 const TestComponent = ({filter, counts, changeFilter}) => {
@@ -26,7 +26,7 @@ const TestComponent = ({filter, counts, changeFilter}) => {
 
 describe('usePageFilter', () => {
   test('should change the filter for the first page', () => {
-    const filter = BaseFilter.fromString('first=10');
+    const filter = QueryFilter.fromString('first=10');
     const counts = {filtered: 100, rows: 10};
     const changeFilter = testing.fn();
 
@@ -40,11 +40,13 @@ describe('usePageFilter', () => {
 
     fireEvent.click(screen.getByTestId('first'));
 
-    expect(changeFilter).toHaveBeenCalledWith(BaseFilter.fromString('first=1'));
+    expect(changeFilter).toHaveBeenCalledWith(
+      QueryFilter.fromString('first=1'),
+    );
   });
 
   test('should change the filter for the last page', () => {
-    const filter = BaseFilter.fromString('first=10');
+    const filter = QueryFilter.fromString('first=10');
     const counts = {filtered: 100, rows: 10};
     const changeFilter = testing.fn();
 
@@ -59,12 +61,12 @@ describe('usePageFilter', () => {
     fireEvent.click(screen.getByTestId('last'));
 
     expect(changeFilter).toHaveBeenCalledWith(
-      BaseFilter.fromString('first=91'),
+      QueryFilter.fromString('first=91'),
     );
   });
 
   test('should change the filter for the next page', () => {
-    const filter = BaseFilter.fromString('first=10');
+    const filter = QueryFilter.fromString('first=10');
     const counts = {filtered: 100, rows: 10};
     const changeFilter = testing.fn();
 
@@ -79,12 +81,12 @@ describe('usePageFilter', () => {
     fireEvent.click(screen.getByTestId('next'));
 
     expect(changeFilter).toHaveBeenCalledWith(
-      BaseFilter.fromString('first=20 rows=10'),
+      QueryFilter.fromString('first=20 rows=10'),
     );
   });
 
   test('should change the filter for the previous page', () => {
-    const filter = BaseFilter.fromString('first=10');
+    const filter = QueryFilter.fromString('first=10');
     const counts = {filtered: 100, rows: 10};
     const changeFilter = testing.fn();
 
@@ -99,7 +101,7 @@ describe('usePageFilter', () => {
     fireEvent.click(screen.getByTestId('previous'));
 
     expect(changeFilter).toHaveBeenCalledWith(
-      BaseFilter.fromString('first=1 rows=10'),
+      QueryFilter.fromString('first=1 rows=10'),
     );
   });
 });

--- a/src/web/hooks/use-query/__tests__/Audits.test.tsx
+++ b/src/web/hooks/use-query/__tests__/Audits.test.tsx
@@ -7,8 +7,8 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, screen, waitFor} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {useGetAudit, useGetAudits} from 'web/hooks/use-query/audits';
 
@@ -28,7 +28,7 @@ const audit2 = Audit.fromElement({
   permissions: {permission: [{name: 'everything'}]},
 });
 
-const filter = BaseFilter.fromString('name~test');
+const filter = QueryFilter.fromString('name~test');
 
 const SingleAuditComponent = ({id}: {id: string}) => {
   const {data, isLoading, isError} = useGetAudit({id});

--- a/src/web/hooks/use-query/__tests__/Permissions.test.tsx
+++ b/src/web/hooks/use-query/__tests__/Permissions.test.tsx
@@ -6,8 +6,8 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, screen, waitFor} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Permission from 'gmp/models/permission';
 import {createSession} from 'gmp/testing';
 import {useGetPermissions} from 'web/hooks/use-query/permissions';
@@ -26,7 +26,7 @@ const permission2 = Permission.fromElement({
   subject: {_id: 'user-1', type: 'user'},
 });
 
-const filter = BaseFilter.fromString('resource_uuid=task-1').all();
+const filter = QueryFilter.fromString('resource_uuid=task-1').all();
 
 const TestComponent = ({filter}: {filter?: FilterType}) => {
   const {data, isLoading, isError} = useGetPermissions({filter});

--- a/src/web/hooks/use-query/__tests__/Policies.test.tsx
+++ b/src/web/hooks/use-query/__tests__/Policies.test.tsx
@@ -6,8 +6,8 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, screen, waitFor} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Policy from 'gmp/models/policy';
 import {createSession} from 'gmp/testing';
 import {useGetPolicy, useGetPolicies} from 'web/hooks/use-query/policies';
@@ -30,7 +30,7 @@ const policy2 = Policy.fromElement({
   permissions: {permission: [{name: 'everything'}]},
 });
 
-const filter = BaseFilter.fromString('name~test');
+const filter = QueryFilter.fromString('name~test');
 
 const SinglePolicyComponent = ({id}: {id: string}) => {
   const {data, isLoading, isError} = useGetPolicy({id});

--- a/src/web/hooks/use-query/__tests__/ReportOperatingSystem.test.tsx
+++ b/src/web/hooks/use-query/__tests__/ReportOperatingSystem.test.tsx
@@ -6,8 +6,8 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, screen, waitFor} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ReportOperatingSystem from 'gmp/models/report/os';
 import {createSession} from 'gmp/testing';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
@@ -25,7 +25,7 @@ const os2 = ReportOperatingSystem.fromElement({
 });
 os2.hosts.count = 5;
 
-const filter = BaseFilter.fromString('rows=10 first=1');
+const filter = QueryFilter.fromString('rows=10 first=1');
 
 const TestComponent = ({
   reportId,

--- a/src/web/hooks/use-query/agents.ts
+++ b/src/web/hooks/use-query/agents.ts
@@ -9,8 +9,8 @@ import type Rejection from 'gmp/http/rejection';
 import type Response from 'gmp/http/response';
 import {type XmlMeta} from 'gmp/http/transform/fast-xml';
 import type Agent from 'gmp/models/agent';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isFilterType} from 'gmp/models/filter/utils';
 import {parseYesNo} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
@@ -49,15 +49,15 @@ export const useGetAgents = ({
   let finalFilter = filter;
 
   if (isDefined(scannerId)) {
-    finalFilter = finalFilter ?? new BaseFilter();
+    finalFilter = finalFilter ?? new QueryFilter();
     finalFilter = finalFilter.and(
-      BaseFilter.fromString(`scanner_uuid=${scannerId}`),
+      QueryFilter.fromString(`scanner_uuid=${scannerId}`),
     );
   }
   if (isDefined(authorized)) {
-    finalFilter = finalFilter ?? new BaseFilter();
+    finalFilter = finalFilter ?? new QueryFilter();
     finalFilter = finalFilter.and(
-      BaseFilter.fromString(`authorized=${parseYesNo(authorized)}`),
+      QueryFilter.fromString(`authorized=${parseYesNo(authorized)}`),
     );
   }
 

--- a/src/web/hooks/use-query/reports.ts
+++ b/src/web/hooks/use-query/reports.ts
@@ -10,7 +10,7 @@ import {
   type default as Filter,
   type FilterType,
 } from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type Report from 'gmp/models/report';
 import type ReportConfig from 'gmp/models/report-config';
 import type ReportFormat from 'gmp/models/report-format';
@@ -27,7 +27,7 @@ interface UseGetReportParams {
   refetchInterval?: number | false | RefetchIntervalFn<Report>;
 }
 
-const REPORT_FORMATS_FILTER = BaseFilter.fromString(
+const REPORT_FORMATS_FILTER = QueryFilter.fromString(
   'active=1 and trust=1 rows=-1',
 );
 

--- a/src/web/hooks/usePageFilter.ts
+++ b/src/web/hooks/usePageFilter.ts
@@ -13,7 +13,7 @@ import {
   type FilterType,
   RESET_FILTER,
 } from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isDefined, hasValue} from 'gmp/utils/identity';
 import useGmp from 'web/hooks/useGmp';
 import useShallowEqualSelector from 'web/hooks/useShallowEqualSelector';
@@ -92,7 +92,7 @@ const usePageFilter = (
 
   const [locationQueryFilter, setLocationQueryFilter] = useState(
     hasValue(locationQueryFilterString)
-      ? BaseFilter.fromString(locationQueryFilterString)
+      ? QueryFilter.fromString(locationQueryFilterString)
       : undefined,
   );
 
@@ -126,7 +126,7 @@ const usePageFilter = (
       dispatch(
         setPageFilter(
           pageName,
-          BaseFilter.fromString(locationQueryFilterString),
+          QueryFilter.fromString(locationQueryFilterString),
         ),
       );
     }

--- a/src/web/pages/agent-groups/AgentGroupsDialog.tsx
+++ b/src/web/pages/agent-groups/AgentGroupsDialog.tsx
@@ -5,7 +5,7 @@
 
 import {useState} from 'react';
 import type AgentGroup from 'gmp/models/agent-group';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   type default as Scanner,
   AGENT_CONTROLLER_SCANNER_TYPE,
@@ -45,7 +45,7 @@ interface AgentGroupsDialogDefaultValues {
 export type AgentGroupDialogData = AgentGroupsDialogDefaultValues &
   AgentGroupsDialogValues;
 
-const AGENT_CONTROLLERS_FILTER = BaseFilter.fromString(
+const AGENT_CONTROLLERS_FILTER = QueryFilter.fromString(
   `type=${AGENT_CONTROLLER_SCANNER_TYPE} or type=${AGENT_CONTROLLER_SENSOR_SCANNER_TYPE}`,
 );
 
@@ -76,7 +76,7 @@ const AgentGroupsDialog = ({
     scannersData?.entities as RenderSelectItemProps[],
   );
 
-  const allAgentsFilter = BaseFilter.fromString('first=1 rows=-1');
+  const allAgentsFilter = QueryFilter.fromString('first=1 rows=-1');
   const {data: agentsData, isLoading: isLoadingAgents} = useGetAgents({
     filter: allAgentsFilter,
     scannerId: selectedAgentController,

--- a/src/web/pages/agent-groups/__tests__/AgentGroupsFilterDialog.test.tsx
+++ b/src/web/pages/agent-groups/__tests__/AgentGroupsFilterDialog.test.tsx
@@ -5,12 +5,12 @@
 
 import {describe, expect, test, testing} from '@gsa/testing';
 import {changeInputValue, fireEvent, rendererWith, screen} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import AgentGroupsFilterDialog from 'web/pages/agent-groups/AgentGroupsFilterDialog';
 
 describe('AgentGroupsFilterDialog tests', () => {
   test('renders default filter dialog with sort fields', () => {
-    const filter = BaseFilter.fromString('first=1 rows=10 sort=name');
+    const filter = QueryFilter.fromString('first=1 rows=10 sort=name');
 
     const onClose = testing.fn();
     const onFilterChanged = testing.fn();
@@ -37,7 +37,7 @@ describe('AgentGroupsFilterDialog tests', () => {
   });
 
   test('calls onFilterChanged when saving modified filter', async () => {
-    const filter = BaseFilter.fromString('first=1 rows=10 sort=name');
+    const filter = QueryFilter.fromString('first=1 rows=10 sort=name');
 
     const onClose = testing.fn();
     const onFilterChanged = testing.fn();

--- a/src/web/pages/agent-groups/__tests__/AgentGroupsListPage.test.tsx
+++ b/src/web/pages/agent-groups/__tests__/AgentGroupsListPage.test.tsx
@@ -8,7 +8,7 @@ import {fireEvent, rendererWith, screen, wait} from 'web/testing';
 import EverythingCapabilities from 'gmp/capabilities/everything';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import AgentGroup from 'gmp/models/agent-group';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import AgentGroupsListPage from 'web/pages/agent-groups/AgentGroupsListPage';
 
@@ -25,7 +25,7 @@ const createGmp = ({
   get = testing.fn().mockResolvedValue({
     data: [makeGroup()],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts({
         first: 1,
         all: 1,
@@ -47,7 +47,7 @@ const createGmp = ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts({
           first: 0,
           all: 0,
@@ -106,7 +106,7 @@ describe('AgentGroupsListPage tests', () => {
 
     const getAgentGroups = testing.fn().mockResolvedValue({
       data: groups,
-      meta: {filter: BaseFilter.fromString(), counts},
+      meta: {filter: QueryFilter.fromString(), counts},
     });
 
     const gmp = createGmp({get: getAgentGroups});

--- a/src/web/pages/agent-installers/__tests__/AgentInstallerFilterDialog.test.tsx
+++ b/src/web/pages/agent-installers/__tests__/AgentInstallerFilterDialog.test.tsx
@@ -5,12 +5,12 @@
 
 import {describe, expect, test, testing} from '@gsa/testing';
 import {changeInputValue, fireEvent, rendererWith, screen} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import AgentInstallersFilterDialog from 'web/pages/agent-installers/AgentInstallerFilterDialog';
 
 describe('AgentInstallersFilterDialog tests', () => {
   test('renders default filter dialog with sort fields', () => {
-    const filter = BaseFilter.fromString('first=1 rows=10 sort=name');
+    const filter = QueryFilter.fromString('first=1 rows=10 sort=name');
 
     const onClose = testing.fn();
     const onFilterChanged = testing.fn();
@@ -35,7 +35,7 @@ describe('AgentInstallersFilterDialog tests', () => {
   });
 
   test('calls onFilterChanged when saving modified filter', async () => {
-    const filter = BaseFilter.fromString('first=1 rows=10 sort=name');
+    const filter = QueryFilter.fromString('first=1 rows=10 sort=name');
 
     const onClose = testing.fn();
     const onFilterChanged = testing.fn();
@@ -61,7 +61,7 @@ describe('AgentInstallersFilterDialog tests', () => {
   });
 
   test('calls onClose when cancel is clicked', () => {
-    const filter = BaseFilter.fromString('first=1 rows=10 sort=name');
+    const filter = QueryFilter.fromString('first=1 rows=10 sort=name');
 
     const onClose = testing.fn();
     const onFilterChanged = testing.fn();
@@ -84,7 +84,7 @@ describe('AgentInstallersFilterDialog tests', () => {
   });
 
   test('renders sort fields correctly', () => {
-    const filter = BaseFilter.fromString('first=1 rows=10 sort=name');
+    const filter = QueryFilter.fromString('first=1 rows=10 sort=name');
 
     const onClose = testing.fn();
     const onFilterChanged = testing.fn();

--- a/src/web/pages/agent-installers/__tests__/AgentInstallerListPage.test.tsx
+++ b/src/web/pages/agent-installers/__tests__/AgentInstallerListPage.test.tsx
@@ -8,7 +8,7 @@ import {fireEvent, rendererWith, screen, wait} from 'web/testing';
 import EverythingCapabilities from 'gmp/capabilities/everything';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import AgentInstaller from 'gmp/models/agent-installer';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import AgentInstallerListPage from 'web/pages/agent-installers/AgentInstallerListPage';
 
@@ -26,7 +26,7 @@ const createGmp = ({
   getAgentInstallers = testing.fn().mockResolvedValue({
     data: [makeInstaller('i1')],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts({
         first: 1,
         all: 1,
@@ -92,7 +92,7 @@ describe('AgentInstallerListPage tests', () => {
 
     const getAgentInstallers = testing.fn().mockResolvedValue({
       data: [],
-      meta: {filter: BaseFilter.fromString(), counts},
+      meta: {filter: QueryFilter.fromString(), counts},
     });
 
     const gmp = createGmp({getAgentInstallers});

--- a/src/web/pages/agent-remote-installer/AgentInstallInstructionsPage.tsx
+++ b/src/web/pages/agent-remote-installer/AgentInstallInstructionsPage.tsx
@@ -6,7 +6,7 @@
 import {useMemo, useState} from 'react';
 import {useQuery} from '@tanstack/react-query';
 import styled from 'styled-components';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   type default as Scanner,
   AGENT_CONTROLLER_SCANNER_TYPE,
@@ -49,7 +49,7 @@ const AgentInstallInstructionsPage = () => {
     queryKey: ['agent-controllers'],
     queryFn: async () => {
       const response = await gmp.scanners.getAll({
-        filter: BaseFilter.fromString(
+        filter: QueryFilter.fromString(
           `type=${AGENT_CONTROLLER_SCANNER_TYPE} or type=${AGENT_CONTROLLER_SENSOR_SCANNER_TYPE}`,
         ),
       });

--- a/src/web/pages/agents/__tests__/AgentFilterDialog.test.tsx
+++ b/src/web/pages/agents/__tests__/AgentFilterDialog.test.tsx
@@ -5,7 +5,7 @@
 
 import {describe, expect, test, testing} from '@gsa/testing';
 import {fireEvent, rendererWith, screen, wait} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import AgentFilterDialog from 'web/pages/agents/AgentFilterDialog';
 
 const createGmp = ({
@@ -70,7 +70,7 @@ describe('AgentFilterDialog tests', () => {
   test('should render with existing filter', () => {
     const onFilterChanged = testing.fn();
 
-    const filter = BaseFilter.fromString('name~test');
+    const filter = QueryFilter.fromString('name~test');
 
     const gmp = createGmp();
 

--- a/src/web/pages/alerts/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/alerts/__tests__/DetailsPage.test.jsx
@@ -7,7 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen, wait} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Alert from 'gmp/models/alert';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
 import DetailsPage, {ToolBarIcons} from 'web/pages/alerts/DetailsPage';
@@ -66,7 +66,7 @@ const createGmp = ({
   getEntities = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),

--- a/src/web/pages/alerts/__tests__/ListPage.test.jsx
+++ b/src/web/pages/alerts/__tests__/ListPage.test.jsx
@@ -16,7 +16,7 @@ import {
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Alert from 'gmp/models/alert';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
 import AlertPage, {ToolBarIcons} from 'web/pages/alerts/ListPage';
@@ -57,14 +57,14 @@ const createGmp = ({
   getAlerts = testing.fn().mockResolvedValue({
     data: [alert],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -116,7 +116,7 @@ describe('Alert ListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('alert', defaultSettingFilter),
@@ -129,8 +129,8 @@ describe('Alert ListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([alert], filter, loadedFilter, counts),
     );
@@ -184,7 +184,7 @@ describe('Alert ListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('alert', defaultSettingFilter),
@@ -197,8 +197,8 @@ describe('Alert ListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([alert], filter, loadedFilter, counts),
     );
@@ -235,7 +235,7 @@ describe('Alert ListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('alert', defaultSettingFilter),
@@ -248,8 +248,8 @@ describe('Alert ListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([alert], filter, loadedFilter, counts),
     );
@@ -294,7 +294,7 @@ describe('Alert ListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('alert', defaultSettingFilter),
@@ -307,8 +307,8 @@ describe('Alert ListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([alert], filter, loadedFilter, counts),
     );

--- a/src/web/pages/audits/AuditComponent.jsx
+++ b/src/web/pages/audits/AuditComponent.jsx
@@ -7,7 +7,7 @@ import {useState, useEffect, useCallback} from 'react';
 import {useDispatch} from 'react-redux';
 import {DEFAULT_MIN_QOD} from 'gmp/models/audit';
 import {ALL_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   OPENVAS_DEFAULT_SCANNER_ID,
   OPENVAS_SCANNER_TYPE,
@@ -58,7 +58,7 @@ import {getUserSettingsDefaults} from 'web/store/usersettings/defaults/selectors
 import PropTypes from 'web/utils/PropTypes';
 import {UNSET_VALUE, generateFilename} from 'web/utils/Render';
 
-const REPORT_FORMATS_FILTER = BaseFilter.fromString(
+const REPORT_FORMATS_FILTER = QueryFilter.fromString(
   'uuid="dc51a40a-c022-11e9-b02d-3f7ca5bdcb11" and active=1 and trust=1',
 );
 

--- a/src/web/pages/audits/DetailsPage.tsx
+++ b/src/web/pages/audits/DetailsPage.tsx
@@ -7,7 +7,7 @@ import {useQueryClient} from '@tanstack/react-query';
 import {useNavigate, useParams} from 'react-router';
 import type Gmp from 'gmp/gmp';
 import type Audit from 'gmp/models/audit';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type Model from 'gmp/models/model';
 import {isDefined} from 'gmp/utils/identity';
 import Download from 'web/components/form/Download';
@@ -118,7 +118,7 @@ const Details = ({entity}: {entity: Audit}) => {
 };
 
 const permissionsResourceFilter = (id: string) =>
-  BaseFilter.fromString(`resource_uuid=${id}`).all();
+  QueryFilter.fromString(`resource_uuid=${id}`).all();
 
 const AuditDetailsPage = () => {
   const [_] = useTranslation();

--- a/src/web/pages/audits/__tests__/DetailsPage.test.tsx
+++ b/src/web/pages/audits/__tests__/DetailsPage.test.tsx
@@ -9,7 +9,7 @@ import {Route, Routes} from 'react-router';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Response from 'gmp/http/response';
 import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Policy from 'gmp/models/policy';
 import Schedule from 'gmp/models/schedule';
 import {createSession} from 'gmp/testing';
@@ -144,13 +144,13 @@ const createGmp = ({
   getPolicyResponse = new Response(policy),
   getScheduleResponse = new Response(schedule),
   getReportFormatsResponse = new Response([], {
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
     counts: new CollectionCounts(),
   }),
   getPermissionsResponse = {
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   },

--- a/src/web/pages/audits/__tests__/ListPage.test.jsx
+++ b/src/web/pages/audits/__tests__/ListPage.test.jsx
@@ -15,7 +15,7 @@ import {
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
 import AuditPage, {ToolBarIcons} from 'web/pages/audits/ListPage';
@@ -64,21 +64,21 @@ const createGmp = ({
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getAudits = testing.fn().mockResolvedValue({
     data: [audit],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getReportFormats = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -113,7 +113,7 @@ describe('AuditPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('audit', defaultSettingFilter),
@@ -126,8 +126,8 @@ describe('AuditPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([audit], filter, loadedFilter, counts),
     );
@@ -150,7 +150,7 @@ describe('AuditPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('audit', defaultSettingFilter),
@@ -163,8 +163,8 @@ describe('AuditPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([audit], filter, loadedFilter, counts),
     );

--- a/src/web/pages/audits/__tests__/Table.test.jsx
+++ b/src/web/pages/audits/__tests__/Table.test.jsx
@@ -7,7 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Audit, {AUDIT_STATUS} from 'gmp/models/audit';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import Table from 'web/pages/audits/Table';
 
@@ -78,7 +78,7 @@ const counts = new CollectionCounts({
   rows: 2,
 });
 
-const filter = BaseFilter.fromString('rows=2');
+const filter = QueryFilter.fromString('rows=2');
 
 const createGmp = () => ({
   session: createSession(),

--- a/src/web/pages/certbund/ListPage.jsx
+++ b/src/web/pages/certbund/ListPage.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import {CERTBUND_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import DashboardControls from 'web/components/dashboard/Controls';
 import {CertBundAdvIcon} from 'web/components/icon';
 import ManualIcon from 'web/components/icon/ManualIcon';
@@ -70,7 +70,7 @@ Page.propTypes = {
   onFilterChanged: PropTypes.func.isRequired,
 };
 
-const fallbackFilter = BaseFilter.fromString('sort-reverse=created');
+const fallbackFilter = QueryFilter.fromString('sort-reverse=created');
 
 export default withEntitiesContainer('certbund', {
   entitiesSelector,

--- a/src/web/pages/container-image-targets/__tests__/ContainerImageTargetFilterDialog.test.tsx
+++ b/src/web/pages/container-image-targets/__tests__/ContainerImageTargetFilterDialog.test.tsx
@@ -12,12 +12,12 @@ import {
   wait,
 } from 'web/testing';
 import Filter from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ContainerImageTargetFilterDialog from 'web/pages/container-image-targets/ContainerImageTargetFilterDialog';
 
 describe('ContainerImageTargetFilterDialog tests', () => {
   test('should render dialog with default fields', () => {
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const gmp = {filter: {}};
     const {render} = rendererWith({capabilities: true, gmp});
     render(<ContainerImageTargetFilterDialog filter={filter} />);
@@ -36,7 +36,7 @@ describe('ContainerImageTargetFilterDialog tests', () => {
   });
 
   test('should call onFilterChanged when filter is updated', () => {
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const handleFilterChanged = testing.fn();
     const gmp = {filter: {}};
     const {render} = rendererWith({capabilities: true, gmp});
@@ -51,12 +51,12 @@ describe('ContainerImageTargetFilterDialog tests', () => {
     const saveButton = screen.getDialogSaveButton();
     fireEvent.click(saveButton);
     expect(handleFilterChanged).toHaveBeenCalledWith(
-      BaseFilter.fromString('foo=bar'),
+      QueryFilter.fromString('foo=bar'),
     );
   });
 
   test('should call onFilterCreated when a new filter is saved', async () => {
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const newFilter = new Filter({
       id: 'new-filter-id',
       name: 'New Filter',

--- a/src/web/pages/container-image-targets/__tests__/ContainerImageTargetsListPage.test.tsx
+++ b/src/web/pages/container-image-targets/__tests__/ContainerImageTargetsListPage.test.tsx
@@ -6,7 +6,7 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {fireEvent, rendererWith, screen, wait} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import OciImageTarget from 'gmp/models/oci-image-target';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -25,7 +25,7 @@ const getSetting = testing.fn().mockResolvedValue({filter: null});
 const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
-    meta: {filter: BaseFilter.fromString(), counts: new CollectionCounts()},
+    meta: {filter: QueryFilter.fromString(), counts: new CollectionCounts()},
   }),
 );
 
@@ -45,7 +45,7 @@ const createGmp = ({
   getOciImageTargets = testing.fn().mockResolvedValue({
     data: [makeTarget()],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts({
         first: 1,
         all: 1,
@@ -91,7 +91,7 @@ describe('ContainerImageTargetsListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success(
@@ -146,7 +146,7 @@ describe('ContainerImageTargetsListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success(

--- a/src/web/pages/cpes/ListPage.jsx
+++ b/src/web/pages/cpes/ListPage.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import {CPES_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import DashboardControls from 'web/components/dashboard/Controls';
 import {CpeLogoIcon} from 'web/components/icon';
 import ManualIcon from 'web/components/icon/ManualIcon';
@@ -60,7 +60,7 @@ Page.propTypes = {
   onFilterChanged: PropTypes.func.isRequired,
 };
 
-const fallbackFilter = BaseFilter.fromString('sort-reverse=modified');
+const fallbackFilter = QueryFilter.fromString('sort-reverse=modified');
 
 export default withEntitiesContainer('cpe', {
   entitiesSelector,

--- a/src/web/pages/cpes/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/cpes/__tests__/DetailsPage.test.jsx
@@ -8,7 +8,7 @@ import {rendererWith, wait, fireEvent, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Response from 'gmp/http/response';
 import CPE from 'gmp/models/cpe';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -43,7 +43,7 @@ const createGmp = ({
   currentSettingsResponse = currentSettingsDefaultResponse,
   getCpeResponse = new Response(cpe),
   getTagsResponse = new Response([], {
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
     counts: new CollectionCounts(),
   }),
   currentSettings = testing.fn().mockResolvedValue(currentSettingsResponse),

--- a/src/web/pages/cpes/__tests__/ListPage.test.jsx
+++ b/src/web/pages/cpes/__tests__/ListPage.test.jsx
@@ -14,7 +14,7 @@ import {
 } from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import CPE from 'gmp/models/cpe';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -51,7 +51,7 @@ const createGmp = ({
   getCpes = testing.fn().mockResolvedValue({
     data: [cpe],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -59,7 +59,7 @@ const createGmp = ({
     Promise.resolve({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts(),
       },
     }),
@@ -67,14 +67,14 @@ const createGmp = ({
   getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -133,7 +133,7 @@ describe('CpesPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('cpe', defaultSettingFilter),
@@ -146,8 +146,8 @@ describe('CpesPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([cpe], filter, loadedFilter, counts),
     );
@@ -216,7 +216,7 @@ describe('CpesPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('cpe', defaultSettingFilter),
@@ -229,8 +229,8 @@ describe('CpesPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([cpe], filter, loadedFilter, counts),
     );
@@ -255,7 +255,7 @@ describe('CpesPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('cpe', defaultSettingFilter),
@@ -268,8 +268,8 @@ describe('CpesPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([cpe], filter, loadedFilter, counts),
     );
@@ -306,7 +306,7 @@ describe('CpesPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('cpe', defaultSettingFilter),
@@ -319,8 +319,8 @@ describe('CpesPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([cpe], filter, loadedFilter, counts),
     );

--- a/src/web/pages/credential-store/__tests__/CredentialStorePage.test.tsx
+++ b/src/web/pages/credential-store/__tests__/CredentialStorePage.test.tsx
@@ -14,7 +14,7 @@ import {
 } from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import CredentialStore from 'gmp/models/credential-store';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import CredentialStorePage from 'web/pages/credential-store/CredentialStorePage';
 
@@ -35,7 +35,7 @@ const credentialStore = CredentialStore.fromElement({
 const createGmp = ({
   get = testing.fn().mockResolvedValue({
     data: [credentialStore],
-    meta: {filter: BaseFilter.fromString(), counts: new CollectionCounts()},
+    meta: {filter: QueryFilter.fromString(), counts: new CollectionCounts()},
   }),
   edit = testing.fn().mockResolvedValue({}),
   verify = testing.fn().mockResolvedValue({}),
@@ -133,7 +133,7 @@ describe('CredentialStorePage tests', () => {
 
     const get = testing.fn().mockResolvedValue({
       data: [credentialStore],
-      meta: {filter: BaseFilter.fromString(), counts: new CollectionCounts()},
+      meta: {filter: QueryFilter.fromString(), counts: new CollectionCounts()},
     });
 
     const gmp = createGmp({get});
@@ -185,7 +185,7 @@ describe('CredentialStorePage tests', () => {
 
     const get = testing.fn().mockResolvedValue({
       data: [credentialStore],
-      meta: {filter: BaseFilter.fromString(), counts: new CollectionCounts()},
+      meta: {filter: QueryFilter.fromString(), counts: new CollectionCounts()},
     });
 
     const gmp = createGmp({get});
@@ -218,7 +218,7 @@ describe('CredentialStorePage tests', () => {
 
     const get = testing.fn().mockResolvedValue({
       data: [credentialStore],
-      meta: {filter: BaseFilter.fromString(), counts: new CollectionCounts()},
+      meta: {filter: QueryFilter.fromString(), counts: new CollectionCounts()},
     });
 
     const gmp = createGmp({get});
@@ -260,7 +260,7 @@ describe('CredentialStorePage tests', () => {
   test('should show no credential store configured message when none exist', async () => {
     const get = testing.fn().mockResolvedValue({
       data: [],
-      meta: {filter: BaseFilter.fromString(), counts: new CollectionCounts()},
+      meta: {filter: QueryFilter.fromString(), counts: new CollectionCounts()},
     });
 
     const gmp = createGmp({get});

--- a/src/web/pages/credentials/__tests__/CredentialDetailsPage.test.tsx
+++ b/src/web/pages/credentials/__tests__/CredentialDetailsPage.test.tsx
@@ -12,7 +12,7 @@ import Credential, {
   PGP_CREDENTIAL_TYPE,
   USERNAME_SSH_KEY_CREDENTIAL_TYPE,
 } from 'gmp/models/credential';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
 import CredentialDetailsPage from 'web/pages/credentials/CredentialDetailsPage';
@@ -69,7 +69,7 @@ const createGmp = ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts(),
       },
     }),

--- a/src/web/pages/credentials/__tests__/CredentialListPage.test.tsx
+++ b/src/web/pages/credentials/__tests__/CredentialListPage.test.tsx
@@ -15,7 +15,7 @@ import {
 } from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Credential from 'gmp/models/credential';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
 import CredentialPage from 'web/pages/credentials/CredentialListPage';
@@ -52,11 +52,11 @@ const createGmp = ({
   getCredentialResponse = {data: credential},
   getCredentialsResponse = {
     data: [credential],
-    meta: {filter: new BaseFilter(), counts: new CollectionCounts()},
+    meta: {filter: new QueryFilter(), counts: new CollectionCounts()},
   },
   getFiltersResponse = {
     data: [],
-    meta: {filter: new BaseFilter(), counts: new CollectionCounts()},
+    meta: {filter: new QueryFilter(), counts: new CollectionCounts()},
   },
   cloneCredential = testing.fn().mockResolvedValue(cloneCredentialResponse),
   deleteCredential = testing.fn().mockResolvedValue(undefined),
@@ -111,7 +111,7 @@ const createGmp = ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: new BaseFilter(),
+        filter: new QueryFilter(),
         counts: new CollectionCounts(),
       },
     }),
@@ -128,7 +128,7 @@ describe('CredentialListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('credential', defaultSettingFilter),
@@ -200,7 +200,7 @@ describe('CredentialListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('credential', defaultSettingFilter),
@@ -230,7 +230,7 @@ describe('CredentialListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('credential', defaultSettingFilter),
@@ -273,7 +273,7 @@ describe('CredentialListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('credential', defaultSettingFilter),

--- a/src/web/pages/cves/ListPage.jsx
+++ b/src/web/pages/cves/ListPage.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import {CVES_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import DashboardControls from 'web/components/dashboard/Controls';
 import {CveIcon} from 'web/components/icon';
 import ManualIcon from 'web/components/icon/ManualIcon';
@@ -61,7 +61,7 @@ Page.propTypes = {
   onFilterChanged: PropTypes.func.isRequired,
 };
 
-const fallbackFilter = BaseFilter.fromString('sort-reverse=name');
+const fallbackFilter = QueryFilter.fromString('sort-reverse=name');
 
 export default withEntitiesContainer('cve', {
   entitiesSelector,

--- a/src/web/pages/cves/__tests__/ListPage.test.jsx
+++ b/src/web/pages/cves/__tests__/ListPage.test.jsx
@@ -14,7 +14,7 @@ import {
 } from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Cve from 'gmp/models/cve';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -45,28 +45,28 @@ const createGmp = ({
   getCves = testing.fn().mockResolvedValue({
     data: [cve],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -125,7 +125,7 @@ describe('CvesPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('cve', defaultSettingFilter),
@@ -138,8 +138,8 @@ describe('CvesPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([cve], filter, loadedFilter, counts),
     );
@@ -207,7 +207,7 @@ describe('CvesPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('cve', defaultSettingFilter),
@@ -220,8 +220,8 @@ describe('CvesPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([cve], filter, loadedFilter, counts),
     );
@@ -245,7 +245,7 @@ describe('CvesPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('cve', defaultSettingFilter),
@@ -258,8 +258,8 @@ describe('CvesPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([cve], filter, loadedFilter, counts),
     );
@@ -295,7 +295,7 @@ describe('CvesPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('cve', defaultSettingFilter),
@@ -308,8 +308,8 @@ describe('CvesPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([cve], filter, loadedFilter, counts),
     );

--- a/src/web/pages/cves/__tests__/Table.test.jsx
+++ b/src/web/pages/cves/__tests__/Table.test.jsx
@@ -8,7 +8,7 @@ import {rendererWith, fireEvent, screen} from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Cve from 'gmp/models/cve';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {parseDate} from 'gmp/parser';
 import {createSession} from 'gmp/testing';
 import CveTable from 'web/pages/cves/Table';
@@ -67,7 +67,7 @@ const counts = new CollectionCounts({
   rows: 3,
 });
 
-const filter = BaseFilter.fromString('rows=2');
+const filter = QueryFilter.fromString('rows=2');
 
 const createGmp = () => ({
   session: createSession(),

--- a/src/web/pages/dfncert/ListPage.jsx
+++ b/src/web/pages/dfncert/ListPage.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import {DFNCERT_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import DashboardControls from 'web/components/dashboard/Controls';
 import {DfnCertAdvIcon} from 'web/components/icon';
 import ManualIcon from 'web/components/icon/ManualIcon';
@@ -70,7 +70,7 @@ Page.propTypes = {
   onFilterChanged: PropTypes.func.isRequired,
 };
 
-const fallbackFilter = BaseFilter.fromString('sort-reverse=created');
+const fallbackFilter = QueryFilter.fromString('sort-reverse=created');
 
 export default withEntitiesContainer('dfncert', {
   entitiesSelector,

--- a/src/web/pages/hosts/ListPage.jsx
+++ b/src/web/pages/hosts/ListPage.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import {useNavigate} from 'react-router';
 import {HOSTS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import DashboardControls from 'web/components/dashboard/Controls';
 import {HostIcon, NewIcon} from 'web/components/icon';
 import ManualIcon from 'web/components/icon/ManualIcon';
@@ -125,7 +125,7 @@ Page.propTypes = {
   onFilterChanged: PropTypes.func.isRequired,
 };
 
-const FALLBACK_HOSTS_LIST_FILTER = BaseFilter.fromString(
+const FALLBACK_HOSTS_LIST_FILTER = QueryFilter.fromString(
   'sort-reverse=severity first=1',
 );
 

--- a/src/web/pages/hosts/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/hosts/__tests__/DetailsPage.test.jsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen, wait, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Host from 'gmp/models/host';
 import {createSession} from 'gmp/testing';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
@@ -150,7 +150,7 @@ const createGmp = ({
   getPermissions = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),

--- a/src/web/pages/hosts/__tests__/HostComponent.test.tsx
+++ b/src/web/pages/hosts/__tests__/HostComponent.test.tsx
@@ -7,7 +7,7 @@ import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen} from 'web/testing';
 
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Host from 'gmp/models/host';
 
 import {type ModelElement} from 'gmp/models/model';
@@ -136,7 +136,7 @@ const createGmp = ({
   getPermissions = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),

--- a/src/web/pages/hosts/__tests__/ListPage.test.jsx
+++ b/src/web/pages/hosts/__tests__/ListPage.test.jsx
@@ -15,7 +15,7 @@ import {
 } from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Host from 'gmp/models/host';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -75,7 +75,7 @@ const createGmp = ({
   getHosts = testing.fn().mockResolvedValue({
     data: [host],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -83,7 +83,7 @@ const createGmp = ({
     Promise.resolve({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts(),
       },
     }),
@@ -91,14 +91,14 @@ const createGmp = ({
   getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -154,7 +154,7 @@ describe('Host ListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('host', defaultSettingFilter),
@@ -167,8 +167,8 @@ describe('Host ListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([host], filter, loadedFilter, counts),
     );
@@ -263,7 +263,7 @@ describe('Host ListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('host', defaultSettingFilter),
@@ -276,8 +276,8 @@ describe('Host ListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([host], filter, loadedFilter, counts),
     );
@@ -306,7 +306,7 @@ describe('Host ListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('host', defaultSettingFilter),
@@ -319,8 +319,8 @@ describe('Host ListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([host], filter, loadedFilter, counts),
     );
@@ -353,7 +353,7 @@ describe('Host ListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('host', defaultSettingFilter),
@@ -366,8 +366,8 @@ describe('Host ListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([host], filter, loadedFilter, counts),
     );

--- a/src/web/pages/hosts/dashboard/Loaders.jsx
+++ b/src/web/pages/hosts/dashboard/Loaders.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isDefined} from 'gmp/utils/identity';
 import {MAX_HOSTS} from 'web/components/chart/HostsTopologyChart';
 import Loader, {
@@ -19,7 +19,7 @@ export const HOSTS_VULN_SCORE = 'hosts-vuln-score';
 
 const HOSTS_MAX_GROUPS = 10;
 
-const DEFAULT_TOPOLOGY_FILTER = BaseFilter.fromString(`rows=${MAX_HOSTS}`);
+const DEFAULT_TOPOLOGY_FILTER = QueryFilter.fromString(`rows=${MAX_HOSTS}`);
 
 export const hostsModifiedLoader = loadFunc(
   ({gmp, filter}) =>

--- a/src/web/pages/hosts/dashboard/ModifiedDisplay.jsx
+++ b/src/web/pages/hosts/dashboard/ModifiedDisplay.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import {_, _l} from 'gmp/locale/lang';
 import {HOSTS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {parseInt, parseDate} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import LineChart, {lineDataPropType} from 'web/components/chart/base/Line';
@@ -58,7 +58,7 @@ export class HostsModifiedDisplay extends React.Component {
     let {x: endDate} = end;
     const dateFormat = 'YYYY-MM-DDTHH:mm';
 
-    let newFilter = isDefined(filter) ? filter.copy() : new BaseFilter();
+    let newFilter = isDefined(filter) ? filter.copy() : new QueryFilter();
 
     if (isDefined(startDate)) {
       if (startDate.isSame(endDate)) {
@@ -71,7 +71,7 @@ export class HostsModifiedDisplay extends React.Component {
       );
 
       if (!newFilter.hasTerm(startTerm)) {
-        newFilter = newFilter.and(BaseFilter.fromTerm(startTerm));
+        newFilter = newFilter.and(QueryFilter.fromTerm(startTerm));
       }
     }
 
@@ -81,7 +81,7 @@ export class HostsModifiedDisplay extends React.Component {
       );
 
       if (!newFilter.hasTerm(endTerm)) {
-        newFilter = newFilter.and(BaseFilter.fromTerm(endTerm));
+        newFilter = newFilter.and(QueryFilter.fromTerm(endTerm));
       }
     }
 

--- a/src/web/pages/hosts/dashboard/ModifiedHighDisplay.jsx
+++ b/src/web/pages/hosts/dashboard/ModifiedHighDisplay.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import {_, _l} from 'gmp/locale/lang';
 import {HOSTS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {parseInt, parseDate} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import LineChart, {lineDataPropType} from 'web/components/chart/base/Line';
@@ -59,7 +59,7 @@ export class HostsModifiedHighDisplay extends React.Component {
     let {x: endDate} = end;
     const dateFormat = 'YYYY-MM-DDTHH:mm';
 
-    let newFilter = isDefined(filter) ? filter.copy() : new BaseFilter();
+    let newFilter = isDefined(filter) ? filter.copy() : new QueryFilter();
 
     if (isDefined(startDate)) {
       if (startDate.isSame(endDate)) {
@@ -72,7 +72,7 @@ export class HostsModifiedHighDisplay extends React.Component {
       );
 
       if (!newFilter.hasTerm(startTerm)) {
-        newFilter = newFilter.and(BaseFilter.fromTerm(startTerm));
+        newFilter = newFilter.and(QueryFilter.fromTerm(startTerm));
       }
     }
 
@@ -82,7 +82,7 @@ export class HostsModifiedHighDisplay extends React.Component {
       );
 
       if (!newFilter.hasTerm(endTerm)) {
-        newFilter = newFilter.and(BaseFilter.fromTerm(endTerm));
+        newFilter = newFilter.and(QueryFilter.fromTerm(endTerm));
       }
     }
 

--- a/src/web/pages/notes/__tests__/NoteDetailsPage.test.tsx
+++ b/src/web/pages/notes/__tests__/NoteDetailsPage.test.tsx
@@ -7,7 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen, wait, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Response from 'gmp/http/response';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Note from 'gmp/models/note';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -46,7 +46,7 @@ const currentSettings = testing
 const createGmp = ({
   getNoteResponse = new Response(note),
   getPermissionsResponse = new Response([], {
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
     counts: new CollectionCounts(),
   }),
   cloneNoteResponse = new Response({id: 'foo'}),

--- a/src/web/pages/notes/__tests__/NoteListPage.test.tsx
+++ b/src/web/pages/notes/__tests__/NoteListPage.test.tsx
@@ -14,7 +14,7 @@ import {
   wait,
 } from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Note from 'gmp/models/note';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -62,28 +62,28 @@ const createGmp = ({
   getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getNotes = testing.fn().mockResolvedValue({
     data: [note],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -135,7 +135,7 @@ describe('NoteListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('note', defaultSettingFilter),
@@ -148,8 +148,8 @@ describe('NoteListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([note], filter, loadedFilter, counts),
     );
@@ -220,7 +220,7 @@ describe('NoteListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('note', defaultSettingFilter),
@@ -233,8 +233,8 @@ describe('NoteListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([note], filter, loadedFilter, counts),
     );
@@ -264,7 +264,7 @@ describe('NoteListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('note', defaultSettingFilter),
@@ -277,8 +277,8 @@ describe('NoteListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([note], filter, loadedFilter, counts),
     );
@@ -320,7 +320,7 @@ describe('NoteListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('note', defaultSettingFilter),
@@ -333,8 +333,8 @@ describe('NoteListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([note], filter, loadedFilter, counts),
     );
@@ -374,7 +374,7 @@ describe('NoteListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('note', defaultSettingFilter),
@@ -400,7 +400,7 @@ describe('NoteListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('note', defaultSettingFilter),
@@ -425,7 +425,7 @@ describe('NoteListPage tests', () => {
       length: 10,
       rows: 10,
     });
-    const listFilter = BaseFilter.fromString('first=11 rows=10');
+    const listFilter = QueryFilter.fromString('first=11 rows=10');
     const getNotes = testing.fn().mockResolvedValue({
       data: notes,
       meta: {

--- a/src/web/pages/notes/dashboard/ActiveDaysDisplay.jsx
+++ b/src/web/pages/notes/dashboard/ActiveDaysDisplay.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import {_, _l} from 'gmp/locale/lang';
 import {NOTES_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   NOTE_ACTIVE_UNLIMITED_VALUE,
   NOTE_INACTIVE_VALUE,
@@ -117,7 +117,7 @@ export class NotesActiveDaysDisplay extends React.Component {
     if (isDefined(filter) && filter.hasTerm(activeDaysTerm)) {
       return;
     }
-    const activeDaysFilter = BaseFilter.fromTerm(activeDaysTerm);
+    const activeDaysFilter = QueryFilter.fromTerm(activeDaysTerm);
 
     const newFilter = isDefined(filter)
       ? filter.copy().and(activeDaysFilter)

--- a/src/web/pages/notes/dashboard/WordCloudDisplay.jsx
+++ b/src/web/pages/notes/dashboard/WordCloudDisplay.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import {_, _l} from 'gmp/locale/lang';
 import {NOTES_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {parseFloat} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
@@ -57,7 +57,7 @@ export class NotesWordCloudDisplay extends React.Component {
       if (isDefined(filter) && filter.hasTerm(wordTerm)) {
         return;
       }
-      wordFilter = BaseFilter.fromTerm(wordTerm);
+      wordFilter = QueryFilter.fromTerm(wordTerm);
     }
 
     const newFilter = isDefined(filter)

--- a/src/web/pages/nvts/DetailsPage.jsx
+++ b/src/web/pages/nvts/DetailsPage.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isDefined} from 'gmp/utils/identity';
 import {NvtIcon} from 'web/components/icon';
 import Divider from 'web/components/layout/Divider';
@@ -178,7 +178,7 @@ Page.propTypes = {
   onError: PropTypes.func.isRequired,
 };
 
-const nvtIdFilter = id => BaseFilter.fromString(`nvt_id=${id}`).all();
+const nvtIdFilter = id => QueryFilter.fromString(`nvt_id=${id}`).all();
 
 const mapStateToProps = (rootState, {id}) => {
   const notesSel = notesSelector(rootState);

--- a/src/web/pages/nvts/ListPage.jsx
+++ b/src/web/pages/nvts/ListPage.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import {NVTS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import DashboardControls from 'web/components/dashboard/Controls';
 import {NvtIcon} from 'web/components/icon';
 import ManualIcon from 'web/components/icon/ManualIcon';
@@ -66,7 +66,7 @@ Page.propTypes = {
   onFilterChanged: PropTypes.func.isRequired,
 };
 
-const fallbackFilter = BaseFilter.fromString('sort-reverse=created');
+const fallbackFilter = QueryFilter.fromString('sort-reverse=created');
 
 export default withEntitiesContainer('nvt', {
   entitiesSelector,

--- a/src/web/pages/nvts/Row.jsx
+++ b/src/web/pages/nvts/Row.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isDefined} from 'gmp/utils/identity';
 import SeverityBar from 'web/components/bar/SeverityBar';
 import DateTime from 'web/components/date/DateTime';
@@ -31,7 +31,7 @@ const Row = ({
 }) => {
   const gmp = useGmp();
   const handleFilterChanged = () => {
-    const filter = BaseFilter.fromString(`family="${entity.family}"`);
+    const filter = QueryFilter.fromString(`family="${entity.family}"`);
     onFilterChanged(filter);
   };
   const epssScore = entity?.epss?.maxEpss?.score;

--- a/src/web/pages/nvts/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/nvts/__tests__/DetailsPage.test.jsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen, wait, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Note from 'gmp/models/note';
 import NVT from 'gmp/models/nvt';
 import Override from 'gmp/models/override';
@@ -200,21 +200,21 @@ const createGmp = ({
   getNotes = testing.fn().mockResolvedValue({
     data: [note1],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getOverrides = testing.fn().mockResolvedValue({
     data: [override1, override2],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getEntities = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),

--- a/src/web/pages/nvts/__tests__/ListPage.test.jsx
+++ b/src/web/pages/nvts/__tests__/ListPage.test.jsx
@@ -13,7 +13,7 @@ import {
   within,
 } from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import NVT from 'gmp/models/nvt';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -75,28 +75,28 @@ const createGmp = ({
   getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getNvts = testing.fn().mockResolvedValue({
     data: [nvt],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -149,7 +149,7 @@ describe('NvtsPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('nvt', defaultSettingFilter),
@@ -162,8 +162,8 @@ describe('NvtsPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([nvt], filter, loadedFilter, counts),
     );
@@ -241,7 +241,7 @@ describe('NvtsPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('nvt', defaultSettingFilter),
@@ -254,8 +254,8 @@ describe('NvtsPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([nvt], filter, loadedFilter, counts),
     );
@@ -279,7 +279,7 @@ describe('NvtsPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('nvt', defaultSettingFilter),
@@ -292,8 +292,8 @@ describe('NvtsPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([nvt], filter, loadedFilter, counts),
     );
@@ -329,7 +329,7 @@ describe('NvtsPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('nvt', defaultSettingFilter),
@@ -342,8 +342,8 @@ describe('NvtsPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([nvt], filter, loadedFilter, counts),
     );

--- a/src/web/pages/nvts/__tests__/Row.test.jsx
+++ b/src/web/pages/nvts/__tests__/Row.test.jsx
@@ -5,7 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWithTableBody, fireEvent, screen} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import NVT from 'gmp/models/nvt';
 import {createSession} from 'gmp/testing';
 import Row from 'web/pages/nvts/Row';
@@ -105,7 +105,7 @@ describe('NVT row tests', () => {
     const handleToggleDetailsClick = testing.fn();
     const handleFilterChanged = testing.fn();
 
-    const filter = BaseFilter.fromString('family="bar"');
+    const filter = QueryFilter.fromString('family="bar"');
 
     const {render} = rendererWithTableBody({
       gmp: createGmp(),

--- a/src/web/pages/nvts/dashboard/FamilyDisplay.jsx
+++ b/src/web/pages/nvts/dashboard/FamilyDisplay.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import {_, _l} from 'gmp/locale/lang';
 import {NVTS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {parseFloat, parseSeverity} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import {DEFAULT_SEVERITY_RATING} from 'gmp/utils/severity';
@@ -86,7 +86,7 @@ export class NvtsFamilyDisplay extends React.Component {
       if (isDefined(filter) && filter.hasTerm(familyTerm)) {
         return;
       }
-      familyFilter = BaseFilter.fromTerm(familyTerm);
+      familyFilter = QueryFilter.fromTerm(familyTerm);
     }
 
     const newFilter = isDefined(filter)

--- a/src/web/pages/nvts/dashboard/QodDisplay.jsx
+++ b/src/web/pages/nvts/dashboard/QodDisplay.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import {_, _l} from 'gmp/locale/lang';
 import {NVTS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {parseFloat} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import DonutChart from 'web/components/chart/Donut';
@@ -67,7 +67,7 @@ export class NvtsQodDisplay extends React.Component {
     if (isDefined(filter) && filter.hasTerm(qodTerm)) {
       return;
     }
-    const qodFilter = BaseFilter.fromTerm(qodTerm);
+    const qodFilter = QueryFilter.fromTerm(qodTerm);
 
     const newFilter = isDefined(filter)
       ? filter.copy().and(qodFilter)

--- a/src/web/pages/nvts/dashboard/QodTypeDisplay.jsx
+++ b/src/web/pages/nvts/dashboard/QodTypeDisplay.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import {_, _l} from 'gmp/locale/lang';
 import {NVTS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isDefined} from 'gmp/utils/identity';
 import DonutChart from 'web/components/chart/Donut';
 import createDisplay from 'web/components/dashboard/display/createDisplay';
@@ -66,7 +66,7 @@ export class NvtsQodTypeDisplay extends React.Component {
     if (isDefined(filter) && filter.hasTerm(qodTypeTerm)) {
       return;
     }
-    const qodTypeFilter = BaseFilter.fromTerm(qodTypeTerm);
+    const qodTypeFilter = QueryFilter.fromTerm(qodTypeTerm);
 
     const newFilter = isDefined(filter)
       ? filter.copy().and(qodTypeFilter)

--- a/src/web/pages/operatingsystems/ListPage.jsx
+++ b/src/web/pages/operatingsystems/ListPage.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import {OS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import DashboardControls from 'web/components/dashboard/Controls';
 import {OsSvgIcon} from 'web/components/icon';
 import ManualIcon from 'web/components/icon/ManualIcon';
@@ -102,7 +102,7 @@ Page.propTypes = {
   onFilterChanged: PropTypes.func.isRequired,
 };
 
-const FALLBACK_OS_LIST_FILTER = BaseFilter.fromString(
+const FALLBACK_OS_LIST_FILTER = QueryFilter.fromString(
   'sort-reverse=latest_severity first=1',
 );
 

--- a/src/web/pages/overrides/__tests__/OverrideDetailsPage.test.tsx
+++ b/src/web/pages/overrides/__tests__/OverrideDetailsPage.test.tsx
@@ -7,7 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Response from 'gmp/http/response';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Override, {type OverrideElement} from 'gmp/models/override';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -62,7 +62,7 @@ const createGmp = ({
   currentSettingsResponse = currentSettingsDefaultResponse,
   getOverrideResponse = new Response(override),
   getPermissionsResponse = new Response([], {
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
     counts: new CollectionCounts(),
   }),
   cloneOverrideResponse = new Response({data: {id: 'foo'}}),

--- a/src/web/pages/overrides/__tests__/OverrideListPage.test.tsx
+++ b/src/web/pages/overrides/__tests__/OverrideListPage.test.tsx
@@ -14,7 +14,7 @@ import {
   wait,
 } from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Override from 'gmp/models/override';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -67,28 +67,28 @@ const createGmp = ({
   getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getOverrides = testing.fn().mockResolvedValue({
     data: [override],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -140,7 +140,7 @@ describe('OverrideListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('override', defaultSettingFilter),
@@ -153,8 +153,8 @@ describe('OverrideListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([override], filter, loadedFilter, counts),
     );
@@ -229,7 +229,7 @@ describe('OverrideListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('override', defaultSettingFilter),
@@ -242,8 +242,8 @@ describe('OverrideListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([override], filter, loadedFilter, counts),
     );
@@ -273,7 +273,7 @@ describe('OverrideListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('override', defaultSettingFilter),
@@ -286,8 +286,8 @@ describe('OverrideListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([override], filter, loadedFilter, counts),
     );
@@ -329,7 +329,7 @@ describe('OverrideListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('override', defaultSettingFilter),
@@ -342,8 +342,8 @@ describe('OverrideListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([override], filter, loadedFilter, counts),
     );
@@ -383,7 +383,7 @@ describe('OverrideListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('override', defaultSettingFilter),
@@ -409,7 +409,7 @@ describe('OverrideListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('override', defaultSettingFilter),
@@ -434,7 +434,7 @@ describe('OverrideListPage tests', () => {
       length: 10,
       rows: 10,
     });
-    const listFilter = BaseFilter.fromString('first=11 rows=10');
+    const listFilter = QueryFilter.fromString('first=11 rows=10');
     const getOverrides = testing.fn().mockResolvedValue({
       data: overrides,
       meta: {

--- a/src/web/pages/overrides/dashboard/ActiveDaysDisplay.jsx
+++ b/src/web/pages/overrides/dashboard/ActiveDaysDisplay.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import {_, _l} from 'gmp/locale/lang';
 import {OVERRIDES_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {parseFloat} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import DonutChart from 'web/components/chart/Donut';
@@ -116,7 +116,7 @@ export class OverridesActiveDaysDisplay extends React.Component {
     if (isDefined(filter) && filter.hasTerm(activeDaysTerm)) {
       return;
     }
-    const activeDaysFilter = BaseFilter.fromTerm(activeDaysTerm);
+    const activeDaysFilter = QueryFilter.fromTerm(activeDaysTerm);
 
     const newFilter = isDefined(filter)
       ? filter.copy().and(activeDaysFilter)

--- a/src/web/pages/overrides/dashboard/WordCloudDisplay.jsx
+++ b/src/web/pages/overrides/dashboard/WordCloudDisplay.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import {_, _l} from 'gmp/locale/lang';
 import {OVERRIDES_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {parseFloat} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
@@ -57,7 +57,7 @@ export class OverridesWordCloudDisplay extends React.Component {
       if (isDefined(filter) && filter.hasTerm(wordTerm)) {
         return;
       }
-      wordFilter = BaseFilter.fromTerm(wordTerm);
+      wordFilter = QueryFilter.fromTerm(wordTerm);
     }
 
     const newFilter = isDefined(filter)

--- a/src/web/pages/performance/PerformancePage.tsx
+++ b/src/web/pages/performance/PerformancePage.tsx
@@ -12,7 +12,7 @@ import {
   type PerformanceReport as PerformanceReportModel,
 } from 'gmp/commands/performance';
 import date, {type Date} from 'gmp/models/date';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   type default as Scanner,
   GREENBONE_SENSOR_SCANNER_TYPE,
@@ -57,7 +57,7 @@ interface SelectorProps {
   className?: string;
 }
 
-const SENSOR_SCANNER_FILTER = BaseFilter.fromString(
+const SENSOR_SCANNER_FILTER = QueryFilter.fromString(
   `type=${GREENBONE_SENSOR_SCANNER_TYPE}`,
 );
 

--- a/src/web/pages/permissions/__tests__/PermissionDetailsPage.test.tsx
+++ b/src/web/pages/permissions/__tests__/PermissionDetailsPage.test.tsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, fireEvent, rendererWith, wait} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Permission from 'gmp/models/permission';
 import {YES_VALUE, NO_VALUE} from 'gmp/parser';
 import {createSession} from 'gmp/testing';
@@ -62,7 +62,7 @@ const reloadInterval = 1;
 const manualUrl = 'test/';
 
 const setupStoreForPermissionDetailsPage = store => {
-  const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+  const defaultSettingFilter = QueryFilter.fromString('foo=bar');
   store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
   store.dispatch(
     defaultFilterLoadingActions.success('permission', defaultSettingFilter),
@@ -79,8 +79,8 @@ const setupStoreForPermissionDetailsPage = store => {
   store.dispatch(
     entitiesLoadingActions.success(
       [permission],
-      BaseFilter.fromString(),
-      BaseFilter.fromString(),
+      QueryFilter.fromString(),
+      QueryFilter.fromString(),
       counts,
     ),
   );
@@ -94,7 +94,7 @@ const createGmp = ({
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),

--- a/src/web/pages/permissions/__tests__/PermissionListPage.test.tsx
+++ b/src/web/pages/permissions/__tests__/PermissionListPage.test.tsx
@@ -12,7 +12,7 @@ import {
   wait,
 } from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Permission from 'gmp/models/permission';
 import {YES_VALUE, NO_VALUE} from 'gmp/parser';
 import {createSession} from 'gmp/testing';
@@ -47,14 +47,14 @@ const createGmp = ({
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getPermissions = testing.fn().mockResolvedValue({
     data: [permission],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -92,7 +92,7 @@ describe('PermissionListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('permission', defaultSettingFilter),
@@ -105,8 +105,8 @@ describe('PermissionListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success(
         [permission],
@@ -132,7 +132,7 @@ describe('PermissionListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('permission', defaultSettingFilter),
@@ -145,8 +145,8 @@ describe('PermissionListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success(
         [permission],

--- a/src/web/pages/policies/DetailsPage.tsx
+++ b/src/web/pages/policies/DetailsPage.tsx
@@ -5,7 +5,7 @@
 
 import {useQueryClient} from '@tanstack/react-query';
 import {useNavigate, useParams} from 'react-router';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type Policy from 'gmp/models/policy';
 import Download from 'web/components/form/Download';
 import useDownload from 'web/components/form/useDownload';
@@ -47,7 +47,7 @@ const Details = ({entity}: {entity: Policy}) => {
 };
 
 const permissionsResourceFilter = (id: string) =>
-  BaseFilter.fromString(`resource_uuid=${id}`).all();
+  QueryFilter.fromString(`resource_uuid=${id}`).all();
 
 const PolicyDetailsPage = () => {
   const [_] = useTranslation();

--- a/src/web/pages/policies/__tests__/DetailsPage.test.tsx
+++ b/src/web/pages/policies/__tests__/DetailsPage.test.tsx
@@ -8,7 +8,7 @@ import {rendererWith, fireEvent, screen, within} from 'web/testing';
 import {Route, Routes} from 'react-router';
 import {vi} from 'vitest';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Policy from 'gmp/models/policy';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -185,14 +185,14 @@ const createGmp = ({
   getTagsResponse = {
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   },
   getPermissionsResponse = {
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   },

--- a/src/web/pages/policies/__tests__/ListPage.test.jsx
+++ b/src/web/pages/policies/__tests__/ListPage.test.jsx
@@ -13,7 +13,7 @@ import {
 } from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Policy from 'gmp/models/policy';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -55,14 +55,14 @@ const createGmp = ({
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getPolicies = testing.fn().mockResolvedValue({
     data: [policy],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -100,7 +100,7 @@ describe('PoliciesPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('policy', defaultSettingFilter),
@@ -113,8 +113,8 @@ describe('PoliciesPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([policy], filter, loadedFilter, counts),
     );
@@ -136,7 +136,7 @@ describe('PoliciesPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('policy', defaultSettingFilter),
@@ -149,8 +149,8 @@ describe('PoliciesPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([policy], filter, loadedFilter, counts),
     );

--- a/src/web/pages/policies/__tests__/PoliciesComponent.test.tsx
+++ b/src/web/pages/policies/__tests__/PoliciesComponent.test.tsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen, wait} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Policy from 'gmp/models/policy';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -40,14 +40,14 @@ const createGmp = ({
   getAlerts = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getScanners = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -55,14 +55,14 @@ const createGmp = ({
   getSchedules = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getTargets = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -206,28 +206,28 @@ describe('PoliciesComponent tests', () => {
     const getAlerts = testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts(),
       },
     });
     const getScanners = testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts(),
       },
     });
     const getSchedules = testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts(),
       },
     });
     const getTargets = testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts(),
       },
     });

--- a/src/web/pages/policies/__tests__/Table.test.jsx
+++ b/src/web/pages/policies/__tests__/Table.test.jsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Policy from 'gmp/models/policy';
 import {createSession} from 'gmp/testing';
 import Table from 'web/pages/policies/Table';
@@ -43,7 +43,7 @@ const counts = new CollectionCounts({
   rows: 2,
 });
 
-const filter = BaseFilter.fromString('rows=2');
+const filter = QueryFilter.fromString('rows=2');
 
 const createGmp = () => ({
   session: createSession(),

--- a/src/web/pages/portlists/__tests__/PortListFilterDialog.test.tsx
+++ b/src/web/pages/portlists/__tests__/PortListFilterDialog.test.tsx
@@ -12,7 +12,7 @@ import {
   wait,
 } from 'web/testing';
 import Filter from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import PortListsFilterDialog from 'web/pages/portlists/PortListFilterDialog';
 
 const newFilter = new Filter({
@@ -34,7 +34,7 @@ const gmp = {
 
 describe('PortListsFilterDialog tests', () => {
   test('should render dialog', () => {
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const {render} = rendererWith({capabilities: true, gmp});
     render(<PortListsFilterDialog filter={filter} />);
 
@@ -55,7 +55,7 @@ describe('PortListsFilterDialog tests', () => {
   });
 
   test('should call onFilterChanged when a filter is updated', async () => {
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const {render} = rendererWith({capabilities: true, gmp});
     const handleFilterChanged = testing.fn();
     render(
@@ -70,12 +70,12 @@ describe('PortListsFilterDialog tests', () => {
     const saveButton = screen.getDialogSaveButton();
     fireEvent.click(saveButton);
     expect(handleFilterChanged).toHaveBeenCalledWith(
-      BaseFilter.fromString('foo=bar'),
+      QueryFilter.fromString('foo=bar'),
     );
   });
 
   test('should call onFilterCreated when a new filter is saved', async () => {
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const {render} = rendererWith({capabilities: true, gmp});
     const handleFilterCreated = testing.fn();
     render(

--- a/src/web/pages/reportconfigs/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/reportconfigs/__tests__/DetailsPage.test.jsx
@@ -7,7 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Response from 'gmp/http/response';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ReportConfig from 'gmp/models/report-config';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -23,7 +23,7 @@ const reportConfig = ReportConfig.fromElement(mockReportConfig);
 const createGmp = ({
   getReportConfigResponse = new Response(reportConfig),
   getPermissionsResponse = new Response([], {
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
     counts: new CollectionCounts(),
   }),
   currentSettingsResponse = currentSettingsDefaultResponse,

--- a/src/web/pages/reportconfigs/__tests__/ListPage.test.jsx
+++ b/src/web/pages/reportconfigs/__tests__/ListPage.test.jsx
@@ -13,7 +13,7 @@ import {
 } from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ReportConfig from 'gmp/models/report-config';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -59,14 +59,14 @@ const createGmp = ({
   getReportConfigs = testing.fn().mockResolvedValue({
     data: [config],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -100,7 +100,7 @@ describe('ReportConfigsPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('reportconfig', defaultSettingFilter),
@@ -113,8 +113,8 @@ describe('ReportConfigsPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([config], filter, loadedFilter, counts),
     );
@@ -135,7 +135,7 @@ describe('ReportConfigsPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('reportconfig', defaultSettingFilter),
@@ -148,8 +148,8 @@ describe('ReportConfigsPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([config], filter, loadedFilter, counts),
     );

--- a/src/web/pages/reportconfigs/__tests__/Table.test.jsx
+++ b/src/web/pages/reportconfigs/__tests__/Table.test.jsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ReportConfig from 'gmp/models/report-config';
 import {createSession} from 'gmp/testing';
 import Table from 'web/pages/reportconfigs/Table';
@@ -55,7 +55,7 @@ const counts = new CollectionCounts({
   rows: 2,
 });
 
-const filter = BaseFilter.fromString('rows=2');
+const filter = QueryFilter.fromString('rows=2');
 
 const createGmp = () => ({
   session: createSession(),

--- a/src/web/pages/reports/AuditDeltaReportDetailsPage.jsx
+++ b/src/web/pages/reports/AuditDeltaReportDetailsPage.jsx
@@ -12,7 +12,7 @@ import {
   RESET_FILTER,
   RESULTS_FILTER_FILTER,
 } from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isActive} from 'gmp/models/task';
 import {first} from 'gmp/utils/array';
 import {isDefined, hasValue} from 'gmp/utils/identity';
@@ -57,11 +57,11 @@ import {generateFilename} from 'web/utils/Render';
 
 const log = logger.getLogger('web.pages.report.deltadetailspage');
 
-const DEFAULT_FILTER = BaseFilter.fromString(
+const DEFAULT_FILTER = QueryFilter.fromString(
   'levels=hmlg rows=100 min_qod=70 first=1 sort-reverse=compliant',
 );
 
-const REPORT_FORMATS_FILTER = BaseFilter.fromString(
+const REPORT_FORMATS_FILTER = QueryFilter.fromString(
   'active=1 and trust=1 rows=-1',
 );
 

--- a/src/web/pages/reports/AuditReportDetailsContent.tsx
+++ b/src/web/pages/reports/AuditReportDetailsContent.tsx
@@ -7,8 +7,8 @@ import React from 'react';
 import styled from 'styled-components';
 import type AuditReport from 'gmp/models/audit-report';
 import type Filter from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type ReportReport from 'gmp/models/report/report';
 import type ReportTask from 'gmp/models/report/task';
 import type ReportTLSCertificate from 'gmp/models/report/tls-certificate';
@@ -184,7 +184,7 @@ const AuditReportDetailsContent = ({
 
   const progress = task?.progress ?? 0;
 
-  const effectiveReportFilter = reportFilter ?? pageFilter ?? new BaseFilter();
+  const effectiveReportFilter = reportFilter ?? pageFilter ?? new QueryFilter();
 
   const showIsLoading = isLoading && !hasReport;
 

--- a/src/web/pages/reports/AuditReportDetailsPage.tsx
+++ b/src/web/pages/reports/AuditReportDetailsPage.tsx
@@ -15,7 +15,7 @@ import {
   type FilterType,
   RESET_FILTER,
 } from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type ReportTLSCertificate from 'gmp/models/report/tls-certificate';
 import {isActive, type TaskStatus} from 'gmp/models/task';
 import {isDefined} from 'gmp/utils/identity';
@@ -74,7 +74,7 @@ interface AuditReportCommand {
 
 const log = logger.getLogger('web.pages.reports.AuditReportDetailsPage');
 
-const DEFAULT_FILTER = BaseFilter.fromString(
+const DEFAULT_FILTER = QueryFilter.fromString(
   'levels=hmlg rows=100 min_qod=70 first=1 compliance_levels=yniu sort=compliant',
 );
 

--- a/src/web/pages/reports/AuditReportsListPage.jsx
+++ b/src/web/pages/reports/AuditReportsListPage.jsx
@@ -6,7 +6,7 @@
 import React, {useEffect, useState} from 'react';
 import {useNavigate} from 'react-router';
 import Filter, {AUDIT_REPORTS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isActive} from 'gmp/models/task';
 import {isDefined} from 'gmp/utils/identity';
 import DashboardControls from 'web/components/dashboard/Controls';
@@ -131,7 +131,7 @@ const reportsReloadInterval = ({entities = []}) =>
     ? USE_DEFAULT_RELOAD_INTERVAL_ACTIVE
     : USE_DEFAULT_RELOAD_INTERVAL;
 
-const FALLBACK_AUDIT_REPORT_LIST_FILTER = BaseFilter.fromString(
+const FALLBACK_AUDIT_REPORT_LIST_FILTER = QueryFilter.fromString(
   'report_compliance_levels=yniu sort-reverse=date first=1',
 );
 

--- a/src/web/pages/reports/DeltaDetailsPage.tsx
+++ b/src/web/pages/reports/DeltaDetailsPage.tsx
@@ -15,7 +15,7 @@ import {
   RESET_FILTER,
   RESULTS_FILTER_FILTER,
 } from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type Report from 'gmp/models/report';
 import type ReportConfig from 'gmp/models/report-config';
 import type ReportFormat from 'gmp/models/report-format';
@@ -74,11 +74,11 @@ interface UseReportStateParams {
 
 const log = logger.getLogger('web.pages.report.deltadetailspage');
 
-const DEFAULT_FILTER = BaseFilter.fromString(
+const DEFAULT_FILTER = QueryFilter.fromString(
   'levels=chml rows=100 min_qod=70 first=1 sort-reverse=severity',
 );
 
-const REPORT_FORMATS_FILTER = BaseFilter.fromString(
+const REPORT_FORMATS_FILTER = QueryFilter.fromString(
   'active=1 and trust=1 rows=-1',
 );
 

--- a/src/web/pages/reports/ReportDetailsPage.tsx
+++ b/src/web/pages/reports/ReportDetailsPage.tsx
@@ -12,7 +12,7 @@ import {
   type FilterType,
   RESET_FILTER,
 } from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type Report from 'gmp/models/report';
 import type ReportTLSCertificate from 'gmp/models/report/tls-certificate';
 import {isActive} from 'gmp/models/task';
@@ -61,7 +61,7 @@ interface ReportTargetRef {
 
 const log = logger.getLogger('web.pages.reports.DetailsPage');
 
-const DEFAULT_FILTER = BaseFilter.fromString(
+const DEFAULT_FILTER = QueryFilter.fromString(
   'levels=chml rows=100 min_qod=70 first=1 sort-reverse=severity result_hosts_only=0',
 );
 

--- a/src/web/pages/reports/ReportListPage.tsx
+++ b/src/web/pages/reports/ReportListPage.tsx
@@ -8,8 +8,8 @@ import {useDispatch} from 'react-redux';
 import {useNavigate} from 'react-router';
 import {type TaskCommandCreateImportTaskParams} from 'gmp/commands/task';
 import {REPORTS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type Report from 'gmp/models/report';
 import {isActive} from 'gmp/models/task';
 import {isDefined} from 'gmp/utils/identity';
@@ -53,7 +53,7 @@ interface ToolBarIconsProps {
 
 type ReportListPageProps = WithEntitiesContainerComponentProps<Report>;
 
-const CONTAINER_TASK_FILTER = BaseFilter.fromString('target=""');
+const CONTAINER_TASK_FILTER = QueryFilter.fromString('target=""');
 
 const ToolBarIcons = ({onUploadReportClick}: ToolBarIconsProps) => {
   const [_] = useTranslation();
@@ -161,7 +161,7 @@ const ReportListPage = ({
         replace: true,
       });
     } else {
-      const newFilter = filter ?? new BaseFilter();
+      const newFilter = filter ?? new QueryFilter();
       isDefined(onFilterChanged) &&
         onFilterChanged(newFilter.first().set('task_id', report?.task?.id));
       setBeforeSelectFilter(newFilter);
@@ -236,7 +236,7 @@ const reportsReloadInterval = ({entities = []}: {entities: Report[]}) =>
     ? USE_DEFAULT_RELOAD_INTERVAL_ACTIVE
     : USE_DEFAULT_RELOAD_INTERVAL;
 
-const FALLBACK_REPORT_LIST_FILTER = BaseFilter.fromString(
+const FALLBACK_REPORT_LIST_FILTER = QueryFilter.fromString(
   'sort-reverse=date first=1',
 );
 

--- a/src/web/pages/reports/__fixtures__/MockAuditReport.tsx
+++ b/src/web/pages/reports/__fixtures__/MockAuditReport.tsx
@@ -6,7 +6,7 @@
 import CollectionCounts from 'gmp/collection/collection-counts';
 import AuditReport from 'gmp/models/audit-report';
 import {COMPLIANCE} from 'gmp/models/compliance';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ReportHost from 'gmp/models/report/host';
 import ReportOperatingSystem from 'gmp/models/report/os';
 import {
@@ -368,7 +368,7 @@ export const getMockAuditReport = () => {
     task: task1,
   });
 
-  const errorsCollection = parseErrors(report, BaseFilter.fromString());
+  const errorsCollection = parseErrors(report, QueryFilter.fromString());
 
   const os1 = new ReportOperatingSystem({
     id: 'cpe:/foo/bar',
@@ -393,7 +393,7 @@ export const getMockAuditReport = () => {
       rows: 2,
       length: 2,
     }),
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
   };
 
   return {

--- a/src/web/pages/reports/__fixtures__/MockReport.tsx
+++ b/src/web/pages/reports/__fixtures__/MockReport.tsx
@@ -5,7 +5,7 @@
 
 import CollectionCounts from 'gmp/collection/collection-counts';
 import {setLocale} from 'gmp/locale/lang';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Report from 'gmp/models/report';
 import ReportHost from 'gmp/models/report/host';
 import ReportOperatingSystem from 'gmp/models/report/os';
@@ -313,7 +313,7 @@ export const getMockReport = () => {
     _id: '1234',
   });
 
-  const errorsCollection = parseErrors(report, BaseFilter.fromString());
+  const errorsCollection = parseErrors(report, QueryFilter.fromString());
 
   const os1 = new ReportOperatingSystem({
     id: 'cpe:/foo/bar',
@@ -336,7 +336,7 @@ export const getMockReport = () => {
       rows: 2,
       length: 2,
     }),
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
   };
 
   const cert1 = ReportTLSCertificate.fromElement(tlsCertificate1);
@@ -350,7 +350,7 @@ export const getMockReport = () => {
       rows: 2,
       length: 2,
     }),
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
   };
 
   const resultsCollection = {
@@ -362,7 +362,7 @@ export const getMockReport = () => {
       rows: report.result_count?.filtered ?? 0,
       length: report.result_count?.filtered ?? 0,
     }),
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
   };
 
   const portsCollection = {
@@ -374,7 +374,7 @@ export const getMockReport = () => {
       rows: report.ports?.count ?? 0,
       length: report.ports?.count ?? 0,
     }),
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
   };
 
   const applicationsCollection = {
@@ -386,7 +386,7 @@ export const getMockReport = () => {
       rows: report.apps?.count ?? 0,
       length: report.apps?.count ?? 0,
     }),
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
   };
 
   const cvesCollection = {
@@ -398,7 +398,7 @@ export const getMockReport = () => {
       rows: report.vulns?.count ?? 0,
       length: report.vulns?.count ?? 0,
     }),
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
   };
 
   const closedCvesCollection = {
@@ -410,7 +410,7 @@ export const getMockReport = () => {
       rows: report.closed_cves?.count ?? 0,
       length: report.closed_cves?.count ?? 0,
     }),
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
   };
 
   return {

--- a/src/web/pages/reports/__tests__/AuditDeltaDetailsPage.test.jsx
+++ b/src/web/pages/reports/__tests__/AuditDeltaDetailsPage.test.jsx
@@ -7,12 +7,12 @@ import {describe, expect, test, testing} from '@gsa/testing';
 import {fireEvent, rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Filter from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {getMockAuditDeltaReport} from 'web/pages/reports/__fixtures__/MockAuditDeltaReport';
 import DeltaReportDetailsContent from 'web/pages/reports/DeltaReportDetailsContent';
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 compliance_levels=ynui rows=10 min_qod=70 first=1 sort=compliant',
 );
 
@@ -44,7 +44,7 @@ const createGmp = ({reportResultsThreshold = 10} = {}) => ({
     get: testing.fn().mockResolvedValue({
       data: mockEntity.report?.results?.entities ?? [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts({
           filtered: 2,
           all: 2,
@@ -63,7 +63,7 @@ const createGmp = ({reportResultsThreshold = 10} = {}) => ({
         {ip: '109.876.54.322', id: '109.876.54.322', hostname: 'host3'},
       ],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts({filtered: 3, all: 3, first: 1, rows: 10}),
       },
     }),

--- a/src/web/pages/reports/__tests__/AuditReportDetailsContent.test.tsx
+++ b/src/web/pages/reports/__tests__/AuditReportDetailsContent.test.tsx
@@ -6,16 +6,16 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {fireEvent, rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {getMockAuditReport} from 'web/pages/reports/__fixtures__/MockAuditReport';
 import AuditReportDetailsContent from 'web/pages/reports/AuditReportDetailsContent';
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 compliance_levels=ynui rows=10 min_qod=70 first=1 sort=compliant',
 );
 
-const resetFilter = BaseFilter.fromString(
+const resetFilter = QueryFilter.fromString(
   'first=1 compliance_levels=ynui sort=compliant',
 );
 

--- a/src/web/pages/reports/__tests__/AuditReportDetailsPage.test.tsx
+++ b/src/web/pages/reports/__tests__/AuditReportDetailsPage.test.tsx
@@ -8,8 +8,8 @@ import {fireEvent, rendererWith, screen, waitFor, within} from 'web/testing';
 import {Route, Routes} from 'react-router';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import {ROWS_PER_PAGE_SETTING_ID} from 'gmp/commands/user';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
 import {getMockAuditReport} from 'web/pages/reports/__fixtures__/MockAuditReport';
@@ -31,7 +31,7 @@ const reportId = entity.report?.id ?? '';
 const emptyCollectionResponse: CollectionResponse = {
   data: [],
   meta: {
-    filter: new BaseFilter(),
+    filter: new QueryFilter(),
     counts: new CollectionCounts(),
   },
 };
@@ -78,7 +78,7 @@ const createGmp = () => ({
   filter: {
     get: testing
       .fn()
-      .mockResolvedValue({data: BaseFilter.fromString('rows=100')}),
+      .mockResolvedValue({data: QueryFilter.fromString('rows=100')}),
   },
   filters: {
     get: testing.fn().mockResolvedValue(emptyCollectionResponse),
@@ -107,7 +107,7 @@ const createGmp = () => ({
         },
       ],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts({
           first: 1,
           all: 1,
@@ -122,7 +122,7 @@ const createGmp = () => ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts(),
       },
     }),

--- a/src/web/pages/reports/__tests__/AuditReportFilterDialog.test.tsx
+++ b/src/web/pages/reports/__tests__/AuditReportFilterDialog.test.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, within, rendererWith} from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import AuditReportFilterDialog from 'web/pages/reports/AuditReportFilterDialog';
 
 const caps = new Capabilities(['everything']);
@@ -20,7 +20,7 @@ describe('AuditReportFilterDialog tests', () => {
     const onFilterCreated = testing.fn();
     const onClose = testing.fn();
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       'apply_overrides=0 levels=hmlg rows=100 min_qod=70 first=1 sort=compliant',
     );
 

--- a/src/web/pages/reports/__tests__/AuditReportsListPage.test.jsx
+++ b/src/web/pages/reports/__tests__/AuditReportsListPage.test.jsx
@@ -15,7 +15,7 @@ import {
   testBulkDeleteDialog,
 } from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {getMockAuditReport} from 'web/pages/reports/__fixtures__/MockAuditReport';
 import AuditReportListPage from 'web/pages/reports/AuditReportsListPage';
@@ -37,14 +37,14 @@ const createGmp = ({
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -54,28 +54,28 @@ const createGmp = ({
   getComplianceAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getReports = testing.fn().mockResolvedValue({
     data: [entity],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getTags = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getReportFormats = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -122,7 +122,7 @@ describe('AuditReportsPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('auditreport', defaultSettingFilter),
@@ -135,8 +135,8 @@ describe('AuditReportsPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesActions.success([entity], filter, loadedFilter, counts),
     );
@@ -209,7 +209,7 @@ describe('AuditReportsPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('auditreport', defaultSettingFilter),
@@ -222,8 +222,8 @@ describe('AuditReportsPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesActions.success([entity], filter, loadedFilter, counts),
     );

--- a/src/web/pages/reports/__tests__/DeltaReportDetailsContent.test.tsx
+++ b/src/web/pages/reports/__tests__/DeltaReportDetailsContent.test.tsx
@@ -7,13 +7,13 @@ import {describe, expect, test, testing} from '@gsa/testing';
 import {fireEvent, rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Filter from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {SEVERITY_RATING_CVSS_3, type SeverityRating} from 'gmp/utils/severity';
 import {getMockDeltaReport} from 'web/pages/reports/__fixtures__/MockDeltaReport';
 import DeltaReportDetailsContent from 'web/pages/reports/DeltaReportDetailsContent';
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 levels=chml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 
@@ -52,7 +52,7 @@ const createGmp = ({
     get: testing.fn().mockResolvedValue({
       data: mockEntity.report?.results?.entities ?? [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts({
           filtered: 2,
           all: 2,
@@ -70,7 +70,7 @@ const createGmp = ({
         {ip: '109.876.54.321', id: '109.876.54.321', hostname: 'lorem.ipsum'},
       ],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts({filtered: 2, all: 2, first: 1, rows: 10}),
       },
     }),

--- a/src/web/pages/reports/__tests__/DownloadReportDialog.test.tsx
+++ b/src/web/pages/reports/__tests__/DownloadReportDialog.test.tsx
@@ -5,12 +5,12 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {render, screen} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ReportFormat from 'gmp/models/report-format';
 import {CONTAINER_SCANNING_RESULTS_THRESHOLD} from 'gmp/settings';
 import DownloadReportDialog from 'web/pages/reports/DownloadReportDialog';
 
-const filter = BaseFilter.fromString('rows=100');
+const filter = QueryFilter.fromString('rows=100');
 
 const reportFormats = [
   ReportFormat.fromElement({_id: 'rf-1', name: 'PDF', report_type: 'scan'}),

--- a/src/web/pages/reports/__tests__/ReportDetailsContent.test.tsx
+++ b/src/web/pages/reports/__tests__/ReportDetailsContent.test.tsx
@@ -7,7 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, within, rendererWith, fireEvent} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Filter from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Report from 'gmp/models/report';
 import {createSession} from 'gmp/testing';
 import {getMockReport} from 'web/pages/reports/__fixtures__/MockReport';
@@ -15,7 +15,7 @@ import ReportDetailsContent from 'web/pages/reports/ReportDetailsContent';
 
 const mockReport = getMockReport();
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 
@@ -25,7 +25,7 @@ const filterWithName = Filter.fromElement({
   _id: '123',
 });
 
-const resetFilter = BaseFilter.fromString('first=1 sort-reverse=severity');
+const resetFilter = QueryFilter.fromString('first=1 sort-reverse=severity');
 
 const manualUrl = 'test/';
 
@@ -53,7 +53,7 @@ const createGmp = ({reportResultsThreshold = 10} = {}) => ({
     get: testing.fn().mockResolvedValue({
       data: mockReport.hosts ?? [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts({filtered: 2, all: 2}),
       },
     }),
@@ -62,7 +62,7 @@ const createGmp = ({reportResultsThreshold = 10} = {}) => ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts({filtered: 2, all: 2}),
       },
     }),
@@ -71,7 +71,7 @@ const createGmp = ({reportResultsThreshold = 10} = {}) => ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts({filtered: 4, all: 4}),
       },
     }),
@@ -80,7 +80,7 @@ const createGmp = ({reportResultsThreshold = 10} = {}) => ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts({filtered: 2, all: 2}),
       },
     }),
@@ -89,7 +89,7 @@ const createGmp = ({reportResultsThreshold = 10} = {}) => ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts({filtered: 2, all: 2}),
       },
     }),
@@ -98,7 +98,7 @@ const createGmp = ({reportResultsThreshold = 10} = {}) => ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts({filtered: 2, all: 2}),
       },
     }),
@@ -107,7 +107,7 @@ const createGmp = ({reportResultsThreshold = 10} = {}) => ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts({filtered: 2, all: 2}),
       },
     }),
@@ -116,7 +116,7 @@ const createGmp = ({reportResultsThreshold = 10} = {}) => ({
     get: testing.fn().mockResolvedValue({
       data: mockReport.errors?.entities ?? [],
       meta: {
-        filter: BaseFilter.fromString('rows=10'),
+        filter: QueryFilter.fromString('rows=10'),
         counts:
           mockReport.errors?.counts ??
           new CollectionCounts({filtered: 2, all: 2}),
@@ -142,7 +142,7 @@ const createGmp = ({reportResultsThreshold = 10} = {}) => ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts({filtered: 0, all: 0}),
       },
     }),

--- a/src/web/pages/reports/__tests__/ReportDetailsFilterDialog.test.tsx
+++ b/src/web/pages/reports/__tests__/ReportDetailsFilterDialog.test.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {describe, test, expect, testing} from '@gsa/testing';
 import {fireEvent, rendererWith, screen, within} from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ReportDetailsFilterDialog from 'web/pages/reports/ReportDetailsFilterDialog';
 
 const caps = new Capabilities(['everything']);
@@ -20,7 +20,7 @@ describe('Details Filter Dialog for Audit report', () => {
     const onFilterCreated = testing.fn();
     const onClose = testing.fn();
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       'apply_overrides=0 levels=hmlg rows=100 min_qod=70 first=1 sort=compliant',
     );
 
@@ -92,7 +92,7 @@ describe('Details Filter Dialog for Audit report', () => {
     const onFilterCreated = testing.fn();
     const onClose = testing.fn();
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       'apply_overrides=0 levels=hmlg rows=100 min_qod=70 first=1 sort=severity',
     );
 
@@ -171,7 +171,7 @@ describe('Details Filter Dialog for Audit report', () => {
     const onFilterCreated = testing.fn();
     const onClose = testing.fn();
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       'levels=hml rows=100 min_qod=70 first=1 sort-reverse=severity result_hosts_only=0',
     );
 
@@ -214,7 +214,7 @@ describe('Details Filter Dialog for Audit report', () => {
     const onFilterCreated = testing.fn();
     const onClose = testing.fn();
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       'levels=hml rows=100 min_qod=70 first=1 sort-reverse=severity result_hosts_only=1',
     );
 

--- a/src/web/pages/reports/__tests__/ReportDetailsPage.test.tsx
+++ b/src/web/pages/reports/__tests__/ReportDetailsPage.test.tsx
@@ -8,8 +8,8 @@ import {rendererWith, fireEvent, screen, within, waitFor} from 'web/testing';
 import {Route, Routes} from 'react-router';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import {ROWS_PER_PAGE_SETTING_ID} from 'gmp/commands/user';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
 import {getMockReport} from 'web/pages/reports/__fixtures__/MockReport';
@@ -31,7 +31,7 @@ const reportId = entity.report?.id ?? '';
 const emptyCollectionResponse: CollectionResponse = {
   data: [],
   meta: {
-    filter: new BaseFilter(),
+    filter: new QueryFilter(),
     counts: new CollectionCounts(),
   },
 };
@@ -77,7 +77,7 @@ const createGmp = () => ({
   filter: {
     get: testing
       .fn()
-      .mockResolvedValue({data: BaseFilter.fromString('rows=100')}),
+      .mockResolvedValue({data: QueryFilter.fromString('rows=100')}),
   },
   filters: {
     get: testing.fn().mockResolvedValue(emptyCollectionResponse),
@@ -106,7 +106,7 @@ const createGmp = () => ({
         },
       ],
       meta: {
-        filter: new BaseFilter(),
+        filter: new QueryFilter(),
         counts: new CollectionCounts({
           first: 1,
           all: 1,
@@ -121,7 +121,7 @@ const createGmp = () => ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: new BaseFilter(),
+        filter: new QueryFilter(),
         counts: new CollectionCounts(),
       },
     }),

--- a/src/web/pages/reports/dashboard/HighResultsDisplay.jsx
+++ b/src/web/pages/reports/dashboard/HighResultsDisplay.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import {_, _l} from 'gmp/locale/lang';
 import {REPORTS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {parseInt, parseFloat, parseDate} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import LineChart from 'web/components/chart/base/Line';
@@ -52,7 +52,7 @@ export class ReportsHighResultsDisplay extends React.Component {
     let {x: endDate} = end;
     const dateFormat = 'YYYY-MM-DDTHH:mm';
 
-    let newFilter = isDefined(filter) ? filter.copy() : new BaseFilter();
+    let newFilter = isDefined(filter) ? filter.copy() : new QueryFilter();
 
     if (isDefined(startDate)) {
       if (startDate.isSame(endDate)) {
@@ -65,7 +65,7 @@ export class ReportsHighResultsDisplay extends React.Component {
       );
 
       if (!newFilter.hasTerm(startTerm)) {
-        newFilter = newFilter.and(BaseFilter.fromTerm(startTerm));
+        newFilter = newFilter.and(QueryFilter.fromTerm(startTerm));
       }
     }
 
@@ -75,7 +75,7 @@ export class ReportsHighResultsDisplay extends React.Component {
       );
 
       if (!newFilter.hasTerm(endTerm)) {
-        newFilter = newFilter.and(BaseFilter.fromTerm(endTerm));
+        newFilter = newFilter.and(QueryFilter.fromTerm(endTerm));
       }
     }
 

--- a/src/web/pages/reports/details/EmptyResultsReport.tsx
+++ b/src/web/pages/reports/details/EmptyResultsReport.tsx
@@ -4,8 +4,8 @@
  */
 
 import styled from 'styled-components';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isDefined} from 'gmp/utils/identity';
 import {CircleXDeleteIcon, EditIcon, FilterIcon} from 'web/components/icon';
 import Divider from 'web/components/layout/Divider';
@@ -39,7 +39,7 @@ const EmptyResultsReport = ({
   onFilterRemoveClick,
 }: EmptyResultsReportProps) => {
   const [_] = useTranslation();
-  filter = filter ?? new BaseFilter();
+  filter = filter ?? new QueryFilter();
   const levels = filter.get('levels', '') as string | undefined;
   const severity = filter.getTerm('severity');
   const minQod = filter.get('min_qod') as number | undefined;

--- a/src/web/pages/reports/details/__tests__/AgentScanningHostsTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/AgentScanningHostsTab.test.tsx
@@ -6,12 +6,12 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
 import {mockReportHosts} from 'web/pages/reports/__fixtures__/MockReport';
 import AgentScanningHostsTab from 'web/pages/reports/details/host/AgentScanningHostsTab';
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 const gmp = {

--- a/src/web/pages/reports/details/__tests__/AgentScanningHostsTable.test.tsx
+++ b/src/web/pages/reports/details/__tests__/AgentScanningHostsTable.test.tsx
@@ -6,7 +6,7 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type Model from 'gmp/models/model';
 import ReportHost from 'gmp/models/report/host';
 import {
@@ -15,7 +15,7 @@ import {
 } from 'gmp/utils/severity';
 import AgentScanningHostsTable from 'web/pages/reports/details/host/AgentScanningHostsTable';
 
-const filter = BaseFilter.fromString('first=1 rows=10');
+const filter = QueryFilter.fromString('first=1 rows=10');
 
 const createMockHost = (overrides = {}) => {
   return ReportHost.fromElement({

--- a/src/web/pages/reports/details/__tests__/ApplicatationsTable.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ApplicatationsTable.test.tsx
@@ -6,11 +6,11 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type ReportApp from 'gmp/models/report/app';
 import ApplicationsTable from 'web/pages/reports/details/application/ApplicationsTable';
 
-const filter = BaseFilter.fromString('first=1 rows=10');
+const filter = QueryFilter.fromString('first=1 rows=10');
 
 const createMockGmp = () => ({
   settings: {

--- a/src/web/pages/reports/details/__tests__/ApplicationsTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ApplicationsTab.test.tsx
@@ -6,10 +6,10 @@
 import {describe, expect, test} from '@gsa/testing';
 import {rendererWith, screen} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ApplicationsTab from 'web/pages/reports/details/application/ApplicationsTab';
 
-const filter = BaseFilter.fromString('first=1 rows=10');
+const filter = QueryFilter.fromString('first=1 rows=10');
 
 const createMockApplication = (overrides = {}) => ({
   id: 'app-default',

--- a/src/web/pages/reports/details/__tests__/ApplicationsTable.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ApplicationsTable.test.tsx
@@ -6,11 +6,11 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type ReportApp from 'gmp/models/report/app';
 import ApplicationsTable from 'web/pages/reports/details/application/ApplicationsTable';
 
-const filter = BaseFilter.fromString('first=1 rows=10');
+const filter = QueryFilter.fromString('first=1 rows=10');
 
 const createMockGmp = () => ({
   settings: {

--- a/src/web/pages/reports/details/__tests__/ClosedCvesTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ClosedCvesTab.test.tsx
@@ -6,10 +6,10 @@
 import {describe, expect, test} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ClosedCvesTab from 'web/pages/reports/details/cve/ClosedCvesTab';
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 

--- a/src/web/pages/reports/details/__tests__/ClosedCvesTable.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ClosedCvesTable.test.tsx
@@ -6,12 +6,12 @@
 import {describe, expect, test} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type {ReportClosedCve} from 'gmp/models/report/parser';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
 import ClosedCvesTable from 'web/pages/reports/details/cve/ClosedCvesTable';
 
-const filter = BaseFilter.fromString('first=1 rows=10');
+const filter = QueryFilter.fromString('first=1 rows=10');
 
 const createGmp = () => ({
   settings: {

--- a/src/web/pages/reports/details/__tests__/ContainerScanningHostsTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ContainerScanningHostsTab.test.tsx
@@ -6,12 +6,12 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
 import {mockReportHosts} from 'web/pages/reports/__fixtures__/MockReport';
 import ContainerScanningHostsTab from 'web/pages/reports/details/host/ContainerScanningHostsTab';
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 const gmp = {

--- a/src/web/pages/reports/details/__tests__/ContainerScanningHostsTable.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ContainerScanningHostsTable.test.tsx
@@ -6,7 +6,7 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type Model from 'gmp/models/model';
 import ReportHost from 'gmp/models/report/host';
 import {
@@ -15,7 +15,7 @@ import {
 } from 'gmp/utils/severity';
 import ContainerScanningHostsTable from 'web/pages/reports/details/host/ContainerScanningHostsTable';
 
-const filter = BaseFilter.fromString('first=1 rows=10');
+const filter = QueryFilter.fromString('first=1 rows=10');
 
 const createMockHost = (overrides = {}) => {
   return ReportHost.fromElement({

--- a/src/web/pages/reports/details/__tests__/ContainerScanningResultsTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ContainerScanningResultsTab.test.tsx
@@ -7,7 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {act, rendererWith} from 'web/testing';
 import {waitFor, screen} from '@testing-library/react';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Result from 'gmp/models/result';
 import {createSession} from 'gmp/testing';
 import ContainerScanningResultsTab from 'web/pages/reports/details/result/ContainerScanningResultsTab';
@@ -25,7 +25,7 @@ const createGmp = ({
     data: [result],
     meta: {
       counts: new CollectionCounts({filtered: 1, all: 1, first: 1, rows: 10}),
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
     },
   }),
 } = {}) => ({
@@ -44,7 +44,7 @@ const createGmp = ({
 describe('ContainerScanningResultsTab', () => {
   test('should render loading state initially', () => {
     const reportId = 'report-123';
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
 
     const gmp = createGmp();
 
@@ -63,7 +63,7 @@ describe('ContainerScanningResultsTab', () => {
 
   test('should fetch results with report ID filter', async () => {
     const reportId = 'report-123';
-    const filter = BaseFilter.fromString('severity>5');
+    const filter = QueryFilter.fromString('severity>5');
     const gmp = createGmp();
 
     const {render} = rendererWith({gmp});
@@ -89,7 +89,7 @@ describe('ContainerScanningResultsTab', () => {
 
   test('should handle sorting', async () => {
     const reportId = 'report-123';
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
     const mockResults = [
       Result.fromElement({
         _id: '1',
@@ -146,7 +146,7 @@ describe('ContainerScanningResultsTab', () => {
 
   test('should handle pagination - next page', async () => {
     const reportId = 'report-123';
-    const filter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
     const mockResults = [
       Result.fromElement({
         _id: '1',
@@ -198,7 +198,7 @@ describe('ContainerScanningResultsTab', () => {
 
   test('should handle pagination - previous page', async () => {
     const reportId = 'report-123';
-    const filter = BaseFilter.fromString('first=11');
+    const filter = QueryFilter.fromString('first=11');
     const mockResults = [
       Result.fromElement({
         _id: '1',
@@ -250,7 +250,7 @@ describe('ContainerScanningResultsTab', () => {
 
   test('should handle pagination - first page', async () => {
     const reportId = 'report-123';
-    const filter = BaseFilter.fromString('first=11');
+    const filter = QueryFilter.fromString('first=11');
     const mockResults = [
       Result.fromElement({
         _id: '1',
@@ -302,7 +302,7 @@ describe('ContainerScanningResultsTab', () => {
 
   test('should handle pagination - last page', async () => {
     const reportId = 'report-123';
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
     const mockResults = [
       Result.fromElement({
         _id: '1',
@@ -354,8 +354,8 @@ describe('ContainerScanningResultsTab', () => {
 
   test('should update filter when reportFilter prop changes', async () => {
     const reportId = 'report-123';
-    const filter1 = BaseFilter.fromString('severity>5');
-    const filter2 = BaseFilter.fromString('severity>7');
+    const filter1 = QueryFilter.fromString('severity>5');
+    const filter2 = QueryFilter.fromString('severity>7');
     const mockResults = [
       Result.fromElement({
         _id: '1',
@@ -410,7 +410,7 @@ describe('ContainerScanningResultsTab', () => {
 
   test('should render error panel on error', async () => {
     const reportId = 'report-123';
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
 
     const getMock = testing.fn().mockRejectedValue(new Error('API Error'));
 
@@ -439,7 +439,7 @@ describe('ContainerScanningResultsTab', () => {
 
   test('should show subtle loading indicator when refetching (not full spinner)', async () => {
     const reportId = 'report-123';
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
     const mockResults = [
       Result.fromElement({
         _id: '1',
@@ -510,7 +510,7 @@ describe('ContainerScanningResultsTab', () => {
             first: 1,
             rows: 10,
           }),
-          filter: BaseFilter.fromString('sort=severity'),
+          filter: QueryFilter.fromString('sort=severity'),
         },
       });
     }
@@ -546,7 +546,7 @@ describe('ContainerScanningResultsTab', () => {
             first: 1,
             rows: 10,
           }),
-          filter: BaseFilter.fromString(),
+          filter: QueryFilter.fromString(),
         },
       });
 
@@ -555,7 +555,7 @@ describe('ContainerScanningResultsTab', () => {
 
       render(
         <ContainerScanningResultsTab
-          reportFilter={BaseFilter.fromString()}
+          reportFilter={QueryFilter.fromString()}
           reportId={'report-123'}
           status={status}
         />,

--- a/src/web/pages/reports/details/__tests__/ContainerScanningResultsTable.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ContainerScanningResultsTable.test.tsx
@@ -6,12 +6,12 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Result from 'gmp/models/result';
 import {createSession} from 'gmp/testing';
 import ContainerScanningResultsTable from 'web/pages/reports/details/result/ContainerScanningResultsTable';
 
-const filter = BaseFilter.fromString('first=1 rows=10');
+const filter = QueryFilter.fromString('first=1 rows=10');
 
 const createMockResult = (overrides = {}) => {
   return Result.fromElement({

--- a/src/web/pages/reports/details/__tests__/CvesTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/CvesTab.test.tsx
@@ -6,10 +6,10 @@
 import {describe, expect, test} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import CvesTab from 'web/pages/reports/details/cve/CvesTab';
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 

--- a/src/web/pages/reports/details/__tests__/CvesTable.test.tsx
+++ b/src/web/pages/reports/details/__tests__/CvesTable.test.tsx
@@ -6,12 +6,12 @@
 import {describe, expect, test} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type {ReportActiveCve} from 'gmp/models/report/parser';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
 import CvesTable from 'web/pages/reports/details/cve/CvesTable';
 
-const filter = BaseFilter.fromString('first=1 rows=10');
+const filter = QueryFilter.fromString('first=1 rows=10');
 
 const createGmp = () => ({
   settings: {

--- a/src/web/pages/reports/details/__tests__/DeltaResultsTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/DeltaResultsTab.test.tsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, rendererWith, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Result from 'gmp/models/result';
 import {type TaskStatus} from 'gmp/models/task';
 import {createSession} from 'gmp/testing';
@@ -14,7 +14,7 @@ import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
 import {getMockDeltaReport} from 'web/pages/reports/__fixtures__/MockDeltaReport';
 import DeltaResultsTab from 'web/pages/reports/details/DeltaResultsTab';
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 

--- a/src/web/pages/reports/details/__tests__/EmptyResultsReport.test.tsx
+++ b/src/web/pages/reports/details/__tests__/EmptyResultsReport.test.tsx
@@ -5,7 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {render, fireEvent} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import EmptyResultsReport from 'web/pages/reports/details/EmptyResultsReport';
 
 describe('Empty Results Report tests', () => {
@@ -16,7 +16,7 @@ describe('Empty Results Report tests', () => {
     const onFilterRemoveClick = testing.fn();
     const onFilterRemoveSeverityClick = testing.fn();
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       'apply_overrides=0 levels=hmlg rows=2 first=1 sort-reverse=severity',
     );
 
@@ -71,7 +71,7 @@ describe('Empty Results Report tests', () => {
     const onFilterRemoveClick = testing.fn();
     const onFilterRemoveSeverityClick = testing.fn();
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       'apply_overrides=0 levels=hml rows=2 first=1 sort-reverse=severity',
     );
 
@@ -130,7 +130,7 @@ describe('Empty Results Report tests', () => {
     const onFilterRemoveClick = testing.fn();
     const onFilterRemoveSeverityClick = testing.fn();
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       'apply_overrides=0 levels=hmlg severity>50 rows=2 first=1 sort-reverse=severity',
     );
 
@@ -189,7 +189,7 @@ describe('Empty Results Report tests', () => {
     const onFilterRemoveClick = testing.fn();
     const onFilterRemoveSeverityClick = testing.fn();
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       'apply_overrides=0 levels=hmlg min_qod>70 rows=2 first=1 sort-reverse=severity',
     );
 
@@ -247,7 +247,7 @@ describe('Empty Results Report tests', () => {
     const onFilterRemoveClick = testing.fn();
     const onFilterRemoveSeverityClick = testing.fn();
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       'apply_overrides=0 levels=hml rows=2 severity>50 min_qod=70 first=1 sort-reverse=severity',
     );
 

--- a/src/web/pages/reports/details/__tests__/ErrorTable.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ErrorTable.test.tsx
@@ -6,11 +6,11 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type {ReportError} from 'gmp/models/report/parser';
 import ErrorsTable from 'web/pages/reports/details/error/ErrorsTable';
 
-const filter = BaseFilter.fromString('first=1 rows=10');
+const filter = QueryFilter.fromString('first=1 rows=10');
 
 const createMockError = (overrides = {}): ReportError => {
   return {

--- a/src/web/pages/reports/details/__tests__/ErrorsTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ErrorsTab.test.tsx
@@ -6,11 +6,11 @@
 import {describe, expect, test} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {getMockReport} from 'web/pages/reports/__fixtures__/MockReport';
 import ErrorsTab from 'web/pages/reports/details/error/ErrorsTab';
 
-const filter = BaseFilter.fromString('first=1 rows=10');
+const filter = QueryFilter.fromString('first=1 rows=10');
 
 const {errors: mockReportErrors} = getMockReport();
 const mockErrors = mockReportErrors?.entities ?? [];

--- a/src/web/pages/reports/details/__tests__/HostsTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/HostsTab.test.tsx
@@ -6,7 +6,7 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ReportHost from 'gmp/models/report/host';
 import {createSession} from 'gmp/testing';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
@@ -26,7 +26,7 @@ const getImgSrc = (row: HTMLTableRowElement): string => {
   return img.getAttribute('src') ?? '';
 };
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 
@@ -182,7 +182,7 @@ describe('Report Hosts Tab tests', () => {
   });
 });
 
-const auditFilter = BaseFilter.fromString(
+const auditFilter = QueryFilter.fromString(
   'apply_overrides=0 levels=hmlg rows=3 min_qod=70 first=1 sort=compliant',
 );
 

--- a/src/web/pages/reports/details/__tests__/HostsTabContent.test.tsx
+++ b/src/web/pages/reports/details/__tests__/HostsTabContent.test.tsx
@@ -6,7 +6,7 @@
 import {describe, expect, test} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ReportHost from 'gmp/models/report/host';
 import {createSession} from 'gmp/testing';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
@@ -15,7 +15,7 @@ import HostsTabContent, {
   type HostsTabContentProps,
 } from 'web/pages/reports/details/host/HostsTabContent';
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 

--- a/src/web/pages/reports/details/__tests__/OperatingSystemsTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/OperatingSystemsTab.test.tsx
@@ -7,11 +7,11 @@ import {describe, expect, test} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import {COMPLIANCE} from 'gmp/models/compliance';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ReportOperatingSystem from 'gmp/models/report/os';
 import OperatingSystemsTab from 'web/pages/reports/details/operating-system/OperatingSystemsTab';
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort=severity',
 );
 
@@ -206,7 +206,7 @@ describe('Report Operating Systems Tab tests', () => {
   });
 });
 
-const auditFilter = BaseFilter.fromString(
+const auditFilter = QueryFilter.fromString(
   'apply_overrides=0 levels=hmlg rows=3 min_qod=70 first=1 sort=compliant',
 );
 

--- a/src/web/pages/reports/details/__tests__/OperatingSystemsTable.test.tsx
+++ b/src/web/pages/reports/details/__tests__/OperatingSystemsTable.test.tsx
@@ -6,13 +6,13 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen, userEvent, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
 import {getMockAuditReport} from 'web/pages/reports/__fixtures__/MockAuditReport';
 import {getMockReport} from 'web/pages/reports/__fixtures__/MockReport';
 import OperatingSystemsTable from 'web/pages/reports/details/operating-system/OperatingSystemsTable';
 
-const filter = BaseFilter.fromString('first=1 rows=10');
+const filter = QueryFilter.fromString('first=1 rows=10');
 
 const createGmp = () => ({
   session: {timezone: 'CET'},
@@ -154,7 +154,7 @@ describe('OperatingSystemsTable', () => {
   test('should render audit report with compliance column', () => {
     const {operatingsystems} = getMockAuditReport();
 
-    const auditFilter = BaseFilter.fromString('first=1 rows=10');
+    const auditFilter = QueryFilter.fromString('first=1 rows=10');
 
     const {render} = rendererWith({
       gmp: createGmp(),
@@ -192,7 +192,7 @@ describe('OperatingSystemsTable', () => {
   test('should render compliance bar instead of severity bar for audit reports', () => {
     const {operatingsystems} = getMockAuditReport();
 
-    const auditFilter = BaseFilter.fromString('first=1 rows=10');
+    const auditFilter = QueryFilter.fromString('first=1 rows=10');
 
     const {render} = rendererWith({
       gmp: createGmp(),

--- a/src/web/pages/reports/details/__tests__/PortsTab.test.jsx
+++ b/src/web/pages/reports/details/__tests__/PortsTab.test.jsx
@@ -6,13 +6,13 @@
 import {describe, expect, test} from '@gsa/testing';
 import {rendererWith, screen} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ReportPort from 'gmp/models/report/port';
 import {createSession} from 'gmp/testing';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
 import PortsTab from 'web/pages/reports/details/port/PortsTab';
 
-const reportFilter = BaseFilter.fromString(
+const reportFilter = QueryFilter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 

--- a/src/web/pages/reports/details/__tests__/ReportDetailsPageToolbarIcons.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ReportDetailsPageToolbarIcons.test.tsx
@@ -6,12 +6,12 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent} from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {getMockReport} from 'web/pages/reports/__fixtures__/MockReport';
 import ReportDetailsPageToolBarIcons from 'web/pages/reports/details/ReportDetailsPageToolBarIcons';
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 

--- a/src/web/pages/reports/details/__tests__/ReportEntitiesContainer.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ReportEntitiesContainer.test.tsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing, type Mock} from '@gsa/testing';
 import {render, screen, wait} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Result from 'gmp/models/result';
 import ReportEntitiesContainer, {
   type ReportEntitiesContainerRenderProps,
@@ -168,7 +168,7 @@ describe('ReportEntitiesContainer tests', () => {
     const result2 = new Result({id: '2', name: 'bar'});
     const results = [result1, result2];
     const counts = new CollectionCounts({rows: 10, filtered: 20});
-    const filter = BaseFilter.fromString('rows=5');
+    const filter = QueryFilter.fromString('rows=5');
     const expectedCounts = new CollectionCounts({
       rows: 5,
       filtered: 20,

--- a/src/web/pages/reports/details/__tests__/ReportTabDefinitions.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ReportTabDefinitions.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import {describe, expect, test} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type ReportReport from 'gmp/models/report/report';
 import type {TaskStatus} from 'gmp/models/task';
 import type {ReportSubEntities} from 'web/hooks/use-query/use-report-sub-entities';
@@ -35,7 +35,7 @@ const entities = {
 
 const baseParams = {
   activeReport: {} as ReportReport,
-  activeFilter: BaseFilter.fromString(),
+  activeFilter: QueryFilter.fromString(),
   reportId: 'report-123',
   isImport: false,
   isAgentScanning: false,

--- a/src/web/pages/reports/details/__tests__/ReportThresholdPanel.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ReportThresholdPanel.test.tsx
@@ -5,7 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {render, fireEvent, screen} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ThresholdPanel from 'web/pages/reports/details/ReportThresholdPanel';
 
 describe('ReportThresholdPanel tests', () => {
@@ -13,7 +13,7 @@ describe('ReportThresholdPanel tests', () => {
     const onFilterEditClick = testing.fn();
     const onFilterChanged = testing.fn();
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       'apply_overrides=0 rows=2 first=1 sort-reverse=severity',
     );
 
@@ -76,7 +76,7 @@ describe('ReportThresholdPanel tests', () => {
     const onFilterEditClick = testing.fn();
     const onFilterChanged = testing.fn();
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       'apply_overrides=0 levels=hmlg rows=2 first=1 sort-reverse=severity',
     );
 
@@ -143,11 +143,11 @@ describe('ReportThresholdPanel tests', () => {
     const onFilterEditClick = testing.fn();
     const onFilterChanged = testing.fn();
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       'apply_overrides=0 rows=2 first=1 sort-reverse=severity',
     );
 
-    const filterMinSeverity = BaseFilter.fromString(
+    const filterMinSeverity = QueryFilter.fromString(
       'apply_overrides=0 rows=2 first=1 sort-reverse=severity',
     ).set('severity', 7.0, '>');
 
@@ -176,19 +176,19 @@ describe('ReportThresholdPanel tests', () => {
     const onFilterEditClick = testing.fn();
     const onFilterChanged = testing.fn();
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       'apply_overrides=0 levels=hmlg rows=2 first=1 sort-reverse=severity',
     );
 
-    const filterLog = BaseFilter.fromString(
+    const filterLog = QueryFilter.fromString(
       'apply_overrides=0 levels=hml rows=2 first=1 sort-reverse=severity',
     );
 
-    const filterLow = BaseFilter.fromString(
+    const filterLow = QueryFilter.fromString(
       'apply_overrides=0 levels=hmg rows=2 first=1 sort-reverse=severity',
     );
 
-    const filterMedium = BaseFilter.fromString(
+    const filterMedium = QueryFilter.fromString(
       'apply_overrides=0 levels=hlg rows=2 first=1 sort-reverse=severity',
     );
 

--- a/src/web/pages/reports/details/__tests__/ResultsTab.test.jsx
+++ b/src/web/pages/reports/details/__tests__/ResultsTab.test.jsx
@@ -8,7 +8,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {act, rendererWith} from 'web/testing';
 import {screen} from '@testing-library/react';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Result from 'gmp/models/result';
 import {createSession} from 'gmp/testing';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
@@ -96,28 +96,28 @@ const createGmp = ({
   getResults = testing.fn().mockResolvedValue({
     data: results,
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -170,7 +170,7 @@ describe('Report Results Tab tests', () => {
       const getResults = testing.fn().mockResolvedValue({
         data: results,
         meta: {
-          filter: BaseFilter.fromString(),
+          filter: QueryFilter.fromString(),
           counts: new CollectionCounts({
             first: 1,
             all: 3,
@@ -190,13 +190,13 @@ describe('Report Results Tab tests', () => {
         router: true,
       });
 
-      const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+      const defaultSettingFilter = QueryFilter.fromString('foo=bar');
       store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
       store.dispatch(
         defaultFilterLoadingActions.success('result', defaultSettingFilter),
       );
 
-      const filter = BaseFilter.fromString('first=1 rows=10');
+      const filter = QueryFilter.fromString('first=1 rows=10');
       const reportResultsCounts = new CollectionCounts({
         first: 1,
         all: 3,
@@ -290,7 +290,7 @@ describe('Report Results Tab tests', () => {
       const getResults = testing.fn().mockResolvedValue({
         data: results,
         meta: {
-          filter: BaseFilter.fromString(),
+          filter: QueryFilter.fromString(),
           counts: new CollectionCounts({
             first: 1,
             all: 3,
@@ -315,7 +315,7 @@ describe('Report Results Tab tests', () => {
         <ResultsTab
           hasTarget={true}
           progress={progress}
-          reportFilter={BaseFilter.fromString('first=1 rows=10')}
+          reportFilter={QueryFilter.fromString('first=1 rows=10')}
           reportId={'123'}
           reportResultsCounts={
             new CollectionCounts({first: 1, all: 3, filtered: 3, rows: 10})

--- a/src/web/pages/reports/details/__tests__/ResultsTabContent.test.tsx
+++ b/src/web/pages/reports/details/__tests__/ResultsTabContent.test.tsx
@@ -5,13 +5,13 @@
 
 import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Result from 'gmp/models/result';
 import {TASK_STATUS} from 'gmp/models/task';
 import {createSession} from 'gmp/testing';
 import ResultsTabContent from 'web/pages/reports/details/result/ResultsTabContent';
 
-const filter = BaseFilter.fromString('first=1 rows=10');
+const filter = QueryFilter.fromString('first=1 rows=10');
 
 const createMockResult = (id = '101') => {
   return Result.fromElement({

--- a/src/web/pages/reports/details/__tests__/Summary.test.tsx
+++ b/src/web/pages/reports/details/__tests__/Summary.test.tsx
@@ -6,13 +6,13 @@
 import {describe, expect, test} from '@gsa/testing';
 import {rendererWith, screen, waitFor} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {getMockDeltaReport} from 'web/pages/reports/__fixtures__/MockDeltaReport';
 import {getMockReport} from 'web/pages/reports/__fixtures__/MockReport';
 import Summary from 'web/pages/reports/details/Summary';
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 

--- a/src/web/pages/reports/details/__tests__/TlsCertificatesTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/TlsCertificatesTab.test.tsx
@@ -6,12 +6,12 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {fireEvent, rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {getMockReport} from 'web/pages/reports/__fixtures__/MockReport';
 import TLSCertificatesTab from 'web/pages/reports/details/tls-certificate/TlsCertificatesTab';
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 levels=hml rows=3 min_qod=70 first=1 sort-reverse=severity',
 );
 const {tlsCertificates: mockTlsCertificates} = getMockReport();

--- a/src/web/pages/reports/details/__tests__/TlsCertificatesTable.test.tsx
+++ b/src/web/pages/reports/details/__tests__/TlsCertificatesTable.test.tsx
@@ -5,12 +5,12 @@
 
 import {describe, expect, test, testing} from '@gsa/testing';
 import {fireEvent, rendererWith, screen, within} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSession} from 'gmp/testing';
 import {getMockReport} from 'web/pages/reports/__fixtures__/MockReport';
 import TLSCertificatesTable from 'web/pages/reports/details/tls-certificate/TlsCertificatesTable';
 
-const filter = BaseFilter.fromString('rows=3 first=1');
+const filter = QueryFilter.fromString('rows=3 first=1');
 
 const createGmp = () => ({
   session: createSession({timezone: 'CET'}),

--- a/src/web/pages/reports/details/__tests__/WebApplicationHostsTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/WebApplicationHostsTab.test.tsx
@@ -6,12 +6,12 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ReportHost from 'gmp/models/report/host';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
 import WebApplicationHostsTab from 'web/pages/reports/details/host/WebApplicationHostsTab';
 
-const filter = BaseFilter.fromString(
+const filter = QueryFilter.fromString(
   'apply_overrides=0 levels=hml rows=2 min_qod=70 first=1 sort-reverse=severity',
 );
 

--- a/src/web/pages/reports/details/__tests__/WebApplicationHostsTable.test.tsx
+++ b/src/web/pages/reports/details/__tests__/WebApplicationHostsTable.test.tsx
@@ -6,12 +6,12 @@
 import {describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ReportHost from 'gmp/models/report/host';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
 import WebApplicationHostsTable from 'web/pages/reports/details/host/WebApplicationHostsTable';
 
-const filter = BaseFilter.fromString('first=1 rows=10');
+const filter = QueryFilter.fromString('first=1 rows=10');
 
 const createMockHost = (overrides = {}) =>
   ReportHost.fromElement({

--- a/src/web/pages/reports/details/__tests__/WebApplicationScanningResultsTab.test.tsx
+++ b/src/web/pages/reports/details/__tests__/WebApplicationScanningResultsTab.test.tsx
@@ -7,7 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {act, rendererWith} from 'web/testing';
 import {waitFor, screen} from '@testing-library/react';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Result from 'gmp/models/result';
 import {createSession} from 'gmp/testing';
 import WebApplicationScanningResultsTab from 'web/pages/reports/details/result/WebApplicationScanningResultsTab';
@@ -25,7 +25,7 @@ const createGmp = ({
     data: [result],
     meta: {
       counts: new CollectionCounts({filtered: 1, all: 1, first: 1, rows: 10}),
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
     },
   }),
 } = {}) => ({
@@ -44,7 +44,7 @@ const createGmp = ({
 describe('WebApplicationScanningResultsTab', () => {
   test('should render loading state initially', () => {
     const reportId = 'report-123';
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
     const gmp = createGmp();
     const {render} = rendererWith({gmp});
 
@@ -61,7 +61,7 @@ describe('WebApplicationScanningResultsTab', () => {
 
   test('should fetch results with report ID filter', async () => {
     const reportId = 'report-123';
-    const filter = BaseFilter.fromString('severity>5');
+    const filter = QueryFilter.fromString('severity>5');
     const gmp = createGmp();
     const {render} = rendererWith({gmp});
 
@@ -86,7 +86,7 @@ describe('WebApplicationScanningResultsTab', () => {
 
   test('should handle sorting', async () => {
     const reportId = 'report-123';
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
     const mockResults = [
       Result.fromElement({
         _id: '1',
@@ -136,7 +136,7 @@ describe('WebApplicationScanningResultsTab', () => {
 
   test('should render error panel on error', async () => {
     const reportId = 'report-123';
-    const filter = BaseFilter.fromString();
+    const filter = QueryFilter.fromString();
     const getMock = testing.fn().mockRejectedValue(new Error('API Error'));
     const gmp = createGmp({get: getMock});
     const {render} = rendererWith({gmp});
@@ -188,7 +188,7 @@ describe('WebApplicationScanningResultsTab', () => {
               first: 1,
               rows: 10,
             }),
-            filter: BaseFilter.fromString(),
+            filter: QueryFilter.fromString(),
           },
         });
 
@@ -197,7 +197,7 @@ describe('WebApplicationScanningResultsTab', () => {
 
         render(
           <WebApplicationScanningResultsTab
-            reportFilter={BaseFilter.fromString()}
+            reportFilter={QueryFilter.fromString()}
             reportId={'report-123'}
             status={status}
           />,

--- a/src/web/pages/reports/details/__tests__/WebApplicationScanningResultsTable.test.tsx
+++ b/src/web/pages/reports/details/__tests__/WebApplicationScanningResultsTable.test.tsx
@@ -6,12 +6,12 @@
 import {describe, expect, test} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Result from 'gmp/models/result';
 import {createSession} from 'gmp/testing';
 import WebApplicationScanningResultsTable from 'web/pages/reports/details/result/WebApplicationScanningResultsTable';
 
-const filter = BaseFilter.fromString('first=1 rows=10');
+const filter = QueryFilter.fromString('first=1 rows=10');
 
 const createGmp = () => ({
   settings: {

--- a/src/web/pages/reports/details/application/ApplicationsTab.tsx
+++ b/src/web/pages/reports/details/application/ApplicationsTab.tsx
@@ -5,8 +5,8 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type ReportApp from 'gmp/models/report/app';
 import {isDefined} from 'gmp/utils/identity';
 import ErrorPanel from 'web/components/error/ErrorPanel';
@@ -48,7 +48,7 @@ const ApplicationsTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    return isDefined(filter) ? filter : new BaseFilter();
+    return isDefined(filter) ? filter : new QueryFilter();
   }, [filter]);
 
   const [appsFilter, setAppsFilter] = useState<FilterType>(baseFilter);

--- a/src/web/pages/reports/details/cve/ClosedCvesTab.tsx
+++ b/src/web/pages/reports/details/cve/ClosedCvesTab.tsx
@@ -5,8 +5,8 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {type ReportClosedCve} from 'gmp/models/report/parser';
 import {isDefined} from 'gmp/utils/identity';
 import ErrorPanel from 'web/components/error/ErrorPanel';
@@ -48,7 +48,7 @@ const ClosedCvesTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    return isDefined(filter) ? filter : new BaseFilter();
+    return isDefined(filter) ? filter : new QueryFilter();
   }, [filter]);
 
   const [closedCvesFilter, setClosedCvesFilter] =

--- a/src/web/pages/reports/details/cve/CvesTab.tsx
+++ b/src/web/pages/reports/details/cve/CvesTab.tsx
@@ -5,8 +5,8 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {type ReportActiveCve} from 'gmp/models/report/parser';
 import {isDefined} from 'gmp/utils/identity';
 import ErrorPanel from 'web/components/error/ErrorPanel';
@@ -48,7 +48,7 @@ const CvesTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    return isDefined(filter) ? filter : new BaseFilter();
+    return isDefined(filter) ? filter : new QueryFilter();
   }, [filter]);
 
   const [cvesFilter, setCvesFilter] = useState<FilterType>(baseFilter);

--- a/src/web/pages/reports/details/error/ErrorsTab.tsx
+++ b/src/web/pages/reports/details/error/ErrorsTab.tsx
@@ -4,8 +4,8 @@
  */
 
 import {useEffect, useMemo, useState} from 'react';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {type ReportError} from 'gmp/models/report/parser';
 import {isDefined} from 'gmp/utils/identity';
 import ErrorPanel from 'web/components/error/ErrorPanel';
@@ -43,7 +43,7 @@ const ErrorsTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    const f = isDefined(filter) ? filter : new BaseFilter();
+    const f = isDefined(filter) ? filter : new QueryFilter();
     // Override sort: 'sort-reverse=error' maps to ascending A→Z via the
     // sortReverse=(sortDir==='asc') convention used in ReportEntitiesContainer
     return f.set('sort-reverse', 'error');

--- a/src/web/pages/reports/details/operating-system/OperatingSystemsTab.tsx
+++ b/src/web/pages/reports/details/operating-system/OperatingSystemsTab.tsx
@@ -5,8 +5,8 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type ReportOperatingSystem from 'gmp/models/report/os';
 import {isDefined} from 'gmp/utils/identity';
 import Loading from 'web/components/loading/Loading';
@@ -58,7 +58,7 @@ const OperatingSystemsTabWrapper = ({
   const [_] = useTranslation();
 
   const baseFilter = useMemo(() => {
-    return isDefined(filter) ? filter : new BaseFilter();
+    return isDefined(filter) ? filter : new QueryFilter();
   }, [filter]);
 
   const [operatingSystemsFilter, setOperatingSystemsFilter] =

--- a/src/web/pages/reports/details/port/PortsTab.tsx
+++ b/src/web/pages/reports/details/port/PortsTab.tsx
@@ -5,7 +5,7 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {type FilterType} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type ReportPort from 'gmp/models/report/port';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
@@ -41,7 +41,7 @@ const PortsTab = ({
   const reportFilterString = reportFilter.toFilterString();
 
   const baseFilter = useMemo(() => {
-    return BaseFilter.fromString(reportFilterString);
+    return QueryFilter.fromString(reportFilterString);
   }, [reportFilterString]);
 
   const [portsFilter, setPortsFilter] = useState<FilterType>(baseFilter);

--- a/src/web/pages/reports/details/result/ContainerScanningResultsTab.tsx
+++ b/src/web/pages/reports/details/result/ContainerScanningResultsTab.tsx
@@ -5,8 +5,8 @@
 
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isActive, type TaskStatus} from 'gmp/models/task';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
@@ -36,8 +36,8 @@ const ContainerScanningResultsTab = ({
 
   const baseFilter = useMemo(() => {
     const filter = reportFilterString
-      ? BaseFilter.fromString(reportFilterString)
-      : new BaseFilter();
+      ? QueryFilter.fromString(reportFilterString)
+      : new QueryFilter();
     return filter.set('_and_report_id', reportId);
   }, [reportFilterString, reportId]);
 

--- a/src/web/pages/reports/details/result/ResultsTab.tsx
+++ b/src/web/pages/reports/details/result/ResultsTab.tsx
@@ -5,8 +5,8 @@
 
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isActive, type TaskStatus} from 'gmp/models/task';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
@@ -64,8 +64,8 @@ const ResultsTabWrapper = ({
   // Create filter with report ID
   const baseFilter = useMemo(() => {
     const filter = reportFilterString
-      ? BaseFilter.fromString(reportFilterString)
-      : new BaseFilter();
+      ? QueryFilter.fromString(reportFilterString)
+      : new QueryFilter();
     return filter.set('_and_report_id', reportId);
   }, [reportFilterString, reportId]);
 

--- a/src/web/pages/reports/details/result/WebApplicationScanningResultsTab.tsx
+++ b/src/web/pages/reports/details/result/WebApplicationScanningResultsTab.tsx
@@ -5,8 +5,8 @@
 
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import type FilterType from 'gmp/models/filter/filter-type';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isActive, type TaskStatus} from 'gmp/models/task';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
@@ -36,8 +36,8 @@ const WebApplicationScanningResultsTab = ({
 
   const baseFilter = useMemo(() => {
     const filter = reportFilterString
-      ? BaseFilter.fromString(reportFilterString)
-      : new BaseFilter();
+      ? QueryFilter.fromString(reportFilterString)
+      : new QueryFilter();
     return filter.set('_and_report_id', reportId);
   }, [reportFilterString, reportId]);
 

--- a/src/web/pages/reports/details/tls-certificate/TlsCertificatesTab.tsx
+++ b/src/web/pages/reports/details/tls-certificate/TlsCertificatesTab.tsx
@@ -5,7 +5,7 @@
 
 import {useEffect, useMemo, useState} from 'react';
 import {type FilterType} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type ReportTLSCertificate from 'gmp/models/report/tls-certificate';
 import ErrorPanel from 'web/components/error/ErrorPanel';
 import Loading from 'web/components/loading/Loading';
@@ -53,7 +53,7 @@ const TLSCertificatesTab = ({
   const reportFilterString = reportFilter.toFilterString();
 
   const baseFilter = useMemo(() => {
-    const f = BaseFilter.fromString(reportFilterString);
+    const f = QueryFilter.fromString(reportFilterString);
     // Override sort: 'sort-reverse=dn' maps to ascending A→Z via the
     // sortReverse=(sortDir==='asc') convention used in ReportEntitiesContainer
     return f.set('sort-reverse', 'dn');

--- a/src/web/pages/results/ListPage.jsx
+++ b/src/web/pages/results/ListPage.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import {RESULTS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import DashboardControls from 'web/components/dashboard/Controls';
 import {ResultIcon} from 'web/components/icon';
 import ManualIcon from 'web/components/icon/ManualIcon';
@@ -69,7 +69,7 @@ Page.propTypes = {
   onFilterChanged: PropTypes.func.isRequired,
 };
 
-const fallbackFilter = BaseFilter.fromString('sort-reverse=severity');
+const fallbackFilter = QueryFilter.fromString('sort-reverse=severity');
 
 export default withEntitiesContainer('result', {
   entitiesSelector,

--- a/src/web/pages/results/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/results/__tests__/DetailsPage.test.jsx
@@ -7,7 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Response from 'gmp/http/response';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Result from 'gmp/models/result';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -100,11 +100,11 @@ const result = Result.fromElement({
 const createGmp = ({
   getResultResponse = new Response(result),
   getPermissionsResponse = new Response([], {
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
     counts: new CollectionCounts(),
   }),
   getUsersResponse = new Response([], {
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
     counts: new CollectionCounts(),
   }),
   currentSettingsResponse = currentSettingsDefaultResponse,

--- a/src/web/pages/results/__tests__/ListPage.test.jsx
+++ b/src/web/pages/results/__tests__/ListPage.test.jsx
@@ -13,7 +13,7 @@ import {
   wait,
 } from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Result from 'gmp/models/result';
 import {createSession} from 'gmp/testing';
 import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
@@ -101,28 +101,28 @@ const createGmp = ({
   getResults = testing.fn().mockResolvedValue({
     data: results,
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -171,7 +171,7 @@ describe('Results listpage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('result', defaultSettingFilter),
@@ -184,8 +184,8 @@ describe('Results listpage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success(results, filter, loadedFilter, counts),
     );
@@ -287,7 +287,7 @@ describe('Results listpage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('result', defaultSettingFilter),
@@ -300,8 +300,8 @@ describe('Results listpage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success(results, filter, loadedFilter, counts),
     );
@@ -323,7 +323,7 @@ describe('Results listpage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('result', defaultSettingFilter),
@@ -336,8 +336,8 @@ describe('Results listpage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success(results, filter, loadedFilter, counts),
     );
@@ -372,7 +372,7 @@ describe('Results listpage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('result', defaultSettingFilter),
@@ -385,8 +385,8 @@ describe('Results listpage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success(results, filter, loadedFilter, counts),
     );

--- a/src/web/pages/results/dashboard/DescriptionWordCloudDisplay.jsx
+++ b/src/web/pages/results/dashboard/DescriptionWordCloudDisplay.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import {_, _l} from 'gmp/locale/lang';
 import {RESULTS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {parseFloat} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
@@ -57,7 +57,7 @@ export class ResultsDescriptionWordCloudDisplay extends React.Component {
       if (isDefined(filter) && filter.hasTerm(wordTerm)) {
         return;
       }
-      wordFilter = BaseFilter.fromTerm(wordTerm);
+      wordFilter = QueryFilter.fromTerm(wordTerm);
     }
 
     const newFilter = isDefined(filter)

--- a/src/web/pages/results/dashboard/WordCloudDisplay.jsx
+++ b/src/web/pages/results/dashboard/WordCloudDisplay.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import {_, _l} from 'gmp/locale/lang';
 import {RESULTS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {parseFloat} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
@@ -57,7 +57,7 @@ export class ResultsWordCloudDisplay extends React.Component {
       if (isDefined(filter) && filter.hasTerm(wordTerm)) {
         return;
       }
-      wordFilter = BaseFilter.fromTerm(wordTerm);
+      wordFilter = QueryFilter.fromTerm(wordTerm);
     }
 
     const newFilter = isDefined(filter)

--- a/src/web/pages/roles/RoleComponent.tsx
+++ b/src/web/pages/roles/RoleComponent.tsx
@@ -10,7 +10,7 @@ import {
   type RoleCommandSaveParams,
 } from 'gmp/commands/role';
 import type Rejection from 'gmp/http/rejection';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type Permission from 'gmp/models/permission';
 import type Role from 'gmp/models/role';
 import {isDefined} from 'gmp/utils/identity';
@@ -212,7 +212,7 @@ const RoleComponent = ({
 
       try {
         const response = await gmp.permissions.getAll({
-          filter: BaseFilter.fromString(
+          filter: QueryFilter.fromString(
             `subject_type=role and subject_uuid=${roleId}`,
           ),
         });

--- a/src/web/pages/roles/RoleDetailsPage.tsx
+++ b/src/web/pages/roles/RoleDetailsPage.tsx
@@ -5,7 +5,7 @@
 
 import {useNavigate} from 'react-router';
 import type Gmp from 'gmp/gmp';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type Permission from 'gmp/models/permission';
 import type Role from 'gmp/models/role';
 import {RoleIcon} from 'web/components/icon';
@@ -217,7 +217,7 @@ const RoleDetailsPage = ({
 };
 
 const generalPermissionsFilter = (id: string) =>
-  BaseFilter.fromString(`subject_uuid=${id} and resource_uuid=""`).all();
+  QueryFilter.fromString(`subject_uuid=${id} and resource_uuid=""`).all();
 
 const load = (gmp: Gmp) => {
   const loadEntityFunc = loadEntity(gmp);

--- a/src/web/pages/roles/__tests__/RoleDetailsPage.test.tsx
+++ b/src/web/pages/roles/__tests__/RoleDetailsPage.test.tsx
@@ -7,7 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, fireEvent, rendererWith, wait} from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Permission from 'gmp/models/permission';
 import Role from 'gmp/models/role';
 import {YES_VALUE, NO_VALUE} from 'gmp/parser';
@@ -90,7 +90,7 @@ const reloadInterval = 1;
 const manualUrl = 'test/';
 
 const setupStoreForRoleDetailsPage = store => {
-  const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+  const defaultSettingFilter = QueryFilter.fromString('foo=bar');
   store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
   store.dispatch(
     defaultFilterLoadingActions.success('role', defaultSettingFilter),
@@ -107,17 +107,17 @@ const setupStoreForRoleDetailsPage = store => {
   store.dispatch(
     entitiesLoadingActions.success(
       [role],
-      BaseFilter.fromString(),
-      BaseFilter.fromString(),
+      QueryFilter.fromString(),
+      QueryFilter.fromString(),
       counts,
     ),
   );
 
-  const permissionsSubjectFilter = BaseFilter.fromString(
+  const permissionsSubjectFilter = QueryFilter.fromString(
     'subject_uuid=12345 and not resource_uuid="" or resource_uuid=12345',
   ).all();
 
-  const generalPermissionsFilter = BaseFilter.fromString(
+  const generalPermissionsFilter = QueryFilter.fromString(
     'subject_uuid=12345 and resource_uuid=""',
   ).all();
 
@@ -148,7 +148,7 @@ const createGmp = ({
     Promise.resolve({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts(),
       },
     }),
@@ -159,7 +159,7 @@ const createGmp = ({
   getPermissions = testing.fn().mockResolvedValue({
     data: [permission1, permission2],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),

--- a/src/web/pages/roles/__tests__/RoleListPage.test.tsx
+++ b/src/web/pages/roles/__tests__/RoleListPage.test.tsx
@@ -13,7 +13,7 @@ import {
 } from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Role from 'gmp/models/role';
 import {YES_VALUE, NO_VALUE} from 'gmp/parser';
 import {createSession} from 'gmp/testing';
@@ -52,7 +52,7 @@ const createGmp = ({
     Promise.resolve({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts(),
       },
     }),
@@ -60,7 +60,7 @@ const createGmp = ({
   getRoles = testing.fn().mockResolvedValue({
     data: [role],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -98,7 +98,7 @@ describe('RoleListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('role', defaultSettingFilter),
@@ -111,8 +111,8 @@ describe('RoleListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([role], filter, loadedFilter, counts),
     );
@@ -133,7 +133,7 @@ describe('RoleListPage tests', () => {
       store: true,
       router: true,
     });
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('role', defaultSettingFilter),
@@ -146,8 +146,8 @@ describe('RoleListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([role], filter, loadedFilter, counts),
     );

--- a/src/web/pages/scanconfigs/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/scanconfigs/__tests__/DetailsPage.test.jsx
@@ -8,7 +8,7 @@ import {screen, rendererWith, fireEvent, wait, within} from 'web/testing';
 import {vi} from 'vitest';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import Response from 'gmp/http/response';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ScanConfig from 'gmp/models/scan-config';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -128,14 +128,14 @@ const createGmp = ({
   getTagsResponse = {
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   },
   getPermissionsResponse = {
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   },

--- a/src/web/pages/scanconfigs/__tests__/ListPage.test.jsx
+++ b/src/web/pages/scanconfigs/__tests__/ListPage.test.jsx
@@ -13,7 +13,7 @@ import {
 } from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ScanConfig, {
   SCANCONFIG_TREND_STATIC,
   SCANCONFIG_TREND_DYNAMIC,
@@ -66,14 +66,14 @@ const createGmp = ({
   getConfigs = testing.fn().mockResolvedValue({
     data: [config],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -111,7 +111,7 @@ describe('ScanConfigsPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('scanconfig', defaultSettingFilter),
@@ -124,8 +124,8 @@ describe('ScanConfigsPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([config], filter, loadedFilter, counts),
     );
@@ -150,7 +150,7 @@ describe('ScanConfigsPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('scanconfig', defaultSettingFilter),
@@ -163,8 +163,8 @@ describe('ScanConfigsPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([config], filter, loadedFilter, counts),
     );

--- a/src/web/pages/scanconfigs/__tests__/Table.test.jsx
+++ b/src/web/pages/scanconfigs/__tests__/Table.test.jsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ScanConfig, {
   SCANCONFIG_TREND_STATIC,
   SCANCONFIG_TREND_DYNAMIC,
@@ -70,7 +70,7 @@ const counts = new CollectionCounts({
   rows: 2,
 });
 
-const filter = BaseFilter.fromString('rows=2');
+const filter = QueryFilter.fromString('rows=2');
 
 const createGmp = () => ({
   session: createSession(),

--- a/src/web/pages/scanners/ScannerComponent.tsx
+++ b/src/web/pages/scanners/ScannerComponent.tsx
@@ -13,8 +13,8 @@ import {
   type CredentialType,
   CERTIFICATE_CREDENTIAL_TYPE,
 } from 'gmp/models/credential';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   type default as Scanner,
   type ScannerType,
@@ -84,7 +84,7 @@ const createCaCertificateFile = (name: string, certificate: string) =>
   new File([certificate], name, {type: MIME_TYPE_PEM});
 
 const createCredentialsFilter = (types: CredentialType[]) => {
-  return new BaseFilter({
+  return new QueryFilter({
     terms: types.map(
       credentialType =>
         new FilterTerm({

--- a/src/web/pages/scanners/__tests__/ScannerComponent.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerComponent.test.tsx
@@ -5,7 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, fireEvent, rendererWith, wait} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Scanner, {
   GREENBONE_SENSOR_SCANNER_TYPE,
   OPENVASD_SCANNER_TYPE,
@@ -209,7 +209,7 @@ describe('ScannerComponent tests', () => {
     fireEvent.click(button);
     expect(gmp.scanner.get).toHaveBeenCalledWith({id: '1234'});
     expect(gmp.credentials.getAll).toHaveBeenCalledWith({
-      filter: BaseFilter.fromString('type=cc'),
+      filter: QueryFilter.fromString('type=cc'),
     });
 
     await wait();

--- a/src/web/pages/scanners/__tests__/ScannerDetailsPage.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerDetailsPage.test.tsx
@@ -7,7 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen} from 'web/testing';
 import Features from 'gmp/capabilities/features';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Scanner, {
   AGENT_CONTROLLER_SCANNER_TYPE,
   AGENT_CONTROLLER_SENSOR_SCANNER_TYPE,
@@ -82,7 +82,7 @@ const createGmp = ({
   getEntities = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),

--- a/src/web/pages/scanners/__tests__/ScannerFilterDialog.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerFilterDialog.test.tsx
@@ -14,8 +14,8 @@ import {
 } from 'web/testing';
 import Features from 'gmp/capabilities/features';
 import Filter from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {OPENVASD_SCANNER_TYPE, scannerTypeName} from 'gmp/models/scanner';
 import ScannerFilterDialog from 'web/pages/scanners/ScannerFilterDialog';
 
@@ -57,7 +57,7 @@ describe('ScannerFilterDialog tests', () => {
   });
 
   test('should allow to create a new filter', async () => {
-    const filter = new BaseFilter({
+    const filter = new QueryFilter({
       terms: [new FilterTerm({keyword: 'name', value: 'test'})],
     });
     const newFilter = new Filter({id: 'new-filter'});
@@ -107,7 +107,7 @@ describe('ScannerFilterDialog tests', () => {
   });
 
   test('should not render create named filter group if not allowed', () => {
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const gmp = {
       settings: {enableGreenboneSensor: true},
       filter: {

--- a/src/web/pages/schedules/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/schedules/__tests__/DetailsPage.test.jsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Schedule from 'gmp/models/schedule';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -38,7 +38,7 @@ const createGmp = ({
   getEntities = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),

--- a/src/web/pages/schedules/__tests__/ListPage.test.jsx
+++ b/src/web/pages/schedules/__tests__/ListPage.test.jsx
@@ -14,7 +14,7 @@ import {
 } from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Schedule from 'gmp/models/schedule';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -54,14 +54,14 @@ const createGmp = ({
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getSchedules = testing.fn().mockResolvedValue({
     data: [schedule],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -107,7 +107,7 @@ describe('SchedulePage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('schedule', defaultSettingFilter),
@@ -120,8 +120,8 @@ describe('SchedulePage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([schedule], filter, loadedFilter, counts),
     );
@@ -184,7 +184,7 @@ describe('SchedulePage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('schedule', defaultSettingFilter),
@@ -197,8 +197,8 @@ describe('SchedulePage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([schedule], filter, loadedFilter, counts),
     );
@@ -228,7 +228,7 @@ describe('SchedulePage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('schedule', defaultSettingFilter),
@@ -241,8 +241,8 @@ describe('SchedulePage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([schedule], filter, loadedFilter, counts),
     );
@@ -284,7 +284,7 @@ describe('SchedulePage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('schedule', defaultSettingFilter),
@@ -297,8 +297,8 @@ describe('SchedulePage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([schedule], filter, loadedFilter, counts),
     );

--- a/src/web/pages/start/__tests__/StartPage.test.jsx
+++ b/src/web/pages/start/__tests__/StartPage.test.jsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {within, rendererWith, wait, screen} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import StartPage from 'web/pages/start/StartPage';
 
 const manualUrl = 'test/';
@@ -15,7 +15,7 @@ const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -24,7 +24,7 @@ const getFilters = testing.fn().mockReturnValue(
 const getDashboardSetting = testing.fn().mockResolvedValue({
   data: {defaults: {foo: 'bar'}},
   meta: {
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
     counts: new CollectionCounts(),
   },
 });
@@ -34,7 +34,7 @@ const saveDashboardSetting = testing.fn().mockResolvedValue({foo: 'bar'});
 const getAggregates = testing.fn().mockResolvedValue({
   data: [],
   meta: {
-    filter: BaseFilter.fromString(),
+    filter: QueryFilter.fromString(),
     counts: new CollectionCounts(),
   },
 });

--- a/src/web/pages/tags/TagDetailsPage.tsx
+++ b/src/web/pages/tags/TagDetailsPage.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import {useQueryClient} from '@tanstack/react-query';
 import {useNavigate, useParams} from 'react-router';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type Tag from 'gmp/models/tag';
 import Download from 'web/components/form/Download';
 import useDownload from 'web/components/form/useDownload';
@@ -119,7 +119,7 @@ const TagDetailsPage = () => {
     id: id ?? '',
   });
 
-  const permFilter = BaseFilter.fromString(`resource_uuid=${id ?? ''}`).all();
+  const permFilter = QueryFilter.fromString(`resource_uuid=${id ?? ''}`).all();
   const {data: permissionsData} = useGetPermissions({
     filter: permFilter,
     enabled: Boolean(id),

--- a/src/web/pages/tags/TagResourceList.tsx
+++ b/src/web/pages/tags/TagResourceList.tsx
@@ -5,7 +5,7 @@
 
 import {useEffect, useState} from 'react';
 import styled from 'styled-components';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type Model from 'gmp/models/model';
 import type Tag from 'gmp/models/tag';
 import {
@@ -40,7 +40,7 @@ const Spacer = styled.div`
 
 const Notification = ({id, resourceType}: NotificationProps) => {
   const [_] = useTranslation();
-  const filter = BaseFilter.fromString(`tag_id=${id}`);
+  const filter = QueryFilter.fromString(`tag_id=${id}`);
   const normalized = normalizeType(resourceType as NormalizeType);
   return (
     <Divider>
@@ -70,7 +70,7 @@ const TagResourceList = ({entity}: ResourceListProps) => {
       return;
     }
 
-    const filter = BaseFilter.fromString(
+    const filter = QueryFilter.fromString(
       `tag_id="${id}" rows=${MAX_RESOURCES}`,
     );
     const entitiesCommand = gmp[pluralizeType(resourceType)];

--- a/src/web/pages/tags/__tests__/TagFilterDialog.test.tsx
+++ b/src/web/pages/tags/__tests__/TagFilterDialog.test.tsx
@@ -5,12 +5,12 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {changeInputValue, fireEvent, rendererWith, screen} from 'web/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import TagFilterDialog from 'web/pages/tags/TagFilterDialog';
 
 describe('TagFilterDialog tests', () => {
   test('should render dialog', () => {
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const gmp = {filter: {}};
     const {render} = rendererWith({capabilities: true, gmp});
 
@@ -37,7 +37,7 @@ describe('TagFilterDialog tests', () => {
   test('should call onFilterChanged on save', () => {
     const handleClose = testing.fn();
     const handleFilterChanged = testing.fn();
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const gmp = {filter: {}};
     const {render} = rendererWith({capabilities: true, gmp});
 
@@ -54,7 +54,7 @@ describe('TagFilterDialog tests', () => {
     fireEvent.click(screen.getDialogSaveButton());
 
     expect(handleFilterChanged).toHaveBeenCalledWith(
-      BaseFilter.fromString('foo=bar'),
+      QueryFilter.fromString('foo=bar'),
     );
   });
 });

--- a/src/web/pages/tags/__tests__/TagListPage.test.tsx
+++ b/src/web/pages/tags/__tests__/TagListPage.test.tsx
@@ -15,7 +15,7 @@ import {
 import EverythingCapabilities from 'gmp/capabilities/everything';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import dayjs from 'gmp/models/date';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Tag from 'gmp/models/tag';
 import {YES_VALUE} from 'gmp/parser';
 import {createSession} from 'gmp/testing';
@@ -33,7 +33,7 @@ const getSetting = testing.fn().mockResolvedValue({filter: null});
 const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
-    meta: {filter: BaseFilter.fromString(), counts: new CollectionCounts()},
+    meta: {filter: QueryFilter.fromString(), counts: new CollectionCounts()},
   }),
 );
 
@@ -59,7 +59,7 @@ const createGmp = ({
   getTags = testing.fn().mockResolvedValue({
     data: [createTag()],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts({
         first: 1,
         all: 1,
@@ -114,7 +114,7 @@ const setupStore = (store: ReturnType<typeof rendererWith>['store']) => {
   store.dispatch(
     defaultFilterLoadingActions.success(
       'tags',
-      BaseFilter.fromString('foo=bar'),
+      QueryFilter.fromString('foo=bar'),
     ),
   );
 };
@@ -167,7 +167,7 @@ describe('TagsListPage tests', () => {
       getTags: testing.fn().mockResolvedValue({
         data: [],
         meta: {
-          filter: BaseFilter.fromString(),
+          filter: QueryFilter.fromString(),
           counts: new CollectionCounts({
             first: 0,
             all: 0,

--- a/src/web/pages/tags/__tests__/TagResourceList.test.tsx
+++ b/src/web/pages/tags/__tests__/TagResourceList.test.tsx
@@ -7,7 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, screen} from 'web/testing';
 import EverythingCapabilities from 'gmp/capabilities/everything';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Tag from 'gmp/models/tag';
 import Task from 'gmp/models/task';
 import TagResourceList from 'web/pages/tags/TagResourceList';
@@ -36,7 +36,7 @@ describe('ResourceList tests', () => {
         get: testing.fn().mockResolvedValue({
           data: [createTask()],
           meta: {
-            filter: BaseFilter.fromString(),
+            filter: QueryFilter.fromString(),
             counts: new CollectionCounts(),
           },
         }),
@@ -62,7 +62,7 @@ describe('ResourceList tests', () => {
         get: testing.fn().mockResolvedValue({
           data: [],
           meta: {
-            filter: BaseFilter.fromString(),
+            filter: QueryFilter.fromString(),
             counts: new CollectionCounts(),
           },
         }),
@@ -86,7 +86,7 @@ describe('ResourceList tests', () => {
             createTask('task-3'),
           ],
           meta: {
-            filter: BaseFilter.fromString(),
+            filter: QueryFilter.fromString(),
             counts: new CollectionCounts(),
           },
         }),
@@ -104,7 +104,7 @@ describe('ResourceList tests', () => {
     const tag = createTag();
     const getTasks = testing.fn().mockResolvedValue({
       data: [createTask()],
-      meta: {filter: BaseFilter.fromString(), counts: new CollectionCounts()},
+      meta: {filter: QueryFilter.fromString(), counts: new CollectionCounts()},
     });
     const gmp = {
       tasks: {

--- a/src/web/pages/targets/__tests__/TargetDetailsPage.test.tsx
+++ b/src/web/pages/targets/__tests__/TargetDetailsPage.test.tsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen, wait} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Target, {ICMP_PING, TCP_SYN} from 'gmp/models/target';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -84,7 +84,7 @@ const createGmp = (settings = {}) => ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts(),
       },
     }),

--- a/src/web/pages/targets/__tests__/TargetListPage.test.tsx
+++ b/src/web/pages/targets/__tests__/TargetListPage.test.tsx
@@ -14,7 +14,7 @@ import {
   wait,
 } from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Target, {SCAN_CONFIG_DEFAULT} from 'gmp/models/target';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -73,7 +73,7 @@ const createGmp = ({
     Promise.resolve({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts(),
       },
     }),
@@ -81,7 +81,7 @@ const createGmp = ({
   getTargets = testing.fn().mockResolvedValue({
     data: [target],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -127,7 +127,7 @@ describe('TargetsListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('target', defaultSettingFilter),
@@ -140,8 +140,8 @@ describe('TargetsListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([target], filter, loadedFilter, counts),
     );
@@ -207,7 +207,7 @@ describe('TargetsListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('target', defaultSettingFilter),
@@ -220,8 +220,8 @@ describe('TargetsListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([target], filter, loadedFilter, counts),
     );
@@ -253,7 +253,7 @@ describe('TargetsListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('target', defaultSettingFilter),
@@ -266,8 +266,8 @@ describe('TargetsListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([target], filter, loadedFilter, counts),
     );
@@ -309,7 +309,7 @@ describe('TargetsListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('target', defaultSettingFilter),
@@ -322,8 +322,8 @@ describe('TargetsListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([target], filter, loadedFilter, counts),
     );

--- a/src/web/pages/tasks/TaskDetailsPage.tsx
+++ b/src/web/pages/tasks/TaskDetailsPage.tsx
@@ -6,7 +6,7 @@
 import React, {useEffect} from 'react';
 import {useNavigate} from 'react-router';
 import type Gmp from 'gmp/gmp';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import type Model from 'gmp/models/model';
 import type Note from 'gmp/models/note';
 import type Override from 'gmp/models/override';
@@ -305,7 +305,7 @@ export const TaskPermissions = withComponentDefaults<
 })(EntityPermissions<Task>);
 
 const taskIdFilter = (id: string) =>
-  BaseFilter.fromString(`task_id=${id}`).all();
+  QueryFilter.fromString(`task_id=${id}`).all();
 
 const mapStateToProps = (rootState: unknown, {id}: {id: string}) => {
   const permSel = permissionsSelector(rootState);

--- a/src/web/pages/tasks/__tests__/TaskDetailsPage.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskDetailsPage.test.tsx
@@ -7,7 +7,7 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen} from 'web/testing';
 import Features from 'gmp/capabilities/features';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import ScanConfig from 'gmp/models/scan-config';
 import {OPENVAS_SCANNER_TYPE} from 'gmp/models/scanner';
 import Schedule from 'gmp/models/schedule';
@@ -175,14 +175,14 @@ const createGmp = ({
   getEntities = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: new QueryFilter(),
       counts: new CollectionCounts(),
     },
   }),
   getTags = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: new QueryFilter(),
       counts: new CollectionCounts(),
     },
   }),

--- a/src/web/pages/tasks/__tests__/TaskFilterDialog.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskFilterDialog.test.tsx
@@ -13,8 +13,8 @@ import {
 } from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import Filter from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import TaskFilterDialog from 'web/pages/tasks/TaskFilterDialog';
 
 describe('TaskFilterDialog tests', () => {
@@ -25,7 +25,7 @@ describe('TaskFilterDialog tests', () => {
     const gmp = {
       filter: {},
     };
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const {render} = rendererWith({capabilities: true, gmp});
 
     render(
@@ -94,7 +94,7 @@ describe('TaskFilterDialog tests', () => {
     const handleClose = testing.fn();
     const handleFilterChanged = testing.fn();
     const handleFilterCreated = testing.fn();
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const gmp = {
       filter: {
         create: testing.fn().mockResolvedValue(new Filter({id: 'new-filter'})),

--- a/src/web/pages/tasks/__tests__/TaskListPage.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskListPage.test.tsx
@@ -13,7 +13,7 @@ import {
   wait,
 } from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Task, {TASK_STATUS} from 'gmp/models/task';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -54,14 +54,14 @@ const createGmp = ({
   getFilters = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -71,21 +71,21 @@ const createGmp = ({
   getAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getTasks = testing.fn().mockResolvedValue({
     data: [task],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getReportFormats = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -135,7 +135,7 @@ describe('TaskListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('task', defaultSettingFilter),
@@ -148,8 +148,8 @@ describe('TaskListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([task], filter, loadedFilter, counts),
     );
@@ -253,7 +253,7 @@ describe('TaskListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('task', defaultSettingFilter),
@@ -266,8 +266,8 @@ describe('TaskListPage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success([task], filter, loadedFilter, counts),
     );

--- a/src/web/pages/tasks/__tests__/TaskTable.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskTable.test.tsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Task, {TASK_STATUS} from 'gmp/models/task';
 import {createSession} from 'gmp/testing';
 import Table from 'web/pages/tasks/TaskTable';
@@ -81,7 +81,7 @@ const counts = new CollectionCounts({
   rows: 2,
 });
 
-const filter = BaseFilter.fromString('rows=2');
+const filter = QueryFilter.fromString('rows=2');
 
 const createGmp = () => ({
   settings: {},

--- a/src/web/pages/tickets/dashboard/Loaders.jsx
+++ b/src/web/pages/tickets/dashboard/Loaders.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import Loader, {
   loadFunc,
   loaderPropTypes,
@@ -12,7 +12,7 @@ import Loader, {
 
 const TICKETS_LIST = 'tickets-list';
 
-const DEFAULT_FILTER = BaseFilter.fromString('sort-reverse=modified');
+const DEFAULT_FILTER = QueryFilter.fromString('sort-reverse=modified');
 
 const ticketsListLoader = loadFunc(
   ({gmp, filter = DEFAULT_FILTER}) =>

--- a/src/web/pages/tlscertificates/__tests__/DetailsPage.test.jsx
+++ b/src/web/pages/tlscertificates/__tests__/DetailsPage.test.jsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, screen} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import TlsCertificate from 'gmp/models/tls-certificate';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -45,7 +45,7 @@ const createGmp = ({
   getEntities = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),

--- a/src/web/pages/tlscertificates/__tests__/ListPage.test.jsx
+++ b/src/web/pages/tlscertificates/__tests__/ListPage.test.jsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, within, rendererWith, wait} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import TlsCertificate from 'gmp/models/tls-certificate';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -41,14 +41,14 @@ const createGmp = ({
   getTlsCertificates = testing.fn().mockResolvedValue({
     data: [tlsCertificate],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
   getAggregates = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -58,7 +58,7 @@ const createGmp = ({
   getDashboardSetting = testing.fn().mockResolvedValue({
     data: [],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts(),
     },
   }),
@@ -66,7 +66,7 @@ const createGmp = ({
     Promise.resolve({
       data: [],
       meta: {
-        filter: BaseFilter.fromString(),
+        filter: QueryFilter.fromString(),
         counts: new CollectionCounts(),
       },
     }),
@@ -105,7 +105,7 @@ describe('TlsCertificatePage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success(
@@ -121,8 +121,8 @@ describe('TlsCertificatePage tests', () => {
       length: 1,
       rows: 10,
     });
-    const filter = BaseFilter.fromString('first=1 rows=10');
-    const loadedFilter = BaseFilter.fromString('first=1 rows=10');
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const loadedFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(
       entitiesLoadingActions.success(
         [tlsCertificate],

--- a/src/web/pages/tlscertificates/__tests__/Table.test.jsx
+++ b/src/web/pages/tlscertificates/__tests__/Table.test.jsx
@@ -6,7 +6,7 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith, fireEvent, screen} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import TlsCertificate from 'gmp/models/tls-certificate';
 import {createSession} from 'gmp/testing';
 import Table from 'web/pages/tlscertificates/Table';
@@ -39,7 +39,7 @@ const counts = new CollectionCounts({
   rows: 1,
 });
 
-const filter = BaseFilter.fromString('rows=2');
+const filter = QueryFilter.fromString('rows=2');
 
 const createGmp = () => ({
   session: createSession({timezone: 'UTC'}),

--- a/src/web/pages/tlscertificates/dashboard/ModifiedDisplay.jsx
+++ b/src/web/pages/tlscertificates/dashboard/ModifiedDisplay.jsx
@@ -6,8 +6,8 @@
 import React from 'react';
 import {_, _l} from 'gmp/locale/lang';
 import {TLS_CERTIFICATES_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {parseInt, parseDate} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import LineChart, {lineDataPropType} from 'web/components/chart/base/Line';
@@ -58,7 +58,7 @@ export class TlsCertificatesModifiedDisplay extends React.Component {
     let {x: endDate} = end;
     const dateFormat = 'YYYY-MM-DDTHH:mm';
 
-    let newFilter = isDefined(filter) ? filter.copy() : new BaseFilter();
+    let newFilter = isDefined(filter) ? filter.copy() : new QueryFilter();
 
     if (isDefined(startDate)) {
       if (startDate.isSame(endDate)) {
@@ -71,7 +71,7 @@ export class TlsCertificatesModifiedDisplay extends React.Component {
       );
 
       if (!newFilter.hasTerm(startTerm)) {
-        newFilter = newFilter.and(BaseFilter.fromTerm(startTerm));
+        newFilter = newFilter.and(QueryFilter.fromTerm(startTerm));
       }
     }
 
@@ -81,7 +81,7 @@ export class TlsCertificatesModifiedDisplay extends React.Component {
       );
 
       if (!newFilter.hasTerm(endTerm)) {
-        newFilter = newFilter.and(BaseFilter.fromTerm(endTerm));
+        newFilter = newFilter.and(QueryFilter.fromTerm(endTerm));
       }
     }
 

--- a/src/web/pages/users/__tests__/UsersListsPage.test.tsx
+++ b/src/web/pages/users/__tests__/UsersListsPage.test.tsx
@@ -14,7 +14,7 @@ import {
 } from 'web/testing';
 import Capabilities from 'gmp/capabilities/capabilities';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import User from 'gmp/models/user';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -55,15 +55,15 @@ const createGmp = ({
   getUserResponse = {data: user},
   getUsersResponse = {
     data: [user],
-    meta: {filter: new BaseFilter(), counts: new CollectionCounts()},
+    meta: {filter: new QueryFilter(), counts: new CollectionCounts()},
   },
   getAllUsersResponse = {
     data: [user],
-    meta: {filter: new BaseFilter(), counts: new CollectionCounts()},
+    meta: {filter: new QueryFilter(), counts: new CollectionCounts()},
   },
   getFiltersResponse = {
     data: [],
-    meta: {filter: new BaseFilter(), counts: new CollectionCounts()},
+    meta: {filter: new QueryFilter(), counts: new CollectionCounts()},
   },
   cloneUser = testing.fn().mockResolvedValue(cloneUserResponse),
   deleteUser = testing.fn().mockResolvedValue(deleteUserResponse),
@@ -116,7 +116,7 @@ const createGmp = ({
     get: testing.fn().mockResolvedValue({
       data: [],
       meta: {
-        filter: new BaseFilter(),
+        filter: new QueryFilter(),
         counts: new CollectionCounts(),
       },
     }),
@@ -135,7 +135,7 @@ describe('UsersListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('user', defaultSettingFilter),
@@ -207,7 +207,7 @@ describe('UsersListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('user', defaultSettingFilter),
@@ -238,7 +238,7 @@ describe('UsersListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('user', defaultSettingFilter),
@@ -282,7 +282,7 @@ describe('UsersListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('user', defaultSettingFilter),
@@ -323,7 +323,7 @@ describe('UsersListPage tests', () => {
     const gmp = createGmp({
       getUsersResponse: {
         data: [user],
-        meta: {filter: new BaseFilter(), counts},
+        meta: {filter: new QueryFilter(), counts},
       },
     });
 
@@ -334,7 +334,7 @@ describe('UsersListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '10'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('user', defaultSettingFilter),
@@ -362,14 +362,14 @@ describe('UsersListPage tests', () => {
 
     const getUsers = testing.fn().mockResolvedValue({
       data: [user],
-      meta: {filter: BaseFilter.fromString('first=1 rows=10'), counts},
+      meta: {filter: QueryFilter.fromString('first=1 rows=10'), counts},
     });
 
     const gmp = createGmp({
       getUsers,
       getUsersResponse: {
         data: [user],
-        meta: {filter: BaseFilter.fromString('first=1 rows=10'), counts},
+        meta: {filter: QueryFilter.fromString('first=1 rows=10'), counts},
       },
     });
 
@@ -380,7 +380,7 @@ describe('UsersListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('first=1 rows=10');
+    const defaultSettingFilter = QueryFilter.fromString('first=1 rows=10');
     store.dispatch(loadingActions.success({rowsperpage: {value: '10'}}));
     store.dispatch(
       defaultFilterLoadingActions.success('user', defaultSettingFilter),

--- a/src/web/pages/vulns/ListPage.jsx
+++ b/src/web/pages/vulns/ListPage.jsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import {VULNS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import DashboardControls from 'web/components/dashboard/Controls';
 import {VulnerabilityIcon} from 'web/components/icon';
 import ManualIcon from 'web/components/icon/ManualIcon';
@@ -73,7 +73,7 @@ Page.propTypes = {
   onFilterChanged: PropTypes.func.isRequired,
 };
 
-const FALLBACK_VULNS_LIST_FILTER = BaseFilter.fromString(
+const FALLBACK_VULNS_LIST_FILTER = QueryFilter.fromString(
   'sort-reverse=severity first=1',
 );
 

--- a/src/web/pages/vulns/dashboard/HostsDisplay.jsx
+++ b/src/web/pages/vulns/dashboard/HostsDisplay.jsx
@@ -7,8 +7,8 @@ import React from 'react';
 import {format as d3format} from 'd3-format';
 import {_, _l} from 'gmp/locale/lang';
 import {VULNS_FILTER_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
 import FilterTerm from 'gmp/models/filter/filter-term';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {parseFloat} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 import BarChart from 'web/components/chart/Bar';
@@ -133,8 +133,8 @@ export class VulnsHostsDisplay extends React.Component {
       ) {
         return;
       }
-      hostFilter = BaseFilter.fromTerm(startTerm).and(
-        BaseFilter.fromTerm(endTerm),
+      hostFilter = QueryFilter.fromTerm(startTerm).and(
+        QueryFilter.fromTerm(endTerm),
       );
     } else {
       let hostTerm;
@@ -151,7 +151,7 @@ export class VulnsHostsDisplay extends React.Component {
         return;
       }
 
-      hostFilter = BaseFilter.fromTerm(hostTerm);
+      hostFilter = QueryFilter.fromTerm(hostTerm);
     }
 
     const newFilter = isDefined(filter)

--- a/src/web/pages/web-application-targets/__tests__/WebApplicationTargetFilterDialog.test.tsx
+++ b/src/web/pages/web-application-targets/__tests__/WebApplicationTargetFilterDialog.test.tsx
@@ -12,12 +12,12 @@ import {
   wait,
 } from 'web/testing';
 import Filter from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import WebApplicationTargetFilterDialog from 'web/pages/web-application-targets/WebApplicationTargetFilterDialog';
 
 describe('WebApplicationTargetFilterDialog tests', () => {
   test('should render dialog with default fields', () => {
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const gmp = {filter: {}};
     const {render} = rendererWith({capabilities: true, gmp});
     render(<WebApplicationTargetFilterDialog filter={filter} />);
@@ -37,7 +37,7 @@ describe('WebApplicationTargetFilterDialog tests', () => {
   });
 
   test('should call onFilterChanged when filter is updated', () => {
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const handleFilterChanged = testing.fn();
     const gmp = {filter: {}};
     const {render} = rendererWith({capabilities: true, gmp});
@@ -52,12 +52,12 @@ describe('WebApplicationTargetFilterDialog tests', () => {
     const saveButton = screen.getDialogSaveButton();
     fireEvent.click(saveButton);
     expect(handleFilterChanged).toHaveBeenCalledWith(
-      BaseFilter.fromString('foo=bar'),
+      QueryFilter.fromString('foo=bar'),
     );
   });
 
   test('should call onFilterCreated when a new filter is saved', async () => {
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const newFilter = new Filter({
       id: 'new-filter-id',
       name: 'New Filter',

--- a/src/web/pages/web-application-targets/__tests__/WebApplicationTargetsListPage.test.tsx
+++ b/src/web/pages/web-application-targets/__tests__/WebApplicationTargetsListPage.test.tsx
@@ -7,7 +7,7 @@ import {describe, expect, test, testing} from '@gsa/testing';
 import {fireEvent, rendererWith, screen, wait} from 'web/testing';
 import Features from 'gmp/capabilities/features';
 import CollectionCounts from 'gmp/collection/collection-counts';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import WebApplicationTarget from 'gmp/models/web-application-target';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -26,7 +26,7 @@ const getSetting = testing.fn().mockResolvedValue({filter: null});
 const getFilters = testing.fn().mockReturnValue(
   Promise.resolve({
     data: [],
-    meta: {filter: BaseFilter.fromString(), counts: new CollectionCounts()},
+    meta: {filter: QueryFilter.fromString(), counts: new CollectionCounts()},
   }),
 );
 
@@ -46,7 +46,7 @@ const createGmp = ({
   getWebApplicationTargets = testing.fn().mockResolvedValue({
     data: [makeTarget()],
     meta: {
-      filter: BaseFilter.fromString(),
+      filter: QueryFilter.fromString(),
       counts: new CollectionCounts({
         first: 1,
         all: 1,
@@ -93,7 +93,7 @@ describe('WebApplicationTargetsListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success(
@@ -143,7 +143,7 @@ describe('WebApplicationTargetsListPage tests', () => {
       router: true,
     });
 
-    const defaultSettingFilter = BaseFilter.fromString('foo=bar');
+    const defaultSettingFilter = QueryFilter.fromString('foo=bar');
     store.dispatch(loadingActions.success({rowsperpage: {value: '2'}}));
     store.dispatch(
       defaultFilterLoadingActions.success(

--- a/src/web/store/__tests__/utils.test.js
+++ b/src/web/store/__tests__/utils.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect, testing} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {combineReducers, filterIdentifier} from 'web/store/utils';
 
 describe('store utils module tests', () => {
@@ -117,7 +117,7 @@ describe('store utils module tests', () => {
     });
 
     test('should create an identifier for an existing filter', () => {
-      const filter = BaseFilter.fromString('foo=bar');
+      const filter = QueryFilter.fromString('foo=bar');
 
       expect(filterIdentifier(filter)).toEqual('filter:foo=bar');
     });

--- a/src/web/store/dashboard/data/__tests__/actions.test.js
+++ b/src/web/store/dashboard/data/__tests__/actions.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   DASHBOARD_DATA_LOADING_SUCCESS,
   DASHBOARD_DATA_LOADING_REQUEST,
@@ -26,7 +26,7 @@ describe('action tests', () => {
 
   test('should create an action to request dashboard data with filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
 
     expect(requestDashboardData(id, filter)).toEqual({
       id,
@@ -49,7 +49,7 @@ describe('action tests', () => {
   test('should create an action to receive dashboard data with filter', () => {
     const id = 'a1';
     const data = {foo: 'bar'};
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
 
     expect(receivedDashboardData(id, data, filter)).toEqual({
       id,
@@ -73,7 +73,7 @@ describe('action tests', () => {
   test('should create an action to receive an error with filter', () => {
     const id = 'a1';
     const error = 'An error occured';
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
 
     expect(receivedDashboardError(id, error, filter)).toEqual({
       id,

--- a/src/web/store/dashboard/data/__tests__/loader.test.js
+++ b/src/web/store/dashboard/data/__tests__/loader.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect, testing} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   DASHBOARD_DATA_LOADING_REQUEST,
   DASHBOARD_DATA_LOADING_SUCCESS,
@@ -29,7 +29,7 @@ describe('loadFunc tests', () => {
     const func = testing.fn().mockResolvedValue(data);
 
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const props = {
       filter,
     };
@@ -56,7 +56,7 @@ describe('loadFunc tests', () => {
 
   test('should not load if data is already loading', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const filterString = filterIdentifier(filter);
     const state = createState({
       [id]: {
@@ -88,7 +88,7 @@ describe('loadFunc tests', () => {
 
   test('should fail loading dashboard data', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const dispatch = testing.fn();
     const getState = testing.fn();
     const func = testing.fn().mockRejectedValue('An error');

--- a/src/web/store/dashboard/data/__tests__/reducers.test.js
+++ b/src/web/store/dashboard/data/__tests__/reducers.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   receivedDashboardData,
   requestDashboardData,
@@ -40,7 +40,7 @@ describe('dashboard data reducers tests', () => {
 
   test('should handle request dashboard data with filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
     const filterString = filterIdentifier(filter);
     const action = requestDashboardData(id, filter);
 
@@ -73,7 +73,7 @@ describe('dashboard data reducers tests', () => {
   test('should handle receive dashboard data with filter', () => {
     const id = 'a1';
     const data = {foo: 'bar'};
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
     const filterString = filterIdentifier(filter);
     const action = receivedDashboardData(id, data, filter);
 
@@ -106,7 +106,7 @@ describe('dashboard data reducers tests', () => {
   test('should handle receive dashboard error with filter', () => {
     const id = 'a1';
     const error = 'An error occured';
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
     const filterString = filterIdentifier(filter);
     const action = receivedDashboardError(id, error, filter);
 

--- a/src/web/store/dashboard/data/__tests__/selectors.test.js
+++ b/src/web/store/dashboard/data/__tests__/selectors.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import getDashboardData from 'web/store/dashboard/data/selectors';
 import {filterIdentifier} from 'web/store/utils';
 
@@ -61,7 +61,7 @@ describe('dashboard data selector isLoading tests', () => {
 
   test('should return true for isLoading with filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const filterString = filterIdentifier(filter);
     const rootState = createState({
       [id]: {
@@ -92,7 +92,7 @@ describe('dashboard data selector error tests', () => {
 
   test('should return true for isLoading with filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const filterString = filterIdentifier(filter);
     const rootState = createState({
       [id]: {
@@ -127,7 +127,7 @@ describe('dashboard data selector getData tests', () => {
 
   test('should return data with filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const filterString = filterIdentifier(filter);
     const rootState = createState({
       [id]: {
@@ -163,7 +163,7 @@ describe('dashboard data selector getData tests', () => {
 
   test('should return undefined if unknown filter is passed', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const filterString = filterIdentifier();
     const rootState = createState({
       [id]: {

--- a/src/web/store/entities/report/__tests__/actions.test.js
+++ b/src/web/store/entities/report/__tests__/actions.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect, testing} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isFunction} from 'gmp/utils/identity';
 import {
   auditReportActions,
@@ -93,7 +93,7 @@ describe('loadReport function tests', () => {
       },
     };
 
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
 
     expect(loadReport).toBeDefined();
     expect(isFunction(loadReport)).toBe(true);
@@ -284,7 +284,7 @@ describe('report loadReportIfNeeded function tests', () => {
       },
     };
 
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
 
     expect.assertions(7);
 
@@ -525,7 +525,7 @@ describe('loadReportWithThreshold tests', () => {
 
   test('should only load "simple" report with filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const rootState = createState('report', {
       isLoading: {
         [reportIdentifier(id, filter)]: false,
@@ -587,7 +587,7 @@ describe('loadReportWithThreshold tests', () => {
 
   test('should load "full" report with filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const rootState = createState('report', {
       isLoading: {
         [reportIdentifier(id, filter)]: false,
@@ -710,7 +710,7 @@ describe('loadReportWithThreshold tests', () => {
 
   test('should not load report if already loading with filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const rootState = createState('report', {
       isLoading: {
         [reportIdentifier(id, filter)]: true,
@@ -832,7 +832,7 @@ describe('loadDeltaReport function tests', () => {
       },
     };
 
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
 
     expect(loadDeltaReport).toBeDefined();
     expect(isFunction(loadDeltaReport)).toBe(true);
@@ -1003,7 +1003,7 @@ describe('loadAuditReport function tests', () => {
       },
     };
 
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
 
     expect(loadAuditReport).toBeDefined();
     expect(isFunction(loadAuditReport)).toBe(true);
@@ -1194,7 +1194,7 @@ describe('report loadAuditReportIfNeeded function tests', () => {
       },
     };
 
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
 
     expect.assertions(7);
 
@@ -1439,7 +1439,7 @@ describe('loadAuditReportWithThreshold tests', () => {
 
   test('should only load "simple" audit report with filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const rootState = createState('auditreport', {
       isLoading: {
         [reportIdentifier(id, filter)]: false,
@@ -1502,7 +1502,7 @@ describe('loadAuditReportWithThreshold tests', () => {
 
   test('should load "full" audit report with filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const rootState = createState('auditreport', {
       isLoading: {
         [reportIdentifier(id, filter)]: false,
@@ -1628,7 +1628,7 @@ describe('loadAuditReportWithThreshold tests', () => {
 
   test('should not audit load report if already loading with filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const rootState = createState('auditreport', {
       isLoading: {
         [reportIdentifier(id, filter)]: true,
@@ -1757,7 +1757,7 @@ describe('loadDeltaAuditReport function tests', () => {
       },
     };
 
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
 
     expect(loadDeltaAuditReport).toBeDefined();
     expect(isFunction(loadDeltaReport)).toBe(true);

--- a/src/web/store/entities/report/__tests__/reducers.test.js
+++ b/src/web/store/entities/report/__tests__/reducers.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isFunction} from 'gmp/utils/identity';
 import {reportActions} from 'web/store/entities/report/actions';
 import {reportReducer} from 'web/store/entities/report/reducers';
@@ -37,7 +37,7 @@ describe('report reducer tests', () => {
 
   test('should reduce request action with filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const action = reportActions.request(id, filter);
 
     expect(reportReducer(undefined, action)).toEqual({
@@ -68,7 +68,7 @@ describe('report reducer tests', () => {
 
   test('should reduce success action with filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const action = reportActions.success(id, {data: 'foo'}, filter);
 
     expect(reportReducer(undefined, action)).toEqual({
@@ -86,8 +86,8 @@ describe('report reducer tests', () => {
 
   test('should reduce success action with simplified filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar rows=10');
-    const filter2 = BaseFilter.fromString('foo=bar first=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
+    const filter2 = QueryFilter.fromString('foo=bar first=10');
     const action = reportActions.success(id, {data: 'foo'}, filter2);
 
     const existingState = {
@@ -139,8 +139,8 @@ describe('report reducer tests', () => {
 
   test('should reduce error action with filter', () => {
     const id = 'a1';
-    const filter = BaseFilter.fromString('foo=bar rows=10');
-    const filter2 = BaseFilter.fromString('foo=bar first=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
+    const filter2 = QueryFilter.fromString('foo=bar first=10');
     const action = reportActions.error(id, 'Another error', filter2);
     const existingState = {
       byId: {

--- a/src/web/store/entities/report/__tests__/selectors.test.js
+++ b/src/web/store/entities/report/__tests__/selectors.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   reportIdentifier,
   simplifiedReportIdentifier,
@@ -21,7 +21,7 @@ describe('reportIdentifier tests', () => {
 
   test('should create identifier with filter', () => {
     const id = 'foo';
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     expect(reportIdentifier(id, filter)).toEqual('foo-foo=bar rows=10');
   });
 });
@@ -34,7 +34,7 @@ describe('simplifiedReportIdentifier tests', () => {
 
   test('should create identifier with filter', () => {
     const id = 'foo';
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     expect(simplifiedReportIdentifier(id, filter)).toEqual('foo-foo=bar');
   });
 });
@@ -52,7 +52,7 @@ describe('report selector tests', () => {
   });
 
   test('should return true for isLoading with filter', () => {
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const state = createState('report', {
       isLoading: {
         [reportIdentifier('foo', filter)]: true,
@@ -75,7 +75,7 @@ describe('report selector tests', () => {
   });
 
   test('should return false for isLoading with filter', () => {
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const state = createState('report', {
       isLoading: {
         [reportIdentifier('foo', filter)]: false,
@@ -107,7 +107,7 @@ describe('report selector tests', () => {
   });
 
   test('should return undefined for isLoading with filter', () => {
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     let state = createState('report', {
       isLoading: {
         foo: true,
@@ -136,7 +136,7 @@ describe('report selector tests', () => {
   });
 
   test('should return error with filter', () => {
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const state = createState('report', {
       errors: {
         [reportIdentifier('foo', filter)]: 'An error',
@@ -147,7 +147,7 @@ describe('report selector tests', () => {
   });
 
   test('should return undefined error', () => {
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const state = createState('report', {
       errors: {
         [simplifiedReportIdentifier('foo', filter)]: 'An error',
@@ -158,7 +158,7 @@ describe('report selector tests', () => {
   });
 
   test('should return undefined error with filter', () => {
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const state = createState('report', {
       errors: {
         foo: 'An error',
@@ -181,7 +181,7 @@ describe('report selector tests', () => {
 
   test('should return report with filter', () => {
     const model = {id: 'foo'};
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const state = createState('report', {
       byId: {
         [simplifiedReportIdentifier('foo', filter)]: model,
@@ -193,8 +193,8 @@ describe('report selector tests', () => {
 
   test('should return report with simplified filter', () => {
     const model = {id: 'foo'};
-    const filter = BaseFilter.fromString('foo=bar rows=10');
-    const filter2 = BaseFilter.fromString('foo=bar first=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
+    const filter2 = QueryFilter.fromString('foo=bar first=10');
     const state = createState('report', {
       byId: {
         [simplifiedReportIdentifier('foo', filter)]: model,

--- a/src/web/store/entities/reports/__tests__/reducers.test.js
+++ b/src/web/store/entities/reports/__tests__/reducers.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isFunction} from 'gmp/utils/identity';
 import {entitiesActions as actions} from 'web/store/entities/reports';
 import {reportsReducer} from 'web/store/entities/reports/reducers';
@@ -44,7 +44,7 @@ describe('report entities reducer tests', () => {
   });
 
   test('should reduce request action with filter', () => {
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const action = actions.request(filter);
 
     const previousState = {
@@ -102,7 +102,7 @@ describe('report entities reducer tests', () => {
   });
 
   test('should reduce success action with filter', () => {
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const action = actions.success([{id: 'foo'}], filter);
 
     const previousState = {
@@ -165,7 +165,7 @@ describe('report entities reducer tests', () => {
   });
 
   test('should reduce error action with filter', () => {
-    const filter = BaseFilter.fromString('foo=bar rows=10');
+    const filter = QueryFilter.fromString('foo=bar rows=10');
     const action = actions.error('An error', filter);
 
     const previousState = {

--- a/src/web/store/entities/utils/__tests__/actions.test.js
+++ b/src/web/store/entities/utils/__tests__/actions.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect, testing} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isFunction} from 'gmp/utils/identity';
 import {
   types,
@@ -40,7 +40,7 @@ describe('entities loading actions tests', () => {
     });
 
     test('should create a load request action with filter', () => {
-      const filter = BaseFilter.fromString('type=abc');
+      const filter = QueryFilter.fromString('type=abc');
       const actions = createEntitiesLoadingActions('foo');
       const action = actions.request(filter);
 
@@ -63,7 +63,7 @@ describe('entities loading actions tests', () => {
     });
 
     test('should create a load success action with filter', () => {
-      const filter = BaseFilter.fromString('type=abc');
+      const filter = QueryFilter.fromString('type=abc');
       const actions = createEntitiesLoadingActions('foo');
       const action = actions.success(['foo', 'bar'], filter);
 
@@ -76,8 +76,8 @@ describe('entities loading actions tests', () => {
     });
 
     test('should create a load success action with meta info', () => {
-      const filter = BaseFilter.fromString('type=abc');
-      const loadedFilter = BaseFilter.fromString('type=abc rows=100');
+      const filter = QueryFilter.fromString('type=abc');
+      const loadedFilter = QueryFilter.fromString('type=abc rows=100');
       const actions = createEntitiesLoadingActions('foo');
       const counts = {first: 1};
       const action = actions.success(
@@ -109,7 +109,7 @@ describe('entities loading actions tests', () => {
     });
 
     test('should create a load error action with filter', () => {
-      const filter = BaseFilter.fromString('type=abc');
+      const filter = QueryFilter.fromString('type=abc');
       const actions = createEntitiesLoadingActions('foo');
       const action = actions.error('An error', filter);
 
@@ -216,7 +216,7 @@ describe('entities loading actions tests', () => {
 
       const getState = testing.fn().mockReturnValue({foo: 'bar'});
 
-      const loadedFilter = BaseFilter.fromString('name=abc');
+      const loadedFilter = QueryFilter.fromString('name=abc');
       const counts = {first: 1};
       const dispatch = testing.fn();
       const get = testing.fn().mockReturnValue(
@@ -245,9 +245,9 @@ describe('entities loading actions tests', () => {
         entityType: 'foo',
       });
 
-      const filter = BaseFilter.fromString('type=teip');
+      const filter = QueryFilter.fromString('type=teip');
 
-      const myFilterAll = new BaseFilter({
+      const myFilterAll = new QueryFilter({
         terms: [
           {
             keyword: 'type',
@@ -316,9 +316,9 @@ describe('entities loading actions tests', () => {
         entityType: 'foo',
       });
 
-      const filter = BaseFilter.fromString('type=teip');
+      const filter = QueryFilter.fromString('type=teip');
 
-      const myFilterAll = new BaseFilter({
+      const myFilterAll = new QueryFilter({
         terms: [
           {
             keyword: 'type',
@@ -402,7 +402,7 @@ describe('entities loading actions tests', () => {
 
       const getState = testing.fn().mockReturnValue({foo: 'bar'});
 
-      const loadedFilter = BaseFilter.fromString('name=abc');
+      const loadedFilter = QueryFilter.fromString('name=abc');
       const counts = {first: 1};
       const dispatch = testing.fn();
       const get = testing.fn().mockReturnValue(

--- a/src/web/store/entities/utils/__tests__/reducers.test.js
+++ b/src/web/store/entities/utils/__tests__/reducers.test.js
@@ -9,7 +9,7 @@ import Rejection, {
   ResponseRejection,
   TimeoutRejection,
 } from 'gmp/http/rejection';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isFunction} from 'gmp/utils/identity';
 import {
   createEntitiesLoadingActions,
@@ -48,7 +48,7 @@ describe('entities reducers test', () => {
   test('should not override byId accidentially', () => {
     const actions = createEntitiesLoadingActions('foo');
     const reducer = createReducer('foo');
-    const filter = BaseFilter.fromString('byId');
+    const filter = QueryFilter.fromString('byId');
     const filterId = filterIdentifier(filter);
     const action = actions.success([{id: 'foo'}], filter);
     const state = {
@@ -91,7 +91,7 @@ describe('entities reducers test', () => {
   test('should not override default accidentially', () => {
     const actions = createEntitiesLoadingActions('foo');
     const reducer = createReducer('foo');
-    const filter = BaseFilter.fromString('default');
+    const filter = QueryFilter.fromString('default');
     const filterId = filterIdentifier(filter);
     const action = actions.success([{id: 'foo'}], filter);
     const state = {
@@ -150,7 +150,7 @@ describe('entities reducers test', () => {
     test('should set isLoading for filter', () => {
       const actions = createEntitiesLoadingActions('foo');
       const reducer = createReducer('foo');
-      const filter = BaseFilter.fromString('name=foo');
+      const filter = QueryFilter.fromString('name=foo');
       const filterId = filterIdentifier(filter);
       const action = actions.request(filter);
 
@@ -167,9 +167,9 @@ describe('entities reducers test', () => {
     test('should set isLoading and not override existing state', () => {
       const actions = createEntitiesLoadingActions('foo');
       const reducer = createReducer('foo');
-      const filter = BaseFilter.fromString('name=foo');
+      const filter = QueryFilter.fromString('name=foo');
       const filterId = filterIdentifier(filter);
-      const otherFilter = BaseFilter.fromString('name=bar');
+      const otherFilter = QueryFilter.fromString('name=bar');
       const otherFilterId = filterIdentifier(otherFilter);
       const action = actions.request(filter);
       const state = {
@@ -194,8 +194,8 @@ describe('entities reducers test', () => {
     test('should set isLoading and not override other properties', () => {
       const actions = createEntitiesLoadingActions('foo');
       const reducer = createReducer('foo');
-      const filter = BaseFilter.fromString('name=foo');
-      const loadedFilter = BaseFilter.fromString('name=foo rows=10');
+      const filter = QueryFilter.fromString('name=foo');
+      const loadedFilter = QueryFilter.fromString('name=foo rows=10');
       const filterId = filterIdentifier(filter);
       const action = actions.request(filter);
       const counts = {first: 1};
@@ -291,10 +291,10 @@ describe('entities reducers test', () => {
     test('should not override other filters', () => {
       const actions = createEntitiesLoadingActions('foo');
       const reducer = createReducer('foo');
-      const filter = BaseFilter.fromString('name=bar');
+      const filter = QueryFilter.fromString('name=bar');
       const filterId = filterIdentifier(filter);
       const counts = {first: 1};
-      const otherFilter = BaseFilter.fromString('name=foo');
+      const otherFilter = QueryFilter.fromString('name=foo');
       const otherFilterId = filterIdentifier(otherFilter);
       const otherCounts = {last: 22};
       const action = actions.success(
@@ -398,9 +398,9 @@ describe('entities reducers test', () => {
     test('should not override other filters', () => {
       const actions = createEntitiesLoadingActions('foo');
       const reducer = createReducer('foo');
-      const filter = BaseFilter.fromString('name=bar');
+      const filter = QueryFilter.fromString('name=bar');
       const filterId = filterIdentifier(filter);
-      const otherFilter = BaseFilter.fromString('name=foo');
+      const otherFilter = QueryFilter.fromString('name=foo');
       const otherFilterId = filterIdentifier(otherFilter);
       const action = actions.error('An error', filter);
       const state = {
@@ -450,9 +450,9 @@ describe('entities reducers test', () => {
     test('should not reduce expected errors', () => {
       const actions = createEntitiesLoadingActions('foo');
       const reducer = createReducer('foo');
-      const filter = BaseFilter.fromString('name=bar');
+      const filter = QueryFilter.fromString('name=bar');
       const filterId = filterIdentifier(filter);
-      const otherFilter = BaseFilter.fromString('name=foo');
+      const otherFilter = QueryFilter.fromString('name=foo');
       const otherFilterId = filterIdentifier(otherFilter);
       const rejection = new ResponseRejection({status: 401}, 'Another error');
       const action = actions.error(rejection, filter);

--- a/src/web/store/entities/utils/__tests__/selectors.test.js
+++ b/src/web/store/entities/utils/__tests__/selectors.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {createSelector} from 'web/store/entities/utils/selectors';
 import {createRootState, createState} from 'web/store/entities/utils/testing';
 import {filterIdentifier} from 'web/store/utils';
@@ -21,7 +21,7 @@ describe('EntitiesSelector isLoadingEntities tests', () => {
   test('should be false for undefined state with filter', () => {
     const selector = createSelector('foo');
     const rootState = createRootState({});
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
     const fooSelector = selector(rootState);
 
     expect(fooSelector.isLoadingEntities(filter)).toEqual(false);
@@ -39,7 +39,7 @@ describe('EntitiesSelector isLoadingEntities tests', () => {
     const selector = createSelector('foo');
     const rootState = createState('foo', {});
     const fooSelector = selector(rootState);
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
 
     expect(fooSelector.isLoadingEntities(filter)).toEqual(false);
   });
@@ -58,7 +58,7 @@ describe('EntitiesSelector isLoadingEntities tests', () => {
   });
 
   test('should be true for filter', () => {
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       isLoading: {
@@ -80,7 +80,7 @@ describe('EntitiesSelector isLoadingEntities tests', () => {
       },
     });
     const fooSelector = selector(rootState);
-    const filter = BaseFilter.fromString('name=bar');
+    const filter = QueryFilter.fromString('name=bar');
 
     expect(fooSelector.isLoadingEntities(filter)).toEqual(false);
   });
@@ -169,7 +169,7 @@ describe('EntitiesSelector getEntities tests', () => {
     const selector = createSelector('foo');
     const rootState = createRootState({});
     const fooSelector = selector(rootState);
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
 
     expect(fooSelector.getEntities(filter)).toBeUndefined();
   });
@@ -186,7 +186,7 @@ describe('EntitiesSelector getEntities tests', () => {
     const selector = createSelector('foo');
     const rootState = createState('foo', {});
     const fooSelector = selector(rootState);
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
 
     expect(fooSelector.getEntities(filter)).toBeUndefined();
   });
@@ -231,7 +231,7 @@ describe('EntitiesSelector getEntities tests', () => {
   });
 
   test('getEntities should return entities with filter', () => {
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       byId: {
@@ -280,7 +280,7 @@ describe('EntitiesSelector getEntities tests', () => {
       'name=foo': ['lorem', 'ipsum'],
     });
     const fooSelector = selector(rootState);
-    const filter = BaseFilter.fromString('name=bar');
+    const filter = QueryFilter.fromString('name=bar');
 
     expect(fooSelector.getEntities(filter)).toBeUndefined();
   });
@@ -288,7 +288,7 @@ describe('EntitiesSelector getEntities tests', () => {
 
 describe('EntitiesSelector getAllEntities tests', () => {
   test('getAllEntities should return entities with all-filter', () => {
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       byId: {
@@ -323,7 +323,7 @@ describe('EntitiesSelector getAllEntities tests', () => {
   });
 
   test('getAllEntities should return entities with all-filter if filter is undefined', () => {
-    const filter = new BaseFilter();
+    const filter = new QueryFilter();
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       byId: {
@@ -371,7 +371,7 @@ describe('EntitiesSelector getEntitiesError tests', () => {
     const selector = createSelector('foo');
     const rootState = createRootState({});
     const fooSelector = selector(rootState);
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
 
     expect(fooSelector.getEntitiesError(filter)).toBeUndefined();
   });
@@ -388,13 +388,13 @@ describe('EntitiesSelector getEntitiesError tests', () => {
     const selector = createSelector('foo');
     const rootState = createState('foo', {});
     const fooSelector = selector(rootState);
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
 
     expect(fooSelector.getEntitiesError(filter)).toBeUndefined();
   });
 
   test('should return error with default filter', () => {
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       errors: {
@@ -408,7 +408,7 @@ describe('EntitiesSelector getEntitiesError tests', () => {
   });
 
   test('should return error with filter', () => {
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       errors: {
@@ -432,7 +432,7 @@ describe('EntitiesSelector getEntitiesError tests', () => {
   });
 
   test('should return undefined for unknown filter', () => {
-    const otherFilter = BaseFilter.fromString('name=foo');
+    const otherFilter = QueryFilter.fromString('name=foo');
     const selector = createSelector('foo');
     const rootState = createState('foo', {
       errors: {
@@ -440,7 +440,7 @@ describe('EntitiesSelector getEntitiesError tests', () => {
         [filterIdentifier(otherFilter)]: 'Another error',
       },
     });
-    const filter = BaseFilter.fromString('name=bar');
+    const filter = QueryFilter.fromString('name=bar');
     const fooSelector = selector(rootState);
 
     expect(fooSelector.getEntitiesError(filter)).toBeUndefined();
@@ -460,7 +460,7 @@ describe('EntitiesSelector getEntitiesCounts tests', () => {
     const selector = createSelector('foo');
     const rootState = createRootState({});
     const fooSelector = selector(rootState);
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
 
     expect(fooSelector.getEntitiesCounts(filter)).toBeUndefined();
   });
@@ -477,7 +477,7 @@ describe('EntitiesSelector getEntitiesCounts tests', () => {
     const selector = createSelector('foo');
     const rootState = createState('foo', {});
     const fooSelector = selector(rootState);
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
 
     expect(fooSelector.getEntitiesCounts(filter)).toBeUndefined();
   });
@@ -502,7 +502,7 @@ describe('EntitiesSelector getEntitiesCounts tests', () => {
     const counts = {
       first: 1,
     };
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
     const filterId = filterIdentifier(filter);
     const rootState = createState('foo', {
       [filterId]: {
@@ -528,7 +528,7 @@ describe('EntitiesSelector getLoadedFilter tests', () => {
     const selector = createSelector('foo');
     const rootState = createRootState({});
     const fooSelector = selector(rootState);
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
 
     expect(fooSelector.getLoadedFilter(filter)).toBeUndefined();
   });
@@ -545,14 +545,14 @@ describe('EntitiesSelector getLoadedFilter tests', () => {
     const selector = createSelector('foo');
     const rootState = createState('foo', {});
     const fooSelector = selector(rootState);
-    const filter = BaseFilter.fromString('name=foo');
+    const filter = QueryFilter.fromString('name=foo');
 
     expect(fooSelector.getLoadedFilter(filter)).toBeUndefined();
   });
 
   test('should return loaded filter', () => {
     const selector = createSelector('foo');
-    const loadedFilter = BaseFilter.fromString('foo=bar');
+    const loadedFilter = QueryFilter.fromString('foo=bar');
     const rootState = createState('foo', {
       default: {
         loadedFilter,
@@ -565,8 +565,8 @@ describe('EntitiesSelector getLoadedFilter tests', () => {
 
   test('should return loadedFilter with filter', () => {
     const selector = createSelector('foo');
-    const loadedFilter = BaseFilter.fromString('foo=bar');
-    const filter = BaseFilter.fromString('name=foo');
+    const loadedFilter = QueryFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('name=foo');
     const filterId = filterIdentifier(filter);
     const rootState = createState('foo', {
       [filterId]: {

--- a/src/web/store/entities/utils/actions.js
+++ b/src/web/store/entities/utils/actions.js
@@ -4,7 +4,7 @@
  */
 
 import {ALL_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {pluralizeType} from 'gmp/utils/entity-type';
 import {isDefined} from 'gmp/utils/identity';
 
@@ -104,7 +104,7 @@ export const createLoadAllEntities =
     if (isDefined(filter)) {
       filter = isDefined(filter.toFilterString)
         ? filter.all()
-        : BaseFilter.fromString(filter).all();
+        : QueryFilter.fromString(filter).all();
     } else {
       filter = ALL_FILTER;
     }

--- a/src/web/store/entities/utils/selectors.js
+++ b/src/web/store/entities/utils/selectors.js
@@ -4,7 +4,7 @@
  */
 
 import {ALL_FILTER} from 'gmp/models/filter';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {isDefined} from 'gmp/utils/identity';
 import {filterIdentifier} from 'web/store/utils';
 
@@ -39,7 +39,7 @@ export class EntitiesSelector {
     }
     filter = isDefined(filter.toFilterString)
       ? filter.all()
-      : BaseFilter.fromString(filter).all();
+      : QueryFilter.fromString(filter).all();
     return isDefined(this.state.isLoading)
       ? !!this.state.isLoading[filterIdentifier(filter)]
       : false;
@@ -79,7 +79,7 @@ export class EntitiesSelector {
     }
     return isDefined(filter.toFilterString)
       ? this.getEntities(filter.all())
-      : this.getEntities(BaseFilter.fromString(filter).all());
+      : this.getEntities(QueryFilter.fromString(filter).all());
   }
 
   getEntitiesCounts(filter) {

--- a/src/web/store/entities/utils/testing.js
+++ b/src/web/store/entities/utils/testing.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect, testing} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {pluralizeType} from 'gmp/utils/entity-type';
 import {isFunction} from 'gmp/utils/identity';
 import {types} from 'web/store/entities/utils/actions';
@@ -101,7 +101,7 @@ export const testEntitiesActions = (entityType, actions) => {
     });
 
     test('should create a load request action with filter', () => {
-      const filter = BaseFilter.fromString('type=abc');
+      const filter = QueryFilter.fromString('type=abc');
       const action = actions.request(filter);
 
       expect(action).toEqual({
@@ -121,7 +121,7 @@ export const testEntitiesActions = (entityType, actions) => {
     });
 
     test('should create a load success action with filter', () => {
-      const filter = BaseFilter.fromString('type=abc');
+      const filter = QueryFilter.fromString('type=abc');
       const action = actions.success(['foo', 'bar'], filter);
 
       expect(action).toEqual({
@@ -136,7 +136,7 @@ export const testEntitiesActions = (entityType, actions) => {
       'should create a load success action with default filter, ' +
         'loadedFilter and counts',
       () => {
-        const loadedFilter = BaseFilter.fromString('foo=bar');
+        const loadedFilter = QueryFilter.fromString('foo=bar');
         const counts = {first: 1};
         const action = actions.success(
           ['foo', 'bar'],
@@ -158,8 +158,8 @@ export const testEntitiesActions = (entityType, actions) => {
       'should create a load success action with filter, ' +
         'loadedFilter and counts',
       () => {
-        const filter = BaseFilter.fromString('type=abc');
-        const loadedFilter = BaseFilter.fromString('foo=bar');
+        const filter = QueryFilter.fromString('type=abc');
+        const loadedFilter = QueryFilter.fromString('foo=bar');
         const counts = {first: 1};
         const action = actions.success(
           ['foo', 'bar'],
@@ -188,7 +188,7 @@ export const testEntitiesActions = (entityType, actions) => {
     });
 
     test('should create a load error action with filter', () => {
-      const filter = BaseFilter.fromString('type=abc');
+      const filter = QueryFilter.fromString('type=abc');
       const action = actions.error('An error', filter);
 
       expect(action).toEqual({
@@ -204,8 +204,8 @@ export const testEntitiesActions = (entityType, actions) => {
 export const testLoadEntities = (entityType, loadEntities) => {
   describe(`${entityType} loadEntities function tests`, () => {
     test('should load all entities successfully', () => {
-      const filter = BaseFilter.fromString('myfilter');
-      const loadedFilter = BaseFilter.fromString('myfilter rows=100');
+      const filter = QueryFilter.fromString('myfilter');
+      const loadedFilter = QueryFilter.fromString('myfilter rows=100');
       const counts = {first: 1};
       const rootState = createState(entityType, {
         isLoading: {
@@ -260,7 +260,7 @@ export const testLoadEntities = (entityType, loadEntities) => {
     });
 
     test('should not load all entities if isLoading is true', () => {
-      const filter = BaseFilter.fromString('myfilter');
+      const filter = QueryFilter.fromString('myfilter');
       const rootState = createState(entityType, {
         isLoading: {
           [filterIdentifier(filter)]: true,
@@ -287,7 +287,7 @@ export const testLoadEntities = (entityType, loadEntities) => {
     });
 
     test('should fail loading all entities with an error', () => {
-      const filter = BaseFilter.fromString('myfilter');
+      const filter = QueryFilter.fromString('myfilter');
       const rootState = createState(entityType, {
         [filterIdentifier(filter)]: {
           isLoading: false,

--- a/src/web/store/usersettings/defaultfilters/__tests__/actions.test.js
+++ b/src/web/store/usersettings/defaultfilters/__tests__/actions.test.js
@@ -5,7 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {DEFAULT_FILTER_SETTINGS} from 'gmp/commands/user';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   defaultFilterLoadingActions,
   USER_SETTINGS_DEFAULT_FILTER_LOADING_REQUEST,
@@ -25,7 +25,7 @@ describe('defaultFilterLoadingActions tests', () => {
   });
 
   test('should create a success action', () => {
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const action = defaultFilterLoadingActions.success('foo', filter);
 
     expect(action).toEqual({
@@ -180,7 +180,7 @@ describe('loadUserSettingsDefaultFilter tests', () => {
   });
 
   test('should dispatch success', () => {
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const entityType = 'task';
     const getSetting = testing.fn().mockResolvedValue({
       data: {

--- a/src/web/store/usersettings/defaultfilters/__tests__/reducers.test.js
+++ b/src/web/store/usersettings/defaultfilters/__tests__/reducers.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {defaultFilterLoadingActions} from 'web/store/usersettings/defaultfilters/actions';
 import reducer from 'web/store/usersettings/defaultfilters/reducers';
 
@@ -26,7 +26,7 @@ describe('default filters reducers tests', () => {
   });
 
   test('should override isLoading when reducing a request action', () => {
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const prevState = {
       foo: {
         isLoading: false,
@@ -58,7 +58,7 @@ describe('default filters reducers tests', () => {
   });
 
   test('should update state when reducing an error action', () => {
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const prevState = {
       foo: {
         isLoading: true,
@@ -78,7 +78,7 @@ describe('default filters reducers tests', () => {
   });
 
   test('should reduce a success action', () => {
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
     const prevState = {};
     const action = defaultFilterLoadingActions.success('foo', filter);
     const state = reducer(prevState, action);
@@ -91,8 +91,8 @@ describe('default filters reducers tests', () => {
   });
 
   test('should update state when reducing a success action', () => {
-    const oldFilter = BaseFilter.fromString('bar=foo');
-    const filter = BaseFilter.fromString('foo=bar');
+    const oldFilter = QueryFilter.fromString('bar=foo');
+    const filter = QueryFilter.fromString('foo=bar');
     const prevState = {
       foo: {
         isLoading: true,

--- a/src/web/store/usersettings/defaultfilters/__tests__/selectors.test.js
+++ b/src/web/store/usersettings/defaultfilters/__tests__/selectors.test.js
@@ -4,7 +4,7 @@
  */
 
 import {describe, test, expect} from '@gsa/testing';
-import BaseFilter from 'gmp/models/filter/base-filter';
+import QueryFilter from 'gmp/models/filter/query-filter';
 import {getUserSettingsDefaultFilter} from 'web/store/usersettings/defaultfilters/selectors';
 
 describe('getUserSettingsDefaultFilter selector tests', () => {
@@ -26,7 +26,7 @@ describe('getUserSettingsDefaultFilter selector tests', () => {
   });
 
   test('should select values with class entity type', () => {
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
 
     const state = {
       userSettings: {
@@ -55,7 +55,7 @@ describe('getUserSettingsDefaultFilter selector tests', () => {
   });
 
   test('should select values without class entity type', () => {
-    const filter = BaseFilter.fromString('foo=bar');
+    const filter = QueryFilter.fromString('foo=bar');
 
     const state = {
       userSettings: {


### PR DESCRIPTION
## What

Rename BaseFilter to QueryFilter
    
## Why

Use a more specific and better name for the filter class.


