### PR TITLE
fix: audit report details report host

### DIFF
--- a/src/gmp/commands/__tests__/audit-report.test.ts
+++ b/src/gmp/commands/__tests__/audit-report.test.ts
@@ -7,6 +7,7 @@ import {describe, test, expect} from '@gsa/testing';
 import AuditReportCommand from 'gmp/commands/audit-report';
 import {
   createHttp,
+  createResponse,
   createEntityResponse,
   createActionResultResponse,
   createHttpError,
@@ -183,5 +184,71 @@ describe('AuditReportCommand tests', () => {
       },
     });
     expect(resp.data.id).toEqual('foo');
+  });
+
+  test('should return audit report hosts', async () => {
+    const response = createResponse({
+      get_audit_report_hosts: {
+        get_audit_report_hosts_response: {
+          host: [
+            {
+              _id: 'host-1',
+              ip: 'host-ip-1',
+              hostname: 'host1.example.com',
+              start: '2019-06-03T11:00:00Z',
+              end: '2019-06-03T11:15:00Z',
+              result_count: {
+                page: 1,
+                high: {__text: 5, page: 1},
+                medium: {__text: 3, page: 1},
+                low: {__text: 0, page: 1},
+                log: {__text: 0, page: 1},
+                false_positive: {__text: 0, page: 1},
+              },
+              detail: [
+                {name: 'hostname', value: 'host1.example.com'},
+                {name: 'best_os_cpe', value: 'cpe:/o:linux'},
+              ],
+            },
+          ],
+          hosts: {count: 1},
+          filters: {
+            term: 'first=1 rows=100 sort=severity',
+            filter: {_id: ''},
+            keywords: {
+              keyword: [
+                {column: 'first', relation: '=', value: '1'},
+                {column: 'rows', relation: '=', value: '100'},
+                {column: 'sort', relation: '=', value: 'severity'},
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    const fakeHttp = createHttp(response);
+    const cmd = new AuditReportCommand(fakeHttp);
+    const resp = await cmd.getHosts({report_id: 'r1'});
+
+    expect(fakeHttp.request).toHaveBeenCalledWith('get', {
+      args: {
+        cmd: 'get_audit_report_hosts',
+        details: 1,
+        report_id: 'r1',
+      },
+    });
+
+    expect(resp.data).toHaveLength(1);
+  });
+
+  test('should throw error for invalid audit hosts response', async () => {
+    const response = createResponse({});
+    const fakeHttp = createHttp(response);
+    const cmd = new AuditReportCommand(fakeHttp);
+
+    await expect(cmd.getHosts({report_id: 'r1'})).rejects.toThrow(
+      'Invalid response: get_audit_report_hosts not found in response',
+    );
   });
 });

--- a/src/gmp/commands/audit-report.ts
+++ b/src/gmp/commands/audit-report.ts
@@ -3,13 +3,25 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import CollectionCounts from 'gmp/collection/collection-counts';
+import {parseFilter} from 'gmp/collection/parser';
+import type {EntitiesMeta} from 'gmp/commands/entities';
 import EntityCommand from 'gmp/commands/entity';
 import type Http from 'gmp/http/http';
+import type Response from 'gmp/http/response';
+import type {XmlResponseData} from 'gmp/http/transform/fast-xml';
 import AuditReport, {type AuditReportElement} from 'gmp/models/audit-report';
-import {ALL_FILTER, type FilterType} from 'gmp/models/filter';
+import {
+  ALL_FILTER,
+  type FilterModelElement,
+  type FilterType,
+} from 'gmp/models/filter';
 import {filterString} from 'gmp/models/filter/utils';
 import {type Element} from 'gmp/models/model';
+import ReportHost from 'gmp/models/report/host';
+import type {ReportHostElement} from 'gmp/models/report/parser';
 import {parseYesNo} from 'gmp/parser';
+import {map} from 'gmp/utils/array';
 import {isDefined} from 'gmp/utils/identity';
 
 interface AuditReportCommandDownloadParams {
@@ -40,6 +52,19 @@ interface AuditReportCommandGetParams {
   ignorePagination?: boolean;
   lean?: boolean;
   options?: Record<string, unknown>;
+}
+
+interface AuditReportHostsData {
+  host?: ReportHostElement | ReportHostElement[];
+  hosts?: {count?: number};
+  filters?: FilterModelElement;
+  [key: string]: unknown;
+}
+
+interface AuditReportHostsResponseData extends XmlResponseData {
+  get_audit_report_hosts?: {
+    get_audit_report_hosts_response: AuditReportHostsData;
+  };
 }
 
 class AuditReportCommand extends EntityCommand<
@@ -141,6 +166,43 @@ class AuditReportCommand extends EntityCommand<
       ...params,
     });
     return this.transformResponseToModel(response);
+  }
+
+  async getHosts(params: {
+    report_id: string;
+    filter?: FilterType | string;
+  }): Promise<Response<ReportHost[], EntitiesMeta>> {
+    const response = await this.httpGetWithTransform({
+      cmd: 'get_audit_report_hosts',
+      details: 1,
+      ...params,
+    });
+
+    const root = response.data as AuditReportHostsResponseData;
+
+    if (!root.get_audit_report_hosts) {
+      throw new Error(
+        'Invalid response: get_audit_report_hosts not found in response',
+      );
+    }
+
+    const data = root.get_audit_report_hosts.get_audit_report_hosts_response;
+    const filter = parseFilter(data);
+
+    const hostsArray = map(data.host, host => ReportHost.fromElement(host));
+
+    const counts = new CollectionCounts({
+      first: 1,
+      all: data.hosts?.count ?? hostsArray.length,
+      filtered: hostsArray.length,
+      length: hostsArray.length,
+      rows: hostsArray.length,
+    });
+
+    return response.set<ReportHost[], EntitiesMeta>(hostsArray, {
+      filter,
+      counts,
+    });
   }
 
   getElementFromRoot(root: Element): AuditReportElement {

--- a/src/web/hooks/use-query/__tests__/AuditReport.test.tsx
+++ b/src/web/hooks/use-query/__tests__/AuditReport.test.tsx
@@ -1,0 +1,131 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, test, expect, testing} from '@gsa/testing';
+import {rendererWith, screen, waitFor} from 'web/testing';
+import CollectionCounts from 'gmp/collection/collection-counts';
+import QueryFilter from 'gmp/models/filter/query-filter';
+import {createSession} from 'gmp/testing';
+import {SEVERITY_RATING_CVSS_3} from 'gmp/utils/severity';
+import {
+  useGetAuditReport,
+  useGetAuditReportHosts,
+} from 'web/hooks/use-query/audit-report';
+
+const filter = QueryFilter.fromString('rows=10 first=1 sort=compliant');
+
+const HostsComponent = ({reportId}: {reportId: string}) => {
+  const {data, isLoading, isError} = useGetAuditReportHosts({
+    reportId,
+    filter,
+  });
+
+  if (isLoading) {
+    return <div data-testid="loading">Loading...</div>;
+  }
+
+  if (isError) {
+    return <div data-testid="error">Error</div>;
+  }
+
+  if (!data) {
+    return <div data-testid="no-data">No data</div>;
+  }
+
+  return (
+    <div data-testid="entities">
+      {data.entities.map(host => (
+        <div key={host.id} data-testid="host-entity">
+          {host.ip}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const AuditReportComponent = ({reportId}: {reportId: string}) => {
+  const {data, isLoading} = useGetAuditReport({id: reportId, filter});
+
+  if (isLoading) {
+    return <div data-testid="loading-report">Loading...</div>;
+  }
+
+  if (!data) {
+    return <div data-testid="no-report">No report</div>;
+  }
+
+  return <div data-testid="report-id">{data.id}</div>;
+};
+
+const createGmp = () => ({
+  session: createSession({token: 'test-token'}),
+  settings: {
+    severityRating: SEVERITY_RATING_CVSS_3,
+    reloadInterval: 0,
+    reloadIntervalActive: 0,
+    reloadIntervalInactive: 0,
+  },
+  auditreport: {
+    get: testing.fn().mockResolvedValue({
+      data: {id: 'report-1234'},
+    }),
+    getHosts: testing.fn().mockResolvedValue({
+      data: [
+        {
+          id: '123.456.78.910',
+          ip: '123.456.78.910',
+          hostname: 'foo.bar',
+        },
+      ],
+      meta: {
+        filter,
+        counts: new CollectionCounts({all: 1, filtered: 1, length: 1}),
+      },
+    }),
+  },
+});
+
+describe('audit-report query hooks', () => {
+  test('should fetch audit report hosts from auditreport command', async () => {
+    const gmp = createGmp();
+    const {render} = rendererWith({gmp, router: true});
+
+    render(<HostsComponent reportId="1234" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('host-entity')).toHaveLength(1);
+    });
+
+    expect(gmp.auditreport.getHosts).toHaveBeenCalledWith(
+      expect.objectContaining({report_id: '1234'}),
+    );
+  });
+
+  test('should fetch audit report entity', async () => {
+    const gmp = createGmp();
+    const {render} = rendererWith({gmp, router: true});
+
+    render(<AuditReportComponent reportId="report-1234" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('report-id')).toHaveTextContent('report-1234');
+    });
+
+    expect(gmp.auditreport.get).toHaveBeenCalledWith(
+      {id: 'report-1234'},
+      expect.objectContaining({details: false}),
+    );
+  });
+
+  test('should not fetch hosts when reportId is empty', () => {
+    const gmp = createGmp();
+    const {render} = rendererWith({gmp, router: true});
+
+    render(<HostsComponent reportId="" />);
+
+    expect(screen.getByTestId('no-data')).toBeInTheDocument();
+    expect(gmp.auditreport.getHosts).not.toHaveBeenCalled();
+  });
+});

--- a/src/web/hooks/use-query/audit-report.ts
+++ b/src/web/hooks/use-query/audit-report.ts
@@ -1,0 +1,65 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type AuditReport from 'gmp/models/audit-report';
+import {type FilterType} from 'gmp/models/filter';
+import type ReportHost from 'gmp/models/report/host';
+import useGmp from 'web/hooks/useGmp';
+import useGetEntities from 'web/queries/useGetEntities';
+import useGetEntity from 'web/queries/useGetEntity';
+
+interface UseGetAuditReportParams {
+  id: string;
+  filter?: FilterType;
+  refetchInterval?: number | false | ((data?: AuditReport) => number | false);
+}
+
+interface UseGetAuditReportHostsParams {
+  reportId: string;
+  filter?: FilterType;
+  refetchInterval?: number | false;
+}
+
+export const useGetAuditReport = ({
+  id,
+  filter = undefined,
+  refetchInterval = undefined,
+}: UseGetAuditReportParams) => {
+  const gmp = useGmp();
+  const filterString = filter?.toFilterString();
+
+  return useGetEntity<AuditReport>({
+    gmpMethod: async ({id: auditReportId}) => {
+      return gmp.auditreport.get({id: auditReportId}, {filter, details: false});
+    },
+    queryId: 'get_audit_report',
+    queryKeyParts: [filterString],
+    id,
+    refetchInterval,
+  });
+};
+
+export const useGetAuditReportHosts = ({
+  reportId,
+  filter = undefined,
+  refetchInterval = undefined,
+}: UseGetAuditReportHostsParams) => {
+  const gmp = useGmp();
+
+  return useGetEntities<ReportHost>({
+    gmpMethod: ({filter: reportFilter}) =>
+      gmp.auditreport.getHosts({
+        report_id: reportId,
+        filter: reportFilter,
+      }),
+    queryId: `get_audit_report_hosts_${reportId}`,
+    filter,
+    refetchInterval,
+    enabled: Boolean(reportId),
+    keepPreviousData: true,
+  });
+};
+
+export default useGetAuditReport;

--- a/src/web/hooks/use-query/use-audit-report-sub-entities.ts
+++ b/src/web/hooks/use-query/use-audit-report-sub-entities.ts
@@ -1,0 +1,44 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {type FilterType} from 'gmp/models/filter';
+import {useGetAuditReportHosts} from 'web/hooks/use-query/audit-report';
+import {useGetReportErrors} from 'web/hooks/use-query/report-errors';
+import {useGetReportOperatingSystems} from 'web/hooks/use-query/report-operating-system';
+import {useGetReportTlsCertificates} from 'web/hooks/use-query/report-tls-certificates';
+
+export interface AuditReportSubEntities {
+  hosts: ReturnType<typeof useGetAuditReportHosts>;
+  operatingSystems: ReturnType<typeof useGetReportOperatingSystems>;
+  tlsCertificates: ReturnType<typeof useGetReportTlsCertificates>;
+  errors: ReturnType<typeof useGetReportErrors>;
+}
+
+interface UseAuditReportSubEntitiesParams {
+  reportId: string;
+  filter?: FilterType;
+  refetchInterval?: number | false;
+}
+
+const useAuditReportSubEntities = ({
+  reportId,
+  filter = undefined,
+  refetchInterval = undefined,
+}: UseAuditReportSubEntitiesParams): AuditReportSubEntities => ({
+  hosts: useGetAuditReportHosts({reportId, filter, refetchInterval}),
+  operatingSystems: useGetReportOperatingSystems({
+    reportId,
+    filter,
+    refetchInterval,
+  }),
+  tlsCertificates: useGetReportTlsCertificates({
+    reportId,
+    filter,
+    refetchInterval,
+  }),
+  errors: useGetReportErrors({reportId, filter, refetchInterval}),
+});
+
+export default useAuditReportSubEntities;

--- a/src/web/pages/reports/AuditReportDetailsContent.tsx
+++ b/src/web/pages/reports/AuditReportDetailsContent.tsx
@@ -34,7 +34,7 @@ import Tabs from 'web/components/tab/Tabs';
 import TabsContainer from 'web/components/tab/TabsContainer';
 import EntityInfo from 'web/entity/EntityInfo';
 import EntityTags from 'web/entity/Tags';
-import useReportSubEntities from 'web/hooks/use-query/use-report-sub-entities';
+import useAuditReportSubEntities from 'web/hooks/use-query/use-audit-report-sub-entities';
 import useGmp from 'web/hooks/useGmp';
 import useTranslation from 'web/hooks/useTranslation';
 import AuditThresholdPanel from 'web/pages/reports/details/AuditThresholdPanel';
@@ -161,7 +161,7 @@ const AuditReportDetailsContent = ({
     : ((scan_run_status as TaskStatus) ?? TASK_STATUS.unknown);
   const refetchInterval = isActive(status) ? undefined : false;
 
-  const reportEntities = useReportSubEntities({
+  const auditReportEntities = useAuditReportSubEntities({
     reportId,
     filter: reportFilter,
     refetchInterval,
@@ -257,7 +257,7 @@ const AuditReportDetailsContent = ({
       key: 'hosts',
       title: (
         <TabTitle
-          counts={reportEntities.hosts.data?.entitiesCounts}
+          counts={auditReportEntities.hosts.data?.entitiesCounts}
           title={_('Hosts')}
         />
       ),
@@ -266,10 +266,10 @@ const AuditReportDetailsContent = ({
         thresholdConfig,
         <HostsTabContent
           audit={true}
-          hostsData={reportEntities.hosts.data}
+          hostsData={auditReportEntities.hosts.data}
           isContainerScanning={false}
-          isHostsError={reportEntities.hosts.isError}
-          isHostsFetching={reportEntities.hosts.isFetching}
+          isHostsError={auditReportEntities.hosts.isError}
+          isHostsFetching={auditReportEntities.hosts.isFetching}
           reportFilter={effectiveReportFilter}
           reportId={reportId}
         />,
@@ -279,7 +279,7 @@ const AuditReportDetailsContent = ({
       key: 'os',
       title: (
         <TabTitle
-          counts={reportEntities.operatingSystems.data?.entitiesCounts}
+          counts={auditReportEntities.operatingSystems.data?.entitiesCounts}
           title={_('Operating Systems')}
         />
       ),
@@ -289,11 +289,11 @@ const AuditReportDetailsContent = ({
         <OperatingSystemsTab
           audit={true}
           filter={effectiveReportFilter}
-          isOperatingSystemsError={reportEntities.operatingSystems.isError}
+          isOperatingSystemsError={auditReportEntities.operatingSystems.isError}
           isOperatingSystemsFetching={
-            reportEntities.operatingSystems.isFetching
+            auditReportEntities.operatingSystems.isFetching
           }
-          operatingSystemsData={reportEntities.operatingSystems.data}
+          operatingSystemsData={auditReportEntities.operatingSystems.data}
           reportId={reportId}
         />,
       ),
@@ -302,7 +302,7 @@ const AuditReportDetailsContent = ({
       key: 'tlscerts',
       title: (
         <TabTitle
-          counts={reportEntities.tlsCertificates.data?.entitiesCounts}
+          counts={auditReportEntities.tlsCertificates.data?.entitiesCounts}
           title={_('TLS Certificates')}
         />
       ),
@@ -310,11 +310,13 @@ const AuditReportDetailsContent = ({
         _('TLS Certificates'),
         thresholdConfig,
         <TLSCertificatesTab
-          isTlsCertificatesError={reportEntities.tlsCertificates.isError}
-          isTlsCertificatesFetching={reportEntities.tlsCertificates.isFetching}
+          isTlsCertificatesError={auditReportEntities.tlsCertificates.isError}
+          isTlsCertificatesFetching={
+            auditReportEntities.tlsCertificates.isFetching
+          }
           reportFilter={effectiveReportFilter}
           reportId={reportId}
-          tlsCertificatesData={reportEntities.tlsCertificates.data}
+          tlsCertificatesData={auditReportEntities.tlsCertificates.data}
           onTlsCertificateDownloadClick={onTlsCertificateDownloadClick}
         />,
       ),
@@ -323,16 +325,16 @@ const AuditReportDetailsContent = ({
       key: 'errors',
       title: (
         <TabTitle
-          counts={reportEntities.errors.data?.entitiesCounts}
+          counts={auditReportEntities.errors.data?.entitiesCounts}
           title={_('Error Messages')}
         />
       ),
       panel: (
         <ErrorsTab
-          errorsData={reportEntities.errors.data}
+          errorsData={auditReportEntities.errors.data}
           filter={effectiveReportFilter}
-          isErrorsError={reportEntities.errors.isError}
-          isErrorsFetching={reportEntities.errors.isFetching}
+          isErrorsError={auditReportEntities.errors.isError}
+          isErrorsFetching={auditReportEntities.errors.isFetching}
           reportId={reportId}
         />
       ),

--- a/src/web/pages/reports/AuditReportDetailsPage.tsx
+++ b/src/web/pages/reports/AuditReportDetailsPage.tsx
@@ -6,8 +6,6 @@
 import {useCallback, useEffect, useState} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
 import {useParams} from 'react-router';
-import type Response from 'gmp/http/response';
-import type {XmlMeta} from 'gmp/http/transform/fast-xml';
 import logger from 'gmp/log';
 import type AuditReport from 'gmp/models/audit-report';
 import {
@@ -17,13 +15,14 @@ import {
 } from 'gmp/models/filter';
 import QueryFilter from 'gmp/models/filter/query-filter';
 import type ReportTLSCertificate from 'gmp/models/report/tls-certificate';
-import {isActive, type TaskStatus} from 'gmp/models/task';
+import {isActive} from 'gmp/models/task';
 import {isDefined} from 'gmp/utils/identity';
 import Download from 'web/components/form/Download';
 import useDownload from 'web/components/form/useDownload';
 import PageTitle from 'web/components/layout/PageTitle';
 import DialogNotification from 'web/components/notification/DialogNotification';
 import useDialogNotification from 'web/components/notification/useDialogNotification';
+import {useGetAuditReport} from 'web/hooks/use-query/audit-report';
 import {
   useGetReportConfigs,
   useGetReportExportFileName,
@@ -38,7 +37,6 @@ import Page from 'web/pages/reports/AuditReportDetailsContent';
 import DownloadReportDialog from 'web/pages/reports/DownloadReportDialog';
 import ReportDetailsFilterDialog from 'web/pages/reports/ReportDetailsFilterDialog';
 import TargetComponent from 'web/pages/targets/TargetComponent';
-import useGetEntity from 'web/queries/useGetEntity';
 import {createPEMCertificate} from 'web/utils/certificates';
 import {generateFilename} from 'web/utils/Render';
 
@@ -60,10 +58,6 @@ interface ReportTargetRef {
 }
 
 interface AuditReportCommand {
-  get: (
-    params: {id: string},
-    options?: {filter?: string; details?: boolean},
-  ) => Promise<Response<AuditReport, XmlMeta>>;
   addAssets: (params: {id: string; filter?: string}) => Promise<unknown>;
   removeAssets: (params: {id: string; filter?: string}) => Promise<unknown>;
   download: (
@@ -99,29 +93,6 @@ const getTarget = (entity?: AuditReport) => {
 
 const getReportFilter = (entity?: AuditReport) => {
   return entity?.report?.filter;
-};
-
-const useGetAuditReport = ({
-  id,
-  filter,
-  refetchInterval,
-}: {
-  id: string;
-  filter?: FilterType;
-  refetchInterval?: number | false | ((data?: AuditReport) => number | false);
-}) => {
-  const gmp = useGmp();
-  const filterString = filter?.toFilterString();
-
-  return useGetEntity<AuditReport>({
-    gmpMethod: async ({id}) => {
-      return gmp.auditreport.get({id}, {filter, details: false});
-    },
-    queryId: 'get_audit_report',
-    queryKeyParts: [filterString],
-    id,
-    refetchInterval,
-  });
 };
 
 const AuditReportDetailsPage = () => {
@@ -161,7 +132,7 @@ const AuditReportDetailsPage = () => {
       if (!isDefined(entity) || !isDefined(entity.report)) {
         return false as const;
       }
-      return isActive(entity.report.scan_run_status as TaskStatus)
+      return isActive(entity.report.scan_run_status)
         ? gmp.settings.reloadIntervalActive
         : false;
     },
@@ -357,7 +328,7 @@ const AuditReportDetailsPage = () => {
 
       try {
         const response = await auditreport.download(
-          {id: entity.id as string},
+          {id: entity.id},
           {
             reportFormatId,
             filter: newFilter,
@@ -369,7 +340,7 @@ const AuditReportDetailsPage = () => {
           creationTime: entity.creationTime,
           extension,
           fileNameFormat: reportExportFileName,
-          id: entity.id as string,
+          id: entity.id,
           modificationTime: entity.modificationTime,
           reportFormat: reportFormat?.name,
           resourceName: entity.task?.name,
@@ -463,7 +434,7 @@ const AuditReportDetailsPage = () => {
             reportFilter={reportFilter}
             reportId={reportId}
             resetFilter={AUDIT_REPORT_RESET_FILTER}
-            showError={showError as (...args: unknown[]) => void}
+            showError={showError}
             showErrorMessage={showErrorMessage}
             showSuccessMessage={showSuccessMessage}
             task={isDefined(report) ? report.task : undefined}

--- a/src/web/pages/reports/__tests__/AuditReportDetailsContent.test.tsx
+++ b/src/web/pages/reports/__tests__/AuditReportDetailsContent.test.tsx
@@ -33,8 +33,8 @@ const createGmp = ({reportResultsThreshold = 10} = {}) => ({
       },
     }),
   },
-  reporthosts: {
-    get: testing.fn().mockResolvedValue({
+  auditreport: {
+    getHosts: testing.fn().mockResolvedValue({
       data: [
         {
           ip: '123.456.78.910',


### PR DESCRIPTION
## What

- Implement `getHosts` method in `AuditReportCommand` to fetch audit report hosts.
- Create `useGetAuditReportHosts` hook for fetching hosts data.
- Update `AuditReportDetailsContent` and `AuditReportDetailsPage` to use new hooks.
- Refactor tests to accommodate changes in data fetching for audit reports.

## Why

- In Audit report details host no data was being displayed

## References

GEA-1970

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


