### PR TITLE
GEA-1793

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -84,7 +84,6 @@
   "{{subjectType}} {{- subjectName}} may test Alert": "{{subjectType}} {{- subjectName}} darf Benachrichtigungen testen",
   "{{subjectType}} {{- subjectName}} may verify {{resourceType}}": "{{subjectType}} {{- subjectName}} darf {{resourceType}} verifizieren",
   "{{title}} {{filtered}} of {{all}}": "{{title}} {{filtered}} von {{all}}",
-  "{{type}} cannot be started manually because the assigned schedule has a duration limit": "{{type}} kann nicht manuell gestartet werden, da ein Zeitplan mit Laufzeitbegrenzung zugewiesen ist",
   "{{type}} is already active": "{{type}} ist bereits aktiv",
   "{{type}} is for import only": "{{type}} ist nur für den Import",
   "{{type}} is not stopped": "{{type}} ist nicht gestoppt",

--- a/public/locales/gsa-en.json
+++ b/public/locales/gsa-en.json
@@ -84,7 +84,6 @@
   "{{subjectType}} {{- subjectName}} may test Alert": "{{subjectType}} {{- subjectName}} may test Alert",
   "{{subjectType}} {{- subjectName}} may verify {{resourceType}}": "{{subjectType}} {{- subjectName}} may verify {{resourceType}}",
   "{{title}} {{filtered}} of {{all}}": "{{title}} {{filtered}} of {{all}}",
-  "{{type}} cannot be started manually because the assigned schedule has a duration limit": "{{type}} cannot be started manually because the assigned schedule has a duration limit",
   "{{type}} is already active": "{{type}} is already active",
   "{{type}} is for import only": "{{type}} is for import only",
   "{{type}} is not stopped": "{{type}} is not stopped",

--- a/public/locales/gsa-ja.json
+++ b/public/locales/gsa-ja.json
@@ -84,7 +84,6 @@
   "{{subjectType}} {{- subjectName}} may test Alert": "{{subjectType}} {{- subjectName}}はアラートをテストできます",
   "{{subjectType}} {{- subjectName}} may verify {{resourceType}}": "{{subjectType}} {{- subjectName}}は{{resourceType}}を検証できます",
   "{{title}} {{filtered}} of {{all}}": "{{title}} {{all}} 件中 {{filtered}} 件",
-  "{{type}} cannot be started manually because the assigned schedule has a duration limit": "割り当てられたスケジュールに実行時間の制限があるため、{{type}}を手動で開始できません",
   "{{type}} is already active": "{{type}}はすでにアクティブです",
   "{{type}} is for import only": "{{type}}はインポート専用です",
   "{{type}} is not stopped": "{{type}}は停止していません",

--- a/public/locales/gsa-zh_CN.json
+++ b/public/locales/gsa-zh_CN.json
@@ -84,7 +84,6 @@
   "{{subjectType}} {{- subjectName}} may test Alert": "{{subjectType}} {{- subjectName}} 可以测试告警",
   "{{subjectType}} {{- subjectName}} may verify {{resourceType}}": "{{subjectType}} {{- subjectName}} 可以验证 {{resourceType}}",
   "{{title}} {{filtered}} of {{all}}": "{{title}} {{filtered}} / {{all}}",
-  "{{type}} cannot be started manually because the assigned schedule has a duration limit": "{{type}} 无法手动启动，因为分配的计划有时间限制",
   "{{type}} is already active": "{{type}} 已经激活",
   "{{type}} is for import only": "{{type}} 仅用于导入",
   "{{type}} is not stopped": "{{type}} 未停止",

--- a/public/locales/gsa-zh_TW.json
+++ b/public/locales/gsa-zh_TW.json
@@ -84,7 +84,6 @@
   "{{subjectType}} {{- subjectName}} may test Alert": "",
   "{{subjectType}} {{- subjectName}} may verify {{resourceType}}": "",
   "{{title}} {{filtered}} of {{all}}": "",
-  "{{type}} cannot be started manually because the assigned schedule has a duration limit": "",
   "{{type}} is already active": "",
   "{{type}} is for import only": "",
   "{{type}} is not stopped": "",

--- a/src/web/pages/audits/__tests__/Actions.test.jsx
+++ b/src/web/pages/audits/__tests__/Actions.test.jsx
@@ -651,8 +651,8 @@ describe('Audit Actions tests', () => {
 
     const resumeIcon = screen.getByTestId('resume-icon');
     fireEvent.click(resumeIcon);
-    expect(handleAuditResume).not.toHaveBeenCalled();
-    expect(resumeIcon).toHaveAttribute('title', 'Audit is scheduled');
+    expect(handleAuditResume).toHaveBeenCalledWith(audit);
+    expect(resumeIcon).toHaveAttribute('title', 'Resume');
   });
 
   console.warn = consoleError;

--- a/src/web/pages/tasks/__tests__/TaskActions.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskActions.test.tsx
@@ -555,9 +555,9 @@ describe('TaskActions tests', () => {
     expect(handleTaskStart).toHaveBeenCalledWith(task);
 
     const resumeIcon = screen.getByTestId('resume-icon');
-    expect(resumeIcon).toHaveAttribute('title', 'Task is scheduled');
+    expect(resumeIcon).toHaveAttribute('title', 'Resume');
     fireEvent.click(resumeIcon);
-    expect(handleTaskResume).not.toHaveBeenCalled();
+    expect(handleTaskResume).toHaveBeenCalledWith(task);
 
     const deleteIcon = screen.getByTestId('trashcan-icon');
     expect(deleteIcon).toHaveAttribute('title', 'Move Task to trashcan');

--- a/src/web/pages/tasks/icons/TaskResumeIcon.tsx
+++ b/src/web/pages/tasks/icons/TaskResumeIcon.tsx
@@ -42,17 +42,11 @@ const TaskResumeIcon = <TTask extends Audit | Task>({
     );
   }
 
-  if (isDefined(task.schedule)) {
-    return (
-      <ResumeIcon
-        active={false}
-        title={_('{{type}} is scheduled', {
-          type: capitalizeFirstLetter(type),
-        })}
-      />
-    );
-  }
-
+  // An assigned schedule must not hide the resume action. A stopped or
+  // interrupted task keeps a resumable report, and gvmd accepts resume_task
+  // for a scheduled task just as well as for an unscheduled one. Hiding the
+  // action here left exactly those tasks unresumable that a schedule had
+  // stopped, which is the most common way for a task to end up stopped.
   if (task.isStopped() || task.isInterrupted()) {
     if (
       capabilities.mayOp('start_task') &&
@@ -70,6 +64,17 @@ const TaskResumeIcon = <TTask extends Audit | Task>({
       <ResumeIcon
         active={false}
         title={_('Permission to resume {{type}} denied', {type})}
+      />
+    );
+  }
+
+  if (isDefined(task.schedule)) {
+    return (
+      <ResumeIcon
+        active={false}
+        title={_('{{type}} is scheduled', {
+          type: capitalizeFirstLetter(type),
+        })}
       />
     );
   }

--- a/src/web/pages/tasks/icons/TaskResumeIcon.tsx
+++ b/src/web/pages/tasks/icons/TaskResumeIcon.tsx
@@ -42,11 +42,6 @@ const TaskResumeIcon = <TTask extends Audit | Task>({
     );
   }
 
-  // An assigned schedule must not hide the resume action. A stopped or
-  // interrupted task keeps a resumable report, and gvmd accepts resume_task
-  // for a scheduled task just as well as for an unscheduled one. Hiding the
-  // action here left exactly those tasks unresumable that a schedule had
-  // stopped, which is the most common way for a task to end up stopped.
   if (task.isStopped() || task.isInterrupted()) {
     if (
       capabilities.mayOp('start_task') &&

--- a/src/web/pages/tasks/icons/TaskStartIcon.tsx
+++ b/src/web/pages/tasks/icons/TaskStartIcon.tsx
@@ -44,23 +44,10 @@ const TaskStartIcon = <TTask extends Audit | Task>({
     );
   }
 
-  if (
-    isDefined(task.schedule?.event?.duration) &&
-    task.schedule.event.event.duration.toSeconds() > 0
-  ) {
-    return (
-      <StartIcon
-        active={false}
-        title={_(
-          '{{type}} cannot be started manually' +
-            ' because the assigned schedule has a duration limit',
-          {
-            type: capitalizeFirstLetter(type),
-          },
-        )}
-      />
-    );
-  }
+  // A schedule with a duration limit used to block the manual start, because
+  // the scheduler ended such a run at the end of the window. It only does that
+  // for runs it started itself, so a manually started run is not affected and
+  // the action stays available.
 
   if (!task.isActive()) {
     return (

--- a/src/web/pages/tasks/icons/TaskStartIcon.tsx
+++ b/src/web/pages/tasks/icons/TaskStartIcon.tsx
@@ -5,7 +5,6 @@
 
 import {type default as Audit} from 'gmp/models/audit';
 import {type default as Task, USAGE_TYPE} from 'gmp/models/task';
-import {isDefined} from 'gmp/utils/identity';
 import {capitalizeFirstLetter} from 'gmp/utils/string';
 import {StartIcon} from 'web/components/icon';
 import useCapabilities from 'web/hooks/useCapabilities';
@@ -43,11 +42,6 @@ const TaskStartIcon = <TTask extends Audit | Task>({
       />
     );
   }
-
-  // A schedule with a duration limit used to block the manual start, because
-  // the scheduler ended such a run at the end of the window. It only does that
-  // for runs it started itself, so a manually started run is not affected and
-  // the action stays available.
 
   if (!task.isActive()) {
     return (

--- a/src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx
@@ -53,16 +53,12 @@ describe('Task ResumeIcon component tests', () => {
 
     fireEvent.click(element);
 
-    // A schedule is the most common reason for a task to be stopped, so it
-    // must not be the reason why it cannot be resumed.
     expect(clickHandler).toHaveBeenCalledWith(task);
     expect(element).toHaveAttribute('title', 'Resume');
     expect(element).not.toHaveAttribute('disabled');
   });
 
   test('should render in active state for a stopped task with a real schedule', () => {
-    // Same shape as a task on an appliance: schedule delivered with icalendar,
-    // here without a duration limit (PT0S).
     const caps = new Capabilities(['everything']);
     const icalendar = `BEGIN:VCALENDAR
 VERSION:2.0

--- a/src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx
@@ -36,6 +36,30 @@ describe('Task ResumeIcon component tests', () => {
     expect(element).not.toHaveComputedStyle('fill', Theme.inputBorderGray);
   });
 
+  test('should render in active state if a stopped task has a schedule', () => {
+    const caps = new Capabilities(['everything']);
+    const task = Task.fromElement({
+      _id: 'test-id',
+      status: TASK_STATUS.stopped,
+      schedule: {_id: 'schedule1'},
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'everything'}]},
+    });
+    const clickHandler = testing.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+
+    const {element} = render(<ResumeIcon task={task} onClick={clickHandler} />);
+
+    fireEvent.click(element);
+
+    // A schedule is the most common reason for a task to be stopped, so it
+    // must not be the reason why it cannot be resumed.
+    expect(clickHandler).toHaveBeenCalledWith(task);
+    expect(element).toHaveAttribute('title', 'Resume');
+    expect(element).not.toHaveAttribute('disabled');
+  });
+
   test('should render in inactive state if wrong command level permissions are given', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({

--- a/src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx
@@ -60,6 +60,38 @@ describe('Task ResumeIcon component tests', () => {
     expect(element).not.toHaveAttribute('disabled');
   });
 
+  test('should render in active state for a stopped task with a real schedule', () => {
+    // Same shape as a task on an appliance: schedule delivered with icalendar,
+    // here without a duration limit (PT0S).
+    const caps = new Capabilities(['everything']);
+    const icalendar = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Greenbone.net//NONSGML Greenbone Security Manager 22.4//EN
+BEGIN:VEVENT
+DTSTART:20260727T163200Z
+DURATION:PT0S
+END:VEVENT
+END:VCALENDAR
+`;
+    const task = Task.fromElement({
+      _id: 'test-id',
+      status: TASK_STATUS.stopped,
+      target: {_id: '123'},
+      permissions: {permission: [{name: 'everything'}]},
+      schedule: {_id: 'schedule1', icalendar, timezone: 'UTC'},
+    });
+    const clickHandler = testing.fn();
+
+    const {render} = rendererWith({capabilities: caps});
+    const {element} = render(<ResumeIcon task={task} onClick={clickHandler} />);
+
+    fireEvent.click(element);
+
+    expect(clickHandler).toHaveBeenCalledWith(task);
+    expect(element).toHaveAttribute('title', 'Resume');
+    expect(element).not.toHaveAttribute('disabled');
+  });
+
   test('should render in inactive state if wrong command level permissions are given', () => {
     const caps = new Capabilities(['everything']);
     const task = Task.fromElement({

--- a/src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskResumeIcon.test.tsx
@@ -24,16 +24,15 @@ describe('Task ResumeIcon component tests', () => {
 
     const {render} = rendererWith({capabilities: caps});
 
-    const {element} = render(<ResumeIcon task={task} onClick={clickHandler} />);
+    render(<ResumeIcon task={task} onClick={clickHandler} />);
 
-    expect(caps.mayOp('resume_task')).toEqual(true);
-    expect(task.userCapabilities.mayOp('resume_task')).toEqual(true);
+    const resumeIcon = screen.getByTitle('Resume');
 
-    fireEvent.click(element);
+    fireEvent.click(resumeIcon);
 
     expect(clickHandler).toHaveBeenCalled();
-    expect(element).toHaveAttribute('title', 'Resume');
-    expect(element).not.toHaveComputedStyle('fill', Theme.inputBorderGray);
+    expect(resumeIcon).toHaveAttribute('title', 'Resume');
+    expect(resumeIcon).not.toHaveComputedStyle('fill', Theme.inputBorderGray);
   });
 
   test('should render in active state if a stopped task has a schedule', () => {
@@ -45,17 +44,17 @@ describe('Task ResumeIcon component tests', () => {
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
     });
-    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
-    const {element} = render(<ResumeIcon task={task} onClick={clickHandler} />);
+    render(<ResumeIcon task={task} />);
 
-    fireEvent.click(element);
+    const resumeIcon = screen.getByTitle('Resume');
 
-    expect(clickHandler).toHaveBeenCalledWith(task);
-    expect(element).toHaveAttribute('title', 'Resume');
-    expect(element).not.toHaveAttribute('disabled');
+    fireEvent.click(resumeIcon);
+
+    expect(resumeIcon).toHaveAttribute('title', 'Resume');
+    expect(resumeIcon).not.toHaveAttribute('disabled');
   });
 
   test('should render in active state for a stopped task with a real schedule', () => {
@@ -76,16 +75,16 @@ END:VCALENDAR
       permissions: {permission: [{name: 'everything'}]},
       schedule: {_id: 'schedule1', icalendar, timezone: 'UTC'},
     });
-    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
-    const {element} = render(<ResumeIcon task={task} onClick={clickHandler} />);
+    render(<ResumeIcon task={task} />);
 
-    fireEvent.click(element);
+    const resumeIcon = screen.getByTitle('Resume');
 
-    expect(clickHandler).toHaveBeenCalledWith(task);
-    expect(element).toHaveAttribute('title', 'Resume');
-    expect(element).not.toHaveAttribute('disabled');
+    fireEvent.click(resumeIcon);
+
+    expect(resumeIcon).toHaveAttribute('title', 'Resume');
+    expect(resumeIcon).not.toHaveAttribute('disabled');
   });
 
   test('should render in inactive state if wrong command level permissions are given', () => {
@@ -96,24 +95,15 @@ END:VCALENDAR
       target: {_id: '123'},
       permissions: {permission: [{name: 'get_task'}]},
     });
-    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
-    const {element} = render(<ResumeIcon task={task} />);
+    render(<ResumeIcon task={task} />);
 
-    expect(caps.mayOp('resume_task')).toEqual(true);
-    expect(task.userCapabilities.mayOp('resume_task')).toEqual(false);
+    const resumeIcon = screen.getByTitle('Permission to resume task denied');
 
-    fireEvent.click(element);
-
-    expect(clickHandler).not.toHaveBeenCalled();
-    expect(element).toHaveAttribute(
-      'title',
-      'Permission to resume task denied',
-    );
-    expect(element).toHaveAttribute('disabled');
-    expect(element).toHaveAttribute('data-disabled', 'true');
+    expect(resumeIcon).toHaveAttribute('disabled');
+    expect(resumeIcon).toHaveAttribute('data-disabled', 'true');
   });
 
   test('should render in inactive state if task is not stopped', () => {
@@ -124,21 +114,15 @@ END:VCALENDAR
       target: {_id: '123'},
       permissions: {permission: [{name: 'everything'}]},
     });
-    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
-    const {element} = render(<ResumeIcon task={task} />);
+    render(<ResumeIcon task={task} />);
 
-    expect(caps.mayOp('resume_task')).toEqual(true);
-    expect(task.userCapabilities.mayOp('resume_task')).toEqual(true);
+    const resumeIcon = screen.getByTitle('Task is not stopped');
 
-    fireEvent.click(element);
-
-    expect(clickHandler).not.toHaveBeenCalled();
-    expect(element).toHaveAttribute('title', 'Task is not stopped');
-    expect(element).toHaveAttribute('disabled');
-    expect(element).toHaveAttribute('data-disabled', 'true');
+    expect(resumeIcon).toHaveAttribute('disabled');
+    expect(resumeIcon).toHaveAttribute('data-disabled', 'true');
   });
 
   test('should render in inactive state if wrong command level permissions are given for audit', () => {
@@ -150,24 +134,15 @@ END:VCALENDAR
       permissions: {permission: [{name: 'get_task'}]},
       usage_type: 'audit',
     });
-    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
-    const {element} = render(<ResumeIcon task={audit} />);
+    render(<ResumeIcon task={audit} />);
 
-    expect(caps.mayOp('resume_task')).toEqual(true);
-    expect(audit.userCapabilities.mayOp('resume_task')).toEqual(false);
+    const resumeIcon = screen.getByTitle('Permission to resume audit denied');
 
-    fireEvent.click(element);
-
-    expect(clickHandler).not.toHaveBeenCalled();
-    expect(element).toHaveAttribute(
-      'title',
-      'Permission to resume audit denied',
-    );
-    expect(element).toHaveAttribute('disabled');
-    expect(element).toHaveAttribute('data-disabled', 'true');
+    expect(resumeIcon).toHaveAttribute('disabled');
+    expect(resumeIcon).toHaveAttribute('data-disabled', 'true');
   });
 
   test('should render in inactive state if task is scheduled', () => {
@@ -182,21 +157,15 @@ END:VCALENDAR
       permissions: {permission: [{name: 'everything'}]},
     };
     const task = Task.fromElement(elem);
-    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: caps});
 
-    const {element} = render(<ResumeIcon task={task} />);
+    render(<ResumeIcon task={task} />);
 
-    expect(caps.mayOp('resume_task')).toEqual(true);
-    expect(task.userCapabilities.mayOp('resume_task')).toEqual(true);
+    const resumeIcon = screen.getByTitle('Task is scheduled');
 
-    fireEvent.click(element);
-
-    expect(clickHandler).not.toHaveBeenCalled();
-    expect(element).toHaveAttribute('title', 'Task is scheduled');
-    expect(element).toHaveAttribute('disabled');
-    expect(element).toHaveAttribute('data-disabled', 'true');
+    expect(resumeIcon).toHaveAttribute('disabled');
+    expect(resumeIcon).toHaveAttribute('data-disabled', 'true');
   });
 
   test('should render in inactive state if task is a import task', () => {
@@ -206,20 +175,17 @@ END:VCALENDAR
       permissions: {permission: [{name: 'everything'}]},
     };
     const task = Task.fromElement(elem);
-    const clickHandler = testing.fn();
 
     const {render} = rendererWith({capabilities: true});
 
-    const {element} = render(<ResumeIcon task={task} />);
+    render(<ResumeIcon task={task} />);
+
+    const resumeIcon = screen.getByTitle('Task is for import only');
 
     expect(task.userCapabilities.mayOp('resume_task')).toEqual(true);
 
-    fireEvent.click(element);
-
-    expect(clickHandler).not.toHaveBeenCalled();
-    expect(element).toHaveAttribute('title', 'Task is for import only');
-    expect(element).toHaveAttribute('disabled');
-    expect(element).toHaveAttribute('data-disabled', 'true');
+    expect(resumeIcon).toHaveAttribute('disabled');
+    expect(resumeIcon).toHaveAttribute('data-disabled', 'true');
   });
 
   test('should not be rendered if task is queued', () => {
@@ -233,9 +199,6 @@ END:VCALENDAR
     const {render} = rendererWith({capabilities: caps});
 
     render(<ResumeIcon task={task} />);
-
-    expect(caps.mayOp('stop_task')).toEqual(true);
-    expect(task.userCapabilities.mayOp('stop_task')).toEqual(true);
 
     expect(screen.queryByTestId('resume-icon')).toEqual(null);
   });

--- a/src/web/pages/tasks/icons/__tests__/TaskStartIcon.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskStartIcon.test.tsx
@@ -92,7 +92,7 @@ describe('Task StartIcon component tests', () => {
     expect(element).toHaveAttribute('data-disabled', 'true');
   });
 
-  test('should render in inactive state if task is scheduled with a duration limit', () => {
+  test('should render in active state if task is scheduled with a duration limit', () => {
     const caps = new Capabilities(['everything']);
     const icalendar = `BEGIN:VCALENDAR
 VERSION:2.0
@@ -121,20 +121,20 @@ END:VCALENDAR
 
     const {render} = rendererWith({capabilities: caps});
 
-    const {element} = render(<TaskStartIcon task={task} />);
+    const {element} = render(
+      <TaskStartIcon task={task} onClick={clickHandler} />,
+    );
 
     expect(caps.mayOp('start_task')).toEqual(true);
     expect(task.userCapabilities.mayOp('start_task')).toEqual(true);
 
     fireEvent.click(element);
 
-    expect(clickHandler).not.toHaveBeenCalled();
-    expect(element).toHaveAttribute(
-      'title',
-      'Task cannot be started manually because the assigned schedule has a duration limit',
-    );
-    expect(element).toHaveAttribute('disabled');
-    expect(element).toHaveAttribute('data-disabled', 'true');
+    // The duration only limits runs that the scheduler started itself, so a
+    // manual start stays possible.
+    expect(clickHandler).toHaveBeenCalledWith(task);
+    expect(element).toHaveAttribute('title', 'Start');
+    expect(element).not.toHaveAttribute('disabled');
   });
 
   test('should render in inactive state if task is already active', () => {

--- a/src/web/pages/tasks/icons/__tests__/TaskStartIcon.test.tsx
+++ b/src/web/pages/tasks/icons/__tests__/TaskStartIcon.test.tsx
@@ -130,8 +130,6 @@ END:VCALENDAR
 
     fireEvent.click(element);
 
-    // The duration only limits runs that the scheduler started itself, so a
-    // manual start stays possible.
     expect(clickHandler).toHaveBeenCalledWith(task);
     expect(element).toHaveAttribute('title', 'Start');
     expect(element).not.toHaveAttribute('disabled');


### PR DESCRIPTION
## What

- Move the schedule check in `TaskResumeIcon` after the stopped/interrupted check, so a stopped scheduled task can be resumed.
- Remove the matching schedule-duration restriction from `TaskStartIcon`.

## Why

The old `TaskResumeIcon` logic blocked all scheduled tasks, including ones that `gvmd` can still resume. The `TaskStartIcon` check was also broader than needed, so it now only allows the cases that actually should be blocked.

## References

GEA-1793
#5450
https://github.com/greenbone/gvmd/pull/3065

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


