### PR TITLE
Only use TicketStatusValue type

### DIFF
--- a/src/gmp/commands/__tests__/tickets.test.ts
+++ b/src/gmp/commands/__tests__/tickets.test.ts
@@ -7,7 +7,7 @@ import {describe, test, expect} from '@gsa/testing';
 import {createHttp, createEntitiesResponse} from 'gmp/commands/testing';
 import TicketsCommand from 'gmp/commands/tickets';
 import {ALL_FILTER} from 'gmp/models/filter';
-import Ticket from 'gmp/models/ticket';
+import Ticket, {TICKET_STATUS} from 'gmp/models/ticket';
 
 describe('TicketsCommand tests', () => {
   test('should fetch all tickets', async () => {
@@ -59,7 +59,7 @@ describe('TicketsCommand tests', () => {
     const response = createEntitiesResponse('ticket', [
       {
         _id: '1',
-        status: 'open',
+        status: TICKET_STATUS.open,
       },
     ]);
 
@@ -75,7 +75,7 @@ describe('TicketsCommand tests', () => {
     expect(resp.data).toEqual([
       new Ticket({
         id: '1',
-        status: 'open',
+        status: TICKET_STATUS.open,
       }),
     ]);
   });

--- a/src/gmp/models/__tests__/ticket.test.ts
+++ b/src/gmp/models/__tests__/ticket.test.ts
@@ -5,7 +5,7 @@
 
 import {describe, test, expect} from '@gsa/testing';
 import {testModel} from 'gmp/models/testing';
-import Ticket from 'gmp/models/ticket';
+import Ticket, {TICKET_STATUS} from 'gmp/models/ticket';
 import {parseDate} from 'gmp/parser';
 
 describe('Ticket Model tests', () => {
@@ -171,16 +171,28 @@ describe('Ticket Model tests', () => {
   });
 
   test('should parse status', () => {
-    const ticket = Ticket.fromElement({_id: 'test-id', status: 'open'});
-    expect(ticket.status).toEqual('open');
+    const ticket = Ticket.fromElement({
+      _id: 'test-id',
+      status: 'Open',
+    });
+    expect(ticket.status).toEqual(TICKET_STATUS.open);
 
-    const ticket2 = Ticket.fromElement({_id: 'test-id', status: 'closed'});
-    expect(ticket2.status).toEqual('closed');
+    const ticket2 = Ticket.fromElement({
+      _id: 'test-id',
+      status: 'Closed',
+    });
+    expect(ticket2.status).toEqual(TICKET_STATUS.closed);
 
-    const ticket3 = Ticket.fromElement({_id: 'test-id', status: 'fixed'});
-    expect(ticket3.status).toEqual('fixed');
+    const ticket3 = Ticket.fromElement({
+      _id: 'test-id',
+      status: 'Fixed',
+    });
+    expect(ticket3.status).toEqual(TICKET_STATUS.fixed);
 
-    const ticket4 = Ticket.fromElement({_id: 'test-id', status: 'verified'});
-    expect(ticket4.status).toEqual('verified');
+    const ticket4 = Ticket.fromElement({
+      _id: 'test-id',
+      status: 'Fix Verified',
+    });
+    expect(ticket4.status).toEqual(TICKET_STATUS.verified);
   });
 });

--- a/src/gmp/models/ticket.ts
+++ b/src/gmp/models/ticket.ts
@@ -10,7 +10,6 @@ import {parseSeverity, parseDate, parseText, type YesNo} from 'gmp/parser';
 import {isDefined, isModelElement} from 'gmp/utils/identity';
 import {isEmpty} from 'gmp/utils/string';
 
-export type TicketStatus = keyof typeof TICKET_STATUS;
 export type TicketStatusValue =
   (typeof TICKET_STATUS)[keyof typeof TICKET_STATUS];
 
@@ -43,7 +42,7 @@ export interface TicketElement extends ModelElement {
   location?: string;
   severity?: number;
   solution_type?: string;
-  status?: TicketStatus;
+  status?: TicketStatusValue;
   task?: {
     _id: string;
     name?: string;
@@ -70,7 +69,7 @@ interface TicketProperties extends ModelProperties {
   location?: string;
   severity?: number;
   solutionType?: string;
-  status?: TicketStatus;
+  status?: TicketStatusValue;
   task?: Model;
 }
 
@@ -88,13 +87,7 @@ export const TICKET_STATUS_TRANSLATIONS = {
   [TICKET_STATUS.closed]: _l('Closed'),
 } as const;
 
-export const TICKET_STATUSES: TicketStatusValue[] = [
-  TICKET_STATUS.open,
-  TICKET_STATUS.fixed,
-  TICKET_STATUS.closed,
-];
-
-export const getTranslatableTicketStatus = (status: TicketStatus) =>
+export const getTranslatableTicketStatus = (status: TicketStatusValue) =>
   `${TICKET_STATUS_TRANSLATIONS[status]}`;
 
 class Ticket extends Model {
@@ -116,7 +109,7 @@ class Ticket extends Model {
   readonly location?: string;
   readonly severity?: number;
   readonly solutionType?: string;
-  readonly status?: TicketStatus;
+  readonly status?: TicketStatusValue;
   readonly task?: Model;
 
   constructor({

--- a/src/web/components/powerfilter/TicketStatusGroup.tsx
+++ b/src/web/components/powerfilter/TicketStatusGroup.tsx
@@ -4,17 +4,17 @@
  */
 
 import {type FilterType} from 'gmp/models/filter';
-import {TICKET_STATUS, type TicketStatus} from 'gmp/models/ticket';
+import {TICKET_STATUS, type TicketStatusValue} from 'gmp/models/ticket';
 import {isDefined} from 'gmp/utils/identity';
 import FormGroup from 'web/components/form/FormGroup';
 import Select from 'web/components/form/Select';
 import useTranslation from 'web/hooks/useTranslation';
 
 interface TicketStatusFilterGroupProps {
-  status?: TicketStatus;
+  status?: TicketStatusValue;
   filter?: FilterType;
   name?: string;
-  onChange: (value: TicketStatus, name: string) => void;
+  onChange: (value: TicketStatusValue, name: string) => void;
 }
 
 const TicketStatusFilterGroup = ({
@@ -26,7 +26,7 @@ const TicketStatusFilterGroup = ({
   const [_] = useTranslation();
 
   if (isDefined(filter)) {
-    status = filter.get('status') as TicketStatus | undefined;
+    status = filter.get('status') as TicketStatusValue | undefined;
   }
 
   return (

--- a/src/web/hooks/use-query/__tests__/Tickets.test.tsx
+++ b/src/web/hooks/use-query/__tests__/Tickets.test.tsx
@@ -8,14 +8,14 @@ import {rendererWith, screen, waitFor} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import type FilterType from 'gmp/models/filter/filter-type';
 import QueryFilter from 'gmp/models/filter/query-filter';
-import Ticket from 'gmp/models/ticket';
+import Ticket, {TICKET_STATUS} from 'gmp/models/ticket';
 import {createSession} from 'gmp/testing';
 import {useGetTicket, useGetTickets} from 'web/hooks/use-query/tickets';
 
 const ticket = Ticket.fromElement({
   _id: 'ticket-1',
   name: 'Test Ticket',
-  status: 'open',
+  status: TICKET_STATUS.open,
   assigned_to: {user: {_id: 'u1', name: 'admin'}},
   open_time: '2024-01-10T08:00:00Z',
   open_note: 'Ticket opened',
@@ -24,7 +24,7 @@ const ticket = Ticket.fromElement({
 const ticket2 = Ticket.fromElement({
   _id: 'ticket-2',
   name: 'Test Ticket 2',
-  status: 'fixed',
+  status: TICKET_STATUS.fixed,
   assigned_to: {user: {_id: 'u1', name: 'admin'}},
   fixed_time: '2024-01-12T09:00:00Z',
   fixed_note: 'Ticket fixed',

--- a/src/web/pages/tickets/TicketComponent.tsx
+++ b/src/web/pages/tickets/TicketComponent.tsx
@@ -7,7 +7,6 @@ import {type ReactNode, useState} from 'react';
 import {type EntityActionData} from 'gmp/commands/entity';
 import {
   TICKET_STATUS,
-  type TicketStatus,
   type TicketStatusValue,
   type default as Ticket,
 } from 'gmp/models/ticket';
@@ -53,14 +52,14 @@ interface TicketComponentProps {
   onSaved?: () => void;
 }
 
-const TICKET_EDIT_STATUS: Record<TicketStatus, TicketStatusValue> = {
-  open: TICKET_STATUS.open,
-  fixed: TICKET_STATUS.fixed,
-  verified: TICKET_STATUS.closed,
-  closed: TICKET_STATUS.closed,
+const TICKET_EDIT_STATUS: Record<TicketStatusValue, TicketStatusValue> = {
+  [TICKET_STATUS.open]: TICKET_STATUS.open,
+  [TICKET_STATUS.fixed]: TICKET_STATUS.fixed,
+  [TICKET_STATUS.verified]: TICKET_STATUS.closed,
+  [TICKET_STATUS.closed]: TICKET_STATUS.closed,
 };
 
-const getTicketEditStatus = (status?: TicketStatus): TicketStatusValue => {
+const getTicketEditStatus = (status?: TicketStatusValue): TicketStatusValue => {
   if (!status) {
     return TICKET_STATUS.open;
   }

--- a/src/web/pages/tickets/TicketEditDialog.tsx
+++ b/src/web/pages/tickets/TicketEditDialog.tsx
@@ -7,7 +7,6 @@ import {useState} from 'react';
 import {
   TICKET_STATUS,
   TICKET_STATUS_TRANSLATIONS,
-  TICKET_STATUSES,
   type TicketStatusValue,
 } from 'gmp/models/ticket';
 import type User from 'gmp/models/user';
@@ -75,10 +74,14 @@ const TicketEditDialog = ({
     },
   );
 
-  const STATUS_ITEMS = TICKET_STATUSES.map(ticketStatus => ({
-    value: ticketStatus,
-    label: `${TICKET_STATUS_TRANSLATIONS[ticketStatus]}`,
-  }));
+  const STATUS_ITEMS = Object.entries(TICKET_STATUS_TRANSLATIONS)
+    // a user should not be able to set the status to "Fix Verified" when editing a ticket
+    // the status "Fix Verified" is only set by the system when a fix is verified, not by the user
+    .filter(([key, value]) => key !== TICKET_STATUS.verified)
+    .map(([ticketStatus, translation]) => ({
+      value: ticketStatus,
+      label: String(translation),
+    }));
 
   title = title || _('Edit Ticket');
 

--- a/src/web/pages/tickets/TicketFilterDialog.tsx
+++ b/src/web/pages/tickets/TicketFilterDialog.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type Filter from 'gmp/models/filter';
+import {type FilterType} from 'gmp/models/filter';
 import CreateNamedFilterGroup from 'web/components/powerfilter/CreateNamedFilterGroup';
 import FilterDialog from 'web/components/powerfilter/FilterDialog';
 import FilterStringGroup from 'web/components/powerfilter/FilterStringGroup';
@@ -22,7 +22,7 @@ import useCapabilities from 'web/hooks/useCapabilities';
 import useTranslation from 'web/hooks/useTranslation';
 
 interface TicketFilterDialogProps extends UseFilterDialogSaveProps {
-  filter?: Filter;
+  filter?: FilterType;
 }
 
 const TicketFilterDialog = ({

--- a/src/web/pages/tickets/TicketsListPage.tsx
+++ b/src/web/pages/tickets/TicketsListPage.tsx
@@ -211,7 +211,7 @@ const TicketsListPage = () => {
             entities={entities}
             entitiesCounts={entitiesCounts}
             filter={filter}
-            filterEditDialog={TicketFilterDialog as never}
+            filterEditDialog={TicketFilterDialog}
             filtersFilter={TICKETS_FILTER_FILTER}
             isLoading={isLoadingEntities}
             sectionIcon={<TicketIcon size="large" />}

--- a/src/web/pages/tickets/__tests__/TicketComponent.test.tsx
+++ b/src/web/pages/tickets/__tests__/TicketComponent.test.tsx
@@ -16,7 +16,7 @@ import TicketComponent from 'web/pages/tickets/TicketComponent';
 const ticket = Ticket.fromElement({
   _id: 'tk1',
   name: 'Test Ticket',
-  status: 'open',
+  status: TICKET_STATUS.open,
   assigned_to: {user: {_id: 'u1', name: 'admin'}},
   open_time: '2024-01-10T08:00:00Z',
   open_note: 'Ticket opened',
@@ -164,7 +164,7 @@ describe('TicketComponent', () => {
     const verifiedTicket = Ticket.fromElement({
       _id: 'tk1',
       name: 'Verified Ticket',
-      status: 'verified',
+      status: TICKET_STATUS.verified,
     });
     const {render} = rendererWith({
       gmp: createGmp(),
@@ -193,7 +193,7 @@ describe('TicketComponent', () => {
     const fixedTicket = Ticket.fromElement({
       _id: 'tk1',
       name: 'Fixed Ticket',
-      status: 'fixed',
+      status: TICKET_STATUS.fixed,
     });
     const {render} = rendererWith({
       gmp: createGmp(),

--- a/src/web/pages/tickets/__tests__/TicketDetails.test.tsx
+++ b/src/web/pages/tickets/__tests__/TicketDetails.test.tsx
@@ -5,14 +5,14 @@
 
 import {describe, test, expect} from '@gsa/testing';
 import {rendererWith, screen} from 'web/testing';
-import Ticket from 'gmp/models/ticket';
+import Ticket, {TICKET_STATUS} from 'gmp/models/ticket';
 import {createSession} from 'gmp/testing';
 import TicketDetails from 'web/pages/tickets/TicketDetails';
 
 const ticket = Ticket.fromElement({
   _id: 'tk1',
   name: 'Test Ticket',
-  status: 'open',
+  status: TICKET_STATUS.open,
   assigned_to: {user: {_id: 'u1', name: 'admin'}},
   open_time: '2024-01-10T08:00:00Z',
   open_note: 'Ticket opened',
@@ -24,7 +24,7 @@ const ticket = Ticket.fromElement({
 const ticketWithStatuses = Ticket.fromElement({
   _id: 'tk2',
   name: 'Closed Ticket',
-  status: 'closed',
+  status: TICKET_STATUS.closed,
   assigned_to: {user: {_id: 'u1', name: 'admin'}},
   open_time: '2024-01-10T08:00:00Z',
   open_note: 'Ticket opened',
@@ -40,7 +40,7 @@ const ticketWithStatuses = Ticket.fromElement({
 const orphanTicket = Ticket.fromElement({
   _id: 'tk3',
   name: 'Orphan Ticket',
-  status: 'open',
+  status: TICKET_STATUS.open,
   orphan: 1,
 });
 

--- a/src/web/pages/tickets/__tests__/TicketsTable.test.tsx
+++ b/src/web/pages/tickets/__tests__/TicketsTable.test.tsx
@@ -7,14 +7,14 @@ import {describe, expect, test} from '@gsa/testing';
 import {rendererWith, screen, within} from 'web/testing';
 import CollectionCounts from 'gmp/collection/collection-counts';
 import QueryFilter from 'gmp/models/filter/query-filter';
-import Ticket from 'gmp/models/ticket';
+import Ticket, {TICKET_STATUS} from 'gmp/models/ticket';
 import {createSession} from 'gmp/testing';
 import TicketsTable from 'web/pages/tickets/TicketsTable';
 
 const ticket = Ticket.fromElement({
   _id: 'tk1',
   name: 'Test Vulnerability',
-  status: 'open',
+  status: TICKET_STATUS.open,
   severity: 8.5,
   host: '192.168.1.100',
   solution_type: 'VendorFix',


### PR DESCRIPTION


## What

Only use TicketStatusValue type

## Why

Drop usage of TicketStatus type and replace it with TicketStatusValue. The TicketStatus used all lower case value which is not the value we get from gvmd.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


