### PR TITLE
GEA-2012

### DIFF
--- a/src/web/pages/scanconfigs/ScanConfigComponent.tsx
+++ b/src/web/pages/scanconfigs/ScanConfigComponent.tsx
@@ -4,6 +4,7 @@
  */
 
 import {useState} from 'react';
+import {type NvtFamily} from 'gmp/commands/nvt-families';
 import {
   type ScanConfigNvtsSelected,
   type ScanConfigFamilyNvt,
@@ -107,7 +108,7 @@ const ScanConfigComponent = ({
   const [importDialogVisible, setImportDialogVisible] = useState(false);
 
   const [config, setConfig] = useState<ScanConfig>();
-  const [families, setFamilies] = useState<ScanConfigFamily[]>();
+  const [families, setFamilies] = useState<NvtFamily[]>();
 
   const [familyName, setFamilyName] = useState<string>();
   const [familyNvts, setFamilyNvts] = useState<

--- a/src/web/pages/scanconfigs/ScanConfigEditDialog.tsx
+++ b/src/web/pages/scanconfigs/ScanConfigEditDialog.tsx
@@ -11,6 +11,7 @@ import {
   memo,
   useRef,
 } from 'react';
+import {type NvtFamily} from 'gmp/commands/nvt-families';
 import {
   type ScanConfigFamilyTrends,
   type ScanConfigNvtsSelected,
@@ -79,7 +80,7 @@ interface ScanConfigEditDialogProps {
   editNvtDetailsTitle: string;
   editNvtFamiliesTitle: string;
   error?: string;
-  families?: ScanConfigFamily[];
+  families?: NvtFamily[];
   familySelectionUpdate?: FamilySelectionUpdate;
   isLoadingConfig?: boolean;
   isLoadingFamilies?: boolean;
@@ -100,7 +101,7 @@ const MemoizedNvtPreferences = memo(ScanConfigNvtPreferences);
 
 const createTrendAndSelect = (
   scanConfigFamilies: ScanConfigFamilies = {},
-  allFamilies: ScanConfigFamily[] = [],
+  allFamilies: NvtFamily[] = [],
 ) => {
   const trend = {};
   const select = {};

--- a/src/web/pages/scanconfigs/ScanConfigNvtFamilies.tsx
+++ b/src/web/pages/scanconfigs/ScanConfigNvtFamilies.tsx
@@ -4,6 +4,7 @@
  */
 
 import {useCallback} from 'react';
+import {type NvtFamily} from 'gmp/commands/nvt-families';
 import {
   type ScanConfigFamilyTrends,
   type ScanConfigNvtsSelected,
@@ -12,7 +13,6 @@ import {
   SCANCONFIG_TREND_DYNAMIC,
   SCANCONFIG_TREND_STATIC,
   type ScanConfigFamilies,
-  type ScanConfigFamily,
   type ScanConfigTrend,
   WHOLE_SELECTION_FAMILIES,
 } from 'gmp/models/scan-config';
@@ -30,7 +30,7 @@ import ScanConfigNvtFamily from 'web/pages/scanconfigs/ScanConfigNvtFamily';
 interface ScanConfigNvtFamiliesProps {
   configFamilies: ScanConfigFamilies;
   editTitle?: string;
-  families?: ScanConfigFamily[];
+  families?: NvtFamily[];
   select: ScanConfigNvtsSelected;
   trend: ScanConfigFamilyTrends;
   onEditConfigFamilyClick?: (familyName: string) => void;
@@ -101,7 +101,7 @@ const ScanConfigNvtFamilies = ({
             return (
               <ScanConfigNvtFamily
                 key={name}
-                familyMaxNvtCount={family.nvts?.max}
+                familyMaxNvtCount={family.maxNvtCount}
                 familyName={family.name}
                 familyNvtCount={
                   isDefined(configFamily?.nvts) ? configFamily.nvts.count : 0

--- a/src/web/pages/scanconfigs/__tests__/ScanConfigEditDialog.test.tsx
+++ b/src/web/pages/scanconfigs/__tests__/ScanConfigEditDialog.test.tsx
@@ -12,11 +12,11 @@ import {
   fireEvent,
   waitFor,
 } from 'web/testing';
+import {type NvtFamily} from 'gmp/commands/nvt-families';
 import {
   SCANCONFIG_TREND_STATIC,
   SCANCONFIG_TREND_DYNAMIC,
   type ScanConfigFamilies,
-  type ScanConfigFamily,
   type ScanConfigPreference,
 } from 'gmp/models/scan-config';
 import {YES_VALUE, NO_VALUE} from 'gmp/parser';
@@ -24,30 +24,22 @@ import ScanConfigEditDialog, {
   handleSearchChange,
 } from 'web/pages/scanconfigs/ScanConfigEditDialog';
 
-const families: ScanConfigFamily[] = [
+const families: NvtFamily[] = [
   {
     name: 'family1',
-    nvts: {
-      max: 1,
-    },
+    maxNvtCount: 1,
   },
   {
     name: 'family2',
-    nvts: {
-      max: 4,
-    },
+    maxNvtCount: 4,
   },
   {
     name: 'family3',
-    nvts: {
-      max: 2,
-    },
+    maxNvtCount: 2,
   },
   {
     name: 'family4',
-    nvts: {
-      max: 6,
-    },
+    maxNvtCount: 6,
   },
 ];
 
@@ -414,9 +406,9 @@ describe('ScanConfigEditDialog tests', () => {
     // `maxNvtCount`, not a `nvts.max` property. The select-all value must not
     // depend on that shape, otherwise it always resolves to NO_VALUE.
     const familiesWithoutNvtsMax = [
-      {name: 'family1'},
-      {name: 'family2'},
-    ] as unknown as ScanConfigFamily[];
+      {name: 'family1', maxNvtCount: 3},
+      {name: 'family2', maxNvtCount: 4},
+    ] satisfies NvtFamily[];
 
     const configFamiliesWithFullSelection: ScanConfigFamilies = {
       family1: {

--- a/src/web/pages/scanconfigs/__tests__/ScanConfigNvtFamilies.test.tsx
+++ b/src/web/pages/scanconfigs/__tests__/ScanConfigNvtFamilies.test.tsx
@@ -5,6 +5,7 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {fireEvent, render, screen, within} from 'web/testing';
+import {type NvtFamily} from 'gmp/commands/nvt-families';
 import {
   type ScanConfigFamilyTrends,
   type ScanConfigNvtsSelected,
@@ -14,23 +15,18 @@ import {
   SCANCONFIG_TREND_STATIC,
   WHOLE_SELECTION_FAMILIES,
   type ScanConfigFamilies,
-  type ScanConfigFamily,
 } from 'gmp/models/scan-config';
 import {NO_VALUE, YES_VALUE} from 'gmp/parser';
 import ScanConfigNvtFamilies from 'web/pages/scanconfigs/ScanConfigNvtFamilies';
 
-const createFamilies = (): ScanConfigFamily[] => [
+const createFamilies = (): NvtFamily[] => [
   {
     name: 'family1',
-    nvts: {
-      max: 5,
-    },
+    maxNvtCount: 5,
   },
   {
     name: WHOLE_SELECTION_FAMILIES[0],
-    nvts: {
-      max: 7,
-    },
+    maxNvtCount: 7,
   },
 ];
 
@@ -140,6 +136,28 @@ describe('NvtFamilies tests', () => {
 
     fireEvent.click(editButtons[0]);
     expect(handleEditConfigFamilyClick).toHaveBeenCalledWith('family1');
+  });
+
+  test('should render zero as the maximum for an empty family', () => {
+    render(
+      <ScanConfigNvtFamilies
+        configFamilies={{
+          empty: {
+            name: 'empty',
+            nvts: {count: 0, max: 0},
+            trend: SCANCONFIG_TREND_STATIC,
+          },
+        }}
+        families={[{name: 'empty', maxNvtCount: 5}]}
+        select={{empty: NO_VALUE}}
+        trend={{empty: SCANCONFIG_TREND_STATIC}}
+        onSelectChange={testing.fn()}
+        onTrendChange={testing.fn()}
+      />,
+    );
+
+    const section = unfoldSection();
+    expect(within(section).getByRole('cell', {name: '0 of 5'})).toBeVisible();
   });
 
   test('should call onValueChange when changing a regular family', () => {


### PR DESCRIPTION
## What

- fix: scan-configs show correct NVT family totals

## Why

- When cloning a scan config it would show always 0 of 0.

## References

GEA-2012

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


