### PR TITLE
GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,5 +43,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "actions/*"
+    ignore:
+      - dependency-name: "greenbone/actions"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "Deps"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,7 +5,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true 
+  cancel-in-progress: true
 
 jobs:
   changelog:
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
         with:
           fetch-depth: 0 # for conventional commits and getting all git tags
           persist-credentials: false

--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -24,9 +24,9 @@ jobs:
           - 22
           - 24
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
       - name: Set up node ${{ matrix.node-version }}
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -47,9 +47,9 @@ jobs:
         node-version:
           - 24
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
       - name: Set up node ${{ matrix.node-version }}
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -72,16 +72,16 @@ jobs:
           - 22
           - 24
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
       - name: Set up node ${{ matrix.node-version }}
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Cache ESLint
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # 6.1.0
         with:
           path: .eslintcache
           key: eslint-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('src/**/*.{js,jsx,ts,tsx}', 'eslint.config.js', 'package.json', 'tsconfig.json') }}
@@ -105,9 +105,9 @@ jobs:
           - 22
           - 24
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
       - name: Set up node ${{ matrix.node-version }}
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -124,9 +124,9 @@ jobs:
         node-version:
           - 24
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
       - name: Set up node ${{ matrix.node-version }}
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -148,9 +148,9 @@ jobs:
         node-version:
           - 24
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
       - name: Set up node ${{ matrix.node-version }}
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,11 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: [main, stable, oldstable]
+    branches:
+      - main
   pull_request:
-    branches: [main, stable, oldstable]
+    branches:
+      - main
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
@@ -27,22 +29,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript']
+        language:
+          - 'javascript'
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # 4.27.5
         with:
           languages: ${{ matrix.language }}
         # build between init and analyze ...
       - name: Install node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # 4.27.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           release-type-input: ${{ inputs.release-type }}
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
         with:
           fetch-depth: 0 # for conventional commits and getting all git tags
           persist-credentials: false
@@ -87,11 +87,11 @@ jobs:
     runs-on: 'ubuntu-latest'
     needs: release
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # 7.0.1
         with:
           ref: ${{ needs.release.outputs.git-release-tag }}
       - name: Set up node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
## What

Change dependabot config for updating github-actions and pin github's native actions to specific commits

## Why

Enhanced security.

Only update greenbone actions for major updates because we trust these tags and don't want to get PRs for each bugfix or minor releases.

Also group updates for github's native actions in one PR to allow for less required reviews. Use commit ids for enhanced security.


