### PR TITLE
Add additional oxlint rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,7 +1,14 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["react", "typescript", "import", "vitest"],
-  "jsPlugins": ["./lint-script/oxlint-plugin.js"],
+  "plugins": [
+    "react",
+    "typescript",
+    "import",
+    "vitest"
+  ],
+  "jsPlugins": [
+    "./lint-script/oxlint-plugin.js"
+  ],
   "rules": {
     "gsa/camelcase": "warn",
     "gsa/filename-convention": "warn",
@@ -9,7 +16,8 @@
     "gsa/jsx-sort-props": "warn",
     "gsa/no-dynamic-i18n": "error",
     "gsa/no-restricted-imports": "warn",
-    "gsa/ts-definitions-top": "warn"
+    "gsa/ts-definitions-top": "warn",
+    "typescript/consistent-type-imports": "error"
   },
   "ignorePatterns": [
     "build/**",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -17,7 +17,27 @@
     "gsa/no-dynamic-i18n": "error",
     "gsa/no-restricted-imports": "warn",
     "gsa/ts-definitions-top": "warn",
-    "typescript/consistent-type-imports": "error"
+    "typescript/consistent-type-imports": "error",
+    "typescript/restrict-template-expressions": [
+      "error",
+      {
+        "allow": [
+          {
+            "from": "lib",
+            "name": [
+              "Error",
+              "URL",
+              "URLSearchParams"
+            ]
+          },
+          {
+            "from": "file",
+            "name": "ToString",
+            "path": "./src/gmp/types.ts"
+          }
+        ]
+      }
+    ]
   },
   "ignorePatterns": [
     "build/**",

--- a/lint-script/header.js
+++ b/lint-script/header.js
@@ -4,7 +4,7 @@
  */
 
 const headerPattern =
-  /^\/\* SPDX-FileCopyrightText: \d{4} Greenbone AG\n \*\n \* SPDX-License-Identifier: AGPL-3\.0-or-later\n \*\//;
+  /^(?:#![^\r\n]*\r?\n)?\/\* SPDX-FileCopyrightText: \d{4} Greenbone AG\n \*\n \* SPDX-License-Identifier: AGPL-3\.0-or-later\n \*\//;
 
 export default {
   meta: {

--- a/oxlint-baseline.json
+++ b/oxlint-baseline.json
@@ -2835,18 +2835,6 @@
       "fingerprint": "src/web/components/chart/WordCloudChart.tsx|typescript(require-array-sort-compare)|Require 'compare' argument.|16|let values = data.map(d => d.value).sort();"
     },
     {
-      "filename": "src/web/components/dashboard/DashboardControls.tsx",
-      "code": "typescript(restrict-template-expressions)",
-      "message": "Invalid type used in template literal expression.",
-      "location": {
-        "line": 83,
-        "column": 15,
-        "offset": 2100
-      },
-      "sourceLine": "label: `${display.title}`,",
-      "fingerprint": "src/web/components/dashboard/DashboardControls.tsx|typescript(restrict-template-expressions)|Invalid type used in template literal expression.|15|label: `${display.title}`,"
-    },
-    {
       "filename": "src/web/components/dashboard/DashboardView.tsx",
       "code": "react(refs)",
       "message": "Cannot access refs during render",

--- a/scripts/lint-with-baseline.mjs
+++ b/scripts/lint-with-baseline.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/* SPDX-FileCopyrightText: 2024 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 
 import {readFile, writeFile} from 'node:fs/promises';
 import {dirname, resolve} from 'node:path';
@@ -34,9 +38,7 @@ const runOxlint = () =>
       stderr += chunk;
     });
     child.on('error', reject);
-    child.on('close', exitCode =>
-      resolvePromise({exitCode, stdout, stderr}),
-    );
+    child.on('close', exitCode => resolvePromise({exitCode, stdout, stderr}));
   });
 
 const getLocation = diagnostic => {
@@ -145,12 +147,18 @@ if (update) {
 
 const baseline = await loadBaseline();
 const current = new Map(diagnostics.map(item => [item.fingerprint, item]));
-const newDiagnostics = diagnostics.filter(item => !baseline.has(item.fingerprint));
+const newDiagnostics = diagnostics.filter(
+  item => !baseline.has(item.fingerprint),
+);
 const staleDiagnostics = [...baseline.values()].filter(
   item => !current.has(item.fingerprint),
 );
 
-if (newDiagnostics.length > 0 || staleDiagnostics.length > 0 || exitCode !== 0) {
+if (
+  newDiagnostics.length > 0 ||
+  staleDiagnostics.length > 0 ||
+  exitCode !== 0
+) {
   if (newDiagnostics.length > 0) {
     console.error(`\nNew Oxlint diagnostics (${newDiagnostics.length}):`);
     newDiagnostics.forEach(item => console.error(formatDiagnostic(item)));

--- a/scripts/lint-with-baseline.mjs
+++ b/scripts/lint-with-baseline.mjs
@@ -108,71 +108,75 @@ const formatDiagnostic = diagnostic => {
   return `${diagnostic.filename}:${line}:${column} ${diagnostic.code}: ${diagnostic.message}`;
 };
 
-const {exitCode, stdout, stderr} = await runOxlint();
-if (stderr) {
-  process.stderr.write(stderr);
-}
+const main = async () => {
+  const {exitCode, stdout, stderr} = await runOxlint();
 
-let report;
-try {
-  report = JSON.parse(stdout);
-} catch (error) {
-  console.error('Unable to parse Oxlint JSON output.');
-  console.error(error.message);
-  process.exit(1);
-}
+  if (stderr) {
+    process.stderr.write(stderr);
+  }
 
-if (exitCode !== 0 && report.diagnostics.length === 0) {
-  process.exit(exitCode);
-}
+  let report;
+  try {
+    report = JSON.parse(stdout);
+  } catch (error) {
+    console.error('Unable to parse Oxlint JSON output.');
+    console.error(error.message);
+    process.exit(1);
+  }
 
-const diagnostics = await Promise.all(report.diagnostics.map(normalize));
-if (update) {
-  const uniqueDiagnostics = [
-    ...new Map(diagnostics.map(item => [item.fingerprint, item])).values(),
-  ];
-  const content = {
-    version: 1,
-    generatedBy: 'npm run lint:baseline:update',
-    diagnostics: uniqueDiagnostics.sort((left, right) =>
-      left.fingerprint.localeCompare(right.fingerprint),
-    ),
-  };
-  await writeFile(baselinePath, `${JSON.stringify(content, null, 2)}\n`);
-  console.log(
-    `Updated ${baselinePath} with ${uniqueDiagnostics.length} diagnostics.`,
+  if (exitCode !== 0 && report.diagnostics.length === 0) {
+    console.error(
+      `Oxlint exited with status ${exitCode} but produced no diagnostics.`,
+    );
+    process.exit(exitCode);
+  }
+
+  const diagnostics = await Promise.all(report.diagnostics.map(normalize));
+  if (update) {
+    const uniqueDiagnostics = [
+      ...new Map(diagnostics.map(item => [item.fingerprint, item])).values(),
+    ];
+    const content = {
+      version: 1,
+      generatedBy: 'npm run lint:baseline:update',
+      diagnostics: uniqueDiagnostics.sort((left, right) =>
+        left.fingerprint.localeCompare(right.fingerprint),
+      ),
+    };
+    await writeFile(baselinePath, `${JSON.stringify(content, null, 2)}\n`);
+    console.log(
+      `Updated ${baselinePath} with ${uniqueDiagnostics.length} diagnostics.`,
+    );
+    process.exit(exitCode === 0 ? 0 : 1);
+  }
+
+  const baseline = await loadBaseline();
+  const current = new Map(diagnostics.map(item => [item.fingerprint, item]));
+  const newDiagnostics = diagnostics.filter(
+    item => !baseline.has(item.fingerprint),
   );
-  process.exit(exitCode === 0 ? 0 : 1);
-}
+  const staleDiagnostics = [...baseline.values()].filter(
+    item => !current.has(item.fingerprint),
+  );
 
-const baseline = await loadBaseline();
-const current = new Map(diagnostics.map(item => [item.fingerprint, item]));
-const newDiagnostics = diagnostics.filter(
-  item => !baseline.has(item.fingerprint),
-);
-const staleDiagnostics = [...baseline.values()].filter(
-  item => !current.has(item.fingerprint),
-);
+  if (newDiagnostics.length > 0 || staleDiagnostics.length > 0) {
+    if (newDiagnostics.length > 0) {
+      console.error(`\nNew Oxlint diagnostics (${newDiagnostics.length}):`);
+      newDiagnostics.forEach(item => console.error(formatDiagnostic(item)));
+    }
+    if (staleDiagnostics.length > 0) {
+      console.error(`\nStale baseline entries (${staleDiagnostics.length}):`);
+      staleDiagnostics.forEach(item => console.error(formatDiagnostic(item)));
+    }
+    if (exitCode !== 0) {
+      console.error(`\nOxlint exited with status ${exitCode}.`);
+    }
+    process.exit(1);
+  }
 
-if (
-  newDiagnostics.length > 0 ||
-  staleDiagnostics.length > 0 ||
-  exitCode !== 0
-) {
-  if (newDiagnostics.length > 0) {
-    console.error(`\nNew Oxlint diagnostics (${newDiagnostics.length}):`);
-    newDiagnostics.forEach(item => console.error(formatDiagnostic(item)));
-  }
-  if (staleDiagnostics.length > 0) {
-    console.error(`\nStale baseline entries (${staleDiagnostics.length}):`);
-    staleDiagnostics.forEach(item => console.error(formatDiagnostic(item)));
-  }
-  if (exitCode !== 0) {
-    console.error(`\nOxlint exited with status ${exitCode}.`);
-  }
-  process.exit(1);
-}
+  console.log(
+    `Oxlint passed: ${diagnostics.length} existing diagnostics acknowledged.`,
+  );
+};
 
-console.log(
-  `Oxlint passed: ${diagnostics.length} existing diagnostics acknowledged.`,
-);
+await main();


### PR DESCRIPTION
## What

Add additional oxlint rules

## Why

* Get back the consistent type imports
* Allow to use `ToString` types in template literals without raising linter errors


