### PR TITLE
fix: charts axis label compact suffix

### DIFF
--- a/src/web/components/chart/base/Axis.tsx
+++ b/src/web/components/chart/base/Axis.tsx
@@ -58,7 +58,11 @@ const FONT_SIZE = 10;
 
 const DEFAULT_TICK_LENGTH = 8;
 
-const standardFormat = d3format('.2~s');
+const compactFormat = d3format('.2~s');
+const decimalFormat = d3format('.2~f');
+
+const standardFormat = (value: number): string =>
+  Math.abs(value) >= 1000 ? compactFormat(value) : decimalFormat(value);
 
 const AXIS_GENERATORS = {
   bottom: axisBottom,

--- a/src/web/components/chart/base/__tests__/Axis.test.tsx
+++ b/src/web/components/chart/base/__tests__/Axis.test.tsx
@@ -71,6 +71,24 @@ describe('Axis tests', () => {
     expect(tickTexts.map(tick => tick.textContent)).toEqual(['0', '1.3M']);
   });
 
+  test('should keep decimal tick values readable', () => {
+    const scale = scaleLinear().range([0, 100]).domain([0, 2]);
+    const mainContainer = renderAxis({
+      orientation: 'bottom',
+      scale,
+      tickValues: [0, 0.5, 1, 1.5, 2],
+    });
+
+    const tickTexts = Array.from(mainContainer.querySelectorAll('.tick text'));
+    expect(tickTexts.map(tick => tick.textContent)).toEqual([
+      '0',
+      '0.5',
+      '1',
+      '1.5',
+      '2',
+    ]);
+  });
+
   test('should render a top axis label with the expected position', () => {
     const scale = scaleLinear().range([0, 200]).domain([0, 100]);
     renderAxis({


### PR DESCRIPTION
## What

- fix: charts axis label compact suffix


## Why

- When we had decimal points the labels displayed a suffix

## References

GEA-2066

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


