### PR TITLE
Use TypeScript for all cert bund chart displays

### DIFF
--- a/src/web/pages/certbund/dashboard/CertBundCvssDisplay.tsx
+++ b/src/web/pages/certbund/dashboard/CertBundCvssDisplay.tsx
@@ -13,10 +13,17 @@ import {CertBundSeverityLoader} from 'web/pages/certbund/dashboard/CertBundLoade
 
 export const CertBundCvssDisplay = createDisplay({
   loaderComponent: CertBundSeverityLoader,
-  displayComponent: CvssDisplay,
-  yLabel: _l('# of CERT-Bund Advs'),
-  title: ({data: tdata}) =>
-    _('CERT-Bund Advisories by CVSS (Total: {{count}})', {count: tdata.total}),
+  displayComponent: props => (
+    <CvssDisplay
+      {...props}
+      title={({data}) =>
+        _('CERT-Bund Advisories by CVSS (Total: {{count}})', {
+          count: data.total,
+        })
+      }
+      yLabel={_('# of CERT-Bund Advs')}
+    />
+  ),
   filtersFilter: CERTBUND_FILTER_FILTER,
   displayId: 'cert_bund_adv-by-cvss',
   displayName: 'CertBundCvssDisplay',
@@ -24,10 +31,17 @@ export const CertBundCvssDisplay = createDisplay({
 
 export const CertBundCvssTableDisplay = createDisplay({
   loaderComponent: CertBundSeverityLoader,
-  displayComponent: CvssTableDisplay,
-  dataTitles: [_l('Severity'), _l('# of CERT-Bund Advisories')],
-  title: ({data: tdata}) =>
-    _('CERT-Bund Advisories by CVSS (Total: {{count}})', {count: tdata.total}),
+  displayComponent: props => (
+    <CvssTableDisplay
+      {...props}
+      dataTitles={[_('Severity'), _('# of CERT-Bund Advisories')]}
+      title={({data}) =>
+        _('CERT-Bund Advisories by CVSS (Total: {{count}})', {
+          count: data.total,
+        })
+      }
+    />
+  ),
   filtersFilter: CERTBUND_FILTER_FILTER,
   displayId: 'cert_bund_adv-by-cvss-table',
   displayName: 'CertBundCvssTableDisplay',

--- a/src/web/pages/certbund/dashboard/CertBundLoaders.tsx
+++ b/src/web/pages/certbund/dashboard/CertBundLoaders.tsx
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {type AggregatesResponseData} from 'gmp/commands/entities';
 import {type CreatedData} from 'web/components/dashboard/display/created/created-transform';
 import Loader, {
   createLoadFunc,
   type DisplayLoaderProps,
 } from 'web/components/dashboard/display/Loader';
+import type {SeverityData} from 'web/components/dashboard/display/severity/severity-class-transform';
 
 export const CERTBUNDS_SEVERITY = 'certbunds-severity';
 export const CERTBUNDS_CREATED = 'certbunds-created';
 
-export const certBundCreatedLoadFunc = createLoadFunc(
+const certBundCreatedLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.certbunds.getCreatedAggregates({filter}).then(r => r.data),
   CERTBUNDS_CREATED,
@@ -33,7 +33,7 @@ export const CertBundCreatedLoader = ({
   </Loader>
 );
 
-export const certBundSeverityLoadFunc = createLoadFunc(
+const certBundSeverityLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.certbunds.getSeverityAggregates({filter}).then(r => r.data),
   CERTBUNDS_SEVERITY,
@@ -42,7 +42,7 @@ export const certBundSeverityLoadFunc = createLoadFunc(
 export const CertBundSeverityLoader = ({
   filter,
   children,
-}: DisplayLoaderProps<AggregatesResponseData>) => (
+}: DisplayLoaderProps<SeverityData>) => (
   <Loader
     dataId={CERTBUNDS_SEVERITY}
     filter={filter}

--- a/src/web/pages/certbund/dashboard/CertBundSeverityClassDisplay.tsx
+++ b/src/web/pages/certbund/dashboard/CertBundSeverityClassDisplay.tsx
@@ -13,11 +13,16 @@ import {CertBundSeverityLoader} from 'web/pages/certbund/dashboard/CertBundLoade
 
 export const CertBundSeverityClassDisplay = createDisplay({
   loaderComponent: CertBundSeverityLoader,
-  displayComponent: SeverityClassDisplay,
-  title: ({data: tdata}) =>
-    _('CERT-Bund Advisories by Severity Class (Total: {{count}})', {
-      count: tdata.total,
-    }),
+  displayComponent: props => (
+    <SeverityClassDisplay
+      {...props}
+      title={({data}) =>
+        _('CERT-Bund Advisories by Severity Class (Total: {{count}})', {
+          count: data.total,
+        })
+      }
+    />
+  ),
   displayId: 'cert_bund_adv-by-severity-class',
   displayName: 'CertBundSeverityClassDisplay',
   filtersFilter: CERTBUND_FILTER_FILTER,
@@ -25,12 +30,17 @@ export const CertBundSeverityClassDisplay = createDisplay({
 
 export const CertBundSeverityClassTableDisplay = createDisplay({
   loaderComponent: CertBundSeverityLoader,
-  displayComponent: SeverityClassTableDisplay,
-  title: ({data: tdata}) =>
-    _('CERT-Bund Advisories by Severity Class (Total: {{count}})', {
-      count: tdata.total,
-    }),
-  dataTitles: [_l('Severity Class'), _l('# of CERT-Bund Advisories')],
+  displayComponent: props => (
+    <SeverityClassTableDisplay
+      {...props}
+      dataTitles={[_('Severity Class'), _('# of CERT-Bund Advisories')]}
+      title={({data}) =>
+        _('CERT-Bund Advisories by Severity Class (Total: {{count}})', {
+          count: data.total,
+        })
+      }
+    />
+  ),
   displayId: 'cert_bund_adv-by-severity-table',
   displayName: 'CertBundSeverityClassTableDisplay',
   filtersFilter: CERTBUND_FILTER_FILTER,

--- a/src/web/pages/certbund/dashboard/__tests__/CertBundCreatedDisplay.test.tsx
+++ b/src/web/pages/certbund/dashboard/__tests__/CertBundCreatedDisplay.test.tsx
@@ -1,0 +1,146 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {ReactElement} from 'react';
+import {describe, expect, test, testing} from '@gsa/testing';
+import {rendererWith, screen, waitFor} from 'web/testing';
+import {
+  SubscriptionContext,
+  type SubscribeFunc,
+} from 'web/components/provider/SubscriptionProvider';
+import {getDisplay} from 'web/components/dashboard/registry';
+import {
+  CertBundCreatedDisplay,
+  CertBundCreatedTableDisplay,
+} from 'web/pages/certbund/dashboard/CertBundCreatedDisplay';
+
+const loaderData = {
+  groups: [{value: '2026-01-01', count: '5', c_count: '10'}],
+};
+
+vi.mock('web/components/dashboard/display/created/CreatedDisplay', () => ({
+  default: ({title, xAxisLabel, yAxisLabel, y2AxisLabel}) => (
+    <div data-testid="mock-created-display">
+      <span data-testid="title">{title?.()}</span>
+      <span data-testid="x-axis-label">{xAxisLabel}</span>
+      <span data-testid="y-axis-label">{yAxisLabel}</span>
+      <span data-testid="y2-axis-label">{y2AxisLabel}</span>
+    </div>
+  ),
+}));
+
+vi.mock('web/components/dashboard/display/DataTableDisplay', () => ({
+  default: ({data, dataRow, dataTitles, dataTransform, title}) => {
+    const transformedData = dataTransform ? dataTransform(data) : data;
+
+    return (
+      <div data-testid="mock-data-table-display">
+        <span data-testid="title">{title?.()}</span>
+        <span data-testid="data-titles">{dataTitles?.join('|')}</span>
+        {transformedData.map((row, index) => (
+          <span key={index} data-testid={`data-row-${index}`}>
+            {dataRow(row).join('|')}
+          </span>
+        ))}
+      </div>
+    );
+  },
+}));
+
+const createGmp = () => ({
+  certbunds: {
+    getCreatedAggregates: testing.fn().mockResolvedValue({data: loaderData}),
+  },
+  filters: {
+    get: testing.fn().mockResolvedValue({
+      data: [],
+      meta: {filter: 'type=cert_bund_advisory', counts: {}},
+    }),
+  },
+});
+
+const renderDisplay = (component: ReactElement) => {
+  const subscribe: SubscribeFunc = testing.fn().mockReturnValue(testing.fn());
+  const {render} = rendererWith({gmp: createGmp()});
+
+  return render(
+    <SubscriptionContext.Provider value={subscribe}>
+      {component}
+    </SubscriptionContext.Provider>,
+  );
+};
+
+describe('CertBundCreatedDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(CertBundCreatedDisplay).toBeDefined();
+    expect(typeof CertBundCreatedDisplay).toBe('function');
+    expect(CertBundCreatedDisplay.displayId).toBe('cert_bund_adv-by-created');
+    expect(CertBundCreatedDisplay.displayName).toBe('CertBundCreatedDisplay');
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(CertBundCreatedDisplay.displayId);
+
+    expect(registered?.component).toBe(CertBundCreatedDisplay);
+    expect(String(registered?.title)).toBe(
+      'Chart: CERT-Bund Advisories by Creation Time',
+    );
+  });
+
+  test('should render the configured chart labels', async () => {
+    renderDisplay(<CertBundCreatedDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'CERT-Bund Advisories by Creation Time',
+      );
+      expect(screen.getByTestId('x-axis-label')).toHaveTextContent('Time');
+      expect(screen.getByTestId('y-axis-label')).toHaveTextContent(
+        '# of created CERT-Bund Advisories',
+      );
+      expect(screen.getByTestId('y2-axis-label')).toHaveTextContent(
+        'Total CERT-Bund Advisories',
+      );
+    });
+  });
+});
+
+describe('CertBundCreatedTableDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(CertBundCreatedTableDisplay).toBeDefined();
+    expect(typeof CertBundCreatedTableDisplay).toBe('function');
+    expect(CertBundCreatedTableDisplay.displayId).toBe(
+      'cert_bund_adv-by-created-table',
+    );
+    expect(CertBundCreatedTableDisplay.displayName).toBe(
+      'CertBundCreatedTableDisplay',
+    );
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(CertBundCreatedTableDisplay.displayId);
+
+    expect(registered?.component).toBe(CertBundCreatedTableDisplay);
+    expect(String(registered?.title)).toBe(
+      'Table: CERT-Bund Advisories by Creation Time',
+    );
+  });
+
+  test('should render the configured table data', async () => {
+    renderDisplay(<CertBundCreatedTableDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'CERT-Bund Advisories by Creation Time',
+      );
+      expect(screen.getByTestId('data-titles')).toHaveTextContent(
+        'Creation Time|# of CERT-Bund Advs|Total CERT-Bund Advs',
+      );
+      expect(screen.getByTestId('data-row-0')).toHaveTextContent(
+        '01/01/2026|5|10',
+      );
+    });
+  });
+});

--- a/src/web/pages/certbund/dashboard/__tests__/CertBundCvssDisplay.test.tsx
+++ b/src/web/pages/certbund/dashboard/__tests__/CertBundCvssDisplay.test.tsx
@@ -1,0 +1,141 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {ReactElement} from 'react';
+import {describe, expect, test, testing} from '@gsa/testing';
+import {rendererWith, screen, waitFor} from 'web/testing';
+import {
+  SubscriptionContext,
+  type SubscribeFunc,
+} from 'web/components/provider/SubscriptionProvider';
+import {getDisplay} from 'web/components/dashboard/registry';
+import {
+  CertBundCvssDisplay,
+  CertBundCvssTableDisplay,
+} from 'web/pages/certbund/dashboard/CertBundCvssDisplay';
+
+const loaderData = {
+  groups: [
+    {value: '0.2', count: 12},
+    {value: '7.5', count: 30},
+  ],
+};
+
+vi.mock('web/components/dashboard/display/cvss/CvssDisplay', () => ({
+  default: ({data, title, yLabel}) => {
+    const total =
+      data?.groups?.reduce((sum, group) => sum + Number(group.count), 0) ?? 0;
+
+    return (
+      <div data-testid="mock-cvss-display">
+        <span data-testid="title">{title?.({data: {total}})}</span>
+        <span data-testid="y-label">{yLabel}</span>
+      </div>
+    );
+  },
+}));
+
+vi.mock('web/components/dashboard/display/cvss/CvssTableDisplay', () => ({
+  default: ({data, dataTitles, title}) => {
+    const total =
+      data?.groups?.reduce((sum, group) => sum + Number(group.count), 0) ?? 0;
+
+    return (
+      <div data-testid="mock-cvss-table-display">
+        <span data-testid="title">{title?.({data: {total}})}</span>
+        <span data-testid="data-titles">{dataTitles?.join('|')}</span>
+      </div>
+    );
+  },
+}));
+
+const createGmp = () => ({
+  certbunds: {
+    getSeverityAggregates: testing.fn().mockResolvedValue({data: loaderData}),
+  },
+  filters: {
+    get: testing.fn().mockResolvedValue({
+      data: [],
+      meta: {filter: 'type=cert_bund_advisory', counts: {}},
+    }),
+  },
+});
+
+const renderDisplay = (component: ReactElement) => {
+  const subscribe: SubscribeFunc = testing.fn().mockReturnValue(testing.fn());
+  const {render} = rendererWith({gmp: createGmp()});
+
+  return render(
+    <SubscriptionContext.Provider value={subscribe}>
+      {component}
+    </SubscriptionContext.Provider>,
+  );
+};
+
+describe('CertBundCvssDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(CertBundCvssDisplay).toBeDefined();
+    expect(typeof CertBundCvssDisplay).toBe('function');
+    expect(CertBundCvssDisplay.displayId).toBe('cert_bund_adv-by-cvss');
+    expect(CertBundCvssDisplay.displayName).toBe('CertBundCvssDisplay');
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(CertBundCvssDisplay.displayId);
+
+    expect(registered?.component).toBe(CertBundCvssDisplay);
+    expect(String(registered?.title)).toBe(
+      'Chart: CERT-Bund Advisories by CVSS',
+    );
+  });
+
+  test('should render the configured title and y-axis label', async () => {
+    renderDisplay(<CertBundCvssDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'CERT-Bund Advisories by CVSS (Total: 42)',
+      );
+      expect(screen.getByTestId('y-label')).toHaveTextContent(
+        '# of CERT-Bund Advs',
+      );
+    });
+  });
+});
+
+describe('CertBundCvssTableDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(CertBundCvssTableDisplay).toBeDefined();
+    expect(typeof CertBundCvssTableDisplay).toBe('function');
+    expect(CertBundCvssTableDisplay.displayId).toBe(
+      'cert_bund_adv-by-cvss-table',
+    );
+    expect(CertBundCvssTableDisplay.displayName).toBe(
+      'CertBundCvssTableDisplay',
+    );
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(CertBundCvssTableDisplay.displayId);
+
+    expect(registered?.component).toBe(CertBundCvssTableDisplay);
+    expect(String(registered?.title)).toBe(
+      'Table: CERT-Bund Advisories by CVSS',
+    );
+  });
+
+  test('should render the configured title and table headings', async () => {
+    renderDisplay(<CertBundCvssTableDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'CERT-Bund Advisories by CVSS (Total: 42)',
+      );
+      expect(screen.getByTestId('data-titles')).toHaveTextContent(
+        'Severity|# of CERT-Bund Advisories',
+      );
+    });
+  });
+});

--- a/src/web/pages/certbund/dashboard/__tests__/CertBundLoaders.test.tsx
+++ b/src/web/pages/certbund/dashboard/__tests__/CertBundLoaders.test.tsx
@@ -1,0 +1,123 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {ReactElement} from 'react';
+import {describe, expect, test, testing} from '@gsa/testing';
+import {rendererWith, waitFor} from 'web/testing';
+import type Gmp from 'gmp/gmp';
+import QueryFilter from 'gmp/models/filter/query-filter';
+import {
+  SubscriptionContext,
+  type SubscribeFunc,
+} from 'web/components/provider/SubscriptionProvider';
+import {
+  CERTBUNDS_CREATED,
+  CERTBUNDS_SEVERITY,
+  CertBundCreatedLoader,
+  CertBundSeverityLoader,
+} from 'web/pages/certbund/dashboard/CertBundLoaders';
+
+const createGmp = (certbunds: Partial<Gmp['certbunds']>) =>
+  ({certbunds}) as unknown as Record<string, unknown>;
+
+const renderWithSubscriptionContext = ({
+  gmp,
+  subscribe,
+  children,
+}: {
+  gmp: Record<string, unknown>;
+  subscribe: SubscribeFunc;
+  children: ReactElement;
+}) => {
+  const {render} = rendererWith({gmp, store: true});
+
+  return render(
+    <SubscriptionContext.Provider value={subscribe}>
+      {children}
+    </SubscriptionContext.Provider>,
+  );
+};
+
+describe('CertBund Loaders', () => {
+  test('should export created data ID', () => {
+    expect(CERTBUNDS_CREATED).toBe('certbunds-created');
+  });
+
+  test('should export severity data ID', () => {
+    expect(CERTBUNDS_SEVERITY).toBe('certbunds-severity');
+  });
+
+  describe('CertBundCreatedLoader', () => {
+    test('should load created aggregates and render them', async () => {
+      const data = {
+        groups: [{value: '2026-01', count: '5', c_count: '10'}],
+      };
+      const mockGetCreatedAggregates = testing.fn().mockResolvedValue({data});
+      const gmp = createGmp({getCreatedAggregates: mockGetCreatedAggregates});
+      const filter = QueryFilter.fromString('first=1 rows=10');
+      const subscribe = testing.fn().mockReturnValue(testing.fn());
+      const children = testing.fn().mockReturnValue(null);
+
+      renderWithSubscriptionContext({
+        gmp,
+        subscribe,
+        children: (
+          <CertBundCreatedLoader filter={filter}>
+            {children}
+          </CertBundCreatedLoader>
+        ),
+      });
+
+      await waitFor(() => {
+        expect(mockGetCreatedAggregates).toHaveBeenCalledWith({filter});
+        expect(children).toHaveBeenLastCalledWith({data, isLoading: false});
+      });
+
+      expect(subscribe).toHaveBeenCalledWith(
+        'certbunds.timer',
+        expect.any(Function),
+      );
+      expect(subscribe).toHaveBeenCalledWith(
+        'certbunds.changed',
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe('CertBundSeverityLoader', () => {
+    test('should load severity aggregates and render them', async () => {
+      const data = {groups: [{value: '5.0', count: 10}]};
+      const mockGetSeverityAggregates = testing.fn().mockResolvedValue({data});
+      const gmp = createGmp({getSeverityAggregates: mockGetSeverityAggregates});
+      const filter = QueryFilter.fromString('first=1 rows=10');
+      const subscribe = testing.fn().mockReturnValue(testing.fn());
+      const children = testing.fn().mockReturnValue(null);
+
+      renderWithSubscriptionContext({
+        gmp,
+        subscribe,
+        children: (
+          <CertBundSeverityLoader filter={filter}>
+            {children}
+          </CertBundSeverityLoader>
+        ),
+      });
+
+      await waitFor(() => {
+        expect(mockGetSeverityAggregates).toHaveBeenCalledWith({filter});
+        expect(children).toHaveBeenLastCalledWith({data, isLoading: false});
+      });
+
+      expect(subscribe).toHaveBeenCalledWith(
+        'certbunds.timer',
+        expect.any(Function),
+      );
+      expect(subscribe).toHaveBeenCalledWith(
+        'certbunds.changed',
+        expect.any(Function),
+      );
+    });
+  });
+});

--- a/src/web/pages/certbund/dashboard/__tests__/CertBundSeverityClassDisplay.test.tsx
+++ b/src/web/pages/certbund/dashboard/__tests__/CertBundSeverityClassDisplay.test.tsx
@@ -1,0 +1,149 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {ReactElement} from 'react';
+import {describe, expect, test, testing} from '@gsa/testing';
+import {rendererWith, screen, waitFor} from 'web/testing';
+import {
+  SubscriptionContext,
+  type SubscribeFunc,
+} from 'web/components/provider/SubscriptionProvider';
+import {getDisplay} from 'web/components/dashboard/registry';
+import {
+  CertBundSeverityClassDisplay,
+  CertBundSeverityClassTableDisplay,
+} from 'web/pages/certbund/dashboard/CertBundSeverityClassDisplay';
+
+const loaderData = {
+  groups: [
+    {value: '2.0', count: 12},
+    {value: '7.5', count: 30},
+  ],
+};
+
+vi.mock(
+  'web/components/dashboard/display/severity/SeverityClassDisplay',
+  () => ({
+    default: ({data, title}) => {
+      const total =
+        data?.groups?.reduce((sum, group) => sum + Number(group.count), 0) ?? 0;
+
+      return (
+        <div data-testid="mock-severity-display">
+          {title?.({data: {total}})}
+        </div>
+      );
+    },
+  }),
+);
+
+vi.mock(
+  'web/components/dashboard/display/severity/SeverityClassTableDisplay',
+  () => ({
+    default: ({data, dataTitles, title}) => {
+      const total =
+        data?.groups?.reduce((sum, group) => sum + Number(group.count), 0) ?? 0;
+
+      return (
+        <div data-testid="mock-severity-table-display">
+          <span data-testid="title">{title?.({data: {total}})}</span>
+          <span data-testid="data-titles">{dataTitles?.join('|')}</span>
+        </div>
+      );
+    },
+  }),
+);
+
+const createGmp = () => ({
+  certbunds: {
+    getSeverityAggregates: testing.fn().mockResolvedValue({data: loaderData}),
+  },
+  filters: {
+    get: testing.fn().mockResolvedValue({
+      data: [],
+      meta: {filter: 'type=cert_bund_advisory', counts: {}},
+    }),
+  },
+});
+
+const renderDisplay = (component: ReactElement) => {
+  const subscribe: SubscribeFunc = testing.fn().mockReturnValue(testing.fn());
+  const {render} = rendererWith({gmp: createGmp()});
+
+  return render(
+    <SubscriptionContext.Provider value={subscribe}>
+      {component}
+    </SubscriptionContext.Provider>,
+  );
+};
+
+describe('CertBundSeverityClassDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(CertBundSeverityClassDisplay).toBeDefined();
+    expect(typeof CertBundSeverityClassDisplay).toBe('function');
+    expect(CertBundSeverityClassDisplay.displayId).toBe(
+      'cert_bund_adv-by-severity-class',
+    );
+    expect(CertBundSeverityClassDisplay.displayName).toBe(
+      'CertBundSeverityClassDisplay',
+    );
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(CertBundSeverityClassDisplay.displayId);
+
+    expect(registered?.component).toBe(CertBundSeverityClassDisplay);
+    expect(String(registered?.title)).toBe(
+      'Chart: CERT-Bund Advisories by Severity Class',
+    );
+  });
+
+  test('should render the total advisories count in the title', async () => {
+    renderDisplay(<CertBundSeverityClassDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-severity-display')).toHaveTextContent(
+        'CERT-Bund Advisories by Severity Class (Total: 42)',
+      );
+    });
+  });
+});
+
+describe('CertBundSeverityClassTableDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(CertBundSeverityClassTableDisplay).toBeDefined();
+    expect(typeof CertBundSeverityClassTableDisplay).toBe('function');
+    expect(CertBundSeverityClassTableDisplay.displayId).toBe(
+      'cert_bund_adv-by-severity-table',
+    );
+    expect(CertBundSeverityClassTableDisplay.displayName).toBe(
+      'CertBundSeverityClassTableDisplay',
+    );
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(CertBundSeverityClassTableDisplay.displayId);
+
+    expect(registered?.component).toBe(CertBundSeverityClassTableDisplay);
+    expect(String(registered?.title)).toBe(
+      'Table: CERT-Bund Advisories by Severity Class',
+    );
+  });
+
+  test('should render the total and table headings', async () => {
+    renderDisplay(
+      <CertBundSeverityClassTableDisplay height={200} width={200} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'CERT-Bund Advisories by Severity Class (Total: 42)',
+      );
+      expect(screen.getByTestId('data-titles')).toHaveTextContent(
+        'Severity Class|# of CERT-Bund Advisories',
+      );
+    });
+  });
+});

--- a/src/web/pages/certbund/dashboard/index.tsx
+++ b/src/web/pages/certbund/dashboard/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
+import type {FilterType} from 'gmp/models/filter';
 import Dashboard from 'web/components/dashboard/Dashboard';
 import {
   CertBundCreatedDisplay,
@@ -12,11 +12,16 @@ import {
 import {
   CertBundCvssDisplay,
   CertBundCvssTableDisplay,
-} from 'web/pages/certbund/dashboard/CvssDisplay';
+} from 'web/pages/certbund/dashboard/CertBundCvssDisplay';
 import {
   CertBundSeverityClassDisplay,
   CertBundSeverityClassTableDisplay,
-} from 'web/pages/certbund/dashboard/SeverityClassDisplay';
+} from 'web/pages/certbund/dashboard/CertBundSeverityClassDisplay';
+
+interface CertBundDashboardProps {
+  filter?: FilterType;
+  onFilterChanged?: (filter: FilterType) => void;
+}
 
 export const CERTBUND_DASHBOARD_ID = 'a6946f44-480f-4f37-8a73-28a4cd5310c4';
 
@@ -29,7 +34,7 @@ export const CERTBUND_DISPLAYS = [
   CertBundSeverityClassTableDisplay.displayId,
 ];
 
-const CertBundDashboard = props => (
+const CertBundDashboard = (props: CertBundDashboardProps) => (
   <Dashboard
     {...props}
     defaultDisplays={[

--- a/src/web/pages/start/NewDashboardDialog.tsx
+++ b/src/web/pages/start/NewDashboardDialog.tsx
@@ -8,7 +8,7 @@ import Select from 'web/components/form/Select';
 import TextField from 'web/components/form/TextField';
 import useTranslation from 'web/hooks/useTranslation';
 import {CertBundCreatedDisplay} from 'web/pages/certbund/dashboard/CertBundCreatedDisplay';
-import {CertBundCvssDisplay} from 'web/pages/certbund/dashboard/CvssDisplay';
+import {CertBundCvssDisplay} from 'web/pages/certbund/dashboard/CertBundCvssDisplay';
 import {CvesCreatedDisplay} from 'web/pages/cves/dashboard/CreatedDisplay';
 import {CvesSeverityClassDisplay} from 'web/pages/cves/dashboard/SeverityClassDisplay';
 import HostsTopologyDisplay from 'web/pages/hosts/dashboard/HostsTopologyDisplay';


### PR DESCRIPTION
## What

Use TypeScript for all cert bund chart displays

## Why

Convert the Cert Bund Chart Displays to TypeScript

## References

https://jira.greenbone.net/browse/GEA-2019

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] I have added tests for the changes
- [x] I have used the following LLMs/AI tools in this pull request: Codex/GPT-5.6 Luna


