### PR TITLE
Address a vite warning for the future native config loader

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import {defineConfig} from 'vite';
 import eslintPlugin from 'vite-plugin-eslint2';
 import svgrPlugin from 'vite-plugin-svgr';
 
-const projectRootDir = path.resolve(__dirname);
+const projectRootDir = import.meta.dirname;
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## What
Address a vite warning for the future `native` config loader

## Why

Vite was complaining about
```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - `__dirname` (vite.config.ts:8:37). Use `import.meta.dirname` instead
Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.
```
