### PR TITLE
Cleanup all task command responses

### DIFF
--- a/src/gmp/commands/__tests__/task.test.ts
+++ b/src/gmp/commands/__tests__/task.test.ts
@@ -921,4 +921,130 @@ describe('TaskCommand tests', () => {
     });
     expect(result).toBeUndefined();
   });
+
+  test('should start a task when feed is not syncing', async () => {
+    const response = createResponse({
+      get_feeds: {
+        get_feeds_response: {
+          feed: [
+            {
+              type: 'NVT',
+              sync_not_available: false,
+              version: 202502170647,
+            },
+            {
+              type: 'SCAP',
+              sync_not_available: false,
+              version: 202502170647,
+            },
+          ],
+        },
+      },
+    });
+    const actionResponse = createActionResultResponse();
+    const fakeHttp = {
+      request: testing
+        .fn()
+        .mockResolvedValueOnce(response)
+        .mockResolvedValueOnce(actionResponse),
+    } as unknown as Http;
+
+    const cmd = new TaskCommand(fakeHttp);
+    const result = await cmd.start({id: 'task1'});
+
+    expect(fakeHttp.request).toHaveBeenNthCalledWith(1, 'get', {
+      args: {
+        cmd: 'get_feeds',
+      },
+    });
+    expect(fakeHttp.request).toHaveBeenNthCalledWith(2, 'post', {
+      data: {
+        cmd: 'start_task',
+        task_id: 'task1',
+      },
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test('should throw an error when starting task with syncing feed', async () => {
+    const response = createResponse({
+      get_feeds: {
+        get_feeds_response: {
+          feed: [
+            {
+              type: 'NVT',
+              currently_syncing: true,
+              sync_not_available: false,
+              version: 202502170647,
+            },
+          ],
+        },
+      },
+    });
+    const fakeHttp = createHttp(response);
+
+    const cmd = new TaskCommand(fakeHttp);
+
+    await expect(cmd.start({id: 'task1'})).rejects.toThrow(
+      'Feed is currently syncing. Please try again later.',
+    );
+  });
+
+  test('should stop a task', async () => {
+    const response = createActionResultResponse();
+    const fakeHttp = createHttp(response);
+
+    const cmd = new TaskCommand(fakeHttp);
+    const result = await cmd.stop({id: 'task1'});
+
+    expect(fakeHttp.request).toHaveBeenCalledWith('post', {
+      data: {
+        cmd: 'stop_task',
+        task_id: 'task1',
+      },
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test('should throw an error when stopping a task fails', async () => {
+    const error = new Error('Failed to stop task');
+    const fakeHttp = {
+      request: testing.fn().mockRejectedValue(error),
+    } as unknown as Http;
+
+    const cmd = new TaskCommand(fakeHttp);
+
+    await expect(cmd.stop({id: 'task1'})).rejects.toThrow(
+      'Failed to stop task',
+    );
+  });
+
+  test('should resume a task', async () => {
+    const response = createActionResultResponse();
+    const fakeHttp = createHttp(response);
+
+    const cmd = new TaskCommand(fakeHttp);
+    const result = await cmd.resume({id: 'task1'});
+
+    expect(fakeHttp.request).toHaveBeenCalledWith('post', {
+      data: {
+        cmd: 'resume_task',
+        task_id: 'task1',
+      },
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test('should throw an error when resuming a task fails', async () => {
+    const error = new Error('Failed to resume task');
+    const fakeHttp = {
+      request: testing.fn().mockRejectedValue(error),
+    } as unknown as Http;
+
+    const cmd = new TaskCommand(fakeHttp);
+
+    await expect(cmd.resume({id: 'task1'})).rejects.toThrow(
+      'Failed to resume task',
+    );
+  });
 });

--- a/src/gmp/commands/task.ts
+++ b/src/gmp/commands/task.ts
@@ -227,7 +227,6 @@ class TaskCommand extends EntityCommand<Task, TaskElement> {
         id,
       });
       log.debug('Stopped task');
-      return await this.get({id});
     } catch (err) {
       log.error('An error occurred while stopping the task', id, err);
       throw err;
@@ -241,7 +240,6 @@ class TaskCommand extends EntityCommand<Task, TaskElement> {
         id,
       });
       log.debug('Resumed task');
-      return await this.get({id});
     } catch (err) {
       log.error('An error occurred while resuming the task', id, err);
       throw err;

--- a/src/web/pages/tasks/TaskComponent.tsx
+++ b/src/web/pages/tasks/TaskComponent.tsx
@@ -6,8 +6,6 @@
 import React, {useState, useEffect, useCallback} from 'react';
 import {useDispatch} from 'react-redux';
 import type Rejection from 'gmp/http/rejection';
-import type Response from 'gmp/http/response';
-import {type XmlMeta} from 'gmp/http/transform/fast-xml';
 import type AgentGroup from 'gmp/models/agent-group';
 import date, {type Date} from 'gmp/models/date';
 import {ALL_FILTER} from 'gmp/models/filter';
@@ -135,7 +133,7 @@ interface TaskComponentProps {
   onModifyTaskWizardError?: (error: Error) => void;
   onModifyTaskWizardSaved?: () => void;
   onReportImported?: () => void;
-  onResumed?: (response: Response<Task, XmlMeta>) => void;
+  onResumed?: () => void;
   onResumeError?: (error: Error) => void;
   onSaved?: () => void;
   onSaveError?: (error: Error) => void;
@@ -449,30 +447,23 @@ const TaskComponent = ({
   };
 
   const handleTaskStop = (task: Task) => {
-    return actionFunction<void, Rejection>(
-      // @ts-expect-error
-      gmp.task.stop(task),
-      {
-        onSuccess: onStopped,
-        onError: onStopError,
-        successMessage: _('Task {{- name}} stopped successfully.', {
-          name: task.name as string,
-        }),
-      },
-    );
+    return actionFunction<void, Rejection>(gmp.task.stop(task), {
+      onSuccess: onStopped,
+      onError: onStopError,
+      successMessage: _('Task {{- name}} stopped successfully.', {
+        name: task.name as string,
+      }),
+    });
   };
 
   const handleTaskResume = (task: Task) => {
-    return actionFunction<Response<Task, XmlMeta>, Rejection>(
-      gmp.task.resume(task),
-      {
-        onSuccess: onResumed,
-        onError: onResumeError,
-        successMessage: _('Task {{- name}} resumed successfully.', {
-          name: task.name as string,
-        }),
-      },
-    );
+    return actionFunction<void, Rejection>(gmp.task.resume(task), {
+      onSuccess: onResumed,
+      onError: onResumeError,
+      successMessage: _('Task {{- name}} resumed successfully.', {
+        name: task.name as string,
+      }),
+    });
   };
 
   const handleTaskWizardNewClick = async () => {


### PR DESCRIPTION


## What
Cleanup all task command responses

## Why

Mutations either return void or if something has been created it returns `Response<EntityActionData>`.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


