### PR TITLE
Dashboard data loader function improvements

### DIFF
--- a/src/web/components/dashboard/display/Loader.tsx
+++ b/src/web/components/dashboard/display/Loader.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import {type Action, type ThunkDispatch} from '@reduxjs/toolkit';
 import {connect} from 'react-redux';
+import type Gmp from 'gmp/gmp';
 import {type FilterType} from 'gmp/models/filter';
 import {isDefined, hasValue} from 'gmp/utils/identity';
 import {
@@ -53,6 +54,7 @@ interface LoaderPropsWithLoad<TData> extends LoaderProps<TData> {
 
 export interface LoadFuncProps {
   filter?: FilterType;
+  gmp: Gmp;
 }
 
 type GetStateFunc = () => unknown;

--- a/src/web/components/dashboard/display/Loader.tsx
+++ b/src/web/components/dashboard/display/Loader.tsx
@@ -16,7 +16,6 @@ import {
 } from 'web/store/dashboard/data/actions';
 import getDashboardData from 'web/store/dashboard/data/selectors';
 import compose from 'web/utils/compose';
-import PropTypes from 'web/utils/prop-types';
 import withGmp from 'web/utils/withGmp';
 import withSubscription from 'web/utils/withSubscription';
 
@@ -64,11 +63,6 @@ type LoaderDispatch = ThunkDispatch<
   unknown,
   Action<string>
 >;
-
-export const loaderPropTypes = {
-  children: PropTypes.func,
-  filter: PropTypes.filter,
-};
 
 export const createLoadFunc =
   <TProps extends LoadFuncProps, TData>(

--- a/src/web/components/dashboard/display/Loader.tsx
+++ b/src/web/components/dashboard/display/Loader.tsx
@@ -70,7 +70,7 @@ export const loaderPropTypes = {
   filter: PropTypes.filter,
 };
 
-export const loadFunc =
+export const createLoadFunc =
   <TProps extends LoadFuncProps, TData>(
     func: (props: TProps) => Promise<TData>,
     id: string,

--- a/src/web/components/dashboard/display/__tests__/Loader.test.tsx
+++ b/src/web/components/dashboard/display/__tests__/Loader.test.tsx
@@ -5,8 +5,13 @@
 
 import {describe, test, expect, testing} from '@gsa/testing';
 import {rendererWith} from 'web/testing';
+import type Gmp from 'gmp/gmp';
 import QueryFilter from 'gmp/models/filter/query-filter';
-import {Loader, loadFunc} from 'web/components/dashboard/display/Loader';
+import {
+  Loader,
+  createLoadFunc,
+  type LoadFuncProps,
+} from 'web/components/dashboard/display/Loader';
 import {
   DASHBOARD_DATA_LOADING_REQUEST,
   DASHBOARD_DATA_LOADING_SUCCESS,
@@ -14,9 +19,13 @@ import {
 } from 'web/store/dashboard/data/actions';
 import {filterIdentifier} from 'web/store/utils';
 
-const createState = (
-  state: Record<string, Record<string, {isLoading: boolean}>>,
-) => ({
+interface TestData {
+  foo: string;
+}
+
+type TestState = Record<string, Record<string, {isLoading: boolean}>>;
+
+const createState = (state: TestState): {dashboardData: TestState} => ({
   dashboardData: {
     ...state,
   },
@@ -248,25 +257,26 @@ describe('Loader component tests', () => {
   });
 });
 
-describe('loadFunc tests', () => {
+describe('createLoadFunc tests', () => {
   test('should request dashboard data successfully', () => {
-    const dispatch = testing.fn();
-    const getState = testing.fn();
-    const data = {
+    const data: TestData = {
       foo: 'bar',
     };
-    const func = testing.fn().mockResolvedValue(data);
+    const func = testing.fn((_props: LoadFuncProps): Promise<TestData> =>
+      Promise.resolve(data),
+    );
 
     const id = 'a1';
     const filter = QueryFilter.fromString('foo=bar');
-    const props = {
+    const props: LoadFuncProps = {
       filter,
+      gmp: {} as Gmp,
     };
+    const thunk = createLoadFunc(func, id)(props);
+    const dispatch = testing.fn() as Parameters<typeof thunk>[0];
+    const getState = testing.fn() as Parameters<typeof thunk>[1];
 
-    return loadFunc(
-      func,
-      id,
-    )(props)(dispatch, getState).then(() => {
+    return thunk(dispatch, getState).then(() => {
       expect(getState).toHaveBeenCalled();
       expect(func).toHaveBeenCalledWith(props);
       expect(dispatch).toHaveBeenNthCalledWith(1, {
@@ -294,21 +304,24 @@ describe('loadFunc tests', () => {
         },
       },
     });
-    const dispatch = testing.fn();
-    const getState = testing.fn().mockReturnValue(state);
-    const data = {
+    const data: TestData = {
       foo: 'bar',
     };
-    const func = testing.fn().mockResolvedValue(data);
+    const func = testing.fn((_props: LoadFuncProps): Promise<TestData> =>
+      Promise.resolve(data),
+    );
 
-    const props = {
+    const props: LoadFuncProps = {
       filter,
+      gmp: {} as Gmp,
     };
+    const thunk = createLoadFunc(func, id)(props);
+    const dispatch = testing.fn() as Parameters<typeof thunk>[0];
+    const getState = testing.fn().mockReturnValue(state) as Parameters<
+      typeof thunk
+    >[1];
 
-    return loadFunc(
-      func,
-      id,
-    )(props)(dispatch, getState).then(() => {
+    return thunk(dispatch, getState).then(() => {
       expect(getState).toHaveBeenCalled();
       expect(func).not.toHaveBeenCalled();
       expect(dispatch).not.toHaveBeenCalled();
@@ -318,18 +331,19 @@ describe('loadFunc tests', () => {
   test('should fail loading dashboard data', () => {
     const id = 'a1';
     const filter = QueryFilter.fromString('foo=bar');
-    const dispatch = testing.fn();
-    const getState = testing.fn();
-    const func = testing.fn().mockRejectedValue('An error');
+    const func = testing.fn((_props: LoadFuncProps): Promise<TestData> =>
+      Promise.reject('An error'),
+    );
 
-    const props = {
+    const props: LoadFuncProps = {
       filter,
+      gmp: {} as Gmp,
     };
+    const thunk = createLoadFunc(func, id)(props);
+    const dispatch = testing.fn() as Parameters<typeof thunk>[0];
+    const getState = testing.fn() as Parameters<typeof thunk>[1];
 
-    return loadFunc(
-      func,
-      id,
-    )(props)(dispatch, getState).then(() => {
+    return thunk(dispatch, getState).then(() => {
       expect(getState).toHaveBeenCalled();
       expect(func).toHaveBeenCalledWith(props);
       expect(dispatch).toHaveBeenNthCalledWith(1, {

--- a/src/web/pages/certbund/dashboard/Loaders.tsx
+++ b/src/web/pages/certbund/dashboard/Loaders.tsx
@@ -3,16 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 export const CERTBUNDS_SEVERITY = 'certbunds-severity';
 export const CERTBUNDS_CREATED = 'certbunds-created';
 
-export const certBundCreatedLoader = loadFunc(
+export const certBundCreatedLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.certbunds.getCreatedAggregates({filter}).then(r => r.data),
   CERTBUNDS_CREATED,
@@ -22,16 +18,14 @@ export const CertBundCreatedLoader = ({filter, children}) => (
   <Loader
     dataId={CERTBUNDS_CREATED}
     filter={filter}
-    load={certBundCreatedLoader}
+    load={certBundCreatedLoadFunc}
     subscriptions={['certbunds.timer', 'certbunds.changed']}
   >
     {children}
   </Loader>
 );
 
-CertBundCreatedLoader.propTypes = loaderPropTypes;
-
-export const certBundSeverityLoader = loadFunc(
+export const certBundSeverityLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.certbunds.getSeverityAggregates({filter}).then(r => r.data),
   CERTBUNDS_SEVERITY,
@@ -41,11 +35,9 @@ export const CertBundSeverityLoader = ({filter, children}) => (
   <Loader
     dataId={CERTBUNDS_SEVERITY}
     filter={filter}
-    load={certBundSeverityLoader}
+    load={certBundSeverityLoadFunc}
     subscriptions={['certbunds.timer', 'certbunds.changed']}
   >
     {children}
   </Loader>
 );
-
-CertBundSeverityLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/cpes/dashboard/Loaders.tsx
+++ b/src/web/pages/cpes/dashboard/Loaders.tsx
@@ -3,16 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 export const CPES_CREATED = 'cpes-created';
 export const CPES_SEVERITY = 'cpes-severity';
 
-export const cpeCreatedLoader = loadFunc(
+export const cpeCreatedLoadFunc = createLoadFunc(
   ({gmp, filter}) => gmp.cpes.getCreatedAggregates({filter}).then(r => r.data),
   CPES_CREATED,
 );
@@ -21,16 +17,14 @@ export const CpesCreatedLoader = ({filter, children}) => (
   <Loader
     dataId={CPES_CREATED}
     filter={filter}
-    load={cpeCreatedLoader}
+    load={cpeCreatedLoadFunc}
     subscriptions={['cpes.timer', 'cpes.changed']}
   >
     {children}
   </Loader>
 );
 
-CpesCreatedLoader.propTypes = loaderPropTypes;
-
-export const cpeSeverityLoader = loadFunc(
+export const cpeSeverityLoadFunc = createLoadFunc(
   ({gmp, filter}) => gmp.cpes.getSeverityAggregates({filter}).then(r => r.data),
   CPES_SEVERITY,
 );
@@ -39,11 +33,9 @@ export const CpesSeverityLoader = ({filter, children}) => (
   <Loader
     dataId={CPES_SEVERITY}
     filter={filter}
-    load={cpeSeverityLoader}
+    load={cpeSeverityLoadFunc}
     subscriptions={['cpes.timer', 'cpes.changed']}
   >
     {children}
   </Loader>
 );
-
-CpesSeverityLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/cves/dashboard/Loaders.tsx
+++ b/src/web/pages/cves/dashboard/Loaders.tsx
@@ -3,16 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 export const CVES_SEVERITY = 'cves-severity';
 export const CVES_CREATED = 'cves-created';
 
-export const cveCreatedLoader = loadFunc(
+export const cveCreatedLoadFunc = createLoadFunc(
   ({gmp, filter}) => gmp.cves.getCreatedAggregates({filter}).then(r => r.data),
   CVES_CREATED,
 );
@@ -21,16 +17,14 @@ export const CvesCreatedLoader = ({filter, children}) => (
   <Loader
     dataId={CVES_CREATED}
     filter={filter}
-    load={cveCreatedLoader}
+    load={cveCreatedLoadFunc}
     subscriptions={['cves.timer', 'cves.changed']}
   >
     {children}
   </Loader>
 );
 
-CvesCreatedLoader.propTypes = loaderPropTypes;
-
-export const cveSeverityLoader = loadFunc(
+export const cveSeverityLoadFunc = createLoadFunc(
   ({gmp, filter}) => gmp.cves.getSeverityAggregates({filter}).then(r => r.data),
   CVES_SEVERITY,
 );
@@ -39,11 +33,9 @@ export const CvesSeverityLoader = ({filter, children}) => (
   <Loader
     dataId={CVES_SEVERITY}
     filter={filter}
-    load={cveSeverityLoader}
+    load={cveSeverityLoadFunc}
     subscriptions={['cves.timer', 'cves.changed']}
   >
     {children}
   </Loader>
 );
-
-CvesSeverityLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/dfncert/dashboard/Loaders.tsx
+++ b/src/web/pages/dfncert/dashboard/Loaders.tsx
@@ -3,16 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 export const DFNCERTS_CREATED = 'dfncerts-created';
 export const DFNCERTS_SEVERITY = 'dfncerts-severity';
 
-export const dfnCertsCreatedLoader = loadFunc(
+export const dfnCertsCreatedLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.dfncerts.getCreatedAggregates({filter}).then(r => r.data),
   DFNCERTS_CREATED,
@@ -22,16 +18,14 @@ export const DfnCertsCreatedLoader = ({filter, children}) => (
   <Loader
     dataId={DFNCERTS_CREATED}
     filter={filter}
-    load={dfnCertsCreatedLoader}
+    load={dfnCertsCreatedLoadFunc}
     subscriptions={['dfncerts.timer', 'dfncerts.changed']}
   >
     {children}
   </Loader>
 );
 
-DfnCertsCreatedLoader.propTypes = loaderPropTypes;
-
-export const dfnCertSeverityLoader = loadFunc(
+export const dfnCertSeverityLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.dfncerts.getSeverityAggregates({filter}).then(r => r.data),
   DFNCERTS_SEVERITY,
@@ -41,11 +35,9 @@ export const DfnCertSeverityLoader = ({filter, children}) => (
   <Loader
     dataId={DFNCERTS_SEVERITY}
     filter={filter}
-    load={dfnCertSeverityLoader}
+    load={dfnCertSeverityLoadFunc}
     subscriptions={['dfncerts.timer', 'dfncerts.changed']}
   >
     {children}
   </Loader>
 );
-
-DfnCertSeverityLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/hosts/dashboard/Loaders.tsx
+++ b/src/web/pages/hosts/dashboard/Loaders.tsx
@@ -3,14 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
 import QueryFilter from 'gmp/models/filter/query-filter';
 import {isDefined} from 'gmp/utils/identity';
 import {MAX_HOSTS} from 'web/components/chart/HostsTopologyChart';
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 export const HOSTS_MODIFIED = 'hosts-modified';
 export const HOSTS_SEVERITY = 'hosts-severity';
@@ -21,7 +17,7 @@ const HOSTS_MAX_GROUPS = 10;
 
 const DEFAULT_TOPOLOGY_FILTER = QueryFilter.fromString(`rows=${MAX_HOSTS}`);
 
-export const hostsModifiedLoader = loadFunc(
+export const hostsModifiedLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.hosts.getModifiedAggregates({filter}).then(r => r.data),
   HOSTS_MODIFIED,
@@ -31,16 +27,14 @@ export const HostsModifiedLoader = ({filter, children}) => (
   <Loader
     dataId={HOSTS_MODIFIED}
     filter={filter}
-    load={hostsModifiedLoader}
+    load={hostsModifiedLoadFunc}
     subscriptions={['hosts.timer', 'hosts.changed']}
   >
     {children}
   </Loader>
 );
 
-HostsModifiedLoader.propTypes = loaderPropTypes;
-
-export const hostsSeverityLoader = loadFunc(
+export const hostsSeverityLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.hosts.getSeverityAggregates({filter}).then(r => r.data),
   HOSTS_SEVERITY,
@@ -50,36 +44,33 @@ export const HostsSeverityLoader = ({filter, children}) => (
   <Loader
     dataId={HOSTS_SEVERITY}
     filter={filter}
-    load={hostsSeverityLoader}
+    load={hostsSeverityLoadFunc}
     subscriptions={['hosts.timer', 'hosts.changed']}
   >
     {children}
   </Loader>
 );
 
-HostsSeverityLoader.propTypes = loaderPropTypes;
-
-export const hostsTopologyLoader = loadFunc(({gmp, filter}) => {
+export const hostsTopologyLoadFunc = createLoadFunc(async ({gmp, filter}) => {
   filter = isDefined(filter)
     ? filter.copy().set('rows', MAX_HOSTS)
     : DEFAULT_TOPOLOGY_FILTER;
-  return gmp.hosts.get({filter}).then(r => r.data);
+  const r = await gmp.hosts.get({filter});
+  return r.data;
 }, HOSTS_TOPOLOGY);
 
 export const HostsTopologyLoader = ({filter, children}) => (
   <Loader
     dataId={HOSTS_TOPOLOGY}
     filter={filter}
-    load={hostsTopologyLoader}
+    load={hostsTopologyLoadFunc}
     subscriptions={['hosts.timer', 'hosts.changed']}
   >
     {children}
   </Loader>
 );
 
-HostsTopologyLoader.propTypes = loaderPropTypes;
-
-export const hostsVulnScoreLoader = loadFunc(
+export const hostsVulnScoreLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.hosts
       .getVulnScoreAggregates({filter, max: HOSTS_MAX_GROUPS})
@@ -91,11 +82,9 @@ export const HostsVulnScoreLoader = ({children, filter}) => (
   <Loader
     dataId={HOSTS_VULN_SCORE}
     filter={filter}
-    load={hostsVulnScoreLoader}
-    subscripions={['hosts.timer', 'hosts.changed']}
+    load={hostsVulnScoreLoadFunc}
+    subscriptions={['hosts.timer', 'hosts.changed']}
   >
     {children}
   </Loader>
 );
-
-HostsVulnScoreLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/notes/dashboard/Loaders.tsx
+++ b/src/web/pages/notes/dashboard/Loaders.tsx
@@ -3,17 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 export const NOTES_ACTIVE_DAYS = 'notes-active-days';
 export const NOTES_CREATED = 'notes-created';
-export const NOTES_WORDCOUNT = 'notes-wordcount';
+export const NOTES_WORD_COUNT = 'notes-wordcount';
 
-export const notesActiveDaysLoader = loadFunc(
+export const notesActiveDaysLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.notes.getActiveDaysAggregates({filter}).then(r => r.data),
   NOTES_ACTIVE_DAYS,
@@ -23,16 +19,14 @@ export const NotesActiveDaysLoader = ({filter, children}) => (
   <Loader
     dataId={NOTES_ACTIVE_DAYS}
     filter={filter}
-    load={notesActiveDaysLoader}
+    load={notesActiveDaysLoadFunc}
     subscriptions={['notes.timer', 'notes.changed']}
   >
     {children}
   </Loader>
 );
 
-NotesActiveDaysLoader.propTypes = loaderPropTypes;
-
-export const notesCreatedLoader = loadFunc(
+export const notesCreatedLoadFunc = createLoadFunc(
   ({gmp, filter}) => gmp.notes.getCreatedAggregates({filter}).then(r => r.data),
   NOTES_CREATED,
 );
@@ -41,24 +35,22 @@ export const NotesCreatedLoader = ({filter, children}) => (
   <Loader
     dataId={NOTES_CREATED}
     filter={filter}
-    load={notesCreatedLoader}
+    load={notesCreatedLoadFunc}
     subscriptions={['notes.timer', 'notes.changed']}
   >
     {children}
   </Loader>
 );
 
-NotesCreatedLoader.propTypes = loaderPropTypes;
-
-export const notesWordCountLoader = loadFunc(
+export const notesWordCountLoader = createLoadFunc(
   ({gmp, filter}) =>
     gmp.notes.getWordCountsAggregates({filter}).then(r => r.data),
-  NOTES_WORDCOUNT,
+  NOTES_WORD_COUNT,
 );
 
 export const NotesWordCountLoader = ({filter, children}) => (
   <Loader
-    dataId={NOTES_WORDCOUNT}
+    dataId={NOTES_WORD_COUNT}
     filter={filter}
     load={notesWordCountLoader}
     subscriptions={['notes.timer', 'notes.changed']}
@@ -66,5 +58,3 @@ export const NotesWordCountLoader = ({filter, children}) => (
     {children}
   </Loader>
 );
-
-NotesWordCountLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/nvts/dashboard/Loaders.tsx
+++ b/src/web/pages/nvts/dashboard/Loaders.tsx
@@ -3,11 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 export const NVTS_FAMILY = 'nvt-family';
 export const NVTS_SEVERITY = 'nvt-severity';
@@ -15,7 +11,7 @@ export const NVTS_QOD = 'nvt-qod';
 export const NVTS_QOD_TYPE = 'nvt-qod-type';
 export const NVTS_CREATED = 'nvt-created';
 
-export const nvtFamilyLoader = loadFunc(
+export const nvtFamilyLoadFunc = createLoadFunc(
   ({gmp, filter}) => gmp.nvts.getFamilyAggregates({filter}).then(r => r.data),
   NVTS_FAMILY,
 );
@@ -24,16 +20,14 @@ export const NvtsFamilyLoader = ({filter, children}) => (
   <Loader
     dataId={NVTS_FAMILY}
     filter={filter}
-    load={nvtFamilyLoader}
+    load={nvtFamilyLoadFunc}
     subscriptions={['nvts.timer', 'nvts.changed']}
   >
     {children}
   </Loader>
 );
 
-NvtsFamilyLoader.propTypes = loaderPropTypes;
-
-export const nvtSeverityLoader = loadFunc(
+export const nvtSeverityLoaderFunc = createLoadFunc(
   ({gmp, filter}) => gmp.nvts.getSeverityAggregates({filter}).then(r => r.data),
   NVTS_SEVERITY,
 );
@@ -42,16 +36,14 @@ export const NvtsSeverityLoader = ({filter, children}) => (
   <Loader
     dataId={NVTS_SEVERITY}
     filter={filter}
-    load={nvtSeverityLoader}
+    load={nvtSeverityLoaderFunc}
     subscriptions={['nvts.timer', 'nvts.changed']}
   >
     {children}
   </Loader>
 );
 
-NvtsSeverityLoader.propTypes = loaderPropTypes;
-
-export const nvtQodLoader = loadFunc(
+export const nvtQodLoaderFunc = createLoadFunc(
   ({gmp, filter}) => gmp.nvts.getQodAggregates({filter}).then(r => r.data),
   NVTS_QOD,
 );
@@ -60,16 +52,14 @@ export const NvtsQodLoader = ({filter, children}) => (
   <Loader
     dataId={NVTS_QOD}
     filter={filter}
-    load={nvtQodLoader}
+    load={nvtQodLoaderFunc}
     subscriptions={['nvts.timer', 'nvts.changed']}
   >
     {children}
   </Loader>
 );
 
-NvtsQodLoader.propTypes = loaderPropTypes;
-
-export const nvtQodTypeLoader = loadFunc(
+export const nvtQodTypeLoadFunc = createLoadFunc(
   ({gmp, filter}) => gmp.nvts.getQodTypeAggregates({filter}).then(r => r.data),
   NVTS_QOD_TYPE,
 );
@@ -78,16 +68,14 @@ export const NvtsQodTypeLoader = ({filter, children}) => (
   <Loader
     dataId={NVTS_QOD_TYPE}
     filter={filter}
-    load={nvtQodTypeLoader}
+    load={nvtQodTypeLoadFunc}
     subscriptions={['nvts.timer', 'nvts.changed']}
   >
     {children}
   </Loader>
 );
 
-NvtsQodTypeLoader.propTypes = loaderPropTypes;
-
-export const nvtCreatedLoader = loadFunc(
+export const nvtCreatedLoadFunc = createLoadFunc(
   ({gmp, filter}) => gmp.nvts.getCreatedAggregates({filter}).then(r => r.data),
   NVTS_CREATED,
 );
@@ -96,11 +84,9 @@ export const NvtCreatedLoader = ({filter, children}) => (
   <Loader
     dataId={NVTS_CREATED}
     filter={filter}
-    load={nvtCreatedLoader}
+    load={nvtCreatedLoadFunc}
     subscriptions={['nvts.timer', 'nvts.changed']}
   >
     {children}
   </Loader>
 );
-
-NvtCreatedLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/operatingsystems/dashboard/Loaders.tsx
+++ b/src/web/pages/operatingsystems/dashboard/Loaders.tsx
@@ -3,17 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 export const OSS_SEVERITY = 'oss-severity';
 export const OSS_VULN_SCORE = 'oss-most-vulnerable';
 const OSS_MAX_GROUPS = 10;
 
-export const osAverageSeverityLoader = loadFunc(
+export const osAverageSeverityLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.operatingsystems
       .getAverageSeverityAggregates({filter})
@@ -25,16 +21,14 @@ export const OsAverageSeverityLoader = ({filter, children}) => (
   <Loader
     dataId={OSS_SEVERITY}
     filter={filter}
-    load={osAverageSeverityLoader}
+    load={osAverageSeverityLoadFunc}
     subscriptions={['operatingsystems.timer', 'operatingsystems.changed']}
   >
     {children}
   </Loader>
 );
 
-OsAverageSeverityLoader.propTypes = loaderPropTypes;
-
-export const osVulnScoreLoader = loadFunc(
+export const osVulnScoreLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.operatingsystems
       .getVulnScoreAggregates({filter, max: OSS_MAX_GROUPS})
@@ -46,11 +40,9 @@ export const OsVulnScoreLoader = ({children, filter}) => (
   <Loader
     dataId={OSS_VULN_SCORE}
     filter={filter}
-    load={osVulnScoreLoader}
-    subscripions={['operatingsystems.timer', 'operatingsystems.changed']}
+    load={osVulnScoreLoadFunc}
+    subscriptions={['operatingsystems.timer', 'operatingsystems.changed']}
   >
     {children}
   </Loader>
 );
-
-OsVulnScoreLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/overrides/dashboard/Loaders.tsx
+++ b/src/web/pages/overrides/dashboard/Loaders.tsx
@@ -3,17 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 export const OVERRIDES_ACTIVE_DAYS = 'overrides-active-days';
 export const OVERRIDES_CREATED = 'overrides-created';
-export const OVERRIDES_WORDCOUNT = 'overrides-wordcount';
+export const OVERRIDES_WORD_COUNT = 'overrides-wordcount';
 
-export const overridesActiveDaysLoader = loadFunc(
+export const overridesActiveDaysLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.overrides.getActiveDaysAggregates({filter}).then(r => r.data),
   OVERRIDES_ACTIVE_DAYS,
@@ -23,16 +19,14 @@ export const OverridesActiveDaysLoader = ({filter, children}) => (
   <Loader
     dataId={OVERRIDES_ACTIVE_DAYS}
     filter={filter}
-    load={overridesActiveDaysLoader}
+    load={overridesActiveDaysLoadFunc}
     subscriptions={['overrides.timer', 'overrides.changed']}
   >
     {children}
   </Loader>
 );
 
-OverridesActiveDaysLoader.propTypes = loaderPropTypes;
-
-export const overridesCreatedLoader = loadFunc(
+export const overridesCreatedLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.overrides.getCreatedAggregates({filter}).then(r => r.data),
   OVERRIDES_CREATED,
@@ -42,30 +36,26 @@ export const OverridesCreatedLoader = ({filter, children}) => (
   <Loader
     dataId={OVERRIDES_CREATED}
     filter={filter}
-    load={overridesCreatedLoader}
+    load={overridesCreatedLoadFunc}
     subscriptions={['overrides.timer', 'overrides.changed']}
   >
     {children}
   </Loader>
 );
 
-OverridesCreatedLoader.propTypes = loaderPropTypes;
-
-export const overridesWordCountLoader = loadFunc(
+export const overridesWordCountLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.overrides.getWordCountsAggregates({filter}).then(r => r.data),
-  OVERRIDES_WORDCOUNT,
+  OVERRIDES_WORD_COUNT,
 );
 
 export const OverridesWordCountLoader = ({filter, children}) => (
   <Loader
-    dataId={OVERRIDES_WORDCOUNT}
+    dataId={OVERRIDES_WORD_COUNT}
     filter={filter}
-    load={overridesWordCountLoader}
+    load={overridesWordCountLoadFunc}
     subscriptions={['overrides.timer', 'overrides.changed']}
   >
     {children}
   </Loader>
 );
-
-OverridesWordCountLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/reports/auditdashboard/Loaders.tsx
+++ b/src/web/pages/reports/auditdashboard/Loaders.tsx
@@ -3,28 +3,23 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 export const REPORTS_COMPLIANCE = 'reports-compliance';
 
-export const reportComplianceLoader = loadFunc(
+export const reportComplianceLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.auditreports.getComplianceAggregates({filter}).then(r => r.data),
   REPORTS_COMPLIANCE,
 );
 
-export const ReportCompianceLoader = ({children, filter}) => (
+export const ReportComplianceLoader = ({children, filter}) => (
   <Loader
     dataId={REPORTS_COMPLIANCE}
     filter={filter}
-    load={reportComplianceLoader}
+    load={reportComplianceLoadFunc}
     subscriptions={['reports.timer', 'reports.changed']}
   >
     {children}
   </Loader>
 );
-
-ReportCompianceLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/reports/auditdashboard/StatusDisplay.jsx
+++ b/src/web/pages/reports/auditdashboard/StatusDisplay.jsx
@@ -16,7 +16,7 @@ import {
   percent,
 } from 'web/components/dashboard/display/utils';
 import {registerDisplay} from 'web/components/dashboard/registry';
-import {ReportCompianceLoader} from 'web/pages/reports/auditdashboard/Loaders';
+import {ReportComplianceLoader} from 'web/pages/reports/auditdashboard/Loaders';
 
 const transformStatusData = (data = {}) => {
   const {groups = []} = data;
@@ -51,13 +51,13 @@ export const ReportComplianceDisplay = createDisplay({
       count: tdata.total,
     }),
   filtersFilter: AUDIT_REPORTS_FILTER_FILTER,
-  loaderComponent: ReportCompianceLoader,
+  loaderComponent: ReportComplianceLoader,
 });
 
 export const ReportComplianceTableDisplay = createDisplay({
   chartComponent: DataTable,
   displayComponent: DataTableDisplay,
-  loaderComponent: ReportCompianceLoader,
+  loaderComponent: ReportComplianceLoader,
   dataTransform: transformStatusData,
   dataTitles: [_l('Status'), _l('# of Reports')],
   dataRow: row => [row.label, row.value],

--- a/src/web/pages/reports/dashboard/Loaders.tsx
+++ b/src/web/pages/reports/dashboard/Loaders.tsx
@@ -3,16 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 export const REPORTS_HIGH_RESULTS = 'reports-high-results';
 export const REPORTS_SEVERITY = 'reports-severity';
 
-export const reportsSeverityLoader = loadFunc(
+export const reportsSeverityLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.reports.getSeverityAggregates({filter}).then(r => r.data),
   REPORTS_SEVERITY,
@@ -22,16 +18,14 @@ export const ReportsSeverityLoader = ({filter, children}) => (
   <Loader
     dataId={REPORTS_SEVERITY}
     filter={filter}
-    load={reportsSeverityLoader}
+    load={reportsSeverityLoadFunc}
     subscriptions={['reports.timer', 'reports.changed']}
   >
     {children}
   </Loader>
 );
 
-ReportsSeverityLoader.propTypes = loaderPropTypes;
-
-export const reportsHighResultsLoader = loadFunc(
+export const reportsHighResultsLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.reports.getHighResultsAggregates({filter}).then(r => r.data),
   REPORTS_HIGH_RESULTS,
@@ -41,11 +35,9 @@ export const ReportsHighResultsLoader = ({filter, children}) => (
   <Loader
     dataId={REPORTS_HIGH_RESULTS}
     filter={filter}
-    load={reportsHighResultsLoader}
+    load={reportsHighResultsLoadFunc}
     subscriptions={['reports.timer', 'reports.changed']}
   >
     {children}
   </Loader>
 );
-
-ReportsHighResultsLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/results/dashboard/Loaders.tsx
+++ b/src/web/pages/results/dashboard/Loaders.tsx
@@ -3,17 +3,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 export const RESULTS_DESCRIPTION_WORDCOUNT = 'results-description-wordcount';
 export const RESULTS_SEVERITY = 'results-severity';
-export const RESULTS_WORDCOUNT = 'results-wordcount';
+export const RESULTS_WORD_COUNT = 'results-wordcount';
 
-export const resultsSeverityLoader = loadFunc(
+export const resultsSeverityLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.results.getSeverityAggregates({filter}).then(r => r.data),
   RESULTS_SEVERITY,
@@ -23,35 +19,31 @@ export const ResultsSeverityLoader = ({filter, children}) => (
   <Loader
     dataId={RESULTS_SEVERITY}
     filter={filter}
-    load={resultsSeverityLoader}
+    load={resultsSeverityLoadFunc}
     subscriptions={['results.timer', 'results.changed']}
   >
     {children}
   </Loader>
 );
 
-ResultsSeverityLoader.propTypes = loaderPropTypes;
-
-export const resultsWordCountLoader = loadFunc(
+export const resultsWordCountLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.results.getWordCountsAggregates({filter}).then(r => r.data),
-  RESULTS_WORDCOUNT,
+  RESULTS_WORD_COUNT,
 );
 
 export const ResultsWordCountLoader = ({filter, children}) => (
   <Loader
-    dataId={RESULTS_WORDCOUNT}
+    dataId={RESULTS_WORD_COUNT}
     filter={filter}
-    load={resultsWordCountLoader}
+    load={resultsWordCountLoadFunc}
     subscriptions={['results.timer', 'results.changed']}
   >
     {children}
   </Loader>
 );
 
-ResultsWordCountLoader.propTypes = loaderPropTypes;
-
-export const resultsDescriptionWordCountLoader = loadFunc(
+export const resultsDescriptionWordCountLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.results.getDescriptionWordCountsAggregates({filter}).then(r => r.data),
   RESULTS_DESCRIPTION_WORDCOUNT,
@@ -61,11 +53,9 @@ export const ResultsDescriptionWordCountLoader = ({filter, children}) => (
   <Loader
     dataId={RESULTS_DESCRIPTION_WORDCOUNT}
     filter={filter}
-    load={resultsDescriptionWordCountLoader}
+    load={resultsDescriptionWordCountLoadFunc}
     subscriptions={['results.timer', 'results.changed']}
   >
     {children}
   </Loader>
 );
-
-ResultsDescriptionWordCountLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/tasks/dashboard/Loaders.tsx
+++ b/src/web/pages/tasks/dashboard/Loaders.tsx
@@ -3,29 +3,25 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 export const TASKS_STATUS = 'tasks-status';
 export const TASKS_SEVERITY = 'tasks-severity';
 export const TASKS_SCHEDULES = 'tasks-schedules';
 export const TASKS_HIGH_RESULTS = 'tasks-high-results';
 
-export const tasksStatusLoader = loadFunc(
+export const tasksStatusLoadFunc = createLoadFunc(
   ({gmp, filter}) => gmp.tasks.getStatusAggregates({filter}).then(r => r.data),
   TASKS_STATUS,
 );
 
-export const tasksSeverityLoader = loadFunc(
+export const tasksSeverityLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.tasks.getSeverityAggregates({filter}).then(r => r.data),
   TASKS_SEVERITY,
 );
 
-export const tasksSchedulesLoader = loadFunc(
+export const tasksSchedulesLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.tasks
       .getAll({
@@ -40,7 +36,7 @@ export const tasksSchedulesLoader = loadFunc(
 
 const MAX_HIGH_RESULT_TASKS_COUNT = 10;
 
-export const tasksHighResultsLoader = loadFunc(
+export const tasksHighResultsLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.tasks
       .getHighResultsAggregates({
@@ -55,50 +51,42 @@ export const TaskStatusLoader = ({children, filter}) => (
   <Loader
     dataId={TASKS_STATUS}
     filter={filter}
-    load={tasksStatusLoader}
+    load={tasksStatusLoadFunc}
     subscriptions={['tasks.timer', 'tasks.changed']}
   >
     {children}
   </Loader>
 );
-
-TaskStatusLoader.propTypes = loaderPropTypes;
 
 export const TasksSchedulesLoader = ({children, filter}) => (
   <Loader
     dataId={TASKS_SCHEDULES}
     filter={filter}
-    load={tasksSchedulesLoader}
+    load={tasksSchedulesLoadFunc}
     subscriptions={['tasks.timer', 'tasks.changed']}
   >
     {children}
   </Loader>
 );
-
-TasksSchedulesLoader.propTypes = loaderPropTypes;
 
 export const TasksSeverityLoader = ({children, filter}) => (
   <Loader
     dataId={TASKS_SEVERITY}
     filter={filter}
-    load={tasksSeverityLoader}
+    load={tasksSeverityLoadFunc}
     subscriptions={['tasks.timer', 'tasks.changed']}
   >
     {children}
   </Loader>
 );
-
-TasksSeverityLoader.propTypes = loaderPropTypes;
 
 export const TasksHighResultsLoader = ({children, filter}) => (
   <Loader
     dataId={TASKS_HIGH_RESULTS}
     filter={filter}
-    load={tasksHighResultsLoader}
+    load={tasksHighResultsLoadFunc}
     subscriptions={['tasks.timer', 'tasks.changed']}
   >
     {children}
   </Loader>
 );
-
-TasksHighResultsLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/tickets/dashboard/Loaders.tsx
+++ b/src/web/pages/tickets/dashboard/Loaders.tsx
@@ -3,18 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
 import QueryFilter from 'gmp/models/filter/query-filter';
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 const TICKETS_LIST = 'tickets-list';
 
 const DEFAULT_FILTER = QueryFilter.fromString('sort-reverse=modified');
 
-const ticketsListLoader = loadFunc(
+const ticketsListLoadFunc = createLoadFunc(
   ({gmp, filter = DEFAULT_FILTER}) =>
     gmp.tickets
       .getAll({
@@ -28,11 +24,9 @@ export const TicketsListLoader = ({children, filter}) => (
   <Loader
     dataId={TICKETS_LIST}
     filter={filter}
-    load={ticketsListLoader}
+    load={ticketsListLoadFunc}
     subscriptions={['tickets.timer', 'tickets.changed']}
   >
     {children}
   </Loader>
 );
-
-TicketsListLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/tlscertificates/dashboard/Loaders.tsx
+++ b/src/web/pages/tlscertificates/dashboard/Loaders.tsx
@@ -3,16 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-import Loader, {
-  loadFunc,
-  loaderPropTypes,
-} from 'web/components/dashboard/display/Loader';
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 const TLS_CERTIFICATES_STATUS = 'tls-certificates-status';
 const TLS_CERTIFICATES_MODIFIED = 'tls-certificates-modification-time';
 
-const tlsCertificatesStatusLoader = loadFunc(
+const tlsCertificatesStatusLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.tlscertificates
       .getAll({
@@ -26,16 +22,14 @@ export const TlsCertificatesStatusLoader = ({children, filter}) => (
   <Loader
     dataId={TLS_CERTIFICATES_STATUS}
     filter={filter}
-    load={tlsCertificatesStatusLoader}
+    load={tlsCertificatesStatusLoadFunc}
     subscriptions={['tlscertificates.timer', 'tlscertificates.changed']}
   >
     {children}
   </Loader>
 );
 
-TlsCertificatesStatusLoader.propTypes = loaderPropTypes;
-
-export const tlsCertificatesModifiedLoader = loadFunc(
+export const tlsCertificatesModifiedLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.tlscertificates
       .getModifiedAggregates({
@@ -49,11 +43,9 @@ export const TlsCertificatesModifiedLoader = ({filter, children}) => (
   <Loader
     dataId={TLS_CERTIFICATES_MODIFIED}
     filter={filter}
-    load={tlsCertificatesModifiedLoader}
+    load={tlsCertificatesModifiedLoadFunc}
     subscriptions={['tlscertificates.timer', 'tlscertificates.changed']}
   >
     {children}
   </Loader>
 );
-
-TlsCertificatesModifiedLoader.propTypes = loaderPropTypes;

--- a/src/web/pages/vulnerabilities/dashboard/VulnerabilitiesLoaders.tsx
+++ b/src/web/pages/vulnerabilities/dashboard/VulnerabilitiesLoaders.tsx
@@ -3,61 +3,38 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
-import type Gmp from 'gmp/gmp';
-import {type default as FilterType} from 'gmp/models/filter/filter-type';
-import Loader, {
-  type LoaderRenderProps,
-  loadFunc,
-  type LoadFuncProps,
-} from 'web/components/dashboard/display/Loader';
-
-interface VulnerabilitiesLoaderProps {
-  filter?: FilterType;
-  children: (props: LoaderRenderProps<unknown>) => React.ReactNode;
-}
-
-interface VulnerabilitiesLoadFuncProps extends LoadFuncProps {
-  gmp: Gmp;
-}
+import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 
 export const VULNS_SEVERITY = 'vulns-severity';
 export const VULNS_HOSTS = 'vulns-hosts';
 
-export const vulnerabilitiesSeverityLoader = loadFunc(
-  ({gmp, filter}: VulnerabilitiesLoadFuncProps) =>
+export const vulnerabilitiesSeverityLoadFunc = createLoadFunc(
+  ({gmp, filter}) =>
     gmp.vulns.getSeverityAggregates({filter}).then(r => r.data),
   VULNS_SEVERITY,
 );
 
-export const VulnerabilitiesSeverityLoader = ({
-  filter,
-  children,
-}: VulnerabilitiesLoaderProps) => (
+export const VulnerabilitiesSeverityLoader = ({filter, children}) => (
   <Loader
     dataId={VULNS_SEVERITY}
     filter={filter}
-    load={vulnerabilitiesSeverityLoader}
+    load={vulnerabilitiesSeverityLoadFunc}
     subscriptions={['vulns.timer', 'vulns.changed']}
   >
     {children}
   </Loader>
 );
 
-export const vulnerabilitiesHostsLoader = loadFunc(
-  ({gmp, filter}: {gmp: Gmp; filter: FilterType}) =>
-    gmp.vulns.getHostAggregates({filter}).then(r => r.data),
+export const vulnerabilitiesHostsLoadFunc = createLoadFunc(
+  ({gmp, filter}) => gmp.vulns.getHostAggregates({filter}).then(r => r.data),
   VULNS_HOSTS,
 );
 
-export const VulnerabilitiesHostsLoader = ({
-  filter,
-  children,
-}: VulnerabilitiesLoaderProps) => (
+export const VulnerabilitiesHostsLoader = ({filter, children}) => (
   <Loader
     dataId={VULNS_HOSTS}
     filter={filter}
-    load={vulnerabilitiesHostsLoader}
+    load={vulnerabilitiesHostsLoadFunc}
     subscriptions={['vulns.timer', 'vulns.changed']}
   >
     {children}

--- a/src/web/pages/vulnerabilities/dashboard/VulnerabilitiesLoaders.tsx
+++ b/src/web/pages/vulnerabilities/dashboard/VulnerabilitiesLoaders.tsx
@@ -8,7 +8,7 @@ import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
 export const VULNS_SEVERITY = 'vulns-severity';
 export const VULNS_HOSTS = 'vulns-hosts';
 
-export const vulnerabilitiesSeverityLoadFunc = createLoadFunc(
+const vulnerabilitiesSeverityLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.vulns.getSeverityAggregates({filter}).then(r => r.data),
   VULNS_SEVERITY,
@@ -25,7 +25,7 @@ export const VulnerabilitiesSeverityLoader = ({filter, children}) => (
   </Loader>
 );
 
-export const vulnerabilitiesHostsLoadFunc = createLoadFunc(
+const vulnerabilitiesHostsLoadFunc = createLoadFunc(
   ({gmp, filter}) => gmp.vulns.getHostAggregates({filter}).then(r => r.data),
   VULNS_HOSTS,
 );

--- a/src/web/pages/vulnerabilities/dashboard/__tests__/VulnerabilitiesLoaders.test.tsx
+++ b/src/web/pages/vulnerabilities/dashboard/__tests__/VulnerabilitiesLoaders.test.tsx
@@ -3,22 +3,42 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import type {ReactElement} from 'react';
 import {describe, expect, test, testing} from '@gsa/testing';
+import {rendererWith, waitFor} from 'web/testing';
 import type Gmp from 'gmp/gmp';
 import QueryFilter from 'gmp/models/filter/query-filter';
 import {
+  SubscriptionContext,
+  type SubscribeFunc,
+} from 'web/components/provider/SubscriptionProvider';
+import {
+  VulnerabilitiesHostsLoader,
+  VulnerabilitiesSeverityLoader,
   VULNS_HOSTS,
   VULNS_SEVERITY,
-  vulnerabilitiesHostsLoadFunc,
-  vulnerabilitiesSeverityLoadFunc,
 } from 'web/pages/vulnerabilities/dashboard/VulnerabilitiesLoaders';
-import {
-  DASHBOARD_DATA_LOADING_ERROR,
-  DASHBOARD_DATA_LOADING_REQUEST,
-  DASHBOARD_DATA_LOADING_SUCCESS,
-} from 'web/store/dashboard/data/actions';
 
-const createGmp = (vulns: Partial<Gmp['vulns']>) => ({vulns}) as unknown as Gmp;
+const createGmp = (vulns: Partial<Gmp['vulns']>) =>
+  ({vulns}) as unknown as Record<string, unknown>;
+
+const renderWithSubscriptionContext = ({
+  gmp,
+  subscribe,
+  children,
+}: {
+  gmp: Record<string, unknown>;
+  subscribe: SubscribeFunc;
+  children: ReactElement;
+}) => {
+  const {render} = rendererWith({gmp, store: true});
+
+  return render(
+    <SubscriptionContext.Provider value={subscribe}>
+      {children}
+    </SubscriptionContext.Provider>,
+  );
+};
 
 describe('Vulnerabilities Loaders', () => {
   test('should export severity data ID', () => {
@@ -29,105 +49,63 @@ describe('Vulnerabilities Loaders', () => {
     expect(VULNS_HOSTS).toBe('vulns-hosts');
   });
 
-  test('should export vulnerabilitiesSeverityLoader as a function', () => {
-    expect(typeof vulnerabilitiesSeverityLoadFunc).toBe('function');
-  });
-
-  test('should export vulnerabilitiesHostsLoader as a function', () => {
-    expect(typeof vulnerabilitiesHostsLoadFunc).toBe('function');
-  });
-
-  test('vulnerabilitiesSeverityLoader should load and dispatch severity aggregates', () => {
+  test('should load severity aggregates and render them', async () => {
     const data = [{value: 5, count: 10}];
     const mockGetSeverityAggregates = testing.fn().mockResolvedValue({data});
     const gmp = createGmp({getSeverityAggregates: mockGetSeverityAggregates});
     const filter = QueryFilter.fromString('first=1 rows=10');
-    const dispatch = testing.fn();
-    const getState = testing.fn();
+    const subscribe = testing.fn().mockReturnValue(testing.fn());
+    const children = testing.fn().mockReturnValue(null);
 
-    return vulnerabilitiesSeverityLoadFunc({gmp, filter})(
-      dispatch,
-      getState,
-    ).then(() => {
+    renderWithSubscriptionContext({
+      gmp,
+      subscribe,
+      children: (
+        <VulnerabilitiesSeverityLoader filter={filter}>
+          {children}
+        </VulnerabilitiesSeverityLoader>
+      ),
+    });
+
+    await waitFor(() => {
       expect(mockGetSeverityAggregates).toHaveBeenCalledWith({filter});
-      expect(dispatch).toHaveBeenNthCalledWith(1, {
-        type: DASHBOARD_DATA_LOADING_REQUEST,
-        id: VULNS_SEVERITY,
-        filter,
-      });
-      expect(dispatch).toHaveBeenNthCalledWith(2, {
-        type: DASHBOARD_DATA_LOADING_SUCCESS,
-        id: VULNS_SEVERITY,
-        filter,
-        data,
-      });
+      expect(children).toHaveBeenLastCalledWith({data, isLoading: false});
     });
+
+    expect(subscribe).toHaveBeenCalledWith('vulns.timer', expect.any(Function));
+    expect(subscribe).toHaveBeenCalledWith(
+      'vulns.changed',
+      expect.any(Function),
+    );
   });
 
-  test('vulnerabilitiesSeverityLoader should dispatch an error when loading fails', () => {
-    const error = new Error('An error');
-    const mockGetSeverityAggregates = testing.fn().mockRejectedValue(error);
-    const gmp = createGmp({getSeverityAggregates: mockGetSeverityAggregates});
-    const filter = QueryFilter.fromString('first=1 rows=10');
-    const dispatch = testing.fn();
-    const getState = testing.fn();
-
-    return vulnerabilitiesSeverityLoadFunc({gmp, filter})(
-      dispatch,
-      getState,
-    ).then(() => {
-      expect(dispatch).toHaveBeenNthCalledWith(2, {
-        type: DASHBOARD_DATA_LOADING_ERROR,
-        id: VULNS_SEVERITY,
-        filter,
-        error,
-      });
-    });
-  });
-
-  test('vulnerabilitiesHostsLoader should load and dispatch host aggregates', () => {
+  test('should load host aggregates and render them', async () => {
     const data = [{value: 1, count: 5}];
     const mockGetHostAggregates = testing.fn().mockResolvedValue({data});
     const gmp = createGmp({getHostAggregates: mockGetHostAggregates});
     const filter = QueryFilter.fromString('first=1 rows=10');
-    const dispatch = testing.fn();
-    const getState = testing.fn();
+    const subscribe = testing.fn().mockReturnValue(testing.fn());
+    const children = testing.fn().mockReturnValue(null);
 
-    return vulnerabilitiesHostsLoadFunc({gmp, filter})(dispatch, getState).then(
-      () => {
-        expect(mockGetHostAggregates).toHaveBeenCalledWith({filter});
-        expect(dispatch).toHaveBeenNthCalledWith(1, {
-          type: DASHBOARD_DATA_LOADING_REQUEST,
-          id: VULNS_HOSTS,
-          filter,
-        });
-        expect(dispatch).toHaveBeenNthCalledWith(2, {
-          type: DASHBOARD_DATA_LOADING_SUCCESS,
-          id: VULNS_HOSTS,
-          filter,
-          data,
-        });
-      },
-    );
-  });
+    renderWithSubscriptionContext({
+      gmp,
+      subscribe,
+      children: (
+        <VulnerabilitiesHostsLoader filter={filter}>
+          {children}
+        </VulnerabilitiesHostsLoader>
+      ),
+    });
 
-  test('vulnerabilitiesHostsLoader should dispatch an error when loading fails', () => {
-    const error = new Error('An error');
-    const mockGetHostAggregates = testing.fn().mockRejectedValue(error);
-    const gmp = createGmp({getHostAggregates: mockGetHostAggregates});
-    const filter = QueryFilter.fromString('first=1 rows=10');
-    const dispatch = testing.fn();
-    const getState = testing.fn();
+    await waitFor(() => {
+      expect(mockGetHostAggregates).toHaveBeenCalledWith({filter});
+      expect(children).toHaveBeenLastCalledWith({data, isLoading: false});
+    });
 
-    return vulnerabilitiesHostsLoadFunc({gmp, filter})(dispatch, getState).then(
-      () => {
-        expect(dispatch).toHaveBeenNthCalledWith(2, {
-          type: DASHBOARD_DATA_LOADING_ERROR,
-          id: VULNS_HOSTS,
-          filter,
-          error,
-        });
-      },
+    expect(subscribe).toHaveBeenCalledWith('vulns.timer', expect.any(Function));
+    expect(subscribe).toHaveBeenCalledWith(
+      'vulns.changed',
+      expect.any(Function),
     );
   });
 });

--- a/src/web/pages/vulnerabilities/dashboard/__tests__/VulnerabilitiesLoaders.test.tsx
+++ b/src/web/pages/vulnerabilities/dashboard/__tests__/VulnerabilitiesLoaders.test.tsx
@@ -9,8 +9,8 @@ import QueryFilter from 'gmp/models/filter/query-filter';
 import {
   VULNS_HOSTS,
   VULNS_SEVERITY,
-  vulnerabilitiesHostsLoader,
-  vulnerabilitiesSeverityLoader,
+  vulnerabilitiesHostsLoadFunc,
+  vulnerabilitiesSeverityLoadFunc,
 } from 'web/pages/vulnerabilities/dashboard/VulnerabilitiesLoaders';
 import {
   DASHBOARD_DATA_LOADING_ERROR,
@@ -30,11 +30,11 @@ describe('Vulnerabilities Loaders', () => {
   });
 
   test('should export vulnerabilitiesSeverityLoader as a function', () => {
-    expect(typeof vulnerabilitiesSeverityLoader).toBe('function');
+    expect(typeof vulnerabilitiesSeverityLoadFunc).toBe('function');
   });
 
   test('should export vulnerabilitiesHostsLoader as a function', () => {
-    expect(typeof vulnerabilitiesHostsLoader).toBe('function');
+    expect(typeof vulnerabilitiesHostsLoadFunc).toBe('function');
   });
 
   test('vulnerabilitiesSeverityLoader should load and dispatch severity aggregates', () => {
@@ -45,7 +45,7 @@ describe('Vulnerabilities Loaders', () => {
     const dispatch = testing.fn();
     const getState = testing.fn();
 
-    return vulnerabilitiesSeverityLoader({gmp, filter})(
+    return vulnerabilitiesSeverityLoadFunc({gmp, filter})(
       dispatch,
       getState,
     ).then(() => {
@@ -72,7 +72,7 @@ describe('Vulnerabilities Loaders', () => {
     const dispatch = testing.fn();
     const getState = testing.fn();
 
-    return vulnerabilitiesSeverityLoader({gmp, filter})(
+    return vulnerabilitiesSeverityLoadFunc({gmp, filter})(
       dispatch,
       getState,
     ).then(() => {
@@ -93,7 +93,7 @@ describe('Vulnerabilities Loaders', () => {
     const dispatch = testing.fn();
     const getState = testing.fn();
 
-    return vulnerabilitiesHostsLoader({gmp, filter})(dispatch, getState).then(
+    return vulnerabilitiesHostsLoadFunc({gmp, filter})(dispatch, getState).then(
       () => {
         expect(mockGetHostAggregates).toHaveBeenCalledWith({filter});
         expect(dispatch).toHaveBeenNthCalledWith(1, {
@@ -119,7 +119,7 @@ describe('Vulnerabilities Loaders', () => {
     const dispatch = testing.fn();
     const getState = testing.fn();
 
-    return vulnerabilitiesHostsLoader({gmp, filter})(dispatch, getState).then(
+    return vulnerabilitiesHostsLoadFunc({gmp, filter})(dispatch, getState).then(
       () => {
         expect(dispatch).toHaveBeenNthCalledWith(2, {
           type: DASHBOARD_DATA_LOADING_ERROR,


### PR DESCRIPTION
## What

Dashboard data loader function improvements
* Add gmp type to loader function props
* Rename loadFunc function to createLoadFunc
* Refactor tests for Vulnerabilities loaders
* Fix reloading of a host and operating system chart when data changes
* Remove obsolete loaderPropTypes

## Why

* All data loader functions require the gmp object
* Make naming more consistent and understandable
* Ensure the public API is tested. The public API are the Loader components and not the loader functions

## References
https://jira.greenbone.net/browse/GEA-2019
Requires https://github.com/greenbone/gsa/pull/5557
## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


