### PR TITLE
Group all actions from GitHub Inc. into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,7 @@ updates:
       github-actions:
         patterns:
           - "actions/*"
+          - "github/*"
     ignore:
       - dependency-name: "greenbone/actions"
         update-types:


### PR DESCRIPTION


## What
Group all actions from GitHub Inc. into a single PR

## Why
Avoid multiple PRs for dependabot updates of actions from GitHub Inc. GitHub Inc. is using two orgs for actions: `github.com/actions` and `github.com/github`.

