### PR TITLE
Add a useLatestCallback hook

### DIFF
--- a/src/web/hooks/__tests__/useLatestCallback.test.tsx
+++ b/src/web/hooks/__tests__/useLatestCallback.test.tsx
@@ -1,0 +1,50 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {describe, expect, test, testing} from '@gsa/testing';
+import {renderHook} from 'web/testing';
+import useLatestCallback from 'web/hooks/useLatestCallback';
+
+describe('useLatestCallback tests', () => {
+  test('should call the latest callback after rerender', () => {
+    const firstCallback = testing.fn((value: number) => value + 1);
+    const secondCallback = testing.fn((value: number) => value + 2);
+
+    const {result, rerender} = renderHook(
+      ({callback}: {callback: (value: number) => number}) =>
+        useLatestCallback(callback),
+      {
+        initialProps: {callback: firstCallback},
+      },
+    );
+
+    expect(result.current(1)).toBe(2);
+    expect(firstCallback).toHaveBeenCalledWith(1);
+
+    rerender({callback: secondCallback});
+
+    expect(result.current(1)).toBe(3);
+    expect(secondCallback).toHaveBeenCalledWith(1);
+  });
+
+  test('should return a stable callback identity', () => {
+    const firstCallback = (value: number) => value + 1;
+    const secondCallback = (value: number) => value + 2;
+
+    const {result, rerender} = renderHook(
+      ({callback}: {callback: (value: number) => number}) =>
+        useLatestCallback(callback),
+      {
+        initialProps: {callback: firstCallback},
+      },
+    );
+
+    const stableCallback = result.current;
+
+    rerender({callback: secondCallback});
+
+    expect(result.current).toBe(stableCallback);
+  });
+});

--- a/src/web/hooks/useLatestCallback.ts
+++ b/src/web/hooks/useLatestCallback.ts
@@ -1,0 +1,20 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {useCallback, useEffect, useRef} from 'react';
+
+const useLatestCallback = <TArgs extends unknown[], TResult>(
+  callback: (...args: TArgs) => TResult,
+) => {
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  return useCallback((...args: TArgs) => callbackRef.current(...args), []);
+};
+
+export default useLatestCallback;


### PR DESCRIPTION


## What

Add a useLatestCallback hook

## Why

This change adds a new hook that should provide a callback function to not trigger effects when it's used inside of the effect and it's identity changes but still provides the latest version of the callback.

With this change a similar behavior as `componentDidMount` can be implemented that uses callback props.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


