### PR TITLE
GEA-2038

### DIFF
--- a/src/web/components/icon/GreenboneApplianceLogo.tsx
+++ b/src/web/components/icon/GreenboneApplianceLogo.tsx
@@ -39,7 +39,7 @@ const LazyIconWrapper = ({
     <DynamicIcon
       dataTestId={testId}
       icon={Icon}
-      size={['150px', '150px']}
+      size={['150px', '40px']}
       {...props}
     />
   );

--- a/src/web/components/structure/__tests__/Header.test.tsx
+++ b/src/web/components/structure/__tests__/Header.test.tsx
@@ -54,6 +54,11 @@ describe('Header tests', () => {
     await waitFor(() => {
       const logo = screen.getByTestId('Enterprise150');
       expect(logo).toBeVisible();
+
+      const logoLink = screen.getByTestId('header-logo-link');
+      expect(logoLink).toHaveAttribute('href', '/dashboards');
+      expect(logoLink.querySelector('svg')).toHaveAttribute('width', '150px');
+      expect(logoLink.querySelector('svg')).toHaveAttribute('height', '40px');
     });
 
     const manualLink = screen.getByTestId('manual-link');


### PR DESCRIPTION
## What

- The header logo dimensions, exceed the header height, and overlapping the `Dashboard` link in the menu. 

## Why

- When user clicks on the Menu>Dashboard, actually clicks on the header logo, which being an <a> tag reloads the whole page.

## References

GEA-2038

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


