### PR TITLE
Scanner Dialog Improvements

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -2126,6 +2126,7 @@
   "The scan did not collect any results": "Der Scan hat keine Ergebnisse gesammelt",
   "The scan is still running and no results have arrived yet": "Der Scan läuft noch und es sind noch keine Ergebnisse eingetroffen",
   "The scan just started and no results have arrived yet": "Der Scan hat gerade begonnen und es sind noch keine Ergebnisse eingetroffen",
+  "The scanner uses a local connection and doesn't use a port": "Der Scanner verwendet eine lokale Verbindung und keinen Port.",
   "The Second": "Jeden zweiten",
   "The Target and Task will be created using the defaults as configured in \"My Settings\".": "Beim Erstellen des Ziels und der Aufgabe wird die Standardauswahl verwendet, wie sie unter \"Eigene Einstellungen\" konfiguriert wurde.",
   "The target hosts could be regarded dead": "Der Ziel-Host kann als unerreichbar angesehen werden",

--- a/public/locales/gsa-en.json
+++ b/public/locales/gsa-en.json
@@ -2126,6 +2126,7 @@
   "The scan did not collect any results": "The scan did not collect any results",
   "The scan is still running and no results have arrived yet": "The scan is still running and no results have arrived yet",
   "The scan just started and no results have arrived yet": "The scan just started and no results have arrived yet",
+  "The scanner uses a local connection and doesn't use a port": "The scanner uses a local connection and doesn't use a port",
   "The Second": "The Second",
   "The Target and Task will be created using the defaults as configured in \"My Settings\".": "The Target and Task will be created using the defaults as configured in \"My Settings\".",
   "The target hosts could be regarded dead": "The target hosts could be regarded dead",

--- a/public/locales/gsa-it.json
+++ b/public/locales/gsa-it.json
@@ -2126,7 +2126,7 @@
   "The scan did not collect any results": "La scansione non ha raccolto alcun risultato",
   "The scan is still running and no results have arrived yet": "La scansione è ancora in esecuzione e non sono ancora arrivati risultati",
   "The scan just started and no results have arrived yet": "La scansione è appena iniziata e non sono ancora arrivati risultati",
-  "The scanner uses a local connection and doesn't use a port": "",
+  "The scanner uses a local connection and doesn't use a port": "Lo scanner utilizza una connessione locale e non richiede una porta.",
   "The Second": "Il secondo",
   "The Target and Task will be created using the defaults as configured in \"My Settings\".": "Il target e il task verranno creati con le impostazioni predefinite configurate in \"Le mie impostazioni\".",
   "The target hosts could be regarded dead": "Gli host di destinazione potrebbero essere considerati non raggiungibili",

--- a/public/locales/gsa-it.json
+++ b/public/locales/gsa-it.json
@@ -2126,6 +2126,7 @@
   "The scan did not collect any results": "La scansione non ha raccolto alcun risultato",
   "The scan is still running and no results have arrived yet": "La scansione è ancora in esecuzione e non sono ancora arrivati risultati",
   "The scan just started and no results have arrived yet": "La scansione è appena iniziata e non sono ancora arrivati risultati",
+  "The scanner uses a local connection and doesn't use a port": "",
   "The Second": "Il secondo",
   "The Target and Task will be created using the defaults as configured in \"My Settings\".": "Il target e il task verranno creati con le impostazioni predefinite configurate in \"Le mie impostazioni\".",
   "The target hosts could be regarded dead": "Gli host di destinazione potrebbero essere considerati non raggiungibili",

--- a/public/locales/gsa-ja.json
+++ b/public/locales/gsa-ja.json
@@ -2126,6 +2126,7 @@
   "The scan did not collect any results": "スキャンは結果を1件も収集しませんでした",
   "The scan is still running and no results have arrived yet": "スキャンはまだ実行中で、結果がまだ届いていません",
   "The scan just started and no results have arrived yet": "スキャンは開始したばかりで、結果がまだ届いていません",
+  "The scanner uses a local connection and doesn't use a port": "",
   "The Second": "第2",
   "The Target and Task will be created using the defaults as configured in \"My Settings\".": "ターゲットとタスクは、「マイ設定」で構成されたデフォルト値を使用して作成されます。",
   "The target hosts could be regarded dead": "ターゲットホストが停止中と見なされた可能性があります",

--- a/public/locales/gsa-zh_CN.json
+++ b/public/locales/gsa-zh_CN.json
@@ -2126,6 +2126,7 @@
   "The scan did not collect any results": "扫描未收集任何结果",
   "The scan is still running and no results have arrived yet": "扫描仍在运行暂时没有任何结果",
   "The scan just started and no results have arrived yet": "扫描刚刚开始暂时没有任何结果",
+  "The scanner uses a local connection and doesn't use a port": "",
   "The Second": "第二周",
   "The Target and Task will be created using the defaults as configured in \"My Settings\".": "此扫描目标和任务将使用\"用户设置\"中的默认值创建.",
   "The target hosts could be regarded dead": "目标主机可以被视为非存活",

--- a/public/locales/gsa-zh_TW.json
+++ b/public/locales/gsa-zh_TW.json
@@ -2126,6 +2126,7 @@
   "The scan did not collect any results": "",
   "The scan is still running and no results have arrived yet": "",
   "The scan just started and no results have arrived yet": "",
+  "The scanner uses a local connection and doesn't use a port": "",
   "The Second": "",
   "The Target and Task will be created using the defaults as configured in \"My Settings\".": "",
   "The target hosts could be regarded dead": "",

--- a/src/gmp/commands/__tests__/scanner.test.ts
+++ b/src/gmp/commands/__tests__/scanner.test.ts
@@ -78,6 +78,66 @@ describe('ScannerCommand tests', () => {
     });
   });
 
+  test('should send an empty port when creating a scanner without a port', async () => {
+    const response = createActionResultResponse({
+      action: 'create_scanner',
+      id: '123',
+      message: 'Scanner created successfully',
+    });
+    const fakeHttp = createHttp(response);
+    const cmd = new ScannerCommand(fakeHttp);
+
+    await cmd.create({
+      name: 'Local Scanner',
+      host: '/var/run/ospd.sock',
+      type: OPENVASD_SCANNER_TYPE,
+    });
+
+    expect(fakeHttp.request).toHaveBeenCalledWith('post', {
+      data: {
+        cmd: 'create_scanner',
+        name: 'Local Scanner',
+        comment: '',
+        credential_id: undefined,
+        scanner_host: '/var/run/ospd.sock',
+        scanner_type: OPENVASD_SCANNER_TYPE,
+        port: '',
+        ca_pub: undefined,
+      },
+    });
+  });
+
+  test('should send an empty port when saving a scanner without a port', async () => {
+    const response = createActionResultResponse({
+      action: 'save_scanner',
+      id: '123',
+      message: 'Scanner updated successfully',
+    });
+    const fakeHttp = createHttp(response);
+    const cmd = new ScannerCommand(fakeHttp);
+
+    await cmd.save({
+      id: '123',
+      name: 'Local Scanner',
+      host: '/var/run/ospd.sock',
+      type: OPENVASD_SCANNER_TYPE,
+    });
+
+    expect(fakeHttp.request).toHaveBeenCalledWith('post', {
+      data: {
+        cmd: 'save_scanner',
+        ca_pub: '',
+        comment: '',
+        credential_id: '',
+        name: 'Local Scanner',
+        port: '',
+        scanner_host: '/var/run/ospd.sock',
+        scanner_id: '123',
+        scanner_type: OPENVASD_SCANNER_TYPE,
+      },
+    });
+  });
+
   test('should remove a credential when saving a scanner', async () => {
     const response = createActionResultResponse({
       action: 'save_scanner',

--- a/src/gmp/commands/scanner.ts
+++ b/src/gmp/commands/scanner.ts
@@ -13,6 +13,7 @@ import Scanner, {
   type ScannerElement,
   type ScannerType,
 } from 'gmp/models/scanner';
+import {isDefined} from 'gmp/utils/identity';
 
 export interface ScannerCommandCreateParams {
   name: string;
@@ -20,7 +21,7 @@ export interface ScannerCommandCreateParams {
   comment?: string;
   credentialId?: string;
   host: string;
-  port: number | '';
+  port?: number;
   type: ScannerType;
 }
 
@@ -86,7 +87,7 @@ class ScannerCommand extends EntityCommand<Scanner, ScannerElement> {
       comment,
       credential_id: credentialId,
       name,
-      port,
+      port: isDefined(port) ? port : '',
       scanner_host: host,
       scanner_type: type,
     };
@@ -113,7 +114,7 @@ class ScannerCommand extends EntityCommand<Scanner, ScannerElement> {
       credential_id: credentialId ?? '',
       id,
       name,
-      port,
+      port: isDefined(port) ? port : '',
       scanner_host: host,
       scanner_type: type,
     };

--- a/src/web/components/form/NumberField.tsx
+++ b/src/web/components/form/NumberField.tsx
@@ -28,6 +28,7 @@ export interface NumberFieldProps extends Omit<
   precision?: number | string;
   type?: 'int' | 'float';
   size?: 'sm' | 'md' | 'lg';
+  toolTipTitle?: string;
   value?: number | '';
 }
 
@@ -78,6 +79,7 @@ const NumberField = forwardRef<HTMLInputElement, NumberFieldProps>(
       value,
       size = 'md',
       onChange,
+      toolTipTitle,
       ...props
     },
     ref,
@@ -121,6 +123,7 @@ const NumberField = forwardRef<HTMLInputElement, NumberFieldProps>(
         size={size}
         step={parseFloat(step)}
         suffix={suffix}
+        title={toolTipTitle}
         type="text"
         value={value}
         onChange={handleChange}

--- a/src/web/components/form/Select.tsx
+++ b/src/web/components/form/Select.tsx
@@ -18,7 +18,7 @@ export interface SelectItem {
 
 export interface SelectProps<TValue> extends Omit<
   React.ComponentPropsWithoutRef<typeof OpenSightSelect>,
-  'onChange' | 'value'
+  'onChange' | 'value' | 'title'
 > {
   allowDeselect?: boolean;
   'data-testid'?: string;

--- a/src/web/components/form/__tests__/NumberField.test.tsx
+++ b/src/web/components/form/__tests__/NumberField.test.tsx
@@ -16,6 +16,21 @@ describe('NumberField tests', () => {
     expect(element).toHaveValue('1');
   });
 
+  test('should render the tooltip title', () => {
+    render(
+      <NumberField
+        data-testid="input"
+        toolTipTitle="The scanner uses a local connection and doesn't use a port"
+        value={1}
+      />,
+    );
+
+    expect(screen.getByTestId('input')).toHaveAttribute(
+      'title',
+      "The scanner uses a local connection and doesn't use a port",
+    );
+  });
+
   test('should call change handler', () => {
     const onChange = testing.fn();
     render(<NumberField data-testid="input" value={1} onChange={onChange} />);

--- a/src/web/pages/scanners/ScannerComponent.tsx
+++ b/src/web/pages/scanners/ScannerComponent.tsx
@@ -15,14 +15,7 @@ import {
 } from 'gmp/models/credential';
 import FilterTerm from 'gmp/models/filter/filter-term';
 import QueryFilter from 'gmp/models/filter/query-filter';
-import {
-  type default as Scanner,
-  type ScannerType,
-  AGENT_CONTROLLER_SCANNER_TYPE,
-  AGENT_CONTROLLER_SENSOR_SCANNER_TYPE,
-  OPENVASD_SCANNER_TYPE,
-  OPENVASD_SENSOR_SCANNER_TYPE,
-} from 'gmp/models/scanner';
+import {type default as Scanner, type ScannerType} from 'gmp/models/scanner';
 import {hasId} from 'gmp/utils/id';
 import {isDefined} from 'gmp/utils/identity';
 import {shorten} from 'gmp/utils/string';
@@ -44,7 +37,9 @@ import useUserName from 'web/hooks/useUserName';
 import CredentialDialog, {
   type CredentialDialogState,
 } from 'web/pages/credentials/CredentialDialog';
-import ScannerDialog from 'web/pages/scanners/ScannerDialog';
+import ScannerDialog, {
+  isScannerTypeSupportingClientCertificates,
+} from 'web/pages/scanners/ScannerDialog';
 import {getUserSettingsDefaults} from 'web/store/usersettings/defaults/selectors';
 import {generateFilename} from 'web/utils/Render';
 
@@ -147,10 +142,7 @@ const ScannerComponent = ({
   const openScannerDialog = async (scanner?: Scanner) => {
     if (isDefined(scanner)) {
       const credentialTypes: CredentialType[] =
-        scanner.scannerType === OPENVASD_SCANNER_TYPE ||
-        scanner.scannerType === AGENT_CONTROLLER_SCANNER_TYPE ||
-        scanner.scannerType === OPENVASD_SENSOR_SCANNER_TYPE ||
-        scanner.scannerType === AGENT_CONTROLLER_SENSOR_SCANNER_TYPE
+        isScannerTypeSupportingClientCertificates(scanner.scannerType)
           ? [CERTIFICATE_CREDENTIAL_TYPE]
           : [];
       const credentialsPromise =

--- a/src/web/pages/scanners/ScannerDialog.tsx
+++ b/src/web/pages/scanners/ScannerDialog.tsx
@@ -53,7 +53,6 @@ interface ScannerDialogProps {
 
 interface ScannerDialogDefaultValues {
   comment: string;
-  host: string;
   id?: string;
   name: string;
 }
@@ -61,14 +60,17 @@ interface ScannerDialogDefaultValues {
 interface ScannerDialogValues {
   caCertificate?: File;
   credentialId?: string;
+  host: string;
   type?: ScannerType;
-  port: number | '';
+  port?: number;
 }
 
 export type ScannerDialogState = ScannerDialogValues &
   ScannerDialogDefaultValues;
 
 const CA_CERTIFICATE_LINE = '-----BEGIN CERTIFICATE-----';
+
+const isLocalConnection = (host?: string) => host?.startsWith('/') ?? false;
 
 const updatePort = (scannerType: ScannerType | undefined) => {
   if (
@@ -88,7 +90,7 @@ const updatePort = (scannerType: ScannerType | undefined) => {
   ) {
     return 443;
   }
-  return '';
+  return undefined;
 };
 
 export const isScannerTypeSupportingClientCertificates = (
@@ -168,9 +170,10 @@ const ScannerDialog = ({
     },
   );
   const [userChangedPort, setUserChangedPort] = useState<boolean>(false);
-  const [scannerPort, setScannerPort] = useState<number | ''>(
-    () => port ?? updatePort(scannerType),
+  const [scannerPort, setScannerPort] = useState<number | undefined>(() =>
+    isLocalConnection(host) ? undefined : (port ?? updatePort(scannerType)),
   );
+  const [scannerHost, setScannerHost] = useState<string>(host);
 
   name = name || _('Unnamed');
   title = title || _('New Scanner');
@@ -250,7 +253,16 @@ const ScannerDialog = ({
   const handleScannerPortChange = (value: number) => {
     // allow to update the port automatically if the field is empty
     setUserChangedPort(!isEmpty(value));
-    setScannerPort(value);
+    setScannerPort(isEmpty(value) ? undefined : value);
+  };
+
+  const handleHostChange = (value: string) => {
+    setScannerHost(value);
+    if (isLocalConnection(value)) {
+      setScannerPort(undefined);
+    } else if (isEmpty(scannerPort)) {
+      setScannerPort(updatePort(scannerType));
+    }
   };
 
   const scannerTypesOptions = map(scannerTypes, scannerType => ({
@@ -267,6 +279,8 @@ const ScannerDialog = ({
     showScannerDetails &&
     isScannerTypeSupportingClientCertificates(scannerType);
 
+  const localConnection = isLocalConnection(scannerHost);
+
   if (isGreenboneSensorType || isAgentControllerSensorScannerType) {
     credentialId = undefined;
   }
@@ -274,7 +288,6 @@ const ScannerDialog = ({
     <SaveDialog<ScannerDialogValues, ScannerDialogDefaultValues>
       defaultValues={{
         comment,
-        host,
         id,
         name,
       }}
@@ -285,6 +298,7 @@ const ScannerDialog = ({
         credentialId,
         type: scannerType,
         port: scannerPort,
+        host: scannerHost,
       }}
       onClose={onClose}
       onSave={onSave}
@@ -322,17 +336,24 @@ const ScannerDialog = ({
                 name="host"
                 placeholder={_('Insert a Host name or IP address')}
                 title={_('Host')}
-                value={state.host}
-                onChange={onValueChange}
+                value={scannerHost}
+                onChange={handleHostChange}
               />
             )}
 
             {showPort && (
               <NumberField
-                disabled={scannerInUse}
+                disabled={scannerInUse || localConnection}
                 name="port"
                 placeholder={_('Insert a Port number')}
                 title={_('Port')}
+                toolTipTitle={
+                  localConnection
+                    ? _(
+                        "The scanner uses a local connection and doesn't use a port",
+                      )
+                    : undefined
+                }
                 value={state.port}
                 onChange={handleScannerPortChange}
               />

--- a/src/web/pages/scanners/ScannerDialog.tsx
+++ b/src/web/pages/scanners/ScannerDialog.tsx
@@ -263,12 +263,10 @@ const ScannerDialog = ({
     scannerType === AGENT_CONTROLLER_SENSOR_SCANNER_TYPE;
   const showScannerDetails = isDefined(scannerType);
   const showPort = showScannerDetails && !isGreenboneSensorType;
-  const showCredentialField =
+  const isClientCertificateSupported =
     showScannerDetails &&
     isScannerTypeSupportingClientCertificates(scannerType);
-  const showCaCertificateField =
-    showScannerDetails &&
-    isScannerTypeSupportingClientCertificates(scannerType);
+
   if (isGreenboneSensorType || isAgentControllerSensorScannerType) {
     credentialId = undefined;
   }
@@ -340,38 +338,38 @@ const ScannerDialog = ({
               />
             )}
 
-            {showCaCertificateField && (
-              <FileField
-                name="caCertificate"
-                placeholder={_('Upload CA Certificate')}
-                title={_('CA Certificate')}
-                value={state.caCertificate ?? null}
-                onChange={handleCaCertificateChange}
-              />
-            )}
+            {isClientCertificateSupported && (
+              <>
+                <FileField
+                  name="caCertificate"
+                  placeholder={_('Upload CA Certificate')}
+                  title={_('CA Certificate')}
+                  value={state.caCertificate ?? null}
+                  onChange={handleCaCertificateChange}
+                />
 
-            {showCredentialField && (
-              <FormGroup direction="row" title={_('Credential')}>
-                <Select
-                  allowDeselect
-                  clearable
-                  aria-label={_('Credential')}
-                  grow="1"
-                  items={renderSelectItems(
-                    credentials as RenderSelectItemProps[],
-                  )}
-                  name="credentialId"
-                  placeholder={_('Select a Credential')}
-                  value={credentialId ?? ''}
-                  onChange={(value: string) =>
-                    onCredentialChange && onCredentialChange(value)
-                  }
-                />
-                <NewIcon
-                  title={_('Create a new Credential')}
-                  onClick={onNewCredentialClick}
-                />
-              </FormGroup>
+                <FormGroup direction="row" title={_('Credential')}>
+                  <Select
+                    allowDeselect
+                    clearable
+                    aria-label={_('Credential')}
+                    grow="1"
+                    items={renderSelectItems(
+                      credentials as RenderSelectItemProps[],
+                    )}
+                    name="credentialId"
+                    placeholder={_('Select a Credential')}
+                    value={credentialId ?? ''}
+                    onChange={(value: string) =>
+                      onCredentialChange && onCredentialChange(value)
+                    }
+                  />
+                  <NewIcon
+                    title={_('Create a new Credential')}
+                    onClick={onNewCredentialClick}
+                  />
+                </FormGroup>
+              </>
             )}
           </>
         );

--- a/src/web/pages/scanners/ScannerDialog.tsx
+++ b/src/web/pages/scanners/ScannerDialog.tsx
@@ -91,6 +91,16 @@ const updatePort = (scannerType: ScannerType | undefined) => {
   return '';
 };
 
+export const isScannerTypeSupportingClientCertificates = (
+  scannerType: ScannerType | undefined,
+) =>
+  scannerType === OPENVAS_SCANNER_TYPE ||
+  scannerType === OPENVASD_SCANNER_TYPE ||
+  scannerType === OPENVASD_SENSOR_SCANNER_TYPE ||
+  scannerType === CONTAINER_IMAGE_SCANNER_TYPE ||
+  scannerType === WEB_APPLICATION_SCANNER_TYPE ||
+  scannerType === AGENT_CONTROLLER_SCANNER_TYPE;
+
 const ScannerDialog = ({
   comment = '',
   scannerInUse = false,
@@ -254,13 +264,11 @@ const ScannerDialog = ({
   const showScannerDetails = isDefined(scannerType);
   const showPort = showScannerDetails && !isGreenboneSensorType;
   const showCredentialField =
-    !isGreenboneSensorType &&
-    !isAgentControllerSensorScannerType &&
-    showScannerDetails;
+    showScannerDetails &&
+    isScannerTypeSupportingClientCertificates(scannerType);
   const showCaCertificateField =
-    !isGreenboneSensorType &&
-    !isAgentControllerSensorScannerType &&
-    showScannerDetails;
+    showScannerDetails &&
+    isScannerTypeSupportingClientCertificates(scannerType);
   if (isGreenboneSensorType || isAgentControllerSensorScannerType) {
     credentialId = undefined;
   }

--- a/src/web/pages/scanners/__tests__/ScannerComponent.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerComponent.test.tsx
@@ -7,8 +7,15 @@ import {describe, test, expect, testing} from '@gsa/testing';
 import {screen, fireEvent, rendererWith, wait} from 'web/testing';
 import QueryFilter from 'gmp/models/filter/query-filter';
 import Scanner, {
+  AGENT_CONTROLLER_SCANNER_TYPE,
+  AGENT_CONTROLLER_SENSOR_SCANNER_TYPE,
+  CONTAINER_IMAGE_SCANNER_TYPE,
+  CVE_SCANNER_TYPE,
   GREENBONE_SENSOR_SCANNER_TYPE,
+  OPENVAS_SCANNER_TYPE,
   OPENVASD_SCANNER_TYPE,
+  OPENVASD_SENSOR_SCANNER_TYPE,
+  WEB_APPLICATION_SCANNER_TYPE,
 } from 'gmp/models/scanner';
 import {createSession} from 'gmp/testing';
 import {currentSettingsDefaultResponse} from 'web/pages/__fixtures__/current-settings';
@@ -31,6 +38,95 @@ const createGmp = (object?: unknown) => {
 };
 
 describe('ScannerComponent tests', () => {
+  test.each([
+    OPENVAS_SCANNER_TYPE,
+    OPENVASD_SCANNER_TYPE,
+    AGENT_CONTROLLER_SCANNER_TYPE,
+    OPENVASD_SENSOR_SCANNER_TYPE,
+    CONTAINER_IMAGE_SCANNER_TYPE,
+    WEB_APPLICATION_SCANNER_TYPE,
+  ])(
+    'should open a client certificate credential dialog for scanner type %s',
+    async scannerType => {
+      const scanner = new Scanner({
+        id: '1234',
+        name: 'Test Scanner',
+        host: 'http://scanner-host',
+        port: 443,
+        scannerType,
+      });
+      const gmp = createGmp({
+        scanner: {
+          get: testing.fn().mockResolvedValue({data: scanner}),
+        },
+        credentials: {
+          getAll: testing.fn().mockResolvedValue({data: []}),
+        },
+      });
+      const {render} = rendererWith({capabilities: true, gmp, store: true});
+
+      render(
+        <ScannerComponent>
+          {({edit}) => (
+            <button onClick={() => edit(scanner)}>Open Scanner</button>
+          )}
+        </ScannerComponent>,
+      );
+
+      fireEvent.click(screen.getByRole('button', {name: 'Open Scanner'}));
+      await wait();
+
+      fireEvent.click(screen.getByTitle('Create a new Credential'));
+
+      expect(screen.getByText('New Credential')).toBeVisible();
+      expect(screen.getByRole('textbox', {name: 'Type'})).toHaveValue(
+        'Client Certificate',
+      );
+    },
+  );
+
+  test.each([
+    CVE_SCANNER_TYPE,
+    GREENBONE_SENSOR_SCANNER_TYPE,
+    AGENT_CONTROLLER_SENSOR_SCANNER_TYPE,
+  ])(
+    'should not render credential fields or creation for scanner type %s',
+    async scannerType => {
+      const scanner = new Scanner({
+        id: '1234',
+        name: 'Test Scanner',
+        host: 'http://scanner-host',
+        port: 443,
+        scannerType,
+      });
+      const gmp = createGmp({
+        scanner: {
+          get: testing.fn().mockResolvedValue({data: scanner}),
+        },
+      });
+      const {render} = rendererWith({capabilities: true, gmp, store: true});
+
+      render(
+        <ScannerComponent>
+          {({edit}) => (
+            <button onClick={() => edit(scanner)}>Open Scanner</button>
+          )}
+        </ScannerComponent>,
+      );
+
+      fireEvent.click(screen.getByRole('button', {name: 'Open Scanner'}));
+      await wait();
+
+      expect(
+        screen.queryByTitle('Create a new Credential'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('textbox', {name: 'Credential'}),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByName('caCertificate')).not.toBeInTheDocument();
+    },
+  );
+
   test('should allow to clone a scanner', async () => {
     const scanner = new Scanner({
       id: '1234',

--- a/src/web/pages/scanners/__tests__/ScannerDialog.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerDialog.test.tsx
@@ -17,6 +17,7 @@ import {
   AGENT_CONTROLLER_SCANNER_TYPE,
   AGENT_CONTROLLER_SENSOR_SCANNER_TYPE,
   CONTAINER_IMAGE_SCANNER_TYPE,
+  CVE_SCANNER_TYPE,
   GREENBONE_SENSOR_SCANNER_TYPE,
   OPENVAS_SCANNER_TYPE,
   OPENVASD_SCANNER_TYPE,
@@ -178,6 +179,39 @@ describe('ScannerDialog tests', () => {
     });
   });
 
+  test('should render the new credential button for client certificate scanners', () => {
+    const gmp = createGmp();
+    const handleNewCredentialClick = testing.fn();
+    const {render} = rendererWith({gmp, capabilities: true});
+
+    render(
+      <ScannerDialog
+        type={OPENVAS_SCANNER_TYPE}
+        onNewCredentialClick={handleNewCredentialClick}
+      />,
+    );
+
+    const newCredentialButton = screen.getByTitle('Create a new Credential');
+    expect(newCredentialButton).toBeVisible();
+    fireEvent.click(newCredentialButton);
+    expect(handleNewCredentialClick).toHaveBeenCalled();
+  });
+
+  test('should not render credential fields for unsupported scanner types', () => {
+    const gmp = createGmp();
+    const {render} = rendererWith({gmp, capabilities: true});
+
+    render(<ScannerDialog type={CVE_SCANNER_TYPE} />);
+
+    expect(
+      screen.queryByTitle('Create a new Credential'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('textbox', {name: 'Credential'}),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByName('caCertificate')).not.toBeInTheDocument();
+  });
+
   test('should display defaults for openvasd scanner', async () => {
     const gmp = createGmp();
     const handleSave = testing.fn();
@@ -274,8 +308,9 @@ describe('ScannerDialog tests', () => {
 
     const scannerType = screen.getByRole('textbox', {name: 'Scanner Type'});
     expect(scannerType).toHaveValue('Container Image Scanner');
-    expect(screen.queryByRole('textbox', {name: 'Credential'})).toHaveValue('');
-    expect(screen.queryByName('caCertificate')).toHaveValue('');
+    expect(screen.getByRole('textbox', {name: 'Credential'})).toHaveValue('');
+    expect(screen.getByName('caCertificate')).toHaveValue('');
+    expect(screen.getByTitle('Create a new Credential')).toBeVisible();
 
     fireEvent.click(screen.getDialogSaveButton());
     expect(handleSave).toHaveBeenCalledWith({
@@ -311,8 +346,9 @@ describe('ScannerDialog tests', () => {
 
     const scannerType = screen.getByRole('textbox', {name: 'Scanner Type'});
     expect(scannerType).toHaveValue('Web Application Scanner');
-    expect(screen.queryByRole('textbox', {name: 'Credential'})).toHaveValue('');
-    expect(screen.queryByName('caCertificate')).toHaveValue('');
+    expect(screen.getByRole('textbox', {name: 'Credential'})).toHaveValue('');
+    expect(screen.getByName('caCertificate')).toHaveValue('');
+    expect(screen.getByTitle('Create a new Credential')).toBeVisible();
 
     fireEvent.click(screen.getDialogSaveButton());
     expect(handleSave).toHaveBeenCalledWith({

--- a/src/web/pages/scanners/__tests__/ScannerDialog.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerDialog.test.tsx
@@ -83,7 +83,7 @@ describe('ScannerDialog tests', () => {
       credentialId: undefined,
       type: undefined,
       id: undefined,
-      port: '',
+      port: undefined,
     });
   });
 
@@ -198,7 +198,7 @@ describe('ScannerDialog tests', () => {
       credentialId: undefined,
       type: OPENVAS_SCANNER_TYPE,
       id: undefined,
-      port: '',
+      port: undefined,
     });
   });
 
@@ -592,6 +592,38 @@ describe('ScannerDialog tests', () => {
     });
   });
 
+  test('should disable port for a local file path host', () => {
+    const gmp = createGmp({enableGreenboneSensor: false});
+    const handleSave = testing.fn();
+    const {render} = rendererWith({gmp, capabilities: true});
+
+    render(
+      <ScannerDialog
+        host="/var/run/ospd.sock"
+        type={OPENVAS_SCANNER_TYPE}
+        onSave={handleSave}
+      />,
+    );
+
+    const portInput = screen.getByName('port');
+    expect(portInput).toHaveValue('');
+    expect(portInput).toBeDisabled();
+    expect(
+      screen.getByTitle(
+        "The scanner uses a local connection and doesn't use a port",
+      ),
+    ).toBeVisible();
+
+    fireEvent.click(screen.getDialogSaveButton());
+
+    expect(handleSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: '/var/run/ospd.sock',
+        port: undefined,
+      }),
+    );
+  });
+
   test('should allow to close the dialog', async () => {
     const gmp = createGmp();
     const handleClose = testing.fn();
@@ -709,7 +741,7 @@ describe('ScannerDialog tests', () => {
       credentialId: undefined,
       type: OPENVAS_SCANNER_TYPE,
       id: undefined,
-      port: '',
+      port: undefined,
     });
   });
 

--- a/src/web/pages/scanners/__tests__/ScannerDialog.test.tsx
+++ b/src/web/pages/scanners/__tests__/ScannerDialog.test.tsx
@@ -21,15 +21,38 @@ import {
   GREENBONE_SENSOR_SCANNER_TYPE,
   OPENVAS_SCANNER_TYPE,
   OPENVASD_SCANNER_TYPE,
+  OPENVASD_SENSOR_SCANNER_TYPE,
   WEB_APPLICATION_SCANNER_TYPE,
 } from 'gmp/models/scanner';
-import ScannerDialog from 'web/pages/scanners/ScannerDialog';
+import ScannerDialog, {
+  isScannerTypeSupportingClientCertificates,
+} from 'web/pages/scanners/ScannerDialog';
 
 const createGmp = ({enableGreenboneSensor = true} = {}) => {
   return {settings: {enableGreenboneSensor}};
 };
 
 describe('ScannerDialog tests', () => {
+  test.each([
+    [OPENVAS_SCANNER_TYPE, true],
+    [OPENVASD_SCANNER_TYPE, true],
+    [OPENVASD_SENSOR_SCANNER_TYPE, true],
+    [AGENT_CONTROLLER_SCANNER_TYPE, true],
+    [CONTAINER_IMAGE_SCANNER_TYPE, true],
+    [WEB_APPLICATION_SCANNER_TYPE, true],
+    [CVE_SCANNER_TYPE, false],
+    [GREENBONE_SENSOR_SCANNER_TYPE, false],
+    [AGENT_CONTROLLER_SENSOR_SCANNER_TYPE, false],
+    [undefined, false],
+  ])(
+    'should report whether scanner type %s supports client certificates',
+    (scannerType, expected) => {
+      expect(isScannerTypeSupportingClientCertificates(scannerType)).toBe(
+        expected,
+      );
+    },
+  );
+
   test('should display defaults without scanner type provided', async () => {
     const gmp = createGmp({enableGreenboneSensor: false});
     const handleSave = testing.fn();


### PR DESCRIPTION
## What

Scanner Dialog Improvements
* Disable port in ScannerDialog when a file path is used for host
* Update ScannerDialog for CA and Client Certificate handling
* Clarify which Scanners use CA and Client Certificates

## Why

Improve and fix creating and saving scanners

## References

https://jira.greenbone.net/browse/GEA-1983

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


