### PR TITLE
GEA-2015

### DIFF
--- a/e2e/reports/report-details-helpers.ts
+++ b/e2e/reports/report-details-helpers.ts
@@ -1,0 +1,75 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {expect, type Page} from '@playwright/test';
+
+const standardReportTabs = [
+  'Results',
+  'Hosts',
+  'Ports',
+  'Applications',
+  'Operating Systems',
+  'CVEs',
+  'Closed CVEs',
+  'TLS Certificates',
+  'Error Messages',
+];
+
+const completedReportsFilter = encodeURIComponent(
+  'status=Done sort-reverse=date first=1',
+);
+
+export const openCompletedReport = async (page: Page) => {
+  await page.goto(`/reports?filter=${completedReportsFilter}`);
+
+  const reportTable = page.getByTestId('entities-table');
+  const noReportsMessage = page.getByText('No reports available');
+
+  await expect(reportTable.or(noReportsMessage)).toBeVisible();
+
+  if (await noReportsMessage.isVisible()) {
+    return undefined;
+  }
+
+  const reportRow = reportTable
+    .locator('tr')
+    .filter({
+      has: page.getByTestId('statusbar-text').filter({hasText: /^Done$/}),
+    })
+    .filter({has: page.locator('a[href^="/report/"]')})
+    .first();
+  const reportLink = reportRow.locator('a[href^="/report/"]').first();
+  const href = await reportLink.getAttribute('href');
+
+  if (!href) {
+    return undefined;
+  }
+
+  expect(href).toMatch(/^\/report\/[^/?#]+$/);
+  await page.goto(href);
+  await expect(page).toHaveURL(new RegExp(`${href}$`));
+
+  const hasStandardTabs = await Promise.all(
+    standardReportTabs.map(async tabName => {
+      try {
+        await expect(
+          page.getByRole('tab', {name: new RegExp(`^${tabName}`)}),
+        ).toBeVisible({timeout: 5000});
+        return true;
+      } catch {
+        return false;
+      }
+    }),
+  );
+
+  if (hasStandardTabs.every(Boolean)) {
+    const reportId = href.split('/').pop();
+    if (reportId) {
+      return reportId;
+    }
+  }
+
+  return undefined;
+};

--- a/e2e/reports/report-details-tabs.spec.ts
+++ b/e2e/reports/report-details-tabs.spec.ts
@@ -1,0 +1,130 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {login} from 'e2e/credentials';
+import {expect, test, type Page} from 'e2e/fixtures';
+import {openCompletedReport} from 'e2e/reports/report-details-helpers';
+
+interface ReportTabTest {
+  name: string;
+  tabName: string;
+  emptyMessage?: RegExp;
+  supportsEmptyReport?: boolean;
+  errorMessage?: RegExp;
+}
+
+const reportTabTests: ReportTabTest[] = [
+  {
+    name: 'Information',
+    tabName: 'Information',
+  },
+  {
+    name: 'Results',
+    tabName: 'Results',
+    emptyMessage: /^The report is empty\./,
+    supportsEmptyReport: true,
+  },
+  {name: 'Hosts', tabName: 'Hosts', emptyMessage: /^No Hosts available$/},
+  {name: 'Ports', tabName: 'Ports', emptyMessage: /^No Ports available$/},
+  {
+    name: 'Applications',
+    tabName: 'Applications',
+    emptyMessage: /^No Applications available$/,
+  },
+  {
+    name: 'Operating Systems',
+    tabName: 'Operating Systems',
+    emptyMessage: /^No Operating Systems available$/,
+    errorMessage: /^Error while loading Operating Systems for Report/,
+  },
+  {name: 'CVEs', tabName: 'CVEs', emptyMessage: /^No CVEs available$/},
+  {
+    name: 'Closed CVEs',
+    tabName: 'Closed CVEs',
+    emptyMessage: /^No Closed CVEs available$/,
+  },
+  {
+    name: 'TLS Certificates',
+    tabName: 'TLS Certificates',
+    emptyMessage: /^No TLS Certificates available$/,
+  },
+  {
+    name: 'Error Messages',
+    tabName: 'Error Messages',
+    emptyMessage: /^No Errors available$/,
+  },
+  {
+    name: 'User Tags',
+    tabName: 'User Tags',
+  },
+];
+
+const assertTabHasLoaded = async (page: Page, tab: ReportTabTest) => {
+  const errorMessage = page.getByTestId('error-message');
+  let terminalContent =
+    tab.tabName === 'Information'
+      ? page.getByRole('row', {name: /^Task Name/})
+      : tab.tabName === 'User Tags'
+        ? page
+            .locator('table')
+            .filter({
+              has: page.locator('th').filter({hasText: /^Name$/}),
+            })
+            .or(page.getByText('No user tags available'))
+        : page.getByTestId('entities-table').or(errorMessage);
+
+  if (tab.emptyMessage) {
+    terminalContent = terminalContent.or(page.getByText(tab.emptyMessage));
+  }
+
+  if (tab.supportsEmptyReport) {
+    terminalContent = terminalContent.or(page.getByTestId('empty-report'));
+  }
+
+  if (tab.errorMessage) {
+    terminalContent = terminalContent.or(page.getByText(tab.errorMessage));
+  }
+
+  await expect(terminalContent).toBeVisible();
+  await expect(errorMessage).toHaveCount(0);
+
+  if (tab.errorMessage) {
+    await expect(page.getByText(tab.errorMessage)).toHaveCount(0);
+  }
+
+  const loading = page.getByTestId('loading');
+  await expect(loading).toHaveCount(0);
+
+  await expect(
+    page.getByRole('tab', {
+      name: new RegExp(`^${tab.tabName}`),
+      selected: true,
+    }),
+  ).toBeVisible();
+};
+
+test.describe('report details tabs', () => {
+  test('clicks through every tab and checks its data', async ({
+    page,
+  }, testInfo) => {
+    await login(page);
+    const reportId = await openCompletedReport(page);
+
+    // The local E2E environment is intentionally not seeded with reports.
+    // eslint-disable-next-line vitest/no-disabled-tests
+    testInfo.skip(
+      !reportId,
+      'No standard completed report is available in the local E2E environment.',
+    );
+
+    for (const reportTab of reportTabTests) {
+      const tab = page.getByRole('tab', {
+        name: new RegExp(`^${reportTab.tabName}`),
+      });
+      await tab.click();
+      await assertTabHasLoaded(page, reportTab);
+    }
+  });
+});

--- a/src/web/hooks/use-query/report-applications.ts
+++ b/src/web/hooks/use-query/report-applications.ts
@@ -11,12 +11,14 @@ interface UseGetReportApplicationsParams {
   reportId: string;
   filter?: FilterType;
   refetchInterval?: number | false;
+  staleTime?: number;
 }
 
 export const useGetReportApplications = ({
   reportId,
   filter = undefined,
   refetchInterval = undefined,
+  staleTime,
 }: UseGetReportApplicationsParams) => {
   const gmp = useGmp();
 
@@ -31,6 +33,7 @@ export const useGetReportApplications = ({
     enabled: Boolean(reportId),
     keepPreviousData: true,
     refetchInterval,
+    staleTime,
   });
 };
 

--- a/src/web/hooks/use-query/report-closed-cves.ts
+++ b/src/web/hooks/use-query/report-closed-cves.ts
@@ -11,12 +11,14 @@ interface UseGetReportClosedCvesParams {
   reportId: string;
   filter?: FilterType;
   refetchInterval?: number | false;
+  staleTime?: number;
 }
 
 export const useGetReportClosedCves = ({
   reportId,
   filter = undefined,
   refetchInterval = false,
+  staleTime,
 }: UseGetReportClosedCvesParams) => {
   const gmp = useGmp();
 
@@ -31,6 +33,7 @@ export const useGetReportClosedCves = ({
     refetchInterval,
     enabled: Boolean(reportId),
     keepPreviousData: true,
+    staleTime,
   });
 };
 

--- a/src/web/hooks/use-query/report-cves.ts
+++ b/src/web/hooks/use-query/report-cves.ts
@@ -11,12 +11,14 @@ interface UseGetReportCvesParams {
   reportId: string;
   filter?: FilterType;
   refetchInterval?: number | false;
+  staleTime?: number;
 }
 
 export const useGetReportCves = ({
   reportId,
   filter = undefined,
   refetchInterval = false,
+  staleTime,
 }: UseGetReportCvesParams) => {
   const gmp = useGmp();
 
@@ -31,6 +33,7 @@ export const useGetReportCves = ({
     refetchInterval,
     enabled: Boolean(reportId),
     keepPreviousData: true,
+    staleTime,
   });
 };
 

--- a/src/web/hooks/use-query/report-errors.ts
+++ b/src/web/hooks/use-query/report-errors.ts
@@ -11,12 +11,14 @@ interface UseGetReportErrorsParams {
   reportId: string;
   filter?: FilterType;
   refetchInterval?: number | false;
+  staleTime?: number;
 }
 
 export const useGetReportErrors = ({
   reportId,
   filter = undefined,
   refetchInterval = undefined,
+  staleTime,
 }: UseGetReportErrorsParams) => {
   const gmp = useGmp();
 
@@ -31,6 +33,7 @@ export const useGetReportErrors = ({
     enabled: Boolean(reportId),
     keepPreviousData: true,
     refetchInterval,
+    staleTime,
   });
 };
 

--- a/src/web/hooks/use-query/report-hosts.ts
+++ b/src/web/hooks/use-query/report-hosts.ts
@@ -11,12 +11,14 @@ interface UseGetReportHostsParams {
   reportId: string;
   filter?: FilterType;
   refetchInterval?: number | false;
+  staleTime?: number;
 }
 
 export const useGetReportHosts = ({
   reportId,
   filter = undefined,
   refetchInterval = undefined,
+  staleTime,
 }: UseGetReportHostsParams) => {
   const gmp = useGmp();
 
@@ -31,6 +33,7 @@ export const useGetReportHosts = ({
     refetchInterval,
     enabled: Boolean(reportId),
     keepPreviousData: true,
+    staleTime,
   });
 };
 

--- a/src/web/hooks/use-query/report-operating-system.ts
+++ b/src/web/hooks/use-query/report-operating-system.ts
@@ -12,12 +12,14 @@ interface UseGetReportOperatingSystemsParams {
   reportId: string;
   filter?: FilterType;
   refetchInterval?: number | false;
+  staleTime?: number;
 }
 
 export const useGetReportOperatingSystems = ({
   reportId,
   filter,
   refetchInterval = undefined,
+  staleTime,
 }: UseGetReportOperatingSystemsParams) => {
   const gmp = useGmp();
 
@@ -32,6 +34,7 @@ export const useGetReportOperatingSystems = ({
     enabled: Boolean(reportId),
     keepPreviousData: true,
     refetchInterval,
+    staleTime,
   });
 };
 

--- a/src/web/hooks/use-query/report-ports.ts
+++ b/src/web/hooks/use-query/report-ports.ts
@@ -12,12 +12,14 @@ interface UseGetReportPortsParams {
   reportId: string;
   filter?: FilterType;
   refetchInterval?: number | false;
+  staleTime?: number;
 }
 
 export const useGetReportPorts = ({
   reportId,
   filter = undefined,
   refetchInterval = undefined,
+  staleTime,
 }: UseGetReportPortsParams) => {
   const gmp = useGmp();
 
@@ -32,6 +34,7 @@ export const useGetReportPorts = ({
     enabled: Boolean(reportId),
     keepPreviousData: true,
     refetchInterval,
+    staleTime,
   });
 };
 

--- a/src/web/hooks/use-query/report-tls-certificates.ts
+++ b/src/web/hooks/use-query/report-tls-certificates.ts
@@ -12,12 +12,14 @@ interface UseGetReportTlsCertificatesParams {
   reportId: string;
   filter?: FilterType;
   refetchInterval?: number | false;
+  staleTime?: number;
 }
 
 export const useGetReportTlsCertificates = ({
   reportId,
   filter = undefined,
   refetchInterval = undefined,
+  staleTime,
 }: UseGetReportTlsCertificatesParams) => {
   const gmp = useGmp();
 
@@ -32,6 +34,7 @@ export const useGetReportTlsCertificates = ({
     enabled: Boolean(reportId),
     keepPreviousData: true,
     refetchInterval,
+    staleTime,
   });
 };
 

--- a/src/web/hooks/use-query/reports.ts
+++ b/src/web/hooks/use-query/reports.ts
@@ -14,6 +14,7 @@ import QueryFilter from 'gmp/models/filter/query-filter';
 import type Report from 'gmp/models/report';
 import type ReportConfig from 'gmp/models/report-config';
 import type ReportFormat from 'gmp/models/report-format';
+import {isActive} from 'gmp/models/task';
 import {isDefined} from 'gmp/utils/identity';
 import useGmp from 'web/hooks/useGmp';
 import useSessionToken from 'web/hooks/useSessionToken';
@@ -47,6 +48,24 @@ export const useGetReport = ({
     queryKeyParts: [filterString],
     id,
     refetchInterval,
+    keepPreviousData: true,
+    /**
+     * We added gcTime: 2 hours, to avoid the report being garbage collected too early.
+     * This is important because the report might still be needed for further display,
+     * even if it is not actively being used at the moment.
+     * The staleTime function checks if the report is defined and if its scan_run_status is not active.
+     * If both conditions are met, it returns Infinity,
+     * indicating that the report should not be considered stale and should not be garbage collected.
+     * Otherwise, it returns 0, allowing the report to be garbage collected if it is no longer needed.
+     */
+    gcTime: 120 * 60 * 1000,
+    staleTime: query => {
+      const report = query.state.data;
+      return isDefined(report?.report) &&
+        !isActive(report.report.scan_run_status)
+        ? Infinity
+        : 0;
+    },
   });
 };
 

--- a/src/web/hooks/use-query/results.ts
+++ b/src/web/hooks/use-query/results.ts
@@ -13,6 +13,7 @@ import useGetEntities, {
 
 interface UseGetResultsParams {
   filter?: FilterType;
+  staleTime?: number;
   refetchInterval?:
     number | false | RefetchIntervalFn<UseGetEntitiesReturn<Result>>;
 }
@@ -26,6 +27,7 @@ interface UseGetResultsParams {
  */
 export const useGetResults = ({
   filter = undefined,
+  staleTime,
   refetchInterval = undefined,
 }: UseGetResultsParams = {}) => {
   const gmp = useGmp();
@@ -36,6 +38,7 @@ export const useGetResults = ({
     filter,
     keepPreviousData: true,
     refetchInterval,
+    staleTime,
   });
 };
 

--- a/src/web/hooks/use-query/use-report-sub-entities.ts
+++ b/src/web/hooks/use-query/use-report-sub-entities.ts
@@ -28,29 +28,43 @@ interface UseReportSubEntitiesParams {
   reportId: string;
   filter?: FilterType;
   refetchInterval?: number | false;
+  staleTime?: number;
 }
 
 const useReportSubEntities = ({
   reportId,
   filter = undefined,
   refetchInterval = undefined,
+  staleTime,
 }: UseReportSubEntitiesParams): ReportSubEntities => ({
-  hosts: useGetReportHosts({reportId, filter, refetchInterval}),
-  ports: useGetReportPorts({reportId, filter, refetchInterval}),
-  applications: useGetReportApplications({reportId, filter, refetchInterval}),
+  hosts: useGetReportHosts({reportId, filter, refetchInterval, staleTime}),
+  ports: useGetReportPorts({reportId, filter, refetchInterval, staleTime}),
+  applications: useGetReportApplications({
+    reportId,
+    filter,
+    refetchInterval,
+    staleTime,
+  }),
   operatingSystems: useGetReportOperatingSystems({
     reportId,
     filter,
     refetchInterval,
+    staleTime,
   }),
-  cves: useGetReportCves({reportId, filter, refetchInterval}),
-  closedCves: useGetReportClosedCves({reportId, filter, refetchInterval}),
+  cves: useGetReportCves({reportId, filter, refetchInterval, staleTime}),
+  closedCves: useGetReportClosedCves({
+    reportId,
+    filter,
+    refetchInterval,
+    staleTime,
+  }),
   tlsCertificates: useGetReportTlsCertificates({
     reportId,
     filter,
     refetchInterval,
+    staleTime,
   }),
-  errors: useGetReportErrors({reportId, filter, refetchInterval}),
+  errors: useGetReportErrors({reportId, filter, refetchInterval, staleTime}),
 });
 
 export default useReportSubEntities;

--- a/src/web/pages/reports/ReportDetailsContent.tsx
+++ b/src/web/pages/reports/ReportDetailsContent.tsx
@@ -150,6 +150,7 @@ const ReportDetailsContent = ({
     reportId,
     filter: reportFilter,
     refetchInterval,
+    staleTime: Infinity,
   });
 
   if (!hasReport && isDefined(reportError)) {

--- a/src/web/pages/reports/details/result/ContainerScanningResultsTab.tsx
+++ b/src/web/pages/reports/details/result/ContainerScanningResultsTab.tsx
@@ -49,6 +49,7 @@ const ContainerScanningResultsTab = ({
 
   const {data, isLoading, isFetching, isError, error} = useGetResults({
     filter: resultsFilter,
+    staleTime: Infinity,
     refetchInterval: isActive(status)
       ? USE_DEFAULT_RELOAD_INTERVAL_ACTIVE
       : NO_RELOAD,

--- a/src/web/pages/reports/details/result/ResultsTab.tsx
+++ b/src/web/pages/reports/details/result/ResultsTab.tsx
@@ -77,6 +77,7 @@ const ResultsTabWrapper = ({
 
   const {data, isLoading, isFetching, isError, error} = useGetResults({
     filter: resultsFilter,
+    staleTime: Infinity,
     refetchInterval: isActive(status)
       ? USE_DEFAULT_RELOAD_INTERVAL_ACTIVE
       : NO_RELOAD,
@@ -120,7 +121,7 @@ const ResultsTabWrapper = ({
     return <Loading />;
   }
 
-  const {entities: results = [], entitiesCounts: resultsCounts} = data || {};
+  const {entities: results = [], entitiesCounts: resultsCounts} = data ?? {};
 
   const displayedFilter = resultsFilter.delete('_and_report_id');
 

--- a/src/web/pages/reports/details/result/WebApplicationScanningResultsTab.tsx
+++ b/src/web/pages/reports/details/result/WebApplicationScanningResultsTab.tsx
@@ -49,6 +49,7 @@ const WebApplicationScanningResultsTab = ({
 
   const {data, isLoading, isFetching, isError, error} = useGetResults({
     filter: resultsFilter,
+    staleTime: Infinity,
     refetchInterval: isActive(status)
       ? USE_DEFAULT_RELOAD_INTERVAL_ACTIVE
       : NO_RELOAD,

--- a/src/web/queries/useGetEntities.ts
+++ b/src/web/queries/useGetEntities.ts
@@ -36,6 +36,8 @@ interface UseGetEntitiesParams<
   refetchInterval?:
     number | false | RefetchIntervalFn<UseGetEntitiesReturn<TModel>>;
   keepPreviousData?: boolean;
+  staleTime?: number;
+  gcTime?: number;
 }
 
 const useGetEntities = <
@@ -48,6 +50,8 @@ const useGetEntities = <
   enabled = true,
   refetchInterval = undefined,
   keepPreviousData = false,
+  staleTime,
+  gcTime,
 }: UseGetEntitiesParams<TModel, TInput>) => {
   const gmp = useGmp();
   const token = useSessionToken();
@@ -73,6 +77,13 @@ const useGetEntities = <
       };
     },
     refetchInterval: resolvedRefetchInterval,
+    staleTime:
+      staleTime ?? (resolvedRefetchInterval === false ? Infinity : undefined),
+    gcTime:
+      gcTime ??
+      (staleTime === Infinity || resolvedRefetchInterval === false
+        ? Infinity
+        : undefined),
     placeholderData: keepPreviousData
       ? previousData => previousData
       : undefined,

--- a/src/web/queries/useGetEntity.ts
+++ b/src/web/queries/useGetEntity.ts
@@ -21,6 +21,9 @@ interface UseGetEntityParams<TModel extends Model> {
   id: string;
   queryKeyParts?: unknown[];
   refetchInterval?: number | false | RefetchIntervalFn<TModel>;
+  staleTime?: number | ((query: {state: {data: TModel | undefined}}) => number);
+  keepPreviousData?: boolean;
+  gcTime?: number;
 }
 
 const useGetEntity = <TModel extends Model>({
@@ -29,6 +32,9 @@ const useGetEntity = <TModel extends Model>({
   id,
   queryKeyParts,
   refetchInterval,
+  staleTime,
+  keepPreviousData = false,
+  gcTime,
 }: UseGetEntityParams<TModel>) => {
   const gmp = useGmp();
   const token = useSessionToken();
@@ -47,6 +53,12 @@ const useGetEntity = <TModel extends Model>({
       return response.data;
     },
     refetchInterval: resolvedRefetchInterval,
+    staleTime,
+    gcTime,
+    placeholderData: keepPreviousData
+      ? (previousData, previousQuery) =>
+          previousQuery?.queryKey[2] === id ? previousData : undefined
+      : undefined,
   });
 };
 


### PR DESCRIPTION
## What

- Added `staleTime` and `gcTime` to queries to preserve the fetched completed report data in tabs.

## Why

- Data was being refetched when switching tabs or reports, even if the report was completed, becoming an issue on bigger reports.

## References

GEA-2015

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


