### PR TITLE
fix: disable cloning for Agent Controller and Sensor scanners

### DIFF
--- a/src/gmp/models/__tests__/scanner.test.ts
+++ b/src/gmp/models/__tests__/scanner.test.ts
@@ -235,10 +235,25 @@ describe('Scanner model method tests', () => {
       id: 'test-id',
       scannerType: GREENBONE_SENSOR_SCANNER_TYPE,
     });
+    const scanner4 = new Scanner({
+      id: 'test-id',
+      scannerType: AGENT_CONTROLLER_SCANNER_TYPE,
+    });
+    const scanner5 = new Scanner({
+      id: 'test-id',
+      scannerType: AGENT_CONTROLLER_SENSOR_SCANNER_TYPE,
+    });
+    const scanner6 = new Scanner({
+      id: 'test-id',
+      scannerType: OPENVASD_SCANNER_TYPE,
+    });
 
     expect(scanner1.isCloneable()).toEqual(false);
     expect(scanner2.isCloneable()).toEqual(true);
     expect(scanner3.isCloneable()).toEqual(true);
+    expect(scanner4.isCloneable()).toEqual(false);
+    expect(scanner5.isCloneable()).toEqual(false);
+    expect(scanner6.isCloneable()).toEqual(false);
   });
 
   test('isWritable() should return correct true/false', () => {

--- a/src/gmp/models/scanner.ts
+++ b/src/gmp/models/scanner.ts
@@ -439,7 +439,9 @@ class Scanner extends Model {
   isCloneable() {
     return (
       this.scannerType !== CVE_SCANNER_TYPE &&
-      this.scannerType !== OPENVASD_SCANNER_TYPE
+      this.scannerType !== OPENVASD_SCANNER_TYPE &&
+      this.scannerType !== AGENT_CONTROLLER_SCANNER_TYPE &&
+      this.scannerType !== AGENT_CONTROLLER_SENSOR_SCANNER_TYPE
     );
   }
 


### PR DESCRIPTION
## What

- Disable cloning for Agent Controller and Agent Controller Sensor scanners.
- Disable the clone action for these scanner types.

## Why

Agent Controller scanners must use a unique host and port.

Cloning these scanners can create another scanner pointing to the same Agent Controller endpoint, which can lead to duplicate agent synchronization and inconsistent scanner-agent associations.


## References

GEA-2011

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] I have added tests for the changes


