### PR TITLE
Pin codecov.io upload action to a commit hash

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run JavaScript tests
         run: npm run test:coverage -- --reporter=default --reporter=junit --outputFile=${{ env.REPORT_DIR }}/test-report.xml
       - name: Submit test coverage to codecov.io
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION


## What

Pin codecov.io upload action to a commit hash

## Why
Enhanced security by pinning the action to a specific git commit.


