### PR TITLE
fix: handle undefined updateToLatest in modify_agent command

### DIFF
--- a/src/gmp/commands/__tests__/agent.test.ts
+++ b/src/gmp/commands/__tests__/agent.test.ts
@@ -68,6 +68,25 @@ describe('AgentCommand tests', () => {
     expect(result).toBeUndefined();
   });
 
+  test('should not include update_to_latest if not provided', async () => {
+    const entityResponse = createActionResultResponse({id: '324'});
+    const http = createHttp(entityResponse);
+    const command = new AgentCommand(http);
+
+    await command.save({
+      agentsIds: ['324'],
+      authorized: true,
+    });
+
+    expect(http.request).toHaveBeenCalledWith('post', {
+      data: {
+        cmd: 'modify_agent',
+        'agent_ids:': ['324'],
+        authorized: YES_VALUE,
+      },
+    });
+  });
+
   test('should allow to clone an agent', async () => {
     const entityResponse = createActionResultResponse({id: '999'});
     const http = createHttp(entityResponse);

--- a/src/gmp/commands/agent.ts
+++ b/src/gmp/commands/agent.ts
@@ -9,6 +9,7 @@ import logger from 'gmp/log';
 import Agent, {type AgentElement} from 'gmp/models/agent';
 import {type Element} from 'gmp/models/model';
 import {parseYesNo} from 'gmp/parser';
+import {isDefined} from 'gmp/utils/identity';
 
 export interface AgentModifyParams {
   agentsIds: string[];
@@ -44,7 +45,9 @@ class AgentCommand extends EntityCommand<Agent, AgentElement> {
       cmd: 'modify_agent',
       'agent_ids:': agentsIds,
       authorized: parseYesNo(authorized),
-      update_to_latest: parseYesNo(updateToLatest),
+      update_to_latest: isDefined(updateToLatest)
+        ? parseYesNo(updateToLatest)
+        : undefined,
       comment,
       interval_in_seconds: intervalInSeconds,
     };


### PR DESCRIPTION
## What

- Conditional payload in `command/agent.ts` to only include the `update_to_latest` field in the API request if it's explicitly defined.

## Why

- When authorizing an agent, the `update_to_latest` field was being overwritten to false regardless of the agent's current configuration.

## References

GEA-1758

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


