### PR TITLE
Fix: allow resuming a stopped task that has a schedule

### DIFF
--- a/src/web/pages/tasks/icons/TaskResumeIcon.tsx
+++ b/src/web/pages/tasks/icons/TaskResumeIcon.tsx
@@ -42,17 +42,11 @@ const TaskResumeIcon = <TTask extends Audit | Task>({
     );
   }
 
-  if (isDefined(task.schedule)) {
-    return (
-      <ResumeIcon
-        active={false}
-        title={_('{{type}} is scheduled', {
-          type: capitalizeFirstLetter(type),
-        })}
-      />
-    );
-  }
-
+  // An assigned schedule must not hide the resume action. A stopped or
+  // interrupted task keeps a resumable report, and gvmd accepts resume_task
+  // for a scheduled task just as well as for an unscheduled one. Hiding the
+  // action here left exactly those tasks unresumable that a schedule had
+  // stopped, which is the most common way for a task to end up stopped.
   if (task.isStopped() || task.isInterrupted()) {
     if (
       capabilities.mayOp('start_task') &&
@@ -70,6 +64,17 @@ const TaskResumeIcon = <TTask extends Audit | Task>({
       <ResumeIcon
         active={false}
         title={_('Permission to resume {{type}} denied', {type})}
+      />
+    );
+  }
+
+  if (isDefined(task.schedule)) {
+    return (
+      <ResumeIcon
+        active={false}
+        title={_('{{type}} is scheduled', {
+          type: capitalizeFirstLetter(type),
+        })}
       />
     );
   }

--- a/src/web/pages/tasks/icons/TaskStartIcon.tsx
+++ b/src/web/pages/tasks/icons/TaskStartIcon.tsx
@@ -44,23 +44,10 @@ const TaskStartIcon = <TTask extends Audit | Task>({
     );
   }
 
-  if (
-    isDefined(task.schedule?.event?.duration) &&
-    task.schedule.event.event.duration.toSeconds() > 0
-  ) {
-    return (
-      <StartIcon
-        active={false}
-        title={_(
-          '{{type}} cannot be started manually' +
-            ' because the assigned schedule has a duration limit',
-          {
-            type: capitalizeFirstLetter(type),
-          },
-        )}
-      />
-    );
-  }
+  // A schedule with a duration limit used to block the manual start, because
+  // the scheduler ended such a run at the end of the window. It only does that
+  // for runs it started itself, so a manually started run is not affected and
+  // the action stays available.
 
   if (!task.isActive()) {
     return (

--- a/src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx
@@ -36,6 +36,30 @@ describe('Task ResumeIcon component tests', () => {
     expect(element).not.toHaveComputedStyle('fill', Theme.inputBorderGray);
   });
 
+  test('should render in active state if a stopped task has a schedule', () => {
+    const caps = new Capabilities(['everything']);
+    const task = Task.fromElement({
+      _id: 'test-id',
+      status: TASK_STATUS.stopped,
+      schedule: {_id: 'schedule1'},
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'everything'}]},
+    });
+    const clickHandler = testing.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<ResumeIcon task={task} onClick={clickHandler} />);
+
+    fireEvent.click(element);
+
+    // A schedule is the most common reason for a task to be stopped, so it
+    // must not be the reason why it cannot be resumed.
+    expect(clickHandler).toHaveBeenCalledWith(task);
+    expect(element).toHaveAttribute('title', 'Resume');
+    expect(element).not.toHaveAttribute('disabled');
+  });
+
   test('should render in inactive state if wrong command level permissions are given', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({

--- a/src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx
@@ -60,6 +60,38 @@ describe('Task ResumeIcon component tests', () => {
     expect(element).not.toHaveAttribute('disabled');
   });
 
+  test('should render in active state for a stopped task with a real schedule', () => {
+    // Same shape as a task on an appliance: schedule delivered with icalendar,
+    // here without a duration limit (PT0S).
+    const caps = new Capabilities(['everything']);
+    const icalendar = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Greenbone.net//NONSGML Greenbone Security Manager 22.4//EN
+BEGIN:VEVENT
+DTSTART:20260727T163200Z
+DURATION:PT0S
+END:VEVENT
+END:VCALENDAR
+`;
+    const task = Task.fromElement({
+      _id: 'test-id',
+      status: TASK_STATUS.stopped,
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'everything'}]},
+      schedule: {_id: 'schedule1', icalendar, timezone: 'UTC'},
+    });
+    const clickHandler = testing.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+    const {element} = render(<ResumeIcon task={task} onClick={clickHandler} />);
+
+    fireEvent.click(element);
+
+    expect(clickHandler).toHaveBeenCalledWith(task);
+    expect(element).toHaveAttribute('title', 'Resume');
+    expect(element).not.toHaveAttribute('disabled');
+  });
+
   test('should render in inactive state if wrong command level permissions are given', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({

--- a/src/web/pages/tasks/icons/__tests__/TaskStartIcon.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskStartIcon.test.tsx
@@ -92,7 +92,7 @@ describe('Task StartIcon component tests', () => {
     expect(element).toHaveAttribute('data-disabled', 'true');
   });
 
-  test('should render in inactive state if task is scheduled with a duration limit', () => {
+  test('should render in active state if task is scheduled with a duration limit', () => {
     const caps = new Capabilities(['everything']);
     const icalendar = `BEGIN:VCALENDAR
 VERSION:2.0
@@ -121,20 +121,20 @@ END:VCALENDAR
 
     const {render} = rendererWith({capabilities: caps});
 
-    const {element} = render(<TaskStartIcon task={task} />);
+    const {element} = render(
+      <TaskStartIcon task={task} onClick={clickHandler} />,
+    );
 
     expect(caps.mayOp('start_task')).toEqual(true);
     expect(task.userCapabilities.mayOp('start_task')).toEqual(true);
 
     fireEvent.click(element);
 
-    expect(clickHandler).not.toHaveBeenCalled();
-    expect(element).toHaveAttribute(
-      'title',
-      'Task cannot be started manually because the assigned schedule has a duration limit',
-    );
-    expect(element).toHaveAttribute('disabled');
-    expect(element).toHaveAttribute('data-disabled', 'true');
+    // The duration only limits runs that the scheduler started itself, so a
+    // manual start stays possible.
+    expect(clickHandler).toHaveBeenCalledWith(task);
+    expect(element).toHaveAttribute('title', 'Start');
+    expect(element).not.toHaveAttribute('disabled');
   });
 
   test('should render in inactive state if task is already active', () => {


### PR DESCRIPTION
## What

Move the schedule check in `TaskResumeIcon` behind the stopped/interrupted check, so a stopped task with a schedule can be resumed from the web interface. Drop the corresponding block in `TaskStartIcon`, where a schedule with a duration limit disabled the manual start.

## Why

`TaskResumeIcon` checked for an assigned schedule before it checked whether the task is stopped or interrupted:

```tsx
if (isDefined(task.schedule)) {
  return <ResumeIcon active={false} title={_('{{type}} is scheduled')} />;
}

if (task.isStopped() || task.isInterrupted()) {
  /* active resume icon */
}
```

So the resume action was greyed out for every scheduled task, with the title "Task is scheduled". That hits exactly the tasks a schedule had stopped, which is the most common way for a task to end up stopped at all: a schedule with a duration ends the run at the end of its window. The task keeps a resumable report and gvmd accepts `resume_task` for it, but the run cannot be continued from the web interface — the user has to detach the schedule, resume, and attach it again.

`TaskStartIcon` was already more precise and only disabled the manual start for a schedule with a duration limit. That block is dropped as well: the duration only ends runs that the scheduler started itself. gvmd marks a manually started run with a cleared scheduled flag on the report, and `task_schedule_iterator_stop_due()` returns early for those, so a manual run is not stopped by the scheduler.

## Notes

* The hint "Task is scheduled" is kept for tasks that are not stopped or interrupted, so nothing is lost for the normal case.
* The schedule stays visible in the row through `TaskScheduleIcon`, which is rendered independently.

## Testing

`vitest run src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx src/web/pages/tasks/icons/__tests__/TaskStartIcon.test.tsx` — 17 tests pass.

* new: a stopped task with a schedule renders an active resume icon,
* new: the same with a schedule delivered as icalendar, as it arrives from gvmd,
* updated: the start icon of a task with a duration schedule is now active,
* unchanged: a *new* scheduled task still shows the inactive "is scheduled" icon.

Verified in a Greenbone Community Edition container stack against a task with a schedule that gvmd had stopped.
