### PR TITLE
Use TypeScript for all DFN Cert chart displays

### DIFF
--- a/src/web/pages/dfncert/dashboard/DfnCertCreatedDisplay.tsx
+++ b/src/web/pages/dfncert/dashboard/DfnCertCreatedDisplay.tsx
@@ -10,25 +10,29 @@ import CreatedDisplay from 'web/components/dashboard/display/created/CreatedDisp
 import createDisplay from 'web/components/dashboard/display/createDisplay';
 import DataTableDisplay from 'web/components/dashboard/display/DataTableDisplay';
 import {registerDisplay} from 'web/components/dashboard/registry';
-import {DfnCertsCreatedLoader} from 'web/pages/dfncert/dashboard/Loaders';
+import {DfnCertsCreatedLoader} from 'web/pages/dfncert/dashboard/DfnCertLoaders';
 import Theme from 'web/utils/theme';
 
 export const DfnCertsCreatedDisplay = createDisplay({
   loaderComponent: DfnCertsCreatedLoader,
-  displayComponent: CreatedDisplay,
-  title: () => _('DFN-CERT Advisories by Creation Time'),
-  yAxisLabel: _l('# of created DFN-CERT Advs'),
-  y2AxisLabel: _l('Total DFN-CERT Advs'),
-  xAxisLabel: _l('Time'),
-  yLine: {
-    color: Theme.darkGreenTransparent,
-    label: _l('Created DFN-CERT Advs'),
-  },
-  y2Line: {
-    color: Theme.darkGreenTransparent,
-    dashArray: '3, 2',
-    label: _l('Total DFN-CERT Advs'),
-  },
+  displayComponent: props => (
+    <CreatedDisplay
+      {...props}
+      title={() => _('DFN-CERT Advisories by Creation Time')}
+      xAxisLabel={_('Time')}
+      y2AxisLabel={_('Total DFN-CERT Advs')}
+      y2Line={{
+        color: Theme.darkGreenTransparent,
+        dashArray: '3, 2',
+        label: _('Total DFN-CERT Advs'),
+      }}
+      yAxisLabel={_('# of created DFN-CERT Advs')}
+      yLine={{
+        color: Theme.darkGreenTransparent,
+        label: _('Created DFN-CERT Advs'),
+      }}
+    />
+  ),
   displayId: 'dfn_cert_adv-by-created',
   displayName: 'DfnCertsCreatedDisplay',
   filtersFilter: DFNCERT_FILTER_FILTER,
@@ -36,15 +40,19 @@ export const DfnCertsCreatedDisplay = createDisplay({
 
 export const DfnCertsCreatedTableDisplay = createDisplay({
   loaderComponent: DfnCertsCreatedLoader,
-  displayComponent: DataTableDisplay,
-  title: () => _('DFN-CERT Advisories by Creation Time'),
-  dataTitles: [
-    _l('Creation Time'),
-    _l('# of DFN-CERT Advs'),
-    _l('Total DFN-CERT Advs'),
-  ],
-  dataRow: row => [row.label, row.y, row.y2],
-  dataTransform: transformCreated,
+  displayComponent: props => (
+    <DataTableDisplay
+      {...props}
+      dataRow={row => [row.label ?? '', row.y, row.y2]}
+      dataTitles={[
+        _('Creation Time'),
+        _('# of DFN-CERT Advs'),
+        _('Total DFN-CERT Advs'),
+      ]}
+      dataTransform={transformCreated}
+      title={() => _('DFN-CERT Advisories by Creation Time')}
+    />
+  ),
   displayId: 'dfn_cert_adv-by-created-table',
   displayName: 'DfnCertsCreatedTableDisplay',
   filtersFilter: DFNCERT_FILTER_FILTER,

--- a/src/web/pages/dfncert/dashboard/DfnCertCvssDisplay.tsx
+++ b/src/web/pages/dfncert/dashboard/DfnCertCvssDisplay.tsx
@@ -9,14 +9,21 @@ import createDisplay from 'web/components/dashboard/display/createDisplay';
 import CvssDisplay from 'web/components/dashboard/display/cvss/CvssDisplay';
 import CvssTableDisplay from 'web/components/dashboard/display/cvss/CvssTableDisplay';
 import {registerDisplay} from 'web/components/dashboard/registry';
-import {DfnCertSeverityLoader} from 'web/pages/dfncert/dashboard/Loaders';
+import {DfnCertSeverityLoader} from 'web/pages/dfncert/dashboard/DfnCertLoaders';
 
 export const DfnCertCvssDisplay = createDisplay({
   loaderComponent: DfnCertSeverityLoader,
-  displayComponent: CvssDisplay,
-  yLabel: _l('# of DFN-CERT Advs'),
-  title: ({data: tdata}) =>
-    _('DFN-CERT Advisories by CVSS (Total: {{count}})', {count: tdata.total}),
+  displayComponent: props => (
+    <CvssDisplay
+      {...props}
+      title={({data}) =>
+        _('DFN-CERT Advisories by CVSS (Total: {{count}})', {
+          count: data.total,
+        })
+      }
+      yLabel={_('# of DFN-CERT Advs')}
+    />
+  ),
   filtersFilter: DFNCERT_FILTER_FILTER,
   displayId: 'dfn_cert_adv-by-cvss',
   displayName: 'DfnCertCvssDisplay',
@@ -24,10 +31,15 @@ export const DfnCertCvssDisplay = createDisplay({
 
 export const DfnCertCvssTableDisplay = createDisplay({
   loaderComponent: DfnCertSeverityLoader,
-  displayComponent: CvssTableDisplay,
-  dataTitles: [_l('Severity'), _l('# of DFN-CERT Advisories')],
-  title: ({data: tdata}) =>
-    _('DFN-CERT Advisories by CVSS (Total: {{count}})', {count: tdata.total}),
+  displayComponent: props => (
+    <CvssTableDisplay
+      {...props}
+      dataTitles={[_('Severity'), _('# of DFN-CERT Advisories')]}
+      title={({data}) =>
+        _('DFN-CERT Advisories by CVSS (Total: {{count}})', {count: data.total})
+      }
+    />
+  ),
   filtersFilter: DFNCERT_FILTER_FILTER,
   displayId: 'dfn_cert_adv-by-cvss-table',
   displayName: 'DfnCertCvssTableDisplay',

--- a/src/web/pages/dfncert/dashboard/DfnCertLoaders.tsx
+++ b/src/web/pages/dfncert/dashboard/DfnCertLoaders.tsx
@@ -3,18 +3,26 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import Loader, {createLoadFunc} from 'web/components/dashboard/display/Loader';
+import {type CreatedData} from 'web/components/dashboard/display/created/created-transform';
+import Loader, {
+  createLoadFunc,
+  type DisplayLoaderProps,
+} from 'web/components/dashboard/display/Loader';
+import {type SeverityData} from 'web/components/dashboard/display/severity/severity-class-transform';
 
 export const DFNCERTS_CREATED = 'dfncerts-created';
 export const DFNCERTS_SEVERITY = 'dfncerts-severity';
 
-export const dfnCertsCreatedLoadFunc = createLoadFunc(
+const dfnCertsCreatedLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.dfncerts.getCreatedAggregates({filter}).then(r => r.data),
   DFNCERTS_CREATED,
 );
 
-export const DfnCertsCreatedLoader = ({filter, children}) => (
+export const DfnCertsCreatedLoader = ({
+  filter,
+  children,
+}: DisplayLoaderProps<CreatedData>) => (
   <Loader
     dataId={DFNCERTS_CREATED}
     filter={filter}
@@ -25,13 +33,16 @@ export const DfnCertsCreatedLoader = ({filter, children}) => (
   </Loader>
 );
 
-export const dfnCertSeverityLoadFunc = createLoadFunc(
+const dfnCertSeverityLoadFunc = createLoadFunc(
   ({gmp, filter}) =>
     gmp.dfncerts.getSeverityAggregates({filter}).then(r => r.data),
   DFNCERTS_SEVERITY,
 );
 
-export const DfnCertSeverityLoader = ({filter, children}) => (
+export const DfnCertSeverityLoader = ({
+  filter,
+  children,
+}: DisplayLoaderProps<SeverityData>) => (
   <Loader
     dataId={DFNCERTS_SEVERITY}
     filter={filter}

--- a/src/web/pages/dfncert/dashboard/DfnCertSeverityClassDisplay.tsx
+++ b/src/web/pages/dfncert/dashboard/DfnCertSeverityClassDisplay.tsx
@@ -9,15 +9,20 @@ import createDisplay from 'web/components/dashboard/display/createDisplay';
 import SeverityClassDisplay from 'web/components/dashboard/display/severity/SeverityClassDisplay';
 import SeverityClassTableDisplay from 'web/components/dashboard/display/severity/SeverityClassTableDisplay';
 import {registerDisplay} from 'web/components/dashboard/registry';
-import {DfnCertSeverityLoader} from 'web/pages/dfncert/dashboard/Loaders';
+import {DfnCertSeverityLoader} from 'web/pages/dfncert/dashboard/DfnCertLoaders';
 
 export const DfnCertSeverityClassDisplay = createDisplay({
   loaderComponent: DfnCertSeverityLoader,
-  displayComponent: SeverityClassDisplay,
-  title: ({data: tdata}) =>
-    _('DFN-CERT Advisories by Severity Class (Total: {{count}})', {
-      count: tdata.total,
-    }),
+  displayComponent: props => (
+    <SeverityClassDisplay
+      {...props}
+      title={({data}) =>
+        _('DFN-CERT Advisories by Severity Class (Total: {{count}})', {
+          count: data.total,
+        })
+      }
+    />
+  ),
   displayId: 'dfn_cert_adv-by-severity-class',
   displayName: 'DfnCertSeverityClassDisplay',
   filtersFilter: DFNCERT_FILTER_FILTER,
@@ -25,12 +30,17 @@ export const DfnCertSeverityClassDisplay = createDisplay({
 
 export const DfnCertSeverityClassTableDisplay = createDisplay({
   loaderComponent: DfnCertSeverityLoader,
-  displayComponent: SeverityClassTableDisplay,
-  title: ({data: tdata}) =>
-    _('DFN-CERT Advisories by Severity Class (Total: {{count}})', {
-      count: tdata.total,
-    }),
-  dataTitles: [_l('Severity Class'), _l('# of DFN-CERT Advs')],
+  displayComponent: props => (
+    <SeverityClassTableDisplay
+      {...props}
+      dataTitles={[_('Severity Class'), _('# of DFN-CERT Advs')]}
+      title={({data}) =>
+        _('DFN-CERT Advisories by Severity Class (Total: {{count}})', {
+          count: data.total,
+        })
+      }
+    />
+  ),
   displayId: 'dfn_cert_adv-by-severity-table',
   displayName: 'DfnCertSeverityClassTableDisplay',
   filtersFilter: DFNCERT_FILTER_FILTER,

--- a/src/web/pages/dfncert/dashboard/__tests__/DfnCertCreatedDisplay.test.tsx
+++ b/src/web/pages/dfncert/dashboard/__tests__/DfnCertCreatedDisplay.test.tsx
@@ -1,0 +1,146 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {ReactElement} from 'react';
+import {describe, expect, test, testing} from '@gsa/testing';
+import {rendererWith, screen, waitFor} from 'web/testing';
+import {
+  SubscriptionContext,
+  type SubscribeFunc,
+} from 'web/components/provider/SubscriptionProvider';
+import {getDisplay} from 'web/components/dashboard/registry';
+import {
+  DfnCertsCreatedDisplay,
+  DfnCertsCreatedTableDisplay,
+} from 'web/pages/dfncert/dashboard/DfnCertCreatedDisplay';
+
+const loaderData = {
+  groups: [{value: '2026-01-01', count: '5', c_count: '10'}],
+};
+
+vi.mock('web/components/dashboard/display/created/CreatedDisplay', () => ({
+  default: ({title, xAxisLabel, yAxisLabel, y2AxisLabel}) => (
+    <div data-testid="mock-created-display">
+      <span data-testid="title">{title?.()}</span>
+      <span data-testid="x-axis-label">{xAxisLabel}</span>
+      <span data-testid="y-axis-label">{yAxisLabel}</span>
+      <span data-testid="y2-axis-label">{y2AxisLabel}</span>
+    </div>
+  ),
+}));
+
+vi.mock('web/components/dashboard/display/DataTableDisplay', () => ({
+  default: ({data, dataRow, dataTitles, dataTransform, title}) => {
+    const transformedData = dataTransform ? dataTransform(data) : data;
+
+    return (
+      <div data-testid="mock-data-table-display">
+        <span data-testid="title">{title?.()}</span>
+        <span data-testid="data-titles">{dataTitles?.join('|')}</span>
+        {transformedData.map((row, index) => (
+          <span key={index} data-testid={`data-row-${index}`}>
+            {dataRow(row).join('|')}
+          </span>
+        ))}
+      </div>
+    );
+  },
+}));
+
+const createGmp = () => ({
+  dfncerts: {
+    getCreatedAggregates: testing.fn().mockResolvedValue({data: loaderData}),
+  },
+  filters: {
+    get: testing.fn().mockResolvedValue({
+      data: [],
+      meta: {filter: 'type=dfn_cert_advisory', counts: {}},
+    }),
+  },
+});
+
+const renderDisplay = (component: ReactElement) => {
+  const subscribe: SubscribeFunc = testing.fn().mockReturnValue(testing.fn());
+  const {render} = rendererWith({gmp: createGmp()});
+
+  return render(
+    <SubscriptionContext.Provider value={subscribe}>
+      {component}
+    </SubscriptionContext.Provider>,
+  );
+};
+
+describe('DfnCertsCreatedDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(DfnCertsCreatedDisplay).toBeDefined();
+    expect(typeof DfnCertsCreatedDisplay).toBe('function');
+    expect(DfnCertsCreatedDisplay.displayId).toBe('dfn_cert_adv-by-created');
+    expect(DfnCertsCreatedDisplay.displayName).toBe('DfnCertsCreatedDisplay');
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(DfnCertsCreatedDisplay.displayId);
+
+    expect(registered?.component).toBe(DfnCertsCreatedDisplay);
+    expect(String(registered?.title)).toBe(
+      'Chart: DFN-CERT Advisories by Creation Time',
+    );
+  });
+
+  test('should render the configured chart labels', async () => {
+    renderDisplay(<DfnCertsCreatedDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'DFN-CERT Advisories by Creation Time',
+      );
+      expect(screen.getByTestId('x-axis-label')).toHaveTextContent('Time');
+      expect(screen.getByTestId('y-axis-label')).toHaveTextContent(
+        '# of created DFN-CERT Advs',
+      );
+      expect(screen.getByTestId('y2-axis-label')).toHaveTextContent(
+        'Total DFN-CERT Advs',
+      );
+    });
+  });
+});
+
+describe('DfnCertsCreatedTableDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(DfnCertsCreatedTableDisplay).toBeDefined();
+    expect(typeof DfnCertsCreatedTableDisplay).toBe('function');
+    expect(DfnCertsCreatedTableDisplay.displayId).toBe(
+      'dfn_cert_adv-by-created-table',
+    );
+    expect(DfnCertsCreatedTableDisplay.displayName).toBe(
+      'DfnCertsCreatedTableDisplay',
+    );
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(DfnCertsCreatedTableDisplay.displayId);
+
+    expect(registered?.component).toBe(DfnCertsCreatedTableDisplay);
+    expect(String(registered?.title)).toBe(
+      'Table: DFN-CERT Advisories by Creation Time',
+    );
+  });
+
+  test('should render the configured table data', async () => {
+    renderDisplay(<DfnCertsCreatedTableDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'DFN-CERT Advisories by Creation Time',
+      );
+      expect(screen.getByTestId('data-titles')).toHaveTextContent(
+        'Creation Time|# of DFN-CERT Advs|Total DFN-CERT Advs',
+      );
+      expect(screen.getByTestId('data-row-0')).toHaveTextContent(
+        '01/01/2026|5|10',
+      );
+    });
+  });
+});

--- a/src/web/pages/dfncert/dashboard/__tests__/DfnCertCvssDisplay.test.tsx
+++ b/src/web/pages/dfncert/dashboard/__tests__/DfnCertCvssDisplay.test.tsx
@@ -1,0 +1,139 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {ReactElement} from 'react';
+import {describe, expect, test, testing} from '@gsa/testing';
+import {rendererWith, screen, waitFor} from 'web/testing';
+import {
+  SubscriptionContext,
+  type SubscribeFunc,
+} from 'web/components/provider/SubscriptionProvider';
+import {getDisplay} from 'web/components/dashboard/registry';
+import {
+  DfnCertCvssDisplay,
+  DfnCertCvssTableDisplay,
+} from 'web/pages/dfncert/dashboard/DfnCertCvssDisplay';
+
+const loaderData = {
+  groups: [
+    {value: '0.2', count: 12},
+    {value: '7.5', count: 30},
+  ],
+};
+
+vi.mock('web/components/dashboard/display/cvss/CvssDisplay', () => ({
+  default: ({data, title, yLabel}) => {
+    const total =
+      data?.groups?.reduce((sum, group) => sum + Number(group.count), 0) ?? 0;
+
+    return (
+      <div data-testid="mock-cvss-display">
+        <span data-testid="title">{title?.({data: {total}})}</span>
+        <span data-testid="y-label">{yLabel}</span>
+      </div>
+    );
+  },
+}));
+
+vi.mock('web/components/dashboard/display/cvss/CvssTableDisplay', () => ({
+  default: ({data, dataTitles, title}) => {
+    const total =
+      data?.groups?.reduce((sum, group) => sum + Number(group.count), 0) ?? 0;
+
+    return (
+      <div data-testid="mock-cvss-table-display">
+        <span data-testid="title">{title?.({data: {total}})}</span>
+        <span data-testid="data-titles">{dataTitles?.join('|')}</span>
+      </div>
+    );
+  },
+}));
+
+const createGmp = () => ({
+  dfncerts: {
+    getSeverityAggregates: testing.fn().mockResolvedValue({data: loaderData}),
+  },
+  filters: {
+    get: testing.fn().mockResolvedValue({
+      data: [],
+      meta: {filter: 'type=dfn_cert_advisory', counts: {}},
+    }),
+  },
+});
+
+const renderDisplay = (component: ReactElement) => {
+  const subscribe: SubscribeFunc = testing.fn().mockReturnValue(testing.fn());
+  const {render} = rendererWith({gmp: createGmp()});
+
+  return render(
+    <SubscriptionContext.Provider value={subscribe}>
+      {component}
+    </SubscriptionContext.Provider>,
+  );
+};
+
+describe('DfnCertCvssDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(DfnCertCvssDisplay).toBeDefined();
+    expect(typeof DfnCertCvssDisplay).toBe('function');
+    expect(DfnCertCvssDisplay.displayId).toBe('dfn_cert_adv-by-cvss');
+    expect(DfnCertCvssDisplay.displayName).toBe('DfnCertCvssDisplay');
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(DfnCertCvssDisplay.displayId);
+
+    expect(registered?.component).toBe(DfnCertCvssDisplay);
+    expect(String(registered?.title)).toBe(
+      'Chart: DFN-CERT Advisories by CVSS',
+    );
+  });
+
+  test('should render the configured title and y-axis label', async () => {
+    renderDisplay(<DfnCertCvssDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'DFN-CERT Advisories by CVSS (Total: 42)',
+      );
+      expect(screen.getByTestId('y-label')).toHaveTextContent(
+        '# of DFN-CERT Advs',
+      );
+    });
+  });
+});
+
+describe('DfnCertCvssTableDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(DfnCertCvssTableDisplay).toBeDefined();
+    expect(typeof DfnCertCvssTableDisplay).toBe('function');
+    expect(DfnCertCvssTableDisplay.displayId).toBe(
+      'dfn_cert_adv-by-cvss-table',
+    );
+    expect(DfnCertCvssTableDisplay.displayName).toBe('DfnCertCvssTableDisplay');
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(DfnCertCvssTableDisplay.displayId);
+
+    expect(registered?.component).toBe(DfnCertCvssTableDisplay);
+    expect(String(registered?.title)).toBe(
+      'Table: DFN-CERT Advisories by CVSS',
+    );
+  });
+
+  test('should render the configured title and table headings', async () => {
+    renderDisplay(<DfnCertCvssTableDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'DFN-CERT Advisories by CVSS (Total: 42)',
+      );
+      expect(screen.getByTestId('data-titles')).toHaveTextContent(
+        'Severity|# of DFN-CERT Advisories',
+      );
+    });
+  });
+});

--- a/src/web/pages/dfncert/dashboard/__tests__/DfnCertLoaders.test.tsx
+++ b/src/web/pages/dfncert/dashboard/__tests__/DfnCertLoaders.test.tsx
@@ -1,0 +1,119 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {ReactElement} from 'react';
+import {describe, expect, test, testing} from '@gsa/testing';
+import {rendererWith, waitFor} from 'web/testing';
+import QueryFilter from 'gmp/models/filter/query-filter';
+import {
+  SubscriptionContext,
+  type SubscribeFunc,
+} from 'web/components/provider/SubscriptionProvider';
+import {
+  DFNCERTS_CREATED,
+  DFNCERTS_SEVERITY,
+  DfnCertsCreatedLoader,
+  DfnCertSeverityLoader,
+} from 'web/pages/dfncert/dashboard/DfnCertLoaders';
+
+const createGmp = dfncerts => ({dfncerts});
+
+const renderWithSubscriptionContext = ({
+  gmp,
+  subscribe,
+  children,
+}: {
+  gmp: Record<string, unknown>;
+  subscribe: SubscribeFunc;
+  children: ReactElement;
+}) => {
+  const {render} = rendererWith({gmp, store: true});
+
+  return render(
+    <SubscriptionContext.Provider value={subscribe}>
+      {children}
+    </SubscriptionContext.Provider>,
+  );
+};
+
+describe('DfnCertsCreatedLoader', () => {
+  test('should export the created data ID', () => {
+    expect(DFNCERTS_CREATED).toBe('dfncerts-created');
+  });
+
+  test('should load created aggregates and render them', async () => {
+    const data = {
+      groups: [{value: '2026-01', count: '5', c_count: '10'}],
+    };
+    const mockGetCreatedAggregates = testing.fn().mockResolvedValue({data});
+    const gmp = createGmp({getCreatedAggregates: mockGetCreatedAggregates});
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const subscribe = testing.fn().mockReturnValue(testing.fn());
+    const children = testing.fn().mockReturnValue(null);
+
+    renderWithSubscriptionContext({
+      gmp,
+      subscribe,
+      children: (
+        <DfnCertsCreatedLoader filter={filter}>
+          {children}
+        </DfnCertsCreatedLoader>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(mockGetCreatedAggregates).toHaveBeenCalledWith({filter});
+      expect(children).toHaveBeenLastCalledWith({data, isLoading: false});
+    });
+
+    expect(subscribe).toHaveBeenCalledWith(
+      'dfncerts.timer',
+      expect.any(Function),
+    );
+    expect(subscribe).toHaveBeenCalledWith(
+      'dfncerts.changed',
+      expect.any(Function),
+    );
+  });
+});
+
+describe('DfnCertSeverityLoader', () => {
+  test('should export the severity data ID', () => {
+    expect(DFNCERTS_SEVERITY).toBe('dfncerts-severity');
+  });
+
+  test('should load severity aggregates and render them', async () => {
+    const data = {groups: [{value: '5.0', count: 10}]};
+    const mockGetSeverityAggregates = testing.fn().mockResolvedValue({data});
+    const gmp = createGmp({getSeverityAggregates: mockGetSeverityAggregates});
+    const filter = QueryFilter.fromString('first=1 rows=10');
+    const subscribe = testing.fn().mockReturnValue(testing.fn());
+    const children = testing.fn().mockReturnValue(null);
+
+    renderWithSubscriptionContext({
+      gmp,
+      subscribe,
+      children: (
+        <DfnCertSeverityLoader filter={filter}>
+          {children}
+        </DfnCertSeverityLoader>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(mockGetSeverityAggregates).toHaveBeenCalledWith({filter});
+      expect(children).toHaveBeenLastCalledWith({data, isLoading: false});
+    });
+
+    expect(subscribe).toHaveBeenCalledWith(
+      'dfncerts.timer',
+      expect.any(Function),
+    );
+    expect(subscribe).toHaveBeenCalledWith(
+      'dfncerts.changed',
+      expect.any(Function),
+    );
+  });
+});

--- a/src/web/pages/dfncert/dashboard/__tests__/DfnCertSeverityClassDisplay.test.tsx
+++ b/src/web/pages/dfncert/dashboard/__tests__/DfnCertSeverityClassDisplay.test.tsx
@@ -1,0 +1,149 @@
+/* SPDX-FileCopyrightText: 2026 Greenbone AG
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {ReactElement} from 'react';
+import {describe, expect, test, testing} from '@gsa/testing';
+import {rendererWith, screen, waitFor} from 'web/testing';
+import {
+  SubscriptionContext,
+  type SubscribeFunc,
+} from 'web/components/provider/SubscriptionProvider';
+import {getDisplay} from 'web/components/dashboard/registry';
+import {
+  DfnCertSeverityClassDisplay,
+  DfnCertSeverityClassTableDisplay,
+} from 'web/pages/dfncert/dashboard/DfnCertSeverityClassDisplay';
+
+const loaderData = {
+  groups: [
+    {value: '2.0', count: 12},
+    {value: '7.5', count: 30},
+  ],
+};
+
+vi.mock(
+  'web/components/dashboard/display/severity/SeverityClassDisplay',
+  () => ({
+    default: ({data, title}) => {
+      const total =
+        data?.groups?.reduce((sum, group) => sum + Number(group.count), 0) ?? 0;
+
+      return (
+        <div data-testid="mock-severity-display">
+          {title?.({data: {total}})}
+        </div>
+      );
+    },
+  }),
+);
+
+vi.mock(
+  'web/components/dashboard/display/severity/SeverityClassTableDisplay',
+  () => ({
+    default: ({data, dataTitles, title}) => {
+      const total =
+        data?.groups?.reduce((sum, group) => sum + Number(group.count), 0) ?? 0;
+
+      return (
+        <div data-testid="mock-severity-table-display">
+          <span data-testid="title">{title?.({data: {total}})}</span>
+          <span data-testid="data-titles">{dataTitles?.join('|')}</span>
+        </div>
+      );
+    },
+  }),
+);
+
+const createGmp = () => ({
+  dfncerts: {
+    getSeverityAggregates: testing.fn().mockResolvedValue({data: loaderData}),
+  },
+  filters: {
+    get: testing.fn().mockResolvedValue({
+      data: [],
+      meta: {filter: 'type=dfn_cert_advisory', counts: {}},
+    }),
+  },
+});
+
+const renderDisplay = (component: ReactElement) => {
+  const subscribe: SubscribeFunc = testing.fn().mockReturnValue(testing.fn());
+  const {render} = rendererWith({gmp: createGmp()});
+
+  return render(
+    <SubscriptionContext.Provider value={subscribe}>
+      {component}
+    </SubscriptionContext.Provider>,
+  );
+};
+
+describe('DfnCertSeverityClassDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(DfnCertSeverityClassDisplay).toBeDefined();
+    expect(typeof DfnCertSeverityClassDisplay).toBe('function');
+    expect(DfnCertSeverityClassDisplay.displayId).toBe(
+      'dfn_cert_adv-by-severity-class',
+    );
+    expect(DfnCertSeverityClassDisplay.displayName).toBe(
+      'DfnCertSeverityClassDisplay',
+    );
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(DfnCertSeverityClassDisplay.displayId);
+
+    expect(registered?.component).toBe(DfnCertSeverityClassDisplay);
+    expect(String(registered?.title)).toBe(
+      'Chart: DFN-CERT Advisories by Severity Class',
+    );
+  });
+
+  test('should render the total advisory count in the title', async () => {
+    renderDisplay(<DfnCertSeverityClassDisplay height={200} width={200} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-severity-display')).toHaveTextContent(
+        'DFN-CERT Advisories by Severity Class (Total: 42)',
+      );
+    });
+  });
+});
+
+describe('DfnCertSeverityClassTableDisplay', () => {
+  test('should export a valid component with the correct configuration', () => {
+    expect(DfnCertSeverityClassTableDisplay).toBeDefined();
+    expect(typeof DfnCertSeverityClassTableDisplay).toBe('function');
+    expect(DfnCertSeverityClassTableDisplay.displayId).toBe(
+      'dfn_cert_adv-by-severity-table',
+    );
+    expect(DfnCertSeverityClassTableDisplay.displayName).toBe(
+      'DfnCertSeverityClassTableDisplay',
+    );
+  });
+
+  test('should be registered with the correct title', () => {
+    const registered = getDisplay(DfnCertSeverityClassTableDisplay.displayId);
+
+    expect(registered?.component).toBe(DfnCertSeverityClassTableDisplay);
+    expect(String(registered?.title)).toBe(
+      'Table: DFN-CERT Advisories by Severity Class',
+    );
+  });
+
+  test('should render the total and table headings', async () => {
+    renderDisplay(
+      <DfnCertSeverityClassTableDisplay height={200} width={200} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('title')).toHaveTextContent(
+        'DFN-CERT Advisories by Severity Class (Total: 42)',
+      );
+      expect(screen.getByTestId('data-titles')).toHaveTextContent(
+        'Severity Class|# of DFN-CERT Advs',
+      );
+    });
+  });
+});

--- a/src/web/pages/dfncert/dashboard/index.tsx
+++ b/src/web/pages/dfncert/dashboard/index.tsx
@@ -3,20 +3,25 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import React from 'react';
+import {type FilterType} from 'gmp/models/filter';
 import Dashboard from 'web/components/dashboard/Dashboard';
 import {
   DfnCertsCreatedDisplay,
   DfnCertsCreatedTableDisplay,
-} from 'web/pages/dfncert/dashboard/CreatedDisplay';
+} from 'web/pages/dfncert/dashboard/DfnCertCreatedDisplay';
 import {
   DfnCertCvssDisplay,
   DfnCertCvssTableDisplay,
-} from 'web/pages/dfncert/dashboard/CvssDisplay';
+} from 'web/pages/dfncert/dashboard/DfnCertCvssDisplay';
 import {
   DfnCertSeverityClassDisplay,
   DfnCertSeverityClassTableDisplay,
-} from 'web/pages/dfncert/dashboard/SeverityClassDisplay';
+} from 'web/pages/dfncert/dashboard/DfnCertSeverityClassDisplay';
+
+interface DfnCertDashboardProps {
+  filter?: FilterType;
+  onFilterChanged?: (filter: FilterType) => void;
+}
 
 export const DFNCERT_DASHBOARD_ID = '9812ea49-682d-4f99-b3cc-eca051d1ce59';
 
@@ -29,7 +34,7 @@ export const DFNCERT_DISPLAYS = [
   DfnCertSeverityClassTableDisplay.displayId,
 ];
 
-const DfnCertDashboard = props => (
+const DfnCertDashboard = (props: DfnCertDashboardProps) => (
   <Dashboard
     {...props}
     defaultDisplays={[


### PR DESCRIPTION


## What

Use TypeScript for all DFN Cert chart displays

## Why

Also add tests for the components to ensure all components work as expected.
## References

https://jira.greenbone.net/browse/GEA-2019

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] I have added tests for the changes
- [x] I have used the following LLMs/AI tools in this pull request: Codex/GPT-5.6 Luna


