### PR TITLE
Add a date picker next to the days field of an override

### DIFF
--- a/src/web/components/form/DaysDatePicker.tsx
+++ b/src/web/components/form/DaysDatePicker.tsx
@@ -1,0 +1,96 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {useCallback, useState} from 'react';
+import {Popover} from '@mantine/core';
+import {DatePicker} from '@mantine/dates';
+import date, {type Date} from 'gmp/models/date';
+import {isDefined} from 'gmp/utils/identity';
+import {CalendarIcon} from 'web/components/icon';
+import useLanguage from 'web/hooks/useLanguage';
+import useTranslation from 'web/hooks/useTranslation';
+
+interface DaysDatePickerProps {
+  disabled?: boolean;
+  maxDate?: Date;
+  minDate?: Date;
+  name?: string;
+  title?: string;
+  value?: Date;
+  onChange?: (value: Date, name?: string) => void;
+}
+
+/**
+ * A calendar icon that unfolds a calendar.
+ *
+ * Sits next to a field that holds a number of days and exists so that the
+ * number does not have to be worked out by hand: pick the day the override
+ * should stop being active on and the caller turns that into the number of
+ * days from today.
+ */
+const DaysDatePicker = ({
+  disabled = false,
+  maxDate = date().add(3, 'years'),
+  minDate = date(),
+  name,
+  title,
+  value = date(),
+  onChange,
+}: DaysDatePickerProps) => {
+  const [_] = useTranslation();
+  const [language] = useLanguage();
+  const [opened, setOpened] = useState(false);
+
+  const handleChange = useCallback(
+    (newValue: string | Date | null) => {
+      if (isDefined(onChange) && newValue !== null) {
+        onChange(date(newValue), name);
+      }
+      setOpened(false);
+    },
+    [name, onChange],
+  );
+
+  return (
+    <Popover
+      withArrow
+      opened={opened}
+      position="bottom-end"
+      shadow="md"
+      /* No fade: the dropdown should be there as soon as it is opened, which
+       * also keeps it testable without waiting for a transition. */
+      transitionProps={{duration: 0}}
+      onChange={setOpened}
+    >
+      {/* Popover.Target needs a child it can attach a ref to for positioning.
+       * CalendarIcon is a plain function component, so it is wrapped. */}
+      <Popover.Target>
+        <span data-testid="days-datepicker-target">
+          <CalendarIcon
+            data-testid="days-datepicker-icon"
+            disabled={disabled}
+            title={title ?? _('Select an end date to fill in the days')}
+            onClick={() => {
+              if (!disabled) {
+                setOpened(current => !current);
+              }
+            }}
+          />
+        </span>
+      </Popover.Target>
+      <Popover.Dropdown data-testid="days-datepicker-dropdown">
+        <DatePicker
+          locale={language}
+          maxDate={isDefined(maxDate) ? maxDate.toDate() : undefined}
+          minDate={isDefined(minDate) ? minDate.toDate() : undefined}
+          value={value.toDate()}
+          onChange={handleChange}
+        />
+      </Popover.Dropdown>
+    </Popover>
+  );
+};
+
+export default DaysDatePicker;

--- a/src/web/pages/notes/NoteDialog.tsx
+++ b/src/web/pages/notes/NoteDialog.tsx
@@ -208,6 +208,7 @@ const NoteDialog = ({
             )}
             <ActiveFormGroup
               active={state.active}
+              days={state.days}
               isEdit={isEdit}
               item={note}
               onValueChange={onValueChange}

--- a/src/web/pages/notes/__tests__/NoteDialog.test.tsx
+++ b/src/web/pages/notes/__tests__/NoteDialog.test.tsx
@@ -346,7 +346,10 @@ describe('NoteDialog tests', () => {
     const activeRadioInputs = activeFormGroup.getRadioInputs();
     expect(activeRadioInputs).toHaveLength(4);
     expect(activeRadioInputs[1]).toBeChecked();
-    expect(activeFormGroup.getAllByText('yes, until')).toHaveLength(2);
+    /* "yes, until <date>" for the existing end time, and the separate
+     * "yes, for the next <n> days" row. */
+    expect(activeFormGroup.getAllByText('yes, until')).toHaveLength(1);
+    expect(activeFormGroup.getByText('yes, for the next')).toBeInTheDocument();
     expect(activeFormGroup.getByText(/2026/)).toBeInTheDocument();
 
     fireEvent.click(nvtRadioInputs[1]);

--- a/src/web/pages/overrides/ActiveFormGroup.tsx
+++ b/src/web/pages/overrides/ActiveFormGroup.tsx
@@ -15,8 +15,9 @@ import {
 } from 'gmp/models/override';
 import {isDefined} from 'gmp/utils/identity';
 import DateTime from 'web/components/date/DateTime';
-import DatePicker from 'web/components/form/DatePicker';
+import DaysDatePicker from 'web/components/form/DaysDatePicker';
 import FormGroup from 'web/components/form/FormGroup';
+import NumberField from 'web/components/form/NumberField';
 import Radio from 'web/components/form/Radio';
 import Row from 'web/components/layout/Row';
 import useTranslation from 'web/hooks/useTranslation';
@@ -28,13 +29,26 @@ export interface ActiveItem {
 
 interface ActiveFormGroupProps {
   active?: Active;
+  days?: number;
   isEdit?: boolean;
   item?: ActiveItem;
   onValueChange: (value: string | number, name?: string) => void;
 }
 
+/**
+ * Number of whole days from today until the given date, at least one.
+ */
 export const computeDaysUntil = (targetDate: Date): number =>
   Math.max(1, targetDate.startOf('day').diff(date().startOf('day'), 'day'));
+
+/**
+ * The date that lies the given number of days ahead of today.
+ *
+ * The counterpart of computeDaysUntil, so that typing a number of days moves
+ * the calendar and picking a date fills in the number of days.
+ */
+export const computeEndDate = (days: number): Date =>
+  date().startOf('day').add(Math.max(1, days), 'day');
 
 export const handleEndDateChange = (
   newDate: Date,
@@ -47,6 +61,7 @@ export const handleEndDateChange = (
 
 const ActiveFormGroup = ({
   active,
+  days = DEFAULT_DAYS,
   isEdit = false,
   item,
   onValueChange,
@@ -56,6 +71,15 @@ const ActiveFormGroup = ({
   const [endDate, setEndDate] = useState(() =>
     isDefined(item?.endTime) ? item.endTime : date().add(DEFAULT_DAYS, 'day'),
   );
+
+  const forNextSelected = active === ACTIVE_YES_FOR_NEXT_VALUE;
+
+  const handleDaysChange = (value: number, name?: string) => {
+    /* Keep the calendar on the day the number points at, so that opening it
+     * again starts from what the field says. */
+    setEndDate(computeEndDate(value));
+    onValueChange(value, name ?? 'days');
+  };
 
   return (
     <FormGroup data-testid="group-active" title={_('Active')}>
@@ -83,14 +107,24 @@ const ActiveFormGroup = ({
         )}
       <Row>
         <Radio
-          checked={active === ACTIVE_YES_FOR_NEXT_VALUE}
+          checked={forNextSelected}
           name="active"
-          title={_('yes, until')}
+          title={_('yes, for the next')}
           value={ACTIVE_YES_FOR_NEXT_VALUE}
           onChange={onValueChange}
         />
-        <DatePicker
-          disabled={active !== ACTIVE_YES_FOR_NEXT_VALUE}
+        <NumberField
+          data-testid="active-days"
+          disabled={!forNextSelected}
+          min={1}
+          name="days"
+          value={days}
+          w={100}
+          onChange={handleDaysChange}
+        />
+        <span>{_('days')}</span>
+        <DaysDatePicker
+          disabled={!forNextSelected}
           minDate={date()}
           name="endDate"
           value={endDate}

--- a/src/web/pages/overrides/OverrideDialog.tsx
+++ b/src/web/pages/overrides/OverrideDialog.tsx
@@ -272,6 +272,7 @@ const OverrideDialog = ({
 
             <ActiveFormGroup
               active={state.active}
+              days={state.days}
               isEdit={isEdit}
               item={override}
               onValueChange={onValueChange}

--- a/src/web/pages/overrides/__tests__/ActiveFormGroup.test.tsx
+++ b/src/web/pages/overrides/__tests__/ActiveFormGroup.test.tsx
@@ -15,6 +15,7 @@ import {
 import {createSession} from 'gmp/testing';
 import ActiveFormGroup, {
   computeDaysUntil,
+  computeEndDate,
   handleEndDateChange,
 } from 'web/pages/overrides/ActiveFormGroup';
 
@@ -48,6 +49,26 @@ describe('computeDaysUntil', () => {
   test('should return 1 for a past date', () => {
     const past = date().subtract(5, 'day');
     expect(computeDaysUntil(past)).toBe(1);
+  });
+});
+
+describe('computeEndDate', () => {
+  test('should return the day that many days ahead', () => {
+    expect(computeEndDate(30).format('YYYY-MM-DD')).toEqual(
+      date().startOf('day').add(30, 'day').format('YYYY-MM-DD'),
+    );
+  });
+
+  test('should round up to one day for zero and negative values', () => {
+    const tomorrow = date().startOf('day').add(1, 'day').format('YYYY-MM-DD');
+    expect(computeEndDate(0).format('YYYY-MM-DD')).toEqual(tomorrow);
+    expect(computeEndDate(-3).format('YYYY-MM-DD')).toEqual(tomorrow);
+  });
+
+  test('should be the inverse of computeDaysUntil', () => {
+    for (const days of [1, 7, 30, 365]) {
+      expect(computeDaysUntil(computeEndDate(days))).toBe(days);
+    }
   });
 });
 
@@ -140,7 +161,7 @@ describe('ActiveFormGroup tests', () => {
     expect(activeGroup.getByText(/2026/)).toBeInTheDocument();
   });
 
-  test('should render the DatePicker disabled by default and enabled when yes for next is selected', () => {
+  test('should render the days field and calendar disabled by default', () => {
     const onValueChange = testing.fn();
     const {render} = rendererWith({gmp: createGmp()});
 
@@ -151,8 +172,8 @@ describe('ActiveFormGroup tests', () => {
       />,
     );
 
-    const datePicker = screen.getByTestId('datepicker-input');
-    expect(datePicker).toBeDisabled();
+    expect(screen.getByTestId('active-days')).toBeDisabled();
+    expect(screen.getByTestId('days-datepicker-icon')).toBeDisabled();
 
     fireEvent.click(
       within(screen.getByTestId('group-active')).getRadioInputs()[1],
@@ -164,7 +185,7 @@ describe('ActiveFormGroup tests', () => {
     );
   });
 
-  test('should enable the DatePicker when active is yes for next', () => {
+  test('should enable the days field and the calendar when active is yes for next', () => {
     const onValueChange = testing.fn();
     const {render} = rendererWith({gmp: createGmp()});
 
@@ -175,7 +196,91 @@ describe('ActiveFormGroup tests', () => {
       />,
     );
 
-    expect(screen.getByTestId('datepicker-input')).not.toBeDisabled();
+    expect(screen.getByTestId('active-days')).not.toBeDisabled();
+    expect(screen.getByTestId('days-datepicker-icon')).not.toBeDisabled();
+  });
+
+  test('should show the days and open the calendar on the icon', () => {
+    const onValueChange = testing.fn();
+    const {render} = rendererWith({gmp: createGmp()});
+
+    render(
+      <ActiveFormGroup
+        active={ACTIVE_YES_FOR_NEXT_VALUE}
+        days={30}
+        onValueChange={onValueChange}
+      />,
+    );
+
+    expect(screen.getByTestId('active-days')).toHaveValue('30');
+    expect(screen.queryByTestId('days-datepicker-dropdown')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('days-datepicker-icon'));
+
+    expect(screen.getByTestId('days-datepicker-dropdown')).toBeInTheDocument();
+  });
+
+  test('should not open the calendar while yes for next is not selected', () => {
+    const onValueChange = testing.fn();
+    const {render} = rendererWith({gmp: createGmp()});
+
+    render(
+      <ActiveFormGroup
+        active={ACTIVE_YES_ALWAYS_VALUE}
+        onValueChange={onValueChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('days-datepicker-icon'));
+
+    expect(screen.queryByTestId('days-datepicker-dropdown')).toBeNull();
+  });
+
+  test('should write the days into the field when a day is picked in the calendar', () => {
+    /* Fixed clock so that the target day is in the month the calendar opens
+     * on and its number is unambiguous. */
+    testing.useFakeTimers();
+    testing.setSystemTime(new Date('2026-03-01T12:00:00Z'));
+
+    const onValueChange = testing.fn();
+    const {render} = rendererWith({gmp: createGmp()});
+
+    render(
+      <ActiveFormGroup
+        active={ACTIVE_YES_FOR_NEXT_VALUE}
+        days={10}
+        onValueChange={onValueChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('days-datepicker-icon'));
+    const dropdown = within(screen.getByTestId('days-datepicker-dropdown'));
+
+    /* 2026-03-21 is twenty days after the frozen today. */
+    fireEvent.click(dropdown.getByText('21'));
+
+    expect(onValueChange).toHaveBeenCalledWith(20, 'days');
+
+    testing.useRealTimers();
+  });
+
+  test('should pass on a typed number of days', () => {
+    const onValueChange = testing.fn();
+    const {render} = rendererWith({gmp: createGmp()});
+
+    render(
+      <ActiveFormGroup
+        active={ACTIVE_YES_FOR_NEXT_VALUE}
+        days={30}
+        onValueChange={onValueChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('active-days'), {
+      target: {value: '45'},
+    });
+
+    expect(onValueChange).toHaveBeenCalledWith(45, 'days');
   });
 
   test('should call onValueChange when the no radio is clicked', () => {

--- a/src/web/pages/overrides/__tests__/OverrideDialog.test.tsx
+++ b/src/web/pages/overrides/__tests__/OverrideDialog.test.tsx
@@ -364,7 +364,10 @@ describe('OverrideDialog tests', () => {
     const activeRadios = activeGroup.getRadioInputs();
     expect(activeRadios).toHaveLength(4);
     expect(activeRadios[1]).toBeChecked();
-    expect(activeGroup.getAllByText('yes, until')).toHaveLength(2);
+    /* "yes, until <date>" for the existing end time, and the separate
+     * "yes, for the next <n> days" row. */
+    expect(activeGroup.getAllByText('yes, until')).toHaveLength(1);
+    expect(activeGroup.getByText('yes, for the next')).toBeInTheDocument();
 
     const newSeverityGroup = within(screen.getByTestId('group-new-severity'));
     const options = await getSelectItemElementsForSelect(
@@ -387,20 +390,20 @@ describe('OverrideDialog tests', () => {
     );
   });
 
-  test('should render DatePicker disabled by default and enabled when yes for next is selected', () => {
+  test('should render the days field disabled by default and enabled when yes for next is selected', () => {
     const onClose = testing.fn();
     const onSave = testing.fn();
     const {render} = rendererWith({gmp: createGmp()});
 
     render(<OverrideDialog tasks={tasks} onClose={onClose} onSave={onSave} />);
 
-    const datePicker = screen.getByTestId('datepicker-input');
-    expect(datePicker).toBeInTheDocument();
-    expect(datePicker).toBeDisabled();
+    const days = screen.getByTestId('active-days');
+    expect(days).toBeInTheDocument();
+    expect(days).toBeDisabled();
 
     const activeGroup = within(screen.getByTestId('group-active'));
     fireEvent.click(activeGroup.getRadioInputs()[1]);
 
-    expect(datePicker).not.toBeDisabled();
+    expect(days).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
The *Active* group of the note and override dialogs offers a date picker and works the number of days out from it, but never shows the number. The days are what actually goes to the manager, and someone who wants to say "thirty days" has to reach for a calendar to find the date, or count.

This shows both. The row now reads **"yes, for the next `[30]` days"** with a calendar icon beside the field. Typing a number moves the calendar, and picking a day in the calendar fills in the number of days from today — so the value you send is visible and editable, and you no longer have to work it out by hand.

The label changed from *"yes, until"* to *"yes, for the next"*, because with a number of days in front of it the old one read wrong ("yes, until 30 days").

## What changed

- **`DaysDatePicker`** (new) is the calendar icon and the calendar it unfolds: a Mantine `Popover` around the `DatePicker` from `@mantine/dates`. `Popover.Target` needs a child it can attach a ref to and the icon is a plain function component, so it is wrapped in a `span`. The transition is off, so the calendar is there as soon as it opens rather than fading in.
- **`ActiveFormGroup`** gains a `days` prop and `computeEndDate`, the counterpart of the existing `computeDaysUntil`, so the field and the calendar always agree in both directions. Both dialogs pass their `days` through.

Notes get the same, because `NoteDialog` and `OverrideDialog` share the component.

## Tested

19 cases for `ActiveFormGroup`, including a real click in the calendar against a frozen clock (1 March 2026, clicking the 21st writes `20` into the field), that the calendar stays shut while *yes, for the next* is not selected, and that `computeEndDate` and `computeDaysUntil` are inverses.

End to end against the manager: 20 days produces an end time exactly 20 days ahead and reads back as such.

🤖 Generated with [Claude Code](https://claude.com/claude-code)