### PR TITLE
GEA-1753

### DIFF
--- a/src/gmp/models/task.ts
+++ b/src/gmp/models/task.ts
@@ -283,6 +283,7 @@ export const TASK_STATUS = {
   uploading: 'Uploading',
   uploadinginterrupted: 'Uploading Interrupted',
   processing: 'Processing',
+  noresults: 'No results available',
   done: 'Done',
   unknown: 'Unknown',
 } as const;
@@ -307,6 +308,7 @@ const TASK_STATUS_TRANSLATIONS = {
   Done: _l('Done'),
   Queued: _l('Queued'),
   Processing: _l('Processing'),
+  'No results available': _l('No results available'),
   'Uploading Interrupted': _l('Interrupted'),
   Unknown: _l('Unknown'),
 } as const;

--- a/src/web/components/bar/StatusBar.tsx
+++ b/src/web/components/bar/StatusBar.tsx
@@ -34,6 +34,7 @@ const StatusBar = ({
     status === TASK_STATUS.unknown ||
     status === TASK_STATUS.new ||
     status === TASK_STATUS.done ||
+    status === TASK_STATUS.noresults ||
     status === TASK_STATUS.import ||
     status === TASK_STATUS.stoprequested ||
     status === TASK_STATUS.deleterequested ||
@@ -67,7 +68,8 @@ const StatusBar = ({
   } else if (
     status === TASK_STATUS.uploading ||
     status === TASK_STATUS.import ||
-    status === TASK_STATUS.done
+    status === TASK_STATUS.done ||
+    status === TASK_STATUS.noresults
   ) {
     background = BACKGROUND_STATES.LOW;
   } else if (status === TASK_STATUS.new) {

--- a/src/web/pages/tasks/TaskStatus.tsx
+++ b/src/web/pages/tasks/TaskStatus.tsx
@@ -24,6 +24,15 @@ const StyledDetailsLink = styled(DetailsLink)`
 const isTask = (taskOrAudit: Task | Audit): taskOrAudit is Task =>
   (taskOrAudit as Task).usageType === USAGE_TYPE.scan;
 
+const hasNoScanResults = (task: Task) => {
+  const resultCount = task.last_report?.result_count;
+  return (
+    !isDefined(task.last_report) ||
+    (isDefined(resultCount) &&
+      Object.values(resultCount).every(count => count === 0))
+  );
+};
+
 const TaskStatus = ({task, links = true}: TaskStatusProps) => {
   let report_id: string | undefined;
   if (isDefined(task.current_report)) {
@@ -35,25 +44,33 @@ const TaskStatus = ({task, links = true}: TaskStatusProps) => {
     links = false;
   }
   const isImport = task.isImport();
+  const status =
+    isTask(task) &&
+    task.isAgent() &&
+    task.status === TASK_STATUS.done &&
+    hasNoScanResults(task)
+      ? TASK_STATUS.noresults
+      : task.status;
+  let statusBarStatus = status;
+  if (isImport) {
+    if (status === TASK_STATUS.interrupted) {
+      statusBarStatus = TASK_STATUS.uploadinginterrupted;
+    } else if (
+      status === TASK_STATUS.running ||
+      status === TASK_STATUS.processing
+    ) {
+      statusBarStatus = TASK_STATUS.processing;
+    } else {
+      statusBarStatus = TASK_STATUS.import;
+    }
+  }
   return (
     <StyledDetailsLink
       id={report_id}
       textOnly={!links}
       type={isTask(task) ? 'report' : 'auditreport'}
     >
-      <StatusBar
-        progress={task.progress}
-        status={
-          isImport
-            ? task.status === TASK_STATUS.interrupted
-              ? TASK_STATUS.uploadinginterrupted
-              : task.status === TASK_STATUS.running ||
-                  task.status === TASK_STATUS.processing
-                ? TASK_STATUS.processing
-                : TASK_STATUS.import
-            : task.status
-        }
-      />
+      <StatusBar progress={task.progress} status={statusBarStatus} />
     </StyledDetailsLink>
   );
 };

--- a/src/web/pages/tasks/__tests__/TaskDetailsPage.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskDetailsPage.test.tsx
@@ -242,6 +242,44 @@ const createGmp = ({
 });
 
 describe('TaskDetailsPage tests', () => {
+  test('should display no results available for an agent task without findings', () => {
+    const gmp = createGmp();
+    const agentTask = Task.fromElement({
+      _id: 'agent-task-id',
+      owner: {name: 'admin'},
+      name: 'agent task',
+      status: TASK_STATUS.done,
+      agent_group: {_id: 'agent-group-id'},
+      last_report: {
+        report: {
+          _id: 'empty-report-id',
+          result_count: {
+            high: 0,
+            medium: 0,
+            low: 0,
+            log: 0,
+            false_positive: 0,
+          },
+          severity: -99,
+        },
+      },
+    });
+
+    const {render, store} = rendererWith({
+      gmp,
+      capabilities: true,
+      router: true,
+      store: true,
+    });
+
+    store.dispatch(entityLoadingActions.success(agentTask.id, agentTask));
+
+    render(<TaskDetailsPage id={agentTask.id} />);
+
+    const progressBar = screen.getByTestId('progressbar-box');
+    expect(progressBar).toHaveTextContent('No results available');
+  });
+
   test('should render full DetailsPage', () => {
     const gmp = createGmp();
 

--- a/src/web/pages/tasks/__tests__/TaskStatus.test.tsx
+++ b/src/web/pages/tasks/__tests__/TaskStatus.test.tsx
@@ -51,6 +51,54 @@ describe('TaskStatus tests', () => {
     expect(detailslink).toHaveAttribute('href', '/report/42');
   });
 
+  test('should render no scan results yet for an agent task with an empty report', () => {
+    const task = Task.fromElement({
+      _id: 'test-id',
+      status: TASK_STATUS.done,
+      alterable: 0,
+      permissions: {permission: [{name: 'everything'}]},
+      target: {_id: 'id', name: 'target'},
+      agent_group: {_id: 'agent-group-id'},
+      last_report: {
+        report: {
+          _id: 'report-id',
+          result_count: {
+            false_positive: 0,
+            high: 0,
+            log: 0,
+            low: 0,
+            medium: 0,
+          },
+          severity: -99,
+        },
+      },
+    });
+
+    const {render} = rendererWith({capabilities: true});
+    render(<Status task={task} />);
+
+    const bar = screen.getByTestId('progressbar-box');
+    expect(bar).toHaveAttribute('title', TASK_STATUS.noresults);
+    expect(bar).toHaveTextContent(TASK_STATUS.noresults);
+  });
+
+  test('should render done for a regular task without a report', () => {
+    const task = Task.fromElement({
+      _id: 'test-id',
+      status: TASK_STATUS.done,
+      alterable: 0,
+      permissions: {permission: [{name: 'everything'}]},
+      target: {_id: 'id', name: 'target'},
+    });
+
+    const {render} = rendererWith({capabilities: true});
+    render(<Status task={task} />);
+
+    const bar = screen.getByTestId('progressbar-box');
+    expect(bar).toHaveAttribute('title', TASK_STATUS.done);
+    expect(bar).toHaveTextContent(TASK_STATUS.done);
+  });
+
   test('should render with current report', () => {
     const task = Task.fromElement({
       _id: 'test-id',


### PR DESCRIPTION
## What

- add: no result status bar for agent tasks

## Why

- In some cases when initializing agents tasks the status done is shown which is misleading.

## References

GEA-1753

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


