### PR TITLE
Fix flacky test when using the searchbar in the ScanConfigEditDialog

### DIFF
--- a/src/web/pages/scanconfigs/__tests__/ScanConfigEditDialog.test.tsx
+++ b/src/web/pages/scanconfigs/__tests__/ScanConfigEditDialog.test.tsx
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {describe, test, expect, testing} from '@gsa/testing';
+import {afterEach, describe, test, expect, testing} from '@gsa/testing';
 import {
   changeInputValue,
   screen,
   within,
   rendererWith,
   fireEvent,
-  waitFor,
+  act,
 } from 'web/testing';
 import {type NvtFamily} from 'gmp/commands/nvt-families';
 import {
@@ -120,6 +120,8 @@ const scannerPreferences = [
 ];
 
 describe('ScanConfigEditDialog tests', () => {
+  afterEach(() => testing.useRealTimers());
+
   test('should render dialog', () => {
     const handleClose = testing.fn();
     const handleSave = testing.fn();
@@ -696,6 +698,8 @@ describe('ScanConfigEditDialog tests', () => {
   });
 
   test('should filter items based on search query', async () => {
+    testing.useFakeTimers();
+
     const handleClose = testing.fn();
     const handleSave = testing.fn();
     const handleOpenEditConfigFamilyDialog = testing.fn();
@@ -731,11 +735,11 @@ describe('ScanConfigEditDialog tests', () => {
 
     expect(searchBar).toHaveValue('family4');
 
-    await waitFor(() => {
-      const rows = screen.getAllByRole('row');
-      expect(rows).toHaveLength(2);
-      expect(rows[1]).toHaveTextContent('family4');
-    });
+    await act(async () => testing.runAllTimers());
+
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toHaveTextContent('family4');
 
     const familyTwo = screen.queryByText('family2');
     expect(familyTwo).not.toBeInTheDocument();


### PR DESCRIPTION

## What

Fix flacky test when using the searchbar in the ScanConfigEditDialog

## Why


When running the tests in parallel using the searchbar in the ScanConfigEditDialog could return the wrong count of displayed rows. Because the timers run in real time and due to concurrency the number of rows might be different. Therefore use fake timers when interacting with the searchbar to always get the expected results.


## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


