### PR TITLE
fix: Add translations for "Open manual" in multiple languages and crete AppHeaderTranslations module

### DIFF
--- a/public/locales/gsa-de.json
+++ b/public/locales/gsa-de.json
@@ -1490,6 +1490,7 @@
   "Open": "Offen",
   "Open all details": "Alle Details öffnen",
   "Open End": "Offenes Ende",
+  "Open manual": "Handbuch öffnen",
   "Opened": "Eröffnet",
   "OPENVAS SCAN": "OPENVAS SCAN",
   "OpenVAS Scanner": "OpenVAS-Scanner",

--- a/public/locales/gsa-en.json
+++ b/public/locales/gsa-en.json
@@ -1490,6 +1490,7 @@
   "Open": "Open",
   "Open all details": "Open all details",
   "Open End": "Open End",
+  "Open manual": "Open manual",
   "Opened": "Opened",
   "OPENVAS SCAN": "OPENVAS SCAN",
   "OpenVAS Scanner": "OpenVAS Scanner",

--- a/public/locales/gsa-it.json
+++ b/public/locales/gsa-it.json
@@ -1490,6 +1490,7 @@
   "Open": "Aperto",
   "Open all details": "Apri tutti i dettagli",
   "Open End": "Fine aperta",
+  "Open manual": "Apri manuale",
   "Opened": "Aperto",
   "OPENVAS SCAN": "OPENVAS SCAN",
   "OpenVAS Scanner": "OpenVAS Scanner",

--- a/public/locales/gsa-ja.json
+++ b/public/locales/gsa-ja.json
@@ -1490,6 +1490,7 @@
   "Open": "オープン",
   "Open all details": "すべての詳細を開く",
   "Open End": "無期限",
+  "Open manual": "",
   "Opened": "オープン済み",
   "OPENVAS SCAN": "OPENVASスキャン",
   "OpenVAS Scanner": "OpenVASスキャナー",

--- a/public/locales/gsa-zh_CN.json
+++ b/public/locales/gsa-zh_CN.json
@@ -1490,6 +1490,7 @@
   "Open": "打开",
   "Open all details": "打开所有详情",
   "Open End": "开放式",
+  "Open manual": "",
   "Opened": "已打开",
   "OPENVAS SCAN": "OPENVAS扫描",
   "OpenVAS Scanner": "OpenVAS 扫描器",

--- a/public/locales/gsa-zh_TW.json
+++ b/public/locales/gsa-zh_TW.json
@@ -1490,6 +1490,7 @@
   "Open": "開啟",
   "Open all details": "",
   "Open End": "",
+  "Open manual": "",
   "Opened": "已開啟",
   "OPENVAS SCAN": "",
   "OpenVAS Scanner": "OpenVAS 掃描器",

--- a/src/web/components/structure/app-header-translations.ts
+++ b/src/web/components/structure/app-header-translations.ts
@@ -1,0 +1,11 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import _ from 'gmp/locale';
+
+// Keep translations used internally by external UI components visible to the extractor.
+export const appHeaderTranslations = {
+  openManual: _('Open manual'),
+};


### PR DESCRIPTION
## What

- fix: Add translations for "Open manual" in multiple languages.

## Why

- Always showed in English.

## References

GEA-1654

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


