### PR TITLE
Use session duration to calculate session timeout

### DIFF
--- a/src/gmp/commands/__tests__/login.test.ts
+++ b/src/gmp/commands/__tests__/login.test.ts
@@ -6,19 +6,21 @@
 import {describe, test, expect, testing} from '@gsa/testing';
 import LoginCommand from 'gmp/commands/login';
 import {createResponse, createHttp} from 'gmp/commands/testing';
-import {type Envelope} from 'gmp/http/transform/fast-xml';
 import date from 'gmp/models/date';
+import {type LoginData} from 'gmp/models/login';
 
 describe('LoginCommand tests', () => {
   test('should return Login model on successful login', async () => {
     testing.useFakeTimers();
-    const response = createResponse<Envelope>({
+    testing.setSystemTime(new Date('1970-01-01T00:00:00.000Z'));
+
+    const response = createResponse<LoginData>({
       token: 'abc123',
       timezone: 'UTC',
       i18n: 'en',
-      session: 3600,
       jwt: 'jwt_token',
       client_address: '127.0.0.123',
+      duration: 180, // 3 minutes
     });
     const fakeHttp = createHttp(response, {
       apiProtocol: 'https',
@@ -36,7 +38,7 @@ describe('LoginCommand tests', () => {
     expect(loginModel.token).toEqual('abc123');
     expect(loginModel.timezone).toEqual('UTC');
     expect(loginModel.locale).toEqual('en');
-    expect(loginModel.sessionTimeout).toEqual(date('1970-01-01T01:00:00.000Z'));
+    expect(loginModel.sessionTimeout).toEqual(date('1970-01-01T00:03:00.000Z'));
     expect(loginModel.jwt).toEqual('jwt_token');
 
     testing.useRealTimers();

--- a/src/gmp/commands/user.ts
+++ b/src/gmp/commands/user.ts
@@ -446,7 +446,7 @@ class UserCommand extends EntityCommand<User, PortListElement> {
     });
     const seconds = parseInt(response.data.message);
     return response.setData(
-      isDefined(seconds) ? date.unix(seconds) : undefined,
+      isDefined(seconds) ? date().add(seconds, 'seconds') : undefined,
     );
   }
 

--- a/src/gmp/http/transform/__tests__/fast-xml.test.ts
+++ b/src/gmp/http/transform/__tests__/fast-xml.test.ts
@@ -16,7 +16,6 @@ const createEnvelopedXml = (xmlStr: string) =>
 <envelope>
   <client_address>1.2.3.4</client_address>
   <i18n>en</i18n>
-  <session>1234567890</session>
   <timezone>UTC</timezone>
   <token>abc123</token>
   <version>1.2.3</version>
@@ -27,7 +26,6 @@ const createEnvelopedXml = (xmlStr: string) =>
 const envelope: Envelope = {
   client_address: '1.2.3.4',
   i18n: 'en',
-  session: 1234567890,
   timezone: 'UTC',
   token: 'abc123',
   version: '1.2.3',

--- a/src/gmp/http/transform/fast-xml.ts
+++ b/src/gmp/http/transform/fast-xml.ts
@@ -16,7 +16,6 @@ export type XmlMeta = Meta;
 export interface Envelope {
   client_address?: string;
   i18n?: string;
-  session?: number;
   timezone?: string;
   token?: string;
   jwt?: string;

--- a/src/gmp/models/__tests__/login.test.ts
+++ b/src/gmp/models/__tests__/login.test.ts
@@ -13,10 +13,10 @@ describe('Login model tests', () => {
     const response = new Response<LoginData>({
       client_address: '1.2.3.4',
       i18n: 'en',
-      session: 12345,
       timezone: 'UTC',
       token: '123abc',
       version: '1337',
+      duration: 180, // 3 minutes
     });
     const login = Login.fromElement(response);
 

--- a/src/gmp/models/login.ts
+++ b/src/gmp/models/login.ts
@@ -9,7 +9,9 @@ import date, {type Date} from 'gmp/models/date';
 import {parseInt} from 'gmp/parser';
 import {isDefined} from 'gmp/utils/identity';
 
-export type LoginData = Envelope;
+export interface LoginData extends Envelope {
+  duration?: number;
+}
 type LoginElement = Response<LoginData>;
 
 class Login {
@@ -30,10 +32,10 @@ class Login {
     this.token = data.token;
     this.jwt = data.jwt;
 
-    const unixSeconds = parseInt(data.session);
+    const duration = parseInt(data.duration);
 
-    this.sessionTimeout = isDefined(unixSeconds)
-      ? date.unix(unixSeconds)
+    this.sessionTimeout = isDefined(duration)
+      ? date().add(duration, 'seconds')
       : undefined;
   }
 


### PR DESCRIPTION
## What

Use session duration to calculate session timeout

**THIS CHANGE REQUIRES A NEW GSAD VERSION!**

## Why

When the system time of the machine running gsad and the users system time where the browser is running GSA is not in sync the session timeout has been displayed incorrectly. Either it did show 0:00 and the session was still valid or the user has been logged out early. With this change the session timeout is calculated by getting the duration instead of the end time.

## References

https://jira.greenbone.net/browse/GEA-1743
https://github.com/greenbone/gsad/pull/433

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


