### PR TITLE
Fix: do not deselect every NVT when the families are not loaded yet

### DIFF
--- a/src/web/pages/scanconfigs/ScanConfigEditDialog.tsx
+++ b/src/web/pages/scanconfigs/ScanConfigEditDialog.tsx
@@ -296,8 +296,16 @@ const ScanConfigEditDialog = ({
     );
   }, [familySelectionUpdate]);
 
-  // trend and select are created only once and only after the whole config is loaded
-  if (!isDefined(trendValues) && !isDefined(selectValues) && !isLoadingConfig) {
+  // trend and select are created only once, and only after the config and the
+  // list of families have both arrived. Without the families the selection
+  // covers no family at all, and saving such a selection deselects every NVT.
+  if (
+    !isDefined(trendValues) &&
+    !isDefined(selectValues) &&
+    !isLoadingConfig &&
+    !isLoadingFamilies &&
+    isDefined(families)
+  ) {
     const {trend, select} = createTrendAndSelect(configFamilies, families);
     setTrendValues(trend);
     setSelectValues(select);
@@ -307,12 +315,21 @@ const ScanConfigEditDialog = ({
     scannerId,
   };
 
+  // While the selection is unknown the family part of the form is left out of
+  // the request. The backend reads a missing selection as "no family selected"
+  // and would drop every NVT of the config.
+  const hasFamilySelection = isDefined(trendValues) && isDefined(selectValues);
+
   const controlledData = {
     id: configId,
     scannerPreferenceValues,
-    select: selectValues,
-    trend: trendValues,
-    familyTrend: configFamiliesTrend,
+    ...(hasFamilySelection
+      ? {
+          select: selectValues,
+          trend: trendValues,
+          familyTrend: configFamiliesTrend,
+        }
+      : {}),
   };
 
   const notification =

--- a/src/web/pages/scanconfigs/__tests__/ScanConfigEditDialog.test.tsx
+++ b/src/web/pages/scanconfigs/__tests__/ScanConfigEditDialog.test.tsx
@@ -308,6 +308,76 @@ describe('ScanConfigEditDialog tests', () => {
     });
   });
 
+  test('should not send a family selection before the families are loaded', () => {
+    const handleClose = testing.fn();
+    const handleSave = testing.fn();
+
+    // The config and the family list are fetched in parallel. When the config
+    // arrives first the family list is still undefined, and a selection built
+    // from it would cover no family at all - which the backend reads as
+    // "deselect every NVT".
+    const props = {
+      comment: 'bar',
+      configFamilies,
+      configId: 'c1',
+      editNvtDetailsTitle: 'Edit Scan Config NVT Details',
+      editNvtFamiliesTitle: 'Edit Scan Config Family',
+      isLoadingScanners: false,
+      name: 'Config',
+      nvtPreferences,
+      scannerPreferences,
+      title: 'Edit Scan Config',
+      onClose: handleClose,
+      onSave: handleSave,
+    };
+
+    const {render} = rendererWith({capabilities: true, router: true});
+    const {rerender} = render(
+      <ScanConfigEditDialog
+        {...props}
+        isLoadingConfig={false}
+        isLoadingFamilies={true}
+      />,
+    );
+
+    fireEvent.click(screen.getDialogSaveButton());
+
+    expect(handleSave).toHaveBeenCalledWith({
+      comment: 'bar',
+      id: 'c1',
+      name: 'Config',
+      scannerId: undefined,
+      scannerPreferenceValues: {
+        scannerpref0: 0,
+      },
+    });
+
+    handleSave.mockClear();
+
+    rerender(
+      <ScanConfigEditDialog
+        {...props}
+        families={families}
+        isLoadingConfig={false}
+        isLoadingFamilies={false}
+      />,
+    );
+
+    fireEvent.click(screen.getDialogSaveButton());
+
+    expect(handleSave).toHaveBeenCalledWith({
+      comment: 'bar',
+      id: 'c1',
+      name: 'Config',
+      scannerId: undefined,
+      scannerPreferenceValues: {
+        scannerpref0: 0,
+      },
+      select,
+      trend,
+    });
+  });
+
   test('should allow to close the dialog', () => {
     const handleClose = testing.fn();
     const handleSave = testing.fn();


### PR DESCRIPTION
## What

- Build `trend` and `select` in `ScanConfigEditDialog` only once the scan config **and** the NVT family list have both arrived.
- Leave `select`, `trend` and `familyTrend` out of the save request while that selection is still unknown.

## Why

Both requests run in parallel. If the config arrives first, `families` is still undefined, the selection is built empty and never rebuilt. Saving then sends a family selection that covers no family at all, which gvmd reads as "deselect everything", so every fully selected family of the config is cleared.

## References

Split out of #5544, which mixed this fix with an unrelated change.

## Checklist

- [x] Tests
