### PR TITLE
Improve readability of Hosts By Modification Time Chart

### DIFF
--- a/src/web/components/chart/LineChart.tsx
+++ b/src/web/components/chart/LineChart.tsx
@@ -63,6 +63,8 @@ interface LineChartProps {
   timeline?: boolean;
   width: number;
   xAxisLabel?: ToString;
+  xAxisLabelOffset?: number;
+  xAxisLabelRotation?: number;
   yAxisLabel?: ToString;
   y2AxisLabel?: ToString;
   yLine?: LineProps;
@@ -239,6 +241,8 @@ const LineChart = ({
   timeline = false,
   width: propWidth,
   xAxisLabel,
+  xAxisLabelOffset,
+  xAxisLabelRotation,
   yAxisLabel,
   y2AxisLabel,
   yLine,
@@ -540,9 +544,11 @@ const LineChart = ({
             )}
             <Axis
               label={String(xAxisLabel)}
+              labelOffset={xAxisLabelOffset}
               numTicks={xAxisTicks}
               orientation="bottom"
               scale={xScale}
+              tickLabelRotation={xAxisLabelRotation}
               top={maxHeight(height)}
             />
             {isDefined(y2Line) && (

--- a/src/web/components/chart/__tests__/LineChart.test.tsx
+++ b/src/web/components/chart/__tests__/LineChart.test.tsx
@@ -54,6 +54,39 @@ describe('LineChart tests', () => {
     ).toBeInTheDocument();
   });
 
+  test('should apply x-axis label offset and tick label rotation', () => {
+    const {render} = rendererWith();
+
+    render(
+      <LineChart
+        data={[
+          {x: 1, y: 10, y2: 3},
+          {x: 2, y: 20, y2: 4},
+        ]}
+        height={300}
+        showLegend={false}
+        width={900}
+        xAxisLabel="X"
+        xAxisLabelOffset={30}
+        xAxisLabelRotation={-20}
+        yLine={{color: '#00aa00', label: 'First'}}
+      />,
+    );
+
+    const mainContainer = screen.getByTestId('main-container');
+    const axisLabels = Array.from(
+      mainContainer.querySelectorAll('.axis-label'),
+    );
+    const xAxisLabel = axisLabels.find(label => label.textContent === 'X');
+    const xAxisTick = Array.from(
+      mainContainer.querySelectorAll('.axis-tick text'),
+    ).find(tick => tick.hasAttribute('transform'));
+
+    expect(xAxisLabel).toHaveAttribute('y', '48');
+    expect(xAxisTick).toHaveAttribute('transform', 'rotate(-20)');
+    expect(xAxisTick).toHaveAttribute('text-anchor', 'end');
+  });
+
   test('should keep the hover info box within the plot bounds', () => {
     const {render} = rendererWith();
 

--- a/src/web/components/chart/base/Axis.tsx
+++ b/src/web/components/chart/base/Axis.tsx
@@ -14,6 +14,7 @@ import {
 import {format as d3format} from 'd3-format';
 import type {ScaleBand, ScaleLinear, ScaleTime} from 'd3-scale';
 import {select} from 'd3-selection';
+import {isDefined} from 'gmp/utils/identity';
 import Theme from 'web/utils/theme';
 
 type AxisDomainValue = string | number | Date;
@@ -26,18 +27,29 @@ type SupportedScale =
 
 interface AxisProps {
   dataTestId?: string;
+  // Whether to hide the axis line (domain). Defaults to false.
   hideDomain?: boolean;
+  // Whether to hide the tick labels. Defaults to false.
   hideTickLabels?: boolean;
   label?: string;
+  // offset of the axis label from the axis line, in pixels. Defaults to 25 for horizontal axes and 36 for vertical axes.
   labelOffset?: number;
   left?: number;
   orientation?: 'bottom' | 'top' | 'left' | 'right';
+  // number of ticks to display on the axis. If not provided, the axis will automatically determine the number of ticks based on the scale and available space.
   numTicks?: number;
   scale: SupportedScale;
+  // padding between the axis line ticks and the tick labels, in pixels. Defaults to 10.
   rangePadding?: number;
+  // rotation of the tick labels, in degrees. Defaults to 0 (no rotation).
   tickLabelRotation?: number;
+  // function to format the tick labels. If not provided, the axis will use a default formatting based on the scale type.
   tickFormat?: (value: AxisDomainValue) => string;
+  // array of values to use for the axis ticks. If not provided, the axis will automatically generate tick values based on the scale and numTicks.
+  // If provided, the axis will only display ticks for the specified values.
+  // Overrides numTicks and tickFormat if provided.
   tickValues?: AxisDomainValue[];
+  // length of the axis ticks, in pixels. Defaults to 8.
   tickLength?: number;
   top?: number;
 }
@@ -87,11 +99,11 @@ const Axis = ({
     );
     generator.tickSize(tickLength);
 
-    if (numTicks !== undefined) {
+    if (isDefined(numTicks)) {
       generator.ticks(numTicks);
     }
 
-    if (rangePadding !== undefined) {
+    if (isDefined(rangePadding)) {
       // Keep compatibility with the old visx prop using the nearest d3-axis equivalent.
       generator.tickPadding(rangePadding);
     }

--- a/src/web/pages/hosts/dashboard/ModifiedDisplay.jsx
+++ b/src/web/pages/hosts/dashboard/ModifiedDisplay.jsx
@@ -95,6 +95,8 @@ export class HostsModifiedDisplay extends React.Component {
                 svgRef={svgRef}
                 width={width}
                 xAxisLabel={_('Time')}
+                xAxisLabelOffset={30}
+                xAxisLabelRotation={-20}
                 y2AxisLabel={_('Total Hosts')}
                 y2Line={{
                   color: Theme.darkGreenTransparent,


### PR DESCRIPTION


## What

 Improve readability of Hosts By Modification Time Chart

## Why

Rotate the tick labels of the chart and increase the padding to the X-Axis label.

