### PR TITLE
fix: asset_type parameter in host bulk export

### DIFF
--- a/src/gmp/commands/__tests__/hosts.test.ts
+++ b/src/gmp/commands/__tests__/hosts.test.ts
@@ -147,7 +147,7 @@ describe('HostsCommand tests', () => {
         'bulk_selected:456': 1,
         cmd: 'bulk_export',
         resource_type: 'asset',
-        assetType: 'host',
+        asset_type: 'host',
         bulk_select: 1,
       },
     });
@@ -169,7 +169,7 @@ describe('HostsCommand tests', () => {
         'bulk_selected:456': 1,
         cmd: 'bulk_export',
         resource_type: 'asset',
-        assetType: 'host',
+        asset_type: 'host',
         bulk_select: 1,
       },
     });

--- a/src/gmp/commands/hosts.ts
+++ b/src/gmp/commands/hosts.ts
@@ -50,7 +50,7 @@ class HostsCommand extends EntitiesCommand<Host> {
     const data = {
       cmd: 'bulk_export',
       resource_type: this.name,
-      assetType: 'host',
+      asset_type: 'host',
       bulk_select: BULK_SELECT_BY_IDS,
     };
     for (const id of ids) {


### PR DESCRIPTION
## What

* Rename the host bulk export parameter from `assetType` to `asset_type`.
* Update the related tests.

## Why

The `gsad` expects the parameter in `snake_case`. Using `assetType` prevents the host asset type from being passed correctly.


## References

fixes https://github.com/greenbone/gsa/issues/5495
## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


