### PR TITLE
Fix: Save muliple roles and groups for one user

### DIFF
--- a/e2e/users/users-helpers.ts
+++ b/e2e/users/users-helpers.ts
@@ -161,6 +161,45 @@ const selectRole = async (page: Page, roleName: string) => {
   await expect(rolesGroup.getByText(roleName, {exact: true})).toBeVisible();
 };
 
+const selectMultipleItems = async (
+  page: Page,
+  groupTitle: string,
+  numberOfItems: number,
+) => {
+  const formGroup = page
+    .locator('[data-testid="form-group"]')
+    .filter({hasText: groupTitle})
+    .first();
+  const input = formGroup.locator('[data-testid="multi-select"]').first();
+
+  await expect(input).toBeVisible();
+  await input.click();
+
+  const options = page.getByRole('option');
+  await expect(options.nth(numberOfItems - 1)).toBeVisible();
+
+  const labels: string[] = [];
+  for (let index = 0; index < numberOfItems; index += 1) {
+    labels.push(await options.nth(index).innerText());
+  }
+
+  for (const label of labels) {
+    const selectedItem = formGroup.getByText(label, {exact: true});
+
+    if ((await selectedItem.count()) === 0) {
+      await page.getByRole('option', {name: label, exact: true}).click();
+    }
+  }
+
+  await page.keyboard.press('Escape');
+
+  for (const label of labels) {
+    await expect(formGroup.getByText(label, {exact: true})).toBeVisible();
+  }
+
+  return labels;
+};
+
 // Saves the currently open user create/edit dialog.
 //
 // Creating a user without a role triggers a 'User without a role' confirmation
@@ -382,6 +421,7 @@ export {
   userLinkByName,
   openUserDetailsFromListRow,
   selectRole,
+  selectMultipleItems,
   saveUserDialog,
   openListCreateDialog,
   openDetailsCreateDialog,

--- a/e2e/users/users-list.spec.ts
+++ b/e2e/users/users-list.spec.ts
@@ -24,6 +24,7 @@ import {
   resetFilter,
   rowByUserName,
   saveUserDialog,
+  selectMultipleItems,
   sortFieldByHeader,
   sortableHeaders,
   closeTopDialog,
@@ -100,6 +101,46 @@ test.describe('users page flows', () => {
     await expect(rowByUserName(page, editedUser)).toBeVisible();
 
     await deleteSingleUserFromList(page, editedUser);
+    await resetFilter(page);
+  });
+
+  test('saves multiple roles and groups when editing a user', async ({
+    page,
+  }) => {
+    const userName = createUniqueUserName('e2e-multiple-assignments');
+
+    await openListCreateDialog(page);
+    await createUserFromCurrentPage(page, userName);
+
+    const row = rowByUserName(page, userName);
+    await row.getByTitle('Edit User').first().click();
+    await expect(page.locator('input[name="name"]')).toBeVisible();
+
+    const roleLabels = await selectMultipleItems(page, 'Roles', 2);
+    const groupLabels = await selectMultipleItems(page, 'Groups', 2);
+    await saveUserDialog(page);
+
+    await applyFilter(page, `name=${userName}`);
+    await rowByUserName(page, userName).getByTitle('Edit User').first().click();
+    await expect(page.locator('input[name="name"]')).toBeVisible();
+    const rolesGroup = page
+      .locator('[data-testid="form-group"]')
+      .filter({hasText: 'Roles'})
+      .first();
+    for (const label of roleLabels) {
+      await expect(rolesGroup.getByText(label, {exact: true})).toBeVisible();
+    }
+
+    const groupsGroup = page
+      .locator('[data-testid="form-group"]')
+      .filter({hasText: 'Groups'})
+      .first();
+    for (const label of groupLabels) {
+      await expect(groupsGroup.getByText(label, {exact: true})).toBeVisible();
+    }
+
+    await closeTopDialog(page);
+    await deleteSingleUserFromList(page, userName);
     await resetFilter(page);
   });
 

--- a/src/gmp/commands/user.ts
+++ b/src/gmp/commands/user.ts
@@ -96,11 +96,11 @@ interface CreateArguments {
   access_hosts: string;
   auth_method: string;
   comment: string;
-  group_ids: string;
+  group_ids: string[];
   hosts_allow: string;
   name: string;
   password: string;
-  role_ids: string;
+  role_ids: string[];
 }
 
 interface SaveArguments {
@@ -108,12 +108,12 @@ interface SaveArguments {
   access_hosts: string;
   auth_method: string;
   comment: string;
-  group_ids: string;
+  group_ids: string[];
   hosts_allow: string;
   name: string;
   old_name: string;
   password: string;
-  role_ids: string;
+  role_ids: string[];
 }
 
 interface DeleteArguments {

--- a/src/web/hooks/use-query/users.ts
+++ b/src/web/hooks/use-query/users.ts
@@ -29,17 +29,15 @@ interface UseUserMutationCallbacks<TResponse> {
   onError?: (error: Error) => void;
 }
 
-type IdsInput = string | string[];
-
 interface UserCreateInput {
   access_hosts: string;
   auth_method: string;
   comment: string;
-  group_ids: IdsInput;
+  group_ids: string[];
   hosts_allow: string;
   name: string;
   password: string;
-  role_ids: IdsInput;
+  role_ids: string[];
 }
 
 interface UserSaveInput extends UserCreateInput {
@@ -53,9 +51,6 @@ interface BulkDeleteUsersInput {
 }
 
 export type UserBulkInput = User[] | FilterType;
-
-const toIdsArgument = (value: IdsInput): string =>
-  Array.isArray(value) ? value.join(',') : value;
 
 export const useGetUsers = ({
   filter,
@@ -90,8 +85,8 @@ export const useCreateUser = ({
     gmpMethod: async data => {
       const response = await gmp.user.create({
         ...data,
-        group_ids: toIdsArgument(data.group_ids),
-        role_ids: toIdsArgument(data.role_ids),
+        group_ids: data.group_ids,
+        role_ids: data.role_ids,
       });
       return response.data;
     },
@@ -111,8 +106,8 @@ export const useSaveUser = ({
       const response = await gmp.user.save({
         ...data,
         old_name: data.old_name ?? data.name,
-        group_ids: toIdsArgument(data.group_ids),
-        role_ids: toIdsArgument(data.role_ids),
+        group_ids: data.group_ids,
+        role_ids: data.role_ids,
       });
       return response.data;
     },

--- a/src/web/pages/users/__tests__/UserComponent.test.tsx
+++ b/src/web/pages/users/__tests__/UserComponent.test.tsx
@@ -27,12 +27,33 @@ const user = User.fromElement({
   },
 });
 
+const userWithMultipleAssignments = User.fromElement({
+  _id: '5678',
+  name: 'user 2',
+  role: [
+    {_id: 'role1', name: 'Admin'},
+    {_id: 'role2', name: 'User'},
+  ],
+  groups: {
+    group: [
+      {_id: 'group1', name: 'Group 1'},
+      {_id: 'group2', name: 'Group 2'},
+    ],
+  },
+});
+
 const authSettings = new Settings();
 authSettings.set('method:ldap_connect', {enabled: false});
 authSettings.set('method:radius_connect', {enabled: false});
 
-const groups = [Group.fromElement({_id: 'group1', name: 'Group 1'})];
-const roles = [Role.fromElement({_id: 'role1', name: 'Admin'})];
+const groups = [
+  Group.fromElement({_id: 'group1', name: 'Group 1'}),
+  Group.fromElement({_id: 'group2', name: 'Group 2'}),
+];
+const roles = [
+  Role.fromElement({_id: 'role1', name: 'Admin'}),
+  Role.fromElement({_id: 'role2', name: 'User'}),
+];
 
 const createGmp = () => ({
   user: {
@@ -63,7 +84,7 @@ describe('UserComponent', () => {
       store: true,
     });
     render(<UserComponent>{() => <span>Child Content</span>}</UserComponent>);
-    screen.getByText('Child Content');
+    expect(screen.getByText('Child Content')).toBeInTheDocument();
   });
 
   test('should open and close user dialog', async () => {
@@ -104,6 +125,43 @@ describe('UserComponent', () => {
     fireEvent.click(screen.getDialogSaveButton());
     await waitFor(() => {
       expect(gmp.user.save).toHaveBeenCalled();
+      expect(gmp.user.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          group_ids: ['group1'],
+          role_ids: ['role1'],
+        }),
+      );
+      expect(onSaved).toHaveBeenCalledWith({id: 'saved'});
+    });
+  });
+
+  test('should save multiple roles and groups for an existing user', async () => {
+    const gmp = createGmp();
+    const onSaved = testing.fn();
+    const {render} = rendererWith({gmp, capabilities: true, store: true});
+
+    render(
+      <UserComponent onSaved={onSaved}>
+        {({edit}) => (
+          <Button
+            data-testid="open"
+            onClick={() => edit(userWithMultipleAssignments)}
+          />
+        )}
+      </UserComponent>,
+    );
+
+    fireEvent.click(screen.getByTestId('open'));
+    await screen.findByText('Edit User user 2');
+
+    fireEvent.click(screen.getDialogSaveButton());
+    await waitFor(() => {
+      expect(gmp.user.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          group_ids: ['group1', 'group2'],
+          role_ids: ['role1', 'role2'],
+        }),
+      );
       expect(onSaved).toHaveBeenCalledWith({id: 'saved'});
     });
   });


### PR DESCRIPTION

## What
In the user dialog it was no longer possible to store more than one role or more than one group for the user. Now it is possible again.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
This was a bug.
<!-- Describe why are these changes necessary? -->

## References
GEA-2043
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
Tested manually on my local development system.
<!-- Remove this section if not applicable to your changes -->



