### PR TITLE
GEA-1719

### DIFF
--- a/src/gmp/gmp.ts
+++ b/src/gmp/gmp.ts
@@ -120,6 +120,7 @@ class Gmp {
   private readonly http: Http;
   private readonly _login: LoginCommand;
   private _logoutListeners: Listener[];
+  private _isLoggingOut: boolean = false;
 
   public readonly agent: AgentCommand;
   public readonly agents: AgentsCommand;
@@ -346,6 +347,8 @@ class Gmp {
     const {token, timezone, locale, sessionTimeout, jwt} =
       await this._login.login(username, password);
 
+    this._isLoggingOut = false;
+
     this.session.login({
       jwt,
       locale,
@@ -360,6 +363,7 @@ class Gmp {
 
   public async doLogout() {
     if (this.session.isLoggedIn()) {
+      this._isLoggingOut = true;
       const url = this.buildUrl('logout');
       const args = {token: this.session.token};
 
@@ -376,6 +380,10 @@ class Gmp {
     }
 
     return Promise.resolve();
+  }
+
+  public isLoggingOut() {
+    return this._isLoggingOut;
   }
 
   public logout() {

--- a/src/web/components/session-timer/__tests__/SessionTimer.test.tsx
+++ b/src/web/components/session-timer/__tests__/SessionTimer.test.tsx
@@ -29,6 +29,7 @@ const createGmp = ({
   user: {
     renewSession,
   },
+  isLoggingOut: testing.fn().mockReturnValue(false),
 });
 
 describe('SessionTimer tests', () => {

--- a/src/web/hooks/__tests__/useSessionTimeout.test.tsx
+++ b/src/web/hooks/__tests__/useSessionTimeout.test.tsx
@@ -27,6 +27,7 @@ const createGmp = ({
     renewSession,
   },
   session: createSession({sessionTimeout}),
+  isLoggingOut: testing.fn().mockReturnValue(false),
 });
 
 describe('useSessionTimeout tests', () => {

--- a/src/web/hooks/__tests__/useSessionTracker.test.tsx
+++ b/src/web/hooks/__tests__/useSessionTracker.test.tsx
@@ -59,7 +59,7 @@ describe('useSessionTracker', () => {
     gmp.user.renewSession.mockClear();
 
     fireEvent.click(btn);
-    expect(gmp.user.renewSession).toHaveBeenCalledOnce();
+    expect(gmp.user.renewSession).not.toHaveBeenCalled();
     gmp.user.renewSession.mockClear();
 
     await runTimers();
@@ -133,6 +133,26 @@ describe('useSessionTracker', () => {
     gmp.user.renewSession.mockClear();
 
     fireEvent.drag(document);
+    expect(gmp.user.renewSession).toHaveBeenCalledOnce();
+  });
+
+  test('should renew session only once for rapid wheel events within the cooldown', () => {
+    testing.useFakeTimers();
+    const gmp = createGmp();
+    const {render} = rendererWith({
+      store: true,
+      gmp,
+    });
+
+    render(<TestSessionTracker />);
+
+    gmp.user.renewSession.mockClear();
+
+    fireEvent.wheel(document);
+    fireEvent.wheel(document);
+    fireEvent.wheel(document);
+    fireEvent.wheel(document);
+
     expect(gmp.user.renewSession).toHaveBeenCalledOnce();
   });
 });

--- a/src/web/hooks/__tests__/useSessionTracker.test.tsx
+++ b/src/web/hooks/__tests__/useSessionTracker.test.tsx
@@ -17,11 +17,13 @@ import useSessionTracker from 'web/hooks/useSessionTracker';
 const createGmp = ({
   newDate = date(),
   renewSession = testing.fn().mockResolvedValue({data: newDate}),
+  isLoggingOut = testing.fn().mockReturnValue(false),
 } = {}) => ({
   user: {
     renewSession,
   },
   session: createSession({sessionTimeout: newDate}),
+  isLoggingOut,
 });
 
 const TestSessionTracker = ({onClick}: {onClick?: () => void}) => {
@@ -84,6 +86,25 @@ describe('useSessionTracker', () => {
     gmp.user.renewSession.mockClear();
 
     fireEvent.click(nonButton);
+    expect(gmp.user.renewSession).not.toHaveBeenCalled();
+  });
+
+  test('should not renew session when the user is logging out', () => {
+    testing.useFakeTimers();
+    const gmp = createGmp({
+      isLoggingOut: testing.fn().mockReturnValue(true),
+    });
+    const {render} = rendererWith({
+      store: true,
+      gmp,
+    });
+
+    render(<TestSessionTracker />);
+    const btn = screen.getByTestId('session-btn');
+
+    gmp.user.renewSession.mockClear();
+
+    fireEvent.click(btn);
     expect(gmp.user.renewSession).not.toHaveBeenCalled();
   });
 

--- a/src/web/hooks/useSessionTimeout.ts
+++ b/src/web/hooks/useSessionTimeout.ts
@@ -28,6 +28,9 @@ const useSessionTimeout = (): [
   );
 
   const renewSessionAndUpdateTimeout = useCallback(async () => {
+    if (gmp.isLoggingOut() || !gmp.session.isLoggedIn()) {
+      return;
+    }
     const response = await gmp.user.renewSession();
     gmp.session.setSessionTimeout(response.data);
   }, [gmp]);

--- a/src/web/hooks/useSessionTracker.ts
+++ b/src/web/hooks/useSessionTracker.ts
@@ -50,15 +50,15 @@ const useSessionTracker = () => {
     const events = ['keypress', 'wheel', 'drag'];
 
     events.forEach(event => {
-      window.addEventListener(event, handleUserActivity);
+      globalThis.addEventListener(event, handleUserActivity);
     });
-    window.addEventListener('click', handleClick);
+    globalThis.addEventListener('click', handleClick);
 
     return () => {
       events.forEach(event => {
-        window.removeEventListener(event, handleUserActivity);
+        globalThis.removeEventListener(event, handleUserActivity);
       });
-      window.removeEventListener('click', handleClick);
+      globalThis.removeEventListener('click', handleClick);
       clearTimeout(cooldownTimeoutId);
       isCooldown = false;
     };

--- a/src/web/hooks/useSessionTracker.ts
+++ b/src/web/hooks/useSessionTracker.ts
@@ -26,8 +26,8 @@ const useSessionTracker = () => {
 
     const handleUserActivity = async () => {
       if (isCooldown) return;
-      await renewSession();
       isCooldown = true;
+      await renewSession();
       cooldownTimeoutId = setTimeout(() => {
         isCooldown = false;
       }, 10000);


### PR DESCRIPTION
## What

Add: new method `isLoggingOut` to keep track and do not call `renew_session` gmp command.

## Why 

Fix: When logging out, the call gmp command `renew_session` gets called.

## References

GEA-1719

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


