### PR TITLE
Declare correct filter type for task.getHighResultsAggregates 

### DIFF
--- a/src/gmp/commands/tasks.ts
+++ b/src/gmp/commands/tasks.ts
@@ -97,7 +97,7 @@ class TasksCommand extends EntitiesCommand<Task, GetTasksResponse> {
   getHighResultsAggregates({
     filter,
     max,
-  }: {filter?: Filter; max?: number} = {}) {
+  }: {filter?: FilterType; max?: number} = {}) {
     return this.getAggregates({
       filter,
       aggregate_type: 'task',


### PR DESCRIPTION


## What

Declare correct filter type for task.getHighResultsAggregates

## Why

We don't require a Filter anymore. It's a FilterType now.

