### PR TITLE
Split Dashboard component into the dashboard and a view

### DIFF
--- a/src/web/components/dashboard/Dashboard.tsx
+++ b/src/web/components/dashboard/Dashboard.tsx
@@ -3,444 +3,106 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {useCallback, useEffect, useMemo, useRef} from 'react';
-import {type ThunkDispatch} from '@reduxjs/toolkit';
-import {connect} from 'react-redux';
-import {type Action} from 'redux';
-import styled from 'styled-components';
-import {DEFAULT_ROW_HEIGHT} from 'gmp/commands/dashboards';
-import type Gmp from 'gmp/gmp';
-import Logger from 'gmp/log';
-import type QueryFilter from 'gmp/models/filter/query-filter';
-import {isDefined} from 'gmp/utils/identity';
-import {excludeObjectProps} from 'gmp/utils/object';
-import {
-  type DisplayState,
-  getDisplay,
-  type DisplayComponent,
-} from 'web/components/dashboard/registry';
-import {
-  convertDefaultDisplays,
-  convertDisplaysToGridItems,
-  convertGridItemsToDisplays,
-  filterDisplays,
-  getDisplaysById,
-  getRows,
-  removeDisplay,
-  type DashboardDisplay as DashboardDisplayData,
-  type DashboardRow as DashboardRowData,
-  type DashboardSettings,
-  type GridItem,
-} from 'web/components/dashboard/utils';
-import ErrorBoundary from 'web/components/error/ErrorBoundary';
-import Loading from 'web/components/loading/Loading';
-import SortableGrid, {
-  type SortableGridRow,
-} from 'web/components/sortable/SortableGrid';
-import {type SortableItemRenderProps} from 'web/components/sortable/SortableItem';
-import useLatestCallback from 'web/hooks/useLatestCallback';
-import useTranslation from 'web/hooks/useTranslation';
+import {useCallback} from 'react';
+import {useDispatch} from 'react-redux';
+import {type FilterType} from 'gmp/models/filter';
+import DashboardView, {
+  DEFAULT_MAX_ITEMS_PER_ROW,
+  DEFAULT_MAX_ROWS,
+} from 'web/components/dashboard/DashboardView';
+import {type DashboardSettings} from 'web/components/dashboard/utils';
+import useGmp from 'web/hooks/useGmp';
+import useShallowEqualSelector from 'web/hooks/useShallowEqualSelector';
 import {
   loadSettings,
   saveSettings,
   setDashboardSettingDefaults,
 } from 'web/store/dashboard/settings/actions';
 import DashboardSettingsSelector from 'web/store/dashboard/settings/selectors';
-import compose from 'web/utils/compose';
-import withGmp from 'web/utils/withGmp';
-
-interface DashboardDisplay extends DashboardDisplayData {
-  filterId?: string;
-  state?: DisplayState;
-}
-
-interface DashboardRow extends Omit<DashboardRowData, 'items'> {
-  items: DashboardDisplay[];
-}
 
 interface DashboardProps {
   defaultDisplays?: string[][];
-  error?: Error;
-  filter?: QueryFilter;
+  filter?: FilterType;
   id: string;
-  isLoading: boolean;
-  loadSettings: (id: string, defaults: DashboardSettings) => void;
   maxItemsPerRow?: number;
   maxRows?: number;
-  notify?: (message: string) => void;
-  onFilterChanged?: (filter: QueryFilter) => void;
   permittedDisplays: string[];
-  saveSettings: (id: string, settings: DashboardSettings) => void;
-  setDefaultSettings: (id: string, settings: DashboardSettings) => void;
-  settings?: DashboardSettings;
   showFilterSelection?: boolean;
   showFilterString?: boolean;
-  [key: string]: unknown;
+  notify?: (message: string) => void;
+  onFilterChanged?: (filter: FilterType) => void;
 }
 
-type DashboardDispatch = ThunkDispatch<
-  Record<string, unknown>,
-  unknown,
-  Action<string>
->;
+export {DEFAULT_MAX_ITEMS_PER_ROW, DEFAULT_MAX_ROWS};
 
-export const DEFAULT_MAX_ITEMS_PER_ROW = 4;
-export const DEFAULT_MAX_ROWS = 4;
-
-const log = Logger.getLogger('web.components.dashboard');
-
-const ownPropNames = [
-  'defaultDisplays',
-  'gmp',
-  'id',
-  'isLoading',
-  'items',
-  'loadSettings',
-  'maxItemsPerRow',
-  'maxRows',
-  'permittedDisplays',
-  'saveSettings',
-];
-
-const RowPlaceHolder = styled.div`
-  display: flex;
-  flex-grow: 1;
-  height: ${DEFAULT_ROW_HEIGHT};
-  justify-content: center;
-  align-items: center;
-  margin: 15px 0;
-`;
-
-export const Dashboard = ({
+const Dashboard = ({
   defaultDisplays,
-  error,
+  filter,
   id,
-  isLoading,
-  loadSettings,
   maxItemsPerRow = DEFAULT_MAX_ITEMS_PER_ROW,
   maxRows = DEFAULT_MAX_ROWS,
   permittedDisplays,
-  saveSettings,
-  setDefaultSettings,
-  settings,
-  ...otherProps
+  showFilterSelection = false,
+  showFilterString = false,
+  notify,
+  onFilterChanged,
 }: DashboardProps) => {
-  const [_] = useTranslation();
-  const callLoadSettings = useLatestCallback(loadSettings);
-  const callSetDefaultSettings = useLatestCallback(setDefaultSettings);
-  const permittedDisplaysSignature = JSON.stringify(permittedDisplays ?? []);
-  const defaultDisplaysSignature = JSON.stringify(defaultDisplays ?? []);
+  const gmp = useGmp();
+  const dispatch = useDispatch();
 
-  const stablePermittedDisplaysRef = useRef(permittedDisplays ?? []);
-  const permittedDisplaysSignatureRef = useRef(permittedDisplaysSignature);
-  const defaultDashboardSettingsRef = useRef(
-    convertDefaultDisplays(defaultDisplays),
-  );
-  const defaultDisplaysSignatureRef = useRef(defaultDisplaysSignature);
+  const isLoading = useShallowEqualSelector(state => {
+    const selector = DashboardSettingsSelector(state);
+    return selector.getIsLoading(id);
+  });
+  const error = useShallowEqualSelector(state => {
+    const selector = DashboardSettingsSelector(state);
+    return selector.getError(id);
+  });
+  const settings = useShallowEqualSelector(state => {
+    const selector = DashboardSettingsSelector(state);
+    return selector.getById(id);
+  });
 
-  // Update the stable permitted displays if the signature has changed
-  if (permittedDisplaysSignatureRef.current !== permittedDisplaysSignature) {
-    stablePermittedDisplaysRef.current = permittedDisplays ?? [];
-    permittedDisplaysSignatureRef.current = permittedDisplaysSignature;
-  }
-
-  // Update the default dashboard settings if the signature has changed
-  if (defaultDisplaysSignatureRef.current !== defaultDisplaysSignature) {
-    defaultDashboardSettingsRef.current =
-      convertDefaultDisplays(defaultDisplays);
-    defaultDisplaysSignatureRef.current = defaultDisplaysSignature;
-  }
-
-  const defaultDashboardSettings = defaultDashboardSettingsRef.current;
-  const stablePermittedDisplays = stablePermittedDisplaysRef.current;
-
-  const defaults = useMemo(
-    () => ({
-      ...defaultDashboardSettings,
-      permittedDisplays: stablePermittedDisplays,
-      maxItemsPerRow,
-      maxRows,
-    }),
-    [
-      defaultDashboardSettings,
-      maxItemsPerRow,
-      maxRows,
-      stablePermittedDisplays,
-    ],
-  );
-
-  const components = useMemo(() => {
-    const mappedComponents: Record<string, DisplayComponent> = {};
-
-    stablePermittedDisplays.forEach((displayId: string) => {
-      const display = getDisplay(displayId);
-
-      if (isDefined(display)) {
-        mappedComponents[displayId] = display.component;
-      } else {
-        log.warn('Unknown Dashboard display', displayId);
-      }
-    });
-
-    return mappedComponents;
-  }, [stablePermittedDisplays]);
-
-  const getRowsFromSettings = useCallback(
-    (defaultRows?: DashboardRow[]) =>
-      getRows(settings, defaultRows) as DashboardRow[],
-    [settings],
-  );
-
-  useEffect(() => {
-    callSetDefaultSettings(id, defaultDashboardSettings);
-    callLoadSettings(id, defaults);
-  }, [
-    callLoadSettings,
-    callSetDefaultSettings,
-    defaultDashboardSettings,
-    defaults,
-    id,
-  ]);
-
-  const rows = getRowsFromSettings();
-  const displaysById = useMemo(() => getDisplaysById(rows ?? []), [rows]);
-
-  const getDisplayComponent = useCallback(
-    (displayId: string): DisplayComponent | undefined => components[displayId],
-    [components],
-  );
-
-  const getDisplayState = useCallback(
-    (displayId: string) => {
-      const display = displaysById[displayId] as DashboardDisplay | undefined;
-      return isDefined(display) ? display.state : undefined;
+  const loadSettingsFunc = useCallback(
+    (dashboardId: string, defaults: DashboardSettings) => {
+      // @ts-expect-error
+      dispatch(loadSettings(gmp)(dashboardId, defaults));
     },
-    [displaysById],
+    [dispatch, gmp],
   );
-
-  const updateRows = useCallback(
-    (nextRows: DashboardRow[]) => {
-      saveSettings(id, {rows: nextRows});
+  const setDefaultSettingsFunc = useCallback(
+    (dashboardId: string, dashboardSettings: DashboardSettings) =>
+      dispatch(setDashboardSettingDefaults(dashboardId, dashboardSettings)),
+    [dispatch],
+  );
+  const saveSettingsFunc = useCallback(
+    (dashboardId: string, dashboardSettings: DashboardSettings) => {
+      // @ts-expect-error
+      dispatch(saveSettings(gmp)(dashboardId, dashboardSettings));
     },
-    [id, saveSettings],
+    [dispatch, gmp],
   );
-
-  const updateDisplay = useCallback(
-    (displayId: string, displayProps: Partial<DashboardDisplay>) => {
-      const currentRows = getRowsFromSettings() ?? [];
-
-      const rowIndex = currentRows.findIndex(row =>
-        row.items.some(item => item.id === displayId),
-      );
-
-      if (rowIndex < 0) {
-        return;
-      }
-
-      const row = currentRows[rowIndex];
-      const rowItems = [...row.items];
-      const displayIndex = rowItems.findIndex(item => item.id === displayId);
-
-      if (displayIndex < 0) {
-        return;
-      }
-
-      rowItems[displayIndex] = {
-        ...rowItems[displayIndex],
-        ...displayProps,
-      };
-
-      const newRows = [...currentRows];
-      newRows[rowIndex] = {
-        ...row,
-        items: rowItems,
-      };
-
-      updateRows(newRows);
-    },
-    [getRowsFromSettings, updateRows],
-  );
-
-  const handleItemsChange = useCallback(
-    (gridItems: SortableGridRow[] = []) => {
-      const currentRows = getRowsFromSettings() ?? [];
-      const currentDisplaysById = getDisplaysById(currentRows);
-
-      updateRows(
-        convertGridItemsToDisplays(
-          gridItems as GridItem[],
-          currentDisplaysById,
-        ),
-      );
-    },
-    [getRowsFromSettings, updateRows],
-  );
-
-  const handleRemoveDisplay = useCallback(
-    (displayId: string) => {
-      const currentRows = getRowsFromSettings() ?? [];
-      updateRows(removeDisplay(currentRows, displayId));
-    },
-    [getRowsFromSettings, updateRows],
-  );
-
-  const handleRowResize = useCallback(
-    (rowId: string, height: number) => {
-      const currentRows = getRowsFromSettings([]) ?? [];
-      const rowIndex = currentRows.findIndex(row => row.id === rowId);
-
-      if (rowIndex < 0) {
-        return;
-      }
-
-      const newRows = [...currentRows];
-      newRows[rowIndex] = {
-        ...newRows[rowIndex],
-        height,
-      };
-
-      updateRows(newRows);
-    },
-    [getRowsFromSettings, updateRows],
-  );
-
-  const handleSetDisplayState = useCallback(
-    (
-      displayId: string,
-      stateFunc: (currentState: DisplayState | undefined) => DisplayState,
-    ) => {
-      const currentState = getDisplayState(displayId);
-      const newState = stateFunc(currentState);
-
-      updateDisplay(displayId, {
-        state: {
-          ...currentState,
-          ...newState,
-        },
-      });
-    },
-    [getDisplayState, updateDisplay],
-  );
-
-  const handleUpdateDisplay = useCallback(
-    (displayId: string, displayProps: Partial<DashboardDisplay>) => {
-      updateDisplay(displayId, displayProps);
-    },
-    [updateDisplay],
-  );
-
-  if (isDefined(error) && !isLoading) {
-    return (
-      <RowPlaceHolder>
-        {_('Could not load dashboard settings. Reason: {{error}}', {
-          error: error.message,
-        })}
-      </RowPlaceHolder>
-    );
-  }
-
-  if (!isDefined(rows) && isLoading) {
-    return (
-      <RowPlaceHolder>
-        <Loading />
-      </RowPlaceHolder>
-    );
-  }
-
-  const getDisplaySettings = (displayId: string) => displaysById[displayId];
-  const isAllowed = (displayId: string) => {
-    const displaySettings = getDisplaySettings(displayId);
-    return (
-      isDefined(displaySettings) &&
-      isDefined(getDisplayComponent(displaySettings.displayId))
-    );
-  };
-
-  const other = excludeObjectProps(otherProps, ownPropNames);
 
   return (
-    <ErrorBoundary message={_('An error occurred on this dashboard.')}>
-      <SortableGrid
-        items={convertDisplaysToGridItems(
-          filterDisplays(rows ?? [], isAllowed),
-        )}
-        maxItemsPerRow={maxItemsPerRow}
-        maxRows={maxRows}
-        onChange={handleItemsChange}
-        onRowResize={handleRowResize}
-      >
-        {({
-          id: displayId,
-          dragHandleRef,
-          height,
-          width,
-        }: SortableItemRenderProps) => {
-          const displaySettings = getDisplaySettings(displayId);
-          if (!isDefined(displaySettings)) {
-            return null;
-          }
-
-          const {displayId: registeredDisplayId, ...displayProps} =
-            displaySettings;
-          const Component = getDisplayComponent(registeredDisplayId);
-          if (!isDefined(Component)) {
-            return null;
-          }
-
-          const state = getDisplayState(displayId);
-
-          return (
-            <Component
-              {...other}
-              {...displayProps}
-              dragHandleRef={dragHandleRef}
-              height={height}
-              id={displayId}
-              setState={stateFunc =>
-                handleSetDisplayState(displayId, stateFunc)
-              }
-              state={state}
-              width={width}
-              onFilterIdChanged={(filterId: string) =>
-                handleUpdateDisplay(displayId, {filterId})
-              }
-              onRemoveClick={() => handleRemoveDisplay(displayId)}
-            />
-          );
-        }}
-      </SortableGrid>
-    </ErrorBoundary>
+    <DashboardView
+      defaultDisplays={defaultDisplays}
+      error={error}
+      filter={filter}
+      id={id}
+      isLoading={isLoading}
+      loadSettings={loadSettingsFunc}
+      maxItemsPerRow={maxItemsPerRow}
+      maxRows={maxRows}
+      notify={notify}
+      permittedDisplays={permittedDisplays}
+      saveSettings={saveSettingsFunc}
+      setDefaultSettings={setDefaultSettingsFunc}
+      settings={settings}
+      showFilterSelection={showFilterSelection}
+      showFilterString={showFilterString}
+      onFilterChanged={onFilterChanged}
+    />
   );
 };
 
-const mapStateToProps = (rootState: unknown, {id}: DashboardProps) => {
-  const settingsSelector = DashboardSettingsSelector(rootState);
-  const settings = settingsSelector.getById(id) as
-    DashboardSettings | undefined;
-  const error = settingsSelector.getError(id) as Error | undefined;
-  const isLoading = settingsSelector.getIsLoading(id) as boolean;
-
-  return {
-    error,
-    isLoading,
-    settings,
-  };
-};
-
-const mapDispatchToProps = (
-  dispatch: DashboardDispatch,
-  {gmp}: {gmp: Gmp},
-) => ({
-  loadSettings: (id: string, defaults: DashboardSettings) =>
-    dispatch(loadSettings(gmp)(id, defaults)),
-  saveSettings: (id: string, settings: DashboardSettings) =>
-    dispatch(saveSettings(gmp)(id, settings)),
-  setDefaultSettings: (id: string, settings: DashboardSettings) =>
-    dispatch(setDashboardSettingDefaults(id, settings)),
-});
-
-export default compose(
-  withGmp,
-  // @ts-expect-error connect types don't match with the component props
-  connect(mapStateToProps, mapDispatchToProps),
-)(Dashboard);
+export default Dashboard;

--- a/src/web/components/dashboard/DashboardView.tsx
+++ b/src/web/components/dashboard/DashboardView.tsx
@@ -1,0 +1,346 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {useCallback, useEffect, useMemo, useRef} from 'react';
+import styled from 'styled-components';
+import {DEFAULT_ROW_HEIGHT} from 'gmp/commands/dashboards';
+import Logger from 'gmp/log';
+import {type FilterType} from 'gmp/models/filter';
+import {isDefined} from 'gmp/utils/identity';
+import {
+  type DisplayState,
+  getDisplay,
+  type DisplayComponent,
+} from 'web/components/dashboard/registry';
+import {
+  convertDefaultDisplays,
+  convertDisplaysToGridItems,
+  convertGridItemsToDisplays,
+  filterDisplays,
+  getDisplaysById,
+  getRows,
+  removeDisplay,
+  type DashboardDisplay as DashboardDisplayData,
+  type DashboardRow as DashboardRowData,
+  type DashboardSettings,
+  type GridItem,
+} from 'web/components/dashboard/utils';
+import ErrorBoundary from 'web/components/error/ErrorBoundary';
+import Loading from 'web/components/loading/Loading';
+import SortableGrid, {
+  type SortableGridRow,
+} from 'web/components/sortable/SortableGrid';
+import {type SortableItemRenderProps} from 'web/components/sortable/SortableItem';
+import useLatestCallback from 'web/hooks/useLatestCallback';
+import useTranslation from 'web/hooks/useTranslation';
+
+interface DashboardDisplay extends DashboardDisplayData {
+  filterId?: string;
+  state?: DisplayState;
+}
+
+interface DashboardRow extends Omit<DashboardRowData, 'items'> {
+  items: DashboardDisplay[];
+}
+
+interface DashboardViewProps {
+  defaultDisplays?: string[][];
+  filter?: FilterType;
+  id: string;
+  maxItemsPerRow?: number;
+  maxRows?: number;
+  permittedDisplays: string[];
+  showFilterSelection?: boolean;
+  showFilterString?: boolean;
+  notify?: (message: string) => void;
+  onFilterChanged?: (filter: FilterType) => void;
+  error?: Error;
+  isLoading: boolean;
+  loadSettings: (id: string, defaults: DashboardSettings) => void;
+  saveSettings: (id: string, settings: DashboardSettings) => void;
+  setDefaultSettings: (id: string, settings: DashboardSettings) => void;
+  settings?: DashboardSettings;
+}
+
+export const DEFAULT_MAX_ITEMS_PER_ROW = 4;
+export const DEFAULT_MAX_ROWS = 4;
+
+const log = Logger.getLogger('web.components.dashboard');
+
+const RowPlaceHolder = styled.div`
+  display: flex;
+  flex-grow: 1;
+  height: ${DEFAULT_ROW_HEIGHT};
+  justify-content: center;
+  align-items: center;
+  margin: 15px 0;
+`;
+
+const DashboardView = ({
+  defaultDisplays,
+  error,
+  id,
+  isLoading,
+  loadSettings,
+  maxItemsPerRow = DEFAULT_MAX_ITEMS_PER_ROW,
+  maxRows = DEFAULT_MAX_ROWS,
+  permittedDisplays,
+  saveSettings,
+  setDefaultSettings,
+  settings,
+}: DashboardViewProps) => {
+  const [_] = useTranslation();
+  const callLoadSettings = useLatestCallback(loadSettings);
+  const callSetDefaultSettings = useLatestCallback(setDefaultSettings);
+  const permittedDisplaysSignature = JSON.stringify(permittedDisplays ?? []);
+  const defaultDisplaysSignature = JSON.stringify(defaultDisplays ?? []);
+
+  const stablePermittedDisplaysRef = useRef(permittedDisplays ?? []);
+  const permittedDisplaysSignatureRef = useRef(permittedDisplaysSignature);
+  const defaultDashboardSettingsRef = useRef(
+    convertDefaultDisplays(defaultDisplays),
+  );
+  const defaultDisplaysSignatureRef = useRef(defaultDisplaysSignature);
+
+  if (permittedDisplaysSignatureRef.current !== permittedDisplaysSignature) {
+    stablePermittedDisplaysRef.current = permittedDisplays ?? [];
+    permittedDisplaysSignatureRef.current = permittedDisplaysSignature;
+  }
+
+  if (defaultDisplaysSignatureRef.current !== defaultDisplaysSignature) {
+    defaultDashboardSettingsRef.current =
+      convertDefaultDisplays(defaultDisplays);
+    defaultDisplaysSignatureRef.current = defaultDisplaysSignature;
+  }
+
+  const defaultDashboardSettings = defaultDashboardSettingsRef.current;
+  const stablePermittedDisplays = stablePermittedDisplaysRef.current;
+
+  const defaults = useMemo(
+    () => ({
+      ...defaultDashboardSettings,
+      permittedDisplays: stablePermittedDisplays,
+      maxItemsPerRow,
+      maxRows,
+    }),
+    [
+      defaultDashboardSettings,
+      maxItemsPerRow,
+      maxRows,
+      stablePermittedDisplays,
+    ],
+  );
+
+  const components = useMemo(() => {
+    const mappedComponents: Record<string, DisplayComponent> = {};
+
+    stablePermittedDisplays.forEach((displayId: string) => {
+      const display = getDisplay(displayId);
+
+      if (isDefined(display)) {
+        mappedComponents[displayId] = display.component;
+      } else {
+        log.warn('Unknown Dashboard display', displayId);
+      }
+    });
+
+    return mappedComponents;
+  }, [stablePermittedDisplays]);
+
+  const getRowsFromSettings = useCallback(
+    (defaultRows?: DashboardRow[]) =>
+      getRows(settings, defaultRows) as DashboardRow[],
+    [settings],
+  );
+
+  useEffect(() => {
+    callSetDefaultSettings(id, defaultDashboardSettings);
+    callLoadSettings(id, defaults);
+  }, [
+    callLoadSettings,
+    callSetDefaultSettings,
+    defaultDashboardSettings,
+    defaults,
+    id,
+  ]);
+
+  const rows = getRowsFromSettings();
+  const displaysById = useMemo(() => getDisplaysById(rows ?? []), [rows]);
+
+  const getDisplayComponent = useCallback(
+    (displayId: string): DisplayComponent | undefined => components[displayId],
+    [components],
+  );
+
+  const getDisplayState = useCallback(
+    (displayId: string) => {
+      const display = displaysById[displayId] as DashboardDisplay | undefined;
+      return isDefined(display) ? display.state : undefined;
+    },
+    [displaysById],
+  );
+
+  const updateRows = useCallback(
+    (nextRows: DashboardRow[]) => {
+      saveSettings(id, {rows: nextRows});
+    },
+    [id, saveSettings],
+  );
+
+  const updateDisplay = useCallback(
+    (displayId: string, displayProps: Partial<DashboardDisplay>) => {
+      const currentRows = getRowsFromSettings() ?? [];
+      const rowIndex = currentRows.findIndex(row =>
+        row.items.some(item => item.id === displayId),
+      );
+
+      if (rowIndex < 0) return;
+
+      const row = currentRows[rowIndex];
+      const rowItems = [...row.items];
+      const displayIndex = rowItems.findIndex(item => item.id === displayId);
+
+      if (displayIndex < 0) return;
+
+      rowItems[displayIndex] = {...rowItems[displayIndex], ...displayProps};
+      const newRows = [...currentRows];
+      newRows[rowIndex] = {...row, items: rowItems};
+      updateRows(newRows);
+    },
+    [getRowsFromSettings, updateRows],
+  );
+
+  const handleItemsChange = useCallback(
+    (gridItems: SortableGridRow[] = []) => {
+      const currentRows = getRowsFromSettings() ?? [];
+      const currentDisplaysById = getDisplaysById(currentRows);
+      updateRows(
+        convertGridItemsToDisplays(
+          gridItems as GridItem[],
+          currentDisplaysById,
+        ),
+      );
+    },
+    [getRowsFromSettings, updateRows],
+  );
+
+  const handleRemoveDisplay = useCallback(
+    (displayId: string) => {
+      const currentRows = getRowsFromSettings() ?? [];
+      updateRows(removeDisplay(currentRows, displayId));
+    },
+    [getRowsFromSettings, updateRows],
+  );
+
+  const handleRowResize = useCallback(
+    (rowId: string, height: number) => {
+      const currentRows = getRowsFromSettings([]) ?? [];
+      const rowIndex = currentRows.findIndex(row => row.id === rowId);
+      if (rowIndex < 0) return;
+
+      const newRows = [...currentRows];
+      newRows[rowIndex] = {...newRows[rowIndex], height};
+      updateRows(newRows);
+    },
+    [getRowsFromSettings, updateRows],
+  );
+
+  const handleSetDisplayState = useCallback(
+    (
+      displayId: string,
+      stateFunc: (currentState: DisplayState | undefined) => DisplayState,
+    ) => {
+      const currentState = getDisplayState(displayId);
+      updateDisplay(displayId, {
+        state: {...currentState, ...stateFunc(currentState)},
+      });
+    },
+    [getDisplayState, updateDisplay],
+  );
+
+  const handleUpdateDisplay = useCallback(
+    (displayId: string, displayProps: Partial<DashboardDisplay>) => {
+      updateDisplay(displayId, displayProps);
+    },
+    [updateDisplay],
+  );
+
+  if (isDefined(error) && !isLoading) {
+    return (
+      <RowPlaceHolder>
+        {_('Could not load dashboard settings. Reason: {{error}}', {
+          error: error.message,
+        })}
+      </RowPlaceHolder>
+    );
+  }
+
+  if (!isDefined(rows) && isLoading) {
+    return (
+      <RowPlaceHolder>
+        <Loading />
+      </RowPlaceHolder>
+    );
+  }
+
+  const getDisplaySettings = (displayId: string) => displaysById[displayId];
+  const isAllowed = (displayId: string) => {
+    const displaySettings = getDisplaySettings(displayId);
+    return (
+      isDefined(displaySettings) &&
+      isDefined(getDisplayComponent(displaySettings.displayId))
+    );
+  };
+
+  return (
+    <ErrorBoundary message={_('An error occurred on this dashboard.')}>
+      <SortableGrid
+        items={convertDisplaysToGridItems(
+          filterDisplays(rows ?? [], isAllowed),
+        )}
+        maxItemsPerRow={maxItemsPerRow}
+        maxRows={maxRows}
+        onChange={handleItemsChange}
+        onRowResize={handleRowResize}
+      >
+        {({
+          id: displayId,
+          dragHandleRef,
+          height,
+          width,
+        }: SortableItemRenderProps) => {
+          const displaySettings = getDisplaySettings(displayId);
+          if (!isDefined(displaySettings)) return null;
+
+          const {displayId: registeredDisplayId, ...displayProps} =
+            displaySettings;
+          const Component = getDisplayComponent(registeredDisplayId);
+          if (!isDefined(Component)) return null;
+
+          const state = getDisplayState(displayId);
+          return (
+            <Component
+              {...displayProps}
+              dragHandleRef={dragHandleRef}
+              height={height}
+              id={displayId}
+              setState={stateFunc =>
+                handleSetDisplayState(displayId, stateFunc)
+              }
+              state={state}
+              width={width}
+              onFilterIdChanged={filterId =>
+                handleUpdateDisplay(displayId, {filterId})
+              }
+              onRemoveClick={() => handleRemoveDisplay(displayId)}
+            />
+          );
+        }}
+      </SortableGrid>
+    </ErrorBoundary>
+  );
+};
+
+export default DashboardView;

--- a/src/web/components/dashboard/DashboardView.tsx
+++ b/src/web/components/dashboard/DashboardView.tsx
@@ -13,6 +13,7 @@ import {
   type DisplayState,
   getDisplay,
   type DisplayComponent,
+  type DisplayProps,
 } from 'web/components/dashboard/registry';
 import {
   convertDefaultDisplays,
@@ -39,6 +40,14 @@ import useTranslation from 'web/hooks/useTranslation';
 interface DashboardDisplay extends DashboardDisplayData {
   filterId?: string;
   state?: DisplayState;
+}
+
+interface DashboardDisplayProps extends DisplayProps {
+  filter?: FilterType;
+  notify?: (message: string) => void;
+  showFilterSelection?: boolean;
+  showFilterString?: boolean;
+  onFilterChanged?: (filter: FilterType) => void;
 }
 
 interface DashboardRow extends Omit<DashboardRowData, 'items'> {
@@ -81,15 +90,20 @@ const RowPlaceHolder = styled.div`
 const DashboardView = ({
   defaultDisplays,
   error,
+  filter,
   id,
   isLoading,
   loadSettings,
   maxItemsPerRow = DEFAULT_MAX_ITEMS_PER_ROW,
   maxRows = DEFAULT_MAX_ROWS,
+  notify,
   permittedDisplays,
   saveSettings,
   setDefaultSettings,
   settings,
+  showFilterSelection = false,
+  showFilterString = false,
+  onFilterChanged,
 }: DashboardViewProps) => {
   const [_] = useTranslation();
   const callLoadSettings = useLatestCallback(loadSettings);
@@ -170,7 +184,8 @@ const DashboardView = ({
   const displaysById = useMemo(() => getDisplaysById(rows ?? []), [rows]);
 
   const getDisplayComponent = useCallback(
-    (displayId: string): DisplayComponent | undefined => components[displayId],
+    (displayId: string): DisplayComponent<DashboardDisplayProps> | undefined =>
+      components[displayId],
     [components],
   );
 
@@ -324,13 +339,18 @@ const DashboardView = ({
             <Component
               {...displayProps}
               dragHandleRef={dragHandleRef}
+              filter={filter}
               height={height}
               id={displayId}
+              notify={notify}
               setState={stateFunc =>
                 handleSetDisplayState(displayId, stateFunc)
               }
+              showFilterSelection={showFilterSelection}
+              showFilterString={showFilterString}
               state={state}
               width={width}
+              onFilterChanged={onFilterChanged}
               onFilterIdChanged={filterId =>
                 handleUpdateDisplay(displayId, {filterId})
               }

--- a/src/web/components/dashboard/__tests__/DashboardView.test.tsx
+++ b/src/web/components/dashboard/__tests__/DashboardView.test.tsx
@@ -7,6 +7,7 @@ import {useState} from 'react';
 import {beforeEach, describe, expect, test, testing} from '@gsa/testing';
 import {rendererWith, screen, waitFor, fireEvent} from 'web/testing';
 import {vi} from 'vitest';
+import {type FilterType} from 'gmp/models/filter';
 import DashboardView, {
   DEFAULT_MAX_ITEMS_PER_ROW,
   DEFAULT_MAX_ROWS,
@@ -144,6 +145,76 @@ describe('DashboardView', () => {
     ]);
     expect(lastCall.maxItemsPerRow).toBe(DEFAULT_MAX_ITEMS_PER_ROW);
     expect(lastCall.maxRows).toBe(DEFAULT_MAX_ROWS);
+  });
+
+  test('should forward display props to the registered display component', async () => {
+    const {
+      dashboardId,
+      defaultDisplays,
+      loadSettings,
+      permittedDisplays,
+      saveSettings,
+      setDefaultSettings,
+      settings,
+    } = createDashboardState();
+    const filter = {} as FilterType;
+    const notify = testing.fn();
+    const onFilterChanged = testing.fn();
+    const {render} = rendererWith({store: true});
+
+    render(
+      <DashboardView
+        showFilterSelection
+        showFilterString
+        defaultDisplays={defaultDisplays}
+        filter={filter}
+        id={dashboardId}
+        isLoading={false}
+        loadSettings={loadSettings}
+        notify={notify}
+        permittedDisplays={permittedDisplays}
+        saveSettings={saveSettings}
+        setDefaultSettings={setDefaultSettings}
+        settings={settings}
+        onFilterChanged={onFilterChanged}
+      />,
+    );
+
+    await waitFor(() => expect(loadSettings).toHaveBeenCalledTimes(1));
+
+    const lastCall = globalThis.__dashboardSortableGridCalls?.at(-1) as {
+      children: (props: {
+        dragHandleRef: () => void;
+        height: number;
+        id: string;
+        width: number;
+      }) => React.ReactElement;
+    };
+    const dragHandleRef = testing.fn();
+    const display = lastCall.children({
+      dragHandleRef,
+      height: 100,
+      id: `item-view-${testCounter}`,
+      width: 200,
+    });
+    const displayProps = display.props as Record<string, unknown>;
+
+    expect(displayProps).toEqual(
+      expect.objectContaining({
+        dragHandleRef,
+        filter,
+        height: 100,
+        id: `item-view-${testCounter}`,
+        notify,
+        onFilterChanged,
+        showFilterSelection: true,
+        showFilterString: true,
+        width: 200,
+      }),
+    );
+    expect(displayProps.onFilterIdChanged).toEqual(expect.any(Function));
+    expect(displayProps.onRemoveClick).toEqual(expect.any(Function));
+    expect(displayProps.setState).toEqual(expect.any(Function));
   });
 
   test('should render a loading indicator', () => {

--- a/src/web/components/dashboard/__tests__/DashboardView.test.tsx
+++ b/src/web/components/dashboard/__tests__/DashboardView.test.tsx
@@ -1,0 +1,268 @@
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {useState} from 'react';
+import {beforeEach, describe, expect, test, testing} from '@gsa/testing';
+import {rendererWith, screen, waitFor, fireEvent} from 'web/testing';
+import {vi} from 'vitest';
+import DashboardView, {
+  DEFAULT_MAX_ITEMS_PER_ROW,
+  DEFAULT_MAX_ROWS,
+} from 'web/components/dashboard/DashboardView';
+import {
+  type DisplayComponent,
+  registerDisplay,
+} from 'web/components/dashboard/registry';
+
+vi.mock('web/components/sortable/SortableGrid', () => ({
+  default: (props: unknown) => {
+    const globals = globalThis as typeof globalThis & {
+      __dashboardSortableGridCalls?: unknown[];
+    };
+    globals.__dashboardSortableGridCalls ??= [];
+    globals.__dashboardSortableGridCalls.push(props);
+    return null;
+  },
+}));
+
+const createDisplayComponent = (displayId: string): DisplayComponent =>
+  Object.assign(() => null, {displayId});
+
+let testCounter = 0;
+
+const createDashboardState = () => {
+  testCounter += 1;
+  const dashboardId = `dashboard-view-${testCounter}`;
+  const ignoredDisplayId = `ignored-view-${testCounter}`;
+  const defaultDisplayId = `default-view-${testCounter}`;
+  const validDisplayId = `valid-view-${testCounter}`;
+
+  registerDisplay(createDisplayComponent(validDisplayId), 'Valid display');
+  registerDisplay(createDisplayComponent(defaultDisplayId), 'Default display');
+
+  const settings = {
+    maxItemsPerRow: 2,
+    maxRows: 3,
+    rows: [
+      {
+        id: `row-view-${testCounter}`,
+        items: [
+          {id: `item-view-${testCounter}`, displayId: validDisplayId},
+          {id: `ignored-view-${testCounter}`, displayId: ignoredDisplayId},
+        ],
+      },
+    ],
+  };
+
+  const defaultDisplays = [[defaultDisplayId]];
+  const permittedDisplays = [
+    validDisplayId,
+    ignoredDisplayId,
+    defaultDisplayId,
+  ];
+  const loadSettings = testing.fn();
+  const saveSettings = testing.fn();
+  const setDefaultSettings = testing.fn();
+
+  return {
+    dashboardId,
+    defaultDisplayId,
+    defaultDisplays,
+    loadSettings,
+    permittedDisplays,
+    saveSettings,
+    setDefaultSettings,
+    settings,
+  };
+};
+
+describe('DashboardView', () => {
+  beforeEach(() => {
+    testing.clearAllMocks();
+    const globals = globalThis as typeof globalThis & {
+      __dashboardSortableGridCalls?: unknown[];
+    };
+    globals.__dashboardSortableGridCalls = [];
+  });
+
+  test('should load defaults and pass filtered rows to SortableGrid', async () => {
+    const {
+      dashboardId,
+      defaultDisplayId,
+      defaultDisplays,
+      loadSettings,
+      permittedDisplays,
+      saveSettings,
+      setDefaultSettings,
+      settings,
+    } = createDashboardState();
+    const {render} = rendererWith({store: true});
+
+    render(
+      <DashboardView
+        defaultDisplays={defaultDisplays}
+        id={dashboardId}
+        isLoading={false}
+        loadSettings={loadSettings}
+        permittedDisplays={permittedDisplays}
+        saveSettings={saveSettings}
+        setDefaultSettings={setDefaultSettings}
+        settings={settings}
+      />,
+    );
+
+    await waitFor(() => expect(loadSettings).toHaveBeenCalledTimes(1));
+    expect(setDefaultSettings).toHaveBeenCalledWith(
+      dashboardId,
+      expect.objectContaining({rows: expect.any(Array)}),
+    );
+    expect(setDefaultSettings.mock.calls[0][1].rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          items: expect.arrayContaining([
+            expect.objectContaining({displayId: defaultDisplayId}),
+          ]),
+        }),
+      ]),
+    );
+
+    const globals = globalThis as typeof globalThis & {
+      __dashboardSortableGridCalls?: unknown[];
+    };
+    const lastCall = globals.__dashboardSortableGridCalls?.at(-1) as {
+      items: Array<{id: string; items: string[]}>;
+      maxItemsPerRow: number;
+      maxRows: number;
+    };
+    expect(lastCall.items).toEqual([
+      expect.objectContaining({
+        id: `row-view-${testCounter}`,
+        items: [`item-view-${testCounter}`],
+      }),
+    ]);
+    expect(lastCall.maxItemsPerRow).toBe(DEFAULT_MAX_ITEMS_PER_ROW);
+    expect(lastCall.maxRows).toBe(DEFAULT_MAX_ROWS);
+  });
+
+  test('should render a loading indicator', () => {
+    const {
+      dashboardId,
+      defaultDisplays,
+      loadSettings,
+      permittedDisplays,
+      saveSettings,
+      setDefaultSettings,
+    } = createDashboardState();
+    const {render} = rendererWith({store: true});
+
+    render(
+      <DashboardView
+        isLoading
+        defaultDisplays={defaultDisplays}
+        id={dashboardId}
+        loadSettings={loadSettings}
+        permittedDisplays={permittedDisplays}
+        saveSettings={saveSettings}
+        setDefaultSettings={setDefaultSettings}
+      />,
+    );
+
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
+    expect(globalThis.__dashboardSortableGridCalls).toEqual([]);
+  });
+
+  test('should not reload when display props keep the same content', async () => {
+    const {
+      dashboardId,
+      defaultDisplays,
+      loadSettings,
+      permittedDisplays,
+      saveSettings,
+      setDefaultSettings,
+    } = createDashboardState();
+    const {render} = rendererWith({store: true});
+
+    const TestComponent = () => {
+      const [rerendered, setRerendered] = useState(false);
+      return (
+        <>
+          <button
+            data-testid="rerender-dashboard-view"
+            onClick={() => setRerendered(true)}
+          />
+          <DashboardView
+            defaultDisplays={
+              rerendered
+                ? [...defaultDisplays.map(row => [...row])]
+                : defaultDisplays
+            }
+            id={dashboardId}
+            isLoading={false}
+            loadSettings={loadSettings}
+            permittedDisplays={
+              rerendered ? [...permittedDisplays] : permittedDisplays
+            }
+            saveSettings={saveSettings}
+            setDefaultSettings={setDefaultSettings}
+          />
+        </>
+      );
+    };
+
+    render(<TestComponent />);
+    await waitFor(() => expect(loadSettings).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByTestId('rerender-dashboard-view'));
+    await waitFor(() => expect(loadSettings).toHaveBeenCalledTimes(1));
+  });
+
+  test('should reload when display props content changes', async () => {
+    const {
+      dashboardId,
+      defaultDisplayId,
+      defaultDisplays,
+      loadSettings,
+      permittedDisplays,
+      saveSettings,
+      setDefaultSettings,
+    } = createDashboardState();
+    const extraDisplayId = `extra-view-${testCounter}`;
+    registerDisplay(createDisplayComponent(extraDisplayId), 'Extra display');
+    const {render} = rendererWith({store: true});
+
+    const TestComponent = () => {
+      const [rerendered, setRerendered] = useState(false);
+      return (
+        <>
+          <button
+            data-testid="rerender-dashboard-view-with-changes"
+            onClick={() => setRerendered(true)}
+          />
+          <DashboardView
+            defaultDisplays={
+              rerendered
+                ? [[defaultDisplayId, extraDisplayId]]
+                : defaultDisplays
+            }
+            id={dashboardId}
+            isLoading={false}
+            loadSettings={loadSettings}
+            permittedDisplays={
+              rerendered
+                ? [...permittedDisplays, extraDisplayId]
+                : permittedDisplays
+            }
+            saveSettings={saveSettings}
+            setDefaultSettings={setDefaultSettings}
+          />
+        </>
+      );
+    };
+
+    render(<TestComponent />);
+    await waitFor(() => expect(loadSettings).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByTestId('rerender-dashboard-view-with-changes'));
+    await waitFor(() => expect(loadSettings).toHaveBeenCalledTimes(2));
+  });
+});

--- a/src/web/components/dashboard/__tests__/registry.test.ts
+++ b/src/web/components/dashboard/__tests__/registry.test.ts
@@ -20,10 +20,14 @@ import {
   registerDisplay,
 } from 'web/components/dashboard/registry';
 
+interface TestDisplayProps {
+  value: string;
+}
+
 const LOG_NAME = 'web.components.dashboard.registry';
 
 describe('dashboard registry', () => {
-  let displayRegistry: DisplayRegistry;
+  let displayRegistry: DisplayRegistry<TestDisplayProps>;
   const log = Logger.getLogger(LOG_NAME);
   let originalDebug: (...args: unknown[]) => void;
   let originalError: (...args: unknown[]) => void;
@@ -44,7 +48,9 @@ describe('dashboard registry', () => {
     log.error = originalError;
   });
 
-  const createDisplayComponent = (displayId?: string): DisplayComponent => {
+  const createDisplayComponent = (
+    displayId?: string,
+  ): DisplayComponent<TestDisplayProps> => {
     return Object.assign(() => null, {displayId} as {displayId: string});
   };
 
@@ -52,9 +58,13 @@ describe('dashboard registry', () => {
     const displayId = 'dummy-valid';
     const DummyDisplay = createDisplayComponent(displayId);
 
-    registerDisplay(DummyDisplay, 'Dummy display', displayRegistry);
+    registerDisplay<TestDisplayProps>(
+      DummyDisplay,
+      'Dummy display',
+      displayRegistry,
+    );
 
-    const display = getDisplay(displayId, displayRegistry);
+    const display = getDisplay<TestDisplayProps>(displayId, displayRegistry);
 
     expect(display).toBeDefined();
     expect(display?.component).toBe(DummyDisplay);
@@ -68,20 +78,26 @@ describe('dashboard registry', () => {
     const unregisteredId = 'dummy-invalid-id';
     const DummyDisplay = createDisplayComponent();
 
-    registerDisplay(DummyDisplay, 'Dummy display', displayRegistry);
+    registerDisplay<TestDisplayProps>(
+      DummyDisplay,
+      'Dummy display',
+      displayRegistry,
+    );
 
     expect(log.error).toHaveBeenCalledWith(
       'Undefined id passed while registering display',
     );
     expect(log.debug).not.toHaveBeenCalled();
-    expect(getDisplay(unregisteredId, displayRegistry)).toBeUndefined();
+    expect(
+      getDisplay<TestDisplayProps>(unregisteredId, displayRegistry),
+    ).toBeUndefined();
   });
 
   test('should log an error for undefined component', () => {
     const displayId = 'dummy-invalid-component';
 
-    registerDisplay(
-      undefined as unknown as DisplayComponent,
+    registerDisplay<TestDisplayProps>(
+      undefined as unknown as DisplayComponent<TestDisplayProps>,
       'Dummy display',
       displayRegistry,
     );
@@ -91,14 +107,16 @@ describe('dashboard registry', () => {
       undefined,
     );
     expect(log.debug).not.toHaveBeenCalled();
-    expect(getDisplay(displayId, displayRegistry)).toBeUndefined();
+    expect(
+      getDisplay<TestDisplayProps>(displayId, displayRegistry),
+    ).toBeUndefined();
   });
 
   test('should log an error for undefined title', () => {
     const displayId = 'dummy-invalid-title';
     const DummyDisplay = createDisplayComponent(displayId);
 
-    registerDisplay(
+    registerDisplay<TestDisplayProps>(
       DummyDisplay,
       undefined as unknown as ToString,
       displayRegistry,
@@ -109,6 +127,8 @@ describe('dashboard registry', () => {
       displayId,
     );
     expect(log.debug).not.toHaveBeenCalled();
-    expect(getDisplay(displayId, displayRegistry)).toBeUndefined();
+    expect(
+      getDisplay<TestDisplayProps>(displayId, displayRegistry),
+    ).toBeUndefined();
   });
 });

--- a/src/web/components/dashboard/display/DataDisplay.tsx
+++ b/src/web/components/dashboard/display/DataDisplay.tsx
@@ -72,7 +72,7 @@ export interface DataDisplayProps<
   TTransformedData = TData,
   TTransformProps extends object = object,
   TChildren = DataDisplayChildren<TTransformedData, TState>,
-> {
+> extends Omit<DisplayProps, 'children' | 'title'> {
   data: TData;
   dataRow: (data: TTransformedData) => string[];
   dataTitles: string[];
@@ -101,7 +101,6 @@ type DataDisplayWithTranslationProps<
   TTransformedData = TData,
   TTransformProps extends object = object,
 > = WithTranslationComponentProps &
-  Omit<DisplayProps, 'children' | 'title'> &
   DataDisplayProps<TData, TState, TTransformedData, TTransformProps>;
 
 interface DataDisplayState<TData, TTransformedData> {

--- a/src/web/components/dashboard/registry.ts
+++ b/src/web/components/dashboard/registry.ts
@@ -17,7 +17,7 @@ export interface DisplayState {
 type DisplayStateFunc = (state: DisplayState | undefined) => DisplayState;
 type DisplaySetStateFunc = (stateFunc: DisplayStateFunc) => void;
 
-interface DisplayProps extends BaseDisplayProps {
+export interface DisplayProps extends BaseDisplayProps {
   height: number;
   id: string;
   width: number;
@@ -26,24 +26,27 @@ interface DisplayProps extends BaseDisplayProps {
   onFilterIdChanged: (filterId: string) => void;
 }
 
-export type DisplayComponent = ComponentType<DisplayProps> & {
+export type DisplayComponent<TProps = DisplayProps> = ComponentType<TProps> & {
   displayId: string;
 };
 
-export interface RegisteredDisplay {
-  component: DisplayComponent;
+export interface RegisteredDisplay<TProps = DisplayProps> {
+  component: DisplayComponent<TProps>;
   title: ToString;
 }
 
-export type DisplayRegistry = Record<string, RegisteredDisplay>;
+export type DisplayRegistry<TProps = DisplayProps> = Record<
+  string,
+  RegisteredDisplay<TProps>
+>;
 
 const log = Logger.getLogger('web.components.dashboard.registry');
 const registry: DisplayRegistry = {};
 
-export const registerDisplay = (
-  component: DisplayComponent,
+export const registerDisplay = <TProps = DisplayProps>(
+  component: DisplayComponent<TProps>,
   title: ToString,
-  targetRegistry: DisplayRegistry = registry,
+  targetRegistry: DisplayRegistry<TProps> = registry as DisplayRegistry<TProps>,
 ) => {
   const displayId = component?.displayId;
 
@@ -73,7 +76,7 @@ export const registerDisplay = (
   log.debug('Registered display', displayId);
 };
 
-export const getDisplay = (
+export const getDisplay = <TProps = DisplayProps>(
   displayId: string,
-  targetRegistry: DisplayRegistry = registry,
-): RegisteredDisplay | undefined => targetRegistry[displayId];
+  targetRegistry: DisplayRegistry<TProps> = registry as DisplayRegistry<TProps>,
+): RegisteredDisplay<TProps> | undefined => targetRegistry[displayId];

--- a/src/web/pages/start/Dashboard.tsx
+++ b/src/web/pages/start/Dashboard.tsx
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {Dashboard} from 'web/components/dashboard/Dashboard';
 import DashboardControls, {
   type OnNewDisplayFunc,
 } from 'web/components/dashboard/DashboardControls';
+import DashboardView from 'web/components/dashboard/DashboardView';
 import {
   canAddDisplay,
   type DashboardSettings,
@@ -80,7 +80,7 @@ const StartDashboard = ({
           onResetClick={onResetDashboard}
         />
       </Layout>
-      <Dashboard
+      <DashboardView
         showFilterSelection
         showFilterString
         defaultDisplays={DEFAULT_DISPLAYS}


### PR DESCRIPTION


## What
Split Dashboard component into the dashboard and a view

## Why

For the main dashboard on the start page the loading functions are used and the connected redux store is bypassed. Therefore we are actually using two different components. While on it the Dashboard component got refactored to use hooks completely and the last used HOCs for redux got dropped.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


