### PR TITLE
Use TypeScript for all CPE chart displays

### DIFF
--- a/src/web/pages/cpes/dashboard/CpeCreatedDisplay.tsx
+++ b/src/web/pages/cpes/dashboard/CpeCreatedDisplay.tsx
@@ -10,25 +10,29 @@ import CreatedDisplay from 'web/components/dashboard/display/created/CreatedDisp
 import createDisplay from 'web/components/dashboard/display/createDisplay';
 import DataTableDisplay from 'web/components/dashboard/display/DataTableDisplay';
 import {registerDisplay} from 'web/components/dashboard/registry';
-import {CpesCreatedLoader} from 'web/pages/cpes/dashboard/Loaders';
+import {CpesCreatedLoader} from 'web/pages/cpes/dashboard/CpeLoaders';
 import Theme from 'web/utils/theme';
 
 export const CpesCreatedDisplay = createDisplay({
   loaderComponent: CpesCreatedLoader,
-  displayComponent: CreatedDisplay,
-  title: () => _('CPEs by Creation Time'),
-  yAxisLabel: _l('# of created CPEs'),
-  y2AxisLabel: _l('Total CPEs'),
-  xAxisLabel: _l('Time'),
-  yLine: {
-    color: Theme.darkGreenTransparent,
-    label: _l('Created CPEs'),
-  },
-  y2Line: {
-    color: Theme.darkGreenTransparent,
-    dashArray: '3, 2',
-    label: _l('Total CPEs'),
-  },
+  displayComponent: props => (
+    <CreatedDisplay
+      {...props}
+      title={() => _('CPEs by Creation Time')}
+      xAxisLabel={_('Time')}
+      y2AxisLabel={_('Total CPEs')}
+      y2Line={{
+        color: Theme.darkGreenTransparent,
+        dashArray: '3, 2',
+        label: _('Total CPEs'),
+      }}
+      yAxisLabel={_('# of created CPEs')}
+      yLine={{
+        color: Theme.darkGreenTransparent,
+        label: _('Created CPEs'),
+      }}
+    />
+  ),
   displayId: 'cpe-by-created',
   displayName: 'CpeCreatedDisplay',
   filtersFilter: CPES_FILTER_FILTER,
@@ -36,11 +40,15 @@ export const CpesCreatedDisplay = createDisplay({
 
 export const CpesCreatedTableDisplay = createDisplay({
   loaderComponent: CpesCreatedLoader,
-  displayComponent: DataTableDisplay,
-  title: () => _('CPEs by Creation Time'),
-  dataTitles: [_l('Creation Time'), _l('# of CPEs'), _l('Total CPEs')],
-  dataRow: row => [row.label, row.y, row.y2],
-  dataTransform: transformCreated,
+  displayComponent: props => (
+    <DataTableDisplay
+      {...props}
+      dataRow={row => [row.label ?? '', row.y, row.y2]}
+      dataTitles={[_('Creation Time'), _('# of CPEs'), _('Total CPEs')]}
+      dataTransform={transformCreated}
+      title={() => _('CPEs by Creation Time')}
+    />
+  ),
   displayId: 'cpe-by-created-table',
   displayName: 'CpeCreatedTableDisplay',
   filtersFilter: CPES_FILTER_FILTER,

--- a/src/web/pages/cpes/dashboard/CpeCvssDisplay.tsx
+++ b/src/web/pages/cpes/dashboard/CpeCvssDisplay.tsx
@@ -9,14 +9,19 @@ import createDisplay from 'web/components/dashboard/display/createDisplay';
 import CvssDisplay from 'web/components/dashboard/display/cvss/CvssDisplay';
 import CvssTableDisplay from 'web/components/dashboard/display/cvss/CvssTableDisplay';
 import {registerDisplay} from 'web/components/dashboard/registry';
-import {CpesSeverityLoader} from 'web/pages/cpes/dashboard/Loaders';
+import {CpesSeverityLoader} from 'web/pages/cpes/dashboard/CpeLoaders';
 
 export const CpesCvssDisplay = createDisplay({
   loaderComponent: CpesSeverityLoader,
-  displayComponent: CvssDisplay,
-  yLabel: _l('# of CPEs'),
-  title: ({data: tdata}) =>
-    _('CPEs by CVSS (Total: {{count}})', {count: tdata.total}),
+  displayComponent: props => (
+    <CvssDisplay
+      {...props}
+      title={({data}) =>
+        _('CPEs by CVSS (Total: {{count}})', {count: data.total})
+      }
+      yLabel={_('# of CPEs')}
+    />
+  ),
   filtersFilter: CPES_FILTER_FILTER,
   displayId: 'cpe-by-cvss',
   displayName: 'CpesCvssDisplay',
@@ -24,10 +29,15 @@ export const CpesCvssDisplay = createDisplay({
 
 export const CpesCvssTableDisplay = createDisplay({
   loaderComponent: CpesSeverityLoader,
-  displayComponent: CvssTableDisplay,
-  dataTitles: [_l('Severity'), _l('# of CPEs')],
-  title: ({data: tdata}) =>
-    _('CPEs by CVSS (Total: {{count}})', {count: tdata.total}),
+  displayComponent: props => (
+    <CvssTableDisplay
+      {...props}
+      dataTitles={[_('Severity'), _('# of CPEs')]}
+      title={({data}) =>
+        _('CPEs by CVSS (Total: {{count}})', {count: data.total})
+      }
+    />
+  ),
   filtersFilter: CPES_FILTER_FILTER,
   displayId: 'cpe-by-cvss-table',
   displayName: 'CpesCvssTableDisplay',

--- a/src/web/pages/cpes/dashboard/CpeLoaders.tsx
+++ b/src/web/pages/cpes/dashboard/CpeLoaders.tsx
@@ -3,17 +3,25 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
+import type {CreatedData} from 'web/components/dashboard/display/created/created-transform';
+import Loader, {
+  createLoadFunc,
+  type DisplayLoaderProps,
+} from 'web/components/dashboard/display/Loader';
+import type {SeverityData} from 'web/components/dashboard/display/severity/severity-class-transform';
 
 export const CPES_CREATED = 'cpes-created';
 export const CPES_SEVERITY = 'cpes-severity';
 
-export const cpeCreatedLoadFunc = createLoadFunc(
+const cpeCreatedLoadFunc = createLoadFunc(
   ({gmp, filter}) => gmp.cpes.getCreatedAggregates({filter}).then(r => r.data),
   CPES_CREATED,
 );
 
-export const CpesCreatedLoader = ({filter, children}) => (
+export const CpesCreatedLoader = ({
+  filter,
+  children,
+}: DisplayLoaderProps<CreatedData>) => (
   <Loader
     dataId={CPES_CREATED}
     filter={filter}
@@ -24,12 +32,15 @@ export const CpesCreatedLoader = ({filter, children}) => (
   </Loader>
 );
 
-export const cpeSeverityLoadFunc = createLoadFunc(
+const cpeSeverityLoadFunc = createLoadFunc(
   ({gmp, filter}) => gmp.cpes.getSeverityAggregates({filter}).then(r => r.data),
   CPES_SEVERITY,
 );
 
-export const CpesSeverityLoader = ({filter, children}) => (
+export const CpesSeverityLoader = ({
+  filter,
+  children,
+}: DisplayLoaderProps<SeverityData>) => (
   <Loader
     dataId={CPES_SEVERITY}
     filter={filter}

--- a/src/web/pages/cpes/dashboard/CpeSeverityClassDisplay.tsx
+++ b/src/web/pages/cpes/dashboard/CpeSeverityClassDisplay.tsx
@@ -9,13 +9,18 @@ import createDisplay from 'web/components/dashboard/display/createDisplay';
 import SeverityClassDisplay from 'web/components/dashboard/display/severity/SeverityClassDisplay';
 import SeverityClassTableDisplay from 'web/components/dashboard/display/severity/SeverityClassTableDisplay';
 import {registerDisplay} from 'web/components/dashboard/registry';
-import {CpesSeverityLoader} from 'web/pages/cpes/dashboard/Loaders';
+import {CpesSeverityLoader} from 'web/pages/cpes/dashboard/CpeLoaders';
 
 export const CpesSeverityClassDisplay = createDisplay({
   loaderComponent: CpesSeverityLoader,
-  displayComponent: SeverityClassDisplay,
-  title: ({data: tdata}) =>
-    _('CPEs by Severity Class (Total: {{count}})', {count: tdata.total}),
+  displayComponent: props => (
+    <SeverityClassDisplay
+      {...props}
+      title={({data}) =>
+        _('CPEs by Severity Class (Total: {{count}})', {count: data.total})
+      }
+    />
+  ),
   displayId: 'cpe-by-severity-class',
   displayName: 'CpesSeverityClassDisplay',
   filtersFilter: CPES_FILTER_FILTER,
@@ -23,10 +28,15 @@ export const CpesSeverityClassDisplay = createDisplay({
 
 export const CpesSeverityClassTableDisplay = createDisplay({
   loaderComponent: CpesSeverityLoader,
-  displayComponent: SeverityClassTableDisplay,
-  title: ({data: tdata}) =>
-    _('CPEs by Severity Class (Total: {{count}})', {count: tdata.total}),
-  dataTitles: [_l('Severity Class'), _l('# of CPEs')],
+  displayComponent: props => (
+    <SeverityClassTableDisplay
+      {...props}
+      dataTitles={[_('Severity Class'), _('# of CPEs')]}
+      title={({data}) =>
+        _('CPEs by Severity Class (Total: {{count}})', {count: data.total})
+      }
+    />
+  ),
   displayId: 'cpe-by-severity-table',
   displayName: 'CpesSeverityClassTableDisplay',
   filtersFilter: CPES_FILTER_FILTER,

--- a/src/web/pages/cpes/dashboard/__tests__/CpeCreatedDisplay.test.tsx
+++ b/src/web/pages/cpes/dashboard/__tests__/CpeCreatedDisplay.test.tsx
@@ -1,0 +1,138 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {ReactElement} from 'react';
+import {describe, expect, test, testing} from '@gsa/testing';
+import {rendererWith, screen, waitFor} from 'web/testing';
+import {
+  SubscriptionContext,
+  type SubscribeFunc,
+} from 'web/components/provider/SubscriptionProvider';
+import {getDisplay} from 'web/components/dashboard/registry';
+import {
+  CpesCreatedDisplay,
+  CpesCreatedTableDisplay,
+} from 'web/pages/cpes/dashboard/CpeCreatedDisplay';
+
+const loaderData = {
+  groups: [{value: '2026-01-01', count: '5', c_count: '10'}],
+};
+
+vi.mock('web/components/dashboard/display/created/CreatedDisplay', () => ({
+  default: ({title, xAxisLabel, yAxisLabel, y2AxisLabel}) => (
+    <div data-testid="mock-created-display">
+      <span data-testid="title">{title?.()}</span>
+      <span data-testid="x-axis-label">{xAxisLabel}</span>
+      <span data-testid="y-axis-label">{yAxisLabel}</span>
+      <span data-testid="y2-axis-label">{y2AxisLabel}</span>
+    </div>
+  ),
+}));
+
+vi.mock('web/components/dashboard/display/DataTableDisplay', () => ({
+  default: ({data, dataRow, dataTitles, dataTransform, title}) => {
+    const transformedData = dataTransform ? dataTransform(data) : data;
+
+    return (
+      <div data-testid="mock-data-table-display">
+        <span data-testid="title">{title?.()}</span>
+        <span data-testid="data-titles">{dataTitles?.join('|')}</span>
+        {transformedData.map((row, index) => (
+          <span key={index} data-testid={`data-row-${index}`}>
+            {dataRow(row).join('|')}
+          </span>
+        ))}
+      </div>
+    );
+  },
+}));
+
+const createGmp = () => ({
+  cpes: {
+    getCreatedAggregates: testing.fn().mockResolvedValue({data: loaderData}),
+  },
+  filters: {
+    get: testing.fn().mockResolvedValue({
+      data: [],
+      meta: {filter: 'type=cpe', counts: {}},
+    }),
+  },
+});
+
+const renderDisplay = (component: ReactElement) => {
+  const subscribe: SubscribeFunc = testing.fn().mockReturnValue(testing.fn());
+  const {render} = rendererWith({gmp: createGmp()});
+
+  return render(
+    <SubscriptionContext.Provider value={subscribe}>
+      {component}
+    </SubscriptionContext.Provider>,
+  );
+};
+
+describe('CpesCreatedDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(CpesCreatedDisplay).toBeDefined();
+    expect(typeof CpesCreatedDisplay).toBe('function');
+    expect(CpesCreatedDisplay.displayId).toBe('cpe-by-created');
+    expect(CpesCreatedDisplay.displayName).toBe('CpeCreatedDisplay');
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(CpesCreatedDisplay.displayId);
+
+    expect(registered?.component).toBe(CpesCreatedDisplay);
+    expect(String(registered?.title)).toBe('Chart: CPEs by Creation Time');
+  });
+
+  test('should render the configured chart labels', async () => {
+    renderDisplay(<CpesCreatedDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'CPEs by Creation Time',
+      );
+      expect(screen.getByTestId('x-axis-label')).toHaveTextContent('Time');
+      expect(screen.getByTestId('y-axis-label')).toHaveTextContent(
+        '# of created CPEs',
+      );
+      expect(screen.getByTestId('y2-axis-label')).toHaveTextContent(
+        'Total CPEs',
+      );
+    });
+  });
+});
+
+describe('CpesCreatedTableDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(CpesCreatedTableDisplay).toBeDefined();
+    expect(typeof CpesCreatedTableDisplay).toBe('function');
+    expect(CpesCreatedTableDisplay.displayId).toBe('cpe-by-created-table');
+    expect(CpesCreatedTableDisplay.displayName).toBe('CpeCreatedTableDisplay');
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(CpesCreatedTableDisplay.displayId);
+
+    expect(registered?.component).toBe(CpesCreatedTableDisplay);
+    expect(String(registered?.title)).toBe('Table: CPEs by Creation Time');
+  });
+
+  test('should render the configured table data', async () => {
+    renderDisplay(<CpesCreatedTableDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'CPEs by Creation Time',
+      );
+      expect(screen.getByTestId('data-titles')).toHaveTextContent(
+        'Creation Time|# of CPEs|Total CPEs',
+      );
+      expect(screen.getByTestId('data-row-0')).toHaveTextContent(
+        '01/01/2026|5|10',
+      );
+    });
+  });
+});

--- a/src/web/pages/cpes/dashboard/__tests__/CpeCvssDisplay.test.tsx
+++ b/src/web/pages/cpes/dashboard/__tests__/CpeCvssDisplay.test.tsx
@@ -1,0 +1,131 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {ReactElement} from 'react';
+import {describe, expect, test, testing} from '@gsa/testing';
+import {rendererWith, screen, waitFor} from 'web/testing';
+import {
+  SubscriptionContext,
+  type SubscribeFunc,
+} from 'web/components/provider/SubscriptionProvider';
+import {getDisplay} from 'web/components/dashboard/registry';
+import {
+  CpesCvssDisplay,
+  CpesCvssTableDisplay,
+} from 'web/pages/cpes/dashboard/CpeCvssDisplay';
+
+const loaderData = {
+  groups: [
+    {value: '0.2', count: 12},
+    {value: '7.5', count: 30},
+  ],
+};
+
+vi.mock('web/components/dashboard/display/cvss/CvssDisplay', () => ({
+  default: ({data, title, yLabel}) => {
+    const total =
+      data?.groups?.reduce((sum, group) => sum + Number(group.count), 0) ?? 0;
+
+    return (
+      <div data-testid="mock-cvss-display">
+        <span data-testid="title">{title?.({data: {total}})}</span>
+        <span data-testid="y-label">{yLabel}</span>
+      </div>
+    );
+  },
+}));
+
+vi.mock('web/components/dashboard/display/cvss/CvssTableDisplay', () => ({
+  default: ({data, dataTitles, title}) => {
+    const total =
+      data?.groups?.reduce((sum, group) => sum + Number(group.count), 0) ?? 0;
+
+    return (
+      <div data-testid="mock-cvss-table-display">
+        <span data-testid="title">{title?.({data: {total}})}</span>
+        <span data-testid="data-titles">{dataTitles?.join('|')}</span>
+      </div>
+    );
+  },
+}));
+
+const createGmp = () => ({
+  cpes: {
+    getSeverityAggregates: testing.fn().mockResolvedValue({data: loaderData}),
+  },
+  filters: {
+    get: testing.fn().mockResolvedValue({
+      data: [],
+      meta: {filter: 'type=cpe', counts: {}},
+    }),
+  },
+});
+
+const renderDisplay = (component: ReactElement) => {
+  const subscribe: SubscribeFunc = testing.fn().mockReturnValue(testing.fn());
+  const {render} = rendererWith({gmp: createGmp()});
+
+  return render(
+    <SubscriptionContext.Provider value={subscribe}>
+      {component}
+    </SubscriptionContext.Provider>,
+  );
+};
+
+describe('CpesCvssDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(CpesCvssDisplay).toBeDefined();
+    expect(typeof CpesCvssDisplay).toBe('function');
+    expect(CpesCvssDisplay.displayId).toBe('cpe-by-cvss');
+    expect(CpesCvssDisplay.displayName).toBe('CpesCvssDisplay');
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(CpesCvssDisplay.displayId);
+
+    expect(registered?.component).toBe(CpesCvssDisplay);
+    expect(String(registered?.title)).toBe('Chart: CPEs by CVSS');
+  });
+
+  test('should render the configured title and y-axis label', async () => {
+    renderDisplay(<CpesCvssDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'CPEs by CVSS (Total: 42)',
+      );
+      expect(screen.getByTestId('y-label')).toHaveTextContent('# of CPEs');
+    });
+  });
+});
+
+describe('CpesCvssTableDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(CpesCvssTableDisplay).toBeDefined();
+    expect(typeof CpesCvssTableDisplay).toBe('function');
+    expect(CpesCvssTableDisplay.displayId).toBe('cpe-by-cvss-table');
+    expect(CpesCvssTableDisplay.displayName).toBe('CpesCvssTableDisplay');
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(CpesCvssTableDisplay.displayId);
+
+    expect(registered?.component).toBe(CpesCvssTableDisplay);
+    expect(String(registered?.title)).toBe('Table: CPEs by CVSS');
+  });
+
+  test('should render the configured title and table headings', async () => {
+    renderDisplay(<CpesCvssTableDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'CPEs by CVSS (Total: 42)',
+      );
+      expect(screen.getByTestId('data-titles')).toHaveTextContent(
+        'Severity|# of CPEs',
+      );
+    });
+  });
+});

--- a/src/web/pages/cpes/dashboard/__tests__/CpeLoaders.test.tsx
+++ b/src/web/pages/cpes/dashboard/__tests__/CpeLoaders.test.tsx
@@ -1,0 +1,110 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {ReactElement} from 'react';
+import {describe, expect, test, testing} from '@gsa/testing';
+import {rendererWith, waitFor} from 'web/testing';
+import type Gmp from 'gmp/gmp';
+import QueryFilter from 'gmp/models/filter/query-filter';
+import {
+  SubscriptionContext,
+  type SubscribeFunc,
+} from 'web/components/provider/SubscriptionProvider';
+import {
+  CPES_CREATED,
+  CPES_SEVERITY,
+  CpesCreatedLoader,
+  CpesSeverityLoader,
+} from 'web/pages/cpes/dashboard/CpeLoaders';
+
+const createGmp = (cpes: Partial<Gmp['cpes']>) => ({cpes});
+
+const renderWithSubscriptionContext = ({
+  gmp,
+  subscribe,
+  children,
+}: {
+  gmp: Record<string, unknown>;
+  subscribe: SubscribeFunc;
+  children: ReactElement;
+}) => {
+  const {render} = rendererWith({gmp, store: true});
+
+  return render(
+    <SubscriptionContext.Provider value={subscribe}>
+      {children}
+    </SubscriptionContext.Provider>,
+  );
+};
+
+describe('CpesCreatedLoader', () => {
+  test('should export the created data ID', () => {
+    expect(CPES_CREATED).toBe('cpes-created');
+  });
+
+  test('should load created aggregates and render them', async () => {
+    const data = {
+      groups: [{value: '2026-01', count: '5', c_count: '10'}],
+    };
+    const mockGetCreatedAggregates = testing.fn().mockResolvedValue({data});
+    const gmp = createGmp({getCreatedAggregates: mockGetCreatedAggregates});
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const subscribe = testing.fn().mockReturnValue(testing.fn());
+    const children = testing.fn().mockReturnValue(null);
+
+    renderWithSubscriptionContext({
+      gmp,
+      subscribe,
+      children: (
+        <CpesCreatedLoader filter={filter}>{children}</CpesCreatedLoader>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(mockGetCreatedAggregates).toHaveBeenCalledWith({filter});
+      expect(children).toHaveBeenLastCalledWith({data, isLoading: false});
+    });
+
+    expect(subscribe).toHaveBeenCalledWith('cpes.timer', expect.any(Function));
+    expect(subscribe).toHaveBeenCalledWith(
+      'cpes.changed',
+      expect.any(Function),
+    );
+  });
+});
+
+describe('CpesSeverityLoader', () => {
+  test('should export the severity data ID', () => {
+    expect(CPES_SEVERITY).toBe('cpes-severity');
+  });
+
+  test('should load severity aggregates and render them', async () => {
+    const data = {groups: [{value: '5.0', count: 10}]};
+    const mockGetSeverityAggregates = testing.fn().mockResolvedValue({data});
+    const gmp = createGmp({getSeverityAggregates: mockGetSeverityAggregates});
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const subscribe = testing.fn().mockReturnValue(testing.fn());
+    const children = testing.fn().mockReturnValue(null);
+
+    renderWithSubscriptionContext({
+      gmp,
+      subscribe,
+      children: (
+        <CpesSeverityLoader filter={filter}>{children}</CpesSeverityLoader>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(mockGetSeverityAggregates).toHaveBeenCalledWith({filter});
+      expect(children).toHaveBeenLastCalledWith({data, isLoading: false});
+    });
+
+    expect(subscribe).toHaveBeenCalledWith('cpes.timer', expect.any(Function));
+    expect(subscribe).toHaveBeenCalledWith(
+      'cpes.changed',
+      expect.any(Function),
+    );
+  });
+});

--- a/src/web/pages/cpes/dashboard/__tests__/CpeSeverityClassDisplay.test.tsx
+++ b/src/web/pages/cpes/dashboard/__tests__/CpeSeverityClassDisplay.test.tsx
@@ -1,0 +1,141 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {ReactElement} from 'react';
+import {describe, expect, test, testing} from '@gsa/testing';
+import {rendererWith, screen, waitFor} from 'web/testing';
+import {
+  SubscriptionContext,
+  type SubscribeFunc,
+} from 'web/components/provider/SubscriptionProvider';
+import {getDisplay} from 'web/components/dashboard/registry';
+import {
+  CpesSeverityClassDisplay,
+  CpesSeverityClassTableDisplay,
+} from 'web/pages/cpes/dashboard/CpeSeverityClassDisplay';
+
+const loaderData = {
+  groups: [
+    {value: '2.0', count: 12},
+    {value: '7.5', count: 30},
+  ],
+};
+
+vi.mock(
+  'web/components/dashboard/display/severity/SeverityClassDisplay',
+  () => ({
+    default: ({data, title}) => {
+      const total =
+        data?.groups?.reduce((sum, group) => sum + Number(group.count), 0) ?? 0;
+
+      return (
+        <div data-testid="mock-severity-display">
+          {title?.({data: {total}})}
+        </div>
+      );
+    },
+  }),
+);
+
+vi.mock(
+  'web/components/dashboard/display/severity/SeverityClassTableDisplay',
+  () => ({
+    default: ({data, dataTitles, title}) => {
+      const total =
+        data?.groups?.reduce((sum, group) => sum + Number(group.count), 0) ?? 0;
+
+      return (
+        <div data-testid="mock-severity-table-display">
+          <span data-testid="title">{title?.({data: {total}})}</span>
+          <span data-testid="data-titles">{dataTitles?.join('|')}</span>
+        </div>
+      );
+    },
+  }),
+);
+
+const createGmp = () => ({
+  cpes: {
+    getSeverityAggregates: testing.fn().mockResolvedValue({data: loaderData}),
+  },
+  filters: {
+    get: testing.fn().mockResolvedValue({
+      data: [],
+      meta: {filter: 'type=cpe', counts: {}},
+    }),
+  },
+});
+
+const renderDisplay = (component: ReactElement) => {
+  const subscribe: SubscribeFunc = testing.fn().mockReturnValue(testing.fn());
+  const {render} = rendererWith({gmp: createGmp()});
+
+  return render(
+    <SubscriptionContext.Provider value={subscribe}>
+      {component}
+    </SubscriptionContext.Provider>,
+  );
+};
+
+describe('CpesSeverityClassDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(CpesSeverityClassDisplay).toBeDefined();
+    expect(typeof CpesSeverityClassDisplay).toBe('function');
+    expect(CpesSeverityClassDisplay.displayId).toBe('cpe-by-severity-class');
+    expect(CpesSeverityClassDisplay.displayName).toBe(
+      'CpesSeverityClassDisplay',
+    );
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(CpesSeverityClassDisplay.displayId);
+
+    expect(registered?.component).toBe(CpesSeverityClassDisplay);
+    expect(String(registered?.title)).toBe('Chart: CPEs by Severity Class');
+  });
+
+  test('should render the total CPE count in the title', async () => {
+    renderDisplay(<CpesSeverityClassDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-severity-display')).toHaveTextContent(
+        'CPEs by Severity Class (Total: 42)',
+      );
+    });
+  });
+});
+
+describe('CpesSeverityClassTableDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(CpesSeverityClassTableDisplay).toBeDefined();
+    expect(typeof CpesSeverityClassTableDisplay).toBe('function');
+    expect(CpesSeverityClassTableDisplay.displayId).toBe(
+      'cpe-by-severity-table',
+    );
+    expect(CpesSeverityClassTableDisplay.displayName).toBe(
+      'CpesSeverityClassTableDisplay',
+    );
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(CpesSeverityClassTableDisplay.displayId);
+
+    expect(registered?.component).toBe(CpesSeverityClassTableDisplay);
+    expect(String(registered?.title)).toBe('Table: CPEs by Severity Class');
+  });
+
+  test('should render the total and table headings', async () => {
+    renderDisplay(<CpesSeverityClassTableDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'CPEs by Severity Class (Total: 42)',
+      );
+      expect(screen.getByTestId('data-titles')).toHaveTextContent(
+        'Severity Class|# of CPEs',
+      );
+    });
+  });
+});

--- a/src/web/pages/cpes/dashboard/index.tsx
+++ b/src/web/pages/cpes/dashboard/index.tsx
@@ -3,20 +3,25 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
+import type {FilterType} from 'gmp/models/filter';
 import Dashboard from 'web/components/dashboard/Dashboard';
 import {
   CpesCreatedDisplay,
   CpesCreatedTableDisplay,
-} from 'web/pages/cpes/dashboard/CreatedDisplay';
+} from 'web/pages/cpes/dashboard/CpeCreatedDisplay';
 import {
   CpesCvssDisplay,
   CpesCvssTableDisplay,
-} from 'web/pages/cpes/dashboard/CvssDisplay';
+} from 'web/pages/cpes/dashboard/CpeCvssDisplay';
 import {
   CpesSeverityClassDisplay,
   CpesSeverityClassTableDisplay,
-} from 'web/pages/cpes/dashboard/SeverityClassDisplay';
+} from 'web/pages/cpes/dashboard/CpeSeverityClassDisplay';
+
+interface CpeDashboardProps {
+  filter?: FilterType;
+  onFilterChanged?: (filter: FilterType) => void;
+}
 
 export const CPES_DASHBOARD_ID = '9cff9b4d-b164-43ce-8687-f2360afc7500';
 
@@ -29,7 +34,7 @@ export const CPES_DISPLAYS = [
   CpesSeverityClassTableDisplay.displayId,
 ];
 
-const CpesDashboard = props => (
+const CpesDashboard = (props: CpeDashboardProps) => (
   <Dashboard
     {...props}
     defaultDisplays={[


### PR DESCRIPTION


## What
Use TypeScript for all CPE chart displays

## Why

Also add tests for the components to ensure the components work as expected.

## References

https://jira.greenbone.net/browse/GEA-2019

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] I have added tests for the changes
- [x] I have used the following LLMs/AI tools in this pull request: Codex/GPT-5.6 Luna


